### PR TITLE
fix: create Application Support directory before opening Room database on iOS

### DIFF
--- a/core/data/src/iosMain/kotlin/com/garfiec/librechat/core/data/di/DataPlatformModule.ios.kt
+++ b/core/data/src/iosMain/kotlin/com/garfiec/librechat/core/data/di/DataPlatformModule.ios.kt
@@ -20,14 +20,21 @@ import okio.Path.Companion.toPath
 import org.koin.core.module.Module
 import org.koin.dsl.binds
 import org.koin.dsl.module
+import platform.Foundation.NSFileManager
 import platform.Foundation.NSHomeDirectory
+
+@OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
+private fun ensureDirectoryExists(path: String) {
+    NSFileManager.defaultManager.createDirectoryAtPath(path, withIntermediateDirectories = true, attributes = null, error = null)
+}
 
 actual val dataPlatformModule: Module = module {
 
     // --- Database ---
     single {
-        val dbPath = NSHomeDirectory() + "/Library/Application Support/librechat.db"
-        Room.databaseBuilder<LibreChatDatabase>(name = dbPath)
+        val dbDir = NSHomeDirectory() + "/Library/Application Support"
+        ensureDirectoryExists(dbDir)
+        Room.databaseBuilder<LibreChatDatabase>(name = "$dbDir/librechat.db")
             .setDriver(BundledSQLiteDriver())
             .setQueryCoroutineContext(Dispatchers.IO)
             .build()
@@ -35,7 +42,9 @@ actual val dataPlatformModule: Module = module {
 
     // --- DataStore ---
     single<DataStore<Preferences>> {
-        val path = NSHomeDirectory() + "/Library/Application Support/datastore/$DATASTORE_FILE_NAME.preferences_pb"
+        val datastoreDir = NSHomeDirectory() + "/Library/Application Support/datastore"
+        ensureDirectoryExists(datastoreDir)
+        val path = "$datastoreDir/$DATASTORE_FILE_NAME.preferences_pb"
         PreferenceDataStoreFactory.createWithPath(
             produceFile = { path.toPath() },
         )


### PR DESCRIPTION
## Problem

The iOS app crashes on launch with `IllegalStateException: Unable to open database`. Room's `BundledSQLiteDriver` attempts to open `~/Library/Application Support/librechat.db`, but the `Application Support` directory does not exist by default in the iOS app sandbox. SQLite creates the database file but cannot create intermediate parent directories. The same latent defect affects DataStore, which writes to `Application Support/datastore/`.

Android avoids this entirely — `Context`-based path resolution creates directories automatically.

### Why this happens

Apple's `Application Support` directory is the [recommended location](https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/FileSystemProgrammingGuide/FileSystemOverview/FileSystemOverview.html) for internal app data like databases — it's hidden from users, backed up by iCloud, and not exposed in the Files app. However, unlike `Documents`, **it does not exist by default** and must be created before first use.

This is documented in Apple's own [File System Programming Guide](https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/FileSystemProgrammingGuide/ManagingFIlesandDirectories/ManagingFIlesandDirectories.html), which shows `createDirectoryAtURL:withIntermediateDirectories:YES` as the standard pattern for working with `Application Support` (Listing 6-1).

Most KMP Room/DataStore tutorials ([official Room KMP docs](https://developer.android.com/kotlin/multiplatform/room), [official DataStore KMP docs](https://developer.android.com/kotlin/multiplatform/datastore)) sidestep this by using `NSDocumentDirectory` in their iOS examples, which always exists. We use `Application Support` because it's the correct location per Apple's [iOS Storage Best Practices](https://developer.apple.com/videos/play/tech-talks/204/).

## Solution

Added `ensureDirectoryExists()` helper that calls `NSFileManager.createDirectoryAtPath()` with `withIntermediateDirectories = true` before building both the Room database and DataStore instances. This matches the pattern shown in Apple's own documentation.
