### PR TITLE
refactor: NavHostViewModel stage 4 — extract favorites state holder

### DIFF
--- a/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/FavoritesStateHolder.kt
+++ b/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/FavoritesStateHolder.kt
@@ -1,0 +1,72 @@
+package com.garfiec.librechat.shared.navigation
+
+import co.touchlab.kermit.Logger
+import com.garfiec.librechat.core.data.datastore.SettingsDataStore
+import com.garfiec.librechat.core.model.Conversation
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+class FavoritesStateHolder(
+    private val settingsDataStore: SettingsDataStore,
+    private val recentConversations: StateFlow<List<Conversation>>,
+    private val scope: CoroutineScope,
+) {
+
+    private val _favorites = MutableStateFlow<Set<String>>(emptySet())
+    val favorites: StateFlow<Set<String>> = _favorites.asStateFlow()
+
+    private val _favoriteConversations = MutableStateFlow<List<Conversation>>(emptyList())
+    val favoriteConversations: StateFlow<List<Conversation>> = _favoriteConversations.asStateFlow()
+
+    init {
+        observeBookmarks()
+        observeRecentConversations()
+    }
+
+    private fun observeBookmarks() {
+        scope.launch {
+            try {
+                settingsDataStore.bookmarkedConversationIds.collect { bookmarkedIds ->
+                    _favorites.value = bookmarkedIds
+                    updateFavoriteConversations()
+                }
+            } catch (e: Exception) {
+                Logger.w(e) { "Failed to observe bookmarks" }
+            }
+        }
+    }
+
+    private fun observeRecentConversations() {
+        scope.launch {
+            recentConversations.collect {
+                updateFavoriteConversations()
+            }
+        }
+    }
+
+    fun toggleFavorite(conversationId: String) {
+        scope.launch {
+            settingsDataStore.toggleBookmark(conversationId)
+        }
+    }
+
+    private fun updateFavoriteConversations() {
+        val bookmarkedIds = _favorites.value
+        val allConversations = recentConversations.value
+        _favoriteConversations.value = allConversations.filter { conversation ->
+            conversation.conversationId in bookmarkedIds ||
+                conversation.tags.any {
+                    it.equals("favorite", ignoreCase = true) ||
+                        it.equals("bookmark", ignoreCase = true)
+                }
+        }
+    }
+
+    fun reset() {
+        _favorites.value = emptySet()
+        _favoriteConversations.value = emptyList()
+    }
+}

--- a/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/NavHostViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/NavHostViewModel.kt
@@ -68,14 +68,12 @@ class NavHostViewModel(
     private val bannerStateHolder = BannerStateHolder(bannerRepository, viewModelScope)
     private val versionCheckStateHolder = VersionCheckStateHolder(configRepository, settingsDataStore, viewModelScope)
     private val conversationListStateHolder = ConversationListStateHolder(conversationRepository, viewModelScope)
+    private val favoritesStateHolder = FavoritesStateHolder(settingsDataStore, conversationListStateHolder.recentConversations, viewModelScope)
 
     private val _isLoggedIn = MutableStateFlow(tokenManager.isAuthenticated)
     val isLoggedIn: StateFlow<Boolean> = _isLoggedIn.asStateFlow()
 
     val versionMismatch: StateFlow<VersionMismatchState?> = versionCheckStateHolder.versionMismatch
-
-    private val _favorites = MutableStateFlow<Set<String>>(emptySet())
-    private val _favoriteConversations = MutableStateFlow<List<Conversation>>(emptyList())
 
     val banners: StateFlow<List<Banner>> = bannerStateHolder.banners
     val dismissedBannerIds: StateFlow<Set<String>> = bannerStateHolder.dismissedBannerIds
@@ -110,8 +108,8 @@ class NavHostViewModel(
         combine(
             conversationListStateHolder.groupedConversations,
             conversationListStateHolder.activeConversationId,
-            _favorites,
-            _favoriteConversations,
+            favoritesStateHolder.favorites,
+            favoritesStateHolder.favoriteConversations,
             conversationListStateHolder.searchQuery,
         ) { grouped, activeId, favIds, favConvos, query ->
             DrawerDataSnapshot(grouped, activeId, favIds, favConvos, query)
@@ -148,17 +146,7 @@ class NavHostViewModel(
                 Logger.w(e) { "Failed to check auth state on init" }
             }
         }
-        observeBookmarks()
-        observeRecentConversationsForFavorites()
         bannerStateHolder.fetchBanners()
-    }
-
-    private fun observeRecentConversationsForFavorites() {
-        viewModelScope.launch {
-            conversationListStateHolder.recentConversations.collect {
-                updateFavoriteConversations()
-            }
-        }
     }
 
     fun loadMoreConversations() {
@@ -184,35 +172,8 @@ class NavHostViewModel(
         conversationListStateHolder.onSearchQueryChanged(query)
     }
 
-    private fun observeBookmarks() {
-        viewModelScope.launch {
-            try {
-                settingsDataStore.bookmarkedConversationIds.collect { bookmarkedIds ->
-                    _favorites.value = bookmarkedIds
-                    updateFavoriteConversations()
-                }
-            } catch (e: Exception) {
-                Logger.w(e) { "Failed to observe bookmarks" }
-            }
-        }
-    }
-
     fun toggleFavorite(conversationId: String) {
-        viewModelScope.launch {
-            settingsDataStore.toggleBookmark(conversationId)
-        }
-    }
-
-    private fun updateFavoriteConversations() {
-        val bookmarkedIds = _favorites.value
-        val allConversations = conversationListStateHolder.recentConversations.value
-        _favoriteConversations.value = allConversations.filter { conversation ->
-            conversation.conversationId in bookmarkedIds ||
-                conversation.tags.any {
-                    it.equals("favorite", ignoreCase = true) ||
-                        it.equals("bookmark", ignoreCase = true)
-                }
-        }
+        favoritesStateHolder.toggleFavorite(conversationId)
     }
 
     fun setTabletSidebarOpen(open: Boolean) {
@@ -238,8 +199,7 @@ class NavHostViewModel(
             authRepository.logout()
             _isLoggedIn.value = false
             conversationListStateHolder.reset()
-            _favorites.value = emptySet()
-            _favoriteConversations.value = emptyList()
+            favoritesStateHolder.reset()
             _sidebarMode.value = SidebarMode.Conversations
             _selectedSettingsCategory.value = null
         }

--- a/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/VersionCheckStateHolder.kt
+++ b/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/VersionCheckStateHolder.kt
@@ -46,7 +46,7 @@ class VersionCheckStateHolder(
                 is Result.Error -> {
                     Logger.w(result.exception) { "Failed to check backend version: ${result.message}" }
                 }
-                else -> {}
+                is Result.Loading -> Unit
             }
         }
     }


### PR DESCRIPTION
## Summary
- Extract `FavoritesStateHolder` — bookmark observation, favorite toggle, and favorite conversation derivation
- FavoritesStateHolder takes a `StateFlow<List<Conversation>>` from ConversationListStateHolder to derive favorites reactively
- NavHostViewModel is now a thin facade (~140 lines of class body) delegating to four state holders
- Make `Result.Loading` handling explicit in `VersionCheckStateHolder`
- No consumer API changes — all composables continue using NavHostViewModel only

## Architecture context
Final stage of the [state holder](https://developer.android.com/topic/architecture/ui-layer/stateholders) decomposition. NavHostViewModel is now a coordination facade with auth management, UI chrome state, a `drawerUiState` combine, and delegation to four state holders.