### PR TITLE
fix(chat): apply safe area padding to iOS chat input

### DIFF
--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/components/ChatInput.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/components/ChatInput.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
-import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -227,7 +226,6 @@ fun ChatInput(
         onStop = onStop,
         onRemoveFile = onRemoveFile,
         modifier = modifier,
-        columnModifier = Modifier.navigationBarsPadding(),
         leadingButtons = {
             // "+" button to open tools bottom sheet
             Box {

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/CommonChatInputCore.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/CommonChatInputCore.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
@@ -79,7 +80,6 @@ fun CommonChatInputCore(
     onStop: () -> Unit,
     onRemoveFile: (AttachedFile) -> Unit,
     modifier: Modifier = Modifier,
-    columnModifier: Modifier = Modifier,
     leadingButtons: @Composable RowScope.() -> Unit = {},
     textFieldContent: @Composable RowScope.() -> Unit,
     trailingSpacer: @Composable RowScope.() -> Unit = {},
@@ -102,7 +102,7 @@ fun CommonChatInputCore(
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .then(columnModifier)
+                .navigationBarsPadding()
                 .padding(horizontal = 12.dp, vertical = 8.dp),
         ) {
             AttachmentChipsRow(


### PR DESCRIPTION
## Summary
- On iOS the chat input row was rendering flush against the screen bottom and overlapping the home indicator. Android was unaffected because `ChatInput` was passing `Modifier.navigationBarsPadding()` through to the shared core, but `IosChatInput` never did.
- Moves `navigationBarsPadding()` into `CommonChatInputCore` itself and removes the now-redundant `columnModifier` parameter / Android pass-through. In Compose Multiplatform this single modifier maps to the Android nav bar inset and the iOS bottom safe area, so both platforms get the right behavior from one shared call site.
- No new dependencies, no `expect`/`actual`, no third-party inset shim.

## Why a single shared modifier is safe
The iOS implementation in JetBrains' `compose-multiplatform-core` defines `WindowInsets.navigationBars` as:

```kotlin
override val navigationBars: PlatformInsets get() =
    PlatformInsets(getBottom = { safeAreaInsets().bottom })
```

— i.e. the bottom component of `UIView.safeAreaInsets`, which is exactly the home indicator inset on modern iPhones (and `0` on devices without one). iOS WindowInsets support has shipped in common code since Compose Multiplatform 1.5.0 (August 2023); this project is on 1.11.0-beta01.

References:
- iOS inset definitions — [`UIKitWindowInsetsManager.ios.kt` on `jb-main`](https://github.com/JetBrains/compose-multiplatform-core/blob/jb-main/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/UIKitWindowInsetsManager.ios.kt)
- Shipping announcement — [CMP 1.5.0 CHANGELOG](https://github.com/JetBrains/compose-multiplatform/blob/master/CHANGELOG.md) ("Insets on iOS" under 1.5.0)

## Screenshots

| Before | After |
| :---: | :---: |
| <img width="559" height="1062" alt="image" src="https://github.com/user-attachments/assets/46da2796-0ff8-49e9-b876-d429c41a790f" /> | <img width="559" height="1062" alt="image" src="https://github.com/user-attachments/assets/52a43972-398b-4859-8988-9da34d76f330" /> |