### PR TITLE
fix(settings): equalize MCP server type segmented button heights

### DIFF
--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/McpServerDialog.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/McpServerDialog.kt
@@ -2,7 +2,9 @@ package com.garfiec.librechat.feature.settings.screen
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.rememberScrollState
@@ -130,7 +132,11 @@ internal fun McpServerDialog(
                 Spacer(modifier = Modifier.height(8.dp))
 
                 val typeOptions = listOf(McpServerType.SSE, McpServerType.STREAMABLE_HTTP)
-                SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
+                SingleChoiceSegmentedButtonRow(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(IntrinsicSize.Max),
+                ) {
                     typeOptions.forEachIndexed { index, type ->
                         SegmentedButton(
                             selected = selectedType == type,
@@ -139,6 +145,7 @@ internal fun McpServerDialog(
                                 index = index,
                                 count = typeOptions.size,
                             ),
+                            modifier = Modifier.fillMaxHeight(),
                         ) {
                             Text(
                                 when (type) {


### PR DESCRIPTION
## Summary
On iPhone, the "Streamable HTTP" segmented button in Settings → Data → Add MCP Server wraps to two lines, making it taller than the single-line "SSE" button. This fix forces both buttons to match the taller one's height.

## Fix
In `McpServerDialog.kt`, the server type `SingleChoiceSegmentedButtonRow` now uses `Modifier.height(IntrinsicSize.Max)` and each `SegmentedButton` gets `Modifier.fillMaxHeight()`. The row sizes itself to the tallest child's intrinsic height, and both buttons stretch to fill it.

## Screenshots

| Before | After |
| --- | --- |
| <img width="559" height="1062" alt="image" src="https://github.com/user-attachments/assets/1976b771-8798-4d0d-b0f3-e26530f80327" /> | <img width="559" height="1062" alt="image" src="https://github.com/user-attachments/assets/ccce16de-d618-4807-92f9-45b55e115aea" /> |