### PR TITLE
fix: clear Room DB and user-scoped DataStore keys on logout

### DIFF
--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/SettingsDataStore.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/SettingsDataStore.kt
@@ -308,6 +308,17 @@ class SettingsDataStore(
         }
     }
 
+    suspend fun clearUserData() {
+        dataStore.edit { prefs ->
+            prefs.remove(KEY_BOOKMARKED_CONVERSATIONS)
+            prefs.remove(KEY_LAST_USED_ENDPOINT)
+            prefs.remove(KEY_LAST_USED_MODEL)
+            prefs.remove(KEY_SELECTED_VOICE_ID)
+            prefs.remove(KEY_SELECTED_MCP_SERVERS)
+            prefs.remove(KEY_ENABLED_TOOLS)
+        }
+    }
+
     suspend fun toggleBookmark(conversationId: String) {
         dataStore.edit { prefs ->
             val current = prefs[KEY_BOOKMARKED_CONVERSATIONS] ?: emptySet()

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/db/LibreChatDatabase.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/db/LibreChatDatabase.kt
@@ -49,6 +49,16 @@ abstract class LibreChatDatabase : RoomDatabase() {
     abstract fun presetDao(): PresetDao
     abstract fun conversationTagDao(): ConversationTagDao
     abstract fun draftDao(): DraftDao
+
+    suspend fun clearAllUserData() {
+        conversationDao().deleteAll()
+        messageDao().deleteAll()
+        fileDao().deleteAll()
+        agentDao().deleteAll()
+        presetDao().deleteAll()
+        conversationTagDao().deleteAll()
+        draftDao().deleteAll()
+    }
 }
 
 // Room KSP auto-generates the actual implementations for each platform

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/db/dao/ConversationTagDao.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/db/dao/ConversationTagDao.kt
@@ -19,4 +19,7 @@ interface ConversationTagDao {
 
     @Query("DELETE FROM conversation_tags WHERE id = :id")
     suspend fun deleteById(id: Long)
+
+    @Query("DELETE FROM conversation_tags")
+    suspend fun deleteAll()
 }

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/db/dao/DraftDao.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/db/dao/DraftDao.kt
@@ -19,4 +19,7 @@ interface DraftDao {
 
     @Query("SELECT * FROM drafts ORDER BY updated_at DESC")
     fun observeAllDrafts(): Flow<List<DraftEntity>>
+
+    @Query("DELETE FROM drafts")
+    suspend fun deleteAll()
 }

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/db/dao/FileDao.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/db/dao/FileDao.kt
@@ -22,4 +22,7 @@ interface FileDao {
 
     @Query("DELETE FROM files WHERE fileId = :fileId")
     suspend fun deleteById(fileId: String)
+
+    @Query("DELETE FROM files")
+    suspend fun deleteAll()
 }

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/db/dao/MessageDao.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/db/dao/MessageDao.kt
@@ -41,4 +41,7 @@ interface MessageDao {
 
     @Query("UPDATE messages SET text = :text, content = NULL WHERE messageId = :messageId")
     suspend fun updateText(messageId: String, text: String)
+
+    @Query("DELETE FROM messages")
+    suspend fun deleteAll()
 }

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/db/dao/PresetDao.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/db/dao/PresetDao.kt
@@ -19,4 +19,7 @@ interface PresetDao {
 
     @Query("DELETE FROM presets WHERE presetId = :presetId")
     suspend fun deleteById(presetId: String)
+
+    @Query("DELETE FROM presets")
+    suspend fun deleteAll()
 }

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/di/DataModule.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/di/DataModule.kt
@@ -93,6 +93,8 @@ val dataModule = module {
             userApi = get(),
             tokenManager = get(),
             sessionCacheCleaner = get(),
+            database = get(),
+            settingsDataStore = get(),
         )
     }
 

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/AuthRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/AuthRepositoryImpl.kt
@@ -5,6 +5,8 @@ import com.garfiec.librechat.core.common.result.safeApiCall
 import com.garfiec.librechat.core.model.LoginOutcome
 import com.garfiec.librechat.core.model.User
 import com.garfiec.librechat.core.model.response.TwoFactorSetupResponse
+import com.garfiec.librechat.core.data.datastore.SettingsDataStore
+import com.garfiec.librechat.core.data.db.LibreChatDatabase
 import com.garfiec.librechat.core.network.api.AuthApi
 import com.garfiec.librechat.core.network.api.UserApi
 import com.garfiec.librechat.core.network.client.TokenManager
@@ -14,6 +16,8 @@ class AuthRepositoryImpl(
     private val userApi: UserApi,
     private val tokenManager: TokenManager,
     private val sessionCacheCleaner: SessionCacheCleaner,
+    private val database: LibreChatDatabase,
+    private val settingsDataStore: SettingsDataStore,
 ) : AuthRepository {
 
     override suspend fun login(email: String, password: String): Result<LoginOutcome> {
@@ -82,6 +86,8 @@ class AuthRepositoryImpl(
             } finally {
                 tokenManager.clearTokens()
                 sessionCacheCleaner.clearSessionCaches()
+                database.clearAllUserData()
+                settingsDataStore.clearUserData()
             }
         }
     }


### PR DESCRIPTION
## Summary

Prevents cross-user data leak when one user logs out and another logs in on the same device. Previously, logout only cleared tokens and file caches (`image_cache`, `artifacts`, `shared_images`) — Room DB and user-scoped DataStore preferences persisted into the next session.

## Changes

- **Room DB cleanup**: Added `deleteAll()` to the 5 DAOs that lacked it (`MessageDao`, `FileDao`, `PresetDao`, `ConversationTagDao`, `DraftDao`). Added `LibreChatDatabase.clearAllUserData()` which wipes all 7 entity tables.
- **DataStore cleanup**: Added `SettingsDataStore.clearUserData()` that removes only user-scoped keys (`bookmarkedConversationIds`, `lastUsedEndpoint`, `lastUsedModel`, `selectedVoiceId`, `selectedMcpServers`, `enabledTools`). Device-level keys (theme, font, layout, server URL, `dismissedVersionWarning`) are preserved, as is `ConfigCacheDataStore` and `ThemeDataStore`.
- **Wiring**: `AuthRepositoryImpl.logout()` now invokes both cleanup methods in its existing `finally` block alongside the current token and file-cache cleanup.

## Scope

Room + DataStore cleanup only. Related gaps tracked separately:
- `BannerStateHolder` / `VersionCheckStateHolder` not reset on logout
- `ApplicationScope` coroutine never cancelled across sessions
- `CommonTokenDataStore.refreshAccessToken()` (401 path) only clears tokens, not Room/DataStore