### PR TITLE
fix(data): mark agent/preset caches @Volatile

### DIFF
--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/AgentRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/AgentRepositoryImpl.kt
@@ -18,11 +18,13 @@ import com.garfiec.librechat.core.model.request.ToolCallRequest
 import com.garfiec.librechat.core.model.request.UpdateAgentRequest
 import com.garfiec.librechat.core.network.api.AgentsApi
 import kotlinx.serialization.json.Json
+import kotlin.concurrent.Volatile
 
 class AgentRepositoryImpl(
     private val agentsApi: AgentsApi,
 ) : AgentRepository {
 
+    @Volatile
     private var cachedAgents: List<Agent>? = null
 
     // --- Agent CRUD ---

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/PresetRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/PresetRepositoryImpl.kt
@@ -4,11 +4,13 @@ import com.garfiec.librechat.core.common.result.Result
 import com.garfiec.librechat.core.common.result.safeApiCall
 import com.garfiec.librechat.core.model.Preset
 import com.garfiec.librechat.core.network.api.PresetsApi
+import kotlin.concurrent.Volatile
 
 class PresetRepositoryImpl(
     private val presetsApi: PresetsApi,
 ) : PresetRepository {
 
+    @Volatile
     private var cachedPresets: List<Preset>? = null
 
     override suspend fun getAll(): Result<List<Preset>> {


### PR DESCRIPTION
## Summary
- Add `@Volatile` (from `kotlin.concurrent.Volatile`) to `AgentRepositoryImpl.cachedAgents` and `PresetRepositoryImpl.cachedPresets`.
- Pure JMM visibility fix: prevents a stale non-null reference from being briefly readable on another thread after `clearCache()` nulls the field.
- Zero behavior change — two imports, two annotations, no new allocations or API surface.

## Why
Both fields are plain `private var`s mutated from `clearCache()` and from the repository's load/save paths. Under the Kotlin/JVM memory model, writes to plain refs aren't guaranteed to be immediately visible to reader threads — a reader racing the null-write could observe the old cache briefly. The window is small but real and sits on the session-teardown path being hardened as part of the broader logout-cleanup work.

## Test plan
- [x] `./gradlew :app:assembleDebug` — passes
- [x] Installed on Android emulator, manual smoke: login → Agents marketplace loads with content → Presets bottom sheet loads → send message → logout / re-login
- [x] Logcat scoped to app PID grep'd for `FATAL | AndroidRuntime | NullPointerException | Suppressed:` — zero hits from `com.garfiec.librechat`
- [x] No regressions observed across Agents, Presets, chat streaming, or logout

## Notes
If the follow-up mutex retrofit for `AgentRepositoryImpl` / `PresetRepositoryImpl` read-API-write races lands later, the `@Volatile` annotation here becomes redundant (mutex provides happens-before) and can be removed in that PR. Kept here so the visibility fix is guaranteed regardless of when the mutex work merges.