### PR TITLE
fix(data): sweep camera_photos cache dir on logout

### DIFF
--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/CacheDirectory.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/CacheDirectory.kt
@@ -5,7 +5,7 @@ import co.touchlab.kermit.Logger
 /**
  * Subdirectories under the platform cache root that are cleared on logout.
  */
-internal val CACHE_SUBDIRECTORIES = listOf("image_cache", "artifacts", "shared_images")
+internal val CACHE_SUBDIRECTORIES = listOf("image_cache", "artifacts", "shared_images", "camera_photos")
 
 /**
  * Deletes a directory and all its contents at the given [path].


### PR DESCRIPTION
## Summary
- Add `"camera_photos"` to `CacheDirectory.CACHE_SUBDIRECTORIES` so `CommonSessionCacheCleaner` deletes `cache/camera_photos/` as part of the logout sweep.
- One-line addition. No new code paths — piggybacks on the existing 3-entry sweep mechanism (`image_cache`, `artifacts`, `shared_images`).

## Why
`ChatInput.kt:409` writes camera captures into `context.cacheDir/camera_photos/` via `File(context.cacheDir, "camera_photos")`, exposed through a `FileProvider` URI for the system camera intent. Before this PR, the subdirectory was missing from the sweep list — so a user's camera captures survived logout and would be readable in the next user's session on shared devices. Small but real cross-user privacy leak on the session-teardown path being hardened as part of the broader logout-cleanup work.

## Test plan
- [x] `./gradlew :app:assembleDebug` — passes
- [x] Manual regression on Android emulator:
  - Login → chat → attachment → Camera → capture → accept
  - **Pre-logout checkpoint:** `adb shell run-as com.garfiec.librechat ls cache/camera_photos/` → shows captured `photo_*.jpg`
  - Sent a message with the attached photo; `FilesApi: uploadFile` log confirmed the capture flowed through the upload pipeline
  - Logout
  - **Post-logout checkpoint:** same `ls` → `No such file or directory` ✅ (sweep removes the entire subdir, same as the 3 pre-existing entries; only `WebView/` and the Room lock file remain)
- [x] Logcat grep for `FATAL | AndroidRuntime | NullPointerException | Suppressed:` scoped to app PID → zero hits

## Notes
`CommonSessionCacheCleaner` deletes the whole subdirectory via `deleteRecursively`, matching the observed behavior of the 3 pre-existing entries — `ChatInput.kt:409`'s `File(..., "camera_photos")` recreates it on the next capture. Producer-side code is unchanged.