### PR TITLE
fix(cache): route Android temp files into named subdirs for logout sweep

### DIFF
--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/CacheDirectory.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/CacheDirectory.kt
@@ -5,7 +5,17 @@ import co.touchlab.kermit.Logger
 /**
  * Subdirectories under the platform cache root that are cleared on logout.
  */
-internal val CACHE_SUBDIRECTORIES = listOf("image_cache", "artifacts", "shared_images", "camera_photos")
+internal val CACHE_SUBDIRECTORIES = listOf(
+    "image_cache",
+    "artifacts",
+    "shared_images",
+    "camera_photos",
+    "pdf_preview",
+    "voice_recording",
+    "audio",
+    "tts",
+    "voice_test",
+)
 
 /**
  * Deletes a directory and all its contents at the given [path].

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/audio/VoiceRecorder.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/audio/VoiceRecorder.kt
@@ -31,7 +31,8 @@ class VoiceRecorder(private val context: Context) {
         if (isCurrentlyRecording) return
 
         val extension = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) "ogg" else "3gp"
-        outputFile = File(context.cacheDir, "voice_recording_${System.currentTimeMillis()}.$extension")
+        val voiceRecordingDir = File(context.cacheDir, "voice_recording").apply { mkdirs() }
+        outputFile = File(voiceRecordingDir, "voice_recording_${System.currentTimeMillis()}.$extension")
 
         try {
             val recorder = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/components/AudioContentPlayer.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/components/AudioContentPlayer.kt
@@ -189,7 +189,8 @@ actual fun AudioContentPlayerFromBytes(
 ) {
     val context = LocalContext.current
     val tempFile = remember(audioBytes) {
-        File.createTempFile("audio_", ".mp3", context.cacheDir).apply {
+        val audioDir = File(context.cacheDir, "audio").apply { mkdirs() }
+        File.createTempFile("audio_", ".mp3", audioDir).apply {
             writeBytes(audioBytes)
         }
     }

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/TextToSpeechDelegate.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/TextToSpeechDelegate.kt
@@ -116,7 +116,8 @@ class TextToSpeechDelegate(
             is Result.Success -> {
                 try {
                     val audioBytes = result.data
-                    val tempFile = File.createTempFile("tts_", ".mp3", appContext.cacheDir)
+                    val ttsDir = File(appContext.cacheDir, "tts").apply { mkdirs() }
+                    val tempFile = File.createTempFile("tts_", ".mp3", ttsDir)
                     tempFile.deleteOnExit()
                     tempFile.writeBytes(audioBytes)
 

--- a/feature/files/src/androidMain/kotlin/com/garfiec/librechat/feature/files/platform/PdfPreview.android.kt
+++ b/feature/files/src/androidMain/kotlin/com/garfiec/librechat/feature/files/platform/PdfPreview.android.kt
@@ -87,7 +87,8 @@ actual fun PdfPreview(
                 return@LaunchedEffect
             }
 
-            val pdfTempFile = File(context.cacheDir, "pdf_preview_${file.fileId}.pdf")
+            val pdfPreviewDir = File(context.cacheDir, "pdf_preview").apply { mkdirs() }
+            val pdfTempFile = File(pdfPreviewDir, "pdf_preview_${file.fileId}.pdf")
             pdfTempFile.writeBytes(bytes)
             tempFile = pdfTempFile
 

--- a/feature/settings/src/androidMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/delegate/SpeechSettingsDelegate.kt
+++ b/feature/settings/src/androidMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/delegate/SpeechSettingsDelegate.kt
@@ -219,7 +219,8 @@ class SpeechSettingsDelegate(
             currentMediaPlayer = null
 
             // Write bytes to a temporary file
-            val tempFile = File.createTempFile("voice_test", ".mp3", context.cacheDir)
+            val voiceTestDir = File(context.cacheDir, "voice_test").apply { mkdirs() }
+            val tempFile = File.createTempFile("voice_test", ".mp3", voiceTestDir)
             tempFile.deleteOnExit()
             tempFile.writeBytes(audioBytes)
 


### PR DESCRIPTION
## Summary
- Move 5 Android temp-file producers into their own named subdirectories and register each in `CacheDirectory.CACHE_SUBDIRECTORIES` so `CommonSessionCacheCleaner` sweeps them on logout.
- New subdirs: `pdf_preview/`, `voice_recording/`, `audio/`, `tts/`, `voice_test/`. Registry expanded from 3 entries to 8.
- Producer-side: each file is now created inside its named subdir via `File(cacheDir, "<name>").apply { mkdirs() }` instead of `createTempFile` in `cacheDir` root. Filenames and extensions unchanged.

## Why
All 5 producers previously wrote temp files directly to `cacheDir` root:

| Producer | File pattern |
|---|---|
| `feature/files/.../PdfPreview.android.kt` | `pdf_preview_<fileId>.pdf` (PDF thumbnail rasterization) |
| `feature/chat/.../audio/VoiceRecorder.kt` | `voice_recording_*.{ogg,3gp}` (chat voice message) |
| `feature/chat/.../components/AudioContentPlayer.kt` | `audio_*.mp3` (server audio content playback) |
| `feature/chat/.../viewmodel/delegate/TextToSpeechDelegate.kt` | `tts_*.mp3` (TTS playback of messages) |
| `feature/settings/.../viewmodel/delegate/SpeechSettingsDelegate.kt` | `voice_test*.mp3` (Settings voice-test preview) |

`CommonSessionCacheCleaner` only deletes named subdirectories listed in its registry — files sitting in `cacheDir` root are invisible to the sweep, and `File.deleteOnExit()` is a no-op when the Android process is force-killed. On shared devices, user A's recordings, TTS audio, and PDF previews would survive logout into user B's session. Same cross-user privacy class as the `camera_photos` PR, broader blast radius.

## Test plan
- [x] `./gradlew :app:assembleDebug` — passes
- [x] Manual regression on Android emulator:
  - **Checkpoint A (live state pre-logout):**
    - `cache/voice_test/voice_test3921804135784256971.mp3` — 47,040 bytes (Settings Speech → Source=Server → Preview Voice)
    - `cache/tts/tts_5147056068826909144.mp3` — 1,017,120 bytes (long-press Claude message → Read aloud)
    - `cache/voice_recording/` — dir exists empty (mic tapped; file auto-cleaned by `onCompletionListener` after STT upload; dir creation proves routing is correct)
    - `cache/pdf_preview/pdf_preview_<uuid>.pdf` — ~13 KB live evidence captured in a prior test cycle via Files screen → `FilePreviewDialog` (file persists while viewer is open)
  - **Checkpoint B (post-logout):** all 5 subdirs return `No such file or directory`. Cache root contains only `WebView/` (not in sweep list) and `librechat.db.lck`. The live 1 MB TTS file and 47 KB voice_test file were removed atomically as part of the sweep.
- [x] Logcat grep for `FATAL | AndroidRuntime | NullPointerException | Suppressed:` scoped to app PID → zero hits
- [x] Baseline smoke (login → chat → Agents → logout → re-login) clean

## Notes
- **`AudioContentPlayerFromBytes` has no call site anywhere in the app.** The `expect`/`actual` pair is fully implemented but unreachable from the current UI, so the `audio/` subdir can't be exercised through a manual flow. The registry entry is defensive — if the producer is ever wired up, the sweep will catch its output without needing another PR. Worth a future follow-up to either plumb it through or delete the dead code; out of scope here.
- PDF attachments in user-message bubbles aren't clickable (`MessageFiles.FileChip` lacks a `clickable` modifier), so `PdfPreview` is only reachable via Files screen → `FilePreviewDialog`. Pre-existing UX gap, not in scope.