### PR TITLE
fix(navigation): fully reset ConversationListStateHolder on logout

### DIFF
--- a/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/ConversationListStateHolder.kt
+++ b/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/ConversationListStateHolder.kt
@@ -8,6 +8,7 @@ import com.garfiec.librechat.core.data.repository.ConversationRepository
 import com.garfiec.librechat.core.model.Conversation
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -48,6 +49,8 @@ class ConversationListStateHolder(
 
     private val _isRefreshing = MutableStateFlow(false)
     val isRefreshing: StateFlow<Boolean> = _isRefreshing.asStateFlow()
+
+    private var searchObserverJob: Job? = null
 
     init {
         observeConversations()
@@ -130,7 +133,8 @@ class ConversationListStateHolder(
 
     @OptIn(FlowPreview::class)
     private fun observeSearchQuery() {
-        scope.launch {
+        searchObserverJob?.cancel()
+        searchObserverJob = scope.launch {
             _searchQuery
                 .filter { it.isNotBlank() }
                 .debounce(SEARCH_DEBOUNCE_MS)
@@ -144,10 +148,17 @@ class ConversationListStateHolder(
     }
 
     fun reset() {
+        searchObserverJob?.cancel()
+        searchObserverJob = null
         _recentConversations.value = emptyList()
         _groupedConversations.value = emptyList()
         _activeConversationId.value = null
         _searchQuery.value = ""
+        nextCursor = null
+        _hasMore.value = true
+        _isLoadingMore.value = false
+        _isRefreshing.value = false
+        observeSearchQuery()
     }
 
     private fun groupConversationsByDate(


### PR DESCRIPTION
## Summary
- Two related bugs in `ConversationListStateHolder.reset()` (called on logout):
  1. **Missing field resets** — `nextCursor`, `_hasMore`, `_isLoadingMore`, `_isRefreshing` were not cleared, so pagination/refresh state leaked into the next user's session.
  2. **Debounce race** — the `observeSearchQuery()` collector started in `init` could have an in-flight debounced emission that landed AFTER `reset()` returned and clobbered the cleared `_groupedConversations` value.
- Fix: add the 4 missing field resets, plus track the search-observer `Job` in a new `searchObserverJob` field, cancel it in `reset()`, then immediately restart `observeSearchQuery()` so the next session has a working debounce.

## Why
On shared devices, after user A logged out and user B logged in:
- A stuck pagination/refresh spinner could appear (because `_isLoadingMore` / `_isRefreshing` was still `true` from user A's mid-flight state).
- The next page fetch could start from the wrong cursor (`nextCursor` was still pointing into user A's pagination window) — potentially skipping pages or hitting a 404.
- If user A had typed a search query right before logout, an in-flight debounced emission (~300ms window) could land milliseconds after `reset()` returned and re-populate `_groupedConversations` with the user-A-filtered result, persisting until the next list update.

**Why `collectLatest` alone wasn't sufficient for Bug B:** the upstream is `_searchQuery.filter { it.isNotBlank() }.debounce(300ms)`. Setting `_searchQuery = ""` inside `reset()` fails the `isNotBlank()` filter, so **no new upstream emission fires** and `collectLatest`'s downstream cancellation never triggers. The pending debounced work continues to its original destination unimpeded. The store-and-cancel-then-restart pattern is required.

## Test plan
- [x] `./gradlew :app:assembleDebug` — passes
- [x] `./gradlew detektMetadataCommonMain` — clean
- [x] Manual regression on Android emulator:
  - Login → open conversations drawer → type `a` in the search bar → wait for the ~300ms debounce → confirmed list filtered to matching items
  - **Without clearing the search**, Settings → Account → Sign out
  - Re-login with same creds, reopen drawer
  - **Checkpoint 1 (stale filter):** search bar empty, list showed full unfiltered set ✅
  - **Checkpoint 2 (stuck spinners):** no top pull-to-refresh or bottom pagination indicator ✅
  - **Checkpoint 3 (debounce collector restart):** typed `a` again — list re-filtered correctly; cleared search, list un-filtered ✅ (this is the critical evidence for Bug B's fix — if the collector had been cancelled but not restarted, search would silently stop working after the first logout)
- [x] Logcat scoped to app PID grep'd for `FATAL | AndroidRuntime | NullPointerException | Suppressed:` → zero hits from `com.garfiec.librechat`

## Notes
The 4 field resets are obvious; Bug B's fix is the load-bearing change. Without restarting `observeSearchQuery()` after cancelling its job, the search bar would still accept input after re-login but the filter would never apply — a worse UX regression than the original bug. The restart is in the same `reset()` call, on the same long-lived `scope`, so the new collector replaces the old one atomically.