### PR TITLE
fix(settings): stop double-invoking authRepository.logout on logout/delete

### DIFF
--- a/feature/settings/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/settings/viewmodel/SettingsViewModelTest.kt
+++ b/feature/settings/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/settings/viewmodel/SettingsViewModelTest.kt
@@ -23,7 +23,6 @@ import com.garfiec.librechat.feature.settings.util.PlatformCacheCleaner
 import com.garfiec.librechat.feature.settings.viewmodel.delegate.SpeechSettingsContract
 import com.garfiec.librechat.feature.settings.viewmodel.delegate.SpeechSettingsFactory
 import com.google.common.truth.Truth.assertThat
-import io.mockk.Ordering
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -158,23 +157,20 @@ class SettingsViewModelTest {
     }
 
     @Test
-    fun `logout calls authRepository and sets isLoggedOut`() = runTest {
-        coEvery { authRepository.logout() } returns Result.Success(Unit)
-
+    fun `logout sets isLoggedOut flag without calling authRepository`() = runTest {
         viewModel = createViewModel()
         advanceUntilIdle()
 
         viewModel.logout()
         advanceUntilIdle()
 
-        coVerify { authRepository.logout() }
+        coVerify(exactly = 0) { authRepository.logout() }
         assertThat(viewModel.uiState.value.isLoggedOut).isTrue()
     }
 
     @Test
-    fun `deleteAccount calls userRepository then authRepository`() = runTest {
+    fun `deleteAccount calls userRepository and sets isAccountDeleted without calling authRepository`() = runTest {
         coEvery { userRepository.deleteUser() } returns Result.Success(Unit)
-        coEvery { authRepository.logout() } returns Result.Success(Unit)
 
         viewModel = createViewModel()
         advanceUntilIdle()
@@ -182,10 +178,8 @@ class SettingsViewModelTest {
         viewModel.deleteAccount()
         advanceUntilIdle()
 
-        coVerify(ordering = Ordering.ORDERED) {
-            userRepository.deleteUser()
-            authRepository.logout()
-        }
+        coVerify { userRepository.deleteUser() }
+        coVerify(exactly = 0) { authRepository.logout() }
         assertThat(viewModel.uiState.value.isAccountDeleted).isTrue()
     }
 

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/SettingsViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/SettingsViewModel.kt
@@ -585,11 +585,7 @@ class SettingsViewModel(
     // ── Auth actions ───────────────────────────────────────────────
 
     fun logout() {
-        viewModelScope.launch {
-            _uiState.update { it.copy(isLoading = true) }
-            authRepository.logout()
-            _uiState.update { it.copy(isLoading = false, isLoggedOut = true) }
-        }
+        _uiState.update { it.copy(isLoggedOut = true) }
     }
 
     fun deleteAccount(token: String? = null, backupCode: String? = null) {
@@ -597,7 +593,6 @@ class SettingsViewModel(
             _uiState.update { it.copy(isLoading = true) }
             when (val result = userRepository.deleteUser(token = token, backupCode = backupCode)) {
                 is Result.Success -> {
-                    authRepository.logout()
                     _uiState.update { it.copy(isLoading = false, isAccountDeleted = true, showDeleteAccountOtpDialog = false) }
                 }
                 is Result.Error -> {


### PR DESCRIPTION
## Summary
- `SettingsViewModel.logout()` no longer calls `authRepository.logout()` directly — only flips `_isLoggedOut = true`.
- `SettingsViewModel.deleteAccount()` no longer calls `authRepository.logout()` directly — only flips `_isAccountDeleted = true` after `userRepository.deleteUser()` succeeds.
- `NavHostViewModel.logout()` (triggered via `SettingsScreen`'s `LaunchedEffect(uiState.isLoggedOut, uiState.isAccountDeleted)` callback) is now the single source of truth for auth tear-down.

## Why
Pre-fix: each Sign Out tap fired `POST /api/auth/logout` **twice** — once from `SettingsViewModel.logout()` directly, then again from `NavHostViewModel.logout()` after the `LaunchedEffect` propagated the state flag through `onLogout`. Same duplication on the `deleteAccount` path. The second call ran after the first call's `finally` block had already cleared the local tokens, so it hit the server with no `Bearer` header → 401 → `AuthInterceptorPlugin` attempted a token refresh → refresh also failed (refresh token gone) → wasted round-trip and log noise.

The functional impact today is minor — extra HTTP round-trip, two 401 retry logs per logout cycle. But if later changes ever expand `NavHostViewModel.logout()` to do more than its current state-holder resets (for example, a full Room + DataStore wipe on logout), the duplicate would run the entire sequence twice. Decoupling now prevents that foot-gun before it has consequences.

## Architectural note

**`NavHostViewModel` is not the architecturally correct long-term owner of the auth call.** It's a navigation class, and putting auth tear-down in it is a separation-of-concerns smell.

This PR lands the auth call there anyway as a **pragmatic interim fix** because:

1. `NavHostViewModel.logout()` already owns the co-located state-holder resets that must happen alongside the auth call (`conversationListStateHolder.reset()`, `tagRepository.clearCache()`, `_sidebarMode`, `_selectedSettingsCategory`).
2. Splitting the auth call back into `SettingsViewModel` while leaving the resets in `NavHostViewModel` would make their ordering depend on `LaunchedEffect` state-flag propagation timing — fragile, and interleaves poorly with in-flight coroutines.
3. Fixing it correctly now requires pulling forward a broader session-clear refactor that is well out of scope for a small deduplication fix.

**Direction of travel:** in a follow-up refactor, the intent is to introduce a per-feature session-clear interface, have `AuthRepository.logout()` (or a thin orchestrator) fan out to all registered clearers, and shrink `NavHostViewModel` back to pure navigation. Under that structure, `SettingsViewModel.logout()` would call `authRepository.logout()` directly (without a duplicate), and the auth call would disappear from `NavHostViewModel` entirely.

This PR is one step in the cleanup process toward that end state — fixing the immediate duplication so the broader refactor doesn't have to untangle a known foot-gun on its way through. Leaving a pointer here so the architectural smell isn't mistaken for intentional design.

## Test plan
- [x] `./gradlew :app:assembleDebug` — passes
- [x] `./gradlew detektMetadataCommonMain` — clean
- [x] `./gradlew :feature:settings:testDebugUnitTest --tests "*SettingsViewModelTest*"` — passes (test contracts updated to assert `authRepository.logout()` is NOT called from either `logout()` or `deleteAccount()`, replacing the previous tests that encoded the old direct-call behavior)
- [x] Manual regression on Android emulator:
  - Login → send a test message → response streamed cleanly
  - Sign out → returned to onboarding screen
  - Re-login → smoke flow worked
- [x] **Inverse-signal logcat verification** (because Ktor's HTTP logging plugin is hardcoded off in debug builds, the `AuthInterceptorPlugin` 401-retry log line is the only available per-request signal):
  - Filter: `grep -E "Auth\\s+:" logcat | grep <app_pid>`
  - **Zero Auth-tag lines from PID after the user began interacting and through the logout sequence.** Pre-fix would have produced 1× `"401 received, attempting token refresh"` + 1× `"Token refresh failed - session expired"` per logout cycle from the duplicate tokenless second call.
  - Note: an unrelated startup-burst pattern produces ~9× `"401 received"` lines within ~600ms at app launch when concurrent initial API calls (config / banner / balance / etc.) hit a persisted-but-expired token. That happens before any user interaction and must be filtered out by timestamp; it is not relevant to this fix.
- [x] Logcat scoped to app PID grep'd for `FATAL | AndroidRuntime | NullPointerException | Suppressed:` → zero hits from `com.garfiec.librechat`
- [x] `deleteAccount` path: **code inspection only (destructive on a real account)**. Confirmed `SettingsViewModel.deleteAccount()` calls `userRepository.deleteUser(...)` then only sets `_isAccountDeleted = true` on success; no direct `authRepository.logout()` call. `SettingsScreen.kt:105-109` has a single `LaunchedEffect(uiState.isLoggedOut, uiState.isAccountDeleted)` that triggers `onLogout()` for both transitions, so both paths converge on the same cleanup.

## Notes
- Both `isLoggedOut` and `isAccountDeleted` state flags are deliberately **preserved separately** in `SettingsViewModel` — not collapsed into one. Future UI differentiation (e.g. distinct "Account deleted" vs "Logged out" snackbars) remains possible.
- The `AuthInterceptorPlugin` log filtering above depends on Ktor's HTTP logging being off in debug. If a future change wires `LibreChatHttpClient.kt:32,47` to read `BuildConfig.DEBUG` instead of the hardcoded `false` default, regression runs for double-logout-style bugs will be able to verify positively (counting actual `POST /api/auth/logout` requests) instead of relying on the inverse signal.