### PR TITLE
feat(ios): prepare for TestFlight / App Store distribution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,19 +173,34 @@ jobs:
           key: ${{ runner.os }}-konan-${{ hashFiles('gradle/libs.versions.toml') }}
           restore-keys: ${{ runner.os }}-konan-
 
-      - name: Build shared KMP framework (simulator)
+      - name: Build shared KMP framework (simulator, debug)
         run: ./gradlew :shared:linkDebugFrameworkIosSimulatorArm64
 
-      - name: Build shared KMP framework (device)
+      - name: Build shared KMP framework (device, debug)
         run: ./gradlew :shared:linkDebugFrameworkIosArm64
 
-      - name: Build iOS app
+      - name: Build shared KMP framework (device, release)
+        run: ./gradlew :shared:linkReleaseFrameworkIosArm64
+
+      - name: Build iOS app (simulator, debug)
         run: |
           xcodebuild -project iosApp/iosApp.xcodeproj \
             -scheme iosApp \
             -sdk iphonesimulator \
             -destination 'generic/platform=iOS Simulator' \
             -configuration Debug \
+            build \
+            CODE_SIGNING_ALLOWED=NO \
+            ARCHS=arm64 \
+            ONLY_ACTIVE_ARCH=YES
+
+      - name: Build iOS app (device, release — compile check)
+        run: |
+          xcodebuild -project iosApp/iosApp.xcodeproj \
+            -scheme iosApp \
+            -sdk iphoneos \
+            -destination 'generic/platform=iOS' \
+            -configuration Release \
             build \
             CODE_SIGNING_ALLOWED=NO \
             ARCHS=arm64 \

--- a/iosApp/ExportOptions.plist
+++ b/iosApp/ExportOptions.plist
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+    Export options for xcodebuild -exportArchive.
+
+    Usage:
+        xcodebuild -exportArchive \
+            -archivePath iosApp/build/iosApp.xcarchive \
+            -exportPath iosApp/build/export \
+            -exportOptionsPlist iosApp/ExportOptions.plist
+
+    Before using:
+      1. Set DEVELOPMENT_TEAM in Xcode (Signing & Capabilities) or via
+         xcodebuild DEVELOPMENT_TEAM=<your-10-char-team-id>
+      2. Make sure your Apple Distribution certificate and an App Store
+         provisioning profile for com.garfiec.librechat.ios are installed
+         in your Keychain / available via fastlane match.
+
+    method options:
+      "app-store"          — Upload to App Store / TestFlight
+      "ad-hoc"             — Install on registered devices (for testing without TestFlight)
+      "development"        — Development-signed IPA (for devices registered in your team)
+      "enterprise"         — In-house distribution (requires Apple Developer Enterprise Program)
+-->
+<plist version="1.0">
+<dict>
+    <key>method</key>
+    <string>app-store</string>
+
+    <key>destination</key>
+    <string>upload</string>
+
+    <key>signingStyle</key>
+    <string>automatic</string>
+
+    <key>stripSwiftSymbols</key>
+    <true/>
+
+    <key>uploadBitcode</key>
+    <false/>
+
+    <key>uploadSymbols</key>
+    <true/>
+
+    <key>compileBitcode</key>
+    <false/>
+</dict>
+</plist>

--- a/iosApp/README.md
+++ b/iosApp/README.md
@@ -94,3 +94,56 @@ The following keys are configured in `Info.plist`:
 ## URL Scheme
 
 The app registers the `librechat://` URL scheme for deep linking (conversations, OAuth callbacks), matching the Android app's behavior.
+
+## TestFlight / App Store Distribution
+
+### Prerequisites
+
+- Apple Developer Program membership (paid — required for TestFlight and App Store)
+- An app record created in [App Store Connect](https://appstoreconnect.apple.com) with bundle ID `com.garfiec.librechat.ios`
+- An **Apple Distribution** certificate installed in your Keychain
+- An **App Store** provisioning profile for `com.garfiec.librechat.ios`
+
+### Build a distributable IPA
+
+```bash
+# 1. Build the Release KMP framework for device
+./gradlew :shared:linkReleaseFrameworkIosArm64
+
+# 2. Open the project in Xcode and set your Team under Signing & Capabilities
+open iosApp/iosApp.xcodeproj
+
+# 3. Archive (Product → Archive in Xcode), or via CLI:
+xcodebuild -project iosApp/iosApp.xcodeproj \
+  -scheme iosApp \
+  -sdk iphoneos \
+  -configuration Release \
+  -archivePath iosApp/build/iosApp.xcarchive \
+  archive \
+  DEVELOPMENT_TEAM=<your-10-char-team-id>
+
+# 4. Export the IPA using the provided ExportOptions.plist
+xcodebuild -exportArchive \
+  -archivePath iosApp/build/iosApp.xcarchive \
+  -exportPath iosApp/build/export \
+  -exportOptionsPlist iosApp/ExportOptions.plist
+```
+
+The signed `.ipa` will be at `iosApp/build/export/iosApp.ipa`. Upload it via Xcode Organizer, `xcrun altool`, or `xcrun notarytool`.
+
+> **DEVELOPMENT_TEAM is intentionally not committed** — set it in Xcode's *Signing & Capabilities* tab or pass it on the command line as shown above. Committing a personal/org Team ID would break other contributors' builds.
+
+### Version bumping
+
+Before each TestFlight build, bump the build number to avoid rejection:
+
+| Setting | File | Key |
+|---|---|---|
+| User-visible version (e.g. `1.0.1`) | `Info.plist` | `CFBundleShortVersionString` |
+| Build number (e.g. `2`) | `Info.plist` | `CFBundleVersion` |
+
+Both are also set in `project.pbxproj` via `MARKETING_VERSION` and `CURRENT_PROJECT_VERSION`. Keeping all four in sync avoids App Store Connect warnings.
+
+### Encryption declaration
+
+`ITSAppUsesNonExemptEncryption` is set to `false` in `Info.plist`. The app uses standard HTTPS (Ktor + NSURLSession) which qualifies as exempt encryption under U.S. Export Regulations (EAR exemption for standard protocols). No annual self-classification report is required.

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -276,7 +276,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "-";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Distribution";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -63,5 +63,7 @@
 			</array>
 		</dict>
 	</array>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 </dict>
 </plist>


### PR DESCRIPTION
## What

Makes the iOS app ready for TestFlight and App Store submission. All changes are code-complete and require no manual decision to merge — except the three items listed below under **Your decisions**.

---

## Changes

### `iosApp/iosApp/Info.plist` — `ITSAppUsesNonExemptEncryption = false`

**Required for every App Store / TestFlight upload.** Without this key Apple holds the binary and asks for clarification before it appears in TestFlight. The value is `false` because the app uses only standard HTTPS (Ktor + NSURLSession/Darwin engine), which qualifies as exempt encryption under U.S. Export Administration Regulations (EAR §740.17(b)(3)(i) — standard security protocols). No annual self-classification report is required.

### `iosApp/iosApp.xcodeproj/project.pbxproj` — Release `CODE_SIGN_IDENTITY` → `"Apple Distribution"`

`"Apple Development"` certificates are issued for development-device trust only — they cannot produce a binary accepted by App Store Connect. The Release configuration now correctly targets `"Apple Distribution"` (the modern umbrella identity that covers both the old `"iPhone Distribution"` and the newer App Store certificate type). Debug builds keep `"Apple Development"` unchanged for day-to-day device testing.

### `iosApp/ExportOptions.plist` — distribution export config template

`xcodebuild -exportArchive` requires an options plist. This provides a ready-to-use file targeting `app-store` / `upload`. Inline comments document how to switch to `ad-hoc` (registered-device distribution without TestFlight) or `enterprise`. `DEVELOPMENT_TEAM` is intentionally omitted — each maintainer passes their own Team ID at build time so no personal/org ID is ever committed.

### `.github/workflows/ci.yml` — Release compile coverage

Adds two steps to the existing `ios` CI job:
1. `linkReleaseFrameworkIosArm64` — ensures the Release KMP framework compiles (different Kotlin/Native optimisation tier from Debug)
2. `xcodebuild -configuration Release -sdk iphoneos CODE_SIGNING_ALLOWED=NO` — compile-checks the Xcode project under the same code path that a real distribution build would use, catching Release-only errors before they surface in a submission attempt

### `iosApp/README.md` — TestFlight / App Store Distribution section

Documents:
- Prerequisites (Apple Developer Program membership, App Store Connect app record, Apple Distribution cert + provisioning profile)
- Full archive + export CLI workflow
- Version bumping strategy (the four places that must stay in sync)
- Encryption declaration rationale (why `ITSAppUsesNonExemptEncryption = false` is correct and sufficient)

---

## Decisions (required before first TestFlight upload — not needed to merge this PR)

| # | What | Where | Why |
|---|------|-------|-----|
| 1 | **Create the App Store Connect app record** | [appstoreconnect.apple.com](https://appstoreconnect.apple.com) → My Apps → `+` | Bundle ID `com.garfiec.librechat.ios` must be registered before any build can be uploaded. Free with a paid Apple Developer Program membership. |
| 2 | **Set `DEVELOPMENT_TEAM` when archiving** | Xcode → Signing & Capabilities, or `DEVELOPMENT_TEAM=XXXXXXXXXX` on the CLI | Your 10-character Team ID cannot be committed — it would break every other contributor's build. Pass it at archive time as shown in the README. |
| 3 | **CI signing automation (optional but recommended for scale)** | New PR — Fastlane Match + GitHub Actions secrets | Automating signing in CI (certificate + provisioning profile stored as repo secrets via `fastlane match`) is a non-trivial separate PR. The current CI job verifies the build compiles clean; actual IPA export and upload require signing secrets that are outside the scope of this PR. |

---

## Testing

```bash
# Verify Debug still works (simulator)
./gradlew :shared:linkDebugFrameworkIosSimulatorArm64
xcodebuild -project iosApp/iosApp.xcodeproj -scheme iosApp \
  -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' \
  -configuration Debug build CODE_SIGNING_ALLOWED=NO ARCHS=arm64

# Verify Release compiles clean (device, no signing)
./gradlew :shared:linkReleaseFrameworkIosArm64
xcodebuild -project iosApp/iosApp.xcodeproj -scheme iosApp \
  -sdk iphoneos -destination 'generic/platform=iOS' \
  -configuration Release build CODE_SIGNING_ALLOWED=NO ARCHS=arm64
```

