### PR TITLE
docs: correct self-signed TLS cert guidance and extract to FAQ

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -1,0 +1,51 @@
+# FAQ
+
+## Can I use a self-signed TLS certificate?
+
+Yes on iOS (with caveats). Not effectively on Android with the current release build — see below for workarounds.
+
+Both platforms enforce TLS certificate requirements that ordinary browsers do not. A certificate that works in Chrome or Safari may still be rejected by the mobile app.
+
+### Common requirements (iOS and Android)
+
+| Requirement | Details |
+|---|---|
+| **Subject Alternative Name** | DNS name must appear in the SAN extension. The CommonName fallback was removed in iOS 13 and in apps targeting Android 9+ (API 28). |
+| **Signature algorithm** | SHA-256 or stronger. SHA-1 is rejected by iOS 13+ and by Android 10+ (API 29). |
+| **Extended Key Usage** | The leaf certificate must include `id-kp-serverAuth` (TLS Web Server Authentication). Required by Apple for certs issued after July 1, 2019. |
+| **Basic Constraints** | The issuing CA certificate must have `CA:TRUE`. |
+| **Key size** | RSA ≥ 2048 bits, or any modern ECDSA curve (e.g. P-256). Much smaller keys may fail handshake via JSSE / Conscrypt algorithm constraints. |
+
+[`mkcert`](https://github.com/FiloSottile/mkcert) generates certificates that meet all of the above automatically.
+
+### iOS
+
+iOS adds one platform-specific requirement on top of the table above:
+
+| Requirement | Details |
+|---|---|
+| **Validity period** | ≤ 825 days for the leaf certificate (Apple's cap for certs issued after July 1, 2019). |
+
+> The widely-cited **398-day cap does not apply here** — that stricter limit only governs certificates chaining to the Root CAs that Apple preinstalls on the device. A CA you install and trust yourself is exempt from the 398-day rule, but the older 825-day cap still applies.
+
+**Setup:**
+
+1. Generate a compliant certificate signed by your own CA.
+2. On your iPhone: **Settings → General → VPN & Device Management** — install your CA certificate.
+3. Go to **Settings → General → About → Certificate Trust Settings** — enable full trust for your CA.
+
+Once the CA is trusted on the device, you only need to re-install it if you create a new CA. The server certificate itself (which you replace when it expires) does not need to be installed separately.
+
+### Android
+
+Android imposes no equivalent validity-period cap — multi-year self-signed certificates are accepted as long as the requirements in the common table above are met.
+
+However, since Android 7.0 (API 24), apps trust **only the system CA store** by default. A CA that a user installs via **Settings → Security → Encryption & credentials → Install a certificate** is *not* trusted by apps unless the app explicitly opts in via its Network Security Config. **LibreChat Mobile does not currently opt in**, so a self-signed CA installed in device settings will not be trusted and the connection will fail with an `SSLHandshakeException` wrapping `CertPathValidatorException: Trust anchor for certification path not found`.
+
+If you need TLS with a self-hosted server on Android today, the practical options are:
+
+- Use a publicly-trusted CA on a resolvable domain (Let's Encrypt, ZeroSSL).
+- Put the server behind a reverse proxy (e.g., Caddy, Cloudflare Tunnel) that terminates TLS with a publicly-trusted certificate.
+- Connect over plain HTTP on a trusted local network and accept the in-app warning. (Cleartext is permitted but TLS validation is **not** weakened — `cleartextTrafficPermitted="true"` only governs `http://`, not which roots are trusted for `https://`.)
+
+> **Looking ahead:** Android 17 (API 37) turns on Certificate Transparency by default for app TLS connections. If user-CA opt-in is added later, self-signed leaf certs without SCTs will additionally need `<certificateTransparency enabled="false"/>` in the Network Security Config to work on Android 17+ devices.

--- a/FAQ.md
+++ b/FAQ.md
@@ -48,4 +48,4 @@ If you need TLS with a self-hosted server on Android today, the practical option
 - Put the server behind a reverse proxy (e.g., Caddy, Cloudflare Tunnel) that terminates TLS with a publicly-trusted certificate.
 - Connect over plain HTTP on a trusted local network and accept the in-app warning. (Cleartext is permitted but TLS validation is **not** weakened — `cleartextTrafficPermitted="true"` only governs `http://`, not which roots are trusted for `https://`.)
 
-> **Looking ahead:** Android 17 (API 37) turns on Certificate Transparency by default for app TLS connections. If user-CA opt-in is added later, self-signed leaf certs without SCTs will additionally need `<certificateTransparency enabled="false"/>` in the Network Security Config to work on Android 17+ devices.
+> **Looking ahead:** Apps that target API 37+ (Android 17) get Certificate Transparency enabled by default for TLS connections. If user-CA opt-in is added later and the app's `targetSdk` reaches 37, self-signed leaf certs without SCTs will additionally need `<certificateTransparency enabled="false"/>` in the Network Security Config.

--- a/README.md
+++ b/README.md
@@ -57,33 +57,10 @@ NON_BROWSER_VIOLATION_SCORE=0
 
 Without this setting, the server's violation system may accumulate ban points against the mobile client if the User-Agent check fails, eventually locking the account out.
 
-### Self-Signed Certificates (iOS)
-
-The iOS app can connect to a LibreChat server using a self-signed certificate, but iOS enforces strict requirements on all TLS certificates regardless of whether they are self-signed or CA-issued. The certificate must meet **all** of the following or iOS will reject the connection:
-
-| Requirement | Details |
-|---|---|
-| **Validity period** | ≤ 398 days (for certificates issued after September 1, 2020) |
-| **Subject Alternative Name** | DNS name must be present in the SAN extension — CommonName alone is not accepted |
-| **Key algorithm** | RSA ≥ 2048 bits |
-| **Signature algorithm** | SHA-256 or better (SHA-1 is not accepted) |
-| **Extended Key Usage** | Must include `id-kp-serverAuth` (TLS Web Server Authentication) |
-
-The 398-day validity limit is the most common cause of failures — a certificate that works in every browser but was generated with a multi-year validity will be rejected by iOS.
-
-**Setup steps:**
-
-1. Generate a compliant certificate signed by your own CA (tools like [`mkcert`](https://github.com/FiloSottile/mkcert) handle all requirements automatically)
-2. On your iPhone: **Settings → General → VPN & Device Management** — install your CA certificate
-3. Go to **Settings → General → About → Certificate Trust Settings** — enable full trust for your CA
-
-Once the CA is trusted on the device, you only need to re-install it if you create a new CA. The server certificate itself (which you replace when it expires) does not need to be installed separately.
-
-> **Android** has no equivalent restrictions — self-signed certificates with any validity period work as long as the CA is trusted on the device.
-
 ### Notes
 
 - **Registration** — The app respects your server's registration settings. If registration is disabled server-side, only the login form is shown.
+- **Self-signed TLS certificates** — Both platforms enforce certificate requirements stricter than browsers, and Android additionally does not trust user-installed CAs by default. See [FAQ.md](FAQ.md#can-i-use-a-self-signed-tls-certificate) for details and workarounds.
 
 ## Requirements
 


### PR DESCRIPTION
## Summary
- Move self-signed TLS cert guidance out of the main README into a new `FAQ.md`; README keeps a single bullet under Notes pointing to it.
- Correct several inaccurate or incomplete claims in the previous iOS-only section, and add the missing Android coverage.

## What was wrong
The previous README section "Self-Signed Certificates (iOS)" had:

- **iOS 398-day cap stated without carve-out.** That cap only applies to certs chaining to Apple's preinstalled root CAs ([Apple 102028](https://support.apple.com/en-us/102028)). A CA you install and trust yourself is exempt from the 398-day rule; the older 825-day cap from [Apple 103769](https://support.apple.com/en-us/103769) applies generally to all TLS server certs (and so to user-trusted-CA chains as well).
- **"Android has no equivalent restrictions — self-signed certs work as long as the CA is trusted on the device."** False. Apps targeting API 24+ trust only the system CA store by default; a user-installed CA is *not* trusted by an app unless the app opts in via Network Security Config ([Changes to Trusted Certificate Authorities in Android Nougat](https://android-developers.googleblog.com/2016/07/changes-to-trusted-certificate.html)). LibreChat Mobile does not currently opt in, so the documented Android path silently does not work.
- Missing iOS-version / API-level cutoffs for the SAN, SHA-1, and EKU rules (iOS 13 / Android 9 (API 28) for SAN; iOS 13+ / Android 10+ (API 29) for SHA-1; Apple's July 1, 2019 issuance threshold for `serverAuth` EKU).
- Key-size requirement framed as a single cross-platform rule. Apple does hard-require RSA ≥ 2048; the FAQ now also acknowledges modern ECDSA curves and notes that Android does not document an equivalent RSA minimum.

## What changed
- `README.md`: removed the 24-line iOS-only section; added one bullet under existing `### Notes` linking to the FAQ entry.
- `FAQ.md` (new): single Q&A entry — common requirements table, iOS-specific validity guidance with the 398-day carve-out explained, full setup steps, and the Android user-CA-opt-in story with current workarounds (publicly-trusted CA, reverse proxy, cleartext on a trusted network).
- Forward-looking note: apps targeting API 37 (Android 17) get Certificate Transparency on by default — relevant if/when user-CA opt-in is ever added and `targetSdk` reaches 37.

All technical claims were fact-checked against Apple support docs ([102028](https://support.apple.com/en-us/102028), [103769](https://support.apple.com/en-us/103769), [102390](https://support.apple.com/en-us/102390)), Android developer docs ([Network Security Configuration](https://developer.android.com/privacy-and-security/security-config) — also the canonical source for the targetSdk-37 CT default — [Android 10 behavior changes](https://developer.android.com/about/versions/10/behavior-changes-all), and [Android 9 behavior changes](https://developer.android.com/about/versions/pie/android-9.0-changes-all)), and the [Changes to Trusted Certificate Authorities in Android Nougat](https://android-developers.googleblog.com/2016/07/changes-to-trusted-certificate.html) blog post. In-repo claims (no `<trust-anchors>` opt-in; no custom `TrustManager`/pinning; standard OkHttp engine) were verified against `app/src/main/res/xml/network_security_config.xml`, `app/src/main/AndroidManifest.xml`, and the `core/network` Android source set.