### PR TITLE
fix(app): pad no-connection banner below status bar

### DIFF
--- a/app/src/main/kotlin/com/garfiec/librechat/MainActivity.kt
+++ b/app/src/main/kotlin/com/garfiec/librechat/MainActivity.kt
@@ -14,9 +14,13 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -96,6 +100,7 @@ class MainActivity : ComponentActivity() {
                                 modifier = Modifier
                                     .fillMaxWidth()
                                     .background(MaterialTheme.colorScheme.errorContainer)
+                                    .windowInsetsPadding(WindowInsets.statusBars)
                                     .padding(vertical = 6.dp, horizontal = 16.dp),
                                 contentAlignment = Alignment.Center,
                             ) {
@@ -111,7 +116,11 @@ class MainActivity : ComponentActivity() {
                             deepLinkUri = deepLinkUri,
                             onDeepLinkConsume = { deepLinkUri = null },
                             shareNavigationTrigger = shareNavigationTrigger,
-                            modifier = Modifier.weight(1f),
+                            modifier = Modifier
+                                .weight(1f)
+                                .consumeWindowInsets(
+                                    if (!isConnected) WindowInsets.statusBars else WindowInsets(0, 0, 0, 0),
+                                ),
                         )
                     }
                 }


### PR DESCRIPTION
## Summary
The offline banner drew underneath the transparent status bar under edge-to-edge,
so the text overlapped the system clock/icons. Pad the banner content below the
status bar inset while letting the red background still extend behind it, and
consume the status bar inset for the NavHost while the banner is visible so
Scaffolded screens below don't double-pad.

## Before / After

| Before | After |
| --- | --- |
| <img width="1236" height="2495" alt="image" src="https://github.com/user-attachments/assets/9dab2842-d180-4752-a1bb-d62597f15a24" /> | <img width="1236" height="2495" alt="image" src="https://github.com/user-attachments/assets/b6c8e128-cb7e-46b0-a826-d00f6de803a9" /> |