### PR TITLE
feat(chat): inline artifact rendering with per-type toggles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,5 +28,6 @@ Thumbs.db
 
 # Local Claude Code working notes (issue repros, scratch captures with secrets)
 .claude/issue-*/
+.claude/inline-artifacts/
 .claude/worktrees/
 .claude/sync-upstream/

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A third-party native mobile client for [LibreChat](https://www.librechat.ai/) (A
 ## Features
 
 - **Chat** — Real-time streaming (SSE), message branching & sibling navigation, stop/regenerate/continue, markdown with syntax highlighting, LaTeX math rendering, code blocks with copy, image display, file attachments, tool call progress cards
+- **Inline Artifacts** — Render Mermaid, SVG, HTML, React, and Markdown artifacts directly in chat messages at full message width with content-fit height. Per-type toggle in Settings → Chat → Artifacts.
 - **Model Selection** — Searchable bottom sheet grouped by endpoint, model comparison mode
 - **Agents** — Marketplace with search and categories, MCP server configuration
 - **Conversations** — Paginated list with date grouping, tags, search, rename, archive, delete, share, fork, duplicate, export/import

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -50,6 +50,7 @@ dependencies {
     implementation(libs.bundles.lifecycle)
     implementation(libs.coil3.compose)
     implementation(libs.coil3.network.ktor)
+    implementation(libs.coil3.svg)
     implementation(libs.kermit)
 
     debugImplementation(libs.leakcanary)

--- a/app/src/main/kotlin/com/garfiec/librechat/LibreChatApplication.kt
+++ b/app/src/main/kotlin/com/garfiec/librechat/LibreChatApplication.kt
@@ -9,6 +9,7 @@ import coil3.disk.directory
 import coil3.memory.MemoryCache
 import coil3.network.ktor3.KtorNetworkFetcherFactory
 import coil3.request.crossfade
+import coil3.svg.SvgDecoder
 import com.garfiec.librechat.core.common.di.commonModule
 import com.garfiec.librechat.core.data.di.dataModule
 import com.garfiec.librechat.core.network.di.networkModule
@@ -64,6 +65,7 @@ class LibreChatApplication : Application(), SingletonImageLoader.Factory {
         return ImageLoader.Builder(context)
             .components {
                 add(KtorNetworkFetcherFactory(httpClient))
+                add(SvgDecoder.Factory())
             }
             .memoryCache {
                 MemoryCache.Builder()

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -117,6 +117,16 @@ exceptions:
 coroutines:
   active: true
 
+# Allowlist for tree-scoped infrastructure CompositionLocals (chat-session render
+# caches and DataStore-projected user prefs). These match the rule's intended
+# legit-use criteria (tree-scoped, cross-cutting, default or error-on-missing);
+# the screen-specific-ViewModel anti-pattern the rule actually targets is absent
+# from this project.
+Compose:
+  CompositionLocalAllowlist:
+    active: true
+    allowedCompositionLocals: LocalInlineArtifactPrefs,LocalMermaidRenderCache,LocalParsedMarkdownCache
+
 # detekt-koin rule overrides (defaults ship in plugin jar; buildUponDefaultConfig = true)
 koin-rules:
   # Scope "test hygiene" rule to test sources only; the rule's heuristic

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/InlineArtifactPrefs.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/InlineArtifactPrefs.kt
@@ -1,0 +1,18 @@
+package com.garfiec.librechat.core.data.datastore
+
+/**
+ * Per-type toggles for rendering message artifacts inline in the chat (instead
+ * of a tap-to-expand button). All types default to off; users opt in via
+ * Settings > Chat > Artifacts.
+ *
+ * The MIME → field mapping lives in `feature/chat` as
+ * `InlineArtifactPrefs.shouldRenderInline(type)` to keep this class
+ * presentation-agnostic.
+ */
+data class InlineArtifactPrefs(
+    val mermaid: Boolean = false,
+    val svg: Boolean = false,
+    val html: Boolean = false,
+    val react: Boolean = false,
+    val markdown: Boolean = false,
+)

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/SettingsDataStore.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/SettingsDataStore.kt
@@ -112,6 +112,16 @@ class SettingsDataStore(
         prefs[KEY_SHOW_BUBBLES] ?: false
     }
 
+    val inlineArtifactPrefs: Flow<InlineArtifactPrefs> = dataStore.data.map { prefs ->
+        InlineArtifactPrefs(
+            mermaid = prefs[KEY_INLINE_ARTIFACT_MERMAID] ?: false,
+            svg = prefs[KEY_INLINE_ARTIFACT_SVG] ?: false,
+            html = prefs[KEY_INLINE_ARTIFACT_HTML] ?: false,
+            react = prefs[KEY_INLINE_ARTIFACT_REACT] ?: false,
+            markdown = prefs[KEY_INLINE_ARTIFACT_MARKDOWN] ?: false,
+        )
+    }
+
     val selectedMcpServers: Flow<Set<String>> = dataStore.data.map { prefs ->
         prefs[KEY_SELECTED_MCP_SERVERS]?.split(",")?.filter { it.isNotBlank() }?.toSet() ?: emptySet()
     }
@@ -273,6 +283,26 @@ class SettingsDataStore(
         }
     }
 
+    suspend fun setInlineArtifactMermaid(enabled: Boolean) {
+        dataStore.edit { prefs -> prefs[KEY_INLINE_ARTIFACT_MERMAID] = enabled }
+    }
+
+    suspend fun setInlineArtifactSvg(enabled: Boolean) {
+        dataStore.edit { prefs -> prefs[KEY_INLINE_ARTIFACT_SVG] = enabled }
+    }
+
+    suspend fun setInlineArtifactHtml(enabled: Boolean) {
+        dataStore.edit { prefs -> prefs[KEY_INLINE_ARTIFACT_HTML] = enabled }
+    }
+
+    suspend fun setInlineArtifactReact(enabled: Boolean) {
+        dataStore.edit { prefs -> prefs[KEY_INLINE_ARTIFACT_REACT] = enabled }
+    }
+
+    suspend fun setInlineArtifactMarkdown(enabled: Boolean) {
+        dataStore.edit { prefs -> prefs[KEY_INLINE_ARTIFACT_MARKDOWN] = enabled }
+    }
+
     /**
      * Saves the backend version for which the user chose "Don't warn again".
      * If the backend later updates to a different version, the warning will reappear.
@@ -329,6 +359,11 @@ class SettingsDataStore(
         private val KEY_CHAT_LAYOUT_STYLE = stringPreferencesKey("chat_layout_style")
         private val KEY_SHOW_AVATARS = booleanPreferencesKey("show_avatars")
         private val KEY_SHOW_BUBBLES = booleanPreferencesKey("show_bubbles")
+        private val KEY_INLINE_ARTIFACT_MERMAID = booleanPreferencesKey("inline_artifact_mermaid")
+        private val KEY_INLINE_ARTIFACT_SVG = booleanPreferencesKey("inline_artifact_svg")
+        private val KEY_INLINE_ARTIFACT_HTML = booleanPreferencesKey("inline_artifact_html")
+        private val KEY_INLINE_ARTIFACT_REACT = booleanPreferencesKey("inline_artifact_react")
+        private val KEY_INLINE_ARTIFACT_MARKDOWN = booleanPreferencesKey("inline_artifact_markdown")
         private val KEY_DISMISSED_VERSION_WARNING = stringPreferencesKey("dismissed_version_warning")
         private val KEY_SELECTED_MCP_SERVERS = stringPreferencesKey("selected_mcp_servers")
         private val KEY_ENABLED_TOOLS = stringPreferencesKey("enabled_tools")

--- a/core/ui/src/commonMain/kotlin/com/garfiec/librechat/core/ui/theme/SurfaceLuminance.kt
+++ b/core/ui/src/commonMain/kotlin/com/garfiec/librechat/core/ui/theme/SurfaceLuminance.kt
@@ -1,0 +1,17 @@
+package com.garfiec.librechat.core.ui.theme
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.ui.graphics.luminance
+
+/**
+ * Single source of truth for "is the current surface dark?" so that inline-vs-modal
+ * paths agree on the dark-mode bit they feed into WebView/HTML themes and caches.
+ * Uses [androidx.compose.ui.graphics.luminance] (Rec.709, gamma-corrected) for
+ * consistency across Android and iOS.
+ */
+@Composable
+@ReadOnlyComposable
+fun isSurfaceDark(): Boolean =
+    MaterialTheme.colorScheme.surface.luminance() < 0.5f

--- a/feature/chat/build.gradle.kts
+++ b/feature/chat/build.gradle.kts
@@ -10,6 +10,7 @@ kotlin {
     sourceSets {
         commonMain.dependencies {
             implementation(project(":core:network"))
+            implementation(libs.atomicfu)
             implementation(libs.kermit)
             implementation(libs.kotlinx.serialization.json)
             implementation(libs.coil3.compose)

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/components/MarkdownContent.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/components/MarkdownContent.kt
@@ -61,7 +61,6 @@ import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import com.garfiec.librechat.feature.chat.resources.*
 import com.garfiec.librechat.feature.chat.resources.Res
-import com.mikepenz.markdown.m3.Markdown
 import com.mikepenz.markdown.m3.markdownColor
 import com.mikepenz.markdown.m3.markdownTypography
 import org.jetbrains.compose.resources.stringResource
@@ -95,6 +94,7 @@ actual fun MarkdownContent(
     searchQuery: String?,
     searchFocusedOccurrence: Int,
     onFocusedOccurrencePosition: ((LayoutCoordinates) -> Unit)?,
+    immediate: Boolean,
 ) {
     val segments = remember(text) { parseMarkdownSegments(text) }
     val isSearchActive = !searchQuery.isNullOrBlank()
@@ -162,6 +162,7 @@ actual fun MarkdownContent(
                                             MarkdownTextSegment(
                                                 content = inlineSegment.text,
                                                 fontSizeMultiplier = fontSizeMultiplier,
+                                                immediate = immediate,
                                             )
                                         }
                                     }
@@ -217,6 +218,7 @@ actual fun MarkdownContent(
                             MarkdownTextSegment(
                                 content = segment.text,
                                 fontSizeMultiplier = fontSizeMultiplier,
+                                immediate = immediate,
                             )
                         }
                     }
@@ -286,6 +288,7 @@ private fun MarkdownTextSegment(
     content: String,
     modifier: Modifier = Modifier,
     fontSizeMultiplier: Float = 1.0f,
+    immediate: Boolean = false,
 ) {
     val colors = markdownColor(
         text = MaterialTheme.colorScheme.onSurface,
@@ -312,16 +315,20 @@ private fun MarkdownTextSegment(
         list = bodyLarge.scaleFontSize(fontSizeMultiplier),
     )
 
-    // The Markdown composable caches internally keyed on content. Wrapping
-    // in key(fontSizeMultiplier) forces disposal and recreation when the
-    // user changes the font size setting, so the new typography takes effect.
+    // CachedMarkdown reads the ParsedMarkdownCache hoisted on ChatViewModel and
+    // renders directly from the cached State.Success on re-entry, which skips the
+    // library's async Loading→Success transition. That transition is what produces
+    // the 0-px → final-height cascade on LazyColumn item recycle.
+    //
+    // key(fontSizeMultiplier) forces a fresh composition when the user changes
+    // the font-size setting so the new typography takes effect.
     key(fontSizeMultiplier) {
-        Markdown(
+        CachedMarkdown(
             content = content,
             colors = colors,
             typography = typography,
-            modifier = modifier
-                .fillMaxWidth(),
+            modifier = modifier.fillMaxWidth(),
+            immediate = immediate,
         )
     }
 }

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/components/MermaidDiagram.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/components/MermaidDiagram.kt
@@ -47,6 +47,7 @@ import androidx.compose.ui.viewinterop.AndroidView
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import co.touchlab.kermit.Logger
+import com.garfiec.librechat.feature.chat.components.web.safelyDestroyWebView
 import com.garfiec.librechat.feature.chat.resources.*
 import com.garfiec.librechat.feature.chat.resources.Res
 import org.jetbrains.compose.resources.stringResource
@@ -241,10 +242,7 @@ private fun MermaidWebView(
                 loadedHtml = html
             }
         },
-        onRelease = { webView ->
-            webView.stopLoading()
-            webView.destroy()
-        },
+        onRelease = ::safelyDestroyWebView,
     )
 }
 
@@ -256,6 +254,7 @@ private fun buildMermaidHtml(escapedCode: String, theme: String): String {
             <meta name="viewport" content="width=device-width, initial-scale=1.0">
             <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'unsafe-inline'; img-src data:;">
             <style>
+                html, body { max-width: 100%; }
                 body {
                     margin: 0;
                     padding: 8px;
@@ -263,7 +262,7 @@ private fun buildMermaidHtml(escapedCode: String, theme: String): String {
                     justify-content: center;
                     align-items: center;
                     background: transparent;
-                    overflow: hidden;
+                    overflow: visible;
                 }
                 .mermaid {
                     width: 100%;

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/ArtifactPanel.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/ArtifactPanel.kt
@@ -52,7 +52,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource
@@ -63,6 +62,7 @@ import androidx.compose.ui.viewinterop.AndroidView
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import co.touchlab.kermit.Logger
+import com.garfiec.librechat.core.ui.theme.isSurfaceDark
 import com.garfiec.librechat.feature.chat.components.CodeBlock
 import com.garfiec.librechat.feature.chat.resources.*
 import com.garfiec.librechat.feature.chat.resources.Res
@@ -98,16 +98,17 @@ actual fun ArtifactPanel(
     }
 }
 
-private fun isPreviewableType(type: String): Boolean {
-    return type.contains("html") ||
-        type.contains("svg") ||
-        type.contains("react") ||
-        type.contains("mermaid") ||
-        type.contains("markdown") ||
-        type == "text/md" ||
-        type == "text/plain" ||
-        type.contains("code-html")
-}
+private fun isPreviewableType(type: String): Boolean =
+    when (ArtifactType.from(type)) {
+        ArtifactType.MERMAID,
+        ArtifactType.REACT,
+        ArtifactType.SVG,
+        ArtifactType.MARKDOWN,
+        ArtifactType.HTML,
+        ArtifactType.PLAIN,
+        -> true
+        ArtifactType.CODE -> false
+    }
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -127,7 +128,7 @@ private fun ArtifactPanelContent(
 
     val currentArtifact = versions.getOrElse(currentVersionIndex) { artifact }
     val isPreviewable = isPreviewableType(currentArtifact.type)
-    val isDarkTheme = MaterialTheme.colorScheme.surface.luminance() < 0.5f
+    val isDarkTheme = isSurfaceDark()
 
     Column(modifier = modifier.fillMaxWidth()) {
         // Title row with version nav and action buttons
@@ -300,7 +301,7 @@ private fun ArtifactPreviewWebView(
     var isLoading by remember { mutableStateOf(true) }
 
     val html = remember(content, type, isDarkTheme) {
-        buildWebViewHtml(content, type, isDarkTheme)
+        ArtifactWebContent.buildHtml(content, type, isDarkTheme, inline = false)
     }
 
     // Track what HTML is currently loaded to avoid reloading on every recomposition.
@@ -395,207 +396,6 @@ private fun ArtifactPreviewWebView(
     }
 }
 
-private fun buildWebViewHtml(content: String, type: String, isDarkTheme: Boolean): String {
-    val bgColor = if (isDarkTheme) "#1C1B1F" else "#FFFBFE"
-    val fgColor = if (isDarkTheme) "#E6E1E5" else "#1C1B1F"
-
-    return when {
-        type.contains("mermaid") -> MermaidWebContent.buildHtml(content, isDarkTheme)
-        type.contains("markdown") || type == "text/md" -> MarkdownWebContent.buildHtml(content, isDarkTheme)
-        type == "text/plain" -> MarkdownWebContent.buildHtml(content, isDarkTheme)
-        type.contains("react") -> buildReactHtml(content, bgColor, fgColor)
-        type.contains("svg") -> buildSvgHtml(content, bgColor)
-        type.contains("html") || type.contains("code-html") -> buildEnhancedHtml(content, bgColor, fgColor)
-        else -> {
-            val escapedContent = escapeHtml(content)
-            """
-            <!DOCTYPE html>
-            <html>
-            <head>
-                <meta name="viewport" content="width=device-width, initial-scale=1.0">
-                <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline';">
-                <style>
-                    :root { --bg: $bgColor; --fg: $fgColor; }
-                    body { background: var(--bg); color: var(--fg); margin: 0; padding: 16px; }
-                </style>
-            </head>
-            <body><pre>$escapedContent</pre></body>
-            </html>
-            """.trimIndent()
-        }
-    }
-}
-
-// Security note: HTML artifacts intentionally render unsanitized HTML content.
-// This is by design — HTML artifacts are meant to be rendered as-is. The WebView
-// is sandboxed with a Content Security Policy restricting script/resource origins.
-private fun buildEnhancedHtml(content: String, bgColor: String, fgColor: String): String {
-    // If content already contains <html> or <!DOCTYPE>, inject Tailwind + theme vars
-    val hasHtmlTag = content.contains("<html", ignoreCase = true) ||
-        content.contains("<!DOCTYPE", ignoreCase = true)
-
-    if (hasHtmlTag) {
-        val themeStyle = """
-            <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline' https://cdn.tailwindcss.com; style-src 'unsafe-inline'; img-src data: blob: https:; connect-src https://cdn.tailwindcss.com;">
-            <style>:root { --bg: $bgColor; --fg: $fgColor; } body { background: var(--bg); color: var(--fg); }</style>
-            <script src="https://cdn.tailwindcss.com"></script>
-        """.trimIndent()
-        // Insert after <head> if present, otherwise before content
-        return if (content.contains("<head>", ignoreCase = true)) {
-            content.replaceFirst(
-                Regex("<head>", RegexOption.IGNORE_CASE),
-                "<head>$themeStyle",
-            )
-        } else if (content.contains("<head ", ignoreCase = true)) {
-            val headMatch = Regex("<head\\s[^>]*>", RegexOption.IGNORE_CASE).find(content)
-            if (headMatch != null) {
-                content.replaceRange(headMatch.range.last + 1, headMatch.range.last + 1, themeStyle)
-            } else {
-                "$themeStyle\n$content"
-            }
-        } else {
-            "$themeStyle\n$content"
-        }
-    }
-
-    return """
-        <!DOCTYPE html>
-        <html>
-        <head>
-            <meta name="viewport" content="width=device-width, initial-scale=1.0">
-            <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline' https://cdn.tailwindcss.com; style-src 'unsafe-inline'; img-src data: blob: https:; connect-src https://cdn.tailwindcss.com;">
-            <script src="https://cdn.tailwindcss.com"></script>
-            <style>
-                :root { --bg: $bgColor; --fg: $fgColor; }
-                body { background: var(--bg); color: var(--fg); margin: 0; padding: 0; }
-            </style>
-        </head>
-        <body>$content</body>
-        </html>
-    """.trimIndent()
-}
-
-// Security note: SVG content is rendered unsanitized because SVG artifacts are
-// designed to display user-provided vector graphics. CSP restricts script execution.
-private fun buildSvgHtml(content: String, bgColor: String): String {
-    return """
-        <!DOCTYPE html>
-        <html>
-        <head>
-            <meta name="viewport" content="width=device-width, initial-scale=1.0">
-            <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; img-src data: blob:;">
-            <style>
-                body {
-                    margin: 0;
-                    padding: 16px;
-                    display: flex;
-                    justify-content: center;
-                    align-items: center;
-                    min-height: 100vh;
-                    background: $bgColor;
-                }
-                svg, .svg-container {
-                    width: 100%;
-                    height: auto;
-                    max-width: 100%;
-                }
-            </style>
-        </head>
-        <body><div class="svg-container">$content</div></body>
-        </html>
-    """.trimIndent()
-}
-
-// Security note: React artifacts intentionally render unsanitized content because they
-// must execute user-provided JSX/JS code. 'unsafe-inline' and 'unsafe-eval' are required
-// in script-src for Babel transpilation and React rendering. CSP restricts script origins
-// to specific CDN hosts (unpkg.com, cdn.tailwindcss.com).
-private fun buildReactHtml(content: String, bgColor: String, fgColor: String): String {
-    // Preprocess: strip ES module imports/exports for browser compatibility.
-    // React/ReactDOM are loaded as UMD globals, so `import { useState } from 'react'`
-    // becomes a destructuring from the global React object.
-    val processed = content
-        .replace(Regex("""import\s*\{([^}]+)\}\s*from\s*['"]react['"];?""")) {
-            "const {${it.groupValues[1]}} = React;"
-        }
-        .replace(Regex("""import\s*React\s*from\s*['"]react['"];?"""), "")
-        .replace(Regex("""import\s*\{([^}]+)\}\s*from\s*['"]react-dom['"];?""")) {
-            "const {${it.groupValues[1]}} = ReactDOM;"
-        }
-        .replace(Regex("""export\s+default\s+function\s+"""), "function ")
-        .replace(Regex("""export\s+default\s+"""), "const _DefaultExport = ")
-
-    return """
-        <!DOCTYPE html>
-        <html>
-        <head>
-            <meta name="viewport" content="width=device-width, initial-scale=1.0">
-            <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline' 'unsafe-eval' https://unpkg.com https://cdn.tailwindcss.com; style-src 'unsafe-inline'; img-src data: blob: https:; connect-src https://cdn.tailwindcss.com;">
-            <script src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
-            <script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
-            <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
-            <script src="https://cdn.tailwindcss.com"></script>
-            <style>
-                :root { --bg: $bgColor; --fg: $fgColor; }
-                body { background: var(--bg); color: var(--fg); margin: 0; padding: 0; }
-                #error-display {
-                    display: none;
-                    padding: 16px;
-                    margin: 16px;
-                    background: #B3261E22;
-                    border: 1px solid #B3261E;
-                    border-radius: 8px;
-                    font-family: monospace;
-                    font-size: 13px;
-                    white-space: pre-wrap;
-                    color: $fgColor;
-                }
-            </style>
-        </head>
-        <body>
-            <div id="root"></div>
-            <div id="error-display"></div>
-            <script>
-                window.addEventListener('error', function(e) {
-                    var errDiv = document.getElementById('error-display');
-                    if (errDiv && !document.getElementById('root').hasChildNodes()) {
-                        errDiv.style.display = 'block';
-                        errDiv.textContent = 'Component compilation failed:\n' + (e.message || 'Unknown error');
-                    }
-                });
-            </script>
-            <script type="text/babel">
-                try {
-                    const { useState, useEffect, useRef, useMemo, useCallback, useReducer, useContext, createContext } = React;
-
-                    $processed
-
-                    const _root = ReactDOM.createRoot(document.getElementById('root'));
-                    // Find the component to render: look for common names or _DefaultExport
-                    const _Component = typeof _DefaultExport !== 'undefined' ? _DefaultExport
-                        : typeof App !== 'undefined' ? App
-                        : typeof Counter !== 'undefined' ? Counter
-                        : typeof Main !== 'undefined' ? Main
-                        : typeof Component !== 'undefined' ? Component
-                        : null;
-                    if (_Component) {
-                        if (typeof _Component === 'function') {
-                            _root.render(React.createElement(_Component));
-                        } else {
-                            _root.render(_Component);
-                        }
-                    }
-                } catch (e) {
-                    var errDiv = document.getElementById('error-display');
-                    errDiv.style.display = 'block';
-                    errDiv.textContent = 'Component compilation failed:\n' + e.message;
-                }
-            </script>
-        </body>
-        </html>
-    """.trimIndent()
-}
-
 /**
  * Intercepts all vertical scroll and manually dispatches it to the given [ScrollState],
  * then reports it all as consumed so the parent ModalBottomSheet never receives it.
@@ -620,19 +420,8 @@ private class SheetScrollBlocker(private val scrollState: ScrollState) : NestedS
     }
 }
 
-/**
- * Escapes HTML special characters to prevent XSS when embedding user-supplied
- * or error-derived text into WebView HTML.
- */
-private fun escapeHtml(text: String): String = text
-    .replace("&", "&amp;")
-    .replace("<", "&lt;")
-    .replace(">", "&gt;")
-    .replace("\"", "&quot;")
-    .replace("'", "&#39;")
-
 private fun buildErrorHtml(errorMessage: String): String {
-    val safeMessage = escapeHtml(errorMessage)
+    val safeMessage = ArtifactWebContent.escapeHtml(errorMessage)
     return """
         <!DOCTYPE html>
         <html>

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/InlineArtifactView.android.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/InlineArtifactView.android.kt
@@ -1,0 +1,130 @@
+package com.garfiec.librechat.feature.chat.components.artifact
+
+import android.annotation.SuppressLint
+import android.net.http.SslError
+import android.view.ViewGroup
+import android.webkit.SslErrorHandler
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import co.touchlab.kermit.Logger
+import com.garfiec.librechat.core.ui.theme.isSurfaceDark
+import com.garfiec.librechat.feature.chat.components.web.configureLazyListWebView
+import com.garfiec.librechat.feature.chat.components.web.safelyDestroyWebView
+
+/**
+ * Android inline artifact preview. The slot is hardcoded to the inline cap for
+ * every type routed here (HTML, React, uncached Mermaid). SVG and cached
+ * Mermaid take the synchronous-aspect-ratio path via `InlineSvgSurface`
+ * upstream; Markdown renders natively. Full content lives in the fullscreen
+ * [ArtifactPanel] on tap. A fixed slot is the only configuration we've
+ * measured that fully eliminates LazyColumn scroll-jump for WebView-hosted
+ * previews.
+ */
+@SuppressLint("SetJavaScriptEnabled")
+@Composable
+actual fun InlineArtifactView(
+    artifact: Artifact,
+    onTap: () -> Unit,
+    modifier: Modifier,
+) {
+    val isDarkTheme = isSurfaceDark()
+    val bgArgb = MaterialTheme.colorScheme.surface.toArgb()
+    val html = remember(artifact, isDarkTheme) {
+        ArtifactWebContent.buildHtml(artifact.content, artifact.type, isDarkTheme, inline = true)
+    }
+    var loadedHtml by remember { mutableStateOf("") }
+
+    val cache = LocalMermaidRenderCache.current
+
+    val mermaidKey: String? = remember(artifact.content, artifact.type, isDarkTheme) {
+        if (ArtifactType.from(artifact.type) == ArtifactType.MERMAID &&
+            isCacheableMermaid(artifact.content)
+        ) {
+            mermaidCacheKey(artifact.content, isDarkTheme)
+        } else {
+            null
+        }
+    }
+
+    // Inline previews are capped to ~70% of the current window so a long HTML /
+    // React doc can never claim multiple screens of LazyColumn space (the full
+    // content lives in the fullscreen ArtifactPanel on tap). A second reason
+    // the cap matters on Android: `LAYER_TYPE_SOFTWARE` on the inline WebView
+    // (see `WebViewSafeDestroy.kt`) allocates a backing bitmap sized to the
+    // WebView's full layout height — an unbounded 380×4500 dp layout produces
+    // either a paint-skipping software-bitmap-too-large failure or an OOM that
+    // shows up as a blank card. Capping the layout keeps the bitmap small.
+    val maxInlineHeightDp = (LocalConfiguration.current.screenHeightDp * INLINE_MAX_HEIGHT_FRACTION).dp
+
+    val androidViewBlock: @Composable () -> Unit = {
+        AndroidView(
+            modifier = Modifier
+                .padding(2.dp)
+                .fillMaxWidth()
+                .height(maxInlineHeightDp),
+            factory = { context ->
+                WebView(context).apply {
+                    layoutParams = ViewGroup.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                    )
+                    configureLazyListWebView(this)
+                    setBackgroundColor(bgArgb)
+                    settings.javaScriptEnabled = true
+                    settings.domStorageEnabled = true
+                    settings.loadWithOverviewMode = true
+                    settings.useWideViewPort = true
+                    settings.allowFileAccess = false
+                    settings.allowContentAccess = false
+                    isVerticalScrollBarEnabled = false
+                    isHorizontalScrollBarEnabled = false
+                    webViewClient = object : WebViewClient() {
+                        override fun onReceivedSslError(
+                            view: WebView?,
+                            handler: SslErrorHandler?,
+                            error: SslError?,
+                        ) {
+                            handler?.cancel()
+                            Logger.w { "SSL error in inline artifact WebView: ${error?.primaryError}" }
+                        }
+                    }
+                    // Must run before loadDataWithBaseURL so MermaidBridge is
+                    // bound when mermaid's IIFE executes.
+                    if (mermaidKey != null) {
+                        val receiver = MermaidBridgeReceiver(cache, mermaidKey)
+                        addJavascriptInterface(MermaidJsBridge(receiver), "MermaidBridge")
+                    }
+                    loadDataWithBaseURL("https://cdn.jsdelivr.net", html, "text/html", "UTF-8", null)
+                    loadedHtml = html
+                }
+            },
+            update = { webView ->
+                webView.setBackgroundColor(bgArgb)
+                if (html != loadedHtml) {
+                    webView.loadDataWithBaseURL("https://cdn.jsdelivr.net", html, "text/html", "UTF-8", null)
+                    loadedHtml = html
+                }
+            },
+            onRelease = ::safelyDestroyWebView,
+        )
+    }
+
+    ArtifactCardSurface(onTap = onTap, modifier = modifier) {
+        if (mermaidKey != null) key(mermaidKey) { androidViewBlock() } else androidViewBlock()
+    }
+}

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/MermaidJsBridge.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/MermaidJsBridge.kt
@@ -1,0 +1,14 @@
+package com.garfiec.librechat.feature.chat.components.artifact
+
+import android.webkit.JavascriptInterface
+
+/**
+ * Android thin adapter that exposes [MermaidBridgeReceiver.onSvg] to JavaScript
+ * as `window.MermaidBridge.onSvg(svg)`. Registered via
+ * `WebView.addJavascriptInterface(this, "MermaidBridge")` before `loadDataWithBaseURL`
+ * so the binding is available when mermaid's IIFE runs.
+ */
+internal class MermaidJsBridge(private val receiver: MermaidBridgeReceiver) {
+    @JavascriptInterface
+    fun onSvg(svg: String) = receiver.onSvg(svg)
+}

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/components/web/WebViewSafeDestroy.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/components/web/WebViewSafeDestroy.kt
@@ -1,0 +1,36 @@
+package com.garfiec.librechat.feature.chat.components.web
+
+import android.view.View
+import android.webkit.WebView
+
+/**
+ * Configures and tears down a WebView that lives inside a Compose
+ * [androidx.compose.ui.viewinterop.AndroidView] slot in a recycling container
+ * (LazyColumn).
+ *
+ * **Why software-rendering:** when the WebView uses the default hardware-
+ * accelerated path, HWUI inserts a `GLFunctorDrawable` into a parent's display
+ * list. If Compose recycles the slot (LazyColumn scroll, theme-toggle
+ * `key(...)` rebuild) while a draw frame is still queued, RenderThread tries
+ * to render the functor whose backing `SkSurface` has been torn down →
+ * SIGSEGV inside `SkSurface::getCanvas()`. Three deferred-destroy strategies
+ * (handler.post, Choreographer.postFrameCallback, skip-destroy-entirely) all
+ * still raced on Android 17 (tombstones captured 2026-05-13). The only fix
+ * that fully closes the window is to never put the WebView on the GL functor
+ * pipeline in the first place: `LAYER_TYPE_SOFTWARE` renders the WebView into
+ * an off-screen bitmap that the parent display list owns, so there is no
+ * shared GL state to race over.
+ *
+ * Inline mermaid/HTML artifacts are all simple DOM + CSS — software rendering
+ * is performance-equivalent for these. For mermaid specifically, the SVG is
+ * harvested via JS bridge after the first render and the cache hit path
+ * never re-runs the WebView at all.
+ */
+internal fun configureLazyListWebView(webView: WebView) {
+    webView.setLayerType(View.LAYER_TYPE_SOFTWARE, null)
+}
+
+internal fun safelyDestroyWebView(webView: WebView) {
+    webView.stopLoading()
+    webView.destroy()
+}

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatScreen.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatScreen.kt
@@ -78,6 +78,7 @@ import com.garfiec.librechat.core.model.content.MessageContentPart
 import com.garfiec.librechat.core.ui.components.LoadingIndicator
 import com.garfiec.librechat.core.ui.components.ModelParameterSheet
 import com.garfiec.librechat.feature.chat.components.ChatInput
+import com.garfiec.librechat.feature.chat.components.ChatRoot
 import com.garfiec.librechat.feature.chat.components.ComparisonDualPane
 import com.garfiec.librechat.feature.chat.components.ComparisonTabBar
 import com.garfiec.librechat.feature.chat.components.ForkOptionsBottomSheet
@@ -317,6 +318,11 @@ actual fun ChatScreen(
         hadConversation = uiState.conversationId != null
     }
 
+    ChatRoot(
+        inlineArtifactPrefs = prefs.inlineArtifactPrefs,
+        mermaidRenderCache = viewModel.mermaidRenderCache,
+        parsedMarkdownCache = viewModel.parsedMarkdownCache,
+    ) {
     Scaffold(
         modifier = modifier
             .fillMaxSize()
@@ -803,6 +809,7 @@ actual fun ChatScreen(
             endpointKeyStates = uiState.endpointKeyStates,
             onSetApiKey = { name -> onNavigateToProviderKeys(name) },
         )
+    }
     }
 }
 

--- a/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/components/artifact/InlineArtifactStrategyTest.kt
+++ b/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/components/artifact/InlineArtifactStrategyTest.kt
@@ -1,0 +1,103 @@
+package com.garfiec.librechat.feature.chat.components.artifact
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class InlineArtifactStrategyTest {
+
+    private val cacheableMermaid = "flowchart TD\n  A --> B"
+    private val nonCacheableMermaid = "sequenceDiagram\n  A->>B: hi"
+    private val cachedSvg = "<svg id='cached'/>"
+
+    @Test
+    fun `cacheable mermaid with cached svg returns CachedMermaidSvg`() {
+        val result = selectInlineArtifactStrategy(
+            type = ArtifactType.MERMAID,
+            content = cacheableMermaid,
+            cachedMermaidSvg = cachedSvg,
+        )
+        assertTrue(result is InlineArtifactStrategy.CachedMermaidSvg)
+        assertEquals(cachedSvg, result.svg)
+    }
+
+    @Test
+    fun `cacheable mermaid without cached svg falls through to WebViewSlot`() {
+        val result = selectInlineArtifactStrategy(
+            type = ArtifactType.MERMAID,
+            content = cacheableMermaid,
+            cachedMermaidSvg = null,
+        )
+        assertEquals(InlineArtifactStrategy.WebViewSlot, result)
+    }
+
+    @Test
+    fun `non-cacheable mermaid with cached svg still returns WebViewSlot`() {
+        val result = selectInlineArtifactStrategy(
+            type = ArtifactType.MERMAID,
+            content = nonCacheableMermaid,
+            cachedMermaidSvg = cachedSvg,
+        )
+        assertEquals(InlineArtifactStrategy.WebViewSlot, result)
+    }
+
+    @Test
+    fun `markdown returns NativeMarkdown`() {
+        val result = selectInlineArtifactStrategy(
+            type = ArtifactType.MARKDOWN,
+            content = "# heading",
+            cachedMermaidSvg = null,
+        )
+        assertEquals(InlineArtifactStrategy.NativeMarkdown, result)
+    }
+
+    @Test
+    fun `svg returns IntrinsicSvg`() {
+        val result = selectInlineArtifactStrategy(
+            type = ArtifactType.SVG,
+            content = "<svg/>",
+            cachedMermaidSvg = null,
+        )
+        assertEquals(InlineArtifactStrategy.IntrinsicSvg, result)
+    }
+
+    @Test
+    fun `html returns WebViewSlot`() {
+        val result = selectInlineArtifactStrategy(
+            type = ArtifactType.HTML,
+            content = "<div/>",
+            cachedMermaidSvg = null,
+        )
+        assertEquals(InlineArtifactStrategy.WebViewSlot, result)
+    }
+
+    @Test
+    fun `react returns WebViewSlot`() {
+        val result = selectInlineArtifactStrategy(
+            type = ArtifactType.REACT,
+            content = "export default () => null",
+            cachedMermaidSvg = null,
+        )
+        assertEquals(InlineArtifactStrategy.WebViewSlot, result)
+    }
+
+    @Test
+    fun `code returns WebViewSlot`() {
+        val result = selectInlineArtifactStrategy(
+            type = ArtifactType.CODE,
+            content = "<!doctype html>",
+            cachedMermaidSvg = null,
+        )
+        assertEquals(InlineArtifactStrategy.WebViewSlot, result)
+    }
+
+    @Test
+    fun `plain returns WebViewSlot`() {
+        val result = selectInlineArtifactStrategy(
+            type = ArtifactType.PLAIN,
+            content = "just text",
+            cachedMermaidSvg = null,
+        )
+        assertEquals(InlineArtifactStrategy.WebViewSlot, result)
+    }
+}

--- a/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/components/artifact/MermaidBridgeReceiverTest.kt
+++ b/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/components/artifact/MermaidBridgeReceiverTest.kt
@@ -1,0 +1,39 @@
+package com.garfiec.librechat.feature.chat.components.artifact
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class MermaidBridgeReceiverTest {
+
+    @Test
+    fun `onSvg writes to cache under bound key`() {
+        val cache = MermaidRenderCache()
+        val receiver = MermaidBridgeReceiver(cache, key = "k1")
+        receiver.onSvg("<svg id='one'/>")
+
+        assertThat(cache["k1"]).isEqualTo("<svg id='one'/>")
+    }
+
+    @Test
+    fun `two receivers with different keys write to distinct entries`() {
+        val cache = MermaidRenderCache()
+        val r1 = MermaidBridgeReceiver(cache, key = "a")
+        val r2 = MermaidBridgeReceiver(cache, key = "b")
+
+        r1.onSvg("<svg id='a'/>")
+        r2.onSvg("<svg id='b'/>")
+
+        assertThat(cache["a"]).isEqualTo("<svg id='a'/>")
+        assertThat(cache["b"]).isEqualTo("<svg id='b'/>")
+    }
+
+    @Test
+    fun `repeated onSvg overwrites the cache entry for the bound key`() {
+        val cache = MermaidRenderCache()
+        val receiver = MermaidBridgeReceiver(cache, key = "k")
+        receiver.onSvg("<svg id='v1'/>")
+        receiver.onSvg("<svg id='v2'/>")
+
+        assertThat(cache["k"]).isEqualTo("<svg id='v2'/>")
+    }
+}

--- a/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/components/artifact/MermaidGateTest.kt
+++ b/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/components/artifact/MermaidGateTest.kt
@@ -1,0 +1,80 @@
+package com.garfiec.librechat.feature.chat.components.artifact
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class MermaidGateTest {
+
+    @Test
+    fun `flowchart prefix is cacheable`() {
+        assertThat(isCacheableMermaid("flowchart TD\n    A --> B")).isTrue()
+        assertThat(isCacheableMermaid("flowchart\n    A --> B")).isTrue()
+    }
+
+    @Test
+    fun `graph prefix is cacheable`() {
+        assertThat(isCacheableMermaid("graph LR\n    A --> B")).isTrue()
+    }
+
+    @Test
+    fun `init directive preamble before flowchart is cacheable`() {
+        val src = """
+            %%{init: { 'theme': 'forest' }}%%
+            flowchart TD
+                A --> B
+        """.trimIndent()
+        assertThat(isCacheableMermaid(src)).isTrue()
+    }
+
+    @Test
+    fun `leading blank lines do not block cacheability`() {
+        val src = "\n\n   \nflowchart TD\n    A --> B"
+        assertThat(isCacheableMermaid(src)).isTrue()
+    }
+
+    @Test
+    fun `state diagram is not cacheable`() {
+        assertThat(isCacheableMermaid("stateDiagram-v2\n    [*] --> Still")).isFalse()
+    }
+
+    @Test
+    fun `gantt is not cacheable`() {
+        assertThat(isCacheableMermaid("gantt\n    title A")).isFalse()
+    }
+
+    @Test
+    fun `sequence diagram is not cacheable`() {
+        assertThat(isCacheableMermaid("sequenceDiagram\n    A->>B: Hi")).isFalse()
+    }
+
+    @Test
+    fun `er diagram is not cacheable`() {
+        assertThat(isCacheableMermaid("erDiagram\n    USER ||--o{ ORDER : places")).isFalse()
+    }
+
+    @Test
+    fun `pie chart is not cacheable`() {
+        assertThat(isCacheableMermaid("pie title Pets\n    \"Dogs\" : 50")).isFalse()
+    }
+
+    @Test
+    fun `class diagram is not cacheable`() {
+        assertThat(isCacheableMermaid("classDiagram\n    class Foo")).isFalse()
+    }
+
+    @Test
+    fun `empty content is not cacheable`() {
+        assertThat(isCacheableMermaid("")).isFalse()
+        assertThat(isCacheableMermaid("   \n\n")).isFalse()
+    }
+
+    @Test
+    fun `comment-only content is not cacheable`() {
+        assertThat(isCacheableMermaid("%%{init: { 'theme': 'forest' }}%%")).isFalse()
+    }
+
+    @Test
+    fun `flowchart with tab-separated direction is cacheable`() {
+        assertThat(isCacheableMermaid("flowchart\tTD\n    A --> B")).isTrue()
+    }
+}

--- a/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/components/artifact/MermaidRenderCacheTest.kt
+++ b/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/components/artifact/MermaidRenderCacheTest.kt
@@ -1,0 +1,56 @@
+package com.garfiec.librechat.feature.chat.components.artifact
+
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import org.junit.Test
+
+class MermaidRenderCacheTest {
+
+    @Test
+    fun `cache plateaus at maxEntries and evicts oldest first`() {
+        val cache = MermaidRenderCache(maxEntries = 100)
+        repeat(110) { i -> cache.put("key-$i", "<svg id='$i'/>") }
+
+        for (i in 0 until 10) {
+            assertThat(cache["key-$i"]).isNull()
+        }
+        for (i in 10 until 110) {
+            assertThat(cache["key-$i"]).isEqualTo("<svg id='$i'/>")
+        }
+    }
+
+    @Test
+    fun `put for existing key updates value without growing insertion order`() {
+        val cache = MermaidRenderCache(maxEntries = 3)
+        cache.put("a", "1")
+        cache.put("b", "b1")
+        cache.put("c", "c1")
+        // Duplicate puts on existing keys must NOT push them later in insertion
+        // order — otherwise the next eviction would target the wrong key.
+        cache.put("a", "2")
+        cache.put("a", "3")
+        cache.put("a", "4")
+        cache.put("d", "d1") // evicts the OLDEST insertion: 'a'
+
+        assertThat(cache["a"]).isNull()
+        assertThat(cache["b"]).isEqualTo("b1")
+        assertThat(cache["c"]).isEqualTo("c1")
+        assertThat(cache["d"]).isEqualTo("d1")
+    }
+
+    @Test
+    fun `concurrent puts do not throw and bound respected`() = runBlocking {
+        val cache = MermaidRenderCache(maxEntries = 50)
+        withContext(Dispatchers.Default) {
+            (0 until 1000).map { i ->
+                async { cache.put("k-$i", "<svg/>") }
+            }.awaitAll()
+        }
+        val present = (0 until 1000).count { cache["k-$it"] != null }
+        assertThat(present).isEqualTo(50)
+    }
+}

--- a/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/components/artifact/SvgIntrinsicSizeTest.kt
+++ b/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/components/artifact/SvgIntrinsicSizeTest.kt
@@ -1,0 +1,55 @@
+package com.garfiec.librechat.feature.chat.components.artifact
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class SvgIntrinsicSizeTest {
+
+    @Test
+    fun `viewBox attribute gives aspect ratio`() {
+        val svg = """<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 200"></svg>"""
+        assertThat(parseSvgAspectRatio(svg)).isEqualTo(2.0f)
+    }
+
+    @Test
+    fun `viewBox tolerates negative origin and decimal extents`() {
+        val svg = """<svg viewBox="-10 -5 320.5 160.25" xmlns="http://www.w3.org/2000/svg"></svg>"""
+        assertThat(parseSvgAspectRatio(svg)).isWithin(0.001f).of(320.5f / 160.25f)
+    }
+
+    @Test
+    fun `width and height attributes are the fallback when viewBox is absent`() {
+        val svg = """<svg xmlns="http://www.w3.org/2000/svg" width="600px" height="300px"></svg>"""
+        assertThat(parseSvgAspectRatio(svg)).isEqualTo(2.0f)
+    }
+
+    @Test
+    fun `returns null when neither viewBox nor width and height present`() {
+        val svg = """<svg xmlns="http://www.w3.org/2000/svg"><g/></svg>"""
+        assertThat(parseSvgAspectRatio(svg)).isNull()
+    }
+
+    @Test
+    fun `returns null when only one of width or height is present`() {
+        val svg = """<svg width="400" xmlns="http://www.w3.org/2000/svg"></svg>"""
+        assertThat(parseSvgAspectRatio(svg)).isNull()
+    }
+
+    @Test
+    fun `returns null when viewBox has zero extent`() {
+        val svg = """<svg viewBox="0 0 0 200"></svg>"""
+        assertThat(parseSvgAspectRatio(svg)).isNull()
+    }
+
+    @Test
+    fun `viewBox match is case-insensitive`() {
+        val svg = """<SVG ViewBox="0 0 100 50"></SVG>"""
+        assertThat(parseSvgAspectRatio(svg)).isEqualTo(2.0f)
+    }
+
+    @Test
+    fun `mermaid-shaped svg output parses`() {
+        val svg = """<svg aria-roledescription="flowchart-v2" role="graphics-document document" viewBox="0 0 312.5 354" style="max-width: 100%;" xmlns="http://www.w3.org/2000/svg" width="100%" id="rendered"><g></g></svg>"""
+        assertThat(parseSvgAspectRatio(svg)).isWithin(0.001f).of(312.5f / 354f)
+    }
+}

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/CachedMarkdown.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/CachedMarkdown.kt
@@ -1,0 +1,68 @@
+package com.garfiec.librechat.feature.chat.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Modifier
+import com.mikepenz.markdown.m3.Markdown
+import com.mikepenz.markdown.model.MarkdownColors
+import com.mikepenz.markdown.model.MarkdownTypography
+import com.mikepenz.markdown.model.State
+import com.mikepenz.markdown.model.rememberMarkdownState
+
+/**
+ * Renders markdown via the m3 [Markdown] composable, preferring a cached
+ * [State.Success] from [LocalParsedMarkdownCache] when available.
+ *
+ * On cache hit the `Markdown(state = ...)` overload is used directly, skipping
+ * the library's `StateFlow<State>` + `LaunchedEffect` parse path — no
+ * Loading→Success transient, so a LazyColumn re-entry doesn't briefly render
+ * at 0 px and push surrounding content down.
+ *
+ * On cache miss the standard `rememberMarkdownState(...)` path runs (async
+ * parse, retainState=true). A side-effect collector watches the state flow
+ * and writes the resulting [State.Success] to the cache for the next encounter.
+ *
+ * Padding/dimens/etc are left at library defaults — callers that need to
+ * customize those should fall back to invoking [Markdown] directly.
+ */
+@Composable
+fun CachedMarkdown(
+    content: String,
+    colors: MarkdownColors,
+    typography: MarkdownTypography,
+    modifier: Modifier = Modifier,
+    immediate: Boolean = false,
+) {
+    val cache = LocalParsedMarkdownCache.current
+    val key = parsedMarkdownCacheKey(content)
+    val cached = cache[key]
+
+    if (cached != null) {
+        Markdown(
+            state = cached,
+            colors = colors,
+            typography = typography,
+            modifier = modifier,
+        )
+        return
+    }
+
+    val mdState = rememberMarkdownState(
+        content = content,
+        immediate = immediate,
+        retainState = true,
+    )
+    LaunchedEffect(mdState, key) {
+        mdState.state.collect { s ->
+            if (s is State.Success) {
+                cache.put(key, s)
+            }
+        }
+    }
+    Markdown(
+        markdownState = mdState,
+        colors = colors,
+        typography = typography,
+        modifier = modifier,
+    )
+}

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ChatRoot.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ChatRoot.kt
@@ -1,0 +1,27 @@
+package com.garfiec.librechat.feature.chat.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import com.garfiec.librechat.core.data.datastore.InlineArtifactPrefs
+import com.garfiec.librechat.feature.chat.components.artifact.LocalInlineArtifactPrefs
+import com.garfiec.librechat.feature.chat.components.artifact.LocalMermaidRenderCache
+import com.garfiec.librechat.feature.chat.components.artifact.MermaidRenderCache
+
+/**
+ * Wraps the chat screen content with all chat-scoped CompositionLocals so that
+ * each platform `Scaffold` doesn't repeat the provider list.
+ */
+@Composable
+fun ChatRoot(
+    inlineArtifactPrefs: InlineArtifactPrefs,
+    mermaidRenderCache: MermaidRenderCache,
+    parsedMarkdownCache: ParsedMarkdownCache,
+    content: @Composable () -> Unit,
+) {
+    CompositionLocalProvider(
+        LocalInlineArtifactPrefs provides inlineArtifactPrefs,
+        LocalMermaidRenderCache provides mermaidRenderCache,
+        LocalParsedMarkdownCache provides parsedMarkdownCache,
+        content = content,
+    )
+}

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/LocalParsedMarkdownCache.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/LocalParsedMarkdownCache.kt
@@ -1,0 +1,7 @@
+package com.garfiec.librechat.feature.chat.components
+
+import androidx.compose.runtime.staticCompositionLocalOf
+
+val LocalParsedMarkdownCache = staticCompositionLocalOf<ParsedMarkdownCache> {
+    error("LocalParsedMarkdownCache not provided; wrap chat content in ChatRoot { }")
+}

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/LruSnapshotCache.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/LruSnapshotCache.kt
@@ -1,0 +1,38 @@
+package com.garfiec.librechat.feature.chat.components
+
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.snapshots.SnapshotStateMap
+import kotlinx.atomicfu.locks.SynchronizedObject
+import kotlinx.atomicfu.locks.synchronized
+
+/**
+ * Compose-observable LRU cache. Reads via [get] participate in Compose snapshots
+ * through the backing [SnapshotStateMap], so a [put] from a background thread
+ * triggers recomposition of any composable that read the same key.
+ *
+ * [SnapshotStateMap] already routes writes through Compose's snapshot system —
+ * an explicit `Snapshot.withMutableSnapshot { ... }` wrap would create one
+ * mutable snapshot per writing thread and cause `SnapshotApplyConflictException`
+ * under concurrent puts. The lock guards [insertionOrder] (a plain `ArrayDeque`,
+ * not thread-safe) and serializes the read-modify-write pair on [map].
+ */
+open class LruSnapshotCache<V>(private val maxEntries: Int) {
+
+    private val map: SnapshotStateMap<String, V> = mutableStateMapOf()
+    private val insertionOrder = ArrayDeque<String>()
+    private val lock = SynchronizedObject()
+
+    operator fun get(key: String): V? = map[key]
+
+    fun put(key: String, value: V) {
+        synchronized(lock) {
+            if (key !in map) {
+                insertionOrder.addLast(key)
+                while (insertionOrder.size > maxEntries) {
+                    map.remove(insertionOrder.removeFirst())
+                }
+            }
+            map[key] = value
+        }
+    }
+}

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ParsedMarkdownCache.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ParsedMarkdownCache.kt
@@ -1,0 +1,31 @@
+package com.garfiec.librechat.feature.chat.components
+
+import com.mikepenz.markdown.model.State
+
+/**
+ * Content-hash-keyed cache of parsed markdown [State.Success] AST. The m3
+ * renderer parses asynchronously; when a LazyColumn item is disposed and later
+ * scrolled back into view its remembered state is gone and parsing restarts
+ * from scratch. During the parse window the rendered height is 0, then jumps
+ * to the final value, and adjacent inline-artifact slots get pushed down — the
+ * visible scroll jump.
+ *
+ * Caching the parsed [State.Success] lets [CachedMarkdown] render directly via
+ * the `Markdown(state, ...)` overload on re-entry, bypassing the library's
+ * Loading→Success transition entirely. The cache is hoisted in `ChatViewModel`
+ * and provided through `ChatRoot`.
+ *
+ * Memory cost: an AST is roughly proportional to the markdown source; 200
+ * messages of ~500 chars each is in the tens of KB range — negligible for a
+ * chat session.
+ */
+class ParsedMarkdownCache(maxEntries: Int = MAX_ENTRIES_DEFAULT) :
+    LruSnapshotCache<State.Success>(maxEntries) {
+
+    private companion object {
+        const val MAX_ENTRIES_DEFAULT = 200
+    }
+}
+
+fun parsedMarkdownCacheKey(content: String): String =
+    content.hashCode().toString(16)

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/PlatformChatComponents.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/PlatformChatComponents.kt
@@ -74,4 +74,5 @@ expect fun MarkdownContent(
     searchQuery: String? = null,
     searchFocusedOccurrence: Int = -1,
     onFocusedOccurrencePosition: ((LayoutCoordinates) -> Unit)? = null,
+    immediate: Boolean = false,
 )

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/SharedContentParts.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/SharedContentParts.kt
@@ -50,12 +50,25 @@ import com.garfiec.librechat.core.common.ToolConstants
 import com.garfiec.librechat.core.model.Attachment
 import com.garfiec.librechat.core.model.ContentType
 import com.garfiec.librechat.core.model.content.MessageContentPart
+import com.garfiec.librechat.core.ui.theme.isSurfaceDark
 import com.garfiec.librechat.feature.chat.components.artifact.Artifact
 import com.garfiec.librechat.feature.chat.components.artifact.ArtifactButton
 import com.garfiec.librechat.feature.chat.components.artifact.ArtifactPanel
 import com.garfiec.librechat.feature.chat.components.artifact.ArtifactSegment
+import com.garfiec.librechat.feature.chat.components.artifact.ArtifactType
+import com.garfiec.librechat.feature.chat.components.artifact.InlineArtifactStrategy
+import com.garfiec.librechat.feature.chat.components.artifact.InlineArtifactView
+import com.garfiec.librechat.feature.chat.components.artifact.InlineMarkdownArtifact
+import com.garfiec.librechat.feature.chat.components.artifact.InlineSvgArtifact
+import com.garfiec.librechat.feature.chat.components.artifact.InlineSvgSurface
+import com.garfiec.librechat.feature.chat.components.artifact.LocalInlineArtifactPrefs
+import com.garfiec.librechat.feature.chat.components.artifact.LocalMermaidRenderCache
 import com.garfiec.librechat.feature.chat.components.artifact.detectArtifacts
 import com.garfiec.librechat.feature.chat.components.artifact.groupArtifactVersions
+import com.garfiec.librechat.feature.chat.components.artifact.isCacheableMermaid
+import com.garfiec.librechat.feature.chat.components.artifact.mermaidCacheKey
+import com.garfiec.librechat.feature.chat.components.artifact.selectInlineArtifactStrategy
+import com.garfiec.librechat.feature.chat.components.artifact.shouldRenderInline
 import com.garfiec.librechat.feature.chat.resources.*
 import com.garfiec.librechat.feature.chat.resources.Res
 import kotlinx.serialization.json.JsonArray
@@ -294,9 +307,18 @@ private fun TextContentPart(
     val hasArtifacts = remember(segments) { segments.any { it is ArtifactSegment.ArtifactReference } }
 
     if (!hasArtifacts) {
-        MarkdownContent(text, modifier, fontSizeMultiplier, useKatex, searchQuery, searchFocusedOccurrence, onFocusedOccurrencePosition)
+        MarkdownContent(
+            text,
+            modifier,
+            fontSizeMultiplier,
+            useKatex,
+            searchQuery,
+            searchFocusedOccurrence,
+            onFocusedOccurrencePosition,
+        )
     } else {
         val versionMap = remember(segments) { groupArtifactVersions(segments) }
+        val inlinePrefs = LocalInlineArtifactPrefs.current
         var activeArtifact by remember {
             mutableStateOf<Artifact?>(null)
         }
@@ -317,11 +339,43 @@ private fun TextContentPart(
                     is ArtifactSegment.ArtifactReference -> {
                         val versions = versionMap[segment.artifact.identifier] ?: listOf(segment.artifact)
                         Spacer(modifier = Modifier.height(8.dp))
-                        ArtifactButton(
-                            artifact = segment.artifact,
-                            onClick = { activeArtifact = segment.artifact },
-                            versionCount = versions.size,
-                        )
+                        if (inlinePrefs.shouldRenderInline(segment.artifact.type)) {
+                            val type = ArtifactType.from(segment.artifact.type)
+                            val cachedSvg = rememberCachedMermaidSvg(segment.artifact.content, type)
+                            when (val strategy = selectInlineArtifactStrategy(type, segment.artifact.content, cachedSvg)) {
+                                is InlineArtifactStrategy.CachedMermaidSvg -> InlineSvgSurface(
+                                    svg = strategy.svg,
+                                    onTap = { activeArtifact = segment.artifact },
+                                    modifier = Modifier.fillMaxWidth(),
+                                    contentPadding = 4.dp,
+                                )
+                                InlineArtifactStrategy.NativeMarkdown -> InlineMarkdownArtifact(
+                                    artifact = segment.artifact,
+                                    onTap = { activeArtifact = segment.artifact },
+                                    modifier = Modifier.fillMaxWidth(),
+                                    fontSizeMultiplier = fontSizeMultiplier,
+                                    searchQuery = searchQuery,
+                                    searchFocusedOccurrence = searchFocusedOccurrence,
+                                    onFocusedOccurrencePosition = onFocusedOccurrencePosition,
+                                )
+                                InlineArtifactStrategy.IntrinsicSvg -> InlineSvgArtifact(
+                                    artifact = segment.artifact,
+                                    onTap = { activeArtifact = segment.artifact },
+                                    modifier = Modifier.fillMaxWidth(),
+                                )
+                                InlineArtifactStrategy.WebViewSlot -> InlineArtifactView(
+                                    artifact = segment.artifact,
+                                    onTap = { activeArtifact = segment.artifact },
+                                    modifier = Modifier.fillMaxWidth(),
+                                )
+                            }
+                        } else {
+                            ArtifactButton(
+                                artifact = segment.artifact,
+                                onClick = { activeArtifact = segment.artifact },
+                                versionCount = versions.size,
+                            )
+                        }
                         Spacer(modifier = Modifier.height(8.dp))
                     }
                 }
@@ -336,6 +390,20 @@ private fun TextContentPart(
             )
         }
     }
+}
+
+/**
+ * Reads the [LocalMermaidRenderCache] for the given artifact content and theme,
+ * returning the cached SVG when present. Returns `null` for non-mermaid types
+ * or non-cacheable mermaid sources so callers don't need to gate themselves.
+ */
+@Composable
+private fun rememberCachedMermaidSvg(content: String, type: ArtifactType): String? {
+    if (type != ArtifactType.MERMAID || !isCacheableMermaid(content)) return null
+    val cache = LocalMermaidRenderCache.current
+    val isDark = isSurfaceDark()
+    val key = remember(content, isDark) { mermaidCacheKey(content, isDark) }
+    return cache[key]
 }
 
 // ─── ThinkingContentPart ────────────────────────────────────────────

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/ArtifactButton.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/ArtifactButton.kt
@@ -107,25 +107,23 @@ fun ArtifactButton(
     }
 }
 
-private fun artifactTypeIcon(type: String): ImageVector {
-    return when {
-        type.contains("mermaid") -> Icons.Default.AccountTree
-        type.contains("react") -> Icons.Default.Widgets
-        type.contains("html") || type.contains("code-html") -> Icons.Default.Web
-        type.contains("svg") || type.contains("image") -> Icons.Default.Image
-        type.contains("markdown") || type == "text/md" -> Icons.AutoMirrored.Filled.Article
-        else -> Icons.Default.Code
+private fun artifactTypeIcon(type: String): ImageVector =
+    when (ArtifactType.from(type)) {
+        ArtifactType.MERMAID -> Icons.Default.AccountTree
+        ArtifactType.REACT -> Icons.Default.Widgets
+        ArtifactType.HTML -> Icons.Default.Web
+        ArtifactType.SVG -> Icons.Default.Image
+        ArtifactType.MARKDOWN -> Icons.AutoMirrored.Filled.Article
+        ArtifactType.PLAIN, ArtifactType.CODE -> Icons.Default.Code
     }
-}
 
-private fun artifactTypeSubtitle(type: String): String {
-    return when {
-        type.contains("mermaid") -> "Mermaid Diagram"
-        type.contains("react") -> "React Component"
-        type.contains("svg") -> "SVG Image"
-        type.contains("markdown") || type == "text/md" -> "Markdown Document"
-        type.contains("html") || type.contains("code-html") -> "HTML Page"
-        type == "text/plain" -> "Plain Text"
-        else -> "Code"
+private fun artifactTypeSubtitle(type: String): String =
+    when (ArtifactType.from(type)) {
+        ArtifactType.MERMAID -> "Mermaid Diagram"
+        ArtifactType.REACT -> "React Component"
+        ArtifactType.SVG -> "SVG Image"
+        ArtifactType.MARKDOWN -> "Markdown Document"
+        ArtifactType.HTML -> "HTML Page"
+        ArtifactType.PLAIN -> "Plain Text"
+        ArtifactType.CODE -> "Code"
     }
-}

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/ArtifactCardSurface.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/ArtifactCardSurface.kt
@@ -1,0 +1,37 @@
+package com.garfiec.librechat.feature.chat.components.artifact
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+/**
+ * Shared rounded-corner Surface chrome used by every inline artifact preview:
+ * 12dp rounded corners, surface background, tonalElevation 1, outline-variant
+ * border, fillMaxWidth, and a click handler that opens the artifact panel.
+ */
+@Composable
+fun ArtifactCardSurface(
+    onTap: () -> Unit,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    Surface(
+        modifier = modifier
+            .fillMaxWidth()
+            .clickable(onClick = onTap),
+        shape = RoundedCornerShape(12.dp),
+        color = MaterialTheme.colorScheme.surface,
+        tonalElevation = 1.dp,
+        border = BorderStroke(
+            width = 1.dp,
+            color = MaterialTheme.colorScheme.outlineVariant,
+        ),
+        content = { content() },
+    )
+}

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/ArtifactType.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/ArtifactType.kt
@@ -1,0 +1,34 @@
+package com.garfiec.librechat.feature.chat.components.artifact
+
+/**
+ * Classification of an artifact MIME type into the renderer/icon families the
+ * UI knows about. Centralises the substring-matching ladder that used to live
+ * in `ArtifactButton`, `ArtifactPanel.isPreviewableType`, `ArtifactWebContent`,
+ * and `InlineArtifactPrefs.shouldRenderInline` — all four sites now classify
+ * via [from] and switch on the resulting enum.
+ *
+ * Matching order matters: `application/vnd.code-html` must be classified as
+ * HTML, not CODE. The [from] cases are ordered so the most-specific tokens
+ * win first.
+ */
+enum class ArtifactType {
+    MERMAID,
+    REACT,
+    SVG,
+    MARKDOWN,
+    HTML,
+    PLAIN,
+    CODE;
+
+    companion object {
+        fun from(mime: String): ArtifactType = when {
+            mime.contains("mermaid") -> MERMAID
+            mime.contains("react") -> REACT
+            mime.contains("svg") -> SVG
+            mime.contains("markdown") || mime == "text/md" -> MARKDOWN
+            mime.contains("html") -> HTML
+            mime == "text/plain" -> PLAIN
+            else -> CODE
+        }
+    }
+}

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/ArtifactWebContent.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/ArtifactWebContent.kt
@@ -1,0 +1,235 @@
+package com.garfiec.librechat.feature.chat.components.artifact
+
+/**
+ * Builds the HTML document for an artifact preview. Used by both the fullscreen
+ * [ArtifactPanel] and the [InlineArtifactView]. Set [inline] to true when
+ * embedding inside a chat message: SVG/Markdown/Plain shrink their body
+ * padding, Mermaid additionally disables htmlLabels so the SVG can round-trip
+ * through Coil's SvgDecoder for the cache-harvest path. HTML and React
+ * templates ignore the flag — the surrounding Compose Surface supplies their
+ * padding.
+ */
+object ArtifactWebContent {
+
+    fun buildHtml(
+        content: String,
+        type: String,
+        isDarkTheme: Boolean,
+        inline: Boolean = false,
+    ): String {
+        val bgColor = if (isDarkTheme) "#1C1B1F" else "#FFFBFE"
+        val fgColor = if (isDarkTheme) "#E6E1E5" else "#1C1B1F"
+
+        return when (ArtifactType.from(type)) {
+            // htmlLabels = !inline: only the inline cache-harvest path needs htmlLabels
+            // disabled so the resulting SVG renders correctly through Coil 3's SvgDecoder
+            // (no foreignObject). The fullscreen ArtifactPanel renders via the live
+            // WebView+mermaid runtime so it keeps mermaid's default htmlLabels=true for
+            // label fidelity (bold/italic, <br/>, nested spans).
+            ArtifactType.MERMAID -> MermaidWebContent.buildHtml(content, isDarkTheme, inline, htmlLabels = !inline)
+            ArtifactType.MARKDOWN, ArtifactType.PLAIN -> MarkdownWebContent.buildHtml(content, isDarkTheme, inline)
+            ArtifactType.REACT -> buildReactHtml(content, bgColor, fgColor)
+            ArtifactType.SVG -> buildSvgHtml(content, bgColor, inline)
+            ArtifactType.HTML -> buildEnhancedHtml(content, bgColor, fgColor)
+            ArtifactType.CODE -> buildPlainHtml(content, bgColor, fgColor, inline)
+        }
+    }
+
+    // Security note: HTML artifacts intentionally render unsanitized HTML content.
+    // This is by design — HTML artifacts are meant to be rendered as-is. The WebView
+    // is sandboxed with a Content Security Policy restricting script/resource origins.
+    private fun buildEnhancedHtml(content: String, bgColor: String, fgColor: String): String {
+        val hasHtmlTag = content.contains("<html", ignoreCase = true) ||
+            content.contains("<!DOCTYPE", ignoreCase = true)
+
+        if (hasHtmlTag) {
+            val themeStyle = """
+                <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline' https://cdn.tailwindcss.com; style-src 'unsafe-inline'; img-src data: blob: https:; connect-src https://cdn.tailwindcss.com;">
+                <style>:root { --bg: $bgColor; --fg: $fgColor; } html, body { max-width: 100%; overflow-x: hidden; } body { background: var(--bg); color: var(--fg); margin: 0; padding: 0; } img, svg, video, iframe { max-width: 100%; height: auto; }</style>
+                <script src="https://cdn.tailwindcss.com"></script>
+            """.trimIndent()
+            return if (content.contains("<head>", ignoreCase = true)) {
+                content.replaceFirst(
+                    Regex("<head>", RegexOption.IGNORE_CASE),
+                    "<head>$themeStyle",
+                )
+            } else if (content.contains("<head ", ignoreCase = true)) {
+                val headMatch = Regex("<head\\s[^>]*>", RegexOption.IGNORE_CASE).find(content)
+                if (headMatch != null) {
+                    content.replaceRange(headMatch.range.last + 1, headMatch.range.last + 1, themeStyle)
+                } else {
+                    "$themeStyle\n$content"
+                }
+            } else {
+                "$themeStyle\n$content"
+            }
+        }
+
+        return """
+            <!DOCTYPE html>
+            <html>
+            <head>
+                <meta name="viewport" content="width=device-width, initial-scale=1.0">
+                <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline' https://cdn.tailwindcss.com; style-src 'unsafe-inline'; img-src data: blob: https:; connect-src https://cdn.tailwindcss.com;">
+                <script src="https://cdn.tailwindcss.com"></script>
+                <style>
+                    :root { --bg: $bgColor; --fg: $fgColor; }
+                    html, body { max-width: 100%; overflow-x: hidden; }
+                    body { background: var(--bg); color: var(--fg); margin: 0; padding: 0; }
+                    img, svg, video, iframe { max-width: 100%; height: auto; }
+                </style>
+            </head>
+            <body>$content</body>
+            </html>
+        """.trimIndent()
+    }
+
+    // Security note: SVG content is rendered unsanitized because SVG artifacts are
+    // designed to display user-provided vector graphics. CSP restricts script execution.
+    private fun buildSvgHtml(content: String, bgColor: String, inline: Boolean): String {
+        val padding = if (inline) "4px" else "16px"
+        val minHeight = if (inline) "0" else "100vh"
+        return """
+            <!DOCTYPE html>
+            <html>
+            <head>
+                <meta name="viewport" content="width=device-width, initial-scale=1.0">
+                <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; img-src data: blob:;">
+                <style>
+                    html, body { max-width: 100%; overflow-x: hidden; }
+                    body {
+                        margin: 0;
+                        padding: $padding;
+                        display: flex;
+                        justify-content: center;
+                        align-items: center;
+                        min-height: $minHeight;
+                        background: $bgColor;
+                    }
+                    svg, .svg-container {
+                        width: 100%;
+                        height: auto;
+                        max-width: 100%;
+                    }
+                </style>
+            </head>
+            <body><div class="svg-container">$content</div></body>
+            </html>
+        """.trimIndent()
+    }
+
+    // Security note: React artifacts intentionally render unsanitized content because they
+    // must execute user-provided JSX/JS code. 'unsafe-inline' and 'unsafe-eval' are required
+    // in script-src for Babel transpilation and React rendering.
+    private fun buildReactHtml(content: String, bgColor: String, fgColor: String): String {
+        val processed = content
+            .replace(Regex("""import\s*\{([^}]+)\}\s*from\s*['"]react['"];?""")) {
+                "const {${it.groupValues[1]}} = React;"
+            }
+            .replace(Regex("""import\s*React\s*from\s*['"]react['"];?"""), "")
+            .replace(Regex("""import\s*\{([^}]+)\}\s*from\s*['"]react-dom['"];?""")) {
+                "const {${it.groupValues[1]}} = ReactDOM;"
+            }
+            .replace(Regex("""export\s+default\s+function\s+"""), "function ")
+            .replace(Regex("""export\s+default\s+"""), "const _DefaultExport = ")
+
+        return """
+            <!DOCTYPE html>
+            <html>
+            <head>
+                <meta name="viewport" content="width=device-width, initial-scale=1.0">
+                <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline' 'unsafe-eval' https://unpkg.com https://cdn.tailwindcss.com; style-src 'unsafe-inline'; img-src data: blob: https:; connect-src https://cdn.tailwindcss.com;">
+                <script src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+                <script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+                <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+                <script src="https://cdn.tailwindcss.com"></script>
+                <style>
+                    :root { --bg: $bgColor; --fg: $fgColor; }
+                    html, body { max-width: 100%; overflow-x: hidden; }
+                    body { background: var(--bg); color: var(--fg); margin: 0; padding: 0; }
+                    img, svg, video, iframe { max-width: 100%; height: auto; }
+                    #error-display {
+                        display: none;
+                        padding: 16px;
+                        margin: 16px;
+                        background: #B3261E22;
+                        border: 1px solid #B3261E;
+                        border-radius: 8px;
+                        font-family: monospace;
+                        font-size: 13px;
+                        white-space: pre-wrap;
+                        color: $fgColor;
+                    }
+                </style>
+            </head>
+            <body>
+                <div id="root"></div>
+                <div id="error-display"></div>
+                <script>
+                    window.addEventListener('error', function(e) {
+                        var errDiv = document.getElementById('error-display');
+                        if (errDiv && !document.getElementById('root').hasChildNodes()) {
+                            errDiv.style.display = 'block';
+                            errDiv.textContent = 'Component compilation failed:\n' + (e.message || 'Unknown error');
+                        }
+                    });
+                </script>
+                <script type="text/babel">
+                    try {
+                        const { useState, useEffect, useRef, useMemo, useCallback, useReducer, useContext, createContext } = React;
+
+                        $processed
+
+                        const _root = ReactDOM.createRoot(document.getElementById('root'));
+                        const _Component = typeof _DefaultExport !== 'undefined' ? _DefaultExport
+                            : typeof App !== 'undefined' ? App
+                            : typeof Counter !== 'undefined' ? Counter
+                            : typeof Main !== 'undefined' ? Main
+                            : typeof Component !== 'undefined' ? Component
+                            : null;
+                        if (_Component) {
+                            if (typeof _Component === 'function') {
+                                _root.render(React.createElement(_Component));
+                            } else {
+                                _root.render(_Component);
+                            }
+                        }
+                    } catch (e) {
+                        var errDiv = document.getElementById('error-display');
+                        errDiv.style.display = 'block';
+                        errDiv.textContent = 'Component compilation failed:\n' + e.message;
+                    }
+                </script>
+            </body>
+            </html>
+        """.trimIndent()
+    }
+
+    private fun buildPlainHtml(content: String, bgColor: String, fgColor: String, inline: Boolean): String {
+        val padding = if (inline) "8px" else "16px"
+        val escaped = escapeHtml(content)
+        return """
+            <!DOCTYPE html>
+            <html>
+            <head>
+                <meta name="viewport" content="width=device-width, initial-scale=1.0">
+                <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline';">
+                <style>
+                    :root { --bg: $bgColor; --fg: $fgColor; }
+                    html, body { max-width: 100%; overflow-x: hidden; }
+                    body { background: var(--bg); color: var(--fg); margin: 0; padding: $padding; font-family: monospace; font-size: 13px; }
+                    pre { white-space: pre-wrap; word-wrap: break-word; margin: 0; }
+                </style>
+            </head>
+            <body><pre>$escaped</pre></body>
+            </html>
+        """.trimIndent()
+    }
+
+    fun escapeHtml(text: String): String = text
+        .replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace("\"", "&quot;")
+        .replace("'", "&#39;")
+}

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/InlineArtifactPrefsExt.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/InlineArtifactPrefsExt.kt
@@ -1,0 +1,18 @@
+package com.garfiec.librechat.feature.chat.components.artifact
+
+import com.garfiec.librechat.core.data.datastore.InlineArtifactPrefs
+
+/**
+ * Maps an artifact's MIME type to its [InlineArtifactPrefs] field via
+ * [ArtifactType]. Plain text and unrecognised code always render as the
+ * tap-to-open button (no toggle).
+ */
+fun InlineArtifactPrefs.shouldRenderInline(type: String): Boolean =
+    when (ArtifactType.from(type)) {
+        ArtifactType.MERMAID -> mermaid
+        ArtifactType.SVG -> svg
+        ArtifactType.HTML -> html
+        ArtifactType.REACT -> react
+        ArtifactType.MARKDOWN -> markdown
+        ArtifactType.PLAIN, ArtifactType.CODE -> false
+    }

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/InlineArtifactSizing.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/InlineArtifactSizing.kt
@@ -1,0 +1,11 @@
+package com.garfiec.librechat.feature.chat.components.artifact
+
+/**
+ * Inline artifact previews are capped to this fraction of the current window
+ * height. The full artifact remains available via the fullscreen [ArtifactPanel]
+ * on tap; the inline view is a "card preview" of the top portion. The cap also
+ * keeps the Android software-layer WebView's backing bitmap inside the
+ * paintable range — see `InlineArtifactView.android.kt` for the rendering
+ * rationale.
+ */
+internal const val INLINE_MAX_HEIGHT_FRACTION = 0.7f

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/InlineArtifactStrategy.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/InlineArtifactStrategy.kt
@@ -1,0 +1,39 @@
+package com.garfiec.librechat.feature.chat.components.artifact
+
+/**
+ * Result of the inline-artifact dispatch ladder. Decouples the routing decision
+ * from the composable that renders the selected strategy so the routing logic
+ * can be unit-tested without Compose.
+ */
+sealed interface InlineArtifactStrategy {
+    data class CachedMermaidSvg(val svg: String) : InlineArtifactStrategy
+    data object NativeMarkdown : InlineArtifactStrategy
+    data object IntrinsicSvg : InlineArtifactStrategy
+    data object WebViewSlot : InlineArtifactStrategy
+}
+
+/**
+ * Pure dispatch function for inline artifacts. Mirrors the previous inline
+ * `when` ladder in `SharedContentParts.TextContentPart`:
+ *  1. Cacheable mermaid with a populated cache entry → render the SVG directly.
+ *  2. Markdown → native compose-markdown renderer.
+ *  3. SVG → intrinsic-aspect-ratio renderer.
+ *  4. Everything else (HTML, React, uncached/non-cacheable Mermaid) →
+ *     platform WebView slot.
+ *
+ * The cache-hit gate intentionally stays narrow: even if a caller supplies a
+ * cached SVG for a non-cacheable mermaid source, we fall through to the WebView
+ * slot to avoid rendering a stale or wrong-shape SVG.
+ */
+fun selectInlineArtifactStrategy(
+    type: ArtifactType,
+    content: String,
+    cachedMermaidSvg: String?,
+): InlineArtifactStrategy = when {
+    type == ArtifactType.MERMAID &&
+        isCacheableMermaid(content) &&
+        !cachedMermaidSvg.isNullOrEmpty() -> InlineArtifactStrategy.CachedMermaidSvg(cachedMermaidSvg)
+    type == ArtifactType.MARKDOWN -> InlineArtifactStrategy.NativeMarkdown
+    type == ArtifactType.SVG -> InlineArtifactStrategy.IntrinsicSvg
+    else -> InlineArtifactStrategy.WebViewSlot
+}

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/InlineArtifactView.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/InlineArtifactView.kt
@@ -1,0 +1,19 @@
+package com.garfiec.librechat.feature.chat.components.artifact
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+/**
+ * Renders an artifact inline in a chat message. Fills the available width and
+ * scales height to match the rendered content. Tapping opens the fullscreen
+ * [ArtifactPanel] via [onTap].
+ *
+ * Used when the user has enabled inline rendering for the artifact's type in
+ * Settings > Chat > Artifacts.
+ */
+@Composable
+expect fun InlineArtifactView(
+    artifact: Artifact,
+    onTap: () -> Unit,
+    modifier: Modifier = Modifier,
+)

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/InlineMarkdownArtifact.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/InlineMarkdownArtifact.kt
@@ -1,0 +1,48 @@
+package com.garfiec.librechat.feature.chat.components.artifact
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.LayoutCoordinates
+import androidx.compose.ui.unit.dp
+import com.garfiec.librechat.feature.chat.components.MarkdownContent
+
+/**
+ * Native inline rendering for `text/markdown` artifacts. Bypasses the WebView
+ * path used by other artifact types — the chat's own `MarkdownContent` already
+ * supports CommonMark, GFM tables, syntax-highlighted code blocks, and native
+ * LaTeX, so we reuse it. This sidesteps async height measurement entirely:
+ * Compose knows the layout at measure time, so `LazyColumn` does not scroll-
+ * jump when these artifacts re-enter the viewport.
+ */
+@Composable
+fun InlineMarkdownArtifact(
+    artifact: Artifact,
+    onTap: () -> Unit,
+    modifier: Modifier = Modifier,
+    fontSizeMultiplier: Float = 1.0f,
+    searchQuery: String? = null,
+    searchFocusedOccurrence: Int = -1,
+    onFocusedOccurrencePosition: ((LayoutCoordinates) -> Unit)? = null,
+) {
+    ArtifactCardSurface(onTap = onTap, modifier = modifier) {
+        MarkdownContent(
+            text = artifact.content,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(12.dp),
+            fontSizeMultiplier = fontSizeMultiplier,
+            useKatex = false,
+            searchQuery = searchQuery,
+            searchFocusedOccurrence = searchFocusedOccurrence,
+            onFocusedOccurrencePosition = onFocusedOccurrencePosition,
+            // Synchronous parsing: the m3 Markdown composable parses async by
+            // default, so each text segment's height arrives over multiple
+            // frames and the LazyColumn scroll-jumps when the artifact item
+            // recycles back into view. The artifact content is already fully
+            // streamed, so blocking-parse is the right trade-off here.
+            immediate = true,
+        )
+    }
+}

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/InlineSvgArtifact.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/InlineSvgArtifact.kt
@@ -1,0 +1,64 @@
+package com.garfiec.librechat.feature.chat.components.artifact
+
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImage
+
+/**
+ * Native inline rendering for `image/svg+xml` artifacts via Coil's SVG decoder.
+ * The decoder produces an image at the SVG's intrinsic aspect ratio, so Compose
+ * sizes the artifact deterministically (width × intrinsic-aspect = height) once
+ * Coil has parsed the bytes — no WebView, no async height measurement, no JS.
+ * SvgDecoder.Factory must be registered on the singleton ImageLoader.
+ */
+@Composable
+fun InlineSvgArtifact(
+    artifact: Artifact,
+    onTap: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    InlineSvgSurface(
+        svg = artifact.content,
+        onTap = onTap,
+        modifier = modifier,
+        contentDescription = artifact.title,
+    )
+}
+
+/**
+ * Pure SVG-string entry point reused by the cached-mermaid path, which doesn't
+ * have an [Artifact] handy at the moment of the cache hit. [contentPadding] is
+ * exposed because mermaid SVGs have their own internal `<g>` translate offset;
+ * the default 12.dp is correct for user-authored SVGs but leaves too much
+ * whitespace around cached mermaids.
+ */
+@Composable
+fun InlineSvgSurface(
+    svg: String,
+    onTap: () -> Unit,
+    modifier: Modifier = Modifier,
+    contentDescription: String? = null,
+    contentPadding: Dp = 12.dp,
+) {
+    val svgBytes = remember(svg) { svg.encodeToByteArray() }
+    val aspectRatio = remember(svg) { parseSvgAspectRatio(svg) }
+    ArtifactCardSurface(onTap = onTap, modifier = modifier) {
+        AsyncImage(
+            model = svgBytes,
+            contentDescription = contentDescription,
+            contentScale = ContentScale.FillWidth,
+            modifier = Modifier
+                .fillMaxWidth()
+                .let { if (aspectRatio != null) it.aspectRatio(aspectRatio) else it.heightIn(min = 80.dp) }
+                .padding(contentPadding),
+        )
+    }
+}

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/LocalInlineArtifactPrefs.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/LocalInlineArtifactPrefs.kt
@@ -1,0 +1,15 @@
+package com.garfiec.librechat.feature.chat.components.artifact
+
+import androidx.compose.runtime.compositionLocalOf
+import com.garfiec.librechat.core.data.datastore.InlineArtifactPrefs
+
+/**
+ * Composition-scoped inline-artifact preferences. Provided once at the chat
+ * screen root after collecting from [SettingsDataStore]; consumed by
+ * [TextContentPart] (deep inside the per-message content renderer) to decide
+ * whether to render an artifact inline or as a tap-to-open button.
+ *
+ * Default value is all-false so any composable outside the provided scope
+ * preserves the existing button behavior.
+ */
+val LocalInlineArtifactPrefs = compositionLocalOf { InlineArtifactPrefs() }

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/LocalMermaidRenderCache.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/LocalMermaidRenderCache.kt
@@ -1,0 +1,18 @@
+package com.garfiec.librechat.feature.chat.components.artifact
+
+import androidx.compose.runtime.staticCompositionLocalOf
+
+/**
+ * Composition-scoped mermaid SVG cache. `static` because the cache instance
+ * reference is stable for the chat session — only its internal map contents
+ * mutate, and those go through [SnapshotStateMap] which observes reads
+ * independently.
+ *
+ * The default `error(...)` initializer forces callers to wrap chat content in
+ * `ChatRoot { }`. Tests that exercise composables consuming the cache can
+ * provide a fresh `MermaidRenderCache()` via `CompositionLocalProvider` in the
+ * test setup.
+ */
+val LocalMermaidRenderCache = staticCompositionLocalOf<MermaidRenderCache> {
+    error("LocalMermaidRenderCache not provided; wrap chat content in ChatRoot { }")
+}

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/MarkdownWebContent.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/MarkdownWebContent.kt
@@ -6,13 +6,14 @@ package com.garfiec.librechat.feature.chat.components.artifact
  */
 object MarkdownWebContent {
 
-    fun buildHtml(markdownContent: String, isDarkTheme: Boolean): String {
+    fun buildHtml(markdownContent: String, isDarkTheme: Boolean, inline: Boolean = false): String {
         val bgColor = if (isDarkTheme) "#1C1B1F" else "#FFFBFE"
         val fgColor = if (isDarkTheme) "#E6E1E5" else "#1C1B1F"
         val codeBg = if (isDarkTheme) "#2B2930" else "#F3EDF7"
         val borderColor = if (isDarkTheme) "#48464C" else "#CAC4D0"
         val linkColor = if (isDarkTheme) "#D0BCFF" else "#6750A4"
         val hlTheme = if (isDarkTheme) "github-dark" else "github"
+        val bodyPadding = if (inline) "8px" else "16px"
         val escapedContent = markdownContent
             .replace("\\", "\\\\")
             .replace("`", "\\`")
@@ -26,9 +27,10 @@ object MarkdownWebContent {
                 <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'unsafe-inline' https://cdn.jsdelivr.net; img-src data: blob: https:;">
                 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/highlight.js@11/styles/$hlTheme.min.css">
                 <style>
+                    html, body { max-width: 100%; overflow-x: hidden; }
                     body {
                         margin: 0;
-                        padding: 16px;
+                        padding: $bodyPadding;
                         background: $bgColor;
                         color: $fgColor;
                         font-family: -apple-system, system-ui, sans-serif;

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/MermaidBridgeReceiver.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/MermaidBridgeReceiver.kt
@@ -1,0 +1,21 @@
+package com.garfiec.librechat.feature.chat.components.artifact
+
+/**
+ * Per-WebView SVG sink. Immutable after construction — one receiver per
+ * (cache, key) pair, allocated inside the AndroidView/UIKitView factory at the
+ * mount site under a `key(mermaidKey) { ... }` block. Content/theme change
+ * destroys the entire view slot, taking this receiver with it; the new slot
+ * gets a fresh receiver bound to the new key.
+ *
+ * Per-key allocation eliminates the stale-capture race (a receiver can never
+ * outlive the key it was constructed with) and the mid-render content-swap
+ * race (the destroyed WebView's JS can no longer reach this receiver).
+ */
+internal class MermaidBridgeReceiver(
+    private val cache: MermaidRenderCache,
+    private val key: String,
+) {
+    fun onSvg(svg: String) {
+        cache.put(key, svg)
+    }
+}

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/MermaidRenderCache.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/MermaidRenderCache.kt
@@ -1,0 +1,39 @@
+package com.garfiec.librechat.feature.chat.components.artifact
+
+import com.garfiec.librechat.feature.chat.components.LruSnapshotCache
+
+/**
+ * Compose-observable in-memory cache of mermaid-rendered SVG strings, keyed by
+ * `${contentHashCode}:$isDark`. Filled by inline-artifact WebViews via a JS
+ * bridge; read by `SharedContentParts` when a recompose reaches an already-
+ * rendered flowchart mermaid.
+ */
+class MermaidRenderCache(maxEntries: Int = MAX_ENTRIES_DEFAULT) :
+    LruSnapshotCache<String>(maxEntries) {
+
+    private companion object {
+        const val MAX_ENTRIES_DEFAULT = 100
+    }
+}
+
+fun mermaidCacheKey(content: String, isDark: Boolean): String =
+    "${content.hashCode()}:$isDark"
+
+/**
+ * Allowlist of mermaid diagram types that render pixel-equivalent through Coil's
+ * SvgDecoder. State and gantt diagrams render incorrectly (wrong-scale and
+ * silent-blank respectively), so only flowchart/graph artifacts route through
+ * the SVG cache; the rest re-render in the WebView on every recompose.
+ *
+ * The scan skips blank lines and `%%`-prefixed mermaid directives (e.g.
+ * `%%{init: {...}}%%`) so flowcharts with config preambles still match.
+ */
+fun isCacheableMermaid(content: String): Boolean {
+    val firstKeyword = content.lineSequence()
+        .map { it.trim() }
+        .firstOrNull { it.isNotEmpty() && !it.startsWith("%%") }
+        ?.substringBefore(' ')
+        ?.substringBefore('\t')
+        ?: return false
+    return firstKeyword == "flowchart" || firstKeyword == "graph"
+}

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/MermaidWebContent.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/MermaidWebContent.kt
@@ -9,11 +9,18 @@ package com.garfiec.librechat.feature.chat.components.artifact
  */
 object MermaidWebContent {
 
-    fun buildHtml(mermaidCode: String, isDarkTheme: Boolean): String {
+    fun buildHtml(
+        mermaidCode: String,
+        isDarkTheme: Boolean,
+        inline: Boolean = false,
+        htmlLabels: Boolean = false,
+    ): String {
         val theme = if (isDarkTheme) "dark" else "default"
         val bgColor = if (isDarkTheme) "#1C1B1F" else "#FFFBFE"
         val fgColor = if (isDarkTheme) "#E6E1E5" else "#1C1B1F"
         val btnBg = if (isDarkTheme) "#332D41" else "#E8DEF8"
+        val bodyPadding = if (inline) "4px" else "16px"
+        val zoomDisplay = if (inline) "none" else "flex"
         val escapedCode = mermaidCode
             .replace("\\", "\\\\")
             .replace("`", "\\`")
@@ -26,9 +33,10 @@ object MermaidWebContent {
                 <meta name="viewport" content="width=device-width, initial-scale=1.0">
                 <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'unsafe-inline'; img-src data:;">
                 <style>
+                    html, body { max-width: 100%; overflow-x: hidden; }
                     body {
                         margin: 0;
-                        padding: 16px;
+                        padding: $bodyPadding;
                         background: $bgColor;
                         color: $fgColor;
                         display: flex;
@@ -52,7 +60,7 @@ object MermaidWebContent {
                         position: fixed;
                         bottom: 12px;
                         right: 12px;
-                        display: flex;
+                        display: $zoomDisplay;
                         gap: 8px;
                         z-index: 10;
                     }
@@ -134,7 +142,8 @@ object MermaidWebContent {
                     mermaid.initialize({
                         startOnLoad: false,
                         theme: '$theme',
-                        securityLevel: 'loose'
+                        securityLevel: 'loose',
+                        flowchart: { htmlLabels: $htmlLabels }
                     });
 
                     (async function() {
@@ -142,6 +151,11 @@ object MermaidWebContent {
                             var code = `$escapedCode`;
                             var result = await mermaid.render('mermaid-graph', code);
                             document.getElementById('mermaid-container').innerHTML = result.svg;
+                            try {
+                                if (window.MermaidBridge && window.MermaidBridge.onSvg) {
+                                    window.MermaidBridge.onSvg(result.svg);
+                                }
+                            } catch (e) { /* swallow; bridge failure must not break visible render */ }
                         } catch (e) {
                             document.getElementById('error-display').style.display = 'block';
                             document.getElementById('error-display').textContent = 'Mermaid parse error:\n' + e.message + '\n\nRaw code:\n' + `$escapedCode`;

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/SvgIntrinsicSize.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/SvgIntrinsicSize.kt
@@ -1,0 +1,42 @@
+package com.garfiec.librechat.feature.chat.components.artifact
+
+private val VIEW_BOX_REGEX = Regex(
+    """<svg\b[^>]*\bviewBox\s*=\s*["']\s*(-?[\d.]+)\s+(-?[\d.]+)\s+([\d.]+)\s+([\d.]+)\s*["']""",
+    RegexOption.IGNORE_CASE,
+)
+
+private val WIDTH_REGEX = Regex(
+    """<svg\b[^>]*\bwidth\s*=\s*["']\s*([\d.]+)(?:px)?\s*["']""",
+    RegexOption.IGNORE_CASE,
+)
+
+private val HEIGHT_REGEX = Regex(
+    """<svg\b[^>]*\bheight\s*=\s*["']\s*([\d.]+)(?:px)?\s*["']""",
+    RegexOption.IGNORE_CASE,
+)
+
+/**
+ * Extracts the SVG's intrinsic aspect ratio (width / height) from the root
+ * `<svg>` tag without doing a full XML parse. `viewBox` is preferred because
+ * mermaid always emits it; explicit `width`/`height` attributes are the
+ * fallback for hand-authored SVG artifacts. Returns null when neither is
+ * usable, which lets callers fall back to the legacy `heightIn(min = 80.dp)`
+ * behavior.
+ *
+ * Used by [InlineSvgArtifact] to apply `Modifier.aspectRatio` so the artifact
+ * occupies its final height before Coil's async decode completes — eliminating
+ * the LazyColumn scroll-jump for cached-mermaid and SVG artifacts.
+ */
+fun parseSvgAspectRatio(svg: String): Float? {
+    val viewBoxMatch = VIEW_BOX_REGEX.find(svg)
+    if (viewBoxMatch != null) {
+        val width = viewBoxMatch.groupValues[3].toFloatOrNull() ?: return null
+        val height = viewBoxMatch.groupValues[4].toFloatOrNull() ?: return null
+        if (width > 0f && height > 0f) return width / height
+    }
+    val widthMatch = WIDTH_REGEX.find(svg) ?: return null
+    val heightMatch = HEIGHT_REGEX.find(svg) ?: return null
+    val width = widthMatch.groupValues[1].toFloatOrNull() ?: return null
+    val height = heightMatch.groupValues[1].toFloatOrNull() ?: return null
+    return if (width > 0f && height > 0f) width / height else null
+}

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatUiState.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatUiState.kt
@@ -5,6 +5,7 @@ import com.garfiec.librechat.core.common.ChatLayoutConstants
 import com.garfiec.librechat.core.common.EndpointConstants
 import com.garfiec.librechat.core.common.ToolConstants
 import com.garfiec.librechat.core.data.datastore.ChatFontSize
+import com.garfiec.librechat.core.data.datastore.InlineArtifactPrefs
 import com.garfiec.librechat.core.data.datastore.LatexRenderer
 import com.garfiec.librechat.core.model.Agent
 import com.garfiec.librechat.core.model.Attachment
@@ -48,6 +49,7 @@ data class ChatPreferences(
     val autoSendAfterStt: Boolean = false,
     val sttEngine: String = "",
     val sttLanguage: String = "",
+    val inlineArtifactPrefs: InlineArtifactPrefs = InlineArtifactPrefs(),
 )
 
 /**

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModel.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModel.kt
@@ -40,6 +40,7 @@ import com.garfiec.librechat.core.model.permissions.hasAccessOrPermissive
 import com.garfiec.librechat.core.model.request.EphemeralAgent
 import com.garfiec.librechat.core.ui.components.ModelParameters
 import com.garfiec.librechat.feature.chat.components.AttachedFile
+import com.garfiec.librechat.feature.chat.components.ParsedMarkdownCache
 import com.garfiec.librechat.feature.chat.model.PresetDisplayData
 import com.garfiec.librechat.feature.chat.model.PromptMentionDisplayData
 import com.garfiec.librechat.feature.chat.util.NEW_CHAT_DRAFT_KEY
@@ -101,6 +102,19 @@ class ChatViewModel(
 
     private val stateHandle = ChatStateHandle(_uiState, viewModelScope)
 
+    // Mermaid SVG cache, scoped to this ViewModel's lifecycle. Filled by inline-
+    // artifact WebViews via a JS bridge; read by SharedContentParts when a
+    // recompose reaches an already-rendered flowchart mermaid.
+    val mermaidRenderCache: com.garfiec.librechat.feature.chat.components.artifact.MermaidRenderCache =
+        com.garfiec.librechat.feature.chat.components.artifact.MermaidRenderCache()
+
+    // Parsed-AST cache for chat-text markdown. m3 parses async; when a LazyColumn
+    // item is recycled its remembered state dies and parsing restarts, producing
+    // a 0-px → final-height cascade that pushes adjacent inline-artifact slots
+    // around (the scroll-jump root cause). Caching the parsed State.Success lets
+    // re-entry render directly from the cached AST. See CachedMarkdown.
+    val parsedMarkdownCache: ParsedMarkdownCache = ParsedMarkdownCache()
+
     // --- Platform delegates (created via factory so they get the ViewModel's stateHandle) ---
     private val fileDelegate = platformDelegateFactory.createFileHandler(stateHandle)
     private val ttsDelegate = platformDelegateFactory.createTts(stateHandle, ::getMessageText)
@@ -130,30 +144,60 @@ class ChatViewModel(
     val attachedFiles: StateFlow<List<AttachedFile>> get() = fileDelegate.attachedFiles
     val shareLinkUrl: StateFlow<String?> get() = conversationActionsDelegate.shareLinkUrl
 
-    @Suppress("UNCHECKED_CAST")
-    val chatPreferences: StateFlow<ChatPreferences> = combine<Any, ChatPreferences>(
-        listOf(
-            settingsDataStore.showImageDescriptions,
-            settingsDataStore.dismissKeyboardOnSend,
-            settingsDataStore.chatLayoutStyle,
-            settingsDataStore.showAvatars,
-            settingsDataStore.showBubbles,
-            settingsDataStore.latexRenderer,
-            settingsDataStore.autoSendAfterStt,
-            settingsDataStore.sttEngine,
-            settingsDataStore.sttLanguage,
-        ),
-    ) { values ->
+    private data class BaseChatPrefs(
+        val showImageDescriptions: Boolean,
+        val dismissKeyboardOnSend: Boolean,
+        val chatLayoutStyle: String,
+        val showAvatars: Boolean,
+        val showBubbles: Boolean,
+    )
+
+    private data class SttAndRendererPrefs(
+        val latexRenderer: LatexRenderer,
+        val autoSendAfterStt: Boolean,
+        val sttEngine: String,
+        val sttLanguage: String,
+        val inlineArtifactPrefs: com.garfiec.librechat.core.data.datastore.InlineArtifactPrefs,
+    )
+
+    // Combined in stages because Kotlin's `combine` maxes out at 5 args. Each stage
+    // produces a typed sub-record, and they're folded into `ChatPreferences` at the end.
+    // Adding a new pref: extend a sub-record (or add a third combine) — no positional casts.
+    private val baseChatPrefs = combine(
+        settingsDataStore.showImageDescriptions,
+        settingsDataStore.dismissKeyboardOnSend,
+        settingsDataStore.chatLayoutStyle,
+        settingsDataStore.showAvatars,
+        settingsDataStore.showBubbles,
+    ) { imgDesc, dismissKb, layout, avatars, bubbles ->
+        BaseChatPrefs(imgDesc, dismissKb, layout, avatars, bubbles)
+    }
+
+    private val sttAndRendererPrefs = combine(
+        settingsDataStore.latexRenderer,
+        settingsDataStore.autoSendAfterStt,
+        settingsDataStore.sttEngine,
+        settingsDataStore.sttLanguage,
+        settingsDataStore.inlineArtifactPrefs,
+    ) { latex, autoSendStt, sttEngine, sttLang, inlineArtifacts ->
+        SttAndRendererPrefs(latex, autoSendStt, sttEngine, sttLang, inlineArtifacts)
+    }
+
+    val chatPreferences: StateFlow<ChatPreferences> = combine(
+        baseChatPrefs,
+        sttAndRendererPrefs,
+    ) { base, sttRenderer ->
         ChatPreferences(
-            showImageDescriptions = values[0] as Boolean,
-            dismissKeyboardOnSend = values[1] as Boolean,
-            chatLayoutStyle = values[2] as String,
-            showAvatars = values[3] as Boolean,
-            showBubbles = values[4] as Boolean,
-            latexRenderer = values[5] as LatexRenderer,
-            autoSendAfterStt = values[6] as Boolean,
-            sttEngine = values[7] as String,
-            sttLanguage = values[8] as String,
+            showImageDescriptions = base.showImageDescriptions,
+            dismissKeyboardOnSend = base.dismissKeyboardOnSend,
+            chatLayoutStyle = base.chatLayoutStyle,
+            showAvatars = base.showAvatars,
+            showBubbles = base.showBubbles,
+            latexRenderer = sttRenderer.latexRenderer,
+            autoSendAfterStt = sttRenderer.autoSendAfterStt,
+            sttEngine = sttRenderer.sttEngine,
+            sttLanguage = sttRenderer.sttLanguage,
+            inlineArtifactPrefs = sttRenderer.inlineArtifactPrefs,
         )
     }.stateIn(viewModelScope, SharingStarted.Eagerly, ChatPreferences())
 

--- a/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/components/PlatformChatComponents.ios.kt
+++ b/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/components/PlatformChatComponents.ios.kt
@@ -72,16 +72,12 @@ import com.garfiec.librechat.feature.chat.resources.cd_expand_table
 import com.garfiec.librechat.feature.chat.resources.dialog_table
 import com.garfiec.librechat.feature.chat.resources.sender_assistant
 import com.garfiec.librechat.feature.chat.resources.sender_you
-import com.mikepenz.markdown.m3.Markdown
 import com.mikepenz.markdown.m3.markdownColor
 import com.mikepenz.markdown.m3.markdownTypography
 import kotlinx.coroutines.delay
-import org.intellij.markdown.flavours.gfm.GFMFlavourDescriptor
 import org.jetbrains.compose.resources.stringResource
 
 private const val ACTION_AUTO_HIDE_MILLIS = 30_000L
-
-private val GFM_FLAVOUR = GFMFlavourDescriptor()
 
 // ─── MessageBubble ───────────────────────────────────────────────────
 
@@ -382,6 +378,7 @@ actual fun MarkdownContent(
     text: String, modifier: Modifier, fontSizeMultiplier: Float, useKatex: Boolean,
     searchQuery: String?, searchFocusedOccurrence: Int,
     onFocusedOccurrencePosition: ((LayoutCoordinates) -> Unit)?,
+    immediate: Boolean,
 ) {
     val segments = remember(text) { parseMarkdownSegments(text) }
 
@@ -441,12 +438,12 @@ actual fun MarkdownContent(
                                 is InlineSegment.Text -> {
                                     if (inlineSegment.text.isNotBlank()) {
                                         key(fontSizeMultiplier) {
-                                            Markdown(
+                                            CachedMarkdown(
                                                 content = inlineSegment.text,
                                                 colors = colors,
                                                 typography = typography,
-                                                flavour = GFM_FLAVOUR,
                                                 modifier = Modifier.fillMaxWidth(),
+                                                immediate = immediate,
                                             )
                                         }
                                     }
@@ -474,12 +471,12 @@ actual fun MarkdownContent(
                 }
                 is MarkdownSegment.TextBlock -> {
                     key(fontSizeMultiplier, index) {
-                        Markdown(
+                        CachedMarkdown(
                             content = segment.text,
                             colors = colors,
                             typography = typography,
-                            flavour = GFM_FLAVOUR,
                             modifier = Modifier.fillMaxWidth(),
+                            immediate = immediate,
                         )
                     }
                 }

--- a/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/components/PlatformMediaComponents.ios.kt
+++ b/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/components/PlatformMediaComponents.ios.kt
@@ -52,7 +52,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.interop.UIKitView
+import androidx.compose.ui.viewinterop.UIKitView
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp

--- a/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/InlineArtifactView.ios.kt
+++ b/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/InlineArtifactView.ios.kt
@@ -1,0 +1,95 @@
+package com.garfiec.librechat.feature.chat.components.artifact
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.UIKitView
+import com.garfiec.librechat.core.ui.theme.isSurfaceDark
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.cValue
+import kotlinx.cinterop.useContents
+import platform.Foundation.NSURL
+import platform.UIKit.UIScreen
+import platform.WebKit.WKWebView
+import platform.WebKit.WKWebViewConfiguration
+
+/**
+ * iOS inline artifact preview. The slot is hardcoded to the inline cap for
+ * every type routed here (HTML, React, uncached Mermaid) — matching Android.
+ * SVG and cached Mermaid take the synchronous-aspect-ratio path via
+ * `InlineSvgSurface` upstream; Markdown renders natively. iOS does not
+ * participate in the mermaid SVG cache (Coil 3 on Apple uses Skia SVGDOM, not
+ * AndroidSVG — fidelity is unverified). Full content lives in the fullscreen
+ * [ArtifactPanel] on tap.
+ */
+@OptIn(ExperimentalForeignApi::class)
+@Composable
+actual fun InlineArtifactView(
+    artifact: Artifact,
+    onTap: () -> Unit,
+    modifier: Modifier,
+) {
+    val isDarkTheme = isSurfaceDark()
+    val html = remember(artifact, isDarkTheme) {
+        ArtifactWebContent.buildHtml(artifact.content, artifact.type, isDarkTheme, inline = true)
+    }
+
+    // Match the Android cap (see InlineArtifactSizing.kt). On iOS, points map
+    // 1:1 to Compose Dp, so UIScreen.mainScreen.bounds.size.height is already
+    // in the unit we want.
+    val maxInlineHeightDp = remember {
+        UIScreen.mainScreen.bounds.useContents { size.height * INLINE_MAX_HEIGHT_FRACTION }.dp
+    }
+
+    val uiKitViewBlock: @Composable () -> Unit = {
+        var loadedHtml by remember { mutableStateOf("") }
+
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(2.dp),
+        ) {
+            UIKitView(
+                modifier = Modifier.fillMaxWidth().height(maxInlineHeightDp),
+                factory = {
+                    val config = WKWebViewConfiguration().apply {
+                        defaultWebpagePreferences.allowsContentJavaScript = true
+                    }
+                    val webView = WKWebView(frame = cValue { }, configuration = config)
+                    webView.setOpaque(false)
+                    webView.scrollView.setScrollEnabled(false)
+                    webView.loadHTMLString(
+                        html,
+                        baseURL = NSURL.URLWithString("https://cdn.jsdelivr.net"),
+                    )
+                    loadedHtml = html
+                    webView
+                },
+                update = { webView ->
+                    if (html != loadedHtml) {
+                        webView.loadHTMLString(
+                            html,
+                            baseURL = NSURL.URLWithString("https://cdn.jsdelivr.net"),
+                        )
+                        loadedHtml = html
+                    }
+                },
+                onRelease = { webView ->
+                    webView.stopLoading()
+                },
+            )
+        }
+    }
+
+    ArtifactCardSurface(onTap = onTap, modifier = modifier) {
+        uiKitViewBlock()
+    }
+}

--- a/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/PlatformArtifactPanel.ios.kt
+++ b/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/PlatformArtifactPanel.ios.kt
@@ -7,32 +7,54 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.interop.UIKitView
+import androidx.compose.ui.viewinterop.UIKitView
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
+import com.garfiec.librechat.core.ui.theme.isSurfaceDark
+import com.garfiec.librechat.feature.chat.components.CodeBlock
 import com.garfiec.librechat.feature.chat.components.shareArtifact
+import com.garfiec.librechat.feature.chat.resources.Res
+import com.garfiec.librechat.feature.chat.resources.code
+import com.garfiec.librechat.feature.chat.resources.preview
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.cValue
+import org.jetbrains.compose.resources.stringResource
 import platform.Foundation.NSURL
 import platform.WebKit.WKWebView
 import platform.WebKit.WKWebViewConfiguration
+
+private fun isPreviewableType(type: String): Boolean =
+    when (ArtifactType.from(type)) {
+        ArtifactType.MERMAID,
+        ArtifactType.REACT,
+        ArtifactType.SVG,
+        ArtifactType.MARKDOWN,
+        ArtifactType.HTML,
+        ArtifactType.PLAIN,
+        -> true
+        ArtifactType.CODE -> false
+    }
 
 @OptIn(ExperimentalForeignApi::class)
 @Composable
@@ -46,16 +68,13 @@ actual fun ArtifactPanel(
         mutableIntStateOf(versions.indexOfFirst { it.identifier == artifact.identifier && it.version == artifact.version }.coerceAtLeast(0))
     }
     val currentArtifact = versions.getOrElse(currentVersionIndex) { artifact }
+    val isPreviewable = isPreviewableType(currentArtifact.type)
+    var selectedTab by remember { mutableIntStateOf(0) }
 
-    val isDarkTheme = MaterialTheme.colorScheme.surface.let { color ->
-        val r = (color.red * 255).toInt()
-        val g = (color.green * 255).toInt()
-        val b = (color.blue * 255).toInt()
-        (r * 0.299 + g * 0.587 + b * 0.114) < 128
-    }
+    val isDarkTheme = isSurfaceDark()
 
     val html = remember(currentArtifact, isDarkTheme) {
-        buildArtifactHtml(currentArtifact, isDarkTheme)
+        ArtifactWebContent.buildHtml(currentArtifact.content, currentArtifact.type, isDarkTheme, inline = false)
     }
 
     Dialog(
@@ -119,83 +138,75 @@ actual fun ArtifactPanel(
                 }
             }
 
-            // WebView content
-            Box(modifier = Modifier.weight(1f).fillMaxWidth()) {
-                UIKitView(
-                    modifier = Modifier.fillMaxSize(),
-                    factory = {
-                        val config = WKWebViewConfiguration().apply {
-                            defaultWebpagePreferences.allowsContentJavaScript = true
-                        }
-                        val webView = WKWebView(
-                            frame = cValue { },
-                            configuration = config,
-                        )
-                        webView.setOpaque(false)
-                        webView.loadHTMLString(
-                            html,
-                            baseURL = NSURL.URLWithString("https://cdn.jsdelivr.net"),
-                        )
-                        webView
-                    },
-                    update = { webView ->
-                        webView.loadHTMLString(
-                            html,
-                            baseURL = NSURL.URLWithString("https://cdn.jsdelivr.net"),
-                        )
-                    },
-                )
+            if (isPreviewable) {
+                TabRow(selectedTabIndex = selectedTab) {
+                    Tab(
+                        selected = selectedTab == 0,
+                        onClick = { selectedTab = 0 },
+                        text = { Text(stringResource(Res.string.code)) },
+                    )
+                    Tab(
+                        selected = selectedTab == 1,
+                        onClick = { selectedTab = 1 },
+                        text = { Text(stringResource(Res.string.preview)) },
+                    )
+                }
             }
-        }
-    }
-}
 
-private fun buildArtifactHtml(artifact: Artifact, isDarkTheme: Boolean): String {
-    return when {
-        artifact.type.contains("mermaid") -> {
-            MermaidWebContent.buildHtml(artifact.content, isDarkTheme)
-        }
-        artifact.type.contains("markdown") || artifact.type == "text/md" -> {
-            MarkdownWebContent.buildHtml(artifact.content, isDarkTheme)
-        }
-        artifact.type.contains("html") || artifact.type.contains("react") || artifact.type.contains("svg") -> {
-            // Render HTML/React/SVG directly
-            val bgColor = if (isDarkTheme) "#1C1B1F" else "#FFFBFE"
-            val fgColor = if (isDarkTheme) "#E6E1E5" else "#1C1B1F"
-            """
-            <!DOCTYPE html>
-            <html>
-            <head>
-                <meta name="viewport" content="width=device-width, initial-scale=1.0">
-                <style>
-                    body { margin: 0; padding: 16px; background: $bgColor; color: $fgColor; font-family: -apple-system, system-ui, sans-serif; }
-                </style>
-            </head>
-            <body>${artifact.content}</body>
-            </html>
-            """.trimIndent()
-        }
-        else -> {
-            // Plain text / code
-            val bgColor = if (isDarkTheme) "#1C1B1F" else "#FFFBFE"
-            val fgColor = if (isDarkTheme) "#E6E1E5" else "#1C1B1F"
-            val escaped = artifact.content
-                .replace("&", "&amp;")
-                .replace("<", "&lt;")
-                .replace(">", "&gt;")
-            """
-            <!DOCTYPE html>
-            <html>
-            <head>
-                <meta name="viewport" content="width=device-width, initial-scale=1.0">
-                <style>
-                    body { margin: 0; padding: 16px; background: $bgColor; color: $fgColor; font-family: monospace; }
-                    pre { white-space: pre-wrap; word-wrap: break-word; }
-                </style>
-            </head>
-            <body><pre>$escaped</pre></body>
-            </html>
-            """.trimIndent()
+            // Content body
+            Box(modifier = Modifier.weight(1f).fillMaxWidth()) {
+                when {
+                    !isPreviewable || selectedTab == 0 -> {
+                        val codeScrollState = rememberScrollState()
+                        Box(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .padding(8.dp)
+                                .verticalScroll(codeScrollState),
+                        ) {
+                            CodeBlock(
+                                code = currentArtifact.content,
+                                language = currentArtifact.language,
+                                modifier = Modifier.fillMaxWidth(),
+                            )
+                        }
+                    }
+                    selectedTab == 1 -> {
+                        // Track what HTML is currently loaded to avoid reloading on every
+                        // recomposition — version-nav swipes and Dialog animations otherwise
+                        // re-trigger loadHTMLString and flash the WebView.
+                        var loadedHtml by remember { mutableStateOf("") }
+                        UIKitView(
+                            modifier = Modifier.fillMaxSize(),
+                            factory = {
+                                val config = WKWebViewConfiguration().apply {
+                                    defaultWebpagePreferences.allowsContentJavaScript = true
+                                }
+                                val webView = WKWebView(
+                                    frame = cValue { },
+                                    configuration = config,
+                                )
+                                webView.setOpaque(false)
+                                webView.loadHTMLString(
+                                    html,
+                                    baseURL = NSURL.URLWithString("https://cdn.jsdelivr.net"),
+                                )
+                                loadedHtml = html
+                                webView
+                            },
+                            update = { webView ->
+                                if (html != loadedHtml) {
+                                    webView.loadHTMLString(
+                                        html,
+                                        baseURL = NSURL.URLWithString("https://cdn.jsdelivr.net"),
+                                    )
+                                    loadedHtml = html
+                                }
+                            },
+                        )
+                    }
+                }
+            }
         }
     }
 }

--- a/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/screen/PlatformScreens.ios.kt
+++ b/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/screen/PlatformScreens.ios.kt
@@ -64,6 +64,7 @@ import com.garfiec.librechat.core.data.datastore.LatexRenderer
 import com.garfiec.librechat.feature.chat.components.InConvoSearchBar
 import com.garfiec.librechat.feature.chat.components.IosChatInput
 import com.garfiec.librechat.feature.chat.components.LandingContent
+import com.garfiec.librechat.feature.chat.components.ChatRoot
 import com.garfiec.librechat.feature.chat.components.MessageList
 import com.garfiec.librechat.feature.chat.components.ModelSelectorButton
 import com.garfiec.librechat.feature.chat.components.ModelSelectorSheet
@@ -166,6 +167,11 @@ actual fun ChatScreen(
 
     val sendBlockMessage = uiState.sendBlockReason?.asString()
 
+    ChatRoot(
+        inlineArtifactPrefs = prefs.inlineArtifactPrefs,
+        mermaidRenderCache = viewModel.mermaidRenderCache,
+        parsedMarkdownCache = viewModel.parsedMarkdownCache,
+    ) {
     Scaffold(
         modifier = modifier.imePadding(),
         snackbarHost = { SnackbarHost(snackbarHostState) },
@@ -642,6 +648,7 @@ actual fun ChatScreen(
                 }
             },
         )
+    }
     }
 }
 

--- a/feature/settings/src/commonMain/composeResources/values/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values/strings.xml
@@ -167,6 +167,20 @@
     <string name="dismiss_keyboard_on_send">Dismiss keyboard after sending</string>
     <string name="dismiss_keyboard_on_send_desc">Automatically hide the keyboard after sending a message</string>
 
+    <!-- Artifacts -->
+    <string name="section_artifacts">Artifacts</string>
+    <string name="artifacts_section_desc">Render artifacts directly in the chat instead of behind a tap-to-open card. Tap an inline artifact to open the fullscreen view.</string>
+    <string name="inline_artifact_mermaid">Mermaid diagrams</string>
+    <string name="inline_artifact_mermaid_desc">Render Mermaid flowcharts and diagrams inline</string>
+    <string name="inline_artifact_svg">SVG images</string>
+    <string name="inline_artifact_svg_desc">Render SVG vector graphics inline</string>
+    <string name="inline_artifact_html">HTML</string>
+    <string name="inline_artifact_html_desc">Render HTML pages inline (loads Tailwind from CDN)</string>
+    <string name="inline_artifact_react">React components</string>
+    <string name="inline_artifact_react_desc">Render React components inline (loads React + Babel from CDN)</string>
+    <string name="inline_artifact_markdown">Markdown documents</string>
+    <string name="inline_artifact_markdown_desc">Render Markdown artifacts inline with syntax-highlighted code blocks</string>
+
     <!-- Security -->
     <string name="two_factor_auth">Two-Factor Authentication</string>
     <string name="enable_two_factor">Enable Two-Factor Authentication</string>

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/ArtifactSettingsSection.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/ArtifactSettingsSection.kt
@@ -1,0 +1,117 @@
+package com.garfiec.librechat.feature.settings.screen
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.garfiec.librechat.core.data.datastore.InlineArtifactPrefs
+import com.garfiec.librechat.feature.settings.resources.*
+import com.garfiec.librechat.feature.settings.resources.Res
+import org.jetbrains.compose.resources.stringResource
+
+@Composable
+internal fun ArtifactSettingsSection(
+    prefs: InlineArtifactPrefs,
+    onMermaidChange: (Boolean) -> Unit,
+    onSvgChange: (Boolean) -> Unit,
+    onHtmlChange: (Boolean) -> Unit,
+    onReactChange: (Boolean) -> Unit,
+    onMarkdownChange: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 8.dp),
+        ) {
+            Text(
+                text = stringResource(Res.string.artifacts_section_desc),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+
+            ArtifactToggleRow(
+                title = stringResource(Res.string.inline_artifact_mermaid),
+                description = stringResource(Res.string.inline_artifact_mermaid_desc),
+                checked = prefs.mermaid,
+                onChange = onMermaidChange,
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+
+            ArtifactToggleRow(
+                title = stringResource(Res.string.inline_artifact_svg),
+                description = stringResource(Res.string.inline_artifact_svg_desc),
+                checked = prefs.svg,
+                onChange = onSvgChange,
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+
+            ArtifactToggleRow(
+                title = stringResource(Res.string.inline_artifact_markdown),
+                description = stringResource(Res.string.inline_artifact_markdown_desc),
+                checked = prefs.markdown,
+                onChange = onMarkdownChange,
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+
+            ArtifactToggleRow(
+                title = stringResource(Res.string.inline_artifact_html),
+                description = stringResource(Res.string.inline_artifact_html_desc),
+                checked = prefs.html,
+                onChange = onHtmlChange,
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+
+            ArtifactToggleRow(
+                title = stringResource(Res.string.inline_artifact_react),
+                description = stringResource(Res.string.inline_artifact_react_desc),
+                checked = prefs.react,
+                onChange = onReactChange,
+            )
+        }
+        HorizontalDivider(modifier = Modifier.padding(top = 8.dp))
+    }
+}
+
+@Composable
+private fun ArtifactToggleRow(
+    title: String,
+    description: String,
+    checked: Boolean,
+    onChange: (Boolean) -> Unit,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.bodyLarge,
+            )
+            Text(
+                text = description,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        Spacer(modifier = Modifier.width(16.dp))
+        Switch(
+            checked = checked,
+            onCheckedChange = onChange,
+        )
+    }
+}

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/ChatSettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/ChatSettingsScreen.kt
@@ -118,6 +118,21 @@ fun ChatSettingsContent(
                 )
             }
 
+            // Artifacts section
+            item(key = "artifacts_header") {
+                SectionHeader(stringResource(Res.string.section_artifacts))
+            }
+            item(key = "artifacts_settings") {
+                ArtifactSettingsSection(
+                    prefs = uiState.inlineArtifactPrefs,
+                    onMermaidChange = viewModel::setInlineArtifactMermaid,
+                    onSvgChange = viewModel::setInlineArtifactSvg,
+                    onHtmlChange = viewModel::setInlineArtifactHtml,
+                    onReactChange = viewModel::setInlineArtifactReact,
+                    onMarkdownChange = viewModel::setInlineArtifactMarkdown,
+                )
+            }
+
             // Presets section
             item(key = "presets_header") {
                 SectionHeader(stringResource(Res.string.section_presets))

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/SettingsViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/SettingsViewModel.kt
@@ -7,6 +7,7 @@ import co.touchlab.kermit.Logger
 import com.garfiec.librechat.core.common.ChatLayoutConstants
 import com.garfiec.librechat.core.common.result.Result
 import com.garfiec.librechat.core.data.datastore.ChatFontSize
+import com.garfiec.librechat.core.data.datastore.InlineArtifactPrefs
 import com.garfiec.librechat.core.data.datastore.LatexRenderer
 import com.garfiec.librechat.core.data.datastore.ServerDataStore
 import com.garfiec.librechat.core.data.datastore.SettingsDataStore
@@ -186,6 +187,8 @@ data class SettingsUiState(
     val showAvatars: Boolean = true,
     val showBubbles: Boolean = false,
     val latexRenderer: LatexRenderer = LatexRenderer.KATEX,
+    // Inline artifact rendering (per-type toggles)
+    val inlineArtifactPrefs: InlineArtifactPrefs = InlineArtifactPrefs(),
     // Role-permission gates. `serverMemoriesEnabled` is the SERVER-level MEMORIES.USE
     // gate and is orthogonal to [memoriesEnabled], which is the user's own opt-out
     // stored on their profile (`user.personalization.memories`).
@@ -337,6 +340,9 @@ class SettingsViewModel(
     private val latexRendererPref: StateFlow<LatexRenderer> = settingsDataStore.latexRenderer
         .stateIn(viewModelScope, SharingStarted.Eagerly, LatexRenderer.KATEX)
 
+    private val inlineArtifactPrefsFlow: StateFlow<InlineArtifactPrefs> = settingsDataStore.inlineArtifactPrefs
+        .stateIn(viewModelScope, SharingStarted.Eagerly, InlineArtifactPrefs())
+
     /** Additional preferences combined separately to stay within the 5-arg combine limit. */
     private data class AdditionalPreferences(
         val tabletSidebarGestureEnabled: Boolean,
@@ -348,6 +354,7 @@ class SettingsViewModel(
         val showAvatars: Boolean = true,
         val showBubbles: Boolean = false,
         val latexRenderer: LatexRenderer = LatexRenderer.KATEX,
+        val inlineArtifactPrefs: InlineArtifactPrefs = InlineArtifactPrefs(),
     )
 
     private val baseAdditionalPreferences = combine(
@@ -368,6 +375,8 @@ class SettingsViewModel(
         latexRendererPref,
     ) { base, layoutStyle, showAvatars, showBubbles, latexRenderer ->
         base.copy(chatLayoutStyle = layoutStyle, showAvatars = showAvatars, showBubbles = showBubbles, latexRenderer = latexRenderer)
+    }.combine(inlineArtifactPrefsFlow) { additional, inlineArtifact ->
+        additional.copy(inlineArtifactPrefs = inlineArtifact)
     }.stateIn(viewModelScope, SharingStarted.Eagerly, AdditionalPreferences(true, false, "", "", true))
 
     /** The single public UI state that merges DataStore preferences with imperative state. */
@@ -404,6 +413,7 @@ class SettingsViewModel(
             showAvatars = additional.showAvatars,
             showBubbles = additional.showBubbles,
             latexRenderer = additional.latexRenderer,
+            inlineArtifactPrefs = additional.inlineArtifactPrefs,
         )
     }.stateIn(viewModelScope, SharingStarted.Eagerly, SettingsUiState())
 
@@ -580,6 +590,26 @@ class SettingsViewModel(
 
     fun setLatexRenderer(renderer: LatexRenderer) {
         viewModelScope.launch { settingsDataStore.setLatexRenderer(renderer) }
+    }
+
+    fun setInlineArtifactMermaid(enabled: Boolean) {
+        viewModelScope.launch { settingsDataStore.setInlineArtifactMermaid(enabled) }
+    }
+
+    fun setInlineArtifactSvg(enabled: Boolean) {
+        viewModelScope.launch { settingsDataStore.setInlineArtifactSvg(enabled) }
+    }
+
+    fun setInlineArtifactHtml(enabled: Boolean) {
+        viewModelScope.launch { settingsDataStore.setInlineArtifactHtml(enabled) }
+    }
+
+    fun setInlineArtifactReact(enabled: Boolean) {
+        viewModelScope.launch { settingsDataStore.setInlineArtifactReact(enabled) }
+    }
+
+    fun setInlineArtifactMarkdown(enabled: Boolean) {
+        viewModelScope.launch { settingsDataStore.setInlineArtifactMarkdown(enabled) }
     }
 
     // ── Tablet preferences ─────────────────────────────────────────

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,6 +28,7 @@ security-crypto = "1.1.0"
 
 # Async
 coroutines = "1.10.2"
+atomicfu = "0.28.0"
 
 # Paging
 paging = "3.5.0"
@@ -131,6 +132,7 @@ security-crypto = { group = "androidx.security", name = "security-crypto", versi
 coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "coroutines" }
 coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "coroutines" }
 coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutines" }
+atomicfu = { group = "org.jetbrains.kotlinx", name = "atomicfu", version.ref = "atomicfu" }
 
 # Paging
 paging-runtime = { group = "androidx.paging", name = "paging-runtime", version.ref = "paging" }
@@ -152,6 +154,7 @@ media3-datasource = { group = "androidx.media3", name = "media3-datasource", ver
 # Image Loading
 coil3-compose = { group = "io.coil-kt.coil3", name = "coil-compose", version.ref = "coil3" }
 coil3-network-ktor = { group = "io.coil-kt.coil3", name = "coil-network-ktor3", version.ref = "coil3" }
+coil3-svg = { group = "io.coil-kt.coil3", name = "coil-svg", version.ref = "coil3" }
 
 # Logging
 kermit = { group = "co.touchlab", name = "kermit", version.ref = "kermit" }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -51,6 +51,7 @@ kotlin {
             implementation(libs.koin.compose.viewmodel.navigation)
             implementation(libs.coil3.compose)
             implementation(libs.coil3.network.ktor)
+            implementation(libs.coil3.svg)
         }
         iosMain.dependencies {
             implementation(libs.ktor.client.darwin)

--- a/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/app/LibreChatApp.kt
+++ b/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/app/LibreChatApp.kt
@@ -10,6 +10,7 @@ import coil3.compose.setSingletonImageLoaderFactory
 import coil3.memory.MemoryCache
 import coil3.network.ktor3.KtorNetworkFetcherFactory
 import coil3.request.crossfade
+import coil3.svg.SvgDecoder
 import com.garfiec.librechat.core.data.datastore.ThemeDataStore
 import com.garfiec.librechat.core.data.datastore.ThemeMode
 import com.garfiec.librechat.core.ui.theme.LibreChatTheme
@@ -35,6 +36,7 @@ fun LibreChatApp() {
             ImageLoader.Builder(context)
                 .components {
                     add(KtorNetworkFetcherFactory(httpClient))
+                    add(SvgDecoder.Factory())
                 }
                 .memoryCache {
                     MemoryCache.Builder()


### PR DESCRIPTION
## Summary

Inline rendering of artifact blocks inside chat messages, controlled by per-type toggles in **Settings → Chat → Artifacts** (default off — opt in per type). Tapping an inline artifact opens the existing fullscreen `ArtifactPanel`, which on iOS now mirrors Android's Code/Preview tabs.

Rendering is dispatched by `selectInlineArtifactStrategy(type, content, cachedSvg)` — a pure function with unit-test coverage. Different artifact types take different paths because each has different layout-determinism guarantees inside a `LazyColumn`:

| Type | Strategy | Sizing | Cached? |
|---|---|---|---|
| Markdown | Native Compose (m3 markdown) | Intrinsic | Parsed AST |
| SVG | Coil `AsyncImage` | `aspectRatio` from `<viewBox>` (or `width`/`height` fallback) | — |
| Mermaid (flowchart/graph) — cache hit | Coil `AsyncImage` of harvested SVG | `aspectRatio` from `<viewBox>` | Yes (read) |
| Mermaid (flowchart/graph) — cache miss | WebView | Fixed `0.7 × screenHeight` | Yes (written via JS bridge on first render) |
| Mermaid (other diagrams) | WebView | Fixed `0.7 × screenHeight` | — |
| HTML | WebView (Tailwind CDN + CSP) | Fixed `0.7 × screenHeight` | — |
| React | WebView (React 18 UMD + Babel standalone) | Fixed `0.7 × screenHeight` | — |
| Plain / Code | Tap-to-open button (not inline) | — | — |

### Why per-type

LazyColumn re-entry and async height arrival don't mix — a slot whose final shape arrives over multiple frames pushes its neighbors around. Each strategy is the lightest path that lets Compose know the final shape before the renderer is asynchronously ready:

- Markdown / SVG have intrinsic sizing in commonMain code paths — no WebView needed.
- Cacheable Mermaid is rendered once in a WebView, the resulting SVG is harvested via JS bridge, and subsequent recomposes route through the SVG path. The WebView leaves the recompose-hot path entirely once cached.
- HTML / React / non-cacheable Mermaid stay on a WebView with a fixed-height slot. The cap (`0.7 × screenHeight`) gives the slot a deterministic size; the full document is reachable by tap.

### Platform notes

- **Android** — inline WebViews use `LAYER_TYPE_SOFTWARE` to render into a parent-owned bitmap. Hardware-accelerated WebViews insert a GL functor whose backing surface can be torn down by LazyColumn recycle, racing with RenderThread. Software rendering is performance-equivalent for these simple DOM/CSS payloads. The height cap also bounds the software-layer bitmap.
- **iOS** — fullscreen `ArtifactPanel` gains Code/Preview tabs to match Android. iOS does not currently participate in the Mermaid SVG cache (Skia SVGDOM fidelity vs Android's AndroidSVG is unverified); the JS-side bridge emission is universal so adding the iOS handler later is mechanical.