### PR TITLE
refactor(app): use Modifier.then for offline-banner status-bar inset

### DIFF
--- a/app/src/main/kotlin/com/garfiec/librechat/MainActivity.kt
+++ b/app/src/main/kotlin/com/garfiec/librechat/MainActivity.kt
@@ -118,8 +118,12 @@ class MainActivity : ComponentActivity() {
                             shareNavigationTrigger = shareNavigationTrigger,
                             modifier = Modifier
                                 .weight(1f)
-                                .consumeWindowInsets(
-                                    if (!isConnected) WindowInsets.statusBars else WindowInsets(0, 0, 0, 0),
+                                .then(
+                                    if (!isConnected) {
+                                        Modifier.consumeWindowInsets(WindowInsets.statusBars)
+                                    } else {
+                                        Modifier
+                                    },
                                 ),
                         )
                     }


### PR DESCRIPTION
Follow-up to #85.

Replaces

```kotlin
.consumeWindowInsets(
    if (!isConnected) WindowInsets.statusBars else WindowInsets(0, 0, 0, 0),
)
```

with

```kotlin
.then(
    if (!isConnected) Modifier.consumeWindowInsets(WindowInsets.statusBars)
    else Modifier,
)
```

Functionally equivalent — consuming a zero inset is a no-op — but `.then` is the standard Compose pattern for conditional modifier application.