### PR TITLE
fix(uploads): move file upload off main thread + per-file progress

### DIFF
--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/FileRepository.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/FileRepository.kt
@@ -6,7 +6,12 @@ import com.garfiec.librechat.core.model.request.DeleteFileEntry
 
 interface FileRepository {
     suspend fun getFiles(): Result<List<FileObject>>
-    suspend fun uploadFile(bytes: ByteArray, filename: String, type: String): Result<FileObject>
+    suspend fun uploadFile(
+        bytes: ByteArray,
+        filename: String,
+        type: String,
+        onProgress: ((Float) -> Unit)? = null,
+    ): Result<FileObject>
     suspend fun uploadFile(
         bytes: ByteArray,
         filename: String,
@@ -18,6 +23,7 @@ interface FileRepository {
         messageFile: Boolean? = null,
         width: Int? = null,
         height: Int? = null,
+        onProgress: ((Float) -> Unit)? = null,
     ): Result<FileObject>
     suspend fun deleteFiles(files: List<DeleteFileEntry>): Result<Unit>
     suspend fun downloadFile(userId: String, fileId: String): Result<ByteArray>

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/FileRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/FileRepositoryImpl.kt
@@ -19,7 +19,12 @@ class FileRepositoryImpl(
     override suspend fun getFiles(): Result<List<FileObject>> =
         safeApiCall { filesApi.getFiles() }
 
-    override suspend fun uploadFile(bytes: ByteArray, filename: String, type: String): Result<FileObject> =
+    override suspend fun uploadFile(
+        bytes: ByteArray,
+        filename: String,
+        type: String,
+        onProgress: ((Float) -> Unit)?,
+    ): Result<FileObject> =
         safeApiCall {
             filesApi.uploadFile(
                 bytes = bytes,
@@ -28,6 +33,7 @@ class FileRepositoryImpl(
                 // file_id and endpoint are required by the backend; provide defaults
                 fileId = Uuid.random().toString(),
                 endpoint = "agents",
+                onProgress = onProgress,
             )
         }
 
@@ -42,6 +48,7 @@ class FileRepositoryImpl(
         messageFile: Boolean?,
         width: Int?,
         height: Int?,
+        onProgress: ((Float) -> Unit)?,
     ): Result<FileObject> =
         safeApiCall {
             filesApi.uploadFile(
@@ -55,6 +62,7 @@ class FileRepositoryImpl(
                 messageFile = messageFile,
                 width = width,
                 height = height,
+                onProgress = onProgress,
             )
         }
 

--- a/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/api/FilesApi.kt
+++ b/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/api/FilesApi.kt
@@ -6,14 +6,17 @@ import com.garfiec.librechat.core.model.request.DeleteFilesRequest
 import com.garfiec.librechat.core.model.response.FileUploadConfig
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
+import io.ktor.client.plugins.onUpload
 import io.ktor.client.request.delete
+import io.ktor.client.request.forms.MultiPartFormDataContent
 import io.ktor.client.request.forms.formData
-import io.ktor.client.request.forms.submitFormWithBinaryData
 import io.ktor.client.request.get
+import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.http.Headers
 import io.ktor.http.HttpHeaders
 import io.ktor.http.path
+import kotlinx.coroutines.CancellationException
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 
@@ -43,14 +46,15 @@ class FilesApi constructor(
         messageFile: Boolean? = null,
         width: Int? = null,
         height: Int? = null,
+        onProgress: ((Float) -> Unit)? = null,
     ): FileObject {
         Logger.d("FilesApi") {
             "uploadFile: filename=$filename, type=$type, size=${bytes.size} bytes, fileId=$fileId, " +
                 "endpoint=$endpoint, model=$model, agentId=$agentId, messageFile=$messageFile, width=$width, height=$height"
         }
 
-        val response: FileObject = client.submitFormWithBinaryData(
-            formData = formData {
+        val multipart = MultiPartFormDataContent(
+            formData {
                 append("file", bytes, Headers.build {
                     append(HttpHeaders.ContentDisposition, "filename=\"${encodeFilename(filename)}\"")
                     append(HttpHeaders.ContentType, type)
@@ -63,9 +67,33 @@ class FilesApi constructor(
                 if (messageFile != null) append("message_file", messageFile.toString())
                 if (width != null) append("width", width.toString())
                 if (height != null) append("height", height.toString())
-            }
-        ) {
+            },
+        )
+
+        val response: FileObject = client.post {
             url { path("api/files") }
+            setBody(multipart)
+            if (onProgress != null) {
+                var lastPct = -1
+                var lastSent = -1L
+                onUpload { sent, total ->
+                    if (total == null || total <= 0L) return@onUpload
+                    // Detect HttpRequestRetry replays: byte counter resets to 0.
+                    if (sent < lastSent) lastPct = -1
+                    lastSent = sent
+                    val pct = ((sent * 100L) / total).toInt().coerceIn(0, 100)
+                    if (pct != lastPct) {
+                        lastPct = pct
+                        try {
+                            onProgress(pct / 100f)
+                        } catch (e: CancellationException) {
+                            throw e
+                        } catch (e: Exception) {
+                            Logger.w("FilesApi", e) { "onProgress callback threw; suppressing to keep upload alive" }
+                        }
+                    }
+                }
+            }
         }.body()
 
         Logger.d("FilesApi") {

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/di/ChatPlatformModule.android.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/di/ChatPlatformModule.android.kt
@@ -1,5 +1,6 @@
 package com.garfiec.librechat.feature.chat.di
 
+import com.garfiec.librechat.core.common.di.KoinQualifiers
 import com.garfiec.librechat.feature.chat.viewmodel.ChatViewModel
 import com.garfiec.librechat.feature.chat.viewmodel.delegate.AndroidDelegateFactory
 import com.garfiec.librechat.feature.chat.viewmodel.delegate.PlatformDelegateFactory
@@ -15,6 +16,7 @@ actual val chatPlatformModule: Module = module {
             fileRepository = get(),
             speechRepository = get(),
             settingsDataStore = get(),
+            ioDispatcher = get(KoinQualifiers.IO),
         )
     }
 

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/AndroidDelegateFactory.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/AndroidDelegateFactory.kt
@@ -5,6 +5,7 @@ import com.garfiec.librechat.core.data.datastore.SettingsDataStore
 import com.garfiec.librechat.core.data.repository.FileRepository
 import com.garfiec.librechat.core.data.repository.SpeechRepository
 import com.garfiec.librechat.feature.chat.viewmodel.ChatStateHandle
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.stateIn
 
@@ -13,6 +14,7 @@ class AndroidDelegateFactory(
     private val fileRepository: FileRepository,
     private val speechRepository: SpeechRepository,
     private val settingsDataStore: SettingsDataStore,
+    private val ioDispatcher: CoroutineDispatcher,
 ) : PlatformDelegateFactory {
 
     override fun createFileHandler(stateHandle: ChatStateHandle): PlatformFileHandler {
@@ -21,6 +23,7 @@ class AndroidDelegateFactory(
                 stateHandle = stateHandle,
                 appContext = appContext,
                 fileRepository = fileRepository,
+                ioDispatcher = ioDispatcher,
             ),
         )
     }

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/FileAttachmentDelegate.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/FileAttachmentDelegate.kt
@@ -15,6 +15,8 @@ import com.garfiec.librechat.feature.chat.util.guessMimeType
 import com.garfiec.librechat.feature.chat.util.reEncodeImageIfNeeded
 import com.garfiec.librechat.feature.chat.util.resolveFileName
 import com.garfiec.librechat.feature.chat.viewmodel.ChatStateHandle
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -28,6 +30,7 @@ class FileAttachmentDelegate(
     private val stateHandle: ChatStateHandle,
     private val appContext: Context,
     private val fileRepository: FileRepository,
+    private val ioDispatcher: CoroutineDispatcher,
 ) {
 
     private val _attachedFiles = MutableStateFlow<List<AttachedFile>>(emptyList())
@@ -61,13 +64,13 @@ class FileAttachmentDelegate(
             uri = uri,
             name = filename,
             isImage = isImage,
-            uploadProgress = 0f,
+            uploadProgress = null,
             type = preliminaryMimeType,
         )
 
         _attachedFiles.update { currentList -> currentList + pendingFile }
 
-        stateHandle.scope.launch {
+        stateHandle.scope.launch(ioDispatcher) {
             try {
                 // Read file bytes
                 val bytes = contentResolver.openInputStream(uri)?.use { it.readBytes() }
@@ -149,9 +152,6 @@ class FileAttachmentDelegate(
                     }
                 }
 
-                // Update progress to 50% (upload starting)
-                updateFileProgress(uri, 0.5f)
-
                 // Generate a UUID for the file_id -- the backend requires this field
                 val fileId = UUID.randomUUID().toString()
 
@@ -170,6 +170,7 @@ class FileAttachmentDelegate(
                     messageFile = true,
                     width = imageWidth,
                     height = imageHeight,
+                    onProgress = { pct -> updateFileProgress(uri, pct) },
                 )
 
                 when (result) {
@@ -214,6 +215,10 @@ class FileAttachmentDelegate(
                         Logger.w { "uploadFile: unexpected Result.Loading received for $filename" }
                     }
                 }
+            } catch (e: CancellationException) {
+                // Cooperative cancellation must propagate — never mark a cancelled
+                // upload as failed (matches safeApiCall behavior in core/common).
+                throw e
             } catch (e: Exception) {
                 Logger.e(e) { "uploadFile: unexpected exception for $filename" }
                 markUploadFailed(uri)

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/AttachmentChipsRow.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/AttachmentChipsRow.kt
@@ -23,11 +23,13 @@ import androidx.compose.material.icons.automirrored.filled.InsertDriveFile
 import androidx.compose.material.icons.filled.AttachFile
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Code
+import androidx.compose.material.icons.filled.ErrorOutline
 import androidx.compose.material.icons.filled.Extension
 import androidx.compose.material.icons.filled.FindInPage
 import androidx.compose.material.icons.filled.TravelExplore
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.AssistChipDefaults
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults
@@ -42,6 +44,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.semantics.Role
@@ -316,6 +319,50 @@ private fun FilePreviewItem(
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
+                )
+            }
+        }
+
+        val progress = file.uploadProgress
+        val inFlight = file.fileId == null && !file.uploadFailed
+        if (inFlight) {
+            Box(
+                modifier = Modifier
+                    .size(56.dp)
+                    .clip(RoundedCornerShape(8.dp))
+                    .background(MaterialTheme.colorScheme.scrim.copy(alpha = 0.45f)),
+                contentAlignment = Alignment.Center,
+            ) {
+                if (progress != null) {
+                    CircularProgressIndicator(
+                        progress = { progress },
+                        modifier = Modifier.size(28.dp),
+                        strokeWidth = 3.dp,
+                        color = Color.White,
+                        trackColor = Color.White.copy(alpha = 0.3f),
+                    )
+                } else {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(28.dp),
+                        strokeWidth = 3.dp,
+                        color = Color.White,
+                        trackColor = Color.White.copy(alpha = 0.3f),
+                    )
+                }
+            }
+        } else if (file.uploadFailed) {
+            Box(
+                modifier = Modifier
+                    .size(56.dp)
+                    .clip(RoundedCornerShape(8.dp))
+                    .background(MaterialTheme.colorScheme.error.copy(alpha = 0.6f)),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    imageVector = Icons.Default.ErrorOutline,
+                    contentDescription = null,
+                    modifier = Modifier.size(28.dp),
+                    tint = MaterialTheme.colorScheme.onError,
                 )
             }
         }

--- a/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/di/ChatPlatformModule.ios.kt
+++ b/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/di/ChatPlatformModule.ios.kt
@@ -1,5 +1,6 @@
 package com.garfiec.librechat.feature.chat.di
 
+import com.garfiec.librechat.core.common.di.KoinQualifiers
 import com.garfiec.librechat.feature.chat.viewmodel.ChatViewModel
 import com.garfiec.librechat.feature.chat.viewmodel.delegate.IosDelegateFactory
 import com.garfiec.librechat.feature.chat.viewmodel.delegate.PlatformDelegateFactory
@@ -13,6 +14,7 @@ actual val chatPlatformModule: Module = module {
             fileRepository = get(),
             speechRepository = get(),
             settingsDataStore = get(),
+            ioDispatcher = get(KoinQualifiers.IO),
         )
     }
 

--- a/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/IosDelegateFactory.kt
+++ b/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/IosDelegateFactory.kt
@@ -4,15 +4,17 @@ import com.garfiec.librechat.core.data.datastore.SettingsDataStore
 import com.garfiec.librechat.core.data.repository.FileRepository
 import com.garfiec.librechat.core.data.repository.SpeechRepository
 import com.garfiec.librechat.feature.chat.viewmodel.ChatStateHandle
+import kotlinx.coroutines.CoroutineDispatcher
 
 class IosDelegateFactory(
     private val fileRepository: FileRepository,
     private val speechRepository: SpeechRepository,
     private val settingsDataStore: SettingsDataStore,
+    private val ioDispatcher: CoroutineDispatcher,
 ) : PlatformDelegateFactory {
 
     override fun createFileHandler(stateHandle: ChatStateHandle): PlatformFileHandler {
-        return IosFileHandler(stateHandle, fileRepository)
+        return IosFileHandler(stateHandle, fileRepository, ioDispatcher)
     }
 
     override fun createVoiceInput(

--- a/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/IosFileHandler.kt
+++ b/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/IosFileHandler.kt
@@ -9,6 +9,8 @@ import com.garfiec.librechat.feature.chat.components.AttachedFile
 import com.garfiec.librechat.feature.chat.util.IosFileData
 import com.garfiec.librechat.feature.chat.util.IosImageData
 import com.garfiec.librechat.feature.chat.viewmodel.ChatStateHandle
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -26,6 +28,7 @@ import kotlin.uuid.Uuid
 class IosFileHandler(
     private val stateHandle: ChatStateHandle,
     private val fileRepository: FileRepository,
+    private val ioDispatcher: CoroutineDispatcher,
 ) : PlatformFileHandler {
     private val _attachedFiles = MutableStateFlow<List<AttachedFile>>(emptyList())
     override val attachedFiles: StateFlow<List<AttachedFile>> = _attachedFiles.asStateFlow()
@@ -48,17 +51,13 @@ class IosFileHandler(
             uri = uniqueId,
             name = imageData.filename,
             isImage = true,
-            uploadProgress = 0f,
+            uploadProgress = null,
             type = imageData.mimeType,
         )
         _attachedFiles.update { it + pendingFile }
 
-        stateHandle.scope.launch {
+        stateHandle.scope.launch(ioDispatcher) {
             try {
-                _attachedFiles.update { list ->
-                    list.map { f -> if (f.uri == uniqueId) f.copy(uploadProgress = 0.5f) else f }
-                }
-
                 val state = stateHandle.state
                 val isAgent = state.selectedEndpoint == EndpointConstants.AGENTS
                 val fileId = Uuid.random().toString()
@@ -74,6 +73,11 @@ class IosFileHandler(
                     messageFile = true,
                     width = imageData.width,
                     height = imageData.height,
+                    onProgress = { pct ->
+                        _attachedFiles.update { list ->
+                            list.map { f -> if (f.uri == uniqueId) f.copy(uploadProgress = pct) else f }
+                        }
+                    },
                 )
 
                 when (result) {
@@ -110,6 +114,8 @@ class IosFileHandler(
                     }
                     is Result.Loading -> { /* unexpected */ }
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 Logger.e(e) { "IosFileHandler: unexpected exception for ${imageData.filename}" }
                 _attachedFiles.update { list ->
@@ -130,17 +136,13 @@ class IosFileHandler(
             uri = uniqueId,
             name = fileData.filename,
             isImage = false,
-            uploadProgress = 0f,
+            uploadProgress = null,
             type = fileData.mimeType,
         )
         _attachedFiles.update { it + pendingFile }
 
-        stateHandle.scope.launch {
+        stateHandle.scope.launch(ioDispatcher) {
             try {
-                _attachedFiles.update { list ->
-                    list.map { f -> if (f.uri == uniqueId) f.copy(uploadProgress = 0.5f) else f }
-                }
-
                 val state = stateHandle.state
                 val isAgent = state.selectedEndpoint == EndpointConstants.AGENTS
                 val fileId = Uuid.random().toString()
@@ -154,6 +156,11 @@ class IosFileHandler(
                     model = if (!isAgent) state.selectedModel else null,
                     agentId = if (isAgent) state.selectedModel else null,
                     messageFile = true,
+                    onProgress = { pct ->
+                        _attachedFiles.update { list ->
+                            list.map { f -> if (f.uri == uniqueId) f.copy(uploadProgress = pct) else f }
+                        }
+                    },
                 )
 
                 when (result) {
@@ -188,6 +195,8 @@ class IosFileHandler(
                     }
                     is Result.Loading -> { /* unexpected */ }
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 Logger.e(e) { "IosFileHandler: unexpected exception for ${fileData.filename}" }
                 _attachedFiles.update { list ->

--- a/feature/files/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/files/di/FilesModuleVerificationTest.kt
+++ b/feature/files/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/files/di/FilesModuleVerificationTest.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import com.garfiec.librechat.core.data.datastore.ServerDataStore
 import com.garfiec.librechat.core.data.repository.FileRepository
 import com.garfiec.librechat.feature.files.platform.FileReader
+import kotlinx.coroutines.CoroutineDispatcher
 import org.junit.Test
 import org.koin.test.verify.verify
 
@@ -18,6 +19,7 @@ class FilesModuleVerificationTest {
                 FileRepository::class,
                 ServerDataStore::class,
                 FileReader::class,
+                CoroutineDispatcher::class,
             ),
         )
     }

--- a/feature/files/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/files/viewmodel/FilesViewModelTest.kt
+++ b/feature/files/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/files/viewmodel/FilesViewModelTest.kt
@@ -75,6 +75,7 @@ class FilesViewModelTest {
         fileRepository = fileRepository,
         fileReader = fileReader,
         serverDataStore = serverDataStore,
+        ioDispatcher = testDispatcher,
     )
 
     @Test

--- a/feature/files/src/commonMain/kotlin/com/garfiec/librechat/feature/files/di/FilesModule.kt
+++ b/feature/files/src/commonMain/kotlin/com/garfiec/librechat/feature/files/di/FilesModule.kt
@@ -1,13 +1,21 @@
 package com.garfiec.librechat.feature.files.di
 
+import com.garfiec.librechat.core.common.di.KoinQualifiers
 import com.garfiec.librechat.feature.files.viewmodel.FilesViewModel
 import org.koin.core.module.Module
-import org.koin.core.module.dsl.viewModelOf
+import org.koin.core.module.dsl.viewModel
 import org.koin.dsl.module
 
 expect val filesPlatformModule: Module
 
 val filesModule = module {
     includes(filesPlatformModule)
-    viewModelOf(::FilesViewModel)
+    viewModel {
+        FilesViewModel(
+            fileRepository = get(),
+            fileReader = get(),
+            serverDataStore = get(),
+            ioDispatcher = get(KoinQualifiers.IO),
+        )
+    }
 }

--- a/feature/files/src/commonMain/kotlin/com/garfiec/librechat/feature/files/viewmodel/FilesViewModel.kt
+++ b/feature/files/src/commonMain/kotlin/com/garfiec/librechat/feature/files/viewmodel/FilesViewModel.kt
@@ -13,12 +13,14 @@ import com.garfiec.librechat.feature.files.FileDisplayData
 import com.garfiec.librechat.feature.files.FilePreviewDisplayData
 import com.garfiec.librechat.feature.files.platform.FileReader
 import com.garfiec.librechat.feature.files.platform.formatFileSize
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
@@ -71,6 +73,7 @@ class FilesViewModel(
     private val fileRepository: FileRepository,
     private val fileReader: FileReader,
     private val serverDataStore: ServerDataStore,
+    private val ioDispatcher: CoroutineDispatcher,
 ) : ViewModel() {
 
     private val _files = MutableStateFlow<List<FileObject>>(emptyList())
@@ -175,7 +178,9 @@ class FilesViewModel(
      */
     @OptIn(ExperimentalUuidApi::class)
     fun uploadFile(fileRef: Any) {
-        uploadJob = viewModelScope.launch {
+        uploadJob?.cancel()
+        lateinit var thisJob: Job
+        thisJob = viewModelScope.launch(ioDispatcher) {
             val filename = fileReader.getFileName(fileRef) ?: "upload"
             updateTransient {
                 copy(
@@ -209,6 +214,11 @@ class FilesViewModel(
                 type = mimeType,
                 fileId = fileId,
                 endpoint = "agents",
+                // Gate progress writes on the launching job: a tardy onProgress
+                // from a cancelled upload must not overwrite the new upload's state.
+                onProgress = { pct ->
+                    if (thisJob.isActive) updateTransient { copy(uploadProgress = pct) }
+                },
             )) {
                 is Result.Success -> {
                     Logger.d { "uploadFile: success -- serverFileId=${result.data.fileId}" }
@@ -235,6 +245,7 @@ class FilesViewModel(
                 is Result.Loading -> { /* no-op */ }
             }
         }
+        uploadJob = thisJob
     }
 
     fun cancelUpload() {
@@ -471,8 +482,8 @@ class FilesViewModel(
         )
     }
 
-    private inline fun updateTransient(update: TransientState.() -> TransientState) {
-        _transientState.value = _transientState.value.update()
+    private inline fun updateTransient(crossinline transform: TransientState.() -> TransientState) {
+        _transientState.update { it.transform() }
     }
 }
 


### PR DESCRIPTION
## Summary
Picking a photo or file ran the read + JPEG→PNG re-encode + `BitmapFactory` decode on the UI thread (via `viewModelScope.launch { }` defaulting to `Dispatchers.Main`), freezing the app for seconds on a high-res image and causing ANRs under memory pressure. There was also no real upload progress — chips showed a hardcoded `0f → 0.5f → 1f` placeholder.

This PR moves all upload work off Main and wires real byte-level progress end-to-end.

## What changed
- **Dispatcher fix.** `FileAttachmentDelegate`, `IosFileHandler`, and `FilesViewModel` launch on the injected `ioDispatcher` (`Dispatchers.IO` on Android, `Dispatchers.Default` on iOS) via `KoinQualifiers.IO`. Factories and Koin wiring updated.
- **Real progress.** `FilesApi.uploadFile` switches from `submitFormWithBinaryData` to `client.post { setBody(MultiPartFormDataContent(...)); onUpload { … } }`. New `onProgress: ((Float) -> Unit)?` parameter threaded through `FileRepository` → delegates. Throttled to integer-percent emits; `lastSent` decrease resets `lastPct` to handle `HttpRequestRetry` replays; user lambda wrapped in try/catch so a bad caller can't abort the upload.
- **Chat-input chip overlay.** Indeterminate Material 3 `CircularProgressIndicator` during the file-read / re-encode phase, determinate ring once bytes flow, red `ErrorOutline` on failure. Scrim uses `MaterialTheme.colorScheme.scrim`.
- **Files screen.** Initial `uploadProgress = null` restores the indeterminate-spinner phase so the card doesn't render an empty 0% determinate bar while bytes are being read.
- **Concurrency hardening.**
  - `FilesViewModel.uploadFile` cancels the prior `uploadJob` before relaunching.
  - `updateTransient` switched to CAS-safe `MutableStateFlow.update {}` so concurrent writes from `onProgress` + success/error don't lose updates.
  - `onProgress` is gated on `thisJob.isActive` so a tardy callback from a cancelled upload can't overwrite the new upload's filename/progress.
  - `CancellationException` is rethrown in the upload coroutines' outer `catch`, matching `safeApiCall`. Cancelled uploads no longer paint the red error overlay.