### PR TITLE
feat(release): signed GitHub release pipeline with Obtainium support

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,14 @@ updates:
     schedule:
       interval: "weekly"
 
+  # Third-party actions in the release workflow are pinned to commit SHAs (not moving
+  # tags) so a compromised action can't slip into the secret-bearing job; this keeps
+  # those pins current — including for security advisories — without manual CVE tracking.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
 # Security scanning: Consider adding Snyk (https://snyk.io) for vulnerability
 # detection. Snyk provides deeper analysis than Dependabot for transitive
 # dependencies and can be integrated via GitHub Actions or the Snyk GitHub App.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,175 @@
+name: Release
+
+# Manual, one-button release. Pick a semver bump; the job bumps version.properties,
+# builds a signed universal APK, and ONLY THEN commits + tags it and publishes a draft
+# GitHub Release with auto-generated notes — so a failed build never leaves an orphaned
+# tag or a burned version on the branch. Review the draft, then publish it;
+# Obtainium/IzzyOnDroid pick up published releases.
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: "Version bump (pre* starts an -rc, rc advances it, finalize promotes to stable)"
+        required: true
+        type: choice
+        default: patch
+        options:
+          - patch
+          - minor
+          - major
+          - prepatch
+          - preminor
+          - premajor
+          - rc
+          - finalize
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+permissions:
+  contents: write       # push the version-bump commit + tag, and create the Release
+  id-token: write       # OIDC identity for keyless Sigstore signing of the attestation
+  attestations: write   # write the build-provenance attestation to the repo's attestation store
+
+jobs:
+  release:
+    name: Build & publish release
+    runs-on: ubuntu-latest
+    # Gate signing secrets behind a protected environment (add required reviewers in repo
+    # settings). Secrets are unavailable to fork PRs, so this stays off the PR path.
+    environment: release
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0   # full history for auto-generated release notes
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - name: Setup Gradle
+        # Pinned to a commit SHA (not a moving tag) so a compromise of the action's
+        # repo can't inject code into this secret-bearing job. Dependabot keeps it
+        # current — see .github/dependabot.yml.
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
+
+      # Fail in seconds if the signing secrets are missing/blank, before doing any
+      # work — rather than deep inside the Gradle signing task after a full build.
+      - name: Verify signing secrets
+        env:
+          SIGNING_KEYSTORE_BASE64: ${{ secrets.SIGNING_KEYSTORE_BASE64 }}
+          SIGNING_STORE_PASSWORD: ${{ secrets.SIGNING_STORE_PASSWORD }}
+          SIGNING_KEY_PASSWORD: ${{ secrets.SIGNING_KEY_PASSWORD }}
+          SIGNING_KEY_ALIAS: ${{ secrets.SIGNING_KEY_ALIAS }}
+        run: |
+          missing=""
+          [ -z "$SIGNING_KEYSTORE_BASE64" ] && missing="$missing SIGNING_KEYSTORE_BASE64"
+          [ -z "$SIGNING_STORE_PASSWORD" ] && missing="$missing SIGNING_STORE_PASSWORD"
+          [ -z "$SIGNING_KEY_PASSWORD" ] && missing="$missing SIGNING_KEY_PASSWORD"
+          [ -z "$SIGNING_KEY_ALIAS" ] && missing="$missing SIGNING_KEY_ALIAS"
+          if [ -n "$missing" ]; then
+            echo "::error title=Missing signing secrets::Set these in the 'release' environment:$missing"
+            exit 1
+          fi
+
+      - name: Bump version
+        id: bump
+        run: ./scripts/bump-version.sh "${{ inputs.bump }}"
+
+      - name: Decode keystore
+        env:
+          KEYSTORE_BASE64: ${{ secrets.SIGNING_KEYSTORE_BASE64 }}
+        run: |
+          echo "$KEYSTORE_BASE64" | base64 --decode > "$RUNNER_TEMP/release.jks"
+          echo "SIGNING_STORE_FILE=$RUNNER_TEMP/release.jks" >> "$GITHUB_ENV"
+
+      - name: Build signed release APK
+        env:
+          SIGNING_STORE_PASSWORD: ${{ secrets.SIGNING_STORE_PASSWORD }}
+          SIGNING_KEY_PASSWORD: ${{ secrets.SIGNING_KEY_PASSWORD }}
+          SIGNING_KEY_ALIAS: ${{ secrets.SIGNING_KEY_ALIAS }}
+        run: ./gradlew :app:assembleRelease --no-daemon
+
+      - name: Prepare artifacts
+        id: artifacts
+        env:
+          VERSION: ${{ steps.bump.outputs.version_name }}
+        run: |
+          src="app/build/outputs/apk/release/app-release.apk"
+          out="librechat-v${VERSION}.apk"
+          cp "$src" "$out"
+          sha256sum "$out" > "${out}.sha256"
+          echo "apk=$out" >> "$GITHUB_OUTPUT"
+
+      # Sign a SLSA provenance attestation for the published APK (keyless, via Sigstore +
+      # Rekor). This is the only check that resists a tampered upload — unlike the .sha256,
+      # it can't be forged outside GitHub's CI. Runs on the renamed artifact so the attested
+      # subject name matches the downloaded asset (verification is by digest regardless).
+      - name: Attest build provenance
+        id: attest
+        # GitHub-owned action → moving major tag, consistent with actions/checkout@v5 and
+        # actions/setup-java@v5; Dependabot tracks it via .github/dependabot.yml.
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-path: ${{ steps.artifacts.outputs.apk }}
+
+      # Commit + tag the bump ONLY after a signed APK exists, so a failed build never
+      # leaves an orphaned tag or a burned version on the branch. --atomic makes the
+      # branch push and the tag push all-or-nothing.
+      - name: Commit, tag & push
+        env:
+          TAG: ${{ steps.bump.outputs.tag }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add version.properties
+          git commit -m "chore(release): $TAG"
+          git tag -a "$TAG" -m "Release $TAG"
+          git push --atomic origin "HEAD:${{ github.ref_name }}" "refs/tags/$TAG"
+
+      - name: Create draft release
+        # Pinned to a commit SHA (not a moving tag): this step runs with a
+        # contents:write token, so a hijacked tag could push tags/releases on our
+        # behalf. Dependabot bumps the pin — see .github/dependabot.yml.
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
+        with:
+          tag_name: ${{ steps.bump.outputs.tag }}
+          name: "LibreChat Mobile ${{ steps.bump.outputs.tag }}"
+          draft: true
+          # A hyphenated version (e.g. 0.2.0-rc1) is a pre-release; Obtainium then
+          # ignores it unless the user opts into "Include prereleases".
+          prerelease: ${{ contains(steps.bump.outputs.tag, '-') }}
+          generate_release_notes: true
+          # Append our provenance block to the auto-generated changelog (don't replace it).
+          append_body: true
+          body: |
+            ## Provenance & verification
+
+            Built by CI — [view the workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) · [view the attestation](${{ steps.attest.outputs.attestation-url }})
+
+            These links show how the APK was built; they are **not** proof on their own (whoever
+            writes a release also writes its links). To cryptographically verify the downloaded
+            APK came from this repo's release workflow, with the [GitHub CLI](https://cli.github.com):
+
+            ```bash
+            gh attestation verify ${{ steps.artifacts.outputs.apk }} \
+              --repo ${{ github.repository }} \
+              --signer-workflow ${{ github.repository }}/.github/workflows/release.yml
+            ```
+
+            Weaker checks: `apksigner verify --print-certs ${{ steps.artifacts.outputs.apk }}`
+            (signing cert) and `sha256sum -c ${{ steps.artifacts.outputs.apk }}.sha256` (checksum).
+          files: |
+            ${{ steps.artifacts.outputs.apk }}
+            ${{ steps.artifacts.outputs.apk }}.sha256
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Remind to publish the draft
+        run: |
+          echo "::warning title=Release is a DRAFT::${{ steps.bump.outputs.tag }} was created as a DRAFT. Obtainium and direct downloads will NOT see it until you open it in the GitHub Releases UI and click Publish."

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ local.properties
 *.jks
 *.keystore
 !app/debug.keystore
+# Release signing credentials (never commit)
+keystore.properties
+*.b64
 
 # OS
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -41,6 +41,52 @@ A third-party native mobile client for [LibreChat](https://www.librechat.ai/) (A
 | **Photo Upload** — Attach images from your gallery or camera | <img src="docs/screenshots/photo-upload-phone.png" width="280"> | <img src="docs/screenshots/photo-upload-tablet.png" width="380"> |
 | **Settings** — Theme, language, layout, and personalization options | <img src="docs/screenshots/settings-phone.png" width="280"> | <img src="docs/screenshots/settings-tablet.png" width="380"> |
 
+## Install (Android)
+
+Pre-built, signed APKs are published on the [Releases](https://github.com/garfiec/Librechat-Mobile/releases) page. No need to build from source.
+
+### Obtainium (recommended)
+
+[Obtainium](https://github.com/ImranR98/Obtainium) installs the app straight from GitHub Releases and keeps it updated automatically.
+
+[![Add to Obtainium](https://img.shields.io/badge/Add%20to-Obtainium-1e88e5?logo=android&logoColor=white)](https://apps.obtainium.imranr.dev/redirect.html?r=obtainium://add/https://github.com/garfiec/Librechat-Mobile)
+
+1. Install Obtainium from its [releases](https://github.com/ImranR98/Obtainium/releases).
+2. Tap the **Add to Obtainium** badge above (or, in Obtainium, *Add App* → paste `https://github.com/garfiec/Librechat-Mobile`).
+3. Obtainium tracks new releases and prompts you to update when one ships.
+
+Release-candidate builds (versions like `0.2.0-rc1`) are published as GitHub *pre-releases* and are ignored unless you enable **Include prereleases** for the app in Obtainium.
+
+### Manual install
+
+Download the latest `librechat-vX.Y.Z.apk` from [Releases](https://github.com/garfiec/Librechat-Mobile/releases) and open it on your device (you may need to allow installs from your browser/file manager).
+
+### Verifying the signing key
+
+All releases are signed with the same key, so updates install in place. Verify a downloaded APK matches the published certificate:
+
+```bash
+apksigner verify --print-certs librechat-vX.Y.Z.apk
+# or check the .sha256 checksum attached to each release:
+sha256sum -c librechat-vX.Y.Z.apk.sha256
+```
+
+> Signing certificate SHA-256: `66:8A:71:96:6A:07:06:14:D1:44:95:5D:83:E7:23:6A:3C:ED:77:F8:64:08:57:C3:FA:84:B0:3C:CD:E4:0E:59`
+
+If the signing key ever changed, Android would refuse the update — so this key is permanent. Never install a build signed with a different certificate over an existing install.
+
+### Verifying build provenance (optional, strongest)
+
+Every release APK carries a [SLSA build-provenance attestation](https://github.com/garfiec/Librechat-Mobile/attestations), signed by GitHub Actions via Sigstore. Unlike the `.sha256` — which whoever attaches a release could regenerate — the attestation proves the binary was produced by this repo's release workflow at a specific commit, and **cannot be forged outside GitHub's CI**. With the [GitHub CLI](https://cli.github.com):
+
+```bash
+gh attestation verify librechat-vX.Y.Z.apk \
+  --repo garfiec/Librechat-Mobile \
+  --signer-workflow garfiec/Librechat-Mobile/.github/workflows/release.yml
+```
+
+A pass confirms the exact bytes you downloaded came from that workflow. The run and attestation are also linked from each release's notes — but those links are convenience, not proof; only the command above verifies the bytes in your hand.
+
 ## Server Setup
 
 The app works with any standard LibreChat server. During onboarding, you'll enter your server URL (e.g., `https://chat.example.com` or `http://192.168.1.100:3080`).

--- a/app/src/test/kotlin/com/garfiec/librechat/KoinGraphVerificationTest.kt
+++ b/app/src/test/kotlin/com/garfiec/librechat/KoinGraphVerificationTest.kt
@@ -2,6 +2,7 @@ package com.garfiec.librechat
 
 import android.app.Application
 import android.content.Context
+import com.garfiec.librechat.core.common.AppInfo
 import com.garfiec.librechat.core.common.di.commonModule
 import com.garfiec.librechat.core.common.network.ConnectivityObserver
 import com.garfiec.librechat.core.data.datastore.ConfigCacheDataStore
@@ -118,6 +119,7 @@ class KoinGraphVerificationTest {
             CoroutineDispatcher::class,
             CoroutineScope::class,
             ConnectivityObserver::class,
+            AppInfo::class,
             // core:network provides
             TokenManager::class,
             SecureTokenStorage::class,

--- a/build-logic/convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt
@@ -3,6 +3,7 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
 import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
+import java.util.Properties
 
 class AndroidApplicationConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) {
@@ -11,6 +12,9 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
             pluginManager.apply("org.jetbrains.kotlin.android")
             pluginManager.apply("librechat.detekt")
             pluginManager.apply("org.jetbrains.kotlinx.kover")
+
+            val appVersion = readAppVersion(target)
+            val release = readReleaseSigning(target)
 
             extensions.configure<KotlinAndroidProjectExtension> {
                 jvmToolchain(BuildConstants.JVM_TOOLCHAIN_VERSION)
@@ -24,8 +28,8 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
                 defaultConfig {
                     minSdk = BuildConstants.MIN_SDK
                     targetSdk = BuildConstants.TARGET_SDK
-                    versionCode = 1
-                    versionName = "0.1.0"
+                    versionCode = appVersion.code
+                    versionName = appVersion.name
                     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
                 }
                 compileOptions {
@@ -34,10 +38,32 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
                 lint {
                     disable += "NullSafeMutableLiveData"
                 }
+                if (release != null) {
+                    signingConfigs {
+                        create("release") {
+                            storeFile = file(release.storeFile)
+                            storePassword = release.storePassword
+                            keyAlias = release.keyAlias
+                            keyPassword = release.keyPassword
+                            enableV1Signing = true
+                            enableV2Signing = true
+                            enableV3Signing = true
+                        }
+                    }
+                }
                 buildTypes {
                     release {
                         isMinifyEnabled = true
-                        signingConfig = signingConfigs.getByName("debug")
+                        // Strip unused resources alongside the code shrink. Requires minify.
+                        isShrinkResources = true
+                        // Use the real release key when credentials are present (CI release
+                        // builds, or a local keystore.properties); otherwise fall back to the
+                        // debug key so local `assembleRelease` and CI checks still work.
+                        signingConfig = if (release != null) {
+                            signingConfigs.getByName("release")
+                        } else {
+                            signingConfigs.getByName("debug")
+                        }
                         proguardFiles(
                             getDefaultProguardFile("proguard-android-optimize.txt"),
                             "proguard-rules.pro",
@@ -49,6 +75,73 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
             dependencies.add("coreLibraryDesugaring", libs.findLibrary("desugar-jdk").get())
             dependencies.add("testImplementation", libs.findBundle("testing").get())
         }
+    }
+}
+
+private data class AppVersion(val name: String, val code: Int)
+
+/**
+ * Reads `versionName` from version.properties and derives a monotonic `versionCode`
+ * from it as `MAJOR * 10_000 + MINOR * 100 + PATCH` (i.e. the digits XXYYZZ), so the
+ * code is a deterministic function of the name with nothing to track separately:
+ * `0.1.0` -> 100, `1.2.3` -> 10203. MINOR and PATCH must each be <= 99 to stay
+ * monotonic; the build fails fast if either overflows.
+ *
+ * Pre-release suffixes (`-rc1`) are stripped, so `0.8.6-rc1` and `0.8.6` map to the
+ * same code — fine for tagged stable releases; bump the patch if you ship an RC users
+ * actually update from.
+ */
+private fun readAppVersion(target: Project): AppVersion {
+    val props = Properties().apply {
+        val file = target.rootProject.file("version.properties")
+        if (file.exists()) file.inputStream().use { load(it) }
+    }
+    val name = props.getProperty("versionName") ?: "0.0.0"
+    val (major, minor, patch) = name.substringBefore('-')
+        .split('.')
+        .map { it.toIntOrNull() ?: 0 }
+        .plus(listOf(0, 0, 0))
+        .take(3)
+    // The XXYYZZ packing only stays monotonic while MINOR and PATCH each fit in two
+    // digits; e.g. 0.1.100 would collide with 0.2.0 (both -> 200). Fail the build
+    // (and therefore CI) rather than silently ship a non-monotonic versionCode.
+    check(minor in 0..99 && patch in 0..99) {
+        "versionName '$name' exceeds the XXYYZZ versionCode scheme: MINOR and PATCH " +
+            "must each be <= 99 (got minor=$minor, patch=$patch). Bump MAJOR/MINOR instead."
+    }
+    return AppVersion(name = name, code = major * 10_000 + minor * 100 + patch)
+}
+
+private data class ReleaseSigning(
+    val storeFile: String,
+    val storePassword: String,
+    val keyAlias: String,
+    val keyPassword: String,
+)
+
+/**
+ * Resolves release signing credentials from environment variables (CI) first, then a
+ * local `keystore.properties` at the repo root. Returns null when any field is missing,
+ * which signals the caller to fall back to debug signing — keeping the keystore out of
+ * the repo while letting local `assembleRelease` and CI lint/test checks run unsigned.
+ */
+private fun readReleaseSigning(target: Project): ReleaseSigning? {
+    val propsFile = target.rootProject.file("keystore.properties")
+    val props = Properties().apply {
+        if (propsFile.exists()) propsFile.inputStream().use { load(it) }
+    }
+    fun value(env: String, prop: String): String? =
+        System.getenv(env) ?: props.getProperty(prop)
+
+    val storeFile = value("SIGNING_STORE_FILE", "storeFile")
+    val storePassword = value("SIGNING_STORE_PASSWORD", "storePassword")
+    val keyAlias = value("SIGNING_KEY_ALIAS", "keyAlias")
+    val keyPassword = value("SIGNING_KEY_PASSWORD", "keyPassword")
+
+    return if (storeFile != null && storePassword != null && keyAlias != null && keyPassword != null) {
+        ReleaseSigning(storeFile, storePassword, keyAlias, keyPassword)
+    } else {
+        null
     }
 }
 

--- a/core/common/build.gradle.kts
+++ b/core/common/build.gradle.kts
@@ -3,8 +3,24 @@ plugins {
     id("librechat.kmp.koin")
 }
 
+// Short commit the build was cut from, baked into BuildConfig so the running app can show it
+// (Settings → About). Falls back to "unknown" when there's no git checkout (e.g. a source
+// tarball). Only this module's BuildConfig references it, so a new commit recompiles core:common
+// alone — it doesn't cascade through the module graph.
+fun gitSha(): String = runCatching {
+    providers.exec {
+        commandLine("git", "rev-parse", "--short=8", "HEAD")
+    }.standardOutput.asText.get().trim()
+}.getOrNull()?.takeIf { it.isNotBlank() } ?: "unknown"
+
 android {
     namespace = "com.garfiec.librechat.core.common"
+    buildFeatures {
+        buildConfig = true
+    }
+    defaultConfig {
+        buildConfigField("String", "GIT_SHA", "\"${gitSha()}\"")
+    }
 }
 
 kotlin {

--- a/core/common/src/androidMain/kotlin/com/garfiec/librechat/core/common/AndroidAppInfo.kt
+++ b/core/common/src/androidMain/kotlin/com/garfiec/librechat/core/common/AndroidAppInfo.kt
@@ -1,0 +1,20 @@
+package com.garfiec.librechat.core.common
+
+import android.content.Context
+import android.os.Build
+
+internal class AndroidAppInfo(context: Context) : AppInfo {
+    private val packageInfo = context.packageManager.getPackageInfo(context.packageName, 0)
+
+    override val versionName: String = packageInfo.versionName ?: "unknown"
+
+    override val versionCode: Long =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            packageInfo.longVersionCode
+        } else {
+            @Suppress("DEPRECATION")
+            packageInfo.versionCode.toLong()
+        }
+
+    override val gitSha: String = BuildConfig.GIT_SHA
+}

--- a/core/common/src/androidMain/kotlin/com/garfiec/librechat/core/common/di/CommonPlatformModule.android.kt
+++ b/core/common/src/androidMain/kotlin/com/garfiec/librechat/core/common/di/CommonPlatformModule.android.kt
@@ -1,5 +1,7 @@
 package com.garfiec.librechat.core.common.di
 
+import com.garfiec.librechat.core.common.AndroidAppInfo
+import com.garfiec.librechat.core.common.AppInfo
 import com.garfiec.librechat.core.common.network.AndroidConnectivityObserver
 import com.garfiec.librechat.core.common.network.ConnectivityObserver
 import org.koin.android.ext.koin.androidContext
@@ -8,4 +10,5 @@ import org.koin.dsl.module
 
 actual val commonPlatformModule: Module = module {
     single<ConnectivityObserver> { AndroidConnectivityObserver(androidContext()) }
+    single<AppInfo> { AndroidAppInfo(androidContext()) }
 }

--- a/core/common/src/commonMain/kotlin/com/garfiec/librechat/core/common/AppInfo.kt
+++ b/core/common/src/commonMain/kotlin/com/garfiec/librechat/core/common/AppInfo.kt
@@ -1,0 +1,22 @@
+package com.garfiec.librechat.core.common
+
+/**
+ * Read-only access to the running app's version, sourced from the installed package
+ * metadata (not a hardcoded constant) so it always reflects the actual build and can
+ * never drift from [version.properties]. Provided per-platform via `commonPlatformModule`.
+ */
+interface AppInfo {
+    /** Human-facing semantic version, e.g. `0.1.0`. */
+    val versionName: String
+
+    /** Monotonic build number. */
+    val versionCode: Long
+
+    /**
+     * Short git commit the build was cut from (e.g. `1a2b3c4d`), or `unknown` when the build
+     * had no git checkout. Shown in Settings → About for transparency and bug reports — it lets
+     * a user cross-reference their build against the source commit and its release attestation.
+     * This is NOT an integrity check: a self-reported SHA proves nothing about a tampered binary.
+     */
+    val gitSha: String
+}

--- a/core/common/src/iosMain/kotlin/com/garfiec/librechat/core/common/IosAppInfo.kt
+++ b/core/common/src/iosMain/kotlin/com/garfiec/librechat/core/common/IosAppInfo.kt
@@ -1,0 +1,18 @@
+package com.garfiec.librechat.core.common
+
+import platform.Foundation.NSBundle
+
+internal class IosAppInfo : AppInfo {
+    private val bundle = NSBundle.mainBundle
+
+    override val versionName: String =
+        bundle.objectForInfoDictionaryKey("CFBundleShortVersionString") as? String ?: "unknown"
+
+    override val versionCode: Long =
+        (bundle.objectForInfoDictionaryKey("CFBundleVersion") as? String)?.toLongOrNull() ?: 0L
+
+    // Reads an Info.plist "GitSHA" key if the iOS build injects one; until that's wired into the
+    // Xcode/xcconfig build, this resolves to "unknown". Android bakes the real value via BuildConfig.
+    override val gitSha: String =
+        bundle.objectForInfoDictionaryKey("GitSHA") as? String ?: "unknown"
+}

--- a/core/common/src/iosMain/kotlin/com/garfiec/librechat/core/common/di/CommonPlatformModule.ios.kt
+++ b/core/common/src/iosMain/kotlin/com/garfiec/librechat/core/common/di/CommonPlatformModule.ios.kt
@@ -1,5 +1,7 @@
 package com.garfiec.librechat.core.common.di
 
+import com.garfiec.librechat.core.common.AppInfo
+import com.garfiec.librechat.core.common.IosAppInfo
 import com.garfiec.librechat.core.common.network.ConnectivityObserver
 import com.garfiec.librechat.core.common.network.IosConnectivityObserver
 import org.koin.core.module.Module
@@ -7,4 +9,5 @@ import org.koin.dsl.module
 
 actual val commonPlatformModule: Module = module {
     single<ConnectivityObserver> { IosConnectivityObserver() }
+    single<AppInfo> { IosAppInfo() }
 }

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,150 @@
+# Releasing
+
+How releases are versioned, signed, and published for LibreChat Mobile (Android).
+
+## Versioning
+
+The app version lives in **one place**: `version.properties` at the repo root.
+
+```properties
+versionName=0.1.0   # human-facing semver — the only thing you bump
+```
+
+- `AndroidApplicationConventionPlugin` reads `versionName` and **derives** `versionCode` as
+  `MAJOR*10000 + MINOR*100 + PATCH` (digits XXYYZZ): `0.1.0` → `100`, `1.2.3` → `10203`.
+  Monotonic as long as semver increases; limits are MINOR ≤ 99, PATCH ≤ 99.
+- The About screen reads the *installed* version via `AppInfo` (package metadata), so it can never drift.
+- This is the **app's** version and is intentionally independent of `SUPPORTED_BACKEND_VERSION`
+  (`core/common/BackendVersion.kt`), which tracks the LibreChat backend the app targets.
+
+Both platforms derive from the same `versionName`, so they stay in lockstep:
+
+| Platform | versionName | versionCode | Where |
+|---|---|---|---|
+| Android | `versionName` verbatim | derived XXYYZZ | `AndroidApplicationConventionPlugin` reads `version.properties` at build |
+| iOS | `CFBundleShortVersionString` | `CFBundleVersion` (same XXYYZZ) | *Stamp Version* Xcode build phase reads `version.properties` at build |
+
+> iOS isn't published on GitHub Releases — the stamp exists only to keep the two platforms'
+> reported versions identical. The "Stamp Version from version.properties" run-script phase
+> runs after Info.plist is in the bundle and before codesign, so the committed `Info.plist`
+> literals (and the unused `MARKETING_VERSION`/`CURRENT_PROJECT_VERSION` build settings) are
+> just a fallback snapshot — the build always reflects `version.properties`.
+
+Bump it with the script (also run by the release workflow):
+
+```bash
+scripts/bump-version.sh patch   # 0.1.0 -> 0.1.1  (versionCode 100 -> 101)
+scripts/bump-version.sh minor   # 0.1.0 -> 0.2.0  (versionCode 100 -> 200)
+scripts/bump-version.sh major   # 0.1.0 -> 1.0.0  (versionCode 100 -> 10000)
+```
+
+### Release candidates
+
+To ship a candidate before a stable release, use the pre-release bumps:
+
+```bash
+scripts/bump-version.sh preminor  # 0.1.0    -> 0.2.0-rc1   (next minor, candidate 1)
+scripts/bump-version.sh rc        # 0.2.0-rc1 -> 0.2.0-rc2  (next candidate)
+scripts/bump-version.sh finalize  # 0.2.0-rc2 -> 0.2.0      (promote to stable)
+```
+
+`prepatch`/`preminor`/`premajor` start a candidate for the bumped version; `rc` advances
+the candidate number; `finalize` drops the suffix to promote the current candidate. A
+hyphenated version is published as a GitHub **pre-release**, which Obtainium skips unless
+the user enables *Include prereleases*.
+
+> The `-rcN` suffix is stripped when deriving the versionCode, so `0.2.0-rc1`, `0.2.0-rc2`,
+> and the final `0.2.0` all share one versionCode. Candidates install over each other fine,
+> but if users update *from* a candidate *to* the final build, bump the patch instead of
+> finalizing so the version visibly advances.
+
+## One-time signing key setup
+
+Releases must be signed with **one permanent key**. If the key ever changes, every existing
+user's update fails with a signature conflict and recovery requires uninstall + reinstall
+(full data loss). There is no key reset for direct/sideloaded distribution.
+
+1. **Generate the keystore** (do this once, keep it forever):
+
+   ```bash
+   keytool -genkeypair -v \
+     -keystore librechat-release.jks \
+     -alias librechat \
+     -keyalg RSA -keysize 4096 -validity 10000 \
+     -storetype PKCS12 \
+     -dname "CN=LibreChat Mobile, O=LibreChat, C=US"
+   ```
+
+   Back it up in **2+ secure locations** (password manager / offline). Do **not** commit it
+   (`.gitignore` already excludes `*.jks` and `keystore.properties`).
+
+2. **Add GitHub repository secrets** (Settings → Secrets and variables → Actions). Ideally put
+   them in an Environment named `release` with required reviewers, so the release job is gated.
+
+   | Secret | Value |
+   |---|---|
+   | `SIGNING_KEYSTORE_BASE64` | `openssl base64 -A < librechat-release.jks` |
+   | `SIGNING_STORE_PASSWORD` | keystore password |
+   | `SIGNING_KEY_PASSWORD` | key password |
+   | `SIGNING_KEY_ALIAS` | `librechat` |
+
+3. **Publish the certificate fingerprint** in the README so users can verify:
+
+   ```bash
+   keytool -list -v -keystore librechat-release.jks -alias librechat   # SHA-256 line
+   ```
+
+### Local signed builds (optional)
+
+Create `keystore.properties` at the repo root (git-ignored):
+
+```properties
+storeFile=librechat-release.jks
+storePassword=...
+keyAlias=librechat
+keyPassword=...
+```
+
+Then `./gradlew :app:assembleRelease` produces a signed APK. Without env vars or this file,
+release builds fall back to the debug key so local builds and CI checks still work.
+
+## Cutting a release
+
+1. Actions → **Release** → *Run workflow* → choose the bump (`patch`/`minor`/`major`, or a
+   `prepatch`/`preminor`/`premajor`/`rc`/`finalize` candidate).
+2. The job bumps `version.properties`, builds a signed universal APK, signs a SLSA
+   build-provenance attestation for it, and **only then** commits + tags `vX.Y.Z` and creates
+   a **draft** GitHub Release with auto-generated notes and a `.sha256` checksum. Candidate
+   versions are flagged as pre-releases automatically. If the build fails, nothing is committed
+   or tagged — just re-run after fixing it.
+3. Review the draft, edit the notes for users, then **publish**.
+4. Obtainium / IzzyOnDroid pick up the published release automatically.
+
+> **Drafts are invisible to Obtainium.** A release stays hidden from every user until you
+> click **Publish** — Obtainium's GitHub source skips drafts. The workflow ends with a
+> warning annotation reminding you to publish; don't skip it.
+
+> **Branch protection:** the workflow pushes the version-bump commit and tag to the default
+> branch. If that branch is protected, allow the `github-actions[bot]` to bypass push
+> restrictions, or the *Commit & tag* step will fail.
+
+## Verifying a release
+
+Three checks are available to anyone who downloads an APK, in descending order of strength:
+
+1. **Build provenance (strongest)** — `gh attestation verify <apk> --repo garfiec/Librechat-Mobile
+   --signer-workflow garfiec/Librechat-Mobile/.github/workflows/release.yml`. This is the only
+   check that resists a *tampered upload*: it's signed by GitHub's CI via Sigstore and can't be
+   forged outside the runner. Each release's notes link the run + attestation, but a link is not
+   proof — only this command verifies the downloaded bytes. See the README install section.
+2. **Signing certificate** — `apksigner verify --print-certs <apk>`, compared against the
+   published cert SHA-256. Catches a build signed with a different key.
+3. **Checksum** — `sha256sum -c <apk>.sha256`. Catches accidental corruption or a download MITM
+   only; it does *not* defend against a malicious release (the attacker would control both files).
+
+## Distribution channels
+
+- **Obtainium** — tracks GitHub Releases directly (see the README install section). Stable
+  releases are full releases; `-rcN` candidate tags are marked pre-release.
+- **IzzyOnDroid** (future) — ingests the developer-signed APK and pins the signing key via
+  `AllowedAPKSigningKeys`. Use the *same* key. Reproducible builds earn a verification badge.

--- a/feature/settings/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/settings/di/SettingsModuleVerificationTest.kt
+++ b/feature/settings/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/settings/di/SettingsModuleVerificationTest.kt
@@ -2,6 +2,7 @@ package com.garfiec.librechat.feature.settings.di
 
 import android.app.Application
 import android.content.Context
+import com.garfiec.librechat.core.common.AppInfo
 import com.garfiec.librechat.core.data.datastore.ServerDataStore
 import com.garfiec.librechat.core.data.datastore.SettingsDataStore
 import com.garfiec.librechat.core.data.datastore.ThemeDataStore
@@ -33,6 +34,7 @@ class SettingsModuleVerificationTest {
             extraTypes = listOf(
                 Context::class,
                 Application::class,
+                AppInfo::class,
                 UserRepository::class,
                 AuthRepository::class,
                 ConfigRepository::class,

--- a/feature/settings/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/settings/viewmodel/SettingsViewModelTest.kt
+++ b/feature/settings/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/settings/viewmodel/SettingsViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.garfiec.librechat.feature.settings.viewmodel
 
+import com.garfiec.librechat.core.common.AppInfo
 import com.garfiec.librechat.core.common.ChatLayoutConstants
 import com.garfiec.librechat.core.common.result.Result
 import com.garfiec.librechat.core.data.datastore.ChatFontSize
@@ -146,6 +147,11 @@ class SettingsViewModelTest {
         roleRepository = roleRepository,
         permissionGate = permissionGate,
         configRepository = configRepository,
+        appInfo = object : AppInfo {
+            override val versionName = "0.1.0"
+            override val versionCode = 1L
+            override val gitSha = "testsha0"
+        },
     )
 
     @Test

--- a/feature/settings/src/commonMain/composeResources/values/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values/strings.xml
@@ -126,7 +126,7 @@
 
     <!-- About info -->
     <string name="app_version_label">App version</string>
-    <string name="app_version_value">1.0.0</string>
+    <string name="app_build_label">Build</string>
     <string name="server_label">Server</string>
     <string name="server_not_configured">Not configured</string>
 

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/GeneralSettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/GeneralSettingsScreen.kt
@@ -151,7 +151,11 @@ fun GeneralSettingsContent(
                 SectionHeader(stringResource(Res.string.section_about))
             }
             item(key = "about_info") {
-                AboutInfo(serverUrl = uiState.serverUrl)
+                AboutInfo(
+                    serverUrl = uiState.serverUrl,
+                    appVersion = uiState.appVersion,
+                    gitSha = uiState.gitSha,
+                )
             }
 
             // Bottom spacing
@@ -278,7 +282,7 @@ private fun TabletSidebarGestureToggle(
 }
 
 @Composable
-private fun AboutInfo(serverUrl: String) {
+private fun AboutInfo(serverUrl: String, appVersion: String, gitSha: String) {
     Column {
         Column(
             modifier = Modifier
@@ -294,10 +298,27 @@ private fun AboutInfo(serverUrl: String) {
                     style = MaterialTheme.typography.bodyMedium,
                 )
                 Text(
-                    text = stringResource(Res.string.app_version_value),
+                    text = appVersion,
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
+            }
+            if (gitSha.isNotBlank()) {
+                Spacer(modifier = Modifier.height(8.dp))
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                ) {
+                    Text(
+                        text = stringResource(Res.string.app_build_label),
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                    Text(
+                        text = gitSha,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
             }
             Spacer(modifier = Modifier.height(8.dp))
             Row(

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/sections/ChatPreferencesSection.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/sections/ChatPreferencesSection.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -23,56 +22,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.garfiec.librechat.feature.settings.resources.*
 import com.garfiec.librechat.feature.settings.resources.Res
 import org.jetbrains.compose.resources.stringResource
-
-@Composable
-internal fun AboutInfo(serverUrl: String) {
-    Column {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 16.dp, vertical = 8.dp),
-        ) {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-            ) {
-                Text(
-                    text = stringResource(Res.string.app_version_label),
-                    style = MaterialTheme.typography.bodyMedium,
-                )
-                Text(
-                    text = stringResource(Res.string.app_version_value),
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
-            Spacer(modifier = Modifier.height(8.dp))
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-            ) {
-                Text(
-                    text = stringResource(Res.string.server_label),
-                    style = MaterialTheme.typography.bodyMedium,
-                )
-                Text(
-                    text = serverUrl.ifBlank { stringResource(Res.string.server_not_configured) },
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                    modifier = Modifier.weight(1f, fill = false),
-                )
-            }
-        }
-        HorizontalDivider(modifier = Modifier.padding(top = 8.dp))
-    }
-}
 
 @Composable
 internal fun DangerZone(

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/SettingsViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/SettingsViewModel.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Immutable
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import co.touchlab.kermit.Logger
+import com.garfiec.librechat.core.common.AppInfo
 import com.garfiec.librechat.core.common.ChatLayoutConstants
 import com.garfiec.librechat.core.common.result.Result
 import com.garfiec.librechat.core.data.datastore.ChatFontSize
@@ -74,6 +75,10 @@ data class SettingsUiState(
     val user: UserDisplayData? = null,
     val themeMode: ThemeMode = ThemeMode.SYSTEM,
     val serverUrl: String = "",
+    /** Human-facing app version (e.g. `0.1.0`), sourced from the installed package. */
+    val appVersion: String = "",
+    /** Short git commit the build was cut from (e.g. `1a2b3c4d`), or `unknown`. */
+    val gitSha: String = "",
     val isDeletingAccount: Boolean = false,
     /**
      * Transient errors surfaced via snackbar; cleared by [SettingsViewModel.dismissError]
@@ -235,10 +240,13 @@ class SettingsViewModel(
     private val roleRepository: RoleRepository,
     private val permissionGate: PermissionGate,
     private val configRepository: ConfigRepository,
+    appInfo: AppInfo,
 ) : ViewModel() {
 
     /** Raw state for everything not driven by DataStore flows. */
-    private val _uiState = MutableStateFlow(SettingsUiState())
+    private val _uiState = MutableStateFlow(
+        SettingsUiState(appVersion = appInfo.versionName, gitSha = appInfo.gitSha),
+    )
 
     private val stateHandle = SettingsStateHandle(_uiState, viewModelScope)
 

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -45,6 +45,22 @@
 			shellPath = /bin/sh;
 			shellScript = "# Aggregate and copy Compose Multiplatform resources into the app bundle.\n# Runs the Gradle aggregation task to ensure resources from all feature\n# modules are collected, then copies them into the .app bundle where\n# the Compose resource reader expects them at runtime.\n\nif [ \"$PLATFORM_NAME\" = \"iphonesimulator\" ]; then\n    ARCH_DIR=\"iosSimulatorArm64\"\n    GRADLE_TASK=\":shared:iosSimulatorArm64AggregateResources\"\nelif [ \"$PLATFORM_NAME\" = \"iphoneos\" ]; then\n    ARCH_DIR=\"iosArm64\"\n    GRADLE_TASK=\":shared:iosArm64AggregateResources\"\nelse\n    echo \"error: Unsupported PLATFORM_NAME: $PLATFORM_NAME\"\n    exit 1\nfi\n\nPROJECT_ROOT=\"$SRCROOT/..\"\nSRC=\"$PROJECT_ROOT/shared/build/kotlin-multiplatform-resources/aggregated-resources/$ARCH_DIR/composeResources\"\nDST=\"$BUILT_PRODUCTS_DIR/$PRODUCT_NAME.app/compose-resources/composeResources\"\n\n# Run Gradle aggregation to ensure resources are up to date\necho \"Running $GRADLE_TASK...\"\ncd \"$PROJECT_ROOT\" && ./gradlew \"$GRADLE_TASK\" 2>&1\nGRADLE_EXIT=$?\nif [ $GRADLE_EXIT -ne 0 ]; then\n    echo \"error: Gradle task $GRADLE_TASK failed with exit code $GRADLE_EXIT\"\n    exit $GRADLE_EXIT\nfi\n\n# Clean stale resources before copying fresh ones\nif [ -d \"$DST\" ]; then\n    rm -rf \"$DST\"\nfi\n\nif [ -d \"$SRC\" ]; then\n    mkdir -p \"$DST\"\n    cp -R \"$SRC/\" \"$DST/\"\n    echo \"Copied Compose resources from $SRC to $DST\"\nelse\n    echo \"error: Compose resources not found at $SRC after Gradle aggregation\"\n    exit 1\nfi\n";
 		};
+		SSS00002 /* Stamp Version from version.properties */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/../version.properties",
+			);
+			name = "Stamp Version from version.properties";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Stamp the iOS bundle version from version.properties, the single source of\n# truth shared with Android. versionName -> CFBundleShortVersionString; a derived\n# XXYYZZ versionCode (MAJOR*10000 + MINOR*100 + PATCH) -> CFBundleVersion, using the\n# same formula as Android so both platforms report the same version. This runs as the\n# last build phase (after Info.plist is in the bundle, before codesign), so the value\n# always reflects version.properties regardless of the committed Info.plist literals.\nset -eu\nPROPS=\"$SRCROOT/../version.properties\"\nif [ ! -f \"$PROPS\" ]; then\n    echo \"error: version.properties not found at $PROPS\"\n    exit 1\nfi\nVERSION_NAME=$(grep -E '^versionName=' \"$PROPS\" | cut -d'=' -f2 | tr -d '[:space:]')\nif [ -z \"$VERSION_NAME\" ]; then\n    echo \"error: versionName missing or malformed in $PROPS\"\n    exit 1\nfi\nCORE=${VERSION_NAME%%-*}\n# Split into MAJOR/MINOR/PATCH on '.'; any missing component defaults to 0.\nIFS=.\nset -f\nset -- $CORE\nset +f\nunset IFS\nMAJOR=${1:-0}\nMINOR=${2:-0}\nPATCH=${3:-0}\n# Treat any empty or non-numeric component as 0, the same way Android parses it.\ncase \"$MAJOR\" in \"\"|*[!0-9]*) MAJOR=0 ;; esac\ncase \"$MINOR\" in \"\"|*[!0-9]*) MINOR=0 ;; esac\ncase \"$PATCH\" in \"\"|*[!0-9]*) PATCH=0 ;; esac\nif [ \"$MINOR\" -gt 99 ] || [ \"$PATCH\" -gt 99 ]; then\n    echo \"error: versionName '$VERSION_NAME' exceeds the XXYYZZ scheme (MINOR/PATCH must be <= 99)\"\n    exit 1\nfi\n# Force base 10 so a zero-padded component (e.g. 08) is not interpreted as octal.\nVERSION_CODE=$((10#$MAJOR * 10000 + 10#$MINOR * 100 + 10#$PATCH))\nPLIST=\"$TARGET_BUILD_DIR/$INFOPLIST_PATH\"\n/usr/libexec/PlistBuddy -c \"Set :CFBundleShortVersionString $VERSION_NAME\" \"$PLIST\"\n/usr/libexec/PlistBuddy -c \"Set :CFBundleVersion $VERSION_CODE\" \"$PLIST\"\necho \"Stamped iOS version $VERSION_NAME ($VERSION_CODE) into $PLIST\"\n";
+		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXResourcesBuildPhase section */
@@ -131,6 +147,7 @@
 				EEE00001 /* Frameworks */,
 				CCC00001 /* Embed Frameworks */,
 				SSS00001 /* Copy Compose Resources */,
+				SSS00002 /* Stamp Version from version.properties */,
 			);
 			buildRules = (
 			);
@@ -239,7 +256,7 @@
 				CODE_SIGN_IDENTITY = "-";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 100;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -259,7 +276,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 0.1.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-lsqlite3",
@@ -278,7 +295,7 @@
 				CODE_SIGN_IDENTITY = "-";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 100;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -298,7 +315,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 0.1.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-lsqlite3",

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -16,10 +16,13 @@
 	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
+	<!-- Overwritten at build time by the "Stamp Version from version.properties"
+	     build phase; version.properties is the single source of truth. These
+	     literals are just a sane fallback snapshot. -->
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>0.1.0</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>100</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+#
+# Bump the app version in version.properties (the single source of truth).
+#
+# Usage:
+#   scripts/bump-version.sh <bump>
+#
+# Stable bumps (clear any pre-release suffix):
+#   major     X.y.z       -> (X+1).0.0
+#   minor     x.Y.z       -> x.(Y+1).0
+#   patch     x.y.Z       -> x.y.(Z+1)
+#
+# Pre-release bumps (append/advance an -rcN suffix):
+#   premajor  X.y.z       -> (X+1).0.0-rc1
+#   preminor  x.Y.z       -> x.(Y+1).0-rc1
+#   prepatch  x.y.Z       -> x.y.(Z+1)-rc1
+#   rc        x.y.z-rcN   -> x.y.z-rc(N+1)   (requires an existing -rcN)
+#   finalize  x.y.z-rcN   -> x.y.z           (promote a candidate to stable)
+#
+# A version with an -rcN suffix is treated as a pre-release: the release workflow
+# marks the GitHub Release as a pre-release so Obtainium ignores it unless the user
+# opts in. versionCode is NOT stored here — it is derived from versionName at build
+# time by the Android convention plugin (MAJOR*10000 + MINOR*100 + PATCH), which
+# strips the suffix, so an -rcN and its final release share a versionCode.
+#
+# Output:
+#   - prints the new version name to stdout
+#   - when running in GitHub Actions, also writes version_name and tag -> $GITHUB_OUTPUT
+#
+set -euo pipefail
+
+BUMP="${1:-}"
+case "$BUMP" in
+  major|minor|patch|premajor|preminor|prepatch|rc|finalize) ;;
+  *)
+    echo "Usage: $0 <major|minor|patch|premajor|preminor|prepatch|rc|finalize>" >&2
+    exit 1
+    ;;
+esac
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROPS="$SCRIPT_DIR/../version.properties"
+
+if [[ ! -f "$PROPS" ]]; then
+  echo "version.properties not found at $PROPS" >&2
+  exit 1
+fi
+
+current_name="$(grep -E '^versionName=' "$PROPS" | cut -d'=' -f2 | tr -d '[:space:]')"
+
+if [[ -z "$current_name" ]]; then
+  echo "versionName missing or malformed in $PROPS" >&2
+  exit 1
+fi
+
+# Parse the semver core (everything before the first '-') and the current rc number.
+core_name="${current_name%%-*}"
+IFS='.' read -r major minor patch <<< "$core_name"
+major="${major:-0}"; minor="${minor:-0}"; patch="${patch:-0}"
+
+# Extract N from a current -rcN suffix, if any (else empty -> not a pre-release).
+rc=""
+if [[ "$current_name" == *-rc* ]]; then
+  rc="${current_name##*-rc}"
+fi
+
+pre=""   # set to "-rcN" to emit a pre-release version
+case "$BUMP" in
+  major)    major=$((major + 1)); minor=0; patch=0 ;;
+  minor)    minor=$((minor + 1)); patch=0 ;;
+  patch)    patch=$((patch + 1)) ;;
+  premajor) major=$((major + 1)); minor=0; patch=0; pre="-rc1" ;;
+  preminor) minor=$((minor + 1)); patch=0; pre="-rc1" ;;
+  prepatch) patch=$((patch + 1)); pre="-rc1" ;;
+  rc)
+    if [[ -z "$rc" || ! "$rc" =~ ^[0-9]+$ ]]; then
+      echo "'rc' requires a current -rcN pre-release (got '$current_name'); start one with prepatch/preminor/premajor" >&2
+      exit 1
+    fi
+    pre="-rc$((rc + 1))"   # core stays put; only the candidate number advances
+    ;;
+  finalize)
+    if [[ -z "$rc" || ! "$rc" =~ ^[0-9]+$ ]]; then
+      echo "'finalize' requires a current -rcN pre-release to promote (got '$current_name')" >&2
+      exit 1
+    fi
+    # core stays put; pre cleared -> stable release
+    ;;
+esac
+
+new_name="${major}.${minor}.${patch}${pre}"
+tag="v${new_name}"
+
+# Rewrite version.properties, preserving the header comments.
+tmp="$(mktemp)"
+while IFS= read -r line || [[ -n "$line" ]]; do
+  if [[ "$line" == versionName=* ]]; then
+    echo "versionName=${new_name}"
+  else
+    echo "$line"
+  fi
+done < "$PROPS" > "$tmp"
+mv "$tmp" "$PROPS"
+
+echo "$new_name"
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  {
+    echo "version_name=${new_name}"
+    echo "tag=${tag}"
+  } >> "$GITHUB_OUTPUT"
+fi

--- a/version.properties
+++ b/version.properties
@@ -1,0 +1,6 @@
+# Single source of truth for the app version.
+# Bumped by scripts/bump-version.sh (major | minor | patch).
+# versionCode is DERIVED from versionName by AndroidApplicationConventionPlugin as
+# MAJOR*10000 + MINOR*100 + PATCH (digits XXYYZZ): 0.1.0 -> 100, 1.2.3 -> 10203.
+# This is the app's own version, independent of SUPPORTED_BACKEND_VERSION.
+versionName=0.1.0


### PR DESCRIPTION
Closes #66

Sets up proper Android releases so users can install and auto-update via GitHub
Releases / Obtainium without building from source.

## Versioning

Introduces `version.properties` at the repo root as the single source of truth for
the app version. It stores only `versionName`; `versionCode` is **derived** from it as
`MAJOR*10000 + MINOR*100 + PATCH` (digits XXYYZZ), so there is nothing to bump by hand
and the two cannot drift. Both platforms derive from the same file at build time — the
Android convention plugin for the APK, and an Xcode "Stamp Version" build phase for iOS —
so they always report identical versions. The build fails fast if MINOR or PATCH exceeds
99, which would break monotonicity. The About screen reads the actual installed version
via a new `AppInfo` provider (PackageManager on Android, `NSBundle` on iOS) instead of a
hardcoded string, so it can't drift either; it also shows the short git commit the build
was cut from (baked into `BuildConfig`) for transparency and bug reports. The app version
stays independent of `SUPPORTED_BACKEND_VERSION` (a different concept).

Start version: `0.1.0` (code `100`).

## Release signing

Adds a `release` signing config that resolves credentials from environment
variables (CI) → `keystore.properties` (local) → debug signing fallback, so local
`assembleRelease` and CI checks still work without the key. A stable release key is
required for in-place updates — a key change forces every sideloaded/Obtainium user
to uninstall and reinstall.

## Build optimization

Release builds enable resource shrinking (`isShrinkResources`) on top of R8 code
shrinking + obfuscation, so unused resources are stripped from the published APK.

## Supply-chain hardening

- **Pinned actions.** Third-party actions in the secret-bearing `release` job are pinned
  to commit SHAs (not moving tags), so a compromised action can't slip into a job that
  holds the signing secrets. GitHub-owned actions (`checkout`, `setup-java`,
  `attest-build-provenance`) stay on major tags. Dependabot tracks the `github-actions`
  ecosystem so the pins stay current — including for security advisories — without manual
  CVE tracking.
- **Build provenance.** Every release APK gets a [SLSA build-provenance
  attestation](https://slsa.dev), signed keylessly via Sigstore using the Actions OIDC
  identity. Unlike the `.sha256` — which whoever attaches a release could regenerate — the
  attestation proves the binary came from this repo's release workflow at a specific
  commit and **can't be forged outside GitHub's CI**. It's the only check that resists a
  tampered upload. The release notes link the run + attestation (transparency) and document
  the `gh attestation verify` command (the part that actually proves it); README and
  `docs/RELEASING.md` document verification, ranked attestation > signing cert > checksum.

## Automation

- `scripts/bump-version.sh <bump>` — bumps `versionName` only (the versionCode is
  derived at build time). Supports stable bumps (`major`/`minor`/`patch`) and a
  release-candidate lifecycle: `prepatch`/`preminor`/`premajor` start an `-rc1`, `rc`
  advances the candidate number, and `finalize` promotes a candidate to stable.
- `.github/workflows/release.yml` — a dispatchable, one-button release gated behind a
  protected `release` environment. It bumps the version and **builds the signed APK
  first**, signs a provenance attestation, then commits + tags `vX.Y.Z` and publishes a
  **draft** release with auto-generated notes + a `.sha256` checksum. Hyphenated versions
  are flagged as GitHub pre-releases (Obtainium skips them by default).

## Release flow

The tag and the version-bump commit are pushed **only after** a signed APK exists, so
a failed build never leaves an orphaned tag or a burned version on the branch; the
push is `--atomic` (branch + tag all-or-nothing). The release is created as a **draft**
— invisible to Obtainium until a maintainer publishes it.

```mermaid
flowchart TD
    A([Dispatch: choose bump]) --> B[Verify signing secrets]
    B -- missing/blank --> X1([Fail fast — nothing changed])
    B -- ok --> C[Bump version.properties on runner]
    C --> D[Decode keystore]
    D --> E[Build signed APK]
    E -- build fails --> X2([Fail — no commit, no tag, clean re-run])
    E -- ok --> F[Prepare APK + .sha256]
    F --> F2[Sign build-provenance attestation]
    F2 --> G[Commit, tag &amp; atomic push to branch]
    G --> H[Create DRAFT GitHub Release]
    H --> I[/Warn: draft is invisible until published/]
    I --> J{{Maintainer reviews &amp; clicks Publish}}
    J --> K([Obtainium / IzzyOnDroid pick it up])
```

## Docs

- README "Install (Android)" section with an Add-to-Obtainium button, signature
  verification, and build-provenance verification steps.
- `docs/RELEASING.md` — keystore generation, secrets setup, the release flow, and a
  "Verifying a release" section.

## Maintainer setup required before the first release

1. Generate the release keystore (see `docs/RELEASING.md`), back it up, and add the
   secrets: `SIGNING_KEYSTORE_BASE64`, `SIGNING_STORE_PASSWORD`,
   `SIGNING_KEY_PASSWORD`, `SIGNING_KEY_ALIAS`.
2. Fill in the certificate SHA-256 fingerprint in the README.
3. Allow `github-actions[bot]` to bypass branch protection on `develop` (the
   workflow pushes the version-bump commit + tag), or the release run will fail.
