### PR TITLE
fix(release): push bump commit via fine-grained PAT to satisfy branch ruleset

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,12 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0   # full history for auto-generated release notes
+          # Pushing the bump commit + tag to the ruleset-protected default branch needs an
+          # actor that bypasses the ruleset. The github-actions bot can't be a bypass actor
+          # on a personal (non-org) repo, so authenticate as the repo owner via a
+          # fine-grained PAT (Contents: write) — already a bypass actor. Set in the
+          # 'release' environment. checkout persists it for the later push.
+          token: ${{ secrets.RELEASE_PAT }}
 
       - name: Set up JDK 21
         uses: actions/setup-java@v5
@@ -66,12 +72,15 @@ jobs:
           SIGNING_STORE_PASSWORD: ${{ secrets.SIGNING_STORE_PASSWORD }}
           SIGNING_KEY_PASSWORD: ${{ secrets.SIGNING_KEY_PASSWORD }}
           SIGNING_KEY_ALIAS: ${{ secrets.SIGNING_KEY_ALIAS }}
+          RELEASE_PAT: ${{ secrets.RELEASE_PAT }}
         run: |
           missing=""
           [ -z "$SIGNING_KEYSTORE_BASE64" ] && missing="$missing SIGNING_KEYSTORE_BASE64"
           [ -z "$SIGNING_STORE_PASSWORD" ] && missing="$missing SIGNING_STORE_PASSWORD"
           [ -z "$SIGNING_KEY_PASSWORD" ] && missing="$missing SIGNING_KEY_PASSWORD"
           [ -z "$SIGNING_KEY_ALIAS" ] && missing="$missing SIGNING_KEY_ALIAS"
+          # PAT used by checkout to push past the branch ruleset (see Checkout step).
+          [ -z "$RELEASE_PAT" ] && missing="$missing RELEASE_PAT"
           if [ -n "$missing" ]; then
             echo "::error title=Missing signing secrets::Set these in the 'release' environment:$missing"
             exit 1

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -125,8 +125,12 @@ release builds fall back to the debug key so local builds and CI checks still wo
 > warning annotation reminding you to publish; don't skip it.
 
 > **Branch protection:** the workflow pushes the version-bump commit and tag to the default
-> branch. If that branch is protected, allow the `github-actions[bot]` to bypass push
-> restrictions, or the *Commit & tag* step will fail.
+> branch, which is ruleset-protected. The `github-actions` bot can't be a ruleset bypass
+> actor on a personal (non-org) repo, so the workflow authenticates the push with a
+> fine-grained PAT instead. Create one (**Contents: read & write**, this repo only, short
+> expiry) and add it as a secret named `RELEASE_PAT` in the `release` environment. It pushes
+> as the repo owner (already a bypass actor); without it the run fails fast at the
+> *Verify signing secrets* step.
 
 ## Verifying a release
 


### PR DESCRIPTION
Follow-up to #95. The release workflow pushes the version-bump commit + tag to the
ruleset-protected default branch, but that push needs an actor that bypasses the ruleset.

The `github-actions` bot **can't** be a ruleset bypass actor on a personal (non-org) repo
— GitHub rejects it (`Actor GitHub Actions integration must be part of the ruleset source or
owner organization`). So the workflow authenticates the push with a fine-grained PAT that
acts as the repo owner, which is already a bypass actor (Repository admin).

## Changes

- `release.yml`: `actions/checkout` uses `secrets.RELEASE_PAT` (persisted for the later
  `git push`); the *Verify signing secrets* step fails fast if `RELEASE_PAT` is missing.
- `docs/RELEASING.md`: branch-protection note rewritten for the PAT approach.

## Maintainer setup (required before the next release run)

A fine-grained PAT — **Contents: read & write**, this repo only, with an expiry — added as
an **environment secret** named `RELEASE_PAT` under the `release` environment (alongside the
signing secrets).

## Tradeoffs

- The PAT expires; the release run fails until it's rotated.
- The bump commit is authored by the repo owner, not the bot.
- The more-hardened alternative (a GitHub App minting short-lived tokens) was considered but
  is heavier setup; the PAT route was chosen.