### PR TITLE
chore(release): slim release-note provenance footer to two links

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,25 +154,14 @@ jobs:
           # ignores it unless the user opts into "Include prereleases".
           prerelease: ${{ contains(steps.bump.outputs.tag, '-') }}
           generate_release_notes: true
-          # Append our provenance block to the auto-generated changelog (don't replace it).
+          # Append a slim provenance footer to the auto-generated changelog (don't replace it).
+          # These links are for discoverability, not proof; the canonical "how to verify a
+          # download" instructions live in docs/RELEASING.md + README, not in every release.
           append_body: true
           body: |
-            ## Provenance & verification
 
-            Built by CI — [view the workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) · [view the attestation](${{ steps.attest.outputs.attestation-url }})
-
-            These links show how the APK was built; they are **not** proof on their own (whoever
-            writes a release also writes its links). To cryptographically verify the downloaded
-            APK came from this repo's release workflow, with the [GitHub CLI](https://cli.github.com):
-
-            ```bash
-            gh attestation verify ${{ steps.artifacts.outputs.apk }} \
-              --repo ${{ github.repository }} \
-              --signer-workflow ${{ github.repository }}/.github/workflows/release.yml
-            ```
-
-            Weaker checks: `apksigner verify --print-certs ${{ steps.artifacts.outputs.apk }}`
-            (signing cert) and `sha256sum -c ${{ steps.artifacts.outputs.apk }}.sha256` (checksum).
+            ---
+            [Build provenance attestation](${{ steps.attest.outputs.attestation-url }}) · [CI workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
           files: |
             ${{ steps.artifacts.outputs.apk }}
             ${{ steps.artifacts.outputs.apk }}.sha256


### PR DESCRIPTION
## What

Trims the provenance block that the release workflow appends to each GitHub Release's auto-generated notes down to a two-link footer.

**Before** — every release note carried a full `## Provenance & verification` section: a "Built by CI —" line, an explanatory "these links aren't proof" paragraph, the inline `gh attestation verify` command, and a weaker-checks line.

**After** — just a horizontal rule and two links:

```
---
[Build provenance attestation](…) · [CI workflow run](…)
```

## Why

Repeating the full verification instructions in every release is redundant — it's the same text each time, and the attestation is verifiable by digest regardless of any link. This matches how projects like `cli/cli` and npm provenance handle it: document verification **once** in a canonical place, keep release notes lean.

The canonical "how to verify a download" instructions already live in `README.md` (user-facing) and `docs/RELEASING.md` (maintainer-facing, three checks in order of strength) — both untouched here. The footer links are for discoverability, not proof.

## Scope

- `.github/workflows/release.yml` — only the `Create draft release` step's `body:` block (−16/+5). No behavioral change to building, signing, attesting, or publishing.