### PR TITLE
fix(chat): eliminate per-token flash while streaming markdown

### DIFF
--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/components/MarkdownContent.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/components/MarkdownContent.kt
@@ -95,6 +95,7 @@ actual fun MarkdownContent(
     searchFocusedOccurrence: Int,
     onFocusedOccurrencePosition: ((LayoutCoordinates) -> Unit)?,
     immediate: Boolean,
+    streaming: Boolean,
 ) {
     val segments = remember(text) { parseMarkdownSegments(text) }
     val isSearchActive = !searchQuery.isNullOrBlank()
@@ -163,6 +164,7 @@ actual fun MarkdownContent(
                                                 content = inlineSegment.text,
                                                 fontSizeMultiplier = fontSizeMultiplier,
                                                 immediate = immediate,
+                                                streaming = streaming,
                                             )
                                         }
                                     }
@@ -219,6 +221,7 @@ actual fun MarkdownContent(
                                 content = segment.text,
                                 fontSizeMultiplier = fontSizeMultiplier,
                                 immediate = immediate,
+                                streaming = streaming,
                             )
                         }
                     }
@@ -289,6 +292,7 @@ private fun MarkdownTextSegment(
     modifier: Modifier = Modifier,
     fontSizeMultiplier: Float = 1.0f,
     immediate: Boolean = false,
+    streaming: Boolean = false,
 ) {
     val colors = markdownColor(
         text = MaterialTheme.colorScheme.onSurface,
@@ -329,6 +333,7 @@ private fun MarkdownTextSegment(
             typography = typography,
             modifier = modifier.fillMaxWidth(),
             immediate = immediate,
+            streaming = streaming,
         )
     }
 }

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/CachedMarkdown.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/CachedMarkdown.kt
@@ -2,6 +2,8 @@ package com.garfiec.librechat.feature.chat.components
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import com.mikepenz.markdown.m3.Markdown
 import com.mikepenz.markdown.model.MarkdownColors
@@ -10,20 +12,41 @@ import com.mikepenz.markdown.model.State
 import com.mikepenz.markdown.model.rememberMarkdownState
 
 /**
- * Renders markdown via the m3 [Markdown] composable, preferring a cached
- * [State.Success] from [LocalParsedMarkdownCache] when available.
+ * Renders markdown via the m3 [Markdown] composable, backed by the session-wide
+ * [LocalParsedMarkdownCache] of parsed ASTs.
  *
- * On cache hit the `Markdown(state = ...)` overload is used directly, skipping
- * the library's `StateFlow<State>` + `LaunchedEffect` parse path — no
- * Loading→Success transient, so a LazyColumn re-entry doesn't briefly render
- * at 0 px and push surrounding content down.
+ * Two paths, chosen by [streaming]:
  *
- * On cache miss the standard `rememberMarkdownState(...)` path runs (async
- * parse, retainState=true). A side-effect collector watches the state flow
- * and writes the resulting [State.Success] to the cache for the next encounter.
+ * **Settled content** ([streaming] = false — finished messages, inline
+ * artifacts). The content is stable, so a valid cache hit is rendered directly
+ * via `Markdown(state = cached)` — no [com.mikepenz.markdown.model.MarkdownState]
+ * is built and no parse runs (not even the synchronous `parseBlocking` that
+ * [immediate] would trigger). This is the LazyColumn re-entry path: scrolling a
+ * message off-screen and back renders instantly from the cache with zero CPU.
+ * Because the content won't change underneath us there is no branch-swap flash.
+ * On a cache miss (first display, or after LRU eviction) it falls through to the
+ * live path below and caches the result.
+ *
+ * **Streaming content** ([streaming] = true — the live reply bubble). Content
+ * changes every delta, so a cache-hit fast path would thrash: an earlier version
+ * branched between `Markdown(state = cached)` and a freshly-remembered live
+ * state, and the post-parse cache write flipped the branch every token, each
+ * flip re-creating a [com.mikepenz.markdown.model.MarkdownState] that started at
+ * [State.Loading] (a 0-px slot) — a visible flash per delta. Instead we keep a
+ * single persistent state with `retainState = true`, so a content change does
+ * NOT reset the flow to Loading; the previous [State.Success] stays on screen
+ * until the next parse lands and the text never blanks between tokens. Streaming
+ * also does NOT write to the cache: a long reply would otherwise stuff hundreds
+ * of partial-content entries into the shared LRU and evict other messages'
+ * settled ASTs. The terminal content is cached once the reply renders as settled.
  *
  * Padding/dimens/etc are left at library defaults — callers that need to
  * customize those should fall back to invoking [Markdown] directly.
+ *
+ * [immediate] parses the *initial* content synchronously (no Loading frame on
+ * first paint) — used for fully-settled artifact content. It only affects the
+ * live path's first parse; it is not involved in the streaming flash fix, which
+ * relies on the persistent-state + `retainState` behavior.
  */
 @Composable
 fun CachedMarkdown(
@@ -32,35 +55,60 @@ fun CachedMarkdown(
     typography: MarkdownTypography,
     modifier: Modifier = Modifier,
     immediate: Boolean = false,
+    streaming: Boolean = false,
 ) {
     val cache = LocalParsedMarkdownCache.current
     val key = parsedMarkdownCacheKey(content)
-    val cached = cache[key]
 
-    if (cached != null) {
-        Markdown(
-            state = cached,
-            colors = colors,
-            typography = typography,
-            modifier = modifier,
-        )
-        return
+    if (!streaming) {
+        // Fast path: stable content + a cache hit → render the cached AST with
+        // no MarkdownState and no parse. The content equality guard (not just
+        // the 32-bit hash key) keeps a hash collision on the shared cache from
+        // rendering a different message's AST.
+        cache[key]?.takeIf { it.content == content }?.let { cached ->
+            Markdown(
+                state = cached,
+                colors = colors,
+                typography = typography,
+                modifier = modifier,
+            )
+            return
+        }
     }
 
+    // Streaming, or a settled cache miss (first render / post-eviction).
     val mdState = rememberMarkdownState(
         content = content,
         immediate = immediate,
         retainState = true,
     )
-    LaunchedEffect(mdState, key) {
-        mdState.state.collect { s ->
-            if (s is State.Success) {
-                cache.put(key, s)
-            }
+    val liveState by mdState.state.collectAsState()
+    val liveSuccess = liveState as? State.Success
+
+    // Cache each parsed AST keyed by its own content (not the current `content`,
+    // which may be a step ahead while retainState holds the previous Success).
+    // Streaming deltas are intentionally not cached — see the kdoc.
+    LaunchedEffect(liveSuccess, streaming) {
+        if (!streaming) {
+            liveSuccess?.let { cache.put(parsedMarkdownCacheKey(it.content), it) }
         }
     }
+
+    // Render priority:
+    //  1. the live parse for *this* content (streaming + settled steady state),
+    //  2. a cached AST for this content (settled re-entry before the parse lands),
+    //  3. whatever the live state is — only the very first paint of brand-new,
+    //     uncached content renders Loading.
+    // Both cache-bearing tiers verify the Success's own `content` matches exactly,
+    // not just its hash key, so a 32-bit hashCode collision can't render another
+    // message's AST. retainState also lets `liveSuccess` lag a delta behind
+    // `content` while streaming, so tier 1 must reject the stale one.
+    val effective = liveSuccess?.takeIf { it.content == content }
+        ?: cache[key]?.takeIf { it.content == content }
+        ?: liveState
+
     Markdown(
-        markdownState = mdState,
+        state = effective,
         colors = colors,
         typography = typography,
         modifier = modifier,

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/PlatformChatComponents.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/PlatformChatComponents.kt
@@ -75,4 +75,5 @@ expect fun MarkdownContent(
     searchFocusedOccurrence: Int = -1,
     onFocusedOccurrencePosition: ((LayoutCoordinates) -> Unit)? = null,
     immediate: Boolean = false,
+    streaming: Boolean = false,
 )

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/StreamingMessageBubble.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/StreamingMessageBubble.kt
@@ -148,7 +148,12 @@ private fun ThreadStreamingBubble(
                 },
         ) {
             if (streamingContent.isNotBlank()) {
-                MarkdownContent(text = streamingContent, fontSizeMultiplier = fontSizeMultiplier, useKatex = useKatex)
+                MarkdownContent(
+                    text = streamingContent,
+                    fontSizeMultiplier = fontSizeMultiplier,
+                    useKatex = useKatex,
+                    streaming = true,
+                )
                 StreamingIndicator()
             } else {
                 StreamingIndicator()
@@ -231,7 +236,12 @@ private fun TwoSidedStreamingBubble(
             )
             Spacer(modifier = Modifier.height(4.dp))
             if (streamingContent.isNotBlank()) {
-                MarkdownContent(text = streamingContent, fontSizeMultiplier = fontSizeMultiplier, useKatex = useKatex)
+                MarkdownContent(
+                    text = streamingContent,
+                    fontSizeMultiplier = fontSizeMultiplier,
+                    useKatex = useKatex,
+                    streaming = true,
+                )
                 StreamingIndicator()
             } else {
                 StreamingIndicator()

--- a/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/components/PlatformChatComponents.ios.kt
+++ b/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/components/PlatformChatComponents.ios.kt
@@ -379,6 +379,7 @@ actual fun MarkdownContent(
     searchQuery: String?, searchFocusedOccurrence: Int,
     onFocusedOccurrencePosition: ((LayoutCoordinates) -> Unit)?,
     immediate: Boolean,
+    streaming: Boolean,
 ) {
     val segments = remember(text) { parseMarkdownSegments(text) }
 
@@ -444,6 +445,7 @@ actual fun MarkdownContent(
                                                 typography = typography,
                                                 modifier = Modifier.fillMaxWidth(),
                                                 immediate = immediate,
+                                                streaming = streaming,
                                             )
                                         }
                                     }
@@ -477,6 +479,7 @@ actual fun MarkdownContent(
                             typography = typography,
                             modifier = Modifier.fillMaxWidth(),
                             immediate = immediate,
+                            streaming = streaming,
                         )
                     }
                 }


### PR DESCRIPTION
## Problem

Assistant messages flickered on every token while streaming — the rendered
markdown briefly collapsed to an empty slot and reappeared with each delta.
Inline markdown artifacts also re-parsed on the main thread on every scroll-back,
and a font-size change re-parsed every visible message at once.

Regression introduced by #86 (inline artifacts), which routed streaming markdown
through `CachedMarkdown`'s cache-hit/miss branch.

## Cause

`CachedMarkdown` chose between two render paths per recomposition: render a
cached AST on a hit, or build a fresh `MarkdownState` on a miss. Because every
streaming delta is new content, each delta missed the cache and built a state
that started at `Loading` (a 0-px slot). The post-parse cache write then flipped
the next recomposition to the hit path, disposing the live state; the following
delta flipped it back. The subtree ping-ponged every token and each re-entry
flashed an empty frame. Separately, the always-build path meant a settled message
re-parsed on every LazyColumn re-entry instead of reusing its cached AST.

## Fix

Split the two concerns with a `streaming` flag threaded from the live reply
bubble through `MarkdownContent` (expect + both actuals) to `CachedMarkdown`:

- **Settled content** (`streaming = false`: finished messages, inline
  artifacts): a valid cache hit renders the cached AST directly — no
  `MarkdownState`, no parse. Content is stable, so there is no branch swap and
  re-entry is instant. A cache miss falls through to the live path and caches
  the result.
- **Streaming content** (`streaming = true`): a single persistent
  `MarkdownState` with `retainState = true` keeps the previous parse on screen
  while the next delta parses, so the text never blanks between tokens.
  Streaming does not write to the cache, so a long reply no longer floods the
  shared LRU and evicts other messages' cached ASTs.

Both cache reads verify the parsed result's own content matches exactly, not
just its hash key, so a hash collision on the shared cache cannot render another
message's content.

## Scope

`feature:chat` only, no API or data-layer changes. `streaming` defaults to
`false`, so existing render sites are unaffected.

## Known follow-ups (not in scope)

- `LruSnapshotCache` is LRU in name only — it evicts by first-insertion order
  (FIFO); neither `get` nor a re-`put` refreshes recency. Only observable once a
  session exceeds the cache cap (200 markdown / 100 mermaid entries) and a hot
  early entry is evicted ahead of a stale one. No correctness impact.
