### PR TITLE
fix(chat): evict markdown/mermaid caches by true LRU

### DIFF
--- a/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/components/LruSnapshotCacheTest.kt
+++ b/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/components/LruSnapshotCacheTest.kt
@@ -1,0 +1,63 @@
+package com.garfiec.librechat.feature.chat.components
+
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import org.junit.Test
+
+class LruSnapshotCacheTest {
+
+    @Test
+    fun `get refreshes recency so a re-read key survives eviction`() {
+        val cache = LruSnapshotCache<String>(maxEntries = 3)
+        cache.put("a", "1")
+        cache.put("b", "2")
+        cache.put("c", "3")
+        // Reading 'a' marks it most-recently-used; 'b' becomes the LRU entry.
+        assertThat(cache["a"]).isEqualTo("1")
+        cache.put("d", "4") // over cap -> evicts the LRU entry: 'b'
+
+        assertThat(cache["b"]).isNull()
+        assertThat(cache["a"]).isEqualTo("1")
+        assertThat(cache["c"]).isEqualTo("3")
+        assertThat(cache["d"]).isEqualTo("4")
+    }
+
+    @Test
+    fun `get on a miss does not perturb eviction order`() {
+        val cache = LruSnapshotCache<String>(maxEntries = 3)
+        cache.put("a", "1")
+        cache.put("b", "2")
+        cache.put("c", "3")
+        // A miss must not refresh anything; 'a' stays the LRU entry.
+        assertThat(cache["absent"]).isNull()
+        cache.put("d", "4") // over cap -> evicts the LRU entry: 'a'
+
+        assertThat(cache["a"]).isNull()
+        assertThat(cache["b"]).isEqualTo("2")
+        assertThat(cache["c"]).isEqualTo("3")
+        assertThat(cache["d"]).isEqualTo("4")
+    }
+
+    @Test
+    fun `concurrent gets and puts do not desync map and accessOrder`() = runBlocking {
+        // get() now does a read-modify-write under the lock (it bumps recency on
+        // a hit). Hammer it against concurrent puts and evictions: the bound must
+        // hold and no exception may escape, which only stays true if map and
+        // accessOrder are mutated atomically together.
+        val cache = LruSnapshotCache<String>(maxEntries = 50)
+        withContext(Dispatchers.Default) {
+            (0 until 1000).flatMap { i ->
+                listOf(
+                    async { cache.put("k-$i", "v-$i") },
+                    async { cache["k-${i / 2}"] },
+                )
+            }.awaitAll()
+        }
+        val present = (0 until 1000).count { cache["k-$it"] != null }
+        assertThat(present).isEqualTo(50)
+    }
+}

--- a/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/components/artifact/MermaidRenderCacheTest.kt
+++ b/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/components/artifact/MermaidRenderCacheTest.kt
@@ -24,20 +24,20 @@ class MermaidRenderCacheTest {
     }
 
     @Test
-    fun `put for existing key updates value without growing insertion order`() {
+    fun `re-put refreshes recency and updates value without growing the cache`() {
         val cache = MermaidRenderCache(maxEntries = 3)
         cache.put("a", "1")
         cache.put("b", "b1")
         cache.put("c", "c1")
-        // Duplicate puts on existing keys must NOT push them later in insertion
-        // order — otherwise the next eviction would target the wrong key.
+        // Re-putting 'a' updates its value AND marks it most-recently-used, so it
+        // must outlive 'b' (now the least-recently-used) on the next eviction.
         cache.put("a", "2")
         cache.put("a", "3")
         cache.put("a", "4")
-        cache.put("d", "d1") // evicts the OLDEST insertion: 'a'
+        cache.put("d", "d1") // over cap -> evicts the LRU entry: 'b'
 
-        assertThat(cache["a"]).isNull()
-        assertThat(cache["b"]).isEqualTo("b1")
+        assertThat(cache["b"]).isNull()
+        assertThat(cache["a"]).isEqualTo("4")
         assertThat(cache["c"]).isEqualTo("c1")
         assertThat(cache["d"]).isEqualTo("d1")
     }

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/LruSnapshotCache.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/LruSnapshotCache.kt
@@ -10,29 +10,52 @@ import kotlinx.atomicfu.locks.synchronized
  * through the backing [SnapshotStateMap], so a [put] from a background thread
  * triggers recomposition of any composable that read the same key.
  *
+ * Eviction is least-recently-used: both [get] (on a hit) and [put] move the key
+ * to the most-recently-used end of [accessOrder], so the entry dropped when the
+ * cache is over capacity is the one untouched longest. A read must refresh
+ * recency, not just a write — a settled entry is typically written once and then
+ * only read back on re-display, so a put-only policy would degrade to FIFO for
+ * exactly the hot entries we want to keep.
+ *
  * [SnapshotStateMap] already routes writes through Compose's snapshot system —
  * an explicit `Snapshot.withMutableSnapshot { ... }` wrap would create one
  * mutable snapshot per writing thread and cause `SnapshotApplyConflictException`
- * under concurrent puts. The lock guards [insertionOrder] (a plain `ArrayDeque`,
- * not thread-safe) and serializes the read-modify-write pair on [map].
+ * under concurrent puts. The lock guards [accessOrder] (a plain `ArrayDeque`,
+ * not thread-safe) and serializes the read-modify-write pair on [map]. [get]'s
+ * recency bump touches only [accessOrder], never [map], so it performs no
+ * snapshot write during composition and cannot trigger a recomposition by reading.
  */
 open class LruSnapshotCache<V>(private val maxEntries: Int) {
 
     private val map: SnapshotStateMap<String, V> = mutableStateMapOf()
-    private val insertionOrder = ArrayDeque<String>()
+
+    // Ordered least- (front) to most-recently-used (back).
+    private val accessOrder = ArrayDeque<String>()
     private val lock = SynchronizedObject()
 
-    operator fun get(key: String): V? = map[key]
+    operator fun get(key: String): V? = synchronized(lock) {
+        val value = map[key]
+        if (value != null) touch(key)
+        value
+    }
 
     fun put(key: String, value: V) {
         synchronized(lock) {
-            if (key !in map) {
-                insertionOrder.addLast(key)
-                while (insertionOrder.size > maxEntries) {
-                    map.remove(insertionOrder.removeFirst())
-                }
-            }
+            touch(key)
             map[key] = value
+            while (accessOrder.size > maxEntries) {
+                map.remove(accessOrder.removeFirst())
+            }
         }
+    }
+
+    /**
+     * Move [key] to the most-recently-used end of [accessOrder]. O(n), n <=
+     * maxEntries. Must be called while holding [lock]. The [remove] is a no-op
+     * when the key is absent (a fresh [put]).
+     */
+    private fun touch(key: String) {
+        accessOrder.remove(key)
+        accessOrder.addLast(key)
     }
 }


### PR DESCRIPTION
## Problem

`LruSnapshotCache` (backing `ParsedMarkdownCache`, cap 200, and
`MermaidRenderCache`, cap 100) was LRU in name only — it evicted by
first-insertion order (FIFO). `put` recorded order only for absent keys, and
`get` never refreshed recency at all.

This matters because the hot path for settled entries is read-only: a parsed
markdown AST is written once, then read back on every LazyColumn re-entry but
never re-`put` (the cache-hit fast path in `CachedMarkdown` returns before
re-inserting). So a frequently-viewed early message was evicted ahead of a
colder-but-newer one once a session exceeded the cap.

Flagged as a follow-up in #106. No wrong-value bug — purely an eviction-quality
defect that only surfaces past the cap.

## Fix

Both `get` (on a hit) and `put` move the key to the most-recently-used end of
the order deque via a shared `touch()` helper.

- A read must refresh recency, not just a write — otherwise the policy degrades
  to FIFO for exactly the read-only hot entries it should protect.
- `get`'s recency bump mutates only the plain deque under the existing lock,
  never the snapshot `map`, so it performs no snapshot write during composition
  and cannot trigger a recomposition by reading.
- Pure-insertion eviction order (no interleaved reads/re-puts) is unchanged, so
  it stays FIFO-equivalent in that case.

Subclasses are untouched — they inherit `get`/`put`.

## Scope

`feature:chat` only, commonMain. No API, data-layer, or platform-specific code.

## Known trade-offs (acceptable at current caps)

- `get` now takes the lock and does an O(n) deque move on the composition read
  path (was a lock-free lookup). Bounded by the cap (n <= 200/100); negligible at
  current sizes but worth noting if a cap grows.
- A main-thread cache read can briefly block on a background mermaid `put` from
  the WebView JS-bridge thread, since both share the lock. Critical section is
  microseconds.
