### PR TITLE
fix(chat): stop first-agent auto-select from flashing over the selected model

### DIFF
--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModel.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModel.kt
@@ -392,7 +392,7 @@ class ChatViewModel(
                 modelDelegate.loadMcpServers()
             }
             if (role?.hasAccess(PermissionType.AGENTS, Permission.USE) != false) {
-                modelDelegate.loadAgents()
+                modelDelegate.loadAgents(isNewConversation)
             }
         }
     }

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/ModelSelectionDelegate.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/ModelSelectionDelegate.kt
@@ -125,12 +125,6 @@ class ModelSelectionDelegate(
                     selectedModel = fallbackModel,
                 )
             }
-            // Persist fallback so the next new chat starts with a valid model
-            if (fallbackModel != null) {
-                stateHandle.scope.launch {
-                    settingsDataStore.setLastUsedModel(firstEndpoint.key, fallbackModel)
-                }
-            }
         }
     }
 
@@ -259,7 +253,7 @@ class ModelSelectionDelegate(
         return agentId.contains("____")
     }
 
-    fun loadAgents() {
+    fun loadAgents(isNewConversation: Boolean) {
         stateHandle.scope.launch {
             // Skip the fetch entirely when the role denies AGENTS.USE; otherwise
             // the server would return 403 and we'd have to decide whether it's a
@@ -270,15 +264,17 @@ class ModelSelectionDelegate(
             when (val result = agentRepository.getAgents()) {
                 is Result.Success -> {
                     stateHandle.update { copy(agents = result.data) }
-                    // Auto-select first agent when on agents endpoint with no model selected
+                    // Auto-select the first agent only for a brand-new chat with no
+                    // model selected yet. For existing conversations, loadConversationModel
+                    // owns the model — auto-selecting here would flash the first agent and
+                    // clobber the persisted last-used model.
                     val state = stateHandle.state
-                    if (state.selectedEndpoint == EndpointConstants.AGENTS &&
+                    if (isNewConversation &&
+                        state.selectedEndpoint == EndpointConstants.AGENTS &&
                         state.selectedModel == null &&
                         result.data.isNotEmpty()
                     ) {
-                        val firstAgent = result.data.first()
-                        stateHandle.update { copy(selectedModel = firstAgent.id) }
-                        settingsDataStore.setLastUsedModel(EndpointConstants.AGENTS, firstAgent.id)
+                        stateHandle.update { copy(selectedModel = result.data.first().id) }
                     }
                 }
                 is Result.Error -> {


### PR DESCRIPTION
## Problem
Sending the first message in a new chat briefly switched the displayed model to the first agent before snapping back to the actual model. The wrong model could also become the persisted default for future new chats.

## Cause
When the first message is sent, navigation (`NewChat` → `Chat(id)`) constructs a fresh `ChatViewModel` for the saved conversation. That VM boots on the default `agents` endpoint with no model selected, so `loadAgents()` auto-selected the first agent before `loadConversationModel()` had resolved the conversation's real model — a visible ~1s flash.

The same auto-select also wrote its pick to `lastUsedModel`, so every time an existing-conversation VM booted it overwrote the user's genuine last-used model with the first agent.

## Fix
- Gate the `loadAgents()` first-agent auto-select on `isNewConversation`. Existing conversations defer to `loadConversationModel()` for their model.
- Stop persisting auto-selections to `lastUsedModel` — removed the `setLastUsedModel` writes from the auto-select path and from `refilterModels` Fallback 2. Only an explicit user pick now updates the last-used model.

May be related to #71 (first agent shown as default), but not confirmed as the root cause of that report.

## Testing
Verified on device: selecting a non-agent model and sending no longer flashes to the first agent, and the explicitly selected model persists across app restarts for new chats.