### PR TITLE
fix(chat): deterministic, race-free new-chat model selection

### DIFF
--- a/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/ModelSelectionDelegateTest.kt
+++ b/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/ModelSelectionDelegateTest.kt
@@ -1,0 +1,632 @@
+package com.garfiec.librechat.feature.chat.viewmodel.delegate
+
+import com.garfiec.librechat.core.common.EndpointConstants
+import com.garfiec.librechat.core.common.result.Result
+import com.garfiec.librechat.core.data.datastore.SettingsDataStore
+import com.garfiec.librechat.core.data.repository.AgentRepository
+import com.garfiec.librechat.core.data.repository.ConfigRepository
+import com.garfiec.librechat.core.data.repository.McpRepository
+import com.garfiec.librechat.core.data.util.PermissionGate
+import com.garfiec.librechat.core.model.Agent
+import com.garfiec.librechat.core.model.EndpointConfig
+import com.garfiec.librechat.core.model.permissions.UserRolePermissions
+import com.garfiec.librechat.feature.chat.viewmodel.ChatStateHandle
+import com.garfiec.librechat.feature.chat.viewmodel.ChatUiState
+import com.google.common.truth.Truth.assertThat
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+/**
+ * Behavior tests for new-chat model-selection seeding and validation.
+ *
+ * These lock in three previously-fixed bugs against regression (issue #71):
+ * - PR #108: first-agent flash/clobber — [loadAgents] must not auto-select for
+ *   saved conversations, and no fallback path may persist last-used.
+ * - PR #110: retained-landing staleness — [ModelSelectionDelegate.seedInitialSelection]
+ *   re-applies a changed last-used while on the blank landing.
+ * - The initial multi-writer race — [ModelSelectionDelegate.seedInitialSelection] is
+ *   the single deterministic authority, with precedence
+ *   last-used → first agent (AGENTS default) → first config model, and WAIT-on-
+ *   unresolved so arrival order can't change the outcome.
+ *
+ * Mirrors [EndpointKeyStatusDelegateTest]: standalone [ChatStateHandle] over a
+ * [TestScope], MockK fakes, `advanceUntilIdle()` to drain, `CompletableDeferred` in
+ * `coAnswers {}` to control ordering. The seeder collects a never-completing combine
+ * on the delegate's [TestScope] (not the runTest scope), so leftover collectors don't
+ * fail the test — same as the template's init-block collector.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class ModelSelectionDelegateTest {
+
+    private val lastUsedEndpoint = MutableStateFlow<String?>(null)
+    private val lastUsedModel = MutableStateFlow<String?>(null)
+    private val availableModels = MutableStateFlow<Map<String, List<String>>>(emptyMap())
+    private val endpointConfigs = MutableStateFlow<Map<String, EndpointConfig>>(emptyMap())
+
+    private val configRepository = mockk<ConfigRepository>(relaxed = true).also {
+        every { it.availableModels } returns availableModels
+        every { it.endpointConfigs } returns endpointConfigs
+    }
+    private val agentRepository = mockk<AgentRepository>(relaxed = true)
+    private val mcpRepository = mockk<McpRepository>(relaxed = true)
+    private val settingsDataStore = mockk<SettingsDataStore>(relaxed = true).also {
+        every { it.lastUsedEndpoint } returns lastUsedEndpoint
+        every { it.lastUsedModel } returns lastUsedModel
+    }
+    private val permissionGate = mockk<PermissionGate>(relaxed = true)
+
+    private fun newHandle(scope: CoroutineScope, state: ChatUiState = ChatUiState()) =
+        ChatStateHandle(stateFlow = MutableStateFlow(state), scope = scope)
+
+    private fun newDelegate(handle: ChatStateHandle) = ModelSelectionDelegate(
+        stateHandle = handle,
+        configRepository = configRepository,
+        agentRepository = agentRepository,
+        mcpRepository = mcpRepository,
+        settingsDataStore = settingsDataStore,
+        permissionGate = permissionGate,
+    )
+
+    private fun allowAgents() {
+        coEvery { permissionGate.awaitRole() } returns UserRolePermissions(name = "user")
+    }
+
+    private fun denyAgents() {
+        coEvery { permissionGate.awaitRole() } returns
+            UserRolePermissions(name = "user", permissions = mapOf("AGENTS" to mapOf("USE" to false)))
+    }
+
+    // ── Group A: refilterModels validation (existing conversations) ──────────
+    // refilterModels owns selection correction ONLY for existing conversations
+    // (new-chat seeding moved to seedInitialSelection). Each test drives the
+    // existing-conversation path: isNewConversation = false, conversationModelLoaded = true.
+
+    @Test
+    fun refilterValidSelectionIsNoOp() = runTest {
+        val scope = TestScope(StandardTestDispatcher(testScheduler))
+        val handle = newHandle(
+            scope,
+            ChatUiState(conversationId = "c1", selectedEndpoint = "openAI", selectedModel = "gpt-4o"),
+        )
+        val delegate = newDelegate(handle)
+        delegate.conversationModelLoaded = true
+        availableModels.value = mapOf("openAI" to listOf("gpt-4o"))
+
+        delegate.refilterModels(isNewConversation = false)
+        advanceUntilIdle()
+
+        assertThat(handle.state.selectedEndpoint).isEqualTo("openAI")
+        assertThat(handle.state.selectedModel).isEqualTo("gpt-4o")
+        assertThat(handle.state.availableModels).containsExactly("openAI", listOf("gpt-4o"))
+    }
+
+    @Test
+    fun refilterInvalidSelectionWithValidLastUsedRestoresLastUsed() = runTest {
+        val scope = TestScope(StandardTestDispatcher(testScheduler))
+        val handle = newHandle(
+            scope,
+            ChatUiState(conversationId = "c1", selectedEndpoint = "openAI", selectedModel = "ghost"),
+        )
+        val delegate = newDelegate(handle)
+        delegate.conversationModelLoaded = true
+        delegate.cachedLastUsedEndpoint = "anthropic"
+        delegate.cachedLastUsedModel = "claude-3"
+        availableModels.value = mapOf("openAI" to listOf("gpt-4o"), "anthropic" to listOf("claude-3"))
+
+        delegate.refilterModels(isNewConversation = false)
+        advanceUntilIdle()
+
+        assertThat(handle.state.selectedEndpoint).isEqualTo("anthropic")
+        assertThat(handle.state.selectedModel).isEqualTo("claude-3")
+    }
+
+    @Test
+    fun refilterInvalidSelectionNoLastUsedPicksFirstConfigModel() = runTest {
+        val scope = TestScope(StandardTestDispatcher(testScheduler))
+        val handle = newHandle(
+            scope,
+            ChatUiState(conversationId = "c1", selectedEndpoint = "openAI", selectedModel = "ghost"),
+        )
+        val delegate = newDelegate(handle)
+        delegate.conversationModelLoaded = true
+        availableModels.value = linkedMapOf("openAI" to listOf("gpt-4o"), "anthropic" to listOf("claude-3"))
+
+        delegate.refilterModels(isNewConversation = false)
+        advanceUntilIdle()
+
+        assertThat(handle.state.selectedEndpoint).isEqualTo("openAI")
+        assertThat(handle.state.selectedModel).isEqualTo("gpt-4o")
+    }
+
+    @Test
+    fun refilterStaleNonAgentModelOnAgentsEndpointIsCorrected() = runTest {
+        // A real model name carried into the AGENTS endpoint must be treated invalid
+        // (it would be sent as a bogus agent_id and the server would reject the chat).
+        val scope = TestScope(StandardTestDispatcher(testScheduler))
+        val handle = newHandle(
+            scope,
+            ChatUiState(conversationId = "c1", selectedEndpoint = EndpointConstants.AGENTS, selectedModel = "gpt-4o"),
+        )
+        val delegate = newDelegate(handle)
+        delegate.conversationModelLoaded = true
+        availableModels.value = linkedMapOf(
+            EndpointConstants.AGENTS to listOf("agent_abc"),
+            "openAI" to listOf("gpt-4o"),
+        )
+
+        delegate.refilterModels(isNewConversation = false)
+        advanceUntilIdle()
+
+        // Corrected away from the stale ("agents", "gpt-4o") pair to a real entry.
+        assertThat(handle.state.selectedModel).isNotEqualTo("gpt-4o")
+        val pair = handle.state.selectedEndpoint to handle.state.selectedModel
+        assertThat(handle.state.availableModels[pair.first]).contains(pair.second)
+    }
+
+    @Test
+    fun refilterAgentsModelsNotLoadedSkipsValidationNoClobber() = runTest {
+        // modelsForEndpoint == null (agents list absent from availableModels) → don't clobber.
+        val scope = TestScope(StandardTestDispatcher(testScheduler))
+        val handle = newHandle(
+            scope,
+            ChatUiState(conversationId = "c1", selectedEndpoint = EndpointConstants.AGENTS, selectedModel = "agent_abc"),
+        )
+        val delegate = newDelegate(handle)
+        delegate.conversationModelLoaded = true
+        availableModels.value = mapOf("openAI" to listOf("gpt-4o"))
+
+        delegate.refilterModels(isNewConversation = false)
+        advanceUntilIdle()
+
+        assertThat(handle.state.selectedEndpoint).isEqualTo(EndpointConstants.AGENTS)
+        assertThat(handle.state.selectedModel).isEqualTo("agent_abc")
+    }
+
+    @Test
+    fun refilterExistingConversationNoFallbackUntilConversationModelLoaded() = runTest {
+        val scope = TestScope(StandardTestDispatcher(testScheduler))
+        val handle = newHandle(
+            scope,
+            ChatUiState(conversationId = "c1", selectedEndpoint = "openAI", selectedModel = null),
+        )
+        val delegate = newDelegate(handle)
+        delegate.conversationModelLoaded = false
+        availableModels.value = mapOf("openAI" to listOf("gpt-4o"))
+
+        delegate.refilterModels(isNewConversation = false)
+        advanceUntilIdle()
+
+        // Gate held: no fallback ran.
+        assertThat(handle.state.selectedModel).isNull()
+
+        // Release the gate → fallback now corrects.
+        delegate.conversationModelLoaded = true
+        delegate.refilterModels(isNewConversation = false)
+        advanceUntilIdle()
+
+        assertThat(handle.state.selectedModel).isEqualTo("gpt-4o")
+    }
+
+    @Test
+    fun refilterFallbackDoesNotPersistLastUsed() = runTest {
+        // Locks PR #108's removal of fallback persistence — refilter must never
+        // write last-used. Only an explicit onModelSelected may.
+        val scope = TestScope(StandardTestDispatcher(testScheduler))
+        val handle = newHandle(
+            scope,
+            ChatUiState(conversationId = "c1", selectedEndpoint = "openAI", selectedModel = "ghost"),
+        )
+        val delegate = newDelegate(handle)
+        delegate.conversationModelLoaded = true
+        availableModels.value = mapOf("openAI" to listOf("gpt-4o"))
+
+        delegate.refilterModels(isNewConversation = false)
+        advanceUntilIdle()
+
+        assertThat(handle.state.selectedModel).isEqualTo("gpt-4o") // fallback fired
+        coVerify(exactly = 0) { settingsDataStore.setLastUsedModel(any(), any()) }
+    }
+
+    @Test
+    fun refilterEmptyModelsIsNoOpNoFallback() = runTest {
+        val scope = TestScope(StandardTestDispatcher(testScheduler))
+        val handle = newHandle(
+            scope,
+            ChatUiState(conversationId = "c1", selectedEndpoint = "openAI", selectedModel = "ghost"),
+        )
+        val delegate = newDelegate(handle)
+        delegate.conversationModelLoaded = true
+        availableModels.value = emptyMap()
+
+        delegate.refilterModels(isNewConversation = false)
+        advanceUntilIdle()
+
+        assertThat(handle.state.selectedModel).isEqualTo("ghost")
+        coVerify(exactly = 0) { settingsDataStore.setLastUsedModel(any(), any()) }
+    }
+
+    @Test
+    fun refilterNewConversationDoesNotApplyFallback() = runTest {
+        // For new chats, refilter is validation-only: it never seeds/fallbacks —
+        // seedInitialSelection owns the selection. An invalid selection is left as-is.
+        val scope = TestScope(StandardTestDispatcher(testScheduler))
+        val handle = newHandle(scope, ChatUiState(selectedEndpoint = "openAI", selectedModel = "ghost"))
+        val delegate = newDelegate(handle)
+        delegate.conversationModelLoaded = true // even so, new-chat path must not fallback
+        delegate.cachedLastUsedEndpoint = "anthropic"
+        delegate.cachedLastUsedModel = "claude-3"
+        availableModels.value = mapOf("openAI" to listOf("gpt-4o"), "anthropic" to listOf("claude-3"))
+
+        delegate.refilterModels(isNewConversation = true)
+        advanceUntilIdle()
+
+        // Untouched by refilter (the seeder would handle it, but it isn't running here).
+        assertThat(handle.state.selectedEndpoint).isEqualTo("openAI")
+        assertThat(handle.state.selectedModel).isEqualTo("ghost")
+        // availableModels still gets filtered/published.
+        assertThat(handle.state.availableModels).containsKey("openAI")
+    }
+
+    // ── Group B: loadAgents (no auto-select; sets agentsLoaded everywhere) ────
+
+    @Test
+    fun loadAgentsSuccessPopulatesAgentsSetsFlagNoSelection() = runTest {
+        val scope = TestScope(StandardTestDispatcher(testScheduler))
+        val handle = newHandle(scope)
+        val delegate = newDelegate(handle)
+        allowAgents()
+        coEvery { agentRepository.getAgents() } returns
+            Result.Success(listOf(Agent(id = "agent_1"), Agent(id = "agent_2")))
+
+        delegate.loadAgents()
+        advanceUntilIdle()
+
+        assertThat(handle.state.agents).hasSize(2)
+        assertThat(delegate.agentsLoaded.value).isTrue()
+        // loadAgents no longer auto-selects — the seeder owns selection.
+        assertThat(handle.state.selectedModel).isNull()
+        coVerify(exactly = 0) { settingsDataStore.setLastUsedModel(any(), any()) }
+    }
+
+    @Test
+    fun loadAgentsPermissionDeniedSkipsFetchButSetsFlag() = runTest {
+        val scope = TestScope(StandardTestDispatcher(testScheduler))
+        val handle = newHandle(scope)
+        val delegate = newDelegate(handle)
+        denyAgents()
+
+        delegate.loadAgents()
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { agentRepository.getAgents() }
+        assertThat(handle.state.agents).isEmpty()
+        assertThat(handle.state.selectedModel).isNull()
+        assertThat(handle.state.error).isNull()
+        // Must still flip so the seeder doesn't wait forever on the agents tier.
+        assertThat(delegate.agentsLoaded.value).isTrue()
+    }
+
+    @Test
+    fun loadAgentsErrorSurfacesErrorSetsFlagNoSelection() = runTest {
+        val scope = TestScope(StandardTestDispatcher(testScheduler))
+        val handle = newHandle(scope)
+        val delegate = newDelegate(handle)
+        allowAgents()
+        coEvery { agentRepository.getAgents() } returns Result.Error(RuntimeException("boom"))
+
+        delegate.loadAgents()
+        advanceUntilIdle()
+
+        assertThat(handle.state.error).isEqualTo("Could not load available agents")
+        assertThat(handle.state.selectedModel).isNull()
+        assertThat(handle.state.agents).isEmpty()
+        assertThat(delegate.agentsLoaded.value).isTrue()
+    }
+
+    // ── Group C: seedInitialSelection precedence + race determinism ──────────
+
+    @Test
+    fun seedLastUsedValidSeededWhenModelsArriveFirst() = runTest {
+        val scope = TestScope(StandardTestDispatcher(testScheduler))
+        val handle = newHandle(scope)
+        val delegate = newDelegate(handle)
+        lastUsedEndpoint.value = "openAI"
+        lastUsedModel.value = "gpt-4o"
+        availableModels.value = mapOf("openAI" to listOf("gpt-4o"), EndpointConstants.AGENTS to listOf("agent_1"))
+
+        delegate.seedInitialSelection(isNewConversation = true)
+        advanceUntilIdle()
+
+        // Models present, agents arrive later — last-used must win and stay.
+        delegate.agentsLoaded.value = true
+        handle.update { copy(agents = listOf(Agent(id = "agent_1"))) }
+        advanceUntilIdle()
+
+        assertThat(handle.state.selectedEndpoint).isEqualTo("openAI")
+        assertThat(handle.state.selectedModel).isEqualTo("gpt-4o")
+    }
+
+    @Test
+    fun seedLastUsedValidWaitsForModelsWhenAgentsArriveFirst() = runTest {
+        // The determinism proof: even if agents load first, a config-endpoint
+        // last-used wins once its models arrive — tier 1 WAITs rather than letting
+        // tier 2 grab the first agent.
+        val scope = TestScope(StandardTestDispatcher(testScheduler))
+        val handle = newHandle(scope)
+        val delegate = newDelegate(handle)
+        lastUsedEndpoint.value = "openAI"
+        lastUsedModel.value = "gpt-4o"
+
+        delegate.seedInitialSelection(isNewConversation = true)
+        advanceUntilIdle()
+
+        // Agents arrive first, models still pending → must NOT pick the first agent.
+        delegate.agentsLoaded.value = true
+        handle.update { copy(agents = listOf(Agent(id = "agent_1"))) }
+        advanceUntilIdle()
+        assertThat(handle.state.selectedModel).isNull()
+
+        // Now models arrive → last-used resolves and wins.
+        availableModels.value = mapOf("openAI" to listOf("gpt-4o"))
+        advanceUntilIdle()
+        assertThat(handle.state.selectedEndpoint).isEqualTo("openAI")
+        assertThat(handle.state.selectedModel).isEqualTo("gpt-4o")
+    }
+
+    @Test
+    fun seedNoLastUsedAgentsDefaultPrefersFirstAgentOverConfigModel() = runTest {
+        val scope = TestScope(StandardTestDispatcher(testScheduler))
+        val handle = newHandle(scope) // default endpoint = AGENTS
+        val delegate = newDelegate(handle)
+        availableModels.value = mapOf("openAI" to listOf("gpt-4o"))
+
+        delegate.seedInitialSelection(isNewConversation = true)
+        advanceUntilIdle()
+
+        // Config model present but agents pending → tier 2 WAITs, no config model grabbed.
+        assertThat(handle.state.selectedModel).isNull()
+
+        delegate.agentsLoaded.value = true
+        handle.update { copy(agents = listOf(Agent(id = "agent_1"))) }
+        advanceUntilIdle()
+
+        assertThat(handle.state.selectedEndpoint).isEqualTo(EndpointConstants.AGENTS)
+        assertThat(handle.state.selectedModel).isEqualTo("agent_1")
+    }
+
+    @Test
+    fun seedNoLastUsedAgentsEmptyFallsToFirstConfigModelNoDeadlock() = runTest {
+        val scope = TestScope(StandardTestDispatcher(testScheduler))
+        val handle = newHandle(scope) // default endpoint = AGENTS
+        val delegate = newDelegate(handle)
+        delegate.agentsLoaded.value = true // agents loaded and empty (e.g. denied / none configured)
+        availableModels.value = linkedMapOf("openAI" to listOf("gpt-4o"), "anthropic" to listOf("claude-3"))
+
+        delegate.seedInitialSelection(isNewConversation = true)
+        advanceUntilIdle()
+
+        assertThat(handle.state.selectedEndpoint).isEqualTo("openAI")
+        assertThat(handle.state.selectedModel).isEqualTo("gpt-4o")
+    }
+
+    @Test
+    fun seedLastUsedInvalidDoesNotSeedStaleFallsThroughPrecedence() = runTest {
+        val scope = TestScope(StandardTestDispatcher(testScheduler))
+        val handle = newHandle(scope) // default endpoint = AGENTS
+        val delegate = newDelegate(handle)
+        delegate.agentsLoaded.value = true
+        lastUsedEndpoint.value = "openAI"
+        lastUsedModel.value = "gpt-OLD" // no longer offered
+        availableModels.value = mapOf("openAI" to listOf("gpt-4o"))
+        handle.update { copy(agents = listOf(Agent(id = "agent_1"))) }
+
+        delegate.seedInitialSelection(isNewConversation = true)
+        advanceUntilIdle()
+
+        assertThat(handle.state.selectedModel).isNotEqualTo("gpt-OLD")
+        // AGENTS is the active default → falls through to the first-agent tier.
+        assertThat(handle.state.selectedEndpoint).isEqualTo(EndpointConstants.AGENTS)
+        assertThat(handle.state.selectedModel).isEqualTo("agent_1")
+    }
+
+    @Test
+    fun seedRetainedLandingReappliesLastUsedWhenConversationIdNull() = runTest {
+        // Locks PR #110: a changed last-used re-applies on the retained blank landing.
+        val scope = TestScope(StandardTestDispatcher(testScheduler))
+        val handle = newHandle(scope)
+        val delegate = newDelegate(handle)
+        delegate.agentsLoaded.value = true
+        lastUsedEndpoint.value = "openAI"
+        lastUsedModel.value = "gpt-4o"
+        availableModels.value = mapOf("openAI" to listOf("gpt-4o", "gpt-4o-mini"))
+
+        delegate.seedInitialSelection(isNewConversation = true)
+        advanceUntilIdle()
+        assertThat(handle.state.selectedModel).isEqualTo("gpt-4o")
+
+        // User picked a different model elsewhere → last-used changes.
+        lastUsedModel.value = "gpt-4o-mini"
+        advanceUntilIdle()
+
+        assertThat(handle.state.selectedModel).isEqualTo("gpt-4o-mini")
+    }
+
+    @Test
+    fun seedStartedConversationDoesNotOverrideOnLastUsedChange() = runTest {
+        // Locks the #110 gate: once a conversation has started (conversationId != null),
+        // a later last-used change must not override the in-conversation selection.
+        val scope = TestScope(StandardTestDispatcher(testScheduler))
+        val handle = newHandle(scope)
+        val delegate = newDelegate(handle)
+        delegate.agentsLoaded.value = true
+        lastUsedEndpoint.value = "openAI"
+        lastUsedModel.value = "gpt-4o"
+        availableModels.value = mapOf("openAI" to listOf("gpt-4o", "gpt-4o-mini"), "anthropic" to listOf("claude-3"))
+
+        delegate.seedInitialSelection(isNewConversation = true)
+        advanceUntilIdle()
+        assertThat(handle.state.selectedModel).isEqualTo("gpt-4o")
+
+        // Conversation starts with its own model.
+        handle.update { copy(conversationId = "conv_new", selectedEndpoint = "anthropic", selectedModel = "claude-3") }
+        advanceUntilIdle()
+
+        // Last-used changes afterwards → must NOT override the started conversation.
+        lastUsedModel.value = "gpt-4o-mini"
+        advanceUntilIdle()
+
+        assertThat(handle.state.selectedEndpoint).isEqualTo("anthropic")
+        assertThat(handle.state.selectedModel).isEqualTo("claude-3")
+    }
+
+    @Test
+    fun seedDoesNotPersistLastUsed() = runTest {
+        val scope = TestScope(StandardTestDispatcher(testScheduler))
+        val handle = newHandle(scope)
+        val delegate = newDelegate(handle)
+        delegate.agentsLoaded.value = true
+        lastUsedEndpoint.value = "openAI"
+        lastUsedModel.value = "gpt-4o"
+        availableModels.value = mapOf("openAI" to listOf("gpt-4o"))
+
+        delegate.seedInitialSelection(isNewConversation = true)
+        advanceUntilIdle()
+
+        assertThat(handle.state.selectedModel).isEqualTo("gpt-4o")
+        coVerify(exactly = 0) { settingsDataStore.setLastUsedModel(any(), any()) }
+    }
+
+    @Test
+    fun seedNoOpForExistingConversation() = runTest {
+        val scope = TestScope(StandardTestDispatcher(testScheduler))
+        val handle = newHandle(scope, ChatUiState(conversationId = "c1", selectedModel = "claude-3", selectedEndpoint = "anthropic"))
+        val delegate = newDelegate(handle)
+        delegate.agentsLoaded.value = true
+        lastUsedEndpoint.value = "openAI"
+        lastUsedModel.value = "gpt-4o"
+        availableModels.value = mapOf("openAI" to listOf("gpt-4o"))
+
+        delegate.seedInitialSelection(isNewConversation = false)
+        advanceUntilIdle()
+
+        // Existing conversation: loadConversationModel owns the model; seeder no-ops.
+        assertThat(handle.state.selectedEndpoint).isEqualTo("anthropic")
+        assertThat(handle.state.selectedModel).isEqualTo("claude-3")
+    }
+
+    @Test
+    fun seedAgentsDeniedFallsThroughToFirstConfigModel() = runTest {
+        // Regression guard: with AGENTS denied, loadAgents flips agentsLoaded with an
+        // empty agent list (no published state change). Because agentsLoaded is a
+        // combine arm, the seeder re-fires and falls through the agents tier to the
+        // first config model instead of waiting on it forever (no model on landing).
+        val scope = TestScope(StandardTestDispatcher(testScheduler))
+        val handle = newHandle(scope) // default endpoint = AGENTS
+        val delegate = newDelegate(handle)
+        denyAgents()
+        availableModels.value = mapOf("openAI" to listOf("gpt-4o"))
+
+        delegate.seedInitialSelection(isNewConversation = true)
+        delegate.loadAgents()
+        advanceUntilIdle()
+
+        assertThat(handle.state.selectedEndpoint).isEqualTo("openAI")
+        assertThat(handle.state.selectedModel).isEqualTo("gpt-4o")
+    }
+
+    @Test
+    fun seedAgentsErrorFallsThroughToFirstConfigModel() = runTest {
+        // Regression guard: a failed getAgents() flips agentsLoaded but only changes
+        // state.error (agents stays empty). The seeder must still re-fire (agentsLoaded
+        // is a combine arm, not filtered out by the agents distinctUntilChanged) and
+        // fall through to the first config model.
+        val scope = TestScope(StandardTestDispatcher(testScheduler))
+        val handle = newHandle(scope) // default endpoint = AGENTS
+        val delegate = newDelegate(handle)
+        allowAgents()
+        coEvery { agentRepository.getAgents() } returns Result.Error(RuntimeException("boom"))
+        availableModels.value = mapOf("openAI" to listOf("gpt-4o"))
+
+        delegate.seedInitialSelection(isNewConversation = true)
+        delegate.loadAgents()
+        advanceUntilIdle()
+
+        assertThat(handle.state.selectedEndpoint).isEqualTo("openAI")
+        assertThat(handle.state.selectedModel).isEqualTo("gpt-4o")
+    }
+
+    @Test
+    fun seedRemovedEndpointSelectionFallsThroughToConfigModel() = runTest {
+        // An endpoint absent from a loaded endpointConfigs is treated as removed
+        // (INVALID), not still-loading (PENDING), so the seeder corrects a stale
+        // selection instead of pinning a non-functional one forever.
+        val scope = TestScope(StandardTestDispatcher(testScheduler))
+        val handle = newHandle(scope, ChatUiState(selectedEndpoint = "openAI", selectedModel = "gpt-4o"))
+        val delegate = newDelegate(handle)
+        delegate.agentsLoaded.value = true
+        endpointConfigs.value = mapOf("anthropic" to EndpointConfig())
+        availableModels.value = mapOf("anthropic" to listOf("claude-3"))
+
+        delegate.seedInitialSelection(isNewConversation = true)
+        advanceUntilIdle()
+
+        assertThat(handle.state.selectedEndpoint).isEqualTo("anthropic")
+        assertThat(handle.state.selectedModel).isEqualTo("claude-3")
+    }
+
+    @Test
+    fun seedExistingConversationCachesLastUsedForFallback() = runTest {
+        // The seeder's collector runs for existing conversations too — only to keep
+        // cachedLastUsed* fresh for refilterModels' corrective fallback. It must not
+        // touch the selection (loadConversationModel owns that), but must populate the
+        // cache the old eager read used to fill for every conversation.
+        val scope = TestScope(StandardTestDispatcher(testScheduler))
+        val handle = newHandle(
+            scope,
+            ChatUiState(conversationId = "c1", selectedEndpoint = "anthropic", selectedModel = "claude-3"),
+        )
+        val delegate = newDelegate(handle)
+        delegate.agentsLoaded.value = true
+        lastUsedEndpoint.value = "openAI"
+        lastUsedModel.value = "gpt-4o"
+        availableModels.value = mapOf("openAI" to listOf("gpt-4o"))
+
+        delegate.seedInitialSelection(isNewConversation = false)
+        advanceUntilIdle()
+
+        assertThat(handle.state.selectedEndpoint).isEqualTo("anthropic")
+        assertThat(handle.state.selectedModel).isEqualTo("claude-3")
+        assertThat(delegate.cachedLastUsedEndpoint).isEqualTo("openAI")
+        assertThat(delegate.cachedLastUsedModel).isEqualTo("gpt-4o")
+    }
+
+    // ── Group D: onModelSelected (the one legitimate writer) ─────────────────
+
+    @Test
+    fun onModelSelectedUpdatesStatePersistsAndSyncsCache() = runTest {
+        val scope = TestScope(StandardTestDispatcher(testScheduler))
+        val handle = newHandle(scope)
+        val delegate = newDelegate(handle)
+
+        delegate.onModelSelected("anthropic", "claude-3")
+        advanceUntilIdle()
+
+        assertThat(handle.state.selectedEndpoint).isEqualTo("anthropic")
+        assertThat(handle.state.selectedModel).isEqualTo("claude-3")
+        assertThat(delegate.cachedLastUsedEndpoint).isEqualTo("anthropic")
+        assertThat(delegate.cachedLastUsedModel).isEqualTo("claude-3")
+        coVerify(exactly = 1) { settingsDataStore.setLastUsedModel("anthropic", "claude-3") }
+    }
+}

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ModelSelectorSheet.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ModelSelectorSheet.kt
@@ -56,6 +56,7 @@ import com.garfiec.librechat.core.ui.components.ErrorBanner
 import com.garfiec.librechat.feature.chat.resources.*
 import com.garfiec.librechat.feature.chat.resources.Res
 import com.garfiec.librechat.feature.chat.util.FuzzyMatch
+import com.garfiec.librechat.feature.chat.viewmodel.delegate.filterModelsByEndpoint
 import org.jetbrains.compose.resources.stringResource
 
 private val IconSize = 20.dp
@@ -121,11 +122,7 @@ fun ModelSelectorSheet(
 
     // Filter to only show models for endpoints the user's server has enabled
     val filteredByEndpoint = remember(availableModels, endpointConfigs) {
-        if (endpointConfigs.isEmpty()) {
-            availableModels
-        } else {
-            availableModels.filterKeys { it in endpointConfigs }
-        }
+        filterModelsByEndpoint(availableModels, endpointConfigs)
     }
 
     // Filter agents by search query (fuzzy matching), sorted by score when searching.

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModel.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModel.kt
@@ -281,28 +281,13 @@ class ChatViewModel(
             }
         }
 
-        // Eagerly load last-used model from DataStore so refilterModels can
-        // use it as a fallback.
-        viewModelScope.launch {
-            val endpoint = settingsDataStore.lastUsedEndpoint.first()
-            val model = settingsDataStore.lastUsedModel.first()
-            modelDelegate.cachedLastUsedEndpoint = endpoint
-            modelDelegate.cachedLastUsedModel = model
-            modelDelegate.lastUsedModelLoaded = true
-            // For new chats, apply the last-used model directly as the
-            // initial selection. refilterModels will validate it when
-            // the available models list arrives.
-            if (isNewConversation && endpoint != null && model != null) {
-                _uiState.update {
-                    it.copy(
-                        selectedEndpoint = endpoint,
-                        selectedModel = model,
-                    )
-                }
-            }
-            // Re-run validation now that we have the DataStore values.
-            modelDelegate.refilterModels(isNewConversation)
-        }
+        // Single authority for a new chat's initial model selection. Continuous so
+        // the retained NewChat landing VM re-syncs to last-used when it changes
+        // (a model picked later inside a conversation), and deterministic so the
+        // selection no longer races between the last-used read, agent auto-select,
+        // and model fallbacks. No-ops for existing conversations (loadConversationModel
+        // owns those). See ModelSelectionDelegate.seedInitialSelection.
+        modelDelegate.seedInitialSelection(isNewConversation)
 
         viewModelScope.launch {
             configRepository.endpointConfigs.collect { configs ->
@@ -324,8 +309,9 @@ class ChatViewModel(
         }
 
         viewModelScope.launch {
-            configRepository.availableModels.collect { models ->
-                _uiState.update { it.copy(availableModels = models) }
+            // refilterModels publishes the filtered availableModels into state; no
+            // need to write the raw map first (it would only be overwritten).
+            configRepository.availableModels.collect {
                 modelDelegate.refilterModels(isNewConversation)
             }
         }
@@ -391,9 +377,11 @@ class ChatViewModel(
             if (role?.hasAccess(PermissionType.MCP_SERVERS, Permission.USE) != false) {
                 modelDelegate.loadMcpServers()
             }
-            if (role?.hasAccess(PermissionType.AGENTS, Permission.USE) != false) {
-                modelDelegate.loadAgents(isNewConversation)
-            }
+            // Always call loadAgents — it self-gates on the AGENTS.USE permission and
+            // flips its agentsLoaded flag on every path (including denial). Skipping it
+            // here would leave the flag false and park the seeder on the agents tier
+            // forever (no model on the landing) for agents-denied users.
+            modelDelegate.loadAgents()
         }
     }
 

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/ModelSelectionDelegate.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/ModelSelectionDelegate.kt
@@ -9,6 +9,8 @@ import com.garfiec.librechat.core.data.repository.AgentRepository
 import com.garfiec.librechat.core.data.repository.ConfigRepository
 import com.garfiec.librechat.core.data.repository.McpRepository
 import com.garfiec.librechat.core.data.util.PermissionGate
+import com.garfiec.librechat.core.model.Agent
+import com.garfiec.librechat.core.model.EndpointConfig
 import com.garfiec.librechat.core.model.mcp.McpServer
 import com.garfiec.librechat.core.model.permissions.Permission
 import com.garfiec.librechat.core.model.permissions.PermissionType
@@ -19,6 +21,11 @@ import com.garfiec.librechat.feature.chat.viewmodel.ChatScreenState
 import com.garfiec.librechat.feature.chat.viewmodel.ChatStateHandle
 import com.garfiec.librechat.feature.chat.viewmodel.ComparisonState
 import com.garfiec.librechat.feature.chat.viewmodel.resolveEndpointDispatch
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 
 class ModelSelectionDelegate(
@@ -35,15 +42,12 @@ class ModelSelectionDelegate(
     val secondaryComparisonBuffer = StringBuilder()
 
     /**
-     * Cached last-used endpoint/model from DataStore. Loaded eagerly so
-     * [refilterModels] can use them as a fallback without waiting for a
-     * separate coroutine to complete. Null until the DataStore read finishes.
+     * Cached last-used endpoint/model from DataStore, kept in sync by
+     * [seedInitialSelection]. Used by [refilterModels]' existing-conversation
+     * fallback. Null until the first DataStore emission.
      */
     var cachedLastUsedEndpoint: String? = null
     var cachedLastUsedModel: String? = null
-
-    /** True once the DataStore read for last-used model has completed. */
-    var lastUsedModelLoaded = false
 
     /**
      * True once the conversation's model has been loaded from the server.
@@ -54,27 +58,52 @@ class ModelSelectionDelegate(
     var conversationModelLoaded = false
 
     /**
-     * Re-filters availableModels by endpointConfigs keys and validates the
-     * currently selected model against the filtered list.
+     * True once [loadAgents] has finished on ANY path (success, error, or
+     * permission-denied). [seedInitialSelection] uses this to tell "agents not
+     * loaded yet" (wait) from "agents loaded and genuinely empty" (fall through).
+     *
+     * Modeled as a flow (not a plain `var`) so it is an arm of the seeder's
+     * `combine`: the error / permission-denied paths flip it without publishing a
+     * new agent list, and a bare var would leave those transitions invisible to
+     * the seeder — it would stay parked on the agents tier forever (no model on
+     * the landing). `internal` for the delegate's unit tests.
+     */
+    internal val agentsLoaded = MutableStateFlow(false)
+
+    /**
+     * The last-used (endpoint, model) pair this delegate last applied as the
+     * active selection. Lets [seedInitialSelection] re-apply a *changed* last-used
+     * even over an already-valid selection (the retained-landing resync) without
+     * re-applying an unchanged value on every unrelated emission.
+     */
+    private var lastAppliedLastUsed: Pair<String, String>? = null
+
+    /**
+     * Re-filters availableModels into UI state and, for EXISTING conversations,
+     * corrects a selection that the latest models/configs invalidated.
+     *
+     * New-chat seeding is owned entirely by [seedInitialSelection] — this method
+     * deliberately does not seed/fallback for new chats, so the two never race.
      */
     fun refilterModels(isNewConversation: Boolean) {
-        val rawModels = configRepository.availableModels.value
-        val endpointCfgs = configRepository.endpointConfigs.value
-        val filtered = if (endpointCfgs.isEmpty()) {
-            rawModels.filterValues { it.isNotEmpty() }
-        } else {
-            rawModels.filterKeys { it in endpointCfgs }
-                .filterValues { it.isNotEmpty() }
-        }
+        val filtered = filterModelsByEndpoint(
+            configRepository.availableModels.value,
+            configRepository.endpointConfigs.value,
+        )
         stateHandle.update { copy(availableModels = filtered) }
 
         // Don't validate against an empty models list — models haven't
         // loaded yet. When they arrive this method will be called again.
         if (filtered.isEmpty()) return
 
+        // New chats: the seeder is the single authority for the selection.
+        // It re-resolves on every input change (availableModels/endpointConfigs
+        // are arms of its combine), so there is nothing to correct here.
+        if (isNewConversation) return
+
         // For existing conversations, don't apply fallbacks until the
         // conversation model has been loaded.
-        if (!isNewConversation && !conversationModelLoaded) return
+        if (!conversationModelLoaded) return
 
         // Validate current selection. The previous version exempted the
         // agents endpoint from the `currentModel in modelsForEndpoint` check,
@@ -93,13 +122,11 @@ class ModelSelectionDelegate(
 
         if (selectionValid) return
 
-        // --- Fallback chain ---
-
-        // Fallback 1: Try the last-used model from DataStore.
-        // Apply the same agents-endpoint guard as the validation above —
-        // a stale lastUsedModel that isn't an agent_id must not be restored
-        // as the agents-endpoint selection, or it'll be sent to the chat
-        // start request as an agent_id and the server will reject it.
+        // --- Corrective fallback (existing conversations only) ---
+        // The loaded conversation's model vanished server-side. Prefer the
+        // last-used model (same agents-endpoint guard as the validation above —
+        // a stale lastUsedModel that isn't an agent_id must not be restored as
+        // the agents-endpoint selection), then fall back to the first model.
         val lastEndpoint = cachedLastUsedEndpoint
         val lastModel = cachedLastUsedModel
         if (lastEndpoint != null && lastModel != null) {
@@ -115,18 +142,229 @@ class ModelSelectionDelegate(
             }
         }
 
-        // Fallback 2: First available model from any endpoint
         val firstEndpoint = filtered.entries.firstOrNull()
         if (firstEndpoint != null) {
-            val fallbackModel = firstEndpoint.value.firstOrNull()
             stateHandle.update {
                 copy(
                     selectedEndpoint = firstEndpoint.key,
-                    selectedModel = fallbackModel,
+                    selectedModel = firstEndpoint.value.firstOrNull(),
                 )
             }
         }
     }
+
+    /**
+     * Single authority for a NEW chat's initial model selection.
+     *
+     * Continuous (not one-shot): the NewChat landing ViewModel is retained in the
+     * back stack, so when last-used changes (e.g. the user picks a different model
+     * inside a conversation) this re-syncs the blank landing to it. Gated on
+     * `conversationId == null` so a started conversation's model is never overridden.
+     *
+     * Deterministic: every input (last-used, config models, endpoint configs, agent
+     * list) is an arm of one `combine`, so each change re-resolves the precedence
+     * atomically — replacing the three coroutines that used to race to seed the
+     * selection. Precedence, with WAIT-on-unresolved so a lower tier never wins
+     * while a higher-precedence input is still loading:
+     *   1. last-used (endpoint + model), if present and valid
+     *   2. first agent, when the active endpoint is agents
+     *   3. first available config model
+     */
+    fun seedInitialSelection(isNewConversation: Boolean) {
+        stateHandle.scope.launch {
+            combine(
+                settingsDataStore.lastUsedEndpoint,
+                settingsDataStore.lastUsedModel,
+                configRepository.availableModels,
+                configRepository.endpointConfigs,
+                agentsInput(),
+            ) { lastEndpoint, lastModel, rawModels, endpointCfgs, agents ->
+                SeedInputs(
+                    lastEndpoint = lastEndpoint,
+                    lastModel = lastModel,
+                    rawModels = rawModels,
+                    endpointConfigs = endpointCfgs,
+                    agents = agents.agents,
+                    agentsLoaded = agents.loaded,
+                    conversationId = agents.conversationId,
+                )
+            }.collect { input ->
+                // Keep the cached last-used fresh for refilterModels' existing-
+                // conversation corrective fallback. This runs for every conversation
+                // (new and existing) — the old eager one-shot read in ChatViewModel
+                // populated the cache for both, and dropping it would leave that
+                // fallback reading nulls for existing conversations.
+                cachedLastUsedEndpoint = input.lastEndpoint
+                cachedLastUsedModel = input.lastModel
+                // Seeding applies only to the blank new-chat landing. Never override
+                // an existing/started conversation's model (loadConversationModel
+                // owns those).
+                if (!isNewConversation || input.conversationId != null) return@collect
+                applySeed(input)
+            }
+        }
+    }
+
+    /**
+     * The agents arm of the seeder's [combine]: the (agents, conversationId) pair
+     * from state plus the [agentsLoaded] flag, so a load-completion with an
+     * unchanged (empty) agent list — error or permission-denied — still re-triggers
+     * the seeder and lets it fall through past the agents tier.
+     */
+    private fun agentsInput(): Flow<AgentsInput> = combine(
+        stateHandle.stateFlow.map { it.agents to it.conversationId }.distinctUntilChanged(),
+        agentsLoaded,
+    ) { agentsAndConvId, loaded ->
+        AgentsInput(
+            agents = agentsAndConvId.first,
+            conversationId = agentsAndConvId.second,
+            loaded = loaded,
+        )
+    }
+
+    private fun applySeed(input: SeedInputs) {
+        val filtered = filterModelsByEndpoint(input.rawModels, input.endpointConfigs)
+        val state = stateHandle.state
+
+        val lastUsed = if (input.lastEndpoint != null && input.lastModel != null) {
+            input.lastEndpoint to input.lastModel
+        } else {
+            null
+        }
+        val lastUsedSelectability = lastUsed?.let {
+            selectability(it.first, it.second, filtered, input.endpointConfigs, input.agents, input.agentsLoaded)
+        }
+        fun applyLastUsed(): Boolean {
+            if (lastUsed != null && lastUsedSelectability == Selectability.VALID) {
+                applySelection(lastUsed.first, lastUsed.second)
+                lastAppliedLastUsed = lastUsed
+                return true
+            }
+            return false
+        }
+
+        // Re-sync: when last-used CHANGES to a new valid value, re-apply it even
+        // over a currently-valid selection, so the retained landing follows a model
+        // picked elsewhere. Also covers the very first valid last-used emission.
+        if (lastUsed != lastAppliedLastUsed && applyLastUsed()) return
+
+        val currentSelectability = selectability(
+            state.selectedEndpoint,
+            state.selectedModel,
+            filtered,
+            input.endpointConfigs,
+            input.agents,
+            input.agentsLoaded,
+        )
+        when (currentSelectability) {
+            // Already usable — leave it (the re-sync above handled last-used changes).
+            Selectability.VALID -> return
+            // The input needed to judge the current selection hasn't arrived yet.
+            // Don't reseed through the lower tiers (that would clobber a legitimately-
+            // loading choice), but DO let a known-good last-used take over rather than
+            // waiting on an input that may never resolve.
+            Selectability.PENDING -> {
+                applyLastUsed()
+                return
+            }
+            // Definitively unusable — fall through to tier resolution.
+            Selectability.INVALID -> {}
+        }
+
+        // Tier 1: last-used.
+        if (lastUsed != null) {
+            when (lastUsedSelectability) {
+                Selectability.VALID -> {
+                    applyLastUsed()
+                    return
+                }
+                // WAIT: last-used's endpoint/agents not loaded yet — don't fall
+                // through to a lower tier and lose to it.
+                Selectability.PENDING -> return
+                // Stale (removed server-side) or absent — fall through.
+                Selectability.INVALID, null -> {}
+            }
+        }
+
+        // Tier 2: first agent, when the active endpoint is agents.
+        if (state.selectedEndpoint == EndpointConstants.AGENTS) {
+            if (!input.agentsLoaded) return // WAIT for the agent list
+            val firstAgent = input.agents.firstOrNull()
+            if (firstAgent != null) {
+                applySelection(EndpointConstants.AGENTS, firstAgent.id)
+                return
+            }
+            // Agents loaded and genuinely empty — fall through.
+        }
+
+        // Tier 3: first available config model.
+        if (filtered.isEmpty()) return // WAIT for models
+        val firstEntry = filtered.entries.firstOrNull() ?: return
+        applySelection(firstEntry.key, firstEntry.value.firstOrNull())
+    }
+
+    private fun applySelection(endpoint: String, model: String?) {
+        stateHandle.update {
+            copy(selectedEndpoint = endpoint, selectedModel = model)
+        }
+    }
+
+    /**
+     * Three-state validity for a candidate (endpoint, model):
+     * - VALID: usable right now
+     * - PENDING: the input needed to judge it hasn't loaded yet (agents list, or
+     *   this endpoint's model list) — callers should WAIT, not fall through
+     * - INVALID: definitively not usable (null, or absent from a loaded list)
+     *
+     * Agents are validated against the authoritative fetched [agents] list, not
+     * `availableModels` (agents are fetched separately and may not appear there).
+     */
+    private fun selectability(
+        endpoint: String?,
+        model: String?,
+        filtered: Map<String, List<String>>,
+        endpointConfigs: Map<String, EndpointConfig>,
+        agents: List<Agent>,
+        agentsLoaded: Boolean,
+    ): Selectability {
+        if (endpoint == null || model == null) return Selectability.INVALID
+        if (endpoint == EndpointConstants.AGENTS) {
+            return when {
+                !agentsLoaded -> Selectability.PENDING
+                agents.any { it.id == model } -> Selectability.VALID
+                else -> Selectability.INVALID
+            }
+        }
+        val modelsForEndpoint = filtered[endpoint]
+        return when {
+            modelsForEndpoint != null && model in modelsForEndpoint -> Selectability.VALID
+            modelsForEndpoint != null -> Selectability.INVALID // models loaded, model gone
+            // modelsForEndpoint == null: distinguish "this endpoint's models haven't
+            // loaded yet" (PENDING) from "this endpoint is no longer configured"
+            // (INVALID). Once configs have loaded, an endpoint absent from them was
+            // removed server-side — don't WAIT on it forever.
+            endpointConfigs.isNotEmpty() && endpoint !in endpointConfigs -> Selectability.INVALID
+            else -> Selectability.PENDING
+        }
+    }
+
+    private enum class Selectability { VALID, PENDING, INVALID }
+
+    private data class SeedInputs(
+        val lastEndpoint: String?,
+        val lastModel: String?,
+        val rawModels: Map<String, List<String>>,
+        val endpointConfigs: Map<String, EndpointConfig>,
+        val agents: List<Agent>,
+        val agentsLoaded: Boolean,
+        val conversationId: String?,
+    )
+
+    private data class AgentsInput(
+        val agents: List<Agent>,
+        val conversationId: String?,
+        val loaded: Boolean,
+    )
 
     fun onModelSelected(endpoint: String, model: String) {
         stateHandle.update {
@@ -253,33 +491,34 @@ class ModelSelectionDelegate(
         return agentId.contains("____")
     }
 
-    fun loadAgents(isNewConversation: Boolean) {
+    /**
+     * Fetches the agent list into state. Auto-selecting the first agent for a new
+     * chat is NOT done here — [seedInitialSelection] owns selection. This sets
+     * [agentsLoaded] on every exit path so the seeder can distinguish "agents
+     * still loading" (wait) from "agents loaded and empty" (fall through).
+     */
+    fun loadAgents() {
         stateHandle.scope.launch {
             // Skip the fetch entirely when the role denies AGENTS.USE; otherwise
             // the server would return 403 and we'd have to decide whether it's a
             // genuine 403 (rate limit, tenancy) vs. permission denial.
             if (permissionGate.awaitRole()?.hasAccess(PermissionType.AGENTS, Permission.USE) == false) {
+                agentsLoaded.value = true
                 return@launch
             }
             when (val result = agentRepository.getAgents()) {
                 is Result.Success -> {
+                    // Set agentsLoaded BEFORE publishing the agent list so the
+                    // seeder emission carrying the agents already sees the flag —
+                    // otherwise tier 2 could fall through to a config model in the
+                    // one-emission window before the flag flips.
+                    agentsLoaded.value = true
                     stateHandle.update { copy(agents = result.data) }
-                    // Auto-select the first agent only for a brand-new chat with no
-                    // model selected yet. For existing conversations, loadConversationModel
-                    // owns the model — auto-selecting here would flash the first agent and
-                    // clobber the persisted last-used model.
-                    val state = stateHandle.state
-                    if (isNewConversation &&
-                        state.selectedEndpoint == EndpointConstants.AGENTS &&
-                        state.selectedModel == null &&
-                        result.data.isNotEmpty()
-                    ) {
-                        stateHandle.update { copy(selectedModel = result.data.first().id) }
-                    }
                 }
                 is Result.Error -> {
                     Logger.e(result.exception) { "Failed to load agents" }
                     stateHandle.update { copy(error = "Could not load available agents") }
+                    agentsLoaded.value = true
                 }
                 is Result.Loading -> { /* no-op */ }
             }
@@ -347,6 +586,22 @@ class ModelSelectionDelegate(
         stateHandle.update { copy(modelParameters = parameters) }
     }
 }
+
+/**
+ * Filters availableModels to the endpoints the user's server has enabled, dropping
+ * endpoints with empty model lists. Single source of truth for "which models are
+ * usable" — shared by [ModelSelectionDelegate] (seeding/validation) and the model
+ * selector UI so they can't drift apart.
+ */
+internal fun filterModelsByEndpoint(
+    rawModels: Map<String, List<String>>,
+    endpointConfigs: Map<String, EndpointConfig>,
+): Map<String, List<String>> =
+    if (endpointConfigs.isEmpty()) {
+        rawModels.filterValues { it.isNotEmpty() }
+    } else {
+        rawModels.filterKeys { it in endpointConfigs }.filterValues { it.isNotEmpty() }
+    }
 
 // --- Display data mapping extensions ---
 


### PR DESCRIPTION
## Problem
A new chat's initial model was set by three uncoordinated coroutines — the last-used DataStore read, `loadAgents`' first-agent auto-select, and `refilterModels`' fallback chain — each guarded only by `selectedModel == null` or a validity check, with no ordering guarantee. Two symptoms:

- With no last-used persisted, the landing settled on the first agent *or* the first config model depending on coroutine scheduling. (Agents come from a separate `getAgents()` list, not `availableModels`, so the first-agent default lived in `loadAgents` and raced the model fallback.)
- The `NewChat` landing ViewModel is retained at the back-stack root, so a model switched inside a conversation never propagated back — returning to the landing showed a stale launch-time default.

## Repro Steps

1. Start with a new install of LibreChat Mobile (or wipe data)
2. Setup server and login
3. Send a message with the default agent/model. Do not change the model.
4. After the initial message, change the model to anything and send a message.
5. Navigate to the new chat screen.

Observed: 
The new chat switched back to the default model instead of the recently selected model.
If you restart the app, the new chat selected model will show the correct previously used model.

Expected: 
The new chat should show the previously used model.

## Change
One continuous authority, `ModelSelectionDelegate.seedInitialSelection()`: a single `combine` over last-used, config models, endpoint configs, and the agent list, re-resolving precedence atomically on every change:

> last-used (valid) → first agent (when agents is the active endpoint) → first config model

with **WAIT-on-unresolved** so a lower tier never wins while a higher-precedence input is still loading (arrival order can't change the outcome). It stays continuous so the retained landing re-syncs to a last-used changed elsewhere, and is gated on `conversationId == null` so a started conversation is never overridden.

- `loadAgents` no longer auto-selects (the seeder owns selection) and sets a new `agentsLoaded` flag on every exit path, so the seeder distinguishes "agents loading" (wait) from "agents empty" (fall through).
- `refilterModels` is reduced to validation-only: it still corrects an invalidated selection for existing conversations but defers all new-chat seeding to the seeder. No fallback path persists last-used — only an explicit pick does.

## Tests
`ModelSelectionDelegateTest` (22 cases): the validation rules, the `loadAgents` contract, the no-persist invariants, the retained-landing resync, and the arrival-order determinism proof (agents-first vs models-first → identical result).

## Note
Another probable fix for #71 (first agent shown as default), but not definitive — the original report's exact scenario wasn't fully reproduced. Verified on device: deterministic default with no Claude flash, no model switch after send, and the retained-landing resync.