### PR TITLE
feat(chat): animated placeholder for in-progress image generation

### DIFF
--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatScreen.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatScreen.kt
@@ -452,6 +452,7 @@ actual fun ChatScreen(
                                     } else {
                                         uiState.activeToolCalls
                                     },
+                                    streamingAttachments = uiState.streamingAttachments,
                                     onSiblingNavigation = viewModel::switchBranch,
                                     onEditMessage = viewModel::startEditing,
                                     onRegenerateMessage = viewModel::regenerateMessage,
@@ -507,6 +508,7 @@ actual fun ChatScreen(
                                     isStreaming = comparisonState.secondaryIsStreaming,
                                     streamingContent = comparisonState.secondaryStreamingContent,
                                     activeToolCalls = comparisonState.secondaryActiveToolCalls,
+                                    streamingAttachments = uiState.streamingAttachments,
                                     error = null,
                                     baseUrl = uiState.serverUrl,
                                     fontSizeMultiplier = fontSizeMultiplier,
@@ -572,6 +574,7 @@ actual fun ChatScreen(
                                 isStreaming = uiState.isStreaming,
                                 streamingContent = uiState.streamingContent,
                                 activeToolCalls = uiState.activeToolCalls,
+                                streamingAttachments = uiState.streamingAttachments,
                                 onSiblingNavigation = viewModel::switchBranch,
                                 onEditMessage = viewModel::startEditing,
                                 onRegenerateMessage = viewModel::regenerateMessage,

--- a/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/components/StreamingImageGenParsingTest.kt
+++ b/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/components/StreamingImageGenParsingTest.kt
@@ -1,0 +1,81 @@
+package com.garfiec.librechat.feature.chat.components
+
+import com.garfiec.librechat.core.model.Attachment
+import com.garfiec.librechat.feature.chat.viewmodel.ActiveToolCall
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class StreamingImageGenParsingTest {
+
+    private val baseUrl = "https://chat.example.com"
+
+    @Test
+    fun `generating state before attachment arrives`() {
+        val toolCall = ActiveToolCall(
+            id = "call_1",
+            name = "image_gen_oai",
+            input = """{"prompt":"a red fox","quality":"high"}""",
+        )
+
+        val result = parseStreamingImageGenResult(toolCall, baseUrl, emptyList())
+
+        assertThat(result.isGenerating).isTrue()
+        assertThat(result.imageUrl).isNull()
+        assertThat(result.prompt).isEqualTo("a red fox")
+        assertThat(result.quality).isEqualTo("high")
+    }
+
+    @Test
+    fun `swaps to image when matching attachment lands mid-stream`() {
+        val toolCall = ActiveToolCall(
+            id = "call_1",
+            name = "image_gen_oai",
+            input = """{"prompt":"a red fox"}""",
+        )
+        val attachments = listOf(
+            Attachment(fileId = "f1", filepath = "/api/files/f1/fox.png", toolCallId = "call_1"),
+        )
+
+        val result = parseStreamingImageGenResult(toolCall, baseUrl, attachments)
+
+        assertThat(result.isGenerating).isFalse()
+        assertThat(result.imageUrl).isEqualTo("https://chat.example.com/api/files/f1/fox.png")
+        assertThat(result.prompt).isEqualTo("a red fox")
+    }
+
+    @Test
+    fun `ignores attachment belonging to a different tool call`() {
+        val toolCall = ActiveToolCall(id = "call_1", name = "image_gen_oai", input = "{}")
+        val attachments = listOf(
+            Attachment(fileId = "f9", filepath = "/api/files/f9/other.png", toolCallId = "call_other"),
+        )
+
+        val result = parseStreamingImageGenResult(toolCall, baseUrl, attachments)
+
+        assertThat(result.isGenerating).isTrue()
+        assertThat(result.imageUrl).isNull()
+    }
+
+    @Test
+    fun `resolves absolute http filepath without prefixing baseUrl`() {
+        val toolCall = ActiveToolCall(id = "call_1", name = "image_gen_oai", input = "{}")
+        val attachments = listOf(
+            Attachment(filepath = "https://cdn.example.com/img.png", toolCallId = "call_1"),
+        )
+
+        val result = parseStreamingImageGenResult(toolCall, baseUrl, attachments)
+
+        assertThat(result.imageUrl).isEqualTo("https://cdn.example.com/img.png")
+    }
+
+    @Test
+    fun `tolerates malformed args json`() {
+        val toolCall = ActiveToolCall(id = "call_1", name = "image_gen_oai", input = "not json")
+
+        val result = parseStreamingImageGenResult(toolCall, baseUrl, emptyList())
+
+        assertThat(result.prompt).isNull()
+        assertThat(result.quality).isNull()
+        assertThat(result.isGenerating).isTrue()
+    }
+}

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ImageGenCard.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ImageGenCard.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
@@ -23,7 +24,9 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -39,12 +42,18 @@ import androidx.compose.ui.unit.dp
 import coil3.compose.SubcomposeAsyncImage
 import com.garfiec.librechat.feature.chat.resources.*
 import com.garfiec.librechat.feature.chat.resources.Res
+import kotlinx.coroutines.delay
 import org.jetbrains.compose.resources.stringResource
+import kotlin.math.pow
+import kotlin.random.Random
 
 data class ImageGenResult(
     val imageUrl: String? = null,
     val prompt: String? = null,
     val isGenerating: Boolean = false,
+    /** Image-gen quality ("low" | "medium" | "high"). Tunes the faux-progress
+     *  duration while [isGenerating], matching the web client. */
+    val quality: String? = null,
 )
 
 /** Renders a DALL-E / image generation result card. [ImageGenResult.isGenerating] drives spinner vs image display. */
@@ -55,6 +64,41 @@ fun ImageGenCard(
     showDescription: Boolean = true,
 ) {
     var showFullscreen by remember { mutableStateOf(false) }
+
+    // Faux progress, ported from web's OpenAIImageGen (the server sends no real
+    // progress). Ticks 0.1 → 0.9 over a quality-tuned duration with jitter, then
+    // snaps to done the moment the real image (imageUrl) lands and isGenerating flips.
+    var fauxProgress by remember { mutableFloatStateOf(0.1f) }
+    LaunchedEffect(result.isGenerating, result.quality) {
+        if (!result.isGenerating) {
+            fauxProgress = 1f
+            return@LaunchedEffect
+        }
+        fauxProgress = 0.1f
+        val baseDuration = when (result.quality?.lowercase()) {
+            "low" -> 10_000
+            "high" -> 50_000
+            else -> 20_000
+        }
+        val jitter = (baseDuration * 0.3f).toInt().coerceAtLeast(1)
+        val totalDuration = Random.nextInt(jitter) + baseDuration
+        val updateInterval = 200L
+        val totalSteps = (totalDuration / updateInterval).toInt().coerceAtLeast(1)
+        var step = 0
+        while (step < totalSteps) {
+            delay(updateInterval)
+            step++
+            val ratio = step.toFloat() / totalSteps
+            val mapRatio = if (ratio < 0.8f) {
+                ratio.pow(1.1f)
+            } else {
+                val sub = (ratio - 0.8f) / 0.2f
+                0.8f + (1f - (1f - sub).pow(2)) * 0.2f
+            }
+            fauxProgress = (0.1f + mapRatio * 0.8f).coerceAtMost(0.9f)
+        }
+        fauxProgress = 0.9f
+    }
 
     Card(
         modifier = modifier.fillMaxWidth(),
@@ -80,9 +124,9 @@ fun ImageGenCard(
                 )
                 if (result.isGenerating) {
                     Spacer(modifier = Modifier.width(8.dp))
-                    CircularProgressIndicator(
-                        modifier = Modifier.size(14.dp),
-                        strokeWidth = 2.dp,
+                    Text(
+                        text = "${(fauxProgress * 100).toInt()}%",
+                        style = MaterialTheme.typography.labelMedium,
                         color = MaterialTheme.colorScheme.primary,
                     )
                 }
@@ -141,13 +185,18 @@ fun ImageGenCard(
                     modifier = Modifier
                         .fillMaxWidth()
                         .height(160.dp)
-                        .background(
-                            MaterialTheme.colorScheme.surfaceContainerHighest,
-                            RoundedCornerShape(8.dp),
-                        ),
-                    contentAlignment = Alignment.Center,
+                        .clip(RoundedCornerShape(8.dp))
+                        .background(MaterialTheme.colorScheme.surfaceContainerHighest),
                 ) {
-                    CircularProgressIndicator(modifier = Modifier.size(32.dp))
+                    PixelRevealCard(
+                        progress = fauxProgress,
+                        modifier = Modifier.fillMaxSize(),
+                        colors = listOf(
+                            MaterialTheme.colorScheme.primary.copy(alpha = 0.35f),
+                            MaterialTheme.colorScheme.primary.copy(alpha = 0.6f),
+                            MaterialTheme.colorScheme.primary.copy(alpha = 0.9f),
+                        ),
+                    )
                 }
             }
 

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/MessageList.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/MessageList.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.layout.boundsInRoot
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
 import com.garfiec.librechat.core.common.ChatLayoutConstants
+import com.garfiec.librechat.core.model.Attachment
 import com.garfiec.librechat.core.model.FeedbackRating
 import com.garfiec.librechat.feature.chat.resources.*
 import com.garfiec.librechat.feature.chat.resources.Res
@@ -59,6 +60,7 @@ fun MessageList(
     onCopyMessage: (messageId: String) -> Unit,
     modifier: Modifier = Modifier,
     activeToolCalls: List<ActiveToolCall> = emptyList(),
+    streamingAttachments: List<Attachment> = emptyList(),
     onFeedback: (messageId: String, rating: String?) -> Unit = { _, _ -> },
     onContinue: (messageId: String) -> Unit = {},
     onReadAloud: (messageId: String) -> Unit = {},
@@ -441,6 +443,9 @@ fun MessageList(
                                 horizontal = 16.dp,
                                 vertical = 4.dp,
                             ),
+                            baseUrl = baseUrl,
+                            streamingAttachments = streamingAttachments,
+                            showImageDescriptions = showImageDescriptions,
                         )
                     }
                 }

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/PixelRevealCard.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/PixelRevealCard.kt
@@ -1,0 +1,160 @@
+package com.garfiec.librechat.feature.chat.components
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.withFrameMillis
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
+import kotlin.math.hypot
+import kotlin.random.Random
+
+private const val MAX_SIZE_INTEGER = 4f
+private const val MIN_SIZE = 1f
+
+/**
+ * Compose port of the web client's `PixelCard` (packages/client/src/components/PixelCard.tsx).
+ *
+ * A grid of tiny squares that "reveal" from the center outward as [progress] rises 0→1:
+ * each pixel has a distance-based activation threshold, grows in once progress passes it,
+ * then shimmers. The whole field fades out as progress approaches 1. Used as the image-gen
+ * placeholder so the in-progress state matches web instead of a plain spinner.
+ */
+@Composable
+internal fun PixelRevealCard(
+    progress: Float,
+    colors: List<Color>,
+    modifier: Modifier = Modifier,
+    gap: Dp = 4.dp,
+    randomness: Float = 0.6f,
+    speed: Int = 35,
+) {
+    var sizePx by remember { mutableStateOf(IntSize.Zero) }
+    val gapPx = with(LocalDensity.current) { gap.toPx() }.coerceAtLeast(4f)
+    val effectiveSpeed = speed.coerceIn(0, 100) * 0.001f
+
+    val pixels = remember(sizePx, gapPx, randomness, colors) {
+        if (sizePx.width == 0 || sizePx.height == 0) {
+            emptyList()
+        } else {
+            buildPixels(sizePx.width, sizePx.height, gapPx, colors, randomness, effectiveSpeed)
+        }
+    }
+
+    val currentProgress by rememberUpdatedState(progress)
+    var frame by remember { mutableLongStateOf(0L) }
+
+    LaunchedEffect(pixels) {
+        if (pixels.isEmpty()) return@LaunchedEffect
+        while (true) {
+            withFrameMillis { now ->
+                for (p in pixels) {
+                    p.appearWithProgress(currentProgress)
+                }
+                frame = now
+            }
+        }
+    }
+
+    // Fade the whole field out as it completes (web: opacity 1→0 over progress 0.9→1.0).
+    val fieldAlpha = if (progress >= 0.9f) {
+        (1f - (progress - 0.9f) / 0.1f).coerceIn(0f, 1f)
+    } else {
+        1f
+    }
+
+    Canvas(modifier.onSizeChanged { sizePx = it }) {
+        frame // read to invalidate the draw each animation frame
+        if (fieldAlpha <= 0f) return@Canvas
+        for (p in pixels) {
+            if (p.size <= 0f) continue
+            val offset = MAX_SIZE_INTEGER * 0.5f - p.size * 0.5f
+            drawRect(
+                color = p.color.copy(alpha = p.color.alpha * fieldAlpha),
+                topLeft = Offset(p.x + offset, p.y + offset),
+                size = Size(p.size, p.size),
+            )
+        }
+    }
+}
+
+private fun buildPixels(
+    width: Int,
+    height: Int,
+    gap: Float,
+    colors: List<Color>,
+    randomness: Float,
+    effectiveSpeed: Float,
+): List<Pixel> {
+    val list = ArrayList<Pixel>()
+    val cx = width / 2f
+    val cy = height / 2f
+    val maxDist = hypot(cx, cy).coerceAtLeast(1f)
+    var x = 0f
+    while (x < width) {
+        var y = 0f
+        while (y < height) {
+            val color = colors[Random.nextInt(colors.size)]
+            val distNorm = hypot(x - cx, y - cy) / maxDist
+            val threshold = (distNorm * (1f - randomness) + Random.nextFloat() * randomness)
+                .coerceIn(0f, 1f)
+            val delay = distNorm * maxDist
+            val pxSpeed = (0.1f + Random.nextFloat() * 0.8f) * effectiveSpeed
+            list.add(Pixel(x, y, color, pxSpeed, delay, threshold, (width + height).toFloat()))
+            y += gap
+        }
+        x += gap
+    }
+    return list
+}
+
+/** A single animated pixel, ported from the web `Pixel` class. */
+private class Pixel(
+    val x: Float,
+    val y: Float,
+    val color: Color,
+    private val speed: Float,
+    private val delay: Float,
+    private val activationThreshold: Float,
+    canvasExtent: Float,
+) {
+    var size = 0f
+    private val sizeStep = Random.nextFloat() * 0.4f
+    private val maxSize = MIN_SIZE + Random.nextFloat() * (MAX_SIZE_INTEGER - MIN_SIZE)
+    private var counter = 0f
+    private val counterStep = Random.nextFloat() * 4f + canvasExtent * 0.01f
+    private var isReverse = false
+    private var isShimmer = false
+
+    fun appearWithProgress(progress: Float) {
+        if (progress - activationThreshold <= 0f) return
+        if (counter <= delay) {
+            counter += counterStep
+            return
+        }
+        if (size >= maxSize) isShimmer = true
+        if (isShimmer) shimmer() else size += sizeStep
+    }
+
+    private fun shimmer() {
+        if (size >= maxSize) {
+            isReverse = true
+        } else if (size <= MIN_SIZE) {
+            isReverse = false
+        }
+        size += if (isReverse) -speed else speed
+    }
+}

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/SecondaryMessageList.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/SecondaryMessageList.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.garfiec.librechat.core.common.ChatLayoutConstants
+import com.garfiec.librechat.core.model.Attachment
 import com.garfiec.librechat.feature.chat.resources.*
 import com.garfiec.librechat.feature.chat.resources.Res
 import com.garfiec.librechat.feature.chat.util.MessageNode
@@ -33,6 +34,7 @@ fun SecondaryMessageList(
     streamingContent: String,
     modifier: Modifier = Modifier,
     activeToolCalls: List<ActiveToolCall> = emptyList(),
+    streamingAttachments: List<Attachment> = emptyList(),
     error: String? = null,
     baseUrl: String = "",
     fontSizeMultiplier: Float = 1.0f,
@@ -131,6 +133,8 @@ fun SecondaryMessageList(
                                     horizontal = 16.dp,
                                     vertical = 4.dp,
                                 ),
+                                baseUrl = baseUrl,
+                                streamingAttachments = streamingAttachments,
                             )
                         }
                     }

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/StreamingToolCallCard.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/StreamingToolCallCard.kt
@@ -32,6 +32,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.garfiec.librechat.core.model.Attachment
 import com.garfiec.librechat.feature.chat.resources.*
 import com.garfiec.librechat.feature.chat.resources.Res
 import com.garfiec.librechat.feature.chat.viewmodel.ActiveToolCall
@@ -41,7 +42,25 @@ import org.jetbrains.compose.resources.stringResource
 fun StreamingToolCallCard(
     toolCall: ActiveToolCall,
     modifier: Modifier = Modifier,
+    baseUrl: String = "",
+    streamingAttachments: List<Attachment> = emptyList(),
+    showImageDescriptions: Boolean = true,
 ) {
+    // Image-gen tool calls render as an ImageGenCard placeholder (matching web): a
+    // faux-progress spinner while generating, swapping to the real image the moment
+    // its attachment SSE event arrives (linked by toolCallId) — before the final reload.
+    if (isImageGenToolCall(toolCall.name.lowercase())) {
+        val imageResult = remember(toolCall, streamingAttachments, baseUrl) {
+            parseStreamingImageGenResult(toolCall, baseUrl, streamingAttachments)
+        }
+        ImageGenCard(
+            result = imageResult,
+            modifier = modifier,
+            showDescription = showImageDescriptions,
+        )
+        return
+    }
+
     var isExpanded by remember { mutableStateOf(false) }
     val canExpand = toolCall.isComplete && !toolCall.output.isNullOrBlank()
 

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ToolCallParsing.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ToolCallParsing.kt
@@ -3,6 +3,7 @@ package com.garfiec.librechat.feature.chat.components
 import co.touchlab.kermit.Logger
 import com.garfiec.librechat.core.model.Attachment
 import com.garfiec.librechat.core.model.content.AgentToolCall
+import com.garfiec.librechat.feature.chat.viewmodel.ActiveToolCall
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
@@ -219,21 +220,7 @@ internal fun parseImageGenResult(
     val toolCallId = toolCall.id
     if (toolCallId != null) {
         val attachment = attachments.firstOrNull { it.toolCallId == toolCallId }
-        val filepath = attachment?.filepath
-        if (filepath != null) {
-            imageUrl = when {
-                filepath.startsWith("http") -> filepath
-                filepath.startsWith("/") && baseUrl.isNotBlank() -> "$baseUrl$filepath"
-                baseUrl.isNotBlank() -> "$baseUrl/$filepath"
-                else -> filepath
-            }
-        }
-        if (imageUrl == null) {
-            val fileId = attachment?.fileId
-            if (fileId != null && baseUrl.isNotBlank()) {
-                imageUrl = "$baseUrl/api/files/$fileId"
-            }
-        }
+        imageUrl = resolveAttachmentUrl(attachment, baseUrl)
     }
 
     if (imageUrl == null && !outputStr.isNullOrBlank()) {
@@ -272,6 +259,64 @@ internal fun parseImageGenResult(
         prompt = prompt,
         isGenerating = outputStr.isNullOrBlank() && imageUrl == null,
     )
+}
+
+/**
+ * Builds an [ImageGenResult] for an in-progress (streaming) image-gen tool call.
+ *
+ * Mirrors the web client: during streaming the prompt/quality are available from the
+ * tool-call args immediately, while the generated image arrives later as a separate
+ * `attachment` SSE event (linked by `toolCallId`). [ImageGenResult.isGenerating] stays
+ * true until the matching attachment lands, at which point the placeholder swaps to the
+ * real image — all before the final message reload.
+ */
+internal fun parseStreamingImageGenResult(
+    toolCall: ActiveToolCall,
+    baseUrl: String,
+    attachments: List<Attachment>,
+): ImageGenResult {
+    val (prompt, quality) = parseImageGenArgs(toolCall.input)
+    val attachment = attachments.firstOrNull { it.toolCallId == toolCall.id }
+    val imageUrl = resolveAttachmentUrl(attachment, baseUrl)
+    return ImageGenResult(
+        imageUrl = imageUrl,
+        prompt = prompt,
+        isGenerating = imageUrl == null,
+        quality = quality,
+    )
+}
+
+/** Extracts (prompt, quality) from a raw image-gen tool-call args JSON string. */
+private fun parseImageGenArgs(argsJson: String?): Pair<String?, String?> {
+    if (argsJson.isNullOrBlank()) return null to null
+    return try {
+        val obj = toolCallJson.parseToJsonElement(argsJson).jsonObject
+        val prompt = obj["prompt"]?.jsonPrimitive?.contentOrNull
+        val quality = obj["quality"]?.jsonPrimitive?.contentOrNull
+        prompt to quality
+    } catch (e: Exception) {
+        log.d(e) { "Failed to parse streaming image gen args" }
+        null to null
+    }
+}
+
+/** Resolves an attachment's `filepath`/`fileId` to a fully-qualified image URL. */
+private fun resolveAttachmentUrl(attachment: Attachment?, baseUrl: String): String? {
+    if (attachment == null) return null
+    val filepath = attachment.filepath
+    if (filepath != null) {
+        return when {
+            filepath.startsWith("http") -> filepath
+            filepath.startsWith("/") && baseUrl.isNotBlank() -> "$baseUrl$filepath"
+            baseUrl.isNotBlank() -> "$baseUrl/$filepath"
+            else -> filepath
+        }
+    }
+    val fileId = attachment.fileId
+    if (fileId != null && baseUrl.isNotBlank()) {
+        return "$baseUrl/api/files/$fileId"
+    }
+    return null
 }
 
 internal fun parseLogContent(toolCall: AgentToolCall?): LogContent {

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatUiState.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatUiState.kt
@@ -75,6 +75,9 @@ data class ActiveToolCall(
     val name: String,
     val isComplete: Boolean = false,
     val output: String? = null,
+    /** Raw tool-call arguments JSON from [StreamEvent.ToolCallStart]. Holds the
+     *  image prompt/quality for image-gen tools so a placeholder can render mid-stream. */
+    val input: String? = null,
 )
 
 @Immutable

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModel.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModel.kt
@@ -1056,6 +1056,7 @@ class ChatViewModel(
                 val newToolCall = ActiveToolCall(
                     id = event.toolCallId,
                     name = event.toolName,
+                    input = event.input,
                 )
                 val isComparison = _uiState.value.comparisonState.isEnabled
                 if (isComparison && modelDelegate.isSecondaryEvent(event.agentId)) {

--- a/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/screen/PlatformScreens.ios.kt
+++ b/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/screen/PlatformScreens.ios.kt
@@ -434,6 +434,7 @@ actual fun ChatScreen(
                         isStreaming = uiState.isStreaming,
                         streamingContent = uiState.streamingContent,
                         activeToolCalls = uiState.activeToolCalls,
+                        streamingAttachments = uiState.streamingAttachments,
                         onSiblingNavigation = viewModel::switchBranch,
                         onEditMessage = viewModel::startEditing,
                         onRegenerateMessage = { messageId -> viewModel.regenerateMessage(messageId) },


### PR DESCRIPTION
## Summary

Image-generation tool calls (DALL·E, `image_gen_oai`, `image_edit_oai`, `gemini_image_gen`, stable-diffusion, flux) previously rendered nothing until the final image arrived — the user saw a blank gap with no sign that work was happening. They now show an animated placeholder during streaming that swaps to the real image the instant its attachment lands, reaching parity with the web client. Closes #105.

| During generation | Result |
| --- | --- |
| <img width="214" height="480" alt="pr_placeholder" src="https://github.com/user-attachments/assets/51762c31-cf6f-4219-b37f-90eef13f32c8" /> |  <img width="214" height="480" alt="pr_result" src="https://github.com/user-attachments/assets/698de585-a911-47fb-bb15-ba92f43d1cbb" /> | 


## How it works

The server emits no real progress and delivers the image as a separate `attachment` SSE event (linked by `toolCallId`) before the final message — both already flow through the existing pipeline, so no network-layer changes were needed.

- **Streaming state** carries the tool-call args (`ActiveToolCall.input`) so the prompt and quality are available mid-stream.
- **`StreamingToolCallCard`** routes image-gen tool calls to `ImageGenCard` with a generating placeholder instead of the generic tool-call card.
- **`parseStreamingImageGenResult`** matches the mid-stream attachment by `toolCallId` and flips `isGenerating` off once the image URL resolves.
- **`PixelRevealCard`** is a Compose port of the web client's `PixelCard`: a grid of pixels that reveals from the center outward as faux progress advances, then fades near completion. The faux-progress timing (0.1→0.9 over a quality-tuned duration with jitter) mirrors the web behavior.
- Attachment URL resolution is shared between the streaming and final parsers.

`streamingAttachments` is threaded through `MessageList` / `SecondaryMessageList` and all call sites (Android, iOS, comparison panes).

## Testing

- New unit tests for `parseStreamingImageGenResult` (generating state, mid-stream swap, cross-tool-call isolation, absolute-URL handling, malformed-args tolerance).
- Compiles on Android + iOS.
- Verified on device: placeholder animates center-outward with a climbing percentage, then swaps to the generated image on completion.

## Known follow-ups (not in this PR)

- A failed/image-less generation keeps the placeholder animating until the stream finalizes (no error/cancelled state yet — web derives this from the tool output).
- `SecondaryMessageList` doesn't forward `showImageDescriptions` to the image-gen card, so the comparison secondary pane ignores that setting.

