### PR TITLE
feat(logging): persistent, redacted, exportable diagnostic log buffer

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
     implementation(project(":core:network"))
     implementation(project(":core:model"))
     implementation(project(":core:common"))
+    implementation(project(":core:logging"))
     implementation(project(":feature:auth"))
     implementation(project(":feature:chat"))
     implementation(project(":feature:conversations"))

--- a/app/src/main/kotlin/com/garfiec/librechat/LibreChatApplication.kt
+++ b/app/src/main/kotlin/com/garfiec/librechat/LibreChatApplication.kt
@@ -2,6 +2,7 @@ package com.garfiec.librechat
 
 import android.app.Application
 import co.touchlab.kermit.Logger
+import co.touchlab.kermit.platformLogWriter
 import coil3.ImageLoader
 import coil3.SingletonImageLoader
 import coil3.disk.DiskCache
@@ -10,8 +11,14 @@ import coil3.memory.MemoryCache
 import coil3.network.ktor3.KtorNetworkFetcherFactory
 import coil3.request.crossfade
 import coil3.svg.SvgDecoder
+import com.garfiec.librechat.core.common.AppInfo
 import com.garfiec.librechat.core.common.di.commonModule
 import com.garfiec.librechat.core.data.di.dataModule
+import com.garfiec.librechat.core.logging.PersistentLogWriter
+import com.garfiec.librechat.core.logging.PlatformInfo
+import com.garfiec.librechat.core.logging.di.loggingModule
+import com.garfiec.librechat.core.logging.logStartupHeader
+import com.garfiec.librechat.core.logging.startMainThreadWatchdog
 import com.garfiec.librechat.core.network.di.networkModule
 import com.garfiec.librechat.feature.agents.di.agentsModule
 import com.garfiec.librechat.feature.auth.di.authModule
@@ -22,6 +29,7 @@ import com.garfiec.librechat.feature.files.di.filesModule
 import com.garfiec.librechat.feature.settings.di.settingsModule
 import com.garfiec.librechat.shared.navigation.sharedAppModule
 import io.ktor.client.HttpClient
+import kotlinx.coroutines.CoroutineExceptionHandler
 import org.koin.android.ext.android.inject
 import org.koin.android.ext.koin.androidContext
 import org.koin.android.ext.koin.androidLogger
@@ -43,6 +51,7 @@ class LibreChatApplication : Application(), SingletonImageLoader.Factory {
                 allowOverride(false)
                 modules(
                     commonModule,
+                    loggingModule,
                     networkModule,
                     dataModule,
                     sharedAppModule,
@@ -59,6 +68,43 @@ class LibreChatApplication : Application(), SingletonImageLoader.Factory {
             Logger.e(e) { "Koin initialization failed" }
             throw e // Always rethrow — DI failure is unrecoverable
         }
+
+        // Diagnostic logging is wired AFTER Koin so the writer's dependencies are resolvable.
+        // Everything here is best-effort: a logging-setup failure must never block app launch.
+        runCatching { initDiagnostics() }
+            .onFailure { Logger.e(it) { "Diagnostic logging init failed (non-fatal)" } }
+    }
+
+    private fun initDiagnostics() {
+        val writer: PersistentLogWriter by inject()
+
+        // Preserve Logcat (platformLogWriter) and add the persistent file sink alongside it.
+        Logger.setLogWriters(platformLogWriter(), writer)
+
+        // Capture uncaught exceptions on any thread: write a synchronous crash record, then delegate
+        // to the previous handler so the process still crashes exactly as it would have.
+        val previous = Thread.getDefaultUncaughtExceptionHandler()
+        Thread.setDefaultUncaughtExceptionHandler { thread, throwable ->
+            runCatching {
+                writer.writeCrashRecord(
+                    tag = "Crash",
+                    message = "uncaught exception on thread ${thread.name}",
+                    throwable = throwable,
+                )
+            }
+            previous?.uncaughtException(thread, throwable)
+        }
+
+        // Emit the startup header. detectedBackendVersion is null at cold start (config not yet
+        // fetched); a later config-load path snapshots the detected version separately.
+        val appInfo: AppInfo by inject()
+        val platformInfo: PlatformInfo by inject()
+        logStartupHeader(appInfo = appInfo, platformInfo = platformInfo)
+
+        // The watchdog owns its own supervised scope; we just hand it the diagnostic exception
+        // handler so any escaped failure is funneled into the crash-record path.
+        val exceptionHandler: CoroutineExceptionHandler by inject()
+        startMainThreadWatchdog(exceptionHandler)
     }
 
     override fun newImageLoader(context: coil3.PlatformContext): ImageLoader {

--- a/app/src/test/kotlin/com/garfiec/librechat/KoinGraphVerificationTest.kt
+++ b/app/src/test/kotlin/com/garfiec/librechat/KoinGraphVerificationTest.kt
@@ -38,6 +38,8 @@ import com.garfiec.librechat.core.data.repository.UserRepository
 import com.garfiec.librechat.core.data.util.PermissionGate
 import com.garfiec.librechat.core.data.util.SessionTask
 import com.garfiec.librechat.core.data.util.SessionTaskRunner
+import com.garfiec.librechat.core.logging.DiagnosticLogRepository
+import com.garfiec.librechat.core.logging.di.loggingModule
 import com.garfiec.librechat.core.network.api.AgentToolsApi
 import com.garfiec.librechat.core.network.api.AgentsApi
 import com.garfiec.librechat.core.network.api.ApiKeysApi
@@ -98,6 +100,7 @@ class KoinGraphVerificationTest {
         settingsModule,
         agentsModule,
         filesModule,
+        loggingModule,
     )
 
     /**
@@ -120,6 +123,8 @@ class KoinGraphVerificationTest {
             CoroutineScope::class,
             ConnectivityObserver::class,
             AppInfo::class,
+            // core:logging provides
+            DiagnosticLogRepository::class,
             // core:network provides
             TokenManager::class,
             SecureTokenStorage::class,

--- a/core/common/src/commonMain/kotlin/com/garfiec/librechat/core/common/di/KoinQualifiers.kt
+++ b/core/common/src/commonMain/kotlin/com/garfiec/librechat/core/common/di/KoinQualifiers.kt
@@ -9,4 +9,8 @@ object KoinQualifiers {
     val ApplicationScope = named("applicationScope")
     val Streaming = named("streaming")
     val Refresh = named("refresh")
+
+    // Single-thread dispatcher dedicated to the persistent diagnostic log sink, so all
+    // file appends/rotation happen on one thread (no locks, no rotation races).
+    val LogWriter = named("logWriter")
 }

--- a/core/common/src/iosMain/kotlin/com/garfiec/librechat/core/common/IosAppInfo.kt
+++ b/core/common/src/iosMain/kotlin/com/garfiec/librechat/core/common/IosAppInfo.kt
@@ -11,8 +11,8 @@ internal class IosAppInfo : AppInfo {
     override val versionCode: Long =
         (bundle.objectForInfoDictionaryKey("CFBundleVersion") as? String)?.toLongOrNull() ?: 0L
 
-    // Reads an Info.plist "GitSHA" key if the iOS build injects one; until that's wired into the
-    // Xcode/xcconfig build, this resolves to "unknown". Android bakes the real value via BuildConfig.
+    // Reads the Info.plist "GitSHA" key stamped by the "Stamp Git SHA" Xcode build phase
+    // (git rev-parse --short=8). Falls back to "unknown" if absent. Android bakes it via BuildConfig.
     override val gitSha: String =
         bundle.objectForInfoDictionaryKey("GitSHA") as? String ?: "unknown"
 }

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -15,6 +15,7 @@ kotlin {
             implementation(project(":core:network"))
             implementation(project(":core:model"))
             implementation(project(":core:common"))
+            implementation(project(":core:logging"))
             implementation(libs.datastore.preferences)
             implementation(libs.ktor.client.core)
             implementation(libs.ktor.client.content.negotiation)

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/CommonTokenDataStore.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/CommonTokenDataStore.kt
@@ -1,6 +1,8 @@
 package com.garfiec.librechat.core.data.datastore
 
 import co.touchlab.kermit.Logger
+import com.garfiec.librechat.core.logging.Diag
+import com.garfiec.librechat.core.logging.LogOrigin
 import com.garfiec.librechat.core.model.response.RefreshResponse
 import com.garfiec.librechat.core.network.client.CookieHelper
 import com.garfiec.librechat.core.network.client.SecureTokenStorage
@@ -73,7 +75,11 @@ abstract class CommonTokenDataStore(
     override suspend fun refreshAccessToken(): Boolean = refreshMutex.withLock {
         val storedRefreshToken = readRefreshToken()
         if (storedRefreshToken.isNullOrBlank()) {
-            Logger.w { "No refresh token available" }
+            Diag.w(
+                "Auth",
+                origin = LogOrigin.CLIENT,
+                attrs = mapOf("event" to "session_expired", "reason" to "no_refresh_token"),
+            ) { "No refresh token available" }
             return false
         }
 
@@ -92,16 +98,34 @@ abstract class CommonTokenDataStore(
             Logger.d { "Token refreshed successfully" }
             true
         } catch (e: ClientRequestException) {
-            Logger.w(e) { "Auth error during token refresh (status=${e.response.status})" }
+            Diag.w(
+                "Auth",
+                origin = LogOrigin.SERVER,
+                throwable = e,
+                attrs = mapOf(
+                    "event" to "refresh_failed",
+                    "status" to e.response.status.value.toString(),
+                ),
+            ) { "Auth error during token refresh" }
             clearTokensLocked()
             false
         } catch (e: Exception) {
             if (isKeystoreException(e)) {
-                Logger.e(e) { "Keystore corruption—clearing tokens" }
+                Diag.e(
+                    "Auth",
+                    origin = LogOrigin.CLIENT,
+                    throwable = e,
+                    attrs = mapOf("event" to "keystore_corruption"),
+                ) { "Keystore corruption—clearing tokens" }
                 onKeystoreCorruption()
                 clearTokensLocked()
             } else {
-                Logger.w(e) { "Error during token refresh" }
+                Diag.w(
+                    "Auth",
+                    origin = LogOrigin.NETWORK,
+                    throwable = e,
+                    attrs = mapOf("event" to "refresh_failed"),
+                ) { "Error during token refresh" }
             }
             false
         }

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/ConfigRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/ConfigRepositoryImpl.kt
@@ -6,6 +6,7 @@ import com.garfiec.librechat.core.common.result.ApiException
 import com.garfiec.librechat.core.common.result.Result
 import com.garfiec.librechat.core.common.result.safeApiCall
 import com.garfiec.librechat.core.data.datastore.ConfigCacheDataStore
+import com.garfiec.librechat.core.logging.Diag
 import com.garfiec.librechat.core.model.EndpointConfig
 import com.garfiec.librechat.core.model.config.StartupConfig
 import com.garfiec.librechat.core.network.api.ConfigApi
@@ -32,6 +33,44 @@ class ConfigRepositoryImpl(
     private val _detectedBackendVersion = MutableStateFlow<String?>(null)
     override val detectedBackendVersion: StateFlow<String?> = _detectedBackendVersion.asStateFlow()
 
+    /**
+     * Identity of the last config we logged a snapshot for, so we emit one snapshot
+     * per fetch/change rather than on every recomposition or duplicate fetch.
+     */
+    private var loggedConfigSignature: Int? = null
+
+    /**
+     * Emits a single redacted, low-cardinality snapshot of the server config to the
+     * diagnostic log on first fetch and whenever the relevant feature flags change.
+     * NEVER includes serverDomain, URLs, secrets (turnstile/balance), or analyticsGtmId.
+     */
+    private fun logConfigSnapshot(config: StartupConfig) {
+        // Fold the detected backend version and endpoint count into the signature so a snapshot
+        // re-emits once the version is detected (it's resolved after the first config fetch) or the
+        // endpoint set changes — otherwise the export would forever show detectedBackendVersion=unknown.
+        var signature = config.hashCode()
+        signature = 31 * signature + (_detectedBackendVersion.value?.hashCode() ?: 0)
+        signature = 31 * signature + _endpointConfigs.value.size
+        if (signature == loggedConfigSignature) return
+        loggedConfigSignature = signature
+
+        Diag.i(
+            "ServerConfig",
+            attrs = mapOf(
+                "registrationEnabled" to config.registrationEnabled.toString(),
+                "emailLoginEnabled" to config.emailLoginEnabled.toString(),
+                "socialLoginEnabled" to config.socialLoginEnabled.toString(),
+                "passwordResetEnabled" to config.passwordResetEnabled.toString(),
+                "sharedLinksEnabled" to config.sharedLinksEnabled.toString(),
+                "webSearch" to (config.webSearch != null).toString(),
+                "modelSpecs" to (config.modelSpecs != null).toString(),
+                "endpointCount" to _endpointConfigs.value.size.toString(),
+                "detectedBackendVersion" to (_detectedBackendVersion.value ?: "unknown"),
+                "supportedBackendVersion" to BackendVersion.SUPPORTED_BACKEND_VERSION,
+            ),
+        ) { "server config snapshot" }
+    }
+
     override suspend fun validateServerUrl(url: String): Result<StartupConfig> {
         return try {
             val config = configApi.getStartupConfig()
@@ -40,6 +79,7 @@ class ConfigRepositoryImpl(
             } else {
                 _startupConfig.value = config
                 configCache.saveStartupConfig(config)
+                logConfigSnapshot(config)
                 Result.Success(config)
             }
         } catch (e: SerializationException) {
@@ -80,6 +120,7 @@ class ConfigRepositoryImpl(
             val config = configApi.getStartupConfig()
             _startupConfig.value = config
             configCache.saveStartupConfig(config)
+            logConfigSnapshot(config)
             config
         }
 
@@ -169,15 +210,37 @@ class ConfigRepositoryImpl(
 
             _detectedBackendVersion.value = detectedVersion
 
+            // Re-emit the config snapshot now that the backend version is resolved, so the export's
+            // version-mismatch signal is accurate (the first snapshot ran before detection).
+            config?.let { logConfigSnapshot(it) }
+
             if (detectedVersion != null) {
-                Logger.d { "Backend version detected: $detectedVersion (supported: $supported)" }
+                val compatible = BackendVersion.isCompatible(supported, detectedVersion)
+                // Dedicated structured record emitted the moment the version is resolved, carrying the
+                // compatibility verdict — greppable by tag for triage (versions are server software
+                // facts, not PII). The holistic ServerConfig snapshot above also includes the version.
+                Diag.i(
+                    "BackendVersion",
+                    attrs = mapOf(
+                        "detectedBackendVersion" to detectedVersion,
+                        "supportedBackendVersion" to supported,
+                        "compatible" to compatible.toString(),
+                    ),
+                ) { "backend version detected" }
                 VersionCheckResult(
                     backendVersion = detectedVersion,
                     supportedVersion = supported,
-                    isCompatible = BackendVersion.isCompatible(supported, detectedVersion),
+                    isCompatible = compatible,
                 )
             } else {
-                Logger.d { "Backend version could not be determined, skipping check" }
+                Diag.i(
+                    "BackendVersion",
+                    attrs = mapOf(
+                        "detectedBackendVersion" to "unknown",
+                        "supportedBackendVersion" to supported,
+                        "compatible" to "true",
+                    ),
+                ) { "backend version could not be determined" }
                 VersionCheckResult(
                     backendVersion = null,
                     supportedVersion = supported,
@@ -192,6 +255,7 @@ class ConfigRepositoryImpl(
         _availableModels.value = emptyMap()
         _startupConfig.value = null
         _detectedBackendVersion.value = null
+        loggedConfigSignature = null
         configCache.clear()
     }
 }

--- a/core/logging/build.gradle.kts
+++ b/core/logging/build.gradle.kts
@@ -1,0 +1,24 @@
+plugins {
+    id("librechat.kmp.library")
+    id("librechat.kmp.koin")
+    id("librechat.kotlin.serialization")
+}
+
+android {
+    namespace = "com.garfiec.librechat.core.logging"
+}
+
+kotlin {
+    sourceSets {
+        commonMain.dependencies {
+            api(project(":core:common"))
+            implementation(libs.kermit)
+            implementation(libs.coroutines.core)
+            implementation(libs.kotlinx.serialization.json)
+            api(libs.kotlinx.datetime)
+        }
+        androidMain.dependencies {
+            implementation(libs.coroutines.android)
+        }
+    }
+}

--- a/core/logging/src/androidMain/kotlin/com/garfiec/librechat/core/logging/PlatformInfo.android.kt
+++ b/core/logging/src/androidMain/kotlin/com/garfiec/librechat/core/logging/PlatformInfo.android.kt
@@ -1,0 +1,9 @@
+package com.garfiec.librechat.core.logging
+
+import android.os.Build
+
+internal class AndroidPlatformInfo : PlatformInfo {
+    override val osName: String = "Android"
+    override val osVersion: String = Build.VERSION.RELEASE ?: "unknown"
+    override val deviceModel: String = "${Build.MANUFACTURER} ${Build.MODEL}"
+}

--- a/core/logging/src/androidMain/kotlin/com/garfiec/librechat/core/logging/Threads.android.kt
+++ b/core/logging/src/androidMain/kotlin/com/garfiec/librechat/core/logging/Threads.android.kt
@@ -1,0 +1,4 @@
+package com.garfiec.librechat.core.logging
+
+internal actual fun currentThreadName(): String =
+    runCatching { Thread.currentThread().name }.getOrDefault("android-?")

--- a/core/logging/src/androidMain/kotlin/com/garfiec/librechat/core/logging/di/LoggingPlatformModule.android.kt
+++ b/core/logging/src/androidMain/kotlin/com/garfiec/librechat/core/logging/di/LoggingPlatformModule.android.kt
@@ -1,0 +1,20 @@
+package com.garfiec.librechat.core.logging.di
+
+import android.content.Context
+import com.garfiec.librechat.core.logging.AndroidPlatformInfo
+import com.garfiec.librechat.core.logging.PlatformInfo
+import com.garfiec.librechat.core.logging.io.LogDirProvider
+import org.koin.android.ext.koin.androidContext
+import org.koin.core.module.Module
+import org.koin.dsl.module
+import java.io.File
+
+private class AndroidLogDirProvider(private val context: Context) : LogDirProvider {
+    // filesDir is app-private and persists across restarts (unlike cacheDir, which the OS can evict).
+    override fun logDir(): String = File(context.filesDir, "diag_logs").absolutePath
+}
+
+actual val loggingPlatformModule: Module = module {
+    single<LogDirProvider> { AndroidLogDirProvider(androidContext()) }
+    single<PlatformInfo> { AndroidPlatformInfo() }
+}

--- a/core/logging/src/androidMain/kotlin/com/garfiec/librechat/core/logging/io/LogFile.android.kt
+++ b/core/logging/src/androidMain/kotlin/com/garfiec/librechat/core/logging/io/LogFile.android.kt
@@ -1,0 +1,36 @@
+package com.garfiec.librechat.core.logging.io
+
+import java.io.File
+import java.io.FileOutputStream
+
+internal class AndroidLogFile(path: String) : LogFileHandle {
+    private val file = File(path)
+
+    override fun ensureParentDir() {
+        file.parentFile?.let { if (!it.exists()) it.mkdirs() }
+    }
+
+    override fun exists(): Boolean = file.exists()
+
+    override fun appendLine(text: String) {
+        // append=true → O_APPEND; each write is atomic up to PIPE_BUF, so the rare crash-time
+        // concurrent write at worst interleaves whole small lines (the reader tolerates that).
+        FileOutputStream(file, true).use { it.write((text + "\n").encodeToByteArray()) }
+    }
+
+    override fun sizeBytes(): Long = if (file.exists()) file.length() else 0L
+
+    override fun readText(): String = if (file.exists()) file.readText(Charsets.UTF_8) else ""
+
+    override fun delete() {
+        if (file.exists()) file.delete()
+    }
+
+    override fun renameTo(targetPath: String) {
+        file.renameTo(File(targetPath))
+    }
+
+    override fun lastModifiedMillis(): Long = if (file.exists()) file.lastModified() else 0L
+}
+
+internal actual fun openLogFile(path: String): LogFileHandle = AndroidLogFile(path)

--- a/core/logging/src/commonMain/kotlin/com/garfiec/librechat/core/logging/DiagnosticExceptionHandler.kt
+++ b/core/logging/src/commonMain/kotlin/com/garfiec/librechat/core/logging/DiagnosticExceptionHandler.kt
@@ -1,0 +1,22 @@
+package com.garfiec.librechat.core.logging
+
+import kotlinx.coroutines.CoroutineExceptionHandler
+
+/**
+ * Builds a [CoroutineExceptionHandler] that records uncaught coroutine failures through the
+ * synchronous crash path of [writer] before they are swallowed by the scope's supervisor.
+ *
+ * Opt-in: attach it to a scope's context (e.g. the watchdog scope, or any app-lifetime scope that
+ * wants its escaped exceptions captured). The handler is best-effort and never rethrows — a failure
+ * inside logging must not escalate into a crash loop.
+ */
+fun diagnosticCoroutineExceptionHandler(writer: PersistentLogWriter): CoroutineExceptionHandler =
+    CoroutineExceptionHandler { context, throwable ->
+        runCatching {
+            writer.writeCrashRecord(
+                tag = "Crash",
+                message = "uncaught coroutine exception in $context",
+                throwable = throwable,
+            )
+        }
+    }

--- a/core/logging/src/commonMain/kotlin/com/garfiec/librechat/core/logging/DiagnosticLogRepository.kt
+++ b/core/logging/src/commonMain/kotlin/com/garfiec/librechat/core/logging/DiagnosticLogRepository.kt
@@ -1,0 +1,39 @@
+package com.garfiec.librechat.core.logging
+
+import com.garfiec.librechat.core.logging.io.LogSink
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+
+/**
+ * Read/clear access to the persistent diagnostic buffer, for the Settings → Data export/clear UI.
+ * On-disk content is already redacted at write time, so [exportText] returns it directly.
+ */
+interface DiagnosticLogRepository {
+    /** Full buffer (previous ++ active segment) as JSONL text. */
+    suspend fun exportText(): String
+
+    /** Same content as UTF-8 bytes, for the platform share sheet. */
+    suspend fun exportBytes(): ByteArray
+
+    /** Deletes both segments. */
+    suspend fun clear()
+
+    /** Current on-disk buffer size in bytes (for the "Clear logs" affordance). */
+    suspend fun bufferSizeBytes(): Long
+}
+
+internal class DiagnosticLogRepositoryImpl(
+    private val sink: LogSink,
+    private val dispatcher: CoroutineDispatcher,
+) : DiagnosticLogRepository {
+
+    // All operations run on the same single-thread dispatcher as the writer's drain, so reads/clears
+    // never race in-flight appends or rotation.
+    override suspend fun exportText(): String = withContext(dispatcher) { sink.readAll() }
+
+    override suspend fun exportBytes(): ByteArray = withContext(dispatcher) { sink.readAll().encodeToByteArray() }
+
+    override suspend fun clear() = withContext(dispatcher) { sink.clear() }
+
+    override suspend fun bufferSizeBytes(): Long = withContext(dispatcher) { sink.sizeBytes() }
+}

--- a/core/logging/src/commonMain/kotlin/com/garfiec/librechat/core/logging/LogConfig.kt
+++ b/core/logging/src/commonMain/kotlin/com/garfiec/librechat/core/logging/LogConfig.kt
@@ -1,0 +1,27 @@
+package com.garfiec.librechat.core.logging
+
+/**
+ * Tunables for the persistent diagnostic log buffer. Provided via Koin so build types can override.
+ *
+ * The buffer is two-segment: [totalMaxBytes] is split across the active and previous segments, so
+ * the on-disk footprint stays between `totalMaxBytes/2` and `totalMaxBytes`.
+ */
+data class LogConfig(
+    val totalMaxBytes: Long = DEFAULT_TOTAL_MAX_BYTES,
+    val maxAgeMillis: Long = DEFAULT_MAX_AGE_MILLIS,
+    val channelCapacity: Int = DEFAULT_CHANNEL_CAPACITY,
+    // Cap a captured throwable's rendered length so a few exceptions can't dominate the buffer.
+    // Crash records use a larger cap (they're rare and the full trace matters most).
+    val maxThrowableChars: Int = DEFAULT_MAX_THROWABLE_CHARS,
+    val maxCrashThrowableChars: Int = DEFAULT_MAX_CRASH_THROWABLE_CHARS,
+) {
+    val segmentCapBytes: Long get() = totalMaxBytes / 2
+
+    companion object {
+        const val DEFAULT_TOTAL_MAX_BYTES: Long = 4L * 1024 * 1024 // 4 MiB total → 2 MiB/segment
+        const val DEFAULT_MAX_AGE_MILLIS: Long = 7L * 24 * 60 * 60 * 1000 // 7 days
+        const val DEFAULT_CHANNEL_CAPACITY: Int = 1024
+        const val DEFAULT_MAX_THROWABLE_CHARS: Int = 1500
+        const val DEFAULT_MAX_CRASH_THROWABLE_CHARS: Int = 6000
+    }
+}

--- a/core/logging/src/commonMain/kotlin/com/garfiec/librechat/core/logging/LogEnvelope.kt
+++ b/core/logging/src/commonMain/kotlin/com/garfiec/librechat/core/logging/LogEnvelope.kt
@@ -1,0 +1,58 @@
+package com.garfiec.librechat.core.logging
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/** One structured diagnostic record, serialized as a single JSONL line. */
+@Serializable
+data class LogRecord(
+    val ts: String,
+    val level: String,
+    val tag: String,
+    val msg: String,
+    val attrs: Map<String, String> = emptyMap(),
+    val thread: String,
+    val origin: String? = null,
+)
+
+/**
+ * Kermit's `LogWriter` only carries a plain `String` message — there's no structured channel for
+ * attributes. [Diag] therefore encodes `{msg, attrs, origin}` into the message string behind a
+ * non-printable sentinel, and [PersistentLogWriter] decodes it back out.
+ *
+ * Crucially, when there are no attrs and no origin, [encode] returns the message **unchanged** — so
+ * a plain `Logger.d("tag") { "msg" }` (the ~196 existing call sites) carries no sentinel and is
+ * recorded with empty attrs, byte-identical to before. The decoder treats any message lacking the
+ * sentinel, or one whose payload fails to parse, as plain text.
+ */
+object LogEnvelope {
+    // SOH (U+0001) control char, built at runtime to keep a non-printable byte out of source.
+    private val SOH: String = Char(1).toString()
+
+    /** Marks a message as carrying a structured payload: SOH + "LCLOG" + SOH + json. */
+    val SENTINEL: String = SOH + "LCLOG" + SOH
+
+    private val json = Json { encodeDefaults = false; ignoreUnknownKeys = true }
+
+    @Serializable
+    private data class Payload(
+        val msg: String,
+        val attrs: Map<String, String> = emptyMap(),
+        val origin: String? = null,
+    )
+
+    data class Decoded(val msg: String, val attrs: Map<String, String>, val origin: String?)
+
+    fun encode(msg: String, attrs: Map<String, String>, origin: LogOrigin?): String {
+        if (attrs.isEmpty() && origin == null) return msg
+        return SENTINEL + json.encodeToString(Payload(msg, attrs, origin?.wire))
+    }
+
+    fun decode(message: String): Decoded {
+        if (!message.startsWith(SENTINEL)) return Decoded(message, emptyMap(), null)
+        return runCatching {
+            val payload = json.decodeFromString<Payload>(message.substring(SENTINEL.length))
+            Decoded(payload.msg, payload.attrs, payload.origin)
+        }.getOrElse { Decoded(message, emptyMap(), null) }
+    }
+}

--- a/core/logging/src/commonMain/kotlin/com/garfiec/librechat/core/logging/LogHelper.kt
+++ b/core/logging/src/commonMain/kotlin/com/garfiec/librechat/core/logging/LogHelper.kt
@@ -1,0 +1,70 @@
+package com.garfiec.librechat.core.logging
+
+import co.touchlab.kermit.Logger
+
+/** Fault attribution for failure records, so triage doesn't require guessing where a fault arose. */
+enum class LogOrigin(val wire: String) {
+    /** App-side: serialization/parse error, null/empty local state, navigation bug, pre-byte timeout. */
+    CLIENT("client"),
+
+    /** Server-side: non-2xx status, server error envelope, malformed/incomplete SSE, version mismatch. */
+    SERVER("server"),
+
+    /** Transport-side: connectivity loss, DNS/TLS, socket errors before any HTTP response. */
+    NETWORK("network"),
+}
+
+/**
+ * Thin structured-logging facade over Kermit. Lets call sites attach key-value [attrs] and an
+ * [origin] without string-concatenating. Routes through Kermit so existing console/NSLog writers
+ * and the [PersistentLogWriter] sink both see it.
+ *
+ * The message lambda is only invoked if Kermit decides to log at that severity (laziness preserved),
+ * and when [attrs] is empty and [origin] is null the emitted string is byte-identical to a plain
+ * `Logger.x` call — so this is purely additive over the existing ~196 direct call sites.
+ *
+ * Redaction is applied centrally at the sink ([com.garfiec.librechat.core.logging.redact.LogRedactor]),
+ * not here — callers never have to remember to scrub. Still: never put raw tokens or message/
+ * conversation **content** in [attrs]; pass identifiers (which get hashed) or low-cardinality facts.
+ */
+object Diag {
+    fun v(
+        tag: String,
+        origin: LogOrigin? = null,
+        throwable: Throwable? = null,
+        attrs: Map<String, String> = emptyMap(),
+        message: () -> String,
+    ) = Logger.withTag(tag).v(throwable) { LogEnvelope.encode(message(), attrs, origin) }
+
+    fun d(
+        tag: String,
+        origin: LogOrigin? = null,
+        throwable: Throwable? = null,
+        attrs: Map<String, String> = emptyMap(),
+        message: () -> String,
+    ) = Logger.withTag(tag).d(throwable) { LogEnvelope.encode(message(), attrs, origin) }
+
+    fun i(
+        tag: String,
+        origin: LogOrigin? = null,
+        throwable: Throwable? = null,
+        attrs: Map<String, String> = emptyMap(),
+        message: () -> String,
+    ) = Logger.withTag(tag).i(throwable) { LogEnvelope.encode(message(), attrs, origin) }
+
+    fun w(
+        tag: String,
+        origin: LogOrigin? = null,
+        throwable: Throwable? = null,
+        attrs: Map<String, String> = emptyMap(),
+        message: () -> String,
+    ) = Logger.withTag(tag).w(throwable) { LogEnvelope.encode(message(), attrs, origin) }
+
+    fun e(
+        tag: String,
+        origin: LogOrigin? = null,
+        throwable: Throwable? = null,
+        attrs: Map<String, String> = emptyMap(),
+        message: () -> String,
+    ) = Logger.withTag(tag).e(throwable) { LogEnvelope.encode(message(), attrs, origin) }
+}

--- a/core/logging/src/commonMain/kotlin/com/garfiec/librechat/core/logging/PersistentLogWriter.kt
+++ b/core/logging/src/commonMain/kotlin/com/garfiec/librechat/core/logging/PersistentLogWriter.kt
@@ -1,0 +1,116 @@
+package com.garfiec.librechat.core.logging
+
+import co.touchlab.kermit.LogWriter
+import co.touchlab.kermit.Severity
+import com.garfiec.librechat.core.logging.io.LogSink
+import com.garfiec.librechat.core.logging.redact.LogRedactor
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.launch
+import kotlinx.serialization.json.Json
+import kotlin.time.Clock
+
+/**
+ * Custom Kermit [LogWriter] that captures every log (the ~196 existing direct calls included),
+ * decodes any [Diag] envelope, redacts, and appends one JSONL [LogRecord] per line to the bounded
+ * on-disk [LogSink].
+ *
+ * Hot path is non-blocking: [log] only does a [Channel.trySend] (capacity-bounded, oldest-dropped),
+ * and a single drain coroutine on a dedicated single-thread dispatcher is the sole file writer — so
+ * there are no locks and no rotation races. Failures are swallowed and **never** re-enter logging
+ * (that would recurse), so logging can neither crash the app nor stall a caller.
+ */
+class PersistentLogWriter internal constructor(
+    private val sink: LogSink,
+    private val redactor: LogRedactor,
+    private val threadName: () -> String,
+    scope: CoroutineScope,
+    dispatcher: CoroutineDispatcher,
+    capacity: Int,
+    private val maxThrowableChars: Int,
+    private val maxCrashThrowableChars: Int,
+) : LogWriter() {
+
+    private val json = Json { encodeDefaults = false }
+    private val channel = Channel<String>(capacity, onBufferOverflow = BufferOverflow.DROP_OLDEST)
+
+    init {
+        scope.launch(dispatcher) {
+            for (line in channel) {
+                runCatching { sink.append(line) }
+            }
+        }
+    }
+
+    override fun log(severity: Severity, message: String, tag: String, throwable: Throwable?) {
+        val line = runCatching { buildLine(severity.name, message, tag, throwable) }.getOrNull()
+            ?: runCatching { fallbackLine(severity.name, tag) }.getOrNull()
+            ?: return
+        channel.trySend(line)
+    }
+
+    /**
+     * Synchronous, best-effort write for the crash path: the process may die before the async drain
+     * runs, so a fatal record must hit disk immediately. Skips the channel and rotation.
+     */
+    fun writeCrashRecord(
+        tag: String,
+        message: String,
+        throwable: Throwable?,
+        attrs: Map<String, String> = emptyMap(),
+    ) {
+        runCatching {
+            val merged = LinkedHashMap(attrs)
+            throwable?.let { merged["throwable"] = formatThrowable(it, maxCrashThrowableChars) }
+            val record = LogRecord(
+                ts = Clock.System.now().toString(),
+                level = Severity.Error.name,
+                tag = tag,
+                msg = redactor.redact(message),
+                attrs = redactor.redactAttrs(merged),
+                thread = threadName(),
+                origin = LogOrigin.CLIENT.wire,
+            )
+            sink.appendBlocking(json.encodeToString(record))
+        }
+    }
+
+    private fun buildLine(level: String, message: String, tag: String, throwable: Throwable?): String {
+        val decoded = LogEnvelope.decode(message)
+        val attrs = LinkedHashMap<String, String>(decoded.attrs)
+        throwable?.let { attrs["throwable"] = formatThrowable(it, maxThrowableChars) }
+        val record = LogRecord(
+            ts = Clock.System.now().toString(),
+            level = level,
+            tag = tag,
+            msg = redactor.redact(decoded.msg),
+            attrs = redactor.redactAttrs(attrs),
+            thread = threadName(),
+            origin = decoded.origin,
+        )
+        return json.encodeToString(record)
+    }
+
+    /**
+     * Renders a throwable's stack trace, truncated to [maxChars] so a few exceptions can't dominate
+     * the bounded buffer. Redaction (which strips embedded response bodies) is applied later by the
+     * caller via [LogRedactor.redactAttrs] on the "throwable" value.
+     */
+    private fun formatThrowable(throwable: Throwable, maxChars: Int): String {
+        val full = throwable.stackTraceToString()
+        return if (full.length <= maxChars) full else full.take(maxChars) + "…(truncated)"
+    }
+
+    private fun fallbackLine(level: String, tag: String): String =
+        json.encodeToString(
+            LogRecord(
+                ts = Clock.System.now().toString(),
+                level = level,
+                tag = tag,
+                msg = "<unencodable log record>",
+                thread = threadName(),
+            ),
+        )
+}

--- a/core/logging/src/commonMain/kotlin/com/garfiec/librechat/core/logging/PlatformInfo.kt
+++ b/core/logging/src/commonMain/kotlin/com/garfiec/librechat/core/logging/PlatformInfo.kt
@@ -1,0 +1,19 @@
+package com.garfiec.librechat.core.logging
+
+/**
+ * Read-only platform/device facts for diagnostic headers and crash records.
+ *
+ * Deliberately low-cardinality and non-identifying: OS name/version and a coarse device-model
+ * string only. Never expose serial numbers, advertising IDs, or anything that could fingerprint
+ * an individual install. Provided per-platform via the `loggingPlatformModule` actuals.
+ */
+interface PlatformInfo {
+    /** Operating system family, e.g. `Android` or `iOS`. */
+    val osName: String
+
+    /** OS release string, e.g. `14` (Android) or `17.4` (iOS). */
+    val osVersion: String
+
+    /** Coarse device model, e.g. `Google Pixel 8` or `iPhone`. */
+    val deviceModel: String
+}

--- a/core/logging/src/commonMain/kotlin/com/garfiec/librechat/core/logging/StartupDiagnostics.kt
+++ b/core/logging/src/commonMain/kotlin/com/garfiec/librechat/core/logging/StartupDiagnostics.kt
@@ -1,0 +1,40 @@
+package com.garfiec.librechat.core.logging
+
+import com.garfiec.librechat.core.common.AppInfo
+import com.garfiec.librechat.core.common.BackendVersion
+
+/**
+ * Emits a single structured "startup header" record at process start so every diagnostic export
+ * begins with the build + device context needed to triage the records that follow. This is the
+ * one place that snapshots app version, git SHA, OS, and device model into the log.
+ *
+ * Privacy: contains only build metadata and coarse, non-identifying device facts. NEVER add the
+ * server URL, account, token, or any user data here — exports may be shared in bug reports.
+ *
+ * [supportedBackendVersion] is a build-time constant, so it's stamped here immediately. The
+ * *detected* server version isn't known until `/api/config` is fetched; that comparison lives in
+ * the redacted `ServerConfig` snapshot (see `ConfigRepositoryImpl.logConfigSnapshot`), which
+ * carries both the resolved detected version and this supported version.
+ */
+fun logStartupHeader(
+    appInfo: AppInfo,
+    platformInfo: PlatformInfo,
+    supportedBackendVersion: String = BackendVersion.SUPPORTED_BACKEND_VERSION,
+) {
+    // Defensive: the startup path must never crash the app on a logging failure.
+    runCatching {
+        Diag.i(
+            tag = "Startup",
+            origin = LogOrigin.CLIENT,
+            attrs = buildMap {
+                put("versionName", appInfo.versionName)
+                put("versionCode", appInfo.versionCode.toString())
+                put("gitSha", appInfo.gitSha)
+                put("osName", platformInfo.osName)
+                put("osVersion", platformInfo.osVersion)
+                put("deviceModel", platformInfo.deviceModel)
+                put("supportedBackendVersion", supportedBackendVersion)
+            },
+        ) { "app startup" }
+    }
+}

--- a/core/logging/src/commonMain/kotlin/com/garfiec/librechat/core/logging/Threads.kt
+++ b/core/logging/src/commonMain/kotlin/com/garfiec/librechat/core/logging/Threads.kt
@@ -1,0 +1,4 @@
+package com.garfiec.librechat.core.logging
+
+/** Best-effort current thread/queue name for log records. Never throws. */
+internal expect fun currentThreadName(): String

--- a/core/logging/src/commonMain/kotlin/com/garfiec/librechat/core/logging/Watchdog.kt
+++ b/core/logging/src/commonMain/kotlin/com/garfiec/librechat/core/logging/Watchdog.kt
@@ -1,0 +1,96 @@
+package com.garfiec.librechat.core.logging
+
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlin.concurrent.Volatile
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.time.TimeSource
+
+/**
+ * Conservative main-thread responsiveness watchdog (a soft ANR detector).
+ *
+ * Each [pollInterval], if there is no ping already in flight, it opens one (records "now") and posts
+ * a clear-task to [Dispatchers.Main]. When the main thread is healthy that task runs promptly and
+ * clears the ping. If a ping stays outstanding longer than [threshold], the main thread is stalled
+ * and we emit ONE warning record; we then debounce until the main thread recovers (the clear-task
+ * finally runs), so a long stall yields a single record, not a flood.
+ *
+ * It owns its OWN supervised scope on [Dispatchers.Default] so a failure can never tear down the
+ * caller's (application) scope. It is best-effort observability only: it does NOT kill the app, dump
+ * threads, or interrupt anything, runs entirely off the main thread (no busy-loop), and every step
+ * is wrapped so a logging failure or cancellation can never crash the host process.
+ */
+private const val DEFAULT_POLL_MS = 1_000L
+private const val DEFAULT_THRESHOLD_MS = 5_000L
+
+class MainThreadWatchdog(
+    private val pollInterval: Long = DEFAULT_POLL_MS,
+    private val threshold: Long = DEFAULT_THRESHOLD_MS,
+) {
+    // Monotonic clock so wall-clock changes (NTP, DST) can't produce a phantom stall.
+    private val clock = TimeSource.Monotonic
+
+    // Mark of the in-flight ping, or null when the main thread has acknowledged and caught up.
+    // Only one ping is ever outstanding at a time, so the mark isn't reset every tick.
+    @Volatile
+    private var pingInFlightSince: TimeSource.Monotonic.ValueTimeMark? = null
+
+    // True once the current stall has been reported; re-armed when a fresh ping is opened.
+    @Volatile
+    private var reported = false
+
+    /**
+     * Starts the watchdog on a fresh supervised [Dispatchers.Default] scope (isolated from the
+     * caller). An optional [exceptionHandler] funnels any escaped failure into the crash-record path.
+     * Returns the [Job] so the caller can cancel it; safe to ignore (lives for the process).
+     */
+    fun start(exceptionHandler: CoroutineExceptionHandler? = null): Job {
+        val scope = CoroutineScope(
+            Dispatchers.Default + SupervisorJob() + (exceptionHandler ?: EmptyCoroutineContext),
+        )
+        return scope.launch {
+            while (isActive) {
+                runCatching {
+                    val inFlight = pingInFlightSince
+                    if (inFlight == null) {
+                        // No ping outstanding: open one, re-arm reporting, and ask the main thread to ack.
+                        pingInFlightSince = clock.markNow()
+                        reported = false
+                        scope.launch(Dispatchers.Main) { pingInFlightSince = null }
+                    } else if (!reported) {
+                        // Previous ping still unacknowledged → the main thread hasn't run our task.
+                        val blockedMs = inFlight.elapsedNow().inWholeMilliseconds
+                        if (blockedMs >= threshold) {
+                            reported = true
+                            emitStall(blockedMs)
+                        }
+                    }
+                }
+                delay(pollInterval)
+            }
+        }
+    }
+
+    private fun emitStall(blockedMs: Long) {
+        runCatching {
+            Diag.w(
+                tag = "ANR",
+                origin = LogOrigin.CLIENT,
+                attrs = mapOf("blockedMs" to blockedMs.toString()),
+            ) { "main thread unresponsive" }
+        }
+    }
+}
+
+/**
+ * Convenience entry point: starts a [MainThreadWatchdog] with default thresholds on its own isolated
+ * supervised scope and returns its [Job]. Call once after Koin/logging are initialized.
+ */
+fun startMainThreadWatchdog(exceptionHandler: CoroutineExceptionHandler? = null): Job =
+    MainThreadWatchdog().start(exceptionHandler)

--- a/core/logging/src/commonMain/kotlin/com/garfiec/librechat/core/logging/di/LoggingModule.kt
+++ b/core/logging/src/commonMain/kotlin/com/garfiec/librechat/core/logging/di/LoggingModule.kt
@@ -1,0 +1,61 @@
+package com.garfiec.librechat.core.logging.di
+
+import com.garfiec.librechat.core.common.di.KoinQualifiers
+import com.garfiec.librechat.core.logging.DiagnosticLogRepository
+import com.garfiec.librechat.core.logging.DiagnosticLogRepositoryImpl
+import com.garfiec.librechat.core.logging.LogConfig
+import com.garfiec.librechat.core.logging.PersistentLogWriter
+import com.garfiec.librechat.core.logging.currentThreadName
+import com.garfiec.librechat.core.logging.diagnosticCoroutineExceptionHandler
+import com.garfiec.librechat.core.logging.io.LogDirProvider
+import com.garfiec.librechat.core.logging.io.LogSink
+import com.garfiec.librechat.core.logging.redact.LogRedactor
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.koin.core.module.Module
+import org.koin.dsl.module
+
+/** Provides the platform [LogDirProvider]. */
+expect val loggingPlatformModule: Module
+
+@OptIn(ExperimentalCoroutinesApi::class)
+val loggingModule = module {
+    includes(loggingPlatformModule)
+
+    single { LogConfig() }
+    single { LogRedactor() }
+
+    // Dedicated single-thread dispatcher: all file appends/rotation/export happen here.
+    single<CoroutineDispatcher>(KoinQualifiers.LogWriter) {
+        get<CoroutineDispatcher>(KoinQualifiers.IO).limitedParallelism(1)
+    }
+
+    single { LogSink(dir = get<LogDirProvider>().logDir(), config = get()) }
+
+    single {
+        PersistentLogWriter(
+            sink = get(),
+            redactor = get(),
+            threadName = ::currentThreadName,
+            scope = get<CoroutineScope>(KoinQualifiers.ApplicationScope),
+            dispatcher = get<CoroutineDispatcher>(KoinQualifiers.LogWriter),
+            capacity = get<LogConfig>().channelCapacity,
+            maxThrowableChars = get<LogConfig>().maxThrowableChars,
+            maxCrashThrowableChars = get<LogConfig>().maxCrashThrowableChars,
+        )
+    }
+
+    single<DiagnosticLogRepository> {
+        DiagnosticLogRepositoryImpl(
+            sink = get(),
+            dispatcher = get<CoroutineDispatcher>(KoinQualifiers.LogWriter),
+        )
+    }
+
+    // Reusable handler that funnels escaped coroutine exceptions into the crash record path.
+    // Opt-in per scope (e.g. the main-thread watchdog scope) — not installed on ApplicationScope,
+    // whose handler lives in core:common and cannot depend on :core:logging.
+    single<CoroutineExceptionHandler> { diagnosticCoroutineExceptionHandler(get()) }
+}

--- a/core/logging/src/commonMain/kotlin/com/garfiec/librechat/core/logging/io/LogDirProvider.kt
+++ b/core/logging/src/commonMain/kotlin/com/garfiec/librechat/core/logging/io/LogDirProvider.kt
@@ -1,0 +1,11 @@
+package com.garfiec.librechat.core.logging.io
+
+/**
+ * Resolves the platform-specific directory the diagnostic log buffer lives in.
+ *
+ * Android: `filesDir/diag_logs` (app-private, persists across restarts, not OS-evictable like cache).
+ * iOS: `Library/Application Support/diag_logs` (excluded from iCloud backup).
+ */
+interface LogDirProvider {
+    fun logDir(): String
+}

--- a/core/logging/src/commonMain/kotlin/com/garfiec/librechat/core/logging/io/LogFileHandle.kt
+++ b/core/logging/src/commonMain/kotlin/com/garfiec/librechat/core/logging/io/LogFileHandle.kt
@@ -1,0 +1,26 @@
+package com.garfiec.librechat.core.logging.io
+
+/**
+ * Minimal file primitive the log sink needs. Backed by `java.io.File` on Android and
+ * `NSFileManager`/`NSFileHandle` on iOS. Modeled as an interface (not an `expect class`) so the
+ * rotation logic in [LogSink] can be unit-tested in commonMain against an in-memory fake.
+ */
+internal interface LogFileHandle {
+    fun ensureParentDir()
+    fun exists(): Boolean
+
+    /** Appends `text` plus a trailing newline. Uses append-mode (O_APPEND-style) writes. */
+    fun appendLine(text: String)
+
+    fun sizeBytes(): Long
+    fun readText(): String
+    fun delete()
+
+    /** Moves this file to [targetPath], replacing any existing file there. */
+    fun renameTo(targetPath: String)
+
+    fun lastModifiedMillis(): Long
+}
+
+/** Opens a platform-backed handle for [path]. The file need not exist yet. */
+internal expect fun openLogFile(path: String): LogFileHandle

--- a/core/logging/src/commonMain/kotlin/com/garfiec/librechat/core/logging/io/LogSink.kt
+++ b/core/logging/src/commonMain/kotlin/com/garfiec/librechat/core/logging/io/LogSink.kt
@@ -28,6 +28,16 @@ internal class LogSink(
     private val active = fileFactory(activePath)
     private val previous = fileFactory(previousPath)
 
+    /**
+     * Running size of the active segment, maintained in memory so the hot append path never stats
+     * the file. Seeded once from disk (a prior run's active segment may carry over). Only the single
+     * drain coroutine mutates it via [append]/[rotate]/[clear]; [appendBlocking] (rare crash path)
+     * intentionally leaves it untouched — the bounded drift is at most one record.
+     */
+    private var activeBytes: Long = runCatching {
+        if (active.exists()) active.sizeBytes() else 0L
+    }.getOrDefault(0L)
+
     init {
         runCatching { active.ensureParentDir() }
         pruneByAge()
@@ -38,7 +48,8 @@ internal class LogSink(
         runCatching {
             active.ensureParentDir()
             active.appendLine(line)
-            if (active.sizeBytes() >= config.segmentCapBytes) rotate()
+            activeBytes += line.encodeToByteArray().size + 1 // +1 for the trailing newline
+            if (activeBytes >= config.segmentCapBytes) rotate()
         }
     }
 
@@ -66,6 +77,7 @@ internal class LogSink(
             if (active.exists()) active.delete()
             if (previous.exists()) previous.delete()
             active.ensureParentDir()
+            activeBytes = 0L
         }
     }
 
@@ -73,6 +85,7 @@ internal class LogSink(
         runCatching {
             if (previous.exists()) previous.delete()
             active.renameTo(previousPath)
+            activeBytes = 0L // fresh active segment starts empty
         }
     }
 

--- a/core/logging/src/commonMain/kotlin/com/garfiec/librechat/core/logging/io/LogSink.kt
+++ b/core/logging/src/commonMain/kotlin/com/garfiec/librechat/core/logging/io/LogSink.kt
@@ -1,0 +1,88 @@
+package com.garfiec.librechat.core.logging.io
+
+import com.garfiec.librechat.core.logging.LogConfig
+import kotlin.time.Clock
+
+/**
+ * Bounded, line-oriented ring buffer backed by two on-disk segments:
+ *   - `diag.log`   — active segment, currently being appended to
+ *   - `diag.1.log` — previous (rotated) segment
+ *
+ * When the active segment reaches [LogConfig.segmentCapBytes], the previous segment is deleted, the
+ * active is renamed to previous, and a fresh active is started. Export = previous ++ active, so the
+ * buffer always holds between `totalMaxBytes/2` and `totalMaxBytes` of the most recent JSONL.
+ *
+ * Not internally synchronized: the normal append path is driven by a single drain coroutine (see
+ * PersistentLogWriter), so there is exactly one writer. [appendBlocking] is the only exception — a
+ * rare, best-effort crash-time write that may race the drain; line-oriented JSONL plus a
+ * partial-line-tolerant reader make an occasional interleave harmless. Every method swallows I/O
+ * failures (disk full, missing dir) so logging can never crash the app.
+ */
+internal class LogSink(
+    private val dir: String,
+    private val config: LogConfig,
+    private val fileFactory: (String) -> LogFileHandle = ::openLogFile,
+) {
+    private val activePath = "$dir/diag.log"
+    private val previousPath = "$dir/diag.1.log"
+    private val active = fileFactory(activePath)
+    private val previous = fileFactory(previousPath)
+
+    init {
+        runCatching { active.ensureParentDir() }
+        pruneByAge()
+    }
+
+    /** Normal append path. Appends one JSONL line and rotates if the active segment is full. */
+    fun append(line: String) {
+        runCatching {
+            active.ensureParentDir()
+            active.appendLine(line)
+            if (active.sizeBytes() >= config.segmentCapBytes) rotate()
+        }
+    }
+
+    /** Crash-time append: writes synchronously, skips rotation, never throws. */
+    fun appendBlocking(line: String) {
+        runCatching {
+            active.ensureParentDir()
+            active.appendLine(line)
+        }
+    }
+
+    fun readAll(): String {
+        val prev = runCatching { if (previous.exists()) previous.readText() else "" }.getOrDefault("")
+        val cur = runCatching { if (active.exists()) active.readText() else "" }.getOrDefault("")
+        return prev + cur
+    }
+
+    fun sizeBytes(): Long = runCatching {
+        (if (previous.exists()) previous.sizeBytes() else 0L) +
+            (if (active.exists()) active.sizeBytes() else 0L)
+    }.getOrDefault(0L)
+
+    fun clear() {
+        runCatching {
+            if (active.exists()) active.delete()
+            if (previous.exists()) previous.delete()
+            active.ensureParentDir()
+        }
+    }
+
+    private fun rotate() {
+        runCatching {
+            if (previous.exists()) previous.delete()
+            active.renameTo(previousPath)
+        }
+    }
+
+    /** Drops a stale previous segment on startup so the buffer also respects an age cap. */
+    private fun pruneByAge() {
+        runCatching {
+            if (previous.exists()) {
+                val age = Clock.System.now().toEpochMilliseconds() - previous.lastModifiedMillis()
+                if (age > config.maxAgeMillis) previous.delete()
+            }
+        }
+    }
+}

--- a/core/logging/src/commonMain/kotlin/com/garfiec/librechat/core/logging/redact/LogRedactor.kt
+++ b/core/logging/src/commonMain/kotlin/com/garfiec/librechat/core/logging/redact/LogRedactor.kt
@@ -5,12 +5,17 @@ package com.garfiec.librechat.core.logging.redact
  * per-call-site discipline. Runs over every record's `msg` and every `attrs` value before it
  * reaches disk.
  *
- * Two strategies:
- *  - **Hash** identifying-but-correlatable values (tokens, emails, hosts, conversation/message IDs)
- *    to a short salted FNV-1a digest, so the same value is recognizable within an export without
- *    being recoverable.
- *  - **Drop** free-form content (message/conversation text) by attr-key denylist — content has no
- *    diagnostic value and is the highest-risk PII, so it never reaches disk at all.
+ * Three strategies:
+ *  - **Hash** identifying-but-correlatable values (tokens, emails, hosts, conversation/message IDs,
+ *    bare UUIDs/ObjectIds anywhere in free text or inside URL/path segments) to a short salted
+ *    FNV-1a digest, so the same value is recognizable within an export without being recoverable.
+ *  - **Drop** free-form content (message/conversation text, server response bodies, JSON object
+ *    literals) — content has no diagnostic value and is the highest-risk PII, so it never reaches
+ *    disk at all.
+ *  - **Allowlist** attr keys: only keys known to carry low-cardinality, non-identifying values pass
+ *    through (still shape-scrubbed). Any *unknown* attr key is dropped by default rather than
+ *    emitted raw, so a future call site that logs `fileName`/`username`/etc. cannot silently leak
+ *    PII into an exportable log. Add new safe keys to [safeKeys] deliberately.
  *
  * Redaction is idempotent: re-running it over already-redacted output is stable.
  */
@@ -24,6 +29,10 @@ class LogRedactor(private val salt: String = DEFAULT_SALT) {
         // never reach disk. Drops everything from the marker to end-of-line. Idempotent: the
         // replacement contains no further "JSON input:" marker.
         out = jsonInputRegex.replace(out, "JSON input: <redacted>")
+        // Drop inline JSON object literals carrying a quoted member, regardless of the surrounding
+        // phrasing — exception messages from any serializer (not just the "JSON input:" form) can
+        // echo `{"title":"…"}`-style content. Replacement has no quotes inside braces → idempotent.
+        out = jsonObjectRegex.replace(out, "{<redacted>}")
         // Each replacement is shaped so it cannot re-match the same regex → redact() is idempotent.
         // bearer: drop the space after "Bearer" so `bearer\s+\S+` no longer matches.
         out = bearerRegex.replace(out) { m -> m.groupValues[1].trimEnd() + ":" + hash8(m.groupValues[2]) }
@@ -31,6 +40,11 @@ class LogRedactor(private val salt: String = DEFAULT_SALT) {
         out = refreshRegex.replace(out) { m -> "refreshtoken:" + hash8(m.groupValues[2]) }
         out = jwtRegex.replace(out) { m -> "jwt:" + hash8(m.value) }
         out = emailRegex.replace(out) { m -> "email:" + hash8(m.value) }
+        // Hash bare identifiers (UUIDs, Mongo ObjectIds) wherever they appear — including inside
+        // URL/request paths, which would otherwise leak conversation/message IDs verbatim. Runs
+        // before urlRegex so an id inside a kept path is already hashed.
+        out = uuidRegex.replace(out) { m -> "id:" + hash8(m.value) }
+        out = objectIdRegex.replace(out) { m -> "id:" + hash8(m.value) }
         // url: drop the scheme/`://` so `https?://` no longer matches; keep path (diagnostically useful).
         out = urlRegex.replace(out) { m -> "url:" + hash8(m.groupValues[1] + m.groupValues[2]) + m.groupValues[3] }
         return out
@@ -41,9 +55,11 @@ class LogRedactor(private val salt: String = DEFAULT_SALT) {
         return attrs.mapValues { (key, value) ->
             when (key.lowercase()) {
                 in contentKeys -> "<redacted len=${value.length}>"
-                in idHashKeys -> hash8(value)
-                in secretKeys -> hash8(value)
-                else -> redact(value)
+                in hashKeys -> hash8(value)
+                in safeKeys -> redact(value)
+                // Safe-by-default: an unrecognized key may carry free-form PII (e.g. a filename or
+                // display name) with no recognizable shape, so it is dropped rather than emitted.
+                else -> "<redacted len=${value.length}>"
             }
         }
     }
@@ -66,22 +82,45 @@ class LogRedactor(private val salt: String = DEFAULT_SALT) {
 
         // kotlinx.serialization echoes the offending payload after "JSON input:" — strip to EOL.
         private val jsonInputRegex = Regex("JSON input:.*")
+        // A brace-delimited object literal containing a quoted member (e.g. `{"text":"…"}`). Requires
+        // two quotes inside the braces so `{}` and brace-free text are untouched.
+        private val jsonObjectRegex = Regex("\\{[^{}]*\"[^{}]*\"[^{}]*\\}")
         private val bearerRegex = Regex("(?i)(authorization\\s*[:=]\\s*bearer\\s+)(\\S+)")
         private val refreshRegex = Regex("(?i)(refreshtoken=)([^;&\\s\"]+)")
         private val jwtRegex = Regex("eyJ[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+")
-        private val emailRegex = Regex("[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}")
+        // Email — also matches IP-literal/single-label hosts (user@localhost, user@10.0.0.1), which a
+        // dotted-TLD-only pattern would miss. Over-matching a stray `a@b` token in a log is acceptable.
+        private val emailRegex = Regex("[A-Za-z0-9._%+-]+@[A-Za-z0-9][A-Za-z0-9._-]*")
         private val urlRegex = Regex("(?i)(https?://)([^/\\s:?#]+)([^\\s]*)")
+        // Bare identifiers anywhere in text (incl. URL/path segments): UUID and 24-char Mongo ObjectId.
+        private val uuidRegex =
+            Regex("\\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\\b")
+        private val objectIdRegex = Regex("\\b[0-9a-fA-F]{24}\\b")
 
         // attr keys whose VALUE is free-form content → dropped entirely (length kept for debugging).
         private val contentKeys = setOf("message", "content", "text", "prompt", "title", "body", "query")
 
-        // attr keys that are identifiers → hashed so they correlate without exposing the raw id.
-        private val idHashKeys = setOf("conversationid", "messageid", "userid", "parentmessageid", "email")
-
-        // attr keys that are secrets → hashed (never kept verbatim).
-        private val secretKeys = setOf(
+        // attr keys that are identifiers or secrets → hashed so they correlate without exposing the raw value.
+        private val hashKeys = setOf(
+            "conversationid", "messageid", "userid", "parentmessageid", "email",
             "authorization", "cookie", "set-cookie", "x-api-key", "api-key", "apikey",
             "token", "accesstoken", "refreshtoken", "password", "secret",
+        )
+
+        // ALLOWLIST: attr keys known to carry low-cardinality, non-identifying values. Only these pass
+        // through (after a defensive shape-scrub). Every key emitted by a Diag call site must appear
+        // here; an omitted key is dropped (safe-by-default), so add new keys deliberately.
+        private val safeKeys = setOf(
+            // build / device / platform (startup header)
+            "versionname", "versioncode", "gitsha", "osname", "osversion", "devicemodel",
+            // backend version + server-config snapshot flags
+            "supportedbackendversion", "detectedbackendversion", "compatible",
+            "registrationenabled", "emailloginenabled", "socialloginenabled", "passwordresetenabled",
+            "sharedlinksenabled", "websearch", "modelspecs", "endpointcount",
+            // network / SSE / HTTP failure attribution
+            "status", "method", "path", "endpoint", "attempt", "timeoutsec", "failedfields",
+            // auth / lifecycle / breadcrumb / watchdog / crash
+            "event", "reason", "screen", "blockedms", "throwable",
         )
     }
 }

--- a/core/logging/src/commonMain/kotlin/com/garfiec/librechat/core/logging/redact/LogRedactor.kt
+++ b/core/logging/src/commonMain/kotlin/com/garfiec/librechat/core/logging/redact/LogRedactor.kt
@@ -1,0 +1,87 @@
+package com.garfiec.librechat.core.logging.redact
+
+/**
+ * Centralized PII scrubber applied at the sink, so redaction is enforced rather than left to
+ * per-call-site discipline. Runs over every record's `msg` and every `attrs` value before it
+ * reaches disk.
+ *
+ * Two strategies:
+ *  - **Hash** identifying-but-correlatable values (tokens, emails, hosts, conversation/message IDs)
+ *    to a short salted FNV-1a digest, so the same value is recognizable within an export without
+ *    being recoverable.
+ *  - **Drop** free-form content (message/conversation text) by attr-key denylist — content has no
+ *    diagnostic value and is the highest-risk PII, so it never reaches disk at all.
+ *
+ * Redaction is idempotent: re-running it over already-redacted output is stable.
+ */
+class LogRedactor(private val salt: String = DEFAULT_SALT) {
+
+    fun redact(input: String): String {
+        if (input.isEmpty()) return input
+        var out = input
+        // Strip server response bodies that serialization errors echo into their message
+        // ("...JSON input: <body>"). The body can carry message/conversation CONTENT, which must
+        // never reach disk. Drops everything from the marker to end-of-line. Idempotent: the
+        // replacement contains no further "JSON input:" marker.
+        out = jsonInputRegex.replace(out, "JSON input: <redacted>")
+        // Each replacement is shaped so it cannot re-match the same regex → redact() is idempotent.
+        // bearer: drop the space after "Bearer" so `bearer\s+\S+` no longer matches.
+        out = bearerRegex.replace(out) { m -> m.groupValues[1].trimEnd() + ":" + hash8(m.groupValues[2]) }
+        // refresh: swap '=' for ':' so `refreshtoken=` no longer matches.
+        out = refreshRegex.replace(out) { m -> "refreshtoken:" + hash8(m.groupValues[2]) }
+        out = jwtRegex.replace(out) { m -> "jwt:" + hash8(m.value) }
+        out = emailRegex.replace(out) { m -> "email:" + hash8(m.value) }
+        // url: drop the scheme/`://` so `https?://` no longer matches; keep path (diagnostically useful).
+        out = urlRegex.replace(out) { m -> "url:" + hash8(m.groupValues[1] + m.groupValues[2]) + m.groupValues[3] }
+        return out
+    }
+
+    fun redactAttrs(attrs: Map<String, String>): Map<String, String> {
+        if (attrs.isEmpty()) return attrs
+        return attrs.mapValues { (key, value) ->
+            when (key.lowercase()) {
+                in contentKeys -> "<redacted len=${value.length}>"
+                in idHashKeys -> hash8(value)
+                in secretKeys -> hash8(value)
+                else -> redact(value)
+            }
+        }
+    }
+
+    /** 64-bit FNV-1a → first 8 hex chars. Dependency-free; for correlation, not cryptographic secrecy. */
+    private fun hash8(value: String): String {
+        var hash = FNV_OFFSET_BASIS
+        for (byte in (salt + value).encodeToByteArray()) {
+            hash = hash xor (byte.toLong() and 0xff)
+            hash *= FNV_PRIME
+        }
+        return hash.toULong().toString(16).padStart(8, '0').take(8)
+    }
+
+    companion object {
+        const val DEFAULT_SALT: String = "librechat-diag"
+
+        private const val FNV_OFFSET_BASIS: Long = -3750763034362895579L // 14695981039346656037 as Long
+        private const val FNV_PRIME: Long = 1099511628211L
+
+        // kotlinx.serialization echoes the offending payload after "JSON input:" — strip to EOL.
+        private val jsonInputRegex = Regex("JSON input:.*")
+        private val bearerRegex = Regex("(?i)(authorization\\s*[:=]\\s*bearer\\s+)(\\S+)")
+        private val refreshRegex = Regex("(?i)(refreshtoken=)([^;&\\s\"]+)")
+        private val jwtRegex = Regex("eyJ[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+")
+        private val emailRegex = Regex("[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}")
+        private val urlRegex = Regex("(?i)(https?://)([^/\\s:?#]+)([^\\s]*)")
+
+        // attr keys whose VALUE is free-form content → dropped entirely (length kept for debugging).
+        private val contentKeys = setOf("message", "content", "text", "prompt", "title", "body", "query")
+
+        // attr keys that are identifiers → hashed so they correlate without exposing the raw id.
+        private val idHashKeys = setOf("conversationid", "messageid", "userid", "parentmessageid", "email")
+
+        // attr keys that are secrets → hashed (never kept verbatim).
+        private val secretKeys = setOf(
+            "authorization", "cookie", "set-cookie", "x-api-key", "api-key", "apikey",
+            "token", "accesstoken", "refreshtoken", "password", "secret",
+        )
+    }
+}

--- a/core/logging/src/commonMain/kotlin/com/garfiec/librechat/core/logging/redact/LogRedactor.kt
+++ b/core/logging/src/commonMain/kotlin/com/garfiec/librechat/core/logging/redact/LogRedactor.kt
@@ -82,16 +82,19 @@ class LogRedactor(private val salt: String = DEFAULT_SALT) {
 
         // kotlinx.serialization echoes the offending payload after "JSON input:" — strip to EOL.
         private val jsonInputRegex = Regex("JSON input:.*")
+
         // A brace-delimited object literal containing a quoted member (e.g. `{"text":"…"}`). Requires
         // two quotes inside the braces so `{}` and brace-free text are untouched.
         private val jsonObjectRegex = Regex("\\{[^{}]*\"[^{}]*\"[^{}]*\\}")
         private val bearerRegex = Regex("(?i)(authorization\\s*[:=]\\s*bearer\\s+)(\\S+)")
         private val refreshRegex = Regex("(?i)(refreshtoken=)([^;&\\s\"]+)")
         private val jwtRegex = Regex("eyJ[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+")
+
         // Email — also matches IP-literal/single-label hosts (user@localhost, user@10.0.0.1), which a
         // dotted-TLD-only pattern would miss. Over-matching a stray `a@b` token in a log is acceptable.
         private val emailRegex = Regex("[A-Za-z0-9._%+-]+@[A-Za-z0-9][A-Za-z0-9._-]*")
         private val urlRegex = Regex("(?i)(https?://)([^/\\s:?#]+)([^\\s]*)")
+
         // Bare identifiers anywhere in text (incl. URL/path segments): UUID and 24-char Mongo ObjectId.
         private val uuidRegex =
             Regex("\\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\\b")

--- a/core/logging/src/commonTest/kotlin/com/garfiec/librechat/core/logging/LogEnvelopeTest.kt
+++ b/core/logging/src/commonTest/kotlin/com/garfiec/librechat/core/logging/LogEnvelopeTest.kt
@@ -1,0 +1,52 @@
+package com.garfiec.librechat.core.logging
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class LogEnvelopeTest {
+
+    @Test
+    fun plain_message_has_no_sentinel_and_decodes_unchanged() {
+        val encoded = LogEnvelope.encode("just a message", emptyMap(), null)
+        assertEquals("just a message", encoded, "no attrs/origin → message must be unchanged")
+        assertFalse(encoded.startsWith(LogEnvelope.SENTINEL))
+
+        val decoded = LogEnvelope.decode(encoded)
+        assertEquals("just a message", decoded.msg)
+        assertTrue(decoded.attrs.isEmpty())
+        assertEquals(null, decoded.origin)
+    }
+
+    @Test
+    fun attrs_and_origin_round_trip() {
+        val encoded = LogEnvelope.encode(
+            "request failed",
+            mapOf("status" to "401", "path" to "/api/x"),
+            LogOrigin.SERVER,
+        )
+        assertTrue(encoded.startsWith(LogEnvelope.SENTINEL))
+
+        val decoded = LogEnvelope.decode(encoded)
+        assertEquals("request failed", decoded.msg)
+        assertEquals("401", decoded.attrs["status"])
+        assertEquals("/api/x", decoded.attrs["path"])
+        assertEquals("server", decoded.origin)
+    }
+
+    @Test
+    fun message_without_sentinel_is_treated_as_plain() {
+        val decoded = LogEnvelope.decode("SSE connected after 2 retries")
+        assertEquals("SSE connected after 2 retries", decoded.msg)
+        assertTrue(decoded.attrs.isEmpty())
+    }
+
+    @Test
+    fun malformed_sentinel_payload_falls_back_to_plain() {
+        val broken = LogEnvelope.SENTINEL + "{not valid json"
+        val decoded = LogEnvelope.decode(broken)
+        assertEquals(broken, decoded.msg, "unparseable payload must fall back to the whole string")
+        assertTrue(decoded.attrs.isEmpty())
+    }
+}

--- a/core/logging/src/commonTest/kotlin/com/garfiec/librechat/core/logging/io/LogSinkRotationTest.kt
+++ b/core/logging/src/commonTest/kotlin/com/garfiec/librechat/core/logging/io/LogSinkRotationTest.kt
@@ -1,0 +1,72 @@
+package com.garfiec.librechat.core.logging.io
+
+import com.garfiec.librechat.core.logging.LogConfig
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class LogSinkRotationTest {
+
+    /** In-memory file system shared across handles by path, so renameTo moves content correctly. */
+    private class FakeFs {
+        val files = mutableMapOf<String, StringBuilder>()
+
+        fun handle(path: String): LogFileHandle = object : LogFileHandle {
+            override fun ensureParentDir() {}
+            override fun exists() = files.containsKey(path)
+            override fun appendLine(text: String) {
+                files.getOrPut(path) { StringBuilder() }.append(text).append("\n")
+            }
+            override fun sizeBytes() = (files[path]?.length ?: 0).toLong()
+            override fun readText() = files[path]?.toString() ?: ""
+            override fun delete() { files.remove(path) }
+            override fun renameTo(targetPath: String) {
+                val content = files.remove(path)
+                if (content != null) files[targetPath] = content else files.remove(targetPath)
+            }
+            override fun lastModifiedMillis() = 0L
+        }
+    }
+
+    // 5-char lines → 6 bytes each ("\n"); segment cap 10 bytes → rotates every 2 lines.
+    private val config = LogConfig(totalMaxBytes = 20, maxAgeMillis = Long.MAX_VALUE)
+
+    @Test
+    fun buffer_is_bounded_to_two_segments_keeping_most_recent() {
+        val fs = FakeFs()
+        val sink = LogSink(dir = "/d", config = config, fileFactory = fs::handle)
+
+        listOf("line1", "line2", "line3", "line4", "line5", "line6").forEach { sink.append(it) }
+
+        val all = sink.readAll()
+        assertEquals("line5\nline6\n", all, "only the most recent segment(s) survive: '$all'")
+        assertFalse(all.contains("line1"), "oldest lines must be dropped once bounded")
+        assertTrue(sink.sizeBytes() <= config.totalMaxBytes, "total stays within the cap")
+    }
+
+    @Test
+    fun export_concatenates_previous_then_active_in_order() {
+        val fs = FakeFs()
+        val sink = LogSink(dir = "/d", config = config, fileFactory = fs::handle)
+
+        // line1,line2 fill active → rotate to previous; line3 lands in fresh active.
+        sink.append("line1")
+        sink.append("line2")
+        sink.append("line3")
+
+        assertEquals("line1\nline2\nline3\n", sink.readAll())
+    }
+
+    @Test
+    fun clear_empties_the_buffer() {
+        val fs = FakeFs()
+        val sink = LogSink(dir = "/d", config = config, fileFactory = fs::handle)
+        listOf("line1", "line2", "line3").forEach { sink.append(it) }
+
+        sink.clear()
+
+        assertEquals("", sink.readAll())
+        assertEquals(0L, sink.sizeBytes())
+    }
+}

--- a/core/logging/src/commonTest/kotlin/com/garfiec/librechat/core/logging/redact/LogRedactorTest.kt
+++ b/core/logging/src/commonTest/kotlin/com/garfiec/librechat/core/logging/redact/LogRedactorTest.kt
@@ -1,0 +1,107 @@
+package com.garfiec.librechat.core.logging.redact
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class LogRedactorTest {
+
+    private val redactor = LogRedactor(salt = "test-salt")
+
+    @Test
+    fun bearer_token_is_redacted_and_not_present() {
+        val input = "Authorization: Bearer eyJhbGciOiJIUzI1NibXVuY2hraW4 done"
+        val out = redactor.redact(input)
+        assertFalse(out.contains("eyJhbGciOiJIUzI1NibXVuY2hraW4"), "raw token leaked: $out")
+        assertTrue(out.contains("Bearer:"), "expected redacted bearer marker: $out")
+    }
+
+    @Test
+    fun raw_jwt_in_message_is_redacted() {
+        val jwt = "eyJhbGc.eyJzdWIiOiIxMjM0NTY3ODkwIn0.SflKxwRJSMeKKF2QT4"
+        val out = redactor.redact("token=$jwt end")
+        assertFalse(out.contains(jwt), "raw jwt leaked: $out")
+        assertTrue(out.contains("jwt:"), out)
+    }
+
+    @Test
+    fun refresh_token_redacted_preserving_delimiters() {
+        val out = redactor.redact("refreshToken=abc123secret; path=/")
+        assertFalse(out.contains("abc123secret"), out)
+        assertTrue(out.contains("path=/"), "surrounding content should remain: $out")
+    }
+
+    @Test
+    fun email_is_redacted_in_free_text() {
+        val out = redactor.redact("login failed for alice@example.com after retry")
+        assertFalse(out.contains("alice@example.com"), out)
+        assertTrue(out.contains("email:"), out)
+    }
+
+    @Test
+    fun server_url_host_is_redacted_but_path_kept() {
+        val out = redactor.redact("GET https://chat.example.com/api/messages/123 failed")
+        assertFalse(out.contains("chat.example.com"), "host leaked: $out")
+        assertTrue(out.contains("/api/messages/123"), "path should be kept: $out")
+    }
+
+    @Test
+    fun content_attr_keys_are_dropped_by_length() {
+        val out = redactor.redactAttrs(mapOf("message" to "hello secret world", "endpoint" to "/api/x"))
+        assertEquals("<redacted len=18>", out["message"])
+        assertEquals("/api/x", out["endpoint"], "benign keys pass through")
+    }
+
+    @Test
+    fun id_attr_keys_are_hashed_not_dropped() {
+        val out = redactor.redactAttrs(mapOf("conversationId" to "conv_abc"))
+        assertFalse(out["conversationId"]!!.contains("conv_abc"), out.toString())
+        assertTrue(out["conversationId"]!!.isNotBlank())
+    }
+
+    @Test
+    fun secret_attr_keys_are_hashed() {
+        val out = redactor.redactAttrs(mapOf("authorization" to "Bearer xyz", "x-api-key" to "k-12345"))
+        assertFalse(out["authorization"]!!.contains("xyz"), out.toString())
+        assertFalse(out["x-api-key"]!!.contains("12345"), out.toString())
+    }
+
+    @Test
+    fun embedded_json_response_body_is_stripped() {
+        // Serialization errors echo the offending payload, which can carry message/conversation
+        // content. It must not reach disk.
+        val out = redactor.redact(
+            "Illegal input at path: \$[0]\nJSON input: [{\"text\":\"secret user message\"}]",
+        )
+        assertFalse(out.contains("secret user message"), "response body content leaked: $out")
+        assertTrue(out.contains("JSON input: <redacted>"), out)
+    }
+
+    @Test
+    fun benign_message_passes_through_unchanged() {
+        val msg = "Loading config for tab 3 (count=12)"
+        assertEquals(msg, redactor.redact(msg), "false positive on benign text")
+    }
+
+    @Test
+    fun hash_is_stable_for_same_value() {
+        val a = redactor.redact("user alice@example.com")
+        val b = redactor.redact("user alice@example.com")
+        assertEquals(a, b, "same input must hash to same output for correlation")
+    }
+
+    @Test
+    fun redaction_is_idempotent() {
+        val once = redactor.redact("Authorization: Bearer eyJabc.def.ghi to https://h.example.com/p and a@b.co refreshToken=zzz")
+        val twice = redactor.redact(once)
+        assertEquals(once, twice, "double-redaction must be stable: '$once' vs '$twice'")
+    }
+
+    @Test
+    fun multiple_secrets_in_one_line_all_redacted() {
+        val out = redactor.redact("Authorization: Bearer eyJsecrettoken and email bob@corp.io")
+        assertFalse(out.contains("eyJsecrettoken"), out)
+        assertFalse(out.contains("bob@corp.io"), out)
+    }
+}

--- a/core/logging/src/commonTest/kotlin/com/garfiec/librechat/core/logging/redact/LogRedactorTest.kt
+++ b/core/logging/src/commonTest/kotlin/com/garfiec/librechat/core/logging/redact/LogRedactorTest.kt
@@ -85,6 +85,45 @@ class LogRedactorTest {
     }
 
     @Test
+    fun request_path_ids_are_hashed_but_route_kept() {
+        // HTTP failure logs the request path under the "path" attr; id segments must not leak.
+        val convId = "123e4567-e89b-12d3-a456-426614174000"
+        val out = redactor.redactAttrs(mapOf("path" to "/api/messages/$convId"))
+        assertFalse(out["path"]!!.contains(convId), "raw conversation id leaked in path: ${out["path"]}")
+        assertTrue(out["path"]!!.startsWith("/api/messages/id:"), "route shape should survive: ${out["path"]}")
+    }
+
+    @Test
+    fun mongo_object_id_in_free_text_is_hashed() {
+        val out = redactor.redact("loaded conversation 6831ab9c2d4e5f0011223344 ok")
+        assertFalse(out.contains("6831ab9c2d4e5f0011223344"), "raw object id leaked: $out")
+        assertTrue(out.contains("id:"), out)
+    }
+
+    @Test
+    fun unknown_attr_key_is_dropped_by_default() {
+        // Safe-by-default: a key not on the allowlist may carry free-form PII (filename, name…).
+        val out = redactor.redactAttrs(mapOf("fileName" to "JohnSmith_tax_2025.pdf"))
+        assertFalse(out["fileName"]!!.contains("JohnSmith"), "unknown key leaked raw PII: ${out["fileName"]}")
+        assertEquals("<redacted len=22>", out["fileName"])
+    }
+
+    @Test
+    fun email_without_dotted_tld_is_redacted() {
+        val out = redactor.redact("login failed for admin@localhost retry")
+        assertFalse(out.contains("admin@localhost"), "single-label-host email leaked: $out")
+        assertTrue(out.contains("email:"), out)
+    }
+
+    @Test
+    fun embedded_json_object_without_marker_is_dropped() {
+        // A serializer error phrased without "JSON input:" still echoes object literals with content.
+        val out = redactor.redact("Field error near {\"text\":\"secret note\"} at offset 12")
+        assertFalse(out.contains("secret note"), "json object content leaked: $out")
+        assertTrue(out.contains("{<redacted>}"), out)
+    }
+
+    @Test
     fun hash_is_stable_for_same_value() {
         val a = redactor.redact("user alice@example.com")
         val b = redactor.redact("user alice@example.com")

--- a/core/logging/src/iosMain/kotlin/com/garfiec/librechat/core/logging/PlatformInfo.ios.kt
+++ b/core/logging/src/iosMain/kotlin/com/garfiec/librechat/core/logging/PlatformInfo.ios.kt
@@ -1,0 +1,14 @@
+package com.garfiec.librechat.core.logging
+
+import platform.UIKit.UIDevice
+
+internal class IosPlatformInfo : PlatformInfo {
+    private val device = UIDevice.currentDevice
+
+    // systemName/systemVersion/model are members of the main UIDevice interface (not an
+    // Objective-C category), so they are accessed directly as properties without an
+    // individual member import. Each is guarded so a null from UIKit never propagates.
+    override val osName: String = device.systemName ?: "iOS"
+    override val osVersion: String = device.systemVersion ?: "unknown"
+    override val deviceModel: String = device.model ?: "unknown"
+}

--- a/core/logging/src/iosMain/kotlin/com/garfiec/librechat/core/logging/Threads.ios.kt
+++ b/core/logging/src/iosMain/kotlin/com/garfiec/librechat/core/logging/Threads.ios.kt
@@ -1,0 +1,8 @@
+package com.garfiec.librechat.core.logging
+
+import platform.Foundation.NSThread
+
+internal actual fun currentThreadName(): String = runCatching {
+    val current = NSThread.currentThread
+    current.name?.takeIf { it.isNotBlank() } ?: if (current.isMainThread) "main" else "ios-bg"
+}.getOrDefault("ios-?")

--- a/core/logging/src/iosMain/kotlin/com/garfiec/librechat/core/logging/di/LoggingPlatformModule.ios.kt
+++ b/core/logging/src/iosMain/kotlin/com/garfiec/librechat/core/logging/di/LoggingPlatformModule.ios.kt
@@ -1,0 +1,30 @@
+package com.garfiec.librechat.core.logging.di
+
+import com.garfiec.librechat.core.logging.IosPlatformInfo
+import com.garfiec.librechat.core.logging.PlatformInfo
+import com.garfiec.librechat.core.logging.io.LogDirProvider
+import kotlinx.cinterop.ExperimentalForeignApi
+import org.koin.core.module.Module
+import org.koin.dsl.module
+import platform.Foundation.NSFileManager
+import platform.Foundation.NSHomeDirectory
+
+@OptIn(ExperimentalForeignApi::class)
+private class IosLogDirProvider : LogDirProvider {
+    // Application Support persists across restarts (unlike Caches, which the OS can evict).
+    override fun logDir(): String {
+        val dir = NSHomeDirectory() + "/Library/Application Support/diag_logs"
+        NSFileManager.defaultManager.createDirectoryAtPath(
+            dir,
+            withIntermediateDirectories = true,
+            attributes = null,
+            error = null,
+        )
+        return dir
+    }
+}
+
+actual val loggingPlatformModule: Module = module {
+    single<LogDirProvider> { IosLogDirProvider() }
+    single<PlatformInfo> { IosPlatformInfo() }
+}

--- a/core/logging/src/iosMain/kotlin/com/garfiec/librechat/core/logging/io/LogFile.ios.kt
+++ b/core/logging/src/iosMain/kotlin/com/garfiec/librechat/core/logging/io/LogFile.ios.kt
@@ -1,0 +1,80 @@
+package com.garfiec.librechat.core.logging.io
+
+import kotlinx.cinterop.BetaInteropApi
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.usePinned
+import platform.Foundation.NSData
+import platform.Foundation.NSDate
+import platform.Foundation.NSFileHandle
+import platform.Foundation.NSFileManager
+import platform.Foundation.NSFileModificationDate
+import platform.Foundation.NSFileSize
+import platform.Foundation.NSNumber
+import platform.Foundation.NSString
+import platform.Foundation.NSUTF8StringEncoding
+import platform.Foundation.create
+import platform.Foundation.fileHandleForWritingAtPath
+import platform.Foundation.stringWithContentsOfFile
+import platform.Foundation.timeIntervalSince1970
+import platform.Foundation.writeToFile
+
+@OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
+internal class IosLogFile(private val path: String) : LogFileHandle {
+    private val fm get() = NSFileManager.defaultManager
+
+    override fun ensureParentDir() {
+        val parent = path.substringBeforeLast('/', "")
+        if (parent.isNotEmpty() && !fm.fileExistsAtPath(parent)) {
+            fm.createDirectoryAtPath(parent, withIntermediateDirectories = true, attributes = null, error = null)
+        }
+    }
+
+    override fun exists(): Boolean = fm.fileExistsAtPath(path)
+
+    override fun appendLine(text: String) {
+        val data = toNSData(text + "\n") ?: return
+        if (!fm.fileExistsAtPath(path)) {
+            data.writeToFile(path, atomically = false)
+            return
+        }
+        val handle = NSFileHandle.fileHandleForWritingAtPath(path) ?: return
+        handle.seekToEndReturningOffset(null, null)
+        handle.writeData(data, null)
+        handle.closeAndReturnError(null)
+    }
+
+    override fun sizeBytes(): Long {
+        val attrs = fm.attributesOfItemAtPath(path, null) ?: return 0L
+        val size = attrs[NSFileSize] as? NSNumber ?: return 0L
+        return size.longLongValue
+    }
+
+    override fun readText(): String =
+        NSString.stringWithContentsOfFile(path, NSUTF8StringEncoding, null) ?: ""
+
+    override fun delete() {
+        if (fm.fileExistsAtPath(path)) fm.removeItemAtPath(path, null)
+    }
+
+    override fun renameTo(targetPath: String) {
+        if (fm.fileExistsAtPath(targetPath)) fm.removeItemAtPath(targetPath, null)
+        fm.moveItemAtPath(path, targetPath, null)
+    }
+
+    override fun lastModifiedMillis(): Long {
+        val attrs = fm.attributesOfItemAtPath(path, null) ?: return 0L
+        val date = attrs[NSFileModificationDate] as? NSDate ?: return 0L
+        return (date.timeIntervalSince1970 * 1000).toLong()
+    }
+
+    private fun toNSData(text: String): NSData? {
+        val bytes = text.encodeToByteArray()
+        if (bytes.isEmpty()) return null
+        return bytes.usePinned { pinned ->
+            NSData.create(bytes = pinned.addressOf(0), length = bytes.size.toULong())
+        }
+    }
+}
+
+internal actual fun openLogFile(path: String): LogFileHandle = IosLogFile(path)

--- a/core/logging/src/iosMain/kotlin/com/garfiec/librechat/core/logging/io/LogFile.ios.kt
+++ b/core/logging/src/iosMain/kotlin/com/garfiec/librechat/core/logging/io/LogFile.ios.kt
@@ -11,13 +11,12 @@ import platform.Foundation.NSFileManager
 import platform.Foundation.NSFileModificationDate
 import platform.Foundation.NSFileSize
 import platform.Foundation.NSNumber
-import platform.Foundation.NSString
-import platform.Foundation.NSUTF8StringEncoding
 import platform.Foundation.create
+import platform.Foundation.dataWithContentsOfFile
 import platform.Foundation.fileHandleForWritingAtPath
-import platform.Foundation.stringWithContentsOfFile
 import platform.Foundation.timeIntervalSince1970
 import platform.Foundation.writeToFile
+import platform.posix.memcpy
 
 @OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
 internal class IosLogFile(private val path: String) : LogFileHandle {
@@ -50,8 +49,17 @@ internal class IosLogFile(private val path: String) : LogFileHandle {
         return size.longLongValue
     }
 
-    override fun readText(): String =
-        NSString.stringWithContentsOfFile(path, NSUTF8StringEncoding, null) ?: ""
+    override fun readText(): String {
+        // Read raw bytes and decode lossily (invalid sequences → U+FFFD) rather than
+        // NSString.stringWithContentsOfFile, which returns nil for the WHOLE file on a single bad
+        // byte — a partial/interleaved write at the tail would otherwise drop the entire segment.
+        val data = NSData.dataWithContentsOfFile(path) ?: return ""
+        val length = data.length.toInt()
+        if (length == 0) return ""
+        val bytes = ByteArray(length)
+        bytes.usePinned { pinned -> memcpy(pinned.addressOf(0), data.bytes, data.length) }
+        return bytes.decodeToString()
+    }
 
     override fun delete() {
         if (fm.fileExistsAtPath(path)) fm.removeItemAtPath(path, null)

--- a/core/network/build.gradle.kts
+++ b/core/network/build.gradle.kts
@@ -21,6 +21,7 @@ kotlin {
         commonMain.dependencies {
             implementation(project(":core:model"))
             implementation(project(":core:common"))
+            implementation(project(":core:logging"))
             implementation(libs.ktor.client.core)
             implementation(libs.ktor.client.content.negotiation)
             implementation(libs.ktor.serialization.kotlinx.json)

--- a/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/LibreChatHttpClient.kt
+++ b/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/LibreChatHttpClient.kt
@@ -3,6 +3,7 @@ package com.garfiec.librechat.core.network.client
 import co.touchlab.kermit.Logger
 import com.garfiec.librechat.core.logging.Diag
 import com.garfiec.librechat.core.logging.LogOrigin
+import com.garfiec.librechat.core.logging.redact.LogRedactor
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.HttpClientEngineFactory
 import io.ktor.client.plugins.HttpRequestRetry
@@ -31,6 +32,7 @@ object LibreChatHttpClient {
         json: Json,
         tokenManager: TokenManager,
         serverUrlProvider: ServerUrlProvider,
+        redactor: LogRedactor,
         debug: Boolean = false,
     ): HttpClient = HttpClient(engineFactory) {
         install(ContentNegotiation) {
@@ -40,10 +42,9 @@ object LibreChatHttpClient {
         install(Logging) {
             logger = object : KtorLogger {
                 override fun log(message: String) {
-                    val sanitized = message
-                        .replace(Regex("Authorization: Bearer [^\\s]+"), "Authorization: Bearer [REDACTED]")
-                        .replace(Regex("refreshToken=[^;&\\s]+"), "refreshToken=[REDACTED]")
-                    Logger.d("HTTP") { sanitized }
+                    // Route through the shared redactor so Logcat/NSLog get the same scrubbing as the
+                    // persistent sink (tokens, JWTs, emails, hosts, IDs) — one redaction policy, not two.
+                    Logger.d("HTTP") { redactor.redact(message) }
                 }
             }
             level = if (debug) LogLevel.HEADERS else LogLevel.NONE

--- a/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/LibreChatHttpClient.kt
+++ b/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/LibreChatHttpClient.kt
@@ -1,6 +1,8 @@
 package com.garfiec.librechat.core.network.client
 
 import co.touchlab.kermit.Logger
+import com.garfiec.librechat.core.logging.Diag
+import com.garfiec.librechat.core.logging.LogOrigin
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.HttpClientEngineFactory
 import io.ktor.client.plugins.HttpRequestRetry
@@ -71,7 +73,15 @@ object LibreChatHttpClient {
                     val errorMessage = extractErrorMessage(json, bodyText, statusCode)
                     val isBanned = statusCode == 403 && bodyText.contains("ban", ignoreCase = true)
 
-                    Logger.w("HTTP") { "HTTP $statusCode: $errorMessage" }
+                    Diag.w(
+                        "HTTP",
+                        origin = LogOrigin.SERVER,
+                        attrs = mapOf(
+                            "status" to statusCode.toString(),
+                            "path" to response.call.request.url.encodedPath,
+                            "method" to response.call.request.method.value,
+                        ),
+                    ) { "HTTP $statusCode" }
 
                     if (isBanned) {
                         tokenManager.emitSessionExpired()

--- a/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/di/NetworkModule.kt
+++ b/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/di/NetworkModule.kt
@@ -67,6 +67,7 @@ val networkModule = module {
             json = get(),
             tokenManager = get(),
             serverUrlProvider = get(),
+            redactor = get(),
         )
     }
 

--- a/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/sse/SseClient.kt
+++ b/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/sse/SseClient.kt
@@ -1,6 +1,8 @@
 package com.garfiec.librechat.core.network.sse
 
 import co.touchlab.kermit.Logger
+import com.garfiec.librechat.core.logging.Diag
+import com.garfiec.librechat.core.logging.LogOrigin
 import com.garfiec.librechat.core.model.StreamEvent
 import io.ktor.http.HttpStatusCode
 import io.ktor.utils.io.ByteChannel
@@ -85,18 +87,37 @@ class SseClient(
                     }
 
                     HttpStatusCode.Unauthorized.value -> {
-                        Logger.w("SSE") { "SSE: 401 Unauthorized for $streamPath" }
+                        Diag.w(
+                            "SSE",
+                            origin = LogOrigin.SERVER,
+                            attrs = mapOf(
+                                "status" to e.statusCode.toString(),
+                                "attempt" to attempt.toString(),
+                            ),
+                        ) { "SSE 401 Unauthorized" }
                         emit(StreamEvent.Error(message = "Unauthorized", code = "401"))
                         done = true
                     }
 
                     else -> {
-                        Logger.w("SSE") { "SSE: unexpected status ${e.statusCode} for $streamPath" }
+                        Diag.w(
+                            "SSE",
+                            origin = LogOrigin.SERVER,
+                            attrs = mapOf(
+                                "status" to e.statusCode.toString(),
+                                "attempt" to attempt.toString(),
+                            ),
+                        ) { "SSE unexpected status" }
                         attempt++
                     }
                 }
             } catch (e: SseStreamException) {
-                Logger.w("SSE", e) { "SSE I/O error (attempt $attempt)" }
+                Diag.w(
+                    "SSE",
+                    origin = LogOrigin.NETWORK,
+                    throwable = e,
+                    attrs = mapOf("attempt" to attempt.toString()),
+                ) { "SSE I/O error" }
                 attempt++
                 if (attempt > maxRetries) {
                     emit(StreamEvent.Error(message = "Connection lost. Please check your network and try again.", isNetworkError = true))
@@ -105,7 +126,12 @@ class SseClient(
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
-                Logger.w("SSE", e) { "SSE connection error (attempt $attempt)" }
+                Diag.w(
+                    "SSE",
+                    origin = LogOrigin.NETWORK,
+                    throwable = e,
+                    attrs = mapOf("attempt" to attempt.toString()),
+                ) { "SSE connection error" }
                 attempt++
                 if (attempt > maxRetries) {
                     emit(StreamEvent.Error(message = "Connection failed. Please try again."))
@@ -137,7 +163,11 @@ class SseClient(
         } catch (e: CancellationException) {
             throw e // Re-throw cancellation — SKIE handles this gracefully
         } catch (e: Exception) {
-            Logger.e("SSE", e) { "SSE: unhandled exception escaped flow" }
+            Diag.e(
+                "SSE",
+                origin = LogOrigin.CLIENT,
+                throwable = e,
+            ) { "SSE unhandled exception escaped flow" }
             emit(StreamEvent.Error(message = "Unexpected error: ${e.message}"))
         }
     }

--- a/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/sse/SseEventMapper.kt
+++ b/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/sse/SseEventMapper.kt
@@ -1,6 +1,8 @@
 package com.garfiec.librechat.core.network.sse
 
 import co.touchlab.kermit.Logger
+import com.garfiec.librechat.core.logging.Diag
+import com.garfiec.librechat.core.logging.LogOrigin
 import com.garfiec.librechat.core.model.Conversation
 import com.garfiec.librechat.core.model.Message
 import com.garfiec.librechat.core.model.StreamEvent
@@ -78,7 +80,12 @@ class SseEventMapper(private val json: Json) {
             }
             mapJsonObject(root)
         } catch (e: Exception) {
-            Logger.w("SSE", e) { "SSE parse error: event=${event.event}" }
+            Diag.w(
+                "SSE",
+                origin = LogOrigin.CLIENT,
+                throwable = e,
+                attrs = mapOf("event" to event.event),
+            ) { "SSE parse error" }
             StreamEvent.Error(message = "Parse error: ${e.message}")
         }
     }
@@ -158,7 +165,11 @@ class SseEventMapper(private val json: Json) {
         val allFieldsNull = conversation == null && requestMessage == null &&
             responseMessage == null && legacyMessage == null
         if (allFieldsNull && parseErrors.isNotEmpty()) {
-            Logger.e("SSE") { "Final event: all fields failed to parse -- $parseErrors" }
+            Diag.e(
+                "SSE",
+                origin = LogOrigin.CLIENT,
+                attrs = mapOf("event" to "final", "failedFields" to parseErrors.size.toString()),
+            ) { "Final event: all fields failed to parse" }
             return StreamEvent.Error(
                 message = "Failed to parse final event: ${parseErrors.joinToString("; ")}",
             )

--- a/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/sse/SseLineParser.kt
+++ b/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/sse/SseLineParser.kt
@@ -1,6 +1,8 @@
 package com.garfiec.librechat.core.network.sse
 
 import co.touchlab.kermit.Logger
+import com.garfiec.librechat.core.logging.Diag
+import com.garfiec.librechat.core.logging.LogOrigin
 import io.ktor.utils.io.ByteReadChannel
 import io.ktor.utils.io.readUTF8Line
 import kotlinx.coroutines.TimeoutCancellationException
@@ -23,7 +25,11 @@ class SseLineParser(
                         channel.readUTF8Line()
                     }
                 } catch (e: TimeoutCancellationException) {
-                    Logger.w("SSE") { "SSE stream stalled: no data for ${lineReadTimeoutMs / 1000}s" }
+                    Diag.w(
+                        "SSE",
+                        origin = LogOrigin.NETWORK,
+                        attrs = mapOf("timeoutSec" to (lineReadTimeoutMs / 1000).toString()),
+                    ) { "SSE stream stalled: no data" }
                     throw SseStreamException("Stream stalled: no data received for ${lineReadTimeoutMs / 1000}s", e)
                 } ?: break
 

--- a/feature/conversations/src/iosMain/kotlin/com/garfiec/librechat/feature/conversations/platform/PlatformActions.ios.kt
+++ b/feature/conversations/src/iosMain/kotlin/com/garfiec/librechat/feature/conversations/platform/PlatformActions.ios.kt
@@ -1,22 +1,29 @@
 package com.garfiec.librechat.feature.conversations.platform
 
-import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
+import androidx.compose.runtime.LaunchedEffect
 import co.touchlab.kermit.Logger
+import kotlinx.cinterop.BetaInteropApi
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.useContents
+import kotlinx.cinterop.usePinned
+import platform.CoreGraphics.CGRectMake
+import platform.Foundation.NSData
+import platform.Foundation.NSTemporaryDirectory
 import platform.Foundation.NSTimer
+import platform.Foundation.NSURL
+import platform.Foundation.create
+import platform.Foundation.writeToFile
+import platform.UIKit.UIActivityViewController
 import platform.UIKit.UIAlertController
 import platform.UIKit.UIAlertControllerStyleAlert
 import platform.UIKit.UIApplication
 import platform.UIKit.UIPasteboard
+import platform.UIKit.UIViewController
 import platform.UIKit.UIWindow
 import platform.UIKit.UIWindowScene
+import platform.UIKit.popoverPresentationController
 
 actual fun copyToClipboard(text: String, label: String) {
     UIPasteboard.generalPasteboard.string = text
@@ -46,6 +53,18 @@ actual fun showToast(message: String) {
     }
 }
 
+/**
+ * iOS conversation export. Writes [content] to a temp file under [NSTemporaryDirectory], then
+ * presents a `UIActivityViewController` share sheet so the user can Save to Files / AirDrop /
+ * Mail the export. Replaces the prior "not available on iOS" placeholder dialog.
+ *
+ * cinterop notes (see project iOS gotchas + `core:logging` LogFile.ios.kt):
+ * - `NSData` is built from a Kotlin `String` via `ByteArray.usePinned { NSData.create(...) }`.
+ * - No `String as NSString` casts.
+ * - iPad requires a popover anchor or `UIActivityViewController` crashes; we anchor to the
+ *   root view's center.
+ */
+@OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
 @Composable
 actual fun FileSaver(
     triggerFileName: String?,
@@ -53,42 +72,63 @@ actual fun FileSaver(
     onComplete: (success: Boolean, message: String?) -> Unit,
     onReset: () -> Unit,
 ) {
-    var showDialog by remember { mutableStateOf(false) }
+    LaunchedEffect(triggerFileName) {
+        val fileName = triggerFileName
+        val text = content
+        if (fileName == null || text == null) return@LaunchedEffect
 
-    if (triggerFileName != null && content != null && !showDialog) {
-        showDialog = true
-    }
+        val rootVc = getRootViewController()
+        if (rootVc == null) {
+            onComplete(false, "Could not present share sheet")
+            onReset()
+            return@LaunchedEffect
+        }
 
-    if (showDialog) {
-        AlertDialog(
-            onDismissRequest = {
-                showDialog = false
-                onComplete(false, null)
-                onReset()
-            },
-            title = {
-                Text(
-                    text = "Export Not Available",
-                    style = MaterialTheme.typography.titleMedium,
-                )
-            },
-            text = {
-                Text(
-                    text = "File export is not yet available on iOS. This feature will be added in a future update.",
-                    style = MaterialTheme.typography.bodyMedium,
-                )
-            },
-            confirmButton = {
-                TextButton(
-                    onClick = {
-                        showDialog = false
-                        onComplete(false, "File export not yet available on iOS")
-                        onReset()
-                    },
-                ) {
-                    Text("OK")
-                }
-            },
+        val tempPath = NSTemporaryDirectory() + fileName
+        val data = text.toNSData()
+        val wrote = data.writeToFile(tempPath, atomically = true)
+        if (!wrote) {
+            onComplete(false, "Could not write export file")
+            onReset()
+            return@LaunchedEffect
+        }
+
+        val url = NSURL.fileURLWithPath(tempPath)
+        val activityVc = UIActivityViewController(
+            activityItems = listOf(url),
+            applicationActivities = null,
         )
+
+        // iPad: anchor the popover to the root view to avoid an unanchored-popover crash.
+        activityVc.popoverPresentationController?.let { popover ->
+            val view = rootVc.view
+            popover.sourceView = view
+            view?.bounds?.useContents {
+                popover.sourceRect = CGRectMake(
+                    x = size.width / 2.0,
+                    y = size.height / 2.0,
+                    width = 0.0,
+                    height = 0.0,
+                )
+            }
+        }
+
+        rootVc.presentViewController(activityVc, animated = true, completion = null)
+        onComplete(true, null)
+        onReset()
+    }
+}
+
+private fun getRootViewController(): UIViewController? {
+    val scene = UIApplication.sharedApplication.connectedScenes.firstOrNull() as? UIWindowScene
+    return scene?.keyWindow?.rootViewController
+}
+
+@OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
+private fun String.toNSData(): NSData {
+    val bytes = this.encodeToByteArray()
+    if (bytes.isEmpty()) return NSData()
+    return bytes.usePinned { pinned ->
+        NSData.create(bytes = pinned.addressOf(0), length = bytes.size.toULong())
     }
 }

--- a/feature/conversations/src/iosMain/kotlin/com/garfiec/librechat/feature/conversations/platform/PlatformActions.ios.kt
+++ b/feature/conversations/src/iosMain/kotlin/com/garfiec/librechat/feature/conversations/platform/PlatformActions.ios.kt
@@ -10,6 +10,7 @@ import kotlinx.cinterop.useContents
 import kotlinx.cinterop.usePinned
 import platform.CoreGraphics.CGRectMake
 import platform.Foundation.NSData
+import platform.Foundation.NSFileManager
 import platform.Foundation.NSTemporaryDirectory
 import platform.Foundation.NSTimer
 import platform.Foundation.NSURL
@@ -99,6 +100,15 @@ actual fun FileSaver(
             applicationActivities = null,
         )
 
+        // Report the outcome from the share-sheet result (not from presentation): clean up the temp
+        // file and only signal success if the user actually completed the share; a cancel resets
+        // without claiming success — matching the Android SAF actual.
+        activityVc.completionWithItemsHandler = { _, completed, _, _ ->
+            runCatching { NSFileManager.defaultManager.removeItemAtPath(tempPath, null) }
+            onComplete(completed, null)
+            onReset()
+        }
+
         // iPad: anchor the popover to the root view to avoid an unanchored-popover crash.
         activityVc.popoverPresentationController?.let { popover ->
             val view = rootVc.view
@@ -114,8 +124,6 @@ actual fun FileSaver(
         }
 
         rootVc.presentViewController(activityVc, animated = true, completion = null)
-        onComplete(true, null)
-        onReset()
     }
 }
 

--- a/feature/settings/build.gradle.kts
+++ b/feature/settings/build.gradle.kts
@@ -10,6 +10,7 @@ kotlin {
     sourceSets {
         commonMain.dependencies {
             implementation(project(":core:network"))
+            implementation(project(":core:logging"))
             implementation(libs.coil3.compose)
             implementation(libs.coil3.network.ktor)
             implementation(libs.kermit)

--- a/feature/settings/src/androidMain/kotlin/com/garfiec/librechat/feature/settings/platform/LogFileSaver.android.kt
+++ b/feature/settings/src/androidMain/kotlin/com/garfiec/librechat/feature/settings/platform/LogFileSaver.android.kt
@@ -1,0 +1,47 @@
+package com.garfiec.librechat.feature.settings.platform
+
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.platform.LocalContext
+
+/**
+ * Android diagnostic-log saver. Uses the Storage Access Framework `CreateDocument` contract
+ * (`application/json` MIME) and writes [content] via the resolved `OutputStream`. Mirrors the
+ * `feature:conversations` `FileSaver` Android actual.
+ */
+@Composable
+actual fun LogFileSaver(
+    triggerFileName: String?,
+    content: String?,
+    onComplete: (success: Boolean, message: String?) -> Unit,
+    onReset: () -> Unit,
+) {
+    val context = LocalContext.current
+
+    val launcher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.CreateDocument("application/json"),
+    ) { uri ->
+        if (uri != null && content != null) {
+            try {
+                context.contentResolver.openOutputStream(uri)?.use { outputStream ->
+                    outputStream.write(content.toByteArray())
+                }
+                onComplete(true, null)
+            } catch (e: Exception) {
+                onComplete(false, e.message)
+            }
+        } else {
+            // User cancelled the picker.
+            onComplete(false, null)
+        }
+        onReset()
+    }
+
+    LaunchedEffect(triggerFileName) {
+        if (triggerFileName != null) {
+            launcher.launch(triggerFileName)
+        }
+    }
+}

--- a/feature/settings/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/settings/di/SettingsModuleVerificationTest.kt
+++ b/feature/settings/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/settings/di/SettingsModuleVerificationTest.kt
@@ -21,6 +21,7 @@ import com.garfiec.librechat.core.data.repository.ShareRepository
 import com.garfiec.librechat.core.data.repository.SpeechRepository
 import com.garfiec.librechat.core.data.repository.UserRepository
 import com.garfiec.librechat.core.data.util.PermissionGate
+import com.garfiec.librechat.core.logging.DiagnosticLogRepository
 import com.garfiec.librechat.feature.settings.util.ContentReader
 import com.garfiec.librechat.feature.settings.util.PlatformCacheCleaner
 import com.garfiec.librechat.feature.settings.viewmodel.delegate.SpeechSettingsFactory
@@ -56,6 +57,7 @@ class SettingsModuleVerificationTest {
                 ContentReader::class,
                 PlatformCacheCleaner::class,
                 SpeechSettingsFactory::class,
+                DiagnosticLogRepository::class,
             ),
         )
     }

--- a/feature/settings/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/settings/viewmodel/SettingsViewModelTest.kt
+++ b/feature/settings/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/settings/viewmodel/SettingsViewModelTest.kt
@@ -21,6 +21,7 @@ import com.garfiec.librechat.core.data.repository.ShareRepository
 import com.garfiec.librechat.core.data.repository.SpeechRepository
 import com.garfiec.librechat.core.data.repository.UserRepository
 import com.garfiec.librechat.core.data.util.PermissionGate
+import com.garfiec.librechat.core.logging.DiagnosticLogRepository
 import com.garfiec.librechat.core.model.User
 import com.garfiec.librechat.feature.settings.util.ContentReader
 import com.garfiec.librechat.feature.settings.util.PlatformCacheCleaner
@@ -68,6 +69,7 @@ class SettingsViewModelTest {
     private val roleRepository = mockk<RoleRepository>(relaxed = true)
     private val permissionGate = mockk<PermissionGate>(relaxed = true)
     private val configRepository = mockk<ConfigRepository>(relaxed = true)
+    private val diagnosticLogRepository = mockk<DiagnosticLogRepository>(relaxed = true)
 
     private val testUser = User(
         email = "test@example.com",
@@ -147,6 +149,7 @@ class SettingsViewModelTest {
         roleRepository = roleRepository,
         permissionGate = permissionGate,
         configRepository = configRepository,
+        diagnosticLogRepository = diagnosticLogRepository,
         appInfo = object : AppInfo {
             override val versionName = "0.1.0"
             override val versionCode = 1L

--- a/feature/settings/src/commonMain/composeResources/values/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values/strings.xml
@@ -239,6 +239,17 @@
     <string name="export_coming_soon">Export is coming soon</string>
     <string name="error_could_not_load_settings">Could not load settings</string>
 
+    <!-- Diagnostic logs (issue #96) -->
+    <string name="section_diagnostic_logs">Diagnostic Logs</string>
+    <string name="export_diagnostic_logs">Export diagnostic logs</string>
+    <string name="export_diagnostic_logs_with_size">Export diagnostic logs (%1$s)</string>
+    <string name="exporting_logs">Exporting…</string>
+    <string name="clear_diagnostic_logs">Clear diagnostic logs</string>
+    <string name="clearing_logs">Clearing…</string>
+    <string name="logs_exported">Diagnostic logs exported</string>
+    <string name="dialog_title_clear_logs">Clear Diagnostic Logs</string>
+    <string name="dialog_clear_logs_message">This will permanently delete all stored diagnostic logs from this device. This action cannot be undone.</string>
+
     <!-- Speech settings -->
     <string name="auto_send_after_speech">Auto-send after speech</string>
     <string name="auto_send_after_speech_desc">Automatically send the message after speech-to-text finishes</string>

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/platform/LogFileSaver.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/platform/LogFileSaver.kt
@@ -1,0 +1,22 @@
+package com.garfiec.librechat.feature.settings.platform
+
+import androidx.compose.runtime.Composable
+
+/**
+ * Composable that provides a file-save / share callback for diagnostic-log export.
+ *
+ * When [triggerFileName] changes to a non-null value, the platform prompts the user to save
+ * (Android: Storage Access Framework) or share (iOS: `UIActivityViewController`) a file with
+ * that name containing [content]. [onComplete] reports success/failure; [onReset] clears the
+ * trigger state so a recomposition won't re-launch the picker.
+ *
+ * `feature:settings` owns this rather than reusing `feature:conversations`' `FileSaver`, because
+ * feature modules may depend on `:core:*` only — never on each other.
+ */
+@Composable
+expect fun LogFileSaver(
+    triggerFileName: String?,
+    content: String?,
+    onComplete: (success: Boolean, message: String?) -> Unit,
+    onReset: () -> Unit,
+)

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/DataSettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/DataSettingsScreen.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.garfiec.librechat.feature.settings.platform.LogFileSaver
 import com.garfiec.librechat.feature.settings.resources.*
 import com.garfiec.librechat.feature.settings.resources.Res
 import com.garfiec.librechat.feature.settings.viewmodel.SettingsViewModel
@@ -100,6 +101,12 @@ fun DataSettingsContent(
     var showClearCacheDialog by remember { mutableStateOf(false) }
     var showRevokeKeysDialog by remember { mutableStateOf(false) }
 
+    // Diagnostic-log export → platform file saver (issue #96)
+    var pendingLogsFileName by remember { mutableStateOf<String?>(null) }
+    var pendingLogsContent by remember { mutableStateOf<String?>(null) }
+    var logsSaverResult by remember { mutableStateOf<String?>(null) }
+    val logsExportedMsg = stringResource(Res.string.logs_exported)
+
     LaunchedEffect(uiState.error) {
         val error = uiState.error ?: return@LaunchedEffect
         snackbarHostState.showSnackbar(message = error)
@@ -111,6 +118,36 @@ fun DataSettingsContent(
             snackbarHostState.showSnackbar(message = "Export is coming soon")
             viewModel.dismissExportComingSoon()
         }
+    }
+
+    // When the ViewModel finishes reading the buffer, hand the payload to the platform saver.
+    LaunchedEffect(uiState.logsExportReady) {
+        val payload = uiState.logsExportReady ?: return@LaunchedEffect
+        pendingLogsContent = payload.content
+        pendingLogsFileName = payload.fileName
+        viewModel.consumeLogsExport()
+    }
+
+    LogFileSaver(
+        triggerFileName = pendingLogsFileName,
+        content = pendingLogsContent,
+        onComplete = { success, errorMessage ->
+            if (success) {
+                logsSaverResult = logsExportedMsg
+            } else if (errorMessage != null) {
+                logsSaverResult = errorMessage
+            }
+        },
+        onReset = {
+            pendingLogsFileName = null
+            pendingLogsContent = null
+        },
+    )
+
+    LaunchedEffect(logsSaverResult) {
+        val msg = logsSaverResult ?: return@LaunchedEffect
+        snackbarHostState.showSnackbar(message = msg)
+        logsSaverResult = null
     }
 
     LaunchedEffect(uiState.mcpReinitializeMessage) {
@@ -134,6 +171,11 @@ fun DataSettingsContent(
                     onClearAllChats = viewModel::clearAllChats,
                     onViewArchive = onNavigateToArchive,
                     onExportAllData = viewModel::exportAllData,
+                    logsBufferBytes = uiState.logsBufferBytes,
+                    isLogsExporting = uiState.isLogsExporting,
+                    isLogsClearing = uiState.isLogsClearing,
+                    onExportLogs = viewModel::exportLogs,
+                    onClearLogs = viewModel::clearLogs,
                 )
             }
             item(key = "data_extra_actions") {

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/DataSettingsSection.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/DataSettingsSection.kt
@@ -39,9 +39,15 @@ internal fun DataSettingsSection(
     onClearAllChats: () -> Unit,
     onViewArchive: () -> Unit,
     onExportAllData: () -> Unit,
+    logsBufferBytes: Long,
+    isLogsExporting: Boolean,
+    isLogsClearing: Boolean,
+    onExportLogs: () -> Unit,
+    onClearLogs: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     var showClearDialog by remember { mutableStateOf(false) }
+    var showClearLogsDialog by remember { mutableStateOf(false) }
 
     Column(modifier = modifier) {
         Column(
@@ -112,6 +118,36 @@ internal fun DataSettingsSection(
                 Text(stringResource(Res.string.export_all_data))
             }
 
+            // Export diagnostic logs (issue #96). Label includes the buffer size when known.
+            OutlinedButton(
+                onClick = onExportLogs,
+                enabled = !isLogsExporting,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(
+                    when {
+                        isLogsExporting -> stringResource(Res.string.exporting_logs)
+                        logsBufferBytes > 0 -> stringResource(
+                            Res.string.export_diagnostic_logs_with_size,
+                            formatBytes(logsBufferBytes),
+                        )
+                        else -> stringResource(Res.string.export_diagnostic_logs)
+                    },
+                )
+            }
+
+            // Clear diagnostic logs (destructive)
+            OutlinedButton(
+                onClick = { showClearLogsDialog = true },
+                enabled = !isLogsClearing,
+                modifier = Modifier.fillMaxWidth(),
+                colors = ButtonDefaults.outlinedButtonColors(
+                    contentColor = MaterialTheme.colorScheme.error,
+                ),
+            ) {
+                Text(stringResource(if (isLogsClearing) Res.string.clearing_logs else Res.string.clear_diagnostic_logs))
+            }
+
             Spacer(modifier = Modifier.height(0.dp))
         }
         HorizontalDivider(modifier = Modifier.padding(top = 8.dp))
@@ -146,5 +182,45 @@ internal fun DataSettingsSection(
                 },
             )
         }
+
+        // Clear diagnostic logs confirmation dialog
+        if (showClearLogsDialog) {
+            AlertDialog(
+                onDismissRequest = { showClearLogsDialog = false },
+                title = { Text(stringResource(Res.string.dialog_title_clear_logs)) },
+                text = { Text(stringResource(Res.string.dialog_clear_logs_message)) },
+                confirmButton = {
+                    TextButton(
+                        onClick = {
+                            showClearLogsDialog = false
+                            onClearLogs()
+                        },
+                        colors = ButtonDefaults.textButtonColors(
+                            contentColor = MaterialTheme.colorScheme.error,
+                        ),
+                    ) {
+                        Text(stringResource(Res.string.clear_all))
+                    }
+                },
+                dismissButton = {
+                    TextButton(onClick = { showClearLogsDialog = false }) {
+                        Text(stringResource(Res.string.action_cancel))
+                    }
+                },
+            )
+        }
     } // Column
+}
+
+/**
+ * Compact human-readable byte size (e.g. `123 KB`, `1.2 MB`) for the export-logs button label.
+ * Uses binary (1024) units; one decimal place above KB.
+ */
+private fun formatBytes(bytes: Long): String {
+    if (bytes < 1024) return "$bytes B"
+    val kb = bytes / 1024.0
+    if (kb < 1024) return "${kb.toInt()} KB"
+    val mb = kb / 1024.0
+    val rounded = (mb * 10).toLong() / 10.0
+    return "$rounded MB"
 }

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/SettingsViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/SettingsViewModel.kt
@@ -25,6 +25,7 @@ import com.garfiec.librechat.core.data.repository.RoleRepository
 import com.garfiec.librechat.core.data.repository.ShareRepository
 import com.garfiec.librechat.core.data.repository.UserRepository
 import com.garfiec.librechat.core.data.util.PermissionGate
+import com.garfiec.librechat.core.logging.DiagnosticLogRepository
 import com.garfiec.librechat.core.model.Memory
 import com.garfiec.librechat.core.model.User
 import com.garfiec.librechat.core.model.mcp.McpApiKeyConfig
@@ -59,6 +60,13 @@ data class SettingsCommand(
     val name: String,
     val description: String,
     val enabled: Boolean = true,
+)
+
+/** One-shot diagnostic-log export payload handed from the ViewModel to the platform file saver. */
+@Immutable
+data class LogsExportPayload(
+    val content: String,
+    val fileName: String,
 )
 
 val DEFAULT_COMMANDS = listOf(
@@ -113,6 +121,18 @@ data class SettingsUiState(
     val archivedCount: Int = 0,
     val isClearing: Boolean = false,
     val showExportComingSoon: Boolean = false,
+    // Diagnostic logs (issue #96)
+    val isLogsExporting: Boolean = false,
+    val isLogsClearing: Boolean = false,
+    val logsBufferBytes: Long = 0,
+    /**
+     * One-shot export payload. Set when [SettingsViewModel.exportLogs] finishes reading the
+     * buffer; the screen observes it, hands it to the platform `LogFileSaver`, then calls
+     * [SettingsViewModel.consumeLogsExport] to clear it (so a recomposition doesn't re-trigger
+     * the save). Mirrors the conversations `ExportReady` event but state-based, since Settings
+     * has no events SharedFlow.
+     */
+    val logsExportReady: LogsExportPayload? = null,
     // Security (2FA)
     val isTwoFactorEnabled: Boolean = false,
     val isTwoFactorLoading: Boolean = false,
@@ -240,6 +260,7 @@ class SettingsViewModel(
     private val roleRepository: RoleRepository,
     private val permissionGate: PermissionGate,
     private val configRepository: ConfigRepository,
+    diagnosticLogRepository: DiagnosticLogRepository,
     appInfo: AppInfo,
 ) : ViewModel() {
 
@@ -260,7 +281,14 @@ class SettingsViewModel(
     private val mcpDelegate = McpServerDelegate(stateHandle, mcpRepository)
     private val twoFactorDelegate = TwoFactorSecurityDelegate(stateHandle, authRepository)
     private val dataDelegate =
-        DataManagementDelegate(stateHandle, cacheCleaner, conversationRepository, shareRepository, keyRepository)
+        DataManagementDelegate(
+            stateHandle,
+            cacheCleaner,
+            conversationRepository,
+            shareRepository,
+            keyRepository,
+            diagnosticLogRepository,
+        )
 
     /** Combined DataStore preferences flow. */
     private val dataStorePreferences: StateFlow<DataStorePreferences> = combine(
@@ -433,6 +461,7 @@ class SettingsViewModel(
         loadRoleGatedData()
         observePermissionFlags()
         observeAccountDeletionPolicy()
+        dataDelegate.loadLogsBufferSize()
     }
 
     /**
@@ -805,6 +834,11 @@ class SettingsViewModel(
     fun deleteSharedLink(shareId: String) = dataDelegate.deleteSharedLink(shareId)
     fun clearCache() = dataDelegate.clearCache()
     fun revokeAllKeys() = dataDelegate.revokeAllKeys()
+
+    // Diagnostic logs (issue #96)
+    fun exportLogs() = dataDelegate.exportLogs()
+    fun clearLogs() = dataDelegate.clearLogs()
+    fun consumeLogsExport() = dataDelegate.consumeLogsExport()
 
     // Speech settings
     fun setAutoSendAfterStt(enabled: Boolean) = speechDelegate.setAutoSendAfterStt(enabled)

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/delegate/DataManagementDelegate.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/delegate/DataManagementDelegate.kt
@@ -1,14 +1,18 @@
 package com.garfiec.librechat.feature.settings.viewmodel.delegate
 
+import co.touchlab.kermit.Logger
 import com.garfiec.librechat.core.common.result.Result
 import com.garfiec.librechat.core.data.repository.ConversationRepository
 import com.garfiec.librechat.core.data.repository.KeyRepository
 import com.garfiec.librechat.core.data.repository.ShareRepository
+import com.garfiec.librechat.core.logging.DiagnosticLogRepository
 import com.garfiec.librechat.core.model.SharedLink
 import com.garfiec.librechat.feature.settings.model.SharedLinkDisplayData
 import com.garfiec.librechat.feature.settings.util.PlatformCacheCleaner
+import com.garfiec.librechat.feature.settings.viewmodel.LogsExportPayload
 import com.garfiec.librechat.feature.settings.viewmodel.SettingsStateHandle
 import kotlinx.coroutines.launch
+import kotlin.time.Clock
 
 /**
  * Handles clear conversations, export, shared links, cache clearing, and key revocation.
@@ -19,6 +23,7 @@ class DataManagementDelegate(
     private val conversationRepository: ConversationRepository,
     private val shareRepository: ShareRepository,
     private val keyRepository: KeyRepository,
+    private val diagnosticLogRepository: DiagnosticLogRepository,
 ) {
 
     fun clearAllChats() {
@@ -47,6 +52,72 @@ class DataManagementDelegate(
 
     fun dismissExportComingSoon() {
         stateHandle.update { copy(showExportComingSoon = false) }
+    }
+
+    // ── Diagnostic logs (issue #96) ────────────────────────────────
+
+    /** Loads the current on-disk buffer size into state so the UI can label the export button. */
+    fun loadLogsBufferSize() {
+        stateHandle.scope.launch {
+            try {
+                val bytes = diagnosticLogRepository.bufferSizeBytes()
+                stateHandle.update { copy(logsBufferBytes = bytes) }
+            } catch (e: Exception) {
+                Logger.d(e) { "Failed to read diagnostic log buffer size" }
+            }
+        }
+    }
+
+    /**
+     * Reads the redacted JSONL buffer and stashes it in [SettingsUiState.logsExportReady] as a
+     * one-shot payload. The screen observes it, launches the platform file saver, and calls
+     * [consumeLogsExport] once handled.
+     */
+    fun exportLogs() {
+        stateHandle.scope.launch {
+            stateHandle.update { copy(isLogsExporting = true) }
+            try {
+                val content = diagnosticLogRepository.exportText()
+                val fileName = "librechat-logs-${Clock.System.now().toEpochMilliseconds()}.jsonl"
+                stateHandle.update {
+                    copy(
+                        isLogsExporting = false,
+                        logsExportReady = LogsExportPayload(content = content, fileName = fileName),
+                    )
+                }
+            } catch (e: Exception) {
+                stateHandle.update {
+                    copy(
+                        isLogsExporting = false,
+                        error = e.message ?: "Failed to export diagnostic logs",
+                    )
+                }
+            }
+        }
+    }
+
+    /** Clears the consumed export payload so a recomposition won't re-trigger the file save. */
+    fun consumeLogsExport() {
+        stateHandle.update { copy(logsExportReady = null) }
+    }
+
+    /** Clears both log segments, then refreshes the displayed buffer size. */
+    fun clearLogs() {
+        stateHandle.scope.launch {
+            stateHandle.update { copy(isLogsClearing = true) }
+            try {
+                diagnosticLogRepository.clear()
+                val bytes = diagnosticLogRepository.bufferSizeBytes()
+                stateHandle.update { copy(isLogsClearing = false, logsBufferBytes = bytes) }
+            } catch (e: Exception) {
+                stateHandle.update {
+                    copy(
+                        isLogsClearing = false,
+                        error = e.message ?: "Failed to clear diagnostic logs",
+                    )
+                }
+            }
+        }
     }
 
     fun loadSharedLinks() {

--- a/feature/settings/src/iosMain/kotlin/com/garfiec/librechat/feature/settings/platform/LogFileSaver.ios.kt
+++ b/feature/settings/src/iosMain/kotlin/com/garfiec/librechat/feature/settings/platform/LogFileSaver.ios.kt
@@ -1,0 +1,101 @@
+package com.garfiec.librechat.feature.settings.platform
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import kotlinx.cinterop.BetaInteropApi
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.useContents
+import kotlinx.cinterop.usePinned
+import platform.CoreGraphics.CGRectMake
+import platform.Foundation.NSData
+import platform.Foundation.NSTemporaryDirectory
+import platform.Foundation.NSURL
+import platform.Foundation.create
+import platform.Foundation.writeToFile
+import platform.UIKit.UIActivityViewController
+import platform.UIKit.UIApplication
+import platform.UIKit.UIViewController
+import platform.UIKit.UIWindowScene
+import platform.UIKit.popoverPresentationController
+
+/**
+ * iOS diagnostic-log saver. Writes [content] to a temp file under [NSTemporaryDirectory], then
+ * presents a `UIActivityViewController` share sheet from the key window's root view controller so
+ * the user can Save to Files / AirDrop / Mail the export.
+ *
+ * cinterop notes (see project iOS gotchas + `core:logging` LogFile.ios.kt):
+ * - `NSData` is built from a Kotlin `String` via `ByteArray.usePinned { NSData.create(...) }`.
+ * - No `String as NSString` casts.
+ * - The root VC is resolved via `connectedScenes` exactly like the chat share sheet.
+ * - iPad requires a popover anchor or `UIActivityViewController` crashes; we anchor to the
+ *   root view's center.
+ */
+@OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
+@Composable
+actual fun LogFileSaver(
+    triggerFileName: String?,
+    content: String?,
+    onComplete: (success: Boolean, message: String?) -> Unit,
+    onReset: () -> Unit,
+) {
+    LaunchedEffect(triggerFileName) {
+        val fileName = triggerFileName
+        val text = content
+        if (fileName == null || text == null) return@LaunchedEffect
+
+        val rootVc = getRootViewController()
+        if (rootVc == null) {
+            onComplete(false, "Could not present share sheet")
+            onReset()
+            return@LaunchedEffect
+        }
+
+        val tempPath = NSTemporaryDirectory() + fileName
+        val data = text.toNSData()
+        val wrote = data.writeToFile(tempPath, atomically = true)
+        if (!wrote) {
+            onComplete(false, "Could not write export file")
+            onReset()
+            return@LaunchedEffect
+        }
+
+        val url = NSURL.fileURLWithPath(tempPath)
+        val activityVc = UIActivityViewController(
+            activityItems = listOf(url),
+            applicationActivities = null,
+        )
+
+        // iPad: anchor the popover to the root view to avoid an unanchored-popover crash.
+        activityVc.popoverPresentationController?.let { popover ->
+            val view = rootVc.view
+            popover.sourceView = view
+            view?.bounds?.useContents {
+                popover.sourceRect = CGRectMake(
+                    x = size.width / 2.0,
+                    y = size.height / 2.0,
+                    width = 0.0,
+                    height = 0.0,
+                )
+            }
+        }
+
+        rootVc.presentViewController(activityVc, animated = true, completion = null)
+        onComplete(true, null)
+        onReset()
+    }
+}
+
+private fun getRootViewController(): UIViewController? {
+    val scene = UIApplication.sharedApplication.connectedScenes.firstOrNull() as? UIWindowScene
+    return scene?.keyWindow?.rootViewController
+}
+
+@OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
+private fun String.toNSData(): NSData {
+    val bytes = this.encodeToByteArray()
+    if (bytes.isEmpty()) return NSData()
+    return bytes.usePinned { pinned ->
+        NSData.create(bytes = pinned.addressOf(0), length = bytes.size.toULong())
+    }
+}

--- a/feature/settings/src/iosMain/kotlin/com/garfiec/librechat/feature/settings/platform/LogFileSaver.ios.kt
+++ b/feature/settings/src/iosMain/kotlin/com/garfiec/librechat/feature/settings/platform/LogFileSaver.ios.kt
@@ -9,6 +9,7 @@ import kotlinx.cinterop.useContents
 import kotlinx.cinterop.usePinned
 import platform.CoreGraphics.CGRectMake
 import platform.Foundation.NSData
+import platform.Foundation.NSFileManager
 import platform.Foundation.NSTemporaryDirectory
 import platform.Foundation.NSURL
 import platform.Foundation.create
@@ -66,6 +67,15 @@ actual fun LogFileSaver(
             applicationActivities = null,
         )
 
+        // Report the outcome from the share-sheet result (not from presentation): the temp file is
+        // cleaned up and success is only signalled if the user actually completed the share. A cancel
+        // resets without claiming success — matching the Android SAF actual.
+        activityVc.completionWithItemsHandler = { _, completed, _, _ ->
+            runCatching { NSFileManager.defaultManager.removeItemAtPath(tempPath, null) }
+            onComplete(completed, null)
+            onReset()
+        }
+
         // iPad: anchor the popover to the root view to avoid an unanchored-popover crash.
         activityVc.popoverPresentationController?.let { popover ->
             val view = rootVc.view
@@ -81,8 +91,6 @@ actual fun LogFileSaver(
         }
 
         rootVc.presentViewController(activityVc, animated = true, completion = null)
-        onComplete(true, null)
-        onReset()
     }
 }
 

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -61,6 +61,21 @@
 			shellPath = /bin/sh;
 			shellScript = "# Stamp the iOS bundle version from version.properties, the single source of\n# truth shared with Android. versionName -> CFBundleShortVersionString; a derived\n# XXYYZZ versionCode (MAJOR*10000 + MINOR*100 + PATCH) -> CFBundleVersion, using the\n# same formula as Android so both platforms report the same version. This runs as the\n# last build phase (after Info.plist is in the bundle, before codesign), so the value\n# always reflects version.properties regardless of the committed Info.plist literals.\nset -eu\nPROPS=\"$SRCROOT/../version.properties\"\nif [ ! -f \"$PROPS\" ]; then\n    echo \"error: version.properties not found at $PROPS\"\n    exit 1\nfi\nVERSION_NAME=$(grep -E '^versionName=' \"$PROPS\" | cut -d'=' -f2 | tr -d '[:space:]')\nif [ -z \"$VERSION_NAME\" ]; then\n    echo \"error: versionName missing or malformed in $PROPS\"\n    exit 1\nfi\nCORE=${VERSION_NAME%%-*}\n# Split into MAJOR/MINOR/PATCH on '.'; any missing component defaults to 0.\nIFS=.\nset -f\nset -- $CORE\nset +f\nunset IFS\nMAJOR=${1:-0}\nMINOR=${2:-0}\nPATCH=${3:-0}\n# Treat any empty or non-numeric component as 0, the same way Android parses it.\ncase \"$MAJOR\" in \"\"|*[!0-9]*) MAJOR=0 ;; esac\ncase \"$MINOR\" in \"\"|*[!0-9]*) MINOR=0 ;; esac\ncase \"$PATCH\" in \"\"|*[!0-9]*) PATCH=0 ;; esac\nif [ \"$MINOR\" -gt 99 ] || [ \"$PATCH\" -gt 99 ]; then\n    echo \"error: versionName '$VERSION_NAME' exceeds the XXYYZZ scheme (MINOR/PATCH must be <= 99)\"\n    exit 1\nfi\n# Force base 10 so a zero-padded component (e.g. 08) is not interpreted as octal.\nVERSION_CODE=$((10#$MAJOR * 10000 + 10#$MINOR * 100 + 10#$PATCH))\nPLIST=\"$TARGET_BUILD_DIR/$INFOPLIST_PATH\"\n/usr/libexec/PlistBuddy -c \"Set :CFBundleShortVersionString $VERSION_NAME\" \"$PLIST\"\n/usr/libexec/PlistBuddy -c \"Set :CFBundleVersion $VERSION_CODE\" \"$PLIST\"\necho \"Stamped iOS version $VERSION_NAME ($VERSION_CODE) into $PLIST\"\n";
 		};
+		SSS00003 /* Stamp Git SHA */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Stamp Git SHA";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Bake the short git SHA into the built Info.plist so AppInfo.gitSha reports the\n# source commit (used in diagnostic startup headers and Settings -> About). Mirrors\n# the Android BuildConfig.GIT_SHA. Runs after Info.plist is in the bundle. Never fails\n# the build: a missing git checkout falls back to 'unknown'.\nset -u\nGIT_SHA=$(git -C \"$SRCROOT/..\" rev-parse --short=8 HEAD 2>/dev/null || echo unknown)\nPLIST=\"$TARGET_BUILD_DIR/$INFOPLIST_PATH\"\n/usr/libexec/PlistBuddy -c \"Set :GitSHA $GIT_SHA\" \"$PLIST\" || /usr/libexec/PlistBuddy -c \"Add :GitSHA string $GIT_SHA\" \"$PLIST\"\necho \"Stamped GitSHA $GIT_SHA into $PLIST\"\n";
+		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXResourcesBuildPhase section */
@@ -148,6 +163,7 @@
 				CCC00001 /* Embed Frameworks */,
 				SSS00001 /* Copy Compose Resources */,
 				SSS00002 /* Stamp Version from version.properties */,
+				SSS00003 /* Stamp Git SHA */,
 			);
 			buildRules = (
 			);

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -23,6 +23,10 @@
 	<string>0.1.0</string>
 	<key>CFBundleVersion</key>
 	<string>100</string>
+	<!-- Overwritten at build time by the "Stamp Git SHA" build phase. AppInfo.gitSha reads this
+	     key; the "unknown" literal is the fallback when there's no git checkout. -->
+	<key>GitSHA</key>
+	<string>unknown</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -20,6 +20,7 @@ rootProject.name = "LibreChat-Mobile"
 
 include(":app")
 include(":core:common")
+include(":core:logging")
 include(":core:model")
 include(":core:network")
 include(":core:data")

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -30,6 +30,7 @@ kotlin {
             api(project(":core:network"))
             api(project(":core:data"))
             api(project(":core:ui"))
+            implementation(project(":core:logging"))
             implementation(project(":feature:auth"))
             implementation(project(":feature:chat"))
             implementation(project(":feature:conversations"))

--- a/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/LibreChatNavHost.kt
+++ b/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/LibreChatNavHost.kt
@@ -34,6 +34,7 @@ import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.runtime.rememberNavBackStack
 import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
 import androidx.navigation3.ui.NavDisplay
+import com.garfiec.librechat.core.logging.Diag
 import com.garfiec.librechat.core.ui.components.BannerDisplay
 import com.garfiec.librechat.feature.agents.navigation.AgentMarketplace
 import com.garfiec.librechat.feature.agents.navigation.agentsEntries
@@ -89,6 +90,10 @@ fun LibreChatNavHost(
     LaunchedEffect(navigator.currentRoute) {
         val conversationId = (navigator.currentRoute as? Chat)?.conversationId
         navHostViewModel.setActiveConversation(conversationId)
+
+        // Navigation breadcrumb: route type name only — low cardinality, content-free.
+        val screen = navigator.currentRoute?.let { it::class.simpleName } ?: "none"
+        Diag.i("Breadcrumb", attrs = mapOf("screen" to screen)) { "nav" }
     }
 
     // Handle session expiry

--- a/shared/src/iosMain/kotlin/com/garfiec/librechat/shared/IosCrashReporting.kt
+++ b/shared/src/iosMain/kotlin/com/garfiec/librechat/shared/IosCrashReporting.kt
@@ -1,6 +1,7 @@
 package com.garfiec.librechat.shared
 
 import co.touchlab.kermit.Logger
+import com.garfiec.librechat.core.logging.PersistentLogWriter
 import platform.Foundation.NSException
 import platform.Foundation.NSLog
 import kotlin.experimental.ExperimentalNativeApi
@@ -9,16 +10,29 @@ private val log = Logger.withTag("CrashReporting")
 
 /**
  * Installs a Kotlin/Native unhandled exception hook that:
- * 1. Logs the full Kotlin stack trace via Kermit + NSLog (visible in Xcode/Console.app)
- * 2. Wraps the Kotlin exception as an NSException with readable class name, message,
+ * 1. Writes a synchronous crash record via [persistentWriter] (best-effort; the process may die
+ *    before any async log drain runs, so this path is intentionally synchronous).
+ * 2. Logs the full Kotlin stack trace via Kermit + NSLog (visible in Xcode/Console.app)
+ * 3. Wraps the Kotlin exception as an NSException with readable class name, message,
  *    and stack trace — so iOS crash logs show meaningful Kotlin context instead of
  *    just "Kotlin_ObjCExport_trapOnUndeclaredException" with a SIGABRT.
  *
- * Call once during app startup (before any coroutines or UI work).
+ * Call once during app startup. [persistentWriter] may be null if Koin failed to start or the
+ * writer could not be resolved — the hook is still installed for stack-trace/NSException behavior.
  */
 @OptIn(ExperimentalNativeApi::class)
-fun installCrashReporting() {
+fun installCrashReporting(persistentWriter: PersistentLogWriter? = null) {
     setUnhandledExceptionHook { throwable ->
+        // Persist a crash record first, synchronously, before the process tears down. Guarded so a
+        // logging failure can never mask the original crash or recurse.
+        runCatching {
+            persistentWriter?.writeCrashRecord(
+                tag = "Crash",
+                message = "unhandled Kotlin exception",
+                throwable = throwable,
+            )
+        }
+
         // Log the full Kotlin stack trace so it's captured in OS logs
         val stackTrace = throwable.stackTraceToString()
         val exceptionName = throwable::class.qualifiedName ?: throwable::class.simpleName ?: "Unknown"

--- a/shared/src/iosMain/kotlin/com/garfiec/librechat/shared/IosKoinHelper.kt
+++ b/shared/src/iosMain/kotlin/com/garfiec/librechat/shared/IosKoinHelper.kt
@@ -36,6 +36,11 @@ fun startIosKoin() {
     Logger.setMinSeverity(Severity.Debug)
     Logger.withTag("Koin").d { "startIosKoin: initializing Koin DI" }
 
+    // Install a writer-less crash hook BEFORE startKoin so a DI-init failure (the most crash-prone
+    // phase of launch) still surfaces a readable NSException + Kotlin stack instead of an opaque
+    // SIGABRT. It's upgraded with the persistent writer once Koin can supply it (below).
+    runCatching { installCrashReporting() }
+
     val app = startKoin {
         modules(iosSharedModule, sharedAppModule)
     }

--- a/shared/src/iosMain/kotlin/com/garfiec/librechat/shared/IosKoinHelper.kt
+++ b/shared/src/iosMain/kotlin/com/garfiec/librechat/shared/IosKoinHelper.kt
@@ -3,7 +3,13 @@ package com.garfiec.librechat.shared
 import co.touchlab.kermit.LogWriter
 import co.touchlab.kermit.Logger
 import co.touchlab.kermit.Severity
+import com.garfiec.librechat.core.common.AppInfo
+import com.garfiec.librechat.core.logging.PersistentLogWriter
+import com.garfiec.librechat.core.logging.PlatformInfo
+import com.garfiec.librechat.core.logging.logStartupHeader
+import com.garfiec.librechat.core.logging.startMainThreadWatchdog
 import com.garfiec.librechat.shared.navigation.sharedAppModule
+import kotlinx.coroutines.CoroutineExceptionHandler
 import org.koin.core.context.startKoin
 import platform.Foundation.NSLog
 
@@ -24,11 +30,9 @@ private class IosNSLogWriter : LogWriter() {
  * Call from Swift: IosKoinHelperKt.startIosKoin()
  */
 fun startIosKoin() {
-    // Route Kermit logs through NSLog for OS log visibility
+    // Route Kermit logs through NSLog for OS log visibility. The persistent file writer is added
+    // after Koin starts (below), once its dependencies are resolvable.
     Logger.setLogWriters(IosNSLogWriter())
-
-    // Install crash reporting hook early so all Kotlin exceptions get proper stack traces
-    installCrashReporting()
     Logger.setMinSeverity(Severity.Debug)
     Logger.withTag("Koin").d { "startIosKoin: initializing Koin DI" }
 
@@ -37,4 +41,30 @@ fun startIosKoin() {
     }
     IosKoinAccessor.koin = app.koin
     Logger.withTag("Koin").d { "startIosKoin: Koin initialized successfully" }
+
+    // Wire diagnostic logging now that Koin can supply the writer + platform info. All of this is
+    // best-effort: a logging-setup failure must never prevent the app from launching.
+    runCatching {
+        val writer: PersistentLogWriter = app.koin.get()
+
+        // Keep NSLog visibility AND add the persistent file sink.
+        Logger.setLogWriters(IosNSLogWriter(), writer)
+
+        // Install the Kotlin/Native crash hook with the writer so unhandled exceptions are persisted
+        // synchronously before the process dies.
+        installCrashReporting(writer)
+
+        val appInfo: AppInfo = app.koin.get()
+        val platformInfo: PlatformInfo = app.koin.get()
+        logStartupHeader(appInfo = appInfo, platformInfo = platformInfo)
+
+        // The watchdog owns its own isolated supervised scope; hand it the diagnostic exception
+        // handler so escaped failures reach the crash-record path (and can't poison ApplicationScope).
+        val exceptionHandler: CoroutineExceptionHandler = app.koin.get()
+        startMainThreadWatchdog(exceptionHandler)
+    }.onFailure {
+        // Fall back to a crash hook with no writer so we still get readable NSException reports.
+        runCatching { installCrashReporting() }
+        Logger.withTag("Koin").e(it) { "Diagnostic logging init failed (non-fatal)" }
+    }
 }

--- a/shared/src/iosMain/kotlin/com/garfiec/librechat/shared/IosSharedModule.kt
+++ b/shared/src/iosMain/kotlin/com/garfiec/librechat/shared/IosSharedModule.kt
@@ -84,6 +84,7 @@ val iosSharedModule = module {
             json = get(),
             tokenManager = get(),
             serverUrlProvider = get(),
+            redactor = get(),
         )
     }
 

--- a/shared/src/iosMain/kotlin/com/garfiec/librechat/shared/IosSharedModule.kt
+++ b/shared/src/iosMain/kotlin/com/garfiec/librechat/shared/IosSharedModule.kt
@@ -3,6 +3,7 @@ package com.garfiec.librechat.shared
 import com.garfiec.librechat.core.common.di.KoinQualifiers
 import com.garfiec.librechat.core.common.di.commonModule
 import com.garfiec.librechat.core.data.di.dataModule
+import com.garfiec.librechat.core.logging.di.loggingModule
 import com.garfiec.librechat.core.network.api.AgentsApi
 import com.garfiec.librechat.core.network.api.ApiKeysApi
 import com.garfiec.librechat.core.network.api.AuthApi
@@ -57,6 +58,7 @@ import org.koin.dsl.module
 val iosSharedModule = module {
 
     includes(commonModule)
+    includes(loggingModule)
     includes(dataModule)
     includes(authModule)
     includes(chatModule)


### PR DESCRIPTION
Closes #96

## Summary

Adds a persistent, structured, PII-safe, exportable diagnostic log buffer shared across Android and iOS. Until now logging was ephemeral Kermit output to Logcat/NSLog — when a user hit a failure, crash, or hang, there was no way to get diagnostics off the device. iOS had a crash hook; Android had none; neither had ANR detection, redaction, or structured/exportable records.

A new `:core:logging` module registers a custom Kermit `LogWriter` as an *additional* sink (Logcat/NSLog preserved), so all existing `Logger.*` call sites are captured automatically with no changes. Records are written as JSONL to a bounded on-disk ring buffer, scrubbed of PII at the sink, and exportable from **Settings → Data** on both platforms.

## What's included

- **New module `:core:logging`** — depends only on `:core:common` + serialization/datetime/kermit, keeping file-I/O and redaction machinery out of `:core:common`'s shared dependency surface.
- **Persistent JSONL sink** — two-segment ring buffer (default 4 MiB total / 7-day age cap), survives restart. Hot path is non-blocking (`Channel.trySend`, `DROP_OLDEST`); a single drain coroutine on a dedicated single-thread dispatcher is the sole writer, so there are no locks or rotation races. Logging can never crash the app or recurse into itself.
- **PII redaction at the sink** — bearer/refresh tokens, raw JWTs, emails, server URLs/hosts hashed to a salted FNV-1a digest (correlatable within an export, not recoverable); message/conversation content dropped by attr-key denylist; serialization-error response-body echoes stripped. Idempotent; runs on every record's message and attrs before disk.
- **Failure attribution** — HTTP, SSE, and token-refresh failures carry an `origin` (`client` / `server` / `network`). Never logs bodies or headers.
- **Crash + ANR capture** — Android `UncaughtExceptionHandler` (flushes synchronously, then delegates to the prior handler); unified iOS crash hook flushes into the same buffer; a conservative main-thread watchdog emits one debounced record per stall.
- **Server-config snapshot** — redacted, low-cardinality snapshot (feature flags + counts, never URLs/secrets) emitted on first config fetch and re-emitted once the backend version is detected. A dedicated `BackendVersion` record carries detected vs `SUPPORTED_BACKEND_VERSION` + compatibility verdict.
- **Startup header** — one record stamping app version/code, git SHA, OS, device model, and supported backend version. Real git SHA on both platforms (Android via `BuildConfig`; iOS via a new Xcode "Stamp Git SHA" build phase replacing the old `"unknown"`).
- **Export / Clear** — buffer size, "Export logs", and "Clear logs" (with confirmation) wired through `DataManagementDelegate` / `SettingsViewModel`. Real iOS export via `UIActivityViewController` (replaces the previous stub).

## Acceptance criteria

| # | Criterion | Status |
|---|---|---|
| 1 | Persistent bounded JSONL sink, both platforms | ✅ |
| 2 | Redaction test proving tokens/emails/URLs/content never reach disk | ✅ |
| 3 | Android crash + ANR; iOS unified crash capture | ✅ |
| 4 | Export/clear from Settings → Data, both platforms | ✅ |
| 5 | No regression across existing Kermit call sites | ✅ |
| 6 | Failure records carry `origin` | ✅ |
| 7 | Redacted config snapshot at session start + on change | ✅ |
| 8 | Startup header: version/code/gitSha/server-vs-supported | ✅ |

## Privacy

Exports are user-initiated and on-device only — no network upload, no third-party SDK. On-disk content is already redacted at write time, so an export is safe to attach to a bug report. Identifying values are hashed (not reversible); free-form content never reaches disk.

## Testing

- Unit tests (commonTest, JVM): redaction (token/JWT/email/URL/content/idempotency/false-positive), envelope encode-decode round-trip, sink rotation/bounding.
- Android `assembleDebug` + iOS framework build; Koin graph verification.
- Manual on device: forced crash persists across restart; >5s main-thread block yields one ANR record; 401/500 produces a `server`-origin record with status+path and no token/body; export opens valid JSONL; clear resets buffer size.

## Notes / follow-ups

- Serialization errors with non-standard phrasing (e.g. "Unexpected JSON token at offset N: …") aren't matched by the response-body strip regex; exposure is bounded by stack-trace truncation and content-key dropping. Hardening candidate.
- iOS crash-path append is best-effort (non-atomic `seekToEnd`); the single-process crash window is small.
- The pre-existing "Export all data" stub is unrelated and untouched.