### PR TITLE
feat(version): single-source the target backend version (#116)

### DIFF
--- a/.claude/skills/sync-upstream/SKILL.md
+++ b/.claude/skills/sync-upstream/SKILL.md
@@ -64,7 +64,7 @@ cat UPSTREAM_VERSION
 ```
 If missing, create from current state:
 ```bash
-VERSION=$(grep 'SUPPORTED_BACKEND_VERSION' core/common/src/commonMain/kotlin/com/garfiec/librechat/core/common/BackendVersion.kt | grep -o '"[^"]*"' | tr -d '"')
+VERSION=$(grep '^backendTargetVersion=' version.properties | cut -d= -f2 | tr -d '[:space:]')
 COMMIT=$(cd upstream && git rev-parse HEAD)
 echo "# Upstream LibreChat version this mobile build tracks." > UPSTREAM_VERSION
 echo "# Updated by the sync-upstream skill. Do not edit manually." >> UPSTREAM_VERSION
@@ -84,15 +84,15 @@ If dirty, ask the user to commit or stash before proceeding.
 Check if a prior sync was partially done in another session:
 ```bash
 TRACKED_TAG=$(grep '^tag=' UPSTREAM_VERSION | cut -d= -f2)
-CODE_VERSION=$(grep 'SUPPORTED_BACKEND_VERSION' core/common/src/commonMain/kotlin/com/garfiec/librechat/core/common/BackendVersion.kt | grep -o '"[^"]*"' | tr -d '"')
+CODE_VERSION=$(grep '^backendTargetVersion=' version.properties | cut -d= -f2 | tr -d '[:space:]')
 SUBMODULE_HEAD=$(cd upstream && git rev-parse HEAD)
 TRACKED_COMMIT=$(grep '^commit=' UPSTREAM_VERSION | cut -d= -f2)
 ```
 
 If `TRACKED_TAG` (without `v` prefix) != `CODE_VERSION`, or `SUBMODULE_HEAD` != `TRACKED_COMMIT`:
 > "It looks like a sync may have been partially done. UPSTREAM_VERSION says {TRACKED_TAG}
-> but BackendVersion.kt says {CODE_VERSION}. Should I treat the higher version as the
-> current baseline, or would you like to investigate?"
+> but version.properties (backendTargetVersion) says {CODE_VERSION}. Should I treat the
+> higher version as the current baseline, or would you like to investigate?"
 
 Wait for user response before continuing.
 
@@ -364,7 +364,7 @@ Create a task for the implementer with the approved change list:
 > content blocks (D2)`).
 >
 > **After all code changes:**
-> 1. Update `SUPPORTED_BACKEND_VERSION` in `core/common/src/commonMain/kotlin/com/garfiec/librechat/core/common/BackendVersion.kt` to "{new_version}" (without `v` prefix)
+> 1. Update `backendTargetVersion` in the root `version.properties` to `{new_version}` (without `v` prefix). This is the single source of truth — a Gradle task code-generates `BackendVersion.SUPPORTED_BACKEND_VERSION` from it, and `release.yml` reads the same key. Do **not** edit the `BackendVersion.kt` literal (it no longer exists).
 > 2. Advance submodule: `cd upstream && git checkout {target_tag}`
 > 3. Update `UPSTREAM_VERSION` at repo root:
 >    ```
@@ -409,7 +409,7 @@ After implementer reports done, create a task for the verifier:
 >    - For new endpoints: was `DISCOVERY.md` updated?
 >
 > **Version consistency:**
-> 7. `SUPPORTED_BACKEND_VERSION` in `core/common/src/commonMain/.../BackendVersion.kt` matches target
+> 7. `backendTargetVersion` in the root `version.properties` matches target (this drives the generated `SUPPORTED_BACKEND_VERSION`)
 > 8. `UPSTREAM_VERSION` file has correct tag, commit, date
 > 9. Submodule is at the correct tag: `cd upstream && git describe --tags`
 > 10. `DISCOVERY.md` reflects endpoint additions/removals
@@ -466,7 +466,7 @@ This is a first pass. Device testing comes next.
 3. Connect to a v{target_tag} server + at least one older supported server and walk the test plan.
 
 ### Version Updates (on this branch, not yet shipped)
-- SUPPORTED_BACKEND_VERSION: {old} → {new}
+- backendTargetVersion (version.properties): {old} → {new}
 - UPSTREAM_VERSION tag: {old_tag} → {new_tag}
 - Submodule: pinned to {target_tag}
 - DISCOVERY.md: {brief summary of what was appended}
@@ -503,7 +503,7 @@ Spawn teammates in parallel (single message, multiple Agent calls).
 | Situation | Recovery |
 |-----------|----------|
 | Submodule missing | `git submodule add https://github.com/danny-avila/LibreChat.git upstream` |
-| `UPSTREAM_VERSION` missing | Create from `SUPPORTED_BACKEND_VERSION` + submodule HEAD |
+| `UPSTREAM_VERSION` missing | Create from `version.properties` `backendTargetVersion` + submodule HEAD |
 | No newer tags | Report "up to date" and stop |
 | Dirty working tree | Ask user to commit/stash |
 | Git fetch fails | Show `git remote -v`, check network |
@@ -511,6 +511,6 @@ Spawn teammates in parallel (single message, multiple Agent calls).
 | iOS framework link fails (but Android passes) | Implementer likely forgot iosMain updates — message them to audit iosMain source sets for affected modules |
 | Detekt fails (any source set) | Implementer fixes findings. Do not use `--ignore-failures`. |
 | User cancels at Phase C | Delete or archive the proposal artifact, tear down the team (`TeamDelete`), stop cleanly |
-| Version mismatch (tracked tag ≠ BackendVersion.kt) | Ask user which is the true baseline |
+| Version mismatch (tracked tag ≠ version.properties backendTargetVersion) | Ask user which is the true baseline |
 | Session compacted mid-run | List `.claude/sync-upstream/artifacts/` — newest file indicates phase reached; resume from there |
 | Teammate unresponsive | Check task status, re-send message; sub-agent as last resort |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,6 +90,14 @@ jobs:
         id: bump
         run: ./scripts/bump-version.sh "${{ inputs.bump }}"
 
+      # Same source of truth the app reads (core/common codegen) — surfaced in the
+      # release notes so users know which LibreChat backend this build targets.
+      - name: Read backend target version
+        id: backend
+        run: |
+          v="$(grep '^backendTargetVersion=' version.properties | cut -d= -f2 | tr -d '[:space:]')"
+          echo "target=$v" >> "$GITHUB_OUTPUT"
+
       - name: Decode keystore
         env:
           KEYSTORE_BASE64: ${{ secrets.SIGNING_KEYSTORE_BASE64 }}
@@ -161,6 +169,8 @@ jobs:
           body: |
 
             ---
+            **Target backend:** LibreChat v${{ steps.backend.outputs.target }}
+
             [Build provenance attestation](${{ steps.attest.outputs.attestation-url }}) · [CI workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
           files: |
             ${{ steps.artifacts.outputs.apk }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,5 +63,5 @@ Each module has its own `CLAUDE.md` with specific guidance.
 
 - **`upstream/`** — Git submodule of the [official LibreChat repo](https://github.com/danny-avila/LibreChat). Read-only reference for API and web app parity. Do not modify.
 - **`UPSTREAM_VERSION`** — Tracks which official tag/commit this mobile build is based on. Updated by the `/sync-upstream` skill.
-- **`BackendVersion.kt`** (`core/common/`) — `SUPPORTED_BACKEND_VERSION` constant must match the tag in `UPSTREAM_VERSION` (without `v` prefix).
+- **`backendTargetVersion`** (root `version.properties`) — single source of truth for the targeted backend; must match the tag in `UPSTREAM_VERSION` (without `v` prefix). A core/common Gradle task code-generates `BackendVersion.SUPPORTED_BACKEND_VERSION` from it, and `release.yml` reads it for release notes. Edit the property, not the constant.
 - **`/sync-upstream`** — Claude Code skill to diff upstream releases, identify gaps, propose changes, and implement them with user approval. Uses Agent Teams (investigator, android-expert, implementer, verifier).

--- a/VERSION_GATES.md
+++ b/VERSION_GATES.md
@@ -16,6 +16,10 @@ The canonical API for version comparisons lives in
 The detected server version is exposed via `ConfigRepository.detectedBackendVersion`
 (populated once `checkBackendVersion()` runs on app startup / server-switch).
 
+`BackendVersion.SUPPORTED_BACKEND_VERSION` (the backend this build targets) is **generated**
+from `backendTargetVersion` in the root `version.properties` by core/common's
+`generateBackendVersion` Gradle task — bump that property, not the constant.
+
 ## Catalog
 
 | Feature | Gated since | Behavior on older | Behavior on newer | File:line | Safe to remove when min supported server ≥ |

--- a/core/common/build.gradle.kts
+++ b/core/common/build.gradle.kts
@@ -1,3 +1,5 @@
+import java.util.Properties
+
 plugins {
     id("librechat.kmp.library")
     id("librechat.kmp.koin")
@@ -13,6 +15,34 @@ fun gitSha(): String = runCatching {
     }.standardOutput.asText.get().trim()
 }.getOrNull()?.takeIf { it.isNotBlank() } ?: "unknown"
 
+// Single-source the target backend version: read `backendTargetVersion` from the root
+// version.properties and emit a commonMain constant both Android and iOS compile.
+// BuildConfig (how GIT_SHA is injected) is Android-only and can't reach iOS, so the
+// shared BackendVersion.SUPPORTED_BACKEND_VERSION must be sourced via codegen instead.
+// Config-cache-safe: the File/dir are captured at configuration time; the action never
+// touches project/rootProject/providers.
+val generateBackendVersion = tasks.register("generateBackendVersion") {
+    val versionFile = rootProject.file("version.properties")
+    val outputDir = layout.buildDirectory.dir("generated/backendVersion/commonMain/kotlin")
+    inputs.file(versionFile)
+    outputs.dir(outputDir)
+    doLast {
+        val props = Properties()
+        versionFile.inputStream().use { stream -> props.load(stream) }
+        val version = props.getProperty("backendTargetVersion")?.trim()?.takeIf { it.isNotEmpty() }
+            ?: error("backendTargetVersion missing or blank in version.properties")
+        val pkgDir = outputDir.get().dir("com/garfiec/librechat/core/common").asFile
+        pkgDir.mkdirs()
+        pkgDir.resolve("BackendTargetVersion.kt").writeText(
+            """
+            package com.garfiec.librechat.core.common
+
+            internal const val BACKEND_TARGET_VERSION = "$version"
+            """.trimIndent() + "\n",
+        )
+    }
+}
+
 android {
     namespace = "com.garfiec.librechat.core.common"
     buildFeatures {
@@ -25,9 +55,12 @@ android {
 
 kotlin {
     sourceSets {
-        commonMain.dependencies {
-            implementation(libs.coroutines.core)
-            api(libs.kotlinx.datetime)
+        commonMain {
+            kotlin.srcDir(generateBackendVersion)
+            dependencies {
+                implementation(libs.coroutines.core)
+                api(libs.kotlinx.datetime)
+            }
         }
         androidMain.dependencies {
             implementation(libs.coroutines.android)

--- a/core/common/src/commonMain/kotlin/com/garfiec/librechat/core/common/BackendVersion.kt
+++ b/core/common/src/commonMain/kotlin/com/garfiec/librechat/core/common/BackendVersion.kt
@@ -17,8 +17,12 @@ object BackendVersion {
      * The LibreChat backend version this app was built and tested against.
      * Matches the VERSION constant from the official LibreChat repo's
      * `packages/data-provider/src/config.ts` and `package.json`.
+     *
+     * Single source of truth: `backendTargetVersion` in the root `version.properties`,
+     * code-generated into [BACKEND_TARGET_VERSION] by core/common's `generateBackendVersion`
+     * task. Edit the property — not this literal — so the app and CI release notes stay in sync.
      */
-    const val SUPPORTED_BACKEND_VERSION = "0.8.5"
+    const val SUPPORTED_BACKEND_VERSION = BACKEND_TARGET_VERSION
 
     /**
      * Represents a parsed semantic version (major.minor.patch).

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -7,15 +7,20 @@ How releases are versioned, signed, and published for LibreChat Mobile (Android)
 The app version lives in **one place**: `version.properties` at the repo root.
 
 ```properties
-versionName=0.1.0   # human-facing semver — the only thing you bump
+versionName=0.1.0          # human-facing semver — the only thing you bump
+backendTargetVersion=0.8.5 # LibreChat backend this build targets (best-tested)
 ```
 
 - `AndroidApplicationConventionPlugin` reads `versionName` and **derives** `versionCode` as
   `MAJOR*10000 + MINOR*100 + PATCH` (digits XXYYZZ): `0.1.0` → `100`, `1.2.3` → `10203`.
   Monotonic as long as semver increases; limits are MINOR ≤ 99, PATCH ≤ 99.
 - The About screen reads the *installed* version via `AppInfo` (package metadata), so it can never drift.
-- This is the **app's** version and is intentionally independent of `SUPPORTED_BACKEND_VERSION`
-  (`core/common/BackendVersion.kt`), which tracks the LibreChat backend the app targets.
+- This is the **app's** version and is intentionally independent of `backendTargetVersion`.
+- `backendTargetVersion` is the **single source of truth** for the LibreChat backend the app
+  targets. The app reads it via `BackendVersion.SUPPORTED_BACKEND_VERSION` (code-generated from
+  this property by core/common's `generateBackendVersion` task), and `release.yml` reads the same
+  key to add a **Target backend:** line to each release's notes. Edit the property — never the
+  `SUPPORTED_BACKEND_VERSION` literal in `core/common/BackendVersion.kt` (it no longer exists as a literal).
 
 Both platforms derive from the same `versionName`, so they stay in lockstep:
 

--- a/version.properties
+++ b/version.properties
@@ -4,3 +4,8 @@
 # MAJOR*10000 + MINOR*100 + PATCH (digits XXYYZZ): 0.1.0 -> 100, 1.2.3 -> 10203.
 # This is the app's own version, independent of SUPPORTED_BACKEND_VERSION.
 versionName=0.1.2
+
+# LibreChat backend release this build targets — best-tested experience.
+# Read by the app (core/common codegen → BackendVersion.SUPPORTED_BACKEND_VERSION)
+# AND by release.yml for the "Target backend" line in release notes.
+backendTargetVersion=0.8.5


### PR DESCRIPTION
Closes #116.

## Problem

The LibreChat backend version a build targets lives only as a hardcoded `const val SUPPORTED_BACKEND_VERSION = "0.8.5"` in `BackendVersion.kt`, and release notes never state which backend a build expects — so Obtainium users have no signal about which server a given app release was tested against.

## Change

One source of truth, read by both the app and CI:

- **`version.properties`** gains `backendTargetVersion=0.8.5` — the single source of truth (sits alongside `versionName`, independent of it).
- **`core/common`** gets a config-cache-safe Gradle task (`generateBackendVersion`) that reads the key and generates a `commonMain` constant `BACKEND_TARGET_VERSION`. `SUPPORTED_BACKEND_VERSION` now delegates to it; all call sites unchanged.
- **`release.yml`** reads the same key and appends `**Target backend:** LibreChat vX.Y.Z` to the draft release-note footer.

`BuildConfig` (how `GIT_SHA` is injected) is Android-only and can't reach iOS, so the shared constant is code-generated into `commonMain`. Passing the task provider to `kotlin.srcDir(...)` auto-wires the implicit task dependency for every consumer (Android + both iOS compiles, metadata, detekt, kover) — no manual `dependsOn`.

To change the targeted backend, edit the property — not the Kotlin literal (which no longer exists).

## Scope

- No version *range* / minimum bound — single target only.
- `isCompatible` exact-match semantics unchanged.

## Validation

- `generateBackendVersion` emits `BACKEND_TARGET_VERSION = "0.8.5"`.
- `compileCommonMainKotlinMetadata` + `compileDebugKotlinAndroid` + `compileKotlinIosSimulatorArm64` all green — the generated constant compiles into both platforms.
- Config cache entry stored (task is config-cache-safe).
- The exact `release.yml` reader returns `0.8.5`; the release-note line is exercised on the next `workflow_dispatch` run.

Docs updated: `docs/RELEASING.md`, `VERSION_GATES.md`.