### PR TITLE
perf: move blocking work off the Main thread (#93)

### DIFF
--- a/app/src/main/kotlin/com/garfiec/librechat/MainActivity.kt
+++ b/app/src/main/kotlin/com/garfiec/librechat/MainActivity.kt
@@ -71,6 +71,10 @@ class MainActivity : ComponentActivity() {
         setContent {
             val windowSizeClass = calculateWindowSizeClass(this)
             val isConnected by connectivityObserver.isConnected.collectAsStateWithLifecycle(initialValue = true)
+            // Hold off drawing themed content until the persisted theme has resolved, so a
+            // dark-mode user on a light-system device never sees a one-frame flash of the wrong
+            // theme. The system window background covers the sub-frame gap.
+            val themeReady by themeDataStore.isReady.collectAsStateWithLifecycle()
             val themeMode by themeDataStore.themeMode.collectAsStateWithLifecycle(initialValue = themeDataStore.initialThemeMode)
             val darkTheme = when (themeMode) {
                 ThemeMode.LIGHT -> false
@@ -88,44 +92,46 @@ class MainActivity : ComponentActivity() {
                 insetsController.isAppearanceLightNavigationBars = !darkTheme
             }
 
-            LibreChatTheme(darkTheme = darkTheme) {
-                Surface(modifier = Modifier.fillMaxSize()) {
-                    Column(modifier = Modifier.fillMaxSize()) {
-                        AnimatedVisibility(
-                            visible = !isConnected,
-                            enter = expandVertically(),
-                            exit = shrinkVertically(),
-                        ) {
-                            Box(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .background(MaterialTheme.colorScheme.errorContainer)
-                                    .windowInsetsPadding(WindowInsets.statusBars)
-                                    .padding(vertical = 6.dp, horizontal = 16.dp),
-                                contentAlignment = Alignment.Center,
+            if (themeReady) {
+                LibreChatTheme(darkTheme = darkTheme) {
+                    Surface(modifier = Modifier.fillMaxSize()) {
+                        Column(modifier = Modifier.fillMaxSize()) {
+                            AnimatedVisibility(
+                                visible = !isConnected,
+                                enter = expandVertically(),
+                                exit = shrinkVertically(),
                             ) {
-                                Text(
-                                    text = stringResource(R.string.no_connection),
-                                    style = MaterialTheme.typography.labelMedium,
-                                    color = MaterialTheme.colorScheme.onErrorContainer,
-                                )
+                                Box(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .background(MaterialTheme.colorScheme.errorContainer)
+                                        .windowInsetsPadding(WindowInsets.statusBars)
+                                        .padding(vertical = 6.dp, horizontal = 16.dp),
+                                    contentAlignment = Alignment.Center,
+                                ) {
+                                    Text(
+                                        text = stringResource(R.string.no_connection),
+                                        style = MaterialTheme.typography.labelMedium,
+                                        color = MaterialTheme.colorScheme.onErrorContainer,
+                                    )
+                                }
                             }
+                            LibreChatNavHost(
+                                windowSizeClass = windowSizeClass,
+                                deepLinkUri = deepLinkUri,
+                                onDeepLinkConsume = { deepLinkUri = null },
+                                shareNavigationTrigger = shareNavigationTrigger,
+                                modifier = Modifier
+                                    .weight(1f)
+                                    .then(
+                                        if (!isConnected) {
+                                            Modifier.consumeWindowInsets(WindowInsets.statusBars)
+                                        } else {
+                                            Modifier
+                                        },
+                                    ),
+                            )
                         }
-                        LibreChatNavHost(
-                            windowSizeClass = windowSizeClass,
-                            deepLinkUri = deepLinkUri,
-                            onDeepLinkConsume = { deepLinkUri = null },
-                            shareNavigationTrigger = shareNavigationTrigger,
-                            modifier = Modifier
-                                .weight(1f)
-                                .then(
-                                    if (!isConnected) {
-                                        Modifier.consumeWindowInsets(WindowInsets.statusBars)
-                                    } else {
-                                        Modifier
-                                    },
-                                ),
-                        )
                     }
                 }
             }

--- a/app/src/main/kotlin/com/garfiec/librechat/navigation/TabletLayout.kt
+++ b/app/src/main/kotlin/com/garfiec/librechat/navigation/TabletLayout.kt
@@ -16,8 +16,10 @@ import androidx.compose.material3.VerticalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.input.pointer.pointerInput
@@ -55,7 +57,9 @@ fun TabletLayout(
     val dismissedBannerIds by navHostViewModel.dismissedBannerIds.collectAsStateWithLifecycle()
 
     // Persisted sidebar state from DataStore -- single source of truth in the ViewModel.
-    val isSidebarOpen by navHostViewModel.tabletSidebarOpen.collectAsStateWithLifecycle()
+    // Null until the persisted value resolves; treat unknown as closed for boolean callers.
+    val resolvedSidebarOpen by navHostViewModel.tabletSidebarOpen.collectAsStateWithLifecycle()
+    val isSidebarOpen = resolvedSidebarOpen == true
 
     // Whether swipe gesture is enabled (from settings)
     val gestureEnabled by navHostViewModel.tabletSidebarGestureEnabled.collectAsStateWithLifecycle()
@@ -64,7 +68,8 @@ fun TabletLayout(
     val sidebarWidthPx = with(density) { SidebarWidth.toPx() }
 
     // Animatable tracks sidebar reveal in pixels: 0 = closed, sidebarWidthPx = open.
-    val sidebarOffset = remember { Animatable(if (isSidebarOpen) sidebarWidthPx else 0f) }
+    val sidebarOffset = remember { Animatable(0f) }
+    var initialStateApplied by remember { mutableStateOf(false) }
     val scope = rememberCoroutineScope()
 
     // Back press closes sidebar before navigating away
@@ -72,11 +77,16 @@ fun TabletLayout(
         navHostViewModel.setTabletSidebarOpen(false)
     }
 
-    // Sync: when ViewModel state changes (e.g. hamburger button, back press),
-    // animate the sidebar to match.
-    LaunchedEffect(isSidebarOpen) {
-        val target = if (isSidebarOpen) sidebarWidthPx else 0f
-        if (sidebarOffset.value != target) {
+    // Sync: when ViewModel state changes (e.g. hamburger button, back press), animate the
+    // sidebar to match. The first resolved value is snapped (not animated) so a tablet that
+    // restores "open" doesn't visibly slide the sidebar in on every cold start.
+    LaunchedEffect(resolvedSidebarOpen) {
+        val resolved = resolvedSidebarOpen ?: return@LaunchedEffect
+        val target = if (resolved) sidebarWidthPx else 0f
+        if (!initialStateApplied) {
+            sidebarOffset.snapTo(target)
+            initialStateApplied = true
+        } else if (sidebarOffset.value != target) {
             sidebarOffset.animateTo(
                 targetValue = target,
                 animationSpec = spring(

--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/datastore/DataStoreRoundTripTest.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/datastore/DataStoreRoundTripTest.kt
@@ -4,6 +4,7 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.Preferences
 import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -40,6 +41,7 @@ class DataStoreRoundTripTest {
         val ds = createDataStore("server")
         val store = ServerDataStore(
             dataStore = ds,
+            appScope = CoroutineScope(testDispatcher),
             ioDispatcher = testDispatcher,
         )
 
@@ -54,6 +56,7 @@ class DataStoreRoundTripTest {
         val ds = createDataStore("server-slash")
         val store = ServerDataStore(
             dataStore = ds,
+            appScope = CoroutineScope(testDispatcher),
             ioDispatcher = testDispatcher,
         )
 
@@ -66,6 +69,7 @@ class DataStoreRoundTripTest {
         val ds = createDataStore("server-has")
         val store = ServerDataStore(
             dataStore = ds,
+            appScope = CoroutineScope(testDispatcher),
             ioDispatcher = testDispatcher,
         )
 
@@ -79,7 +83,7 @@ class DataStoreRoundTripTest {
     @Test
     fun themeDataStore_defaultIsSystem() = runTest(testDispatcher) {
         val ds = createDataStore("theme")
-        val store = ThemeDataStore(ds)
+        val store = ThemeDataStore(ds, CoroutineScope(testDispatcher), testDispatcher)
 
         assertThat(store.themeMode.first()).isEqualTo(ThemeMode.SYSTEM)
     }
@@ -87,7 +91,7 @@ class DataStoreRoundTripTest {
     @Test
     fun themeDataStore_roundTrip_allModes() = runTest(testDispatcher) {
         val ds = createDataStore("theme-all")
-        val store = ThemeDataStore(ds)
+        val store = ThemeDataStore(ds, CoroutineScope(testDispatcher), testDispatcher)
 
         store.setThemeMode(ThemeMode.LIGHT)
         assertThat(store.themeMode.first()).isEqualTo(ThemeMode.LIGHT)

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/ServerDataStore.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/ServerDataStore.kt
@@ -5,12 +5,18 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import com.garfiec.librechat.core.network.client.ServerUrlProvider
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlin.concurrent.Volatile
 
 /**
  * Optional fallback for reading/writing the server URL in a location
@@ -25,38 +31,74 @@ interface ServerUrlKeychainFallback {
 
 class ServerDataStore(
     private val dataStore: DataStore<Preferences>,
-    ioDispatcher: CoroutineDispatcher,
+    appScope: CoroutineScope,
+    private val ioDispatcher: CoroutineDispatcher,
     private val keychainFallback: ServerUrlKeychainFallback? = null,
 ) : ServerUrlProvider {
 
     private val _currentUrl = MutableStateFlow("")
     val currentUrlFlow: Flow<String> = _currentUrl
 
+    // Set once an explicit setServerUrl/clearServerUrl has run, so the async warm-up below
+    // never clobbers a caller's value with the stale persisted read if they raced. Guarded
+    // together with [_currentUrl] by [urlMutex] so the warm-up's check-then-set is atomic
+    // against a concurrent set/clear (a plain @Volatile only guarantees visibility).
+    @Volatile
+    private var urlExplicitlySet = false
+    private val urlMutex = Mutex()
+
+    // Completes once the async warm-up has resolved (success, failure, or cancellation), so
+    // [awaitBaseUrl] callers on the startup path never observe the empty pre-warm-up value.
+    private val warmedUp = CompletableDeferred<Unit>()
+
     init {
-        // Load the persisted URL synchronously so getBaseUrl() is ready
-        // immediately after construction. This is a singleton created once
-        // at app startup, so a brief block is acceptable.
-        var url = runBlocking(ioDispatcher) {
-            dataStore.data
-                .map { prefs -> prefs[KEY_SERVER_URL].orEmpty() }
-                .first()
-        }
-        // If DataStore is empty (e.g. after reinstall), try the Keychain fallback.
-        // Keychain items persist across iOS app reinstalls.
-        if (url.isBlank() && keychainFallback != null) {
-            val restored = keychainFallback.readServerUrl()
-            if (!restored.isNullOrBlank()) {
-                url = restored
-                // Re-persist to DataStore so subsequent reads don't need the fallback
-                runBlocking(ioDispatcher) {
-                    dataStore.edit { prefs -> prefs[KEY_SERVER_URL] = restored }
+        // Warm up the persisted URL asynchronously off the Main thread. Koin instantiates
+        // this singleton on Main at startup, so the read must not block. getBaseUrl() reads
+        // are lazy (per HTTP request / inside viewModelScope launches) and only happen after
+        // the first frame, by which point this warm-up has resolved.
+        appScope.launch(ioDispatcher) {
+            try {
+                var url = dataStore.data
+                    .map { prefs -> prefs[KEY_SERVER_URL].orEmpty() }
+                    .first()
+                // If DataStore is empty (e.g. after reinstall), try the Keychain fallback.
+                // Keychain items persist across iOS app reinstalls.
+                var restoredFromKeychain = false
+                if (url.isBlank() && keychainFallback != null) {
+                    val restored = keychainFallback.readServerUrl()
+                    if (!restored.isNullOrBlank()) {
+                        url = restored
+                        restoredFromKeychain = true
+                    }
                 }
+                // Don't overwrite (or re-persist) a URL a caller set/cleared while the warm-up
+                // was in flight. The keychain re-persist must also sit under the lock + flag,
+                // otherwise a clearServerUrl() that raced the read could be resurrected on disk.
+                urlMutex.withLock {
+                    if (!urlExplicitlySet) {
+                        _currentUrl.value = url
+                        // Re-persist the keychain-restored URL so subsequent reads skip the fallback.
+                        if (restoredFromKeychain) {
+                            dataStore.edit { prefs -> prefs[KEY_SERVER_URL] = url }
+                        }
+                    }
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (_: Exception) {
+                // Leave the URL empty; onboarding will prompt for a server URL.
+            } finally {
+                warmedUp.complete(Unit)
             }
         }
-        _currentUrl.value = url
     }
 
     override fun getBaseUrl(): String = _currentUrl.value
+
+    override suspend fun awaitBaseUrl(): String {
+        warmedUp.await()
+        return _currentUrl.value
+    }
 
     fun hasServerUrl(): Flow<Boolean> =
         dataStore.data.map { prefs ->
@@ -65,7 +107,10 @@ class ServerDataStore(
 
     suspend fun setServerUrl(url: String) {
         val trimmed = url.trimEnd('/')
-        _currentUrl.value = trimmed
+        urlMutex.withLock {
+            urlExplicitlySet = true
+            _currentUrl.value = trimmed
+        }
         dataStore.edit { prefs ->
             prefs[KEY_SERVER_URL] = trimmed
         }
@@ -77,7 +122,10 @@ class ServerDataStore(
      * Clear the server URL from both DataStore and Keychain fallback.
      */
     suspend fun clearServerUrl() {
-        _currentUrl.value = ""
+        urlMutex.withLock {
+            urlExplicitlySet = true
+            _currentUrl.value = ""
+        }
         dataStore.edit { prefs -> prefs.remove(KEY_SERVER_URL) }
         keychainFallback?.removeServerUrl()
     }

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/ThemeDataStore.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/ThemeDataStore.kt
@@ -4,23 +4,55 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.IO
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.launch
+import kotlin.concurrent.Volatile
 
 class ThemeDataStore(
     private val dataStore: DataStore<Preferences>,
+    appScope: CoroutineScope,
+    ioDispatcher: CoroutineDispatcher,
 ) {
 
     /**
-     * Synchronously loaded initial value so the first compose frame uses the correct theme
-     * and avoids a flash of light mode when the user has dark mode saved.
+     * Initial value seeded for the first compose frame. Warmed up asynchronously off the
+     * Main thread (Koin instantiates this singleton on Main at startup, so the read must not
+     * block). Until the warm-up resolves it stays [ThemeMode.SYSTEM]; callers gate themed
+     * content on [isReady] so the persisted value is in place before the first frame draws.
      */
-    val initialThemeMode: ThemeMode = runBlocking(Dispatchers.IO) {
-        dataStore.data.map { prefs -> prefs[KEY_THEME].toThemeMode() }.first()
+    @Volatile
+    var initialThemeMode: ThemeMode = ThemeMode.SYSTEM
+        private set
+
+    private val _isReady = MutableStateFlow(false)
+
+    /**
+     * Flips true once the async warm-up has resolved [initialThemeMode] (success, failure, or
+     * cancellation). The root composable holds off drawing themed content until this is true so
+     * a dark-mode user on a light-system device never sees a first-frame flash of the wrong theme.
+     */
+    val isReady: StateFlow<Boolean> = _isReady.asStateFlow()
+
+    init {
+        appScope.launch(ioDispatcher) {
+            try {
+                initialThemeMode = dataStore.data.map { prefs -> prefs[KEY_THEME].toThemeMode() }.first()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (_: Exception) {
+                // Keep the default; the themeMode flow still drives the live UI value.
+            } finally {
+                _isReady.value = true
+            }
+        }
     }
 
     val themeMode: Flow<ThemeMode> = dataStore.data.map { prefs ->

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/di/DataModule.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/di/DataModule.kt
@@ -92,11 +92,18 @@ val dataModule = module {
     single {
         ServerDataStore(
             dataStore = get(),
+            appScope = get<CoroutineScope>(KoinQualifiers.ApplicationScope),
             ioDispatcher = get(KoinQualifiers.IO),
             keychainFallback = getOrNull(),
         )
     } bind ServerUrlProvider::class
-    singleOf(::ThemeDataStore)
+    single {
+        ThemeDataStore(
+            dataStore = get(),
+            appScope = get<CoroutineScope>(KoinQualifiers.ApplicationScope),
+            ioDispatcher = get(KoinQualifiers.IO),
+        )
+    }
     singleOf(::ConfigCacheDataStore)
     singleOf(::RoleCacheDataStore)
     singleOf(::SettingsDataStore)
@@ -145,6 +152,15 @@ val dataModule = module {
             chatApi = get(),
             sseClient = get(),
             connectivityObserver = get(),
+            dispatcher = get(KoinQualifiers.Default),
+        )
+    }
+
+    single<MessageRepository> {
+        MessageRepositoryImpl(
+            messagesApi = get(),
+            messageDao = get(),
+            dispatcher = get(KoinQualifiers.Default),
         )
     }
 
@@ -160,7 +176,6 @@ val dataModule = module {
     singleOf(::BalanceRepositoryImpl) bind BalanceRepository::class
     singleOf(::ConfigRepositoryImpl) bind ConfigRepository::class
     singleOf(::ConversationRepositoryImpl) bind ConversationRepository::class
-    singleOf(::MessageRepositoryImpl) bind MessageRepository::class
     singleOf(::FileRepositoryImpl) bind FileRepository::class
     singleOf(::AgentRepositoryImpl) bind AgentRepository::class
     singleOf(::AgentToolsRepositoryImpl) bind AgentToolsRepository::class

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/ChatRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/ChatRepositoryImpl.kt
@@ -10,14 +10,17 @@ import com.garfiec.librechat.core.model.request.EphemeralAgent
 import com.garfiec.librechat.core.model.response.ChatStatusResponse
 import com.garfiec.librechat.core.network.api.ChatApi
 import com.garfiec.librechat.core.network.sse.SseClient
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
 
 class ChatRepositoryImpl(
     private val chatApi: ChatApi,
     private val sseClient: SseClient,
     private val connectivityObserver: ConnectivityObserver,
+    private val dispatcher: CoroutineDispatcher,
 ) : ChatRepository {
 
     override fun startChat(
@@ -75,7 +78,7 @@ class ChatRepositoryImpl(
         // Phase 2: GET the SSE stream using the streamId
         val streamUrl = "api/agents/chat/stream/$streamId"
         emitAll(sseClient.connect(streamUrl, connectivityFlow = connectivityObserver.isConnected))
-    }
+    }.flowOn(dispatcher)
 
     override suspend fun abortChat(streamId: String): Result<Unit> = safeApiCall {
         chatApi.abortChat(streamId)
@@ -88,5 +91,5 @@ class ChatRepositoryImpl(
     override fun resumeStream(conversationId: String): Flow<StreamEvent> = flow {
         val streamUrl = "api/agents/chat/stream/$conversationId"
         emitAll(sseClient.connect(streamUrl, resume = true, connectivityFlow = connectivityObserver.isConnected))
-    }
+    }.flowOn(dispatcher)
 }

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/MessageRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/MessageRepositoryImpl.kt
@@ -10,18 +10,22 @@ import com.garfiec.librechat.core.model.Message
 import com.garfiec.librechat.core.model.request.BranchMessageRequest
 import com.garfiec.librechat.core.model.request.UpdateMessageRequest
 import com.garfiec.librechat.core.network.api.MessagesApi
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 
 class MessageRepositoryImpl(
     private val messagesApi: MessagesApi,
     private val messageDao: MessageDao,
+    private val dispatcher: CoroutineDispatcher,
 ) : MessageRepository {
 
     override fun observeMessages(conversationId: String): Flow<List<Message>> {
         return messageDao.getMessagesForConversation(conversationId)
             .map { entities -> entities.toModels() }
+            .flowOn(dispatcher)
     }
 
     override suspend fun getMessages(conversationId: String): Result<List<Message>> {

--- a/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/LibreChatHttpClient.kt
+++ b/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/LibreChatHttpClient.kt
@@ -66,6 +66,12 @@ object LibreChatHttpClient {
             this.tokenManager = tokenManager
         }
 
+        // Resolve the server-URL warm-up before defaultRequest reads getBaseUrl(), so a
+        // cold-start request can't be built against an empty base URL.
+        install(ServerUrlReadyPlugin) {
+            this.serverUrlProvider = serverUrlProvider
+        }
+
         HttpResponseValidator {
             validateResponse { response ->
                 if (!response.status.isSuccess()) {

--- a/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/ServerUrlProvider.kt
+++ b/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/ServerUrlProvider.kt
@@ -2,4 +2,13 @@ package com.garfiec.librechat.core.network.client
 
 interface ServerUrlProvider {
     fun getBaseUrl(): String
+
+    /**
+     * Suspends until the server URL has been resolved (e.g. the implementation's async
+     * warm-up of the persisted value finishes), then returns it. Startup-path coroutines
+     * that must not race the warm-up window — where [getBaseUrl] can transiently be empty —
+     * should await this instead of reading [getBaseUrl] directly. Defaults to [getBaseUrl]
+     * for implementations that resolve eagerly.
+     */
+    suspend fun awaitBaseUrl(): String = getBaseUrl()
 }

--- a/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/ServerUrlReadyPlugin.kt
+++ b/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/ServerUrlReadyPlugin.kt
@@ -1,0 +1,43 @@
+package com.garfiec.librechat.core.network.client
+
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.HttpClientPlugin
+import io.ktor.client.request.HttpRequestPipeline
+import io.ktor.util.AttributeKey
+import io.ktor.util.pipeline.PipelinePhase
+
+/**
+ * Awaits the server URL's async warm-up before each request is built.
+ *
+ * [ServerDataStore] resolves the persisted base URL asynchronously off the Main thread, so
+ * during a narrow cold-start window [ServerUrlProvider.getBaseUrl] (which the non-suspend
+ * `defaultRequest` block reads) can transiently return an empty string. Rather than relying on
+ * every individual caller to remember to await, this plugin resolves the readiness at the
+ * network layer: it runs in a phase inserted *before* [HttpRequestPipeline.Before] — where
+ * Ktor's `DefaultRequest` applies the URL — so by the time `defaultRequest` reads
+ * `getBaseUrl()` the warm-up has completed. After warm-up it is a no-op suspension point.
+ */
+class ServerUrlReadyPlugin private constructor(
+    private val serverUrlProvider: ServerUrlProvider,
+) {
+    class Config {
+        lateinit var serverUrlProvider: ServerUrlProvider
+    }
+
+    companion object : HttpClientPlugin<Config, ServerUrlReadyPlugin> {
+        override val key = AttributeKey<ServerUrlReadyPlugin>("ServerUrlReady")
+        private val AwaitServerUrlPhase = PipelinePhase("AwaitServerUrl")
+
+        override fun prepare(block: Config.() -> Unit): ServerUrlReadyPlugin {
+            val config = Config().apply(block)
+            return ServerUrlReadyPlugin(config.serverUrlProvider)
+        }
+
+        override fun install(plugin: ServerUrlReadyPlugin, scope: HttpClient) {
+            scope.requestPipeline.insertPhaseBefore(HttpRequestPipeline.Before, AwaitServerUrlPhase)
+            scope.requestPipeline.intercept(AwaitServerUrlPhase) {
+                plugin.serverUrlProvider.awaitBaseUrl()
+            }
+        }
+    }
+}

--- a/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/di/NetworkModule.kt
+++ b/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/di/NetworkModule.kt
@@ -29,6 +29,7 @@ import com.garfiec.librechat.core.network.api.UserApi
 import com.garfiec.librechat.core.network.client.AuthInterceptorPlugin
 import com.garfiec.librechat.core.network.client.LibreChatHttpClient
 import com.garfiec.librechat.core.network.client.ServerUrlProvider
+import com.garfiec.librechat.core.network.client.ServerUrlReadyPlugin
 import com.garfiec.librechat.core.network.client.TokenManager
 import com.garfiec.librechat.core.network.sse.SseClient
 import io.ktor.client.HttpClient
@@ -79,6 +80,9 @@ val networkModule = module {
             install(AuthInterceptorPlugin) {
                 this.tokenManager = tokenManager
             }
+            install(ServerUrlReadyPlugin) {
+                this.serverUrlProvider = serverUrlProvider
+            }
             install(HttpTimeout) {
                 connectTimeoutMillis = 10_000
                 requestTimeoutMillis = Long.MAX_VALUE
@@ -100,6 +104,9 @@ val networkModule = module {
         val engineFactory = get<HttpClientEngineFactory<*>>()
         HttpClient(engineFactory) {
             install(ContentNegotiation) { json(json) }
+            install(ServerUrlReadyPlugin) {
+                this.serverUrlProvider = serverUrlProvider
+            }
             install(HttpTimeout) {
                 requestTimeoutMillis = 15_000
                 connectTimeoutMillis = 10_000

--- a/core/network/src/iosMain/kotlin/com/garfiec/librechat/core/network/sse/SseHttpTransport.ios.kt
+++ b/core/network/src/iosMain/kotlin/com/garfiec/librechat/core/network/sse/SseHttpTransport.ios.kt
@@ -137,7 +137,9 @@ actual class SseHttpTransport(
         // them. ServerUrlProvider may or may not return a trailing slash, and
         // SseClient passes the stream path without a leading slash, matching
         // how ChatRepositoryImpl builds it ("api/agents/chat/stream/$streamId").
-        val baseUrl = serverUrlProvider.getBaseUrl().trimEnd('/')
+        // awaitBaseUrl (not getBaseUrl) so a reconnect during the warm-up window can't
+        // build the SSE URL against an empty host.
+        val baseUrl = serverUrlProvider.awaitBaseUrl().trimEnd('/')
         val normalizedPath = streamPath.trimStart('/')
         val queryString = if (resume) "?resume=true" else ""
         val fullUrl = "$baseUrl/$normalizedPath$queryString"

--- a/feature/agents/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/agents/di/AgentsModuleVerificationTest.kt
+++ b/feature/agents/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/agents/di/AgentsModuleVerificationTest.kt
@@ -11,6 +11,7 @@ import com.garfiec.librechat.core.data.repository.McpRepository
 import com.garfiec.librechat.core.data.repository.PermissionsRepository
 import com.garfiec.librechat.core.data.repository.RoleRepository
 import com.garfiec.librechat.core.data.util.PermissionGate
+import kotlinx.coroutines.CoroutineDispatcher
 import org.junit.Test
 import org.koin.test.verify.verify
 
@@ -30,6 +31,8 @@ class AgentsModuleVerificationTest {
                 RoleRepository::class,
                 PermissionGate::class,
                 ServerDataStore::class,
+                // Provided by core:common CommonModule via KoinQualifiers.IO.
+                CoroutineDispatcher::class,
             ),
         )
     }

--- a/feature/agents/src/commonMain/kotlin/com/garfiec/librechat/feature/agents/di/AgentsModule.kt
+++ b/feature/agents/src/commonMain/kotlin/com/garfiec/librechat/feature/agents/di/AgentsModule.kt
@@ -1,5 +1,6 @@
 package com.garfiec.librechat.feature.agents.di
 
+import com.garfiec.librechat.core.common.di.KoinQualifiers
 import com.garfiec.librechat.feature.agents.viewmodel.AgentAclViewModel
 import com.garfiec.librechat.feature.agents.viewmodel.AgentDetailViewModel
 import com.garfiec.librechat.feature.agents.viewmodel.AgentEditorViewModel
@@ -38,6 +39,7 @@ val agentsModule = module {
             agentToolsRepository = get(),
             fileRepository = get(),
             contentReader = get(),
+            ioDispatcher = get(KoinQualifiers.IO),
             initialAgentId = params.getOrNull(),
         )
     }

--- a/feature/agents/src/commonMain/kotlin/com/garfiec/librechat/feature/agents/viewmodel/AgentEditorViewModel.kt
+++ b/feature/agents/src/commonMain/kotlin/com/garfiec/librechat/feature/agents/viewmodel/AgentEditorViewModel.kt
@@ -41,6 +41,8 @@ import com.garfiec.librechat.feature.agents.components.model.SupportContactState
 import com.garfiec.librechat.feature.agents.components.model.buildAgentVersionList
 import com.garfiec.librechat.feature.agents.util.ContentReader
 import com.garfiec.librechat.feature.agents.util.OpenApiSpecParser
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -48,6 +50,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
@@ -197,6 +200,7 @@ class AgentEditorViewModel(
     private val agentToolsRepository: AgentToolsRepository,
     private val fileRepository: FileRepository,
     private val contentReader: ContentReader,
+    private val ioDispatcher: CoroutineDispatcher,
     initialAgentId: String? = null,
 ) : ViewModel() {
 
@@ -992,7 +996,10 @@ class AgentEditorViewModel(
         val agentId = _uiState.value.agentId ?: return
         viewModelScope.launch {
             try {
-                val bytes = contentReader.readBytes(uri) ?: return@launch
+                // Reading bytes off the URI is blocking I/O — keep it off the Main
+                // dispatcher (viewModelScope = Main.immediate) to avoid an ANR on
+                // large images. Mirrors the #92 FileAttachmentDelegate fix.
+                val bytes = withContext(ioDispatcher) { contentReader.readBytes(uri) } ?: return@launch
                 if (bytes.size > AVATAR_SIZE_LIMIT_BYTES) {
                     val limitMb = AVATAR_SIZE_LIMIT_BYTES / (1024 * 1024)
                     _uiState.value = _uiState.value.copy(
@@ -1015,6 +1022,9 @@ class AgentEditorViewModel(
                     }
                     is Result.Loading -> { /* no-op */ }
                 }
+            } catch (e: CancellationException) {
+                // Cooperative cancellation must propagate (SKIE/iOS requirement).
+                throw e
             } catch (e: Exception) {
                 _uiState.value = _uiState.value.copy(
                     error = "Failed to read image: ${e.message}",

--- a/feature/auth/src/commonMain/kotlin/com/garfiec/librechat/feature/auth/viewmodel/ServerUrlViewModel.kt
+++ b/feature/auth/src/commonMain/kotlin/com/garfiec/librechat/feature/auth/viewmodel/ServerUrlViewModel.kt
@@ -31,7 +31,9 @@ class ServerUrlViewModel(
 
     init {
         viewModelScope.launch {
-            val existingUrl = serverDataStore.getBaseUrl()
+            // awaitBaseUrl (not getBaseUrl) so a cold-start relaunch doesn't read "" before
+            // ServerDataStore's async warm-up resolves, which would skip pre-filling the saved URL.
+            val existingUrl = serverDataStore.awaitBaseUrl()
             if (existingUrl.isNotBlank()) {
                 _uiState.value = _uiState.value.copy(
                     url = existingUrl,

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/audio/VoiceRecorder.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/audio/VoiceRecorder.kt
@@ -4,14 +4,24 @@ import android.content.Context
 import android.media.MediaRecorder
 import android.os.Build
 import co.touchlab.kermit.Logger
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.withContext
 import java.io.File
 
 /**
  * Manages audio recording using Android's MediaRecorder.
  * Records to a temporary file in the app's cache directory, returning
  * the raw bytes when stopped. Uses OGG/Opus on API 29+ and 3GP/AMR_NB on older devices.
+ *
+ * [prepare]/[start] and the final [stop] file read run on [ioDispatcher] so the
+ * recorder setup and disk read never block the Main thread.
  */
-class VoiceRecorder(private val context: Context) {
+class VoiceRecorder(
+    private val context: Context,
+    private val ioDispatcher: CoroutineDispatcher,
+) {
 
     private var mediaRecorder: MediaRecorder? = null
     private var outputFile: File? = null
@@ -27,7 +37,7 @@ class VoiceRecorder(private val context: Context) {
             "audio/3gpp"
         }
 
-    fun start() {
+    suspend fun start() {
         if (isCurrentlyRecording) return
 
         val extension = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) "ogg" else "3gp"
@@ -35,31 +45,37 @@ class VoiceRecorder(private val context: Context) {
         outputFile = File(voiceRecordingDir, "voice_recording_${System.currentTimeMillis()}.$extension")
 
         try {
-            val recorder = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                MediaRecorder(context)
-            } else {
-                @Suppress("DEPRECATION")
-                MediaRecorder()
-            }
-
-            recorder.apply {
-                setAudioSource(MediaRecorder.AudioSource.MIC)
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                    setOutputFormat(MediaRecorder.OutputFormat.OGG)
-                    setAudioEncoder(MediaRecorder.AudioEncoder.OPUS)
+            val recorder = withContext(ioDispatcher) {
+                val recorder = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                    MediaRecorder(context)
                 } else {
-                    setOutputFormat(MediaRecorder.OutputFormat.THREE_GPP)
-                    setAudioEncoder(MediaRecorder.AudioEncoder.AMR_NB)
+                    @Suppress("DEPRECATION")
+                    MediaRecorder()
                 }
-                setAudioSamplingRate(16_000)
-                setAudioChannels(1)
-                setOutputFile(outputFile?.absolutePath)
-                prepare()
-                start()
+
+                recorder.apply {
+                    setAudioSource(MediaRecorder.AudioSource.MIC)
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                        setOutputFormat(MediaRecorder.OutputFormat.OGG)
+                        setAudioEncoder(MediaRecorder.AudioEncoder.OPUS)
+                    } else {
+                        setOutputFormat(MediaRecorder.OutputFormat.THREE_GPP)
+                        setAudioEncoder(MediaRecorder.AudioEncoder.AMR_NB)
+                    }
+                    setAudioSamplingRate(16_000)
+                    setAudioChannels(1)
+                    setOutputFile(outputFile?.absolutePath)
+                    prepare()
+                    start()
+                }
+                recorder
             }
 
             mediaRecorder = recorder
             isCurrentlyRecording = true
+        } catch (e: CancellationException) {
+            cleanup()
+            throw e
         } catch (e: Exception) {
             Logger.e(e) { "Failed to start voice recording" }
             cleanup()
@@ -67,22 +83,27 @@ class VoiceRecorder(private val context: Context) {
         }
     }
 
-    fun stop(): ByteArray? {
+    suspend fun stop(): ByteArray? {
         if (!isCurrentlyRecording) return null
 
         return try {
-            mediaRecorder?.apply {
-                stop()
-                release()
-            }
-            mediaRecorder = null
-            isCurrentlyRecording = false
+            withContext(ioDispatcher) {
+                mediaRecorder?.apply {
+                    stop()
+                    release()
+                }
+                mediaRecorder = null
+                isCurrentlyRecording = false
 
-            val file = outputFile
-            val bytes = file?.readBytes()
-            file?.delete()
-            outputFile = null
-            bytes
+                val file = outputFile
+                val bytes = file?.readBytes()
+                file?.delete()
+                outputFile = null
+                bytes
+            }
+        } catch (e: CancellationException) {
+            cleanup()
+            throw e
         } catch (e: Exception) {
             Logger.e(e) { "Failed to stop voice recording" }
             cleanup()
@@ -90,22 +111,27 @@ class VoiceRecorder(private val context: Context) {
         }
     }
 
-    fun cancel() {
+    suspend fun cancel() {
         cleanup()
     }
 
-    private fun cleanup() {
-        try {
-            mediaRecorder?.apply {
-                stop()
-                release()
+    // Runs the blocking MediaRecorder.stop()/release() + file delete off the Main thread.
+    // NonCancellable so it still completes when invoked from a cancelled coroutine (the
+    // CancellationException catch blocks above) — otherwise the recorder would leak.
+    private suspend fun cleanup() {
+        withContext(ioDispatcher + NonCancellable) {
+            try {
+                mediaRecorder?.apply {
+                    stop()
+                    release()
+                }
+            } catch (_: Exception) {
+                // Recorder may not have been started
             }
-        } catch (_: Exception) {
-            // Recorder may not have been started
+            mediaRecorder = null
+            isCurrentlyRecording = false
+            outputFile?.delete()
+            outputFile = null
         }
-        mediaRecorder = null
-        isCurrentlyRecording = false
-        outputFile?.delete()
-        outputFile = null
     }
 }

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/components/AudioContent.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/components/AudioContent.kt
@@ -10,6 +10,8 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -22,6 +24,8 @@ import androidx.media3.datasource.ByteArrayDataSource
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.source.ProgressiveMediaSource
 import androidx.media3.ui.PlayerView
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 @OptIn(UnstableApi::class)
 @Composable
@@ -42,15 +46,22 @@ actual fun AudioContent(
         else -> "audio/wav"
     }
 
-    val exoPlayer = remember(data) {
-        val audioBytes = try {
-            Base64.decode(data, Base64.DEFAULT)
-        } catch (_: IllegalArgumentException) {
-            return@remember null
+    // Base64 decode is heavy for large clips; do it off the composition thread.
+    val audioBytes by produceState<ByteArray?>(initialValue = null, data) {
+        value = withContext(Dispatchers.Default) {
+            try {
+                Base64.decode(data, Base64.DEFAULT)
+            } catch (_: IllegalArgumentException) {
+                null
+            }
         }
+    }
 
-        val dataSource = ByteArrayDataSource(audioBytes)
-
+    // ExoPlayer must be created/accessed on the thread it will be used (Main); keep it here,
+    // built only once the decoded bytes are available.
+    val exoPlayer = remember(audioBytes) {
+        val bytes = audioBytes ?: return@remember null
+        val dataSource = ByteArrayDataSource(bytes)
         ExoPlayer.Builder(context).build().apply {
             val mediaSource = ProgressiveMediaSource.Factory { dataSource }
                 .createMediaSource(MediaItem.fromUri("data:$mimeType;base64,placeholder"))

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/components/AudioContentPlayer.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/components/AudioContentPlayer.kt
@@ -27,6 +27,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -36,7 +37,9 @@ import androidx.compose.ui.unit.dp
 import co.touchlab.kermit.Logger
 import com.garfiec.librechat.feature.chat.resources.*
 import com.garfiec.librechat.feature.chat.resources.Res
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
 import org.jetbrains.compose.resources.stringResource
 import java.io.File
 import java.util.Locale
@@ -188,19 +191,23 @@ actual fun AudioContentPlayerFromBytes(
     modifier: Modifier,
 ) {
     val context = LocalContext.current
-    val tempFile = remember(audioBytes) {
-        val audioDir = File(context.cacheDir, "audio").apply { mkdirs() }
-        File.createTempFile("audio_", ".mp3", audioDir).apply {
-            writeBytes(audioBytes)
+    // Writing the temp file is blocking; do it off the composition thread.
+    val tempFile by produceState<File?>(initialValue = null, audioBytes) {
+        value = withContext(Dispatchers.IO) {
+            val audioDir = File(context.cacheDir, "audio").apply { mkdirs() }
+            File.createTempFile("audio_", ".mp3", audioDir).apply {
+                writeBytes(audioBytes)
+            }
         }
     }
-    DisposableEffect(tempFile) {
+    val file = tempFile ?: return
+    DisposableEffect(file) {
         onDispose {
-            tempFile.delete()
+            file.delete()
         }
     }
     AudioContentPlayer(
-        audioUrl = tempFile.absolutePath,
+        audioUrl = file.absolutePath,
         modifier = modifier,
     )
 }

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/components/FullscreenImageViewer.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/components/FullscreenImageViewer.kt
@@ -270,14 +270,16 @@ actual fun FullscreenImageViewer(
                                     ?: return@launch
 
                                 val imagesDir = File(context.cacheDir, "shared_images")
-                                imagesDir.mkdirs()
                                 val imageFile = File(
                                     imagesDir,
                                     "shared_image_${System.currentTimeMillis()}.png",
                                 )
                                 try {
-                                    imageFile.outputStream().use { out ->
-                                        bitmap.compress(Bitmap.CompressFormat.PNG, 100, out)
+                                    withContext(Dispatchers.IO) {
+                                        imagesDir.mkdirs()
+                                        imageFile.outputStream().use { out ->
+                                            bitmap.compress(Bitmap.CompressFormat.PNG, 100, out)
+                                        }
                                     }
                                 } finally {
                                     bitmap.recycle()

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/ArtifactDownloadHelper.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/ArtifactDownloadHelper.kt
@@ -6,6 +6,8 @@ import android.net.Uri
 import android.os.Handler
 import android.os.Looper
 import androidx.core.content.FileProvider
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import java.io.File
 
 /**
@@ -21,7 +23,7 @@ object ArtifactDownloadHelper {
     /** Files older than this are considered stale and cleaned up opportunistically. */
     private const val STALE_THRESHOLD_MS = 60_000L
 
-    fun share(context: Context, artifact: Artifact) {
+    suspend fun share(context: Context, artifact: Artifact) {
         val intent = try {
             shareViaFile(context, artifact)
         } catch (_: Exception) {
@@ -30,11 +32,15 @@ object ArtifactDownloadHelper {
         context.startActivity(Intent.createChooser(intent, "Share artifact"))
     }
 
-    private fun shareViaFile(context: Context, artifact: Artifact): Intent {
+    private suspend fun shareViaFile(context: Context, artifact: Artifact): Intent {
         val extension = extensionForArtifact(artifact)
         val fileName = sanitizeFileName(artifact.title) + extension
-        val dir = File(context.cacheDir, "artifacts").apply { mkdirs() }
-        val file = File(dir, fileName).apply { writeText(artifact.content) }
+        val dir = File(context.cacheDir, "artifacts")
+        val file = File(dir, fileName)
+        withContext(Dispatchers.IO) {
+            dir.mkdirs()
+            file.writeText(artifact.content)
+        }
 
         // Schedule cleanup: delete this file and any stale artifacts after a delay
         scheduleCleanup(file, dir)

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/ArtifactPanel.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/ArtifactPanel.kt
@@ -159,10 +159,12 @@ private fun ArtifactPanelContent(
             Spacer(modifier = Modifier.weight(1f))
             IconButton(
                 onClick = {
-                    ArtifactDownloadHelper.share(
-                        context = context,
-                        artifact = currentArtifact,
-                    )
+                    scope.launch {
+                        ArtifactDownloadHelper.share(
+                            context = context,
+                            artifact = currentArtifact,
+                        )
+                    }
                 },
                 modifier = Modifier.size(36.dp),
             ) {

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/di/ChatPlatformModule.android.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/di/ChatPlatformModule.android.kt
@@ -42,6 +42,7 @@ actual val chatPlatformModule: Module = module {
             serverDataStore = get(),
             settingsDataStore = get(),
             platformDelegateFactory = get(),
+            defaultDispatcher = get(KoinQualifiers.Default),
         )
     }
 }

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/AndroidDelegateFactory.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/AndroidDelegateFactory.kt
@@ -39,6 +39,7 @@ class AndroidDelegateFactory(
                 speechRepository = speechRepository,
                 autoSendAfterStt = settingsDataStore.autoSendAfterStt
                     .stateIn(stateHandle.scope, SharingStarted.Eagerly, false),
+                ioDispatcher = ioDispatcher,
                 onTranscriptionComplete = onTranscriptionComplete,
             ),
         )
@@ -54,6 +55,7 @@ class AndroidDelegateFactory(
                 appContext = appContext,
                 speechRepository = speechRepository,
                 settingsDataStore = settingsDataStore,
+                ioDispatcher = ioDispatcher,
                 getMessageText = getMessageText,
             ),
         )

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/TextToSpeechDelegate.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/TextToSpeechDelegate.kt
@@ -9,8 +9,11 @@ import com.garfiec.librechat.core.common.result.Result
 import com.garfiec.librechat.core.data.datastore.SettingsDataStore
 import com.garfiec.librechat.core.data.repository.SpeechRepository
 import com.garfiec.librechat.feature.chat.viewmodel.ChatStateHandle
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.io.File
 
 class TextToSpeechDelegate(
@@ -18,6 +21,7 @@ class TextToSpeechDelegate(
     private val appContext: Context,
     private val speechRepository: SpeechRepository,
     private val settingsDataStore: SettingsDataStore,
+    private val ioDispatcher: CoroutineDispatcher,
     private val getMessageText: (String) -> String,
 ) {
 
@@ -116,35 +120,46 @@ class TextToSpeechDelegate(
             is Result.Success -> {
                 try {
                     val audioBytes = result.data
-                    val ttsDir = File(appContext.cacheDir, "tts").apply { mkdirs() }
-                    val tempFile = File.createTempFile("tts_", ".mp3", ttsDir)
-                    tempFile.deleteOnExit()
-                    tempFile.writeBytes(audioBytes)
-
                     serverTtsPlayer?.release()
-                    serverTtsPlayer = MediaPlayer().apply {
-                        setDataSource(tempFile.absolutePath)
-                        setOnCompletionListener {
-                            it.release()
-                            serverTtsPlayer = null
-                            tempFile.delete()
-                            stateHandle.update { copy(currentlyReadingMessageId = null) }
-                        }
-                        setOnErrorListener { mp, _, _ ->
-                            mp.release()
-                            serverTtsPlayer = null
-                            tempFile.delete()
-                            stateHandle.update {
-                                copy(
-                                    currentlyReadingMessageId = null,
-                                    error = "Server TTS playback failed",
-                                )
+                    serverTtsPlayer = withContext(ioDispatcher) {
+                        val ttsDir = File(appContext.cacheDir, "tts").apply { mkdirs() }
+                        val tempFile = File.createTempFile("tts_", ".mp3", ttsDir)
+                        tempFile.deleteOnExit()
+                        tempFile.writeBytes(audioBytes)
+
+                        MediaPlayer().apply {
+                            setDataSource(tempFile.absolutePath)
+                            // MediaPlayer is created on a Looper-less ioDispatcher thread, so
+                            // these callbacks fire on the Main looper. release() + temp-file
+                            // delete are blocking, so hand them to ioDispatcher.
+                            setOnCompletionListener { mp ->
+                                serverTtsPlayer = null
+                                stateHandle.update { copy(currentlyReadingMessageId = null) }
+                                stateHandle.scope.launch(ioDispatcher) {
+                                    mp.release()
+                                    tempFile.delete()
+                                }
                             }
-                            true
+                            setOnErrorListener { mp, _, _ ->
+                                serverTtsPlayer = null
+                                stateHandle.update {
+                                    copy(
+                                        currentlyReadingMessageId = null,
+                                        error = "Server TTS playback failed",
+                                    )
+                                }
+                                stateHandle.scope.launch(ioDispatcher) {
+                                    mp.release()
+                                    tempFile.delete()
+                                }
+                                true
+                            }
+                            prepare()
+                            start()
                         }
-                        prepare()
-                        start()
                     }
+                } catch (e: CancellationException) {
+                    throw e
                 } catch (e: Exception) {
                     stateHandle.update {
                         copy(

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/VoiceInputDelegate.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/VoiceInputDelegate.kt
@@ -5,6 +5,10 @@ import com.garfiec.librechat.core.common.result.Result
 import com.garfiec.librechat.core.data.repository.SpeechRepository
 import com.garfiec.librechat.feature.chat.audio.VoiceRecorder
 import com.garfiec.librechat.feature.chat.viewmodel.ChatStateHandle
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 
@@ -13,37 +17,54 @@ class VoiceInputDelegate(
     private val appContext: Context,
     private val speechRepository: SpeechRepository,
     private val autoSendAfterStt: StateFlow<Boolean>,
+    private val ioDispatcher: CoroutineDispatcher,
     private val onTranscriptionComplete: () -> Unit,
 ) {
 
     private var voiceRecorder: VoiceRecorder? = null
+    // Tracks the in-flight VoiceRecorder.start(). stop()/cancel() join it before touching the
+    // recorder so a tap-stop (or second tap) during the MediaRecorder warm-up can't race the
+    // not-yet-finished start() and orphan a recording that keeps the mic hot.
+    private var startJob: Job? = null
 
     fun startRecording() {
         if (stateHandle.state.isRecording) return
-        try {
-            val recorder = VoiceRecorder(appContext)
-            recorder.start()
-            voiceRecorder = recorder
-            stateHandle.update { copy(isRecording = true) }
-        } catch (e: Exception) {
-            stateHandle.update { copy(error = "Could not start recording: ${e.message}") }
+        // Set state + assign the recorder synchronously on Main so the isRecording guard above
+        // and stopRecording()/cancelRecording() see a consistent recorder during start()'s warm-up.
+        val recorder = VoiceRecorder(appContext, ioDispatcher)
+        voiceRecorder = recorder
+        stateHandle.update { copy(isRecording = true) }
+        startJob = stateHandle.scope.launch {
+            try {
+                recorder.start()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                if (voiceRecorder === recorder) {
+                    voiceRecorder = null
+                    stateHandle.update {
+                        copy(isRecording = false, error = "Could not start recording: ${e.message}")
+                    }
+                }
+            }
         }
     }
 
     fun stopRecording() {
         val recorder = voiceRecorder ?: return
         val mimeType = recorder.mimeType
-        val audioData = recorder.stop()
         voiceRecorder = null
-        stateHandle.update { copy(isRecording = false) }
+        stateHandle.update { copy(isRecording = false, isTranscribing = true) }
 
-        if (audioData == null || audioData.isEmpty()) {
-            stateHandle.update { copy(error = "Recording was empty") }
-            return
-        }
-
-        stateHandle.update { copy(isTranscribing = true) }
         stateHandle.scope.launch {
+            // Ensure start() finished before we stop the recorder.
+            startJob?.join()
+            val audioData = recorder.stop()
+            if (audioData == null || audioData.isEmpty()) {
+                stateHandle.update { copy(isTranscribing = false, error = "Recording was empty") }
+                return@launch
+            }
+
             when (val result = speechRepository.transcribeAudio(audioData, mimeType)) {
                 is Result.Success -> {
                     val transcribedText = result.data.text
@@ -74,9 +95,15 @@ class VoiceInputDelegate(
     }
 
     fun cancelRecording() {
-        voiceRecorder?.cancel()
+        val recorder = voiceRecorder ?: return
         voiceRecorder = null
         stateHandle.update { copy(isRecording = false) }
+        // Join start() first so cancel() can't race the in-flight warm-up; cancel() then runs
+        // MediaRecorder.stop()/release() off the Main thread.
+        stateHandle.scope.launch {
+            startJob?.join()
+            recorder.cancel()
+        }
     }
 
     /**
@@ -112,7 +139,12 @@ class VoiceInputDelegate(
     }
 
     fun release() {
-        voiceRecorder?.cancel()
+        val recorder = voiceRecorder ?: return
         voiceRecorder = null
+        // Called from onCleared(), at which point stateHandle.scope is already cancelled — a
+        // launch on it would never run and the recorder/mic would leak. Run the cleanup on a
+        // detached IO scope so the blocking MediaRecorder.stop()/release() still happens off the
+        // Main thread and is guaranteed to complete (cancel() uses NonCancellable internally).
+        CoroutineScope(ioDispatcher).launch { recorder.cancel() }
     }
 }

--- a/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/di/ChatModuleVerificationTest.kt
+++ b/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/di/ChatModuleVerificationTest.kt
@@ -22,6 +22,7 @@ import com.garfiec.librechat.core.data.repository.ShareRepository
 import com.garfiec.librechat.core.data.repository.SpeechRepository
 import com.garfiec.librechat.core.data.repository.UserRepository
 import com.garfiec.librechat.core.data.util.PermissionGate
+import kotlinx.coroutines.CoroutineDispatcher
 import org.junit.Test
 import org.koin.test.verify.verify
 
@@ -52,6 +53,9 @@ class ChatModuleVerificationTest {
                 ConnectivityObserver::class,
                 ServerDataStore::class,
                 SettingsDataStore::class,
+                // Dispatchers are supplied via Koin qualifiers in explicit blocks; verify()
+                // can't see qualifiers, so whitelist the type as externally provided.
+                CoroutineDispatcher::class,
             ),
         )
     }

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/MarkdownParsing.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/MarkdownParsing.kt
@@ -51,15 +51,26 @@ internal fun looksLikeLatex(content: String): Boolean {
 }
 
 private fun looksLikeHtmlBlock(text: String): Boolean {
-    val match = HTML_OPENING_TAG_REGEX.find(text) ?: return false
+    val tagName = htmlOpeningTagName(text) ?: return false
+    return hasHtmlClosingTag(text, tagName)
+}
+
+/**
+ * Returns the normalized block-level HTML tag name that [text] opens with (the regex is
+ * anchored at `^\s*<`, so leading whitespace/newlines are skipped), or null if [text] does
+ * not begin with a recognized block tag. Split out from [looksLikeHtmlBlock] so callers can
+ * test the opening tag against a single line without scanning a whole joined suffix.
+ */
+private fun htmlOpeningTagName(text: String): String? {
+    val match = HTML_OPENING_TAG_REGEX.find(text) ?: return null
     val tagName = match.groupValues[1].lowercase().let {
         if (it.startsWith("!doctype")) "html" else it
     }
-    if (tagName !in HTML_BLOCK_TAG_NAMES) return false
-    val hasClosingTag = text.contains("</$tagName", ignoreCase = true) ||
-        text.contains("/>")
-    return hasClosingTag
+    return tagName.takeIf { it in HTML_BLOCK_TAG_NAMES }
 }
+
+private fun hasHtmlClosingTag(text: String, tagName: String): Boolean =
+    text.contains("</$tagName", ignoreCase = true) || text.contains("/>")
 
 private fun extractHtmlBlocks(segments: List<MarkdownSegment>): List<MarkdownSegment> {
     val result = mutableListOf<MarkdownSegment>()
@@ -77,13 +88,33 @@ private fun extractHtmlBlocks(segments: List<MarkdownSegment>): List<MarkdownSeg
         }
 
         val lines = text.split('\n')
+        // The original probed looksLikeHtmlBlock on the entire joined tail for every line
+        // (an O(N^2) re-join). Equivalent, cheaper pass: the opening-tag regex is anchored
+        // with `^\s*<`, so a suffix opens a block iff its first non-blank line opens one.
+        // Walk the non-blank lines testing only that single line for an opening tag (no
+        // join); a non-blank line that is not an opening tag can still be followed by one,
+        // so keep scanning. Only when a line opens a recognized tag do we materialize the
+        // tail once (folding in any contiguous leading blank run, which `^\s*` collapses) to
+        // run the closing-tag check, then stop at that first match.
         var htmlStart = -1
-        for (i in lines.indices) {
-            val lineText = lines.subList(i, lines.size).joinToString("\n")
-            if (looksLikeHtmlBlock(lineText)) {
-                htmlStart = i
-                break
+        var lineIdx = 0
+        while (lineIdx < lines.size) {
+            val line = lines[lineIdx]
+            if (line.isBlank()) {
+                lineIdx++
+                continue
             }
+            val tagName = htmlOpeningTagName(line)
+            if (tagName != null) {
+                var start = lineIdx
+                while (start > 0 && lines[start - 1].isBlank()) start--
+                val suffix = lines.subList(start, lines.size).joinToString("\n")
+                if (hasHtmlClosingTag(suffix, tagName)) {
+                    htmlStart = start
+                    break
+                }
+            }
+            lineIdx++
         }
 
         if (htmlStart < 0) {

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModel.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModel.kt
@@ -53,6 +53,7 @@ import com.garfiec.librechat.feature.chat.viewmodel.delegate.ModelSelectionDeleg
 import com.garfiec.librechat.feature.chat.viewmodel.delegate.PlatformDelegateFactory
 import com.garfiec.librechat.feature.chat.viewmodel.delegate.PresetPromptDelegate
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
@@ -63,6 +64,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
@@ -74,7 +76,7 @@ import kotlin.time.Clock
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 
-@Suppress("TooManyFunctions")
+@Suppress("TooManyFunctions", "LongParameterList")
 class ChatViewModel(
     initialConversationId: String? = null,
     private val agentRepository: AgentRepository,
@@ -96,6 +98,7 @@ class ChatViewModel(
     serverDataStore: ServerDataStore,
     private val settingsDataStore: SettingsDataStore,
     platformDelegateFactory: PlatformDelegateFactory,
+    private val defaultDispatcher: CoroutineDispatcher,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(ChatUiState())
@@ -402,16 +405,28 @@ class ChatViewModel(
                     )
                 }
             }
-            messageRepository.observeMessages(conversationId).collect { messages ->
-                _uiState.update {
-                    val displayMessages = buildActiveMessagePath(messages, it.activeBranches)
-                    it.copy(
-                        messages = messages,
-                        displayMessages = displayMessages,
-                        screenState = ChatScreenState.ACTIVE,
-                    )
-                }
+            // buildActiveMessagePath is pure/synchronous CPU work; computing it on the Default
+            // dispatcher keeps the tree walk off Main. Combining the active-branch selection in
+            // (rather than peeking _uiState.value inside the map) keeps the branch snapshot
+            // consistent with the emission — no torn read — and means switchBranch only has to
+            // mutate activeBranches: the heavy recompute happens here off Main, not on the click
+            // thread. The result feeds a StateFlow (not a Compose snapshot), so it's safe off-Main.
+            combine(
+                messageRepository.observeMessages(conversationId),
+                _uiState.map { it.activeBranches }.distinctUntilChanged(),
+            ) { messages, branches ->
+                messages to buildActiveMessagePath(messages, branches)
             }
+                .flowOn(defaultDispatcher)
+                .collect { (messages, displayMessages) ->
+                    _uiState.update {
+                        it.copy(
+                            messages = messages,
+                            displayMessages = displayMessages,
+                            screenState = ChatScreenState.ACTIVE,
+                        )
+                    }
+                }
         }
     }
 
@@ -486,19 +501,15 @@ class ChatViewModel(
         }
     }
 
-    private fun rebuildDisplayMessages() {
-        _uiState.update {
-            it.copy(displayMessages = buildActiveMessagePath(it.messages, it.activeBranches))
-        }
-    }
-
     fun switchBranch(parentMessageId: String, siblingIndex: Int) {
+        // Only mutate the branch selection; the observeMessages/activeBranches combine in
+        // loadConversation recomputes displayMessages off the Main thread in response, so the
+        // tree walk no longer runs synchronously on this UI click path.
         _uiState.update {
             val newBranches = it.activeBranches.toMutableMap()
             newBranches[parentMessageId] = siblingIndex
             it.copy(activeBranches = newBranches)
         }
-        rebuildDisplayMessages()
     }
 
     fun onInputChanged(text: String) {

--- a/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/components/PlatformMediaComponents.ios.kt
+++ b/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/components/PlatformMediaComponents.ios.kt
@@ -43,6 +43,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -67,7 +68,9 @@ import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.addressOf
 import kotlinx.cinterop.cValue
 import kotlinx.cinterop.usePinned
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
 import org.jetbrains.compose.resources.stringResource
 import platform.AVFAudio.AVAudioPlayer
 import platform.AVFoundation.AVLayerVideoGravityResizeAspect
@@ -110,20 +113,19 @@ actual fun AudioContent(
         Text(stringResource(Res.string.audio_no_data), modifier = modifier)
         return
     }
-    // Decode base64 audio data and play via AVAudioPlayer
-    val audioData = remember(data) {
-        try {
-            val nsData = NSData.create(
-                base64EncodedString = data,
-                options = 0u,
-            )
-            nsData
-        } catch (e: Exception) {
-            Logger.e(e) { "Failed to decode audio data" }
-            null
+    // Decode base64 audio data off the composition thread, then play via AVAudioPlayer.
+    // `decodeState`: null = still decoding, Result wraps the decoded NSData (or null on failure).
+    val decodeState by produceState<Result<NSData?>?>(initialValue = null, data) {
+        value = withContext(Dispatchers.Default) {
+            runCatching {
+                NSData.create(base64EncodedString = data, options = 0u)
+            }.onFailure { Logger.e(it) { "Failed to decode audio data" } }
         }
     }
 
+    // While decoding, render nothing to avoid flashing a failure message.
+    val decodeResult = decodeState ?: return
+    val audioData = decodeResult.getOrNull()
     if (audioData == null) {
         Text(stringResource(Res.string.audio_decode_failed), modifier = modifier)
         return
@@ -325,27 +327,31 @@ actual fun AudioContentPlayerFromBytes(
     audioBytes: ByteArray,
     modifier: Modifier,
 ) {
-    // Write bytes to a temp file and play via AudioContentPlayer
-    val tempPath = remember(audioBytes) {
-        val path = NSTemporaryDirectory() + "audio_${audioBytes.hashCode()}.mp3"
-        val nsData = audioBytes.usePinned { pinned ->
-            NSData.create(
-                bytes = pinned.addressOf(0),
-                length = audioBytes.size.toULong(),
-            )
+    // Write bytes to a temp file off the composition thread, then play via AudioContentPlayer.
+    val tempPath by produceState<String?>(initialValue = null, audioBytes) {
+        value = withContext(Dispatchers.Default) {
+            val path = NSTemporaryDirectory() + "audio_${audioBytes.hashCode()}.mp3"
+            val nsData = audioBytes.usePinned { pinned ->
+                NSData.create(
+                    bytes = pinned.addressOf(0),
+                    length = audioBytes.size.toULong(),
+                )
+            }
+            nsData.writeToFile(path, atomically = true)
+            path
         }
-        nsData.writeToFile(path, atomically = true)
-        path
     }
 
-    DisposableEffect(tempPath) {
+    val path = tempPath ?: return
+
+    DisposableEffect(path) {
         onDispose {
-            NSFileManager.defaultManager.removeItemAtPath(tempPath, null)
+            NSFileManager.defaultManager.removeItemAtPath(path, null)
         }
     }
 
     AudioContentPlayer(
-        audioUrl = tempPath,
+        audioUrl = path,
         modifier = modifier,
     )
 }

--- a/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/di/ChatPlatformModule.ios.kt
+++ b/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/di/ChatPlatformModule.ios.kt
@@ -40,6 +40,7 @@ actual val chatPlatformModule: Module = module {
             serverDataStore = get(),
             settingsDataStore = get(),
             platformDelegateFactory = get(),
+            defaultDispatcher = get(KoinQualifiers.Default),
         )
     }
 }

--- a/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/screen/PlatformScreens.ios.kt
+++ b/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/screen/PlatformScreens.ios.kt
@@ -81,6 +81,7 @@ import com.garfiec.librechat.feature.chat.util.readClipboardImage
 import com.garfiec.librechat.feature.chat.viewmodel.ChatScreenState
 import com.garfiec.librechat.feature.chat.viewmodel.ChatViewModel
 import com.garfiec.librechat.feature.chat.viewmodel.asString
+import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.parameter.parametersOf
@@ -506,12 +507,14 @@ actual fun ChatScreen(
                 onRemoveFile = viewModel::removeFile,
                 hasClipboardImage = hasClipboardImage,
                 onPasteImage = {
-                    val imageData = readClipboardImage()
-                    if (imageData != null) {
-                        viewModel.onFilesSelected(listOf(imageData))
+                    coroutineScope.launch {
+                        val imageData = readClipboardImage()
+                        if (imageData != null) {
+                            viewModel.onFilesSelected(listOf(imageData))
+                        }
+                        // Re-check clipboard after paste
+                        hasClipboardImage = clipboardHasImage()
                     }
-                    // Re-check clipboard after paste
-                    hasClipboardImage = clipboardHasImage()
                 },
                 onAttachFiles = {
                     openDocumentPicker { files ->

--- a/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/util/IosClipboardImageReader.kt
+++ b/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/util/IosClipboardImageReader.kt
@@ -3,6 +3,8 @@ package com.garfiec.librechat.feature.chat.util
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.addressOf
 import kotlinx.cinterop.usePinned
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import platform.CoreGraphics.CGImageGetHeight
 import platform.CoreGraphics.CGImageGetWidth
 import platform.Foundation.NSData
@@ -24,29 +26,34 @@ fun clipboardHasImage(): Boolean {
  * Reads the first image from the system clipboard and returns it as [IosImageData],
  * or null if no image is available.
  *
- * The image is converted to PNG format for consistent server-side handling.
+ * The image is converted to PNG format for consistent server-side handling. The
+ * pasteboard handle is grabbed on the calling (Main) thread, but the PNG encode —
+ * which is heavy for a full-resolution screenshot — runs on [Dispatchers.Default]
+ * so it never blocks the UI click handler.
  */
 @OptIn(ExperimentalForeignApi::class)
-fun readClipboardImage(): IosImageData? {
+suspend fun readClipboardImage(): IosImageData? {
     val image: UIImage = UIPasteboard.generalPasteboard.image ?: return null
 
-    val pngData: NSData = UIImagePNGRepresentation(image) ?: return null
-    val bytes = pngData.toByteArray() ?: return null
-    if (bytes.isEmpty()) return null
+    return withContext(Dispatchers.Default) {
+        val pngData: NSData = UIImagePNGRepresentation(image) ?: return@withContext null
+        val bytes = pngData.toByteArray() ?: return@withContext null
+        if (bytes.isEmpty()) return@withContext null
 
-    val cgImage = image.CGImage
-    val width = if (cgImage != null) CGImageGetWidth(cgImage).toInt() else null
-    val height = if (cgImage != null) CGImageGetHeight(cgImage).toInt() else null
+        val cgImage = image.CGImage
+        val width = if (cgImage != null) CGImageGetWidth(cgImage).toInt() else null
+        val height = if (cgImage != null) CGImageGetHeight(cgImage).toInt() else null
 
-    val timestamp = NSDate().timeIntervalSince1970.toLong()
+        val timestamp = NSDate().timeIntervalSince1970.toLong()
 
-    return IosImageData(
-        bytes = bytes,
-        filename = "clipboard_$timestamp.png",
-        mimeType = "image/png",
-        width = width,
-        height = height,
-    )
+        IosImageData(
+            bytes = bytes,
+            filename = "clipboard_$timestamp.png",
+            mimeType = "image/png",
+            width = width,
+            height = height,
+        )
+    }
 }
 
 @OptIn(ExperimentalForeignApi::class)

--- a/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/util/IosFilePicker.kt
+++ b/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/util/IosFilePicker.kt
@@ -31,8 +31,10 @@ import platform.UIKit.UIViewController
 import platform.UIKit.UIWindowScene
 import platform.UniformTypeIdentifiers.UTType
 import platform.UniformTypeIdentifiers.UTTypeContent
+import platform.darwin.DISPATCH_QUEUE_PRIORITY_DEFAULT
 import platform.darwin.NSObject
 import platform.darwin.dispatch_async
+import platform.darwin.dispatch_get_global_queue
 import platform.darwin.dispatch_get_main_queue
 import platform.posix.memcpy
 
@@ -131,6 +133,9 @@ fun openCamera(onResult: (List<Any>) -> Unit) {
 
 // ── Delegates ──────────────────────────────────────────────────
 
+/** A document whose bytes were materialized inside the security-scoped callback. */
+private class LoadedDocument(val data: NSData, val filename: String)
+
 private class DocumentPickerDelegate(
     private val onResult: (List<Any>) -> Unit,
 ) : NSObject(), UIDocumentPickerDelegateProtocol {
@@ -140,37 +145,51 @@ private class DocumentPickerDelegate(
         controller: UIDocumentPickerViewController,
         didPickDocumentsAtURLs: List<*>,
     ) {
-        val results = mutableListOf<Any>()
+        // Pull each file's bytes into memory while its security-scoped resource
+        // is held — the scope is only valid for the duration of this callback,
+        // so the read must happen here. dataWithContentsOfURL fully materializes
+        // the NSData, so the scope can be released immediately afterward; the
+        // heavy byte-copy + image decode then runs off the Main thread.
+        val loaded = mutableListOf<LoadedDocument>()
         for (item in didPickDocumentsAtURLs) {
             val url = item as? NSURL ?: continue
             val accessing = url.startAccessingSecurityScopedResource()
             try {
                 val data = NSData.dataWithContentsOfURL(url) ?: continue
-                val bytes = data.toByteArray() ?: continue
                 val filename = url.lastPathComponent ?: "file"
-                val mimeType = guessMimeType(filename)
+                loaded.add(LoadedDocument(data = data, filename = filename))
+            } finally {
+                if (accessing) url.stopAccessingSecurityScopedResource()
+            }
+        }
+        activePickerDelegate = null
+
+        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT.toLong(), 0u)) {
+            val results = mutableListOf<Any>()
+            for (doc in loaded) {
+                val bytes = doc.data.toByteArray() ?: continue
+                val mimeType = guessMimeType(doc.filename)
 
                 if (mimeType.startsWith("image/")) {
-                    val image = UIImage(data = data)
+                    val image = UIImage(data = doc.data)
                     val cgImage = image?.CGImage
                     results.add(
                         IosImageData(
                             bytes = bytes,
-                            filename = filename,
+                            filename = doc.filename,
                             mimeType = mimeType,
                             width = cgImage?.let { CGImageGetWidth(it).toInt() },
                             height = cgImage?.let { CGImageGetHeight(it).toInt() },
                         ),
                     )
                 } else {
-                    results.add(IosFileData(bytes = bytes, filename = filename, mimeType = mimeType))
+                    results.add(IosFileData(bytes = bytes, filename = doc.filename, mimeType = mimeType))
                 }
-            } finally {
-                if (accessing) url.stopAccessingSecurityScopedResource()
+            }
+            dispatch_async(dispatch_get_main_queue()) {
+                onResult(results)
             }
         }
-        activePickerDelegate = null
-        onResult(results)
     }
 
     override fun documentPickerWasCancelled(controller: UIDocumentPickerViewController) {
@@ -192,14 +211,29 @@ private class PhotoPickerDelegate(
             return
         }
 
+        // All `results`/`remaining` mutation and the terminal delivery happen on
+        // the Main queue so they're serialized — the per-item image decode runs
+        // off Main inside the loadDataRepresentation callback, which only hops
+        // back to Main to record its outcome. The non-image branches mirror that
+        // hop so every completion path is consistent.
         val results = mutableListOf<Any>()
         var remaining = didFinishPicking.size
+
+        fun completeOne(imageData: IosImageData?) {
+            dispatch_async(dispatch_get_main_queue()) {
+                if (imageData != null) results.add(imageData)
+                remaining--
+                if (remaining == 0) {
+                    activePickerDelegate = null
+                    onResult(results)
+                }
+            }
+        }
 
         for (item in didFinishPicking) {
             val pickerResult = item as? PHPickerResult
             if (pickerResult == null) {
-                remaining--
-                if (remaining == 0) onResult(results)
+                completeOne(null)
                 continue
             }
             val provider = pickerResult.itemProvider
@@ -226,18 +260,10 @@ private class PhotoPickerDelegate(
                     if (imageData == null) {
                         Logger.e { "PHPicker: failed to load image: ${error?.localizedDescription}" }
                     }
-                    dispatch_async(dispatch_get_main_queue()) {
-                        if (imageData != null) results.add(imageData)
-                        remaining--
-                        if (remaining == 0) {
-                            activePickerDelegate = null
-                            onResult(results)
-                        }
-                    }
+                    completeOne(imageData)
                 }
             } else {
-                remaining--
-                if (remaining == 0) onResult(results)
+                completeOne(null)
             }
         }
     }
@@ -255,25 +281,30 @@ private class CameraDelegate(
         picker.dismissViewControllerAnimated(true, completion = null)
         activePickerDelegate = null
 
-        val image = didFinishPickingMediaWithInfo[UIImagePickerControllerOriginalImage] as? UIImage
-        if (image != null) {
-            val data = UIImageJPEGRepresentation(image, 0.85) ?: return
-            val bytes = data.toByteArray() ?: return
+        val image = didFinishPickingMediaWithInfo[UIImagePickerControllerOriginalImage] as? UIImage ?: return
+        // A full-resolution capture (12MP+) is expensive to JPEG-encode and copy.
+        // The UIImage is already in memory, so hand the encode to a background
+        // queue and deliver the result back on Main.
+        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT.toLong(), 0u)) {
+            val data = UIImageJPEGRepresentation(image, 0.85) ?: return@dispatch_async
+            val bytes = data.toByteArray() ?: return@dispatch_async
             val cgImage = image.CGImage
             val width = cgImage?.let { CGImageGetWidth(it).toInt() }
             val height = cgImage?.let { CGImageGetHeight(it).toInt() }
             val timestamp = NSDate().timeIntervalSince1970.toLong()
-            onResult(
-                listOf(
-                    IosImageData(
-                        bytes = bytes,
-                        filename = "photo_$timestamp.jpg",
-                        mimeType = "image/jpeg",
-                        width = width,
-                        height = height,
+            dispatch_async(dispatch_get_main_queue()) {
+                onResult(
+                    listOf(
+                        IosImageData(
+                            bytes = bytes,
+                            filename = "photo_$timestamp.jpg",
+                            mimeType = "image/jpeg",
+                            width = width,
+                            height = height,
+                        ),
                     ),
-                ),
-            )
+                )
+            }
         }
     }
 

--- a/feature/conversations/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/conversations/di/ConversationsModuleVerificationTest.kt
+++ b/feature/conversations/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/conversations/di/ConversationsModuleVerificationTest.kt
@@ -10,6 +10,7 @@ import com.garfiec.librechat.core.data.repository.RoleRepository
 import com.garfiec.librechat.core.data.repository.SearchRepository
 import com.garfiec.librechat.core.data.repository.ShareRepository
 import com.garfiec.librechat.core.data.repository.TagRepository
+import kotlinx.coroutines.CoroutineDispatcher
 import org.junit.Test
 import org.koin.test.verify.verify
 
@@ -28,6 +29,7 @@ class ConversationsModuleVerificationTest {
                 ConfigRepository::class,
                 RoleRepository::class,
                 ServerDataStore::class,
+                CoroutineDispatcher::class,
             ),
         )
     }

--- a/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/di/ConversationsModule.kt
+++ b/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/di/ConversationsModule.kt
@@ -1,16 +1,26 @@
 package com.garfiec.librechat.feature.conversations.di
 
+import com.garfiec.librechat.core.common.di.KoinQualifiers
 import com.garfiec.librechat.feature.conversations.export.ConversationExporter
 import com.garfiec.librechat.feature.conversations.export.ConversationImporter
 import com.garfiec.librechat.feature.conversations.viewmodel.ArchivedConversationsViewModel
 import com.garfiec.librechat.feature.conversations.viewmodel.ConversationListViewModel
-import org.koin.core.module.dsl.singleOf
 import org.koin.core.module.dsl.viewModelOf
 import org.koin.dsl.module
 
 val conversationsModule = module {
-    singleOf(::ConversationExporter)
-    singleOf(::ConversationImporter)
+    single {
+        ConversationExporter(
+            conversationRepository = get(),
+            messageRepository = get(),
+            ioDispatcher = get(KoinQualifiers.IO),
+        )
+    }
+    single {
+        ConversationImporter(
+            ioDispatcher = get(KoinQualifiers.IO),
+        )
+    }
 
     viewModelOf(::ConversationListViewModel)
     viewModelOf(::ArchivedConversationsViewModel)

--- a/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/export/ConversationExporter.kt
+++ b/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/export/ConversationExporter.kt
@@ -5,6 +5,8 @@ import com.garfiec.librechat.core.data.repository.ConversationRepository
 import com.garfiec.librechat.core.data.repository.MessageRepository
 import com.garfiec.librechat.core.model.ConversationExport
 import com.garfiec.librechat.core.model.Message
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import kotlinx.serialization.json.Json
@@ -13,6 +15,7 @@ import kotlin.time.Clock
 class ConversationExporter(
     private val conversationRepository: ConversationRepository,
     private val messageRepository: MessageRepository,
+    private val ioDispatcher: CoroutineDispatcher,
 ) {
     private val json = Json {
         prettyPrint = true
@@ -36,7 +39,10 @@ class ConversationExporter(
             exportedAt = Clock.System.now().toEpochMilliseconds(),
             version = 1,
         )
-        return Result.Success(json.encodeToString(ConversationExport.serializer(), export))
+        val encoded = withContext(ioDispatcher) {
+            json.encodeToString(ConversationExport.serializer(), export)
+        }
+        return Result.Success(encoded)
     }
 
     suspend fun exportAsMarkdown(conversationId: String): Result<String> {
@@ -51,26 +57,29 @@ class ConversationExporter(
             is Result.Loading -> return Result.Error(message = "Unexpected loading state")
         }
 
-        val now = Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault())
-        val month = now.monthNumber.toString().padStart(2, '0')
-        val day = now.dayOfMonth.toString().padStart(2, '0')
-        val hour = now.hour.toString().padStart(2, '0')
-        val minute = now.minute.toString().padStart(2, '0')
-        val exportDate = "${now.year}-$month-$day $hour:$minute"
+        val markdown = withContext(ioDispatcher) {
+            val now = Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault())
+            val month = now.monthNumber.toString().padStart(2, '0')
+            val day = now.dayOfMonth.toString().padStart(2, '0')
+            val hour = now.hour.toString().padStart(2, '0')
+            val minute = now.minute.toString().padStart(2, '0')
+            val exportDate = "${now.year}-$month-$day $hour:$minute"
 
-        val sb = StringBuilder()
-        sb.appendLine("# ${conversation.title ?: "Untitled Conversation"}")
-        sb.appendLine("Exported on $exportDate")
-        sb.appendLine()
-
-        for (message in messages) {
-            val role = if (message.isCreatedByUser) "User" else "Assistant"
-            sb.appendLine("## $role")
-            sb.appendLine(extractMessageText(message))
+            val sb = StringBuilder()
+            sb.appendLine("# ${conversation.title ?: "Untitled Conversation"}")
+            sb.appendLine("Exported on $exportDate")
             sb.appendLine()
+
+            for (message in messages) {
+                val role = if (message.isCreatedByUser) "User" else "Assistant"
+                sb.appendLine("## $role")
+                sb.appendLine(extractMessageText(message))
+                sb.appendLine()
+            }
+            sb.toString().trimEnd()
         }
 
-        return Result.Success(sb.toString().trimEnd())
+        return Result.Success(markdown)
     }
 
     private fun extractMessageText(message: Message): String {

--- a/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/export/ConversationImporter.kt
+++ b/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/export/ConversationImporter.kt
@@ -2,17 +2,24 @@ package com.garfiec.librechat.feature.conversations.export
 
 import com.garfiec.librechat.core.common.result.Result
 import com.garfiec.librechat.core.model.ConversationExport
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 
-class ConversationImporter {
+class ConversationImporter(
+    private val ioDispatcher: CoroutineDispatcher,
+) {
     private val json = Json {
         ignoreUnknownKeys = true
         isLenient = true
     }
 
-    fun parseJson(jsonString: String): Result<ConversationExport> {
+    suspend fun parseJson(jsonString: String): Result<ConversationExport> {
         return try {
-            val export = json.decodeFromString(ConversationExport.serializer(), jsonString)
+            val export = withContext(ioDispatcher) {
+                json.decodeFromString(ConversationExport.serializer(), jsonString)
+            }
             if (export.conversation.conversationId == null) {
                 return Result.Error(message = "Invalid export: missing conversation ID")
             }
@@ -20,6 +27,8 @@ class ConversationImporter {
                 return Result.Error(message = "Invalid export: no messages found")
             }
             Result.Success(export)
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Result.Error(e, "Failed to parse conversation file: ${e.message}")
         }

--- a/feature/files/src/androidMain/kotlin/com/garfiec/librechat/feature/files/platform/PdfPreview.android.kt
+++ b/feature/files/src/androidMain/kotlin/com/garfiec/librechat/feature/files/platform/PdfPreview.android.kt
@@ -45,6 +45,9 @@ import com.garfiec.librechat.feature.files.FilePreviewDisplayData
 import com.garfiec.librechat.feature.files.resources.*
 import com.garfiec.librechat.feature.files.resources.Res
 import com.garfiec.librechat.feature.files.screen.InfoRow
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import org.jetbrains.compose.resources.stringResource
 import java.io.File
 
@@ -81,59 +84,64 @@ actual fun PdfPreview(
     LaunchedEffect(file.fileId) {
         loadState = PdfLoadState.Loading
         try {
-            val bytes = onDownloadFile?.invoke(file.fileId, file.userId)
-            if (bytes == null) {
-                loadState = PdfLoadState.Error("Failed to download PDF")
-                return@LaunchedEffect
-            }
+            // Download, disk write, and PdfRenderer page rendering are all blocking.
+            // Run them off the Main thread; only the resulting state lands on Main.
+            val result = withContext(Dispatchers.IO) {
+                val bytes = onDownloadFile?.invoke(file.fileId, file.userId)
+                    ?: return@withContext PdfLoadState.Error("Failed to download PDF")
 
-            val pdfPreviewDir = File(context.cacheDir, "pdf_preview").apply { mkdirs() }
-            val pdfTempFile = File(pdfPreviewDir, "pdf_preview_${file.fileId}.pdf")
-            pdfTempFile.writeBytes(bytes)
-            tempFile = pdfTempFile
+                val pdfPreviewDir = File(context.cacheDir, "pdf_preview").apply { mkdirs() }
+                val pdfTempFile = File(pdfPreviewDir, "pdf_preview_${file.fileId}.pdf")
+                pdfTempFile.writeBytes(bytes)
+                tempFile = pdfTempFile
 
-            val fd = ParcelFileDescriptor.open(
-                pdfTempFile,
-                ParcelFileDescriptor.MODE_READ_ONLY,
-            )
-            val renderer = PdfRenderer(fd)
-            val pageCount = renderer.pageCount
-            Logger.d { "PdfPreview: opened PDF with $pageCount pages" }
-
-            val maxPages = minOf(pageCount, 50)
-            val bitmaps = mutableListOf<Bitmap>()
-            val displayMetrics = context.resources.displayMetrics
-            val targetWidth = displayMetrics.widthPixels
-
-            for (i in 0 until maxPages) {
-                val page = renderer.openPage(i)
-                val scale = targetWidth.toFloat() / page.width
-                val bitmapWidth = targetWidth
-                val bitmapHeight = (page.height * scale).toInt()
-
-                val bitmap = Bitmap.createBitmap(
-                    bitmapWidth,
-                    bitmapHeight,
-                    Bitmap.Config.ARGB_8888,
+                val fd = ParcelFileDescriptor.open(
+                    pdfTempFile,
+                    ParcelFileDescriptor.MODE_READ_ONLY,
                 )
-                bitmap.eraseColor(Color.WHITE)
-                page.render(
-                    bitmap,
-                    null,
-                    null,
-                    PdfRenderer.Page.RENDER_MODE_FOR_DISPLAY,
-                )
-                page.close()
-                bitmaps.add(bitmap)
+                val renderer = PdfRenderer(fd)
+                val pageCount = renderer.pageCount
+                Logger.d { "PdfPreview: opened PDF with $pageCount pages" }
+
+                val maxPages = minOf(pageCount, 50)
+                val bitmaps = mutableListOf<Bitmap>()
+                val displayMetrics = context.resources.displayMetrics
+                val targetWidth = displayMetrics.widthPixels
+
+                for (i in 0 until maxPages) {
+                    val page = renderer.openPage(i)
+                    val scale = targetWidth.toFloat() / page.width
+                    val bitmapWidth = targetWidth
+                    val bitmapHeight = (page.height * scale).toInt()
+
+                    val bitmap = Bitmap.createBitmap(
+                        bitmapWidth,
+                        bitmapHeight,
+                        Bitmap.Config.ARGB_8888,
+                    )
+                    bitmap.eraseColor(Color.WHITE)
+                    page.render(
+                        bitmap,
+                        null,
+                        null,
+                        PdfRenderer.Page.RENDER_MODE_FOR_DISPLAY,
+                    )
+                    page.close()
+                    bitmaps.add(bitmap)
+                }
+
+                renderer.close()
+                fd.close()
+
+                if (pageCount > maxPages) {
+                    Logger.d { "PdfPreview: showing first $maxPages of $pageCount pages" }
+                }
+                PdfLoadState.Success(bitmaps)
             }
 
-            renderer.close()
-            fd.close()
-
-            loadState = PdfLoadState.Success(bitmaps)
-            if (pageCount > maxPages) {
-                Logger.d { "PdfPreview: showing first $maxPages of $pageCount pages" }
-            }
+            loadState = result
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Logger.e(e) { "PdfPreview: failed to render PDF" }
             loadState = PdfLoadState.Error(

--- a/feature/settings/src/androidMain/kotlin/com/garfiec/librechat/feature/settings/di/SettingsPlatformModule.android.kt
+++ b/feature/settings/src/androidMain/kotlin/com/garfiec/librechat/feature/settings/di/SettingsPlatformModule.android.kt
@@ -1,5 +1,6 @@
 package com.garfiec.librechat.feature.settings.di
 
+import com.garfiec.librechat.core.common.di.KoinQualifiers
 import com.garfiec.librechat.feature.settings.util.AndroidCacheCleaner
 import com.garfiec.librechat.feature.settings.util.AndroidContentReader
 import com.garfiec.librechat.feature.settings.util.ContentReader
@@ -21,6 +22,7 @@ actual val settingsPlatformModule: Module = module {
                 context = androidContext(),
                 speechRepository = get(),
                 settingsDataStore = get(),
+                ioDispatcher = get(KoinQualifiers.IO),
             )
         }
     }

--- a/feature/settings/src/androidMain/kotlin/com/garfiec/librechat/feature/settings/util/AndroidCacheCleaner.kt
+++ b/feature/settings/src/androidMain/kotlin/com/garfiec/librechat/feature/settings/util/AndroidCacheCleaner.kt
@@ -1,9 +1,13 @@
 package com.garfiec.librechat.feature.settings.util
 
 import android.content.Context
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 class AndroidCacheCleaner(private val context: Context) : PlatformCacheCleaner {
-    override fun clearCache() {
-        context.cacheDir.deleteRecursively()
+    override suspend fun clearCache() {
+        withContext(Dispatchers.IO) {
+            context.cacheDir.deleteRecursively()
+        }
     }
 }

--- a/feature/settings/src/androidMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/delegate/SpeechSettingsDelegate.kt
+++ b/feature/settings/src/androidMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/delegate/SpeechSettingsDelegate.kt
@@ -11,7 +11,10 @@ import com.garfiec.librechat.core.data.repository.SpeechRepository
 import com.garfiec.librechat.core.model.speech.TtsVoice
 import com.garfiec.librechat.feature.settings.screen.DeviceVoiceInfo
 import com.garfiec.librechat.feature.settings.viewmodel.SettingsStateHandle
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.io.File
 
 /**
@@ -22,6 +25,7 @@ class SpeechSettingsDelegate(
     private val context: Context,
     private val speechRepository: SpeechRepository,
     private val settingsDataStore: SettingsDataStore,
+    private val ioDispatcher: CoroutineDispatcher,
 ) : SpeechSettingsContract {
 
     private var currentMediaPlayer: MediaPlayer? = null
@@ -42,16 +46,29 @@ class SpeechSettingsDelegate(
     }
 
     override fun loadDeviceVoices() {
-        deviceTtsEngine = TextToSpeech(context) { status ->
-            if (status == TextToSpeech.SUCCESS) {
-                val voices = deviceTtsEngine?.voices?.map { voice ->
-                    DeviceVoiceInfo(
-                        name = voice.name,
-                        locale = voice.locale.displayName,
-                    )
-                }?.sortedBy { it.name } ?: emptyList()
-                stateHandle.update { copy(availableDeviceVoices = voices) }
+        stateHandle.scope.launch {
+            // TextToSpeech construction touches disk/IPC; build it off the Main thread.
+            val engine = withContext(ioDispatcher) {
+                lateinit var tts: TextToSpeech
+                tts = TextToSpeech(context) { status ->
+                    if (status == TextToSpeech.SUCCESS) {
+                        // .voices enumeration is heavy; do it off Main before publishing.
+                        stateHandle.scope.launch {
+                            val voices = withContext(ioDispatcher) {
+                                tts.voices?.map { voice ->
+                                    DeviceVoiceInfo(
+                                        name = voice.name,
+                                        locale = voice.locale.displayName,
+                                    )
+                                }?.sortedBy { it.name } ?: emptyList()
+                            }
+                            stateHandle.update { copy(availableDeviceVoices = voices) }
+                        }
+                    }
+                }
+                tts
             }
+            deviceTtsEngine = engine
         }
     }
 
@@ -212,51 +229,62 @@ class SpeechSettingsDelegate(
      * Plays audio bytes via MediaPlayer. Attaches listeners before calling prepare()
      * and wraps prepare/start in try-catch to release on failure (fixes resource leak).
      */
-    private fun playAudioBytes(audioBytes: ByteArray, isPreview: Boolean = false) {
+    private suspend fun playAudioBytes(audioBytes: ByteArray, isPreview: Boolean = false) {
         try {
             // Stop any currently playing audio
             currentMediaPlayer?.release()
             currentMediaPlayer = null
 
-            // Write bytes to a temporary file
-            val voiceTestDir = File(context.cacheDir, "voice_test").apply { mkdirs() }
-            val tempFile = File.createTempFile("voice_test", ".mp3", voiceTestDir)
-            tempFile.deleteOnExit()
-            tempFile.writeBytes(audioBytes)
+            // File write + MediaPlayer prepare are blocking; run them off the Main thread.
+            val mediaPlayer = withContext(ioDispatcher) {
+                val voiceTestDir = File(context.cacheDir, "voice_test").apply { mkdirs() }
+                val tempFile = File.createTempFile("voice_test", ".mp3", voiceTestDir)
+                tempFile.deleteOnExit()
+                tempFile.writeBytes(audioBytes)
 
-            // Create and configure MediaPlayer
-            val mediaPlayer = MediaPlayer()
-            // Attach listeners BEFORE calling prepare() to avoid resource leak
-            mediaPlayer.setDataSource(tempFile.absolutePath)
-            mediaPlayer.setOnCompletionListener {
-                it.release()
-                currentMediaPlayer = null
-                tempFile.delete()
-                if (isPreview) {
-                    stateHandle.update { copy(isTtsPreviewPlaying = false) }
+                val mp = MediaPlayer()
+                // Attach listeners BEFORE calling prepare() to avoid resource leak
+                mp.setDataSource(tempFile.absolutePath)
+                // The MediaPlayer is built on a Looper-less ioDispatcher thread, so these
+                // callbacks fire on the Main looper. release() + temp-file delete are blocking,
+                // so hand them to ioDispatcher rather than running them on Main.
+                mp.setOnCompletionListener { player ->
+                    currentMediaPlayer = null
+                    if (isPreview) {
+                        stateHandle.update { copy(isTtsPreviewPlaying = false) }
+                    }
+                    stateHandle.scope.launch(ioDispatcher) {
+                        player.release()
+                        tempFile.delete()
+                    }
                 }
-            }
-            mediaPlayer.setOnErrorListener { mp, what, extra ->
-                Logger.e { "MediaPlayer error: what=$what, extra=$extra" }
-                mp.release()
-                currentMediaPlayer = null
-                tempFile.delete()
-                stateHandle.update {
-                    copy(error = "Audio playback failed", isTtsPreviewPlaying = false)
+                mp.setOnErrorListener { player, what, extra ->
+                    Logger.e { "MediaPlayer error: what=$what, extra=$extra" }
+                    currentMediaPlayer = null
+                    stateHandle.update {
+                        copy(error = "Audio playback failed", isTtsPreviewPlaying = false)
+                    }
+                    stateHandle.scope.launch(ioDispatcher) {
+                        player.release()
+                        tempFile.delete()
+                    }
+                    true
                 }
-                true
-            }
-            try {
-                mediaPlayer.prepare()
-                mediaPlayer.start()
-            } catch (e: Exception) {
-                // Release MediaPlayer if prepare() or start() throws
-                mediaPlayer.release()
-                tempFile.delete()
-                throw e
+                try {
+                    mp.prepare()
+                    mp.start()
+                } catch (e: Exception) {
+                    // Release MediaPlayer if prepare() or start() throws
+                    mp.release()
+                    tempFile.delete()
+                    throw e
+                }
+                mp
             }
 
             currentMediaPlayer = mediaPlayer
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Logger.e(e) { "Failed to play audio" }
             stateHandle.update {

--- a/feature/settings/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/settings/di/SettingsModuleVerificationTest.kt
+++ b/feature/settings/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/settings/di/SettingsModuleVerificationTest.kt
@@ -25,6 +25,7 @@ import com.garfiec.librechat.core.logging.DiagnosticLogRepository
 import com.garfiec.librechat.feature.settings.util.ContentReader
 import com.garfiec.librechat.feature.settings.util.PlatformCacheCleaner
 import com.garfiec.librechat.feature.settings.viewmodel.delegate.SpeechSettingsFactory
+import kotlinx.coroutines.CoroutineDispatcher
 import org.junit.Test
 import org.koin.test.verify.verify
 
@@ -58,6 +59,8 @@ class SettingsModuleVerificationTest {
                 PlatformCacheCleaner::class,
                 SpeechSettingsFactory::class,
                 DiagnosticLogRepository::class,
+                // Provided by core:common CommonModule via KoinQualifiers.IO.
+                CoroutineDispatcher::class,
             ),
         )
     }

--- a/feature/settings/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/settings/viewmodel/SettingsViewModelTest.kt
+++ b/feature/settings/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/settings/viewmodel/SettingsViewModelTest.kt
@@ -155,6 +155,7 @@ class SettingsViewModelTest {
             override val versionCode = 1L
             override val gitSha = "testsha0"
         },
+        ioDispatcher = testDispatcher,
     )
 
     @Test

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/di/SettingsModule.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/di/SettingsModule.kt
@@ -1,5 +1,6 @@
 package com.garfiec.librechat.feature.settings.di
 
+import com.garfiec.librechat.core.common.di.KoinQualifiers
 import com.garfiec.librechat.feature.settings.viewmodel.ApiKeysViewModel
 import com.garfiec.librechat.feature.settings.viewmodel.FavoritesViewModel
 import com.garfiec.librechat.feature.settings.viewmodel.McpViewModel
@@ -18,7 +19,32 @@ expect val settingsPlatformModule: Module
 val settingsModule = module {
     includes(settingsPlatformModule)
 
-    viewModelOf(::SettingsViewModel)
+    // Explicit block (not viewModelOf) so the IO dispatcher can be resolved by
+    // qualifier — constructor-DSL resolves CoroutineDispatcher by type only.
+    viewModel {
+        SettingsViewModel(
+            contentReader = get(),
+            cacheCleaner = get(),
+            userRepository = get(),
+            authRepository = get(),
+            conversationRepository = get(),
+            themeDataStore = get(),
+            serverDataStore = get(),
+            settingsDataStore = get(),
+            mcpRepository = get(),
+            memoryRepository = get(),
+            speechSettingsFactory = get(),
+            balanceRepository = get(),
+            shareRepository = get(),
+            keyRepository = get(),
+            roleRepository = get(),
+            permissionGate = get(),
+            configRepository = get(),
+            diagnosticLogRepository = get(),
+            appInfo = get(),
+            ioDispatcher = get(KoinQualifiers.IO),
+        )
+    }
     viewModelOf(::ApiKeysViewModel)
     viewModelOf(::FavoritesViewModel)
     viewModelOf(::MemoriesViewModel)

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/util/PlatformCacheCleaner.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/util/PlatformCacheCleaner.kt
@@ -1,5 +1,5 @@
 package com.garfiec.librechat.feature.settings.util
 
 interface PlatformCacheCleaner {
-    fun clearCache()
+    suspend fun clearCache()
 }

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/SettingsViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/SettingsViewModel.kt
@@ -47,6 +47,8 @@ import com.garfiec.librechat.feature.settings.viewmodel.delegate.McpServerDelega
 import com.garfiec.librechat.feature.settings.viewmodel.delegate.MemoryManagementDelegate
 import com.garfiec.librechat.feature.settings.viewmodel.delegate.SpeechSettingsFactory
 import com.garfiec.librechat.feature.settings.viewmodel.delegate.TwoFactorSecurityDelegate
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -55,6 +57,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 data class SettingsCommand(
     val name: String,
@@ -242,6 +245,7 @@ private data class DataStorePreferences(
     val selectedVoiceId: String,
 )
 
+@Suppress("LongParameterList")
 class SettingsViewModel(
     private val contentReader: ContentReader,
     private val cacheCleaner: PlatformCacheCleaner,
@@ -262,6 +266,7 @@ class SettingsViewModel(
     private val configRepository: ConfigRepository,
     diagnosticLogRepository: DiagnosticLogRepository,
     appInfo: AppInfo,
+    private val ioDispatcher: CoroutineDispatcher,
 ) : ViewModel() {
 
     /** Raw state for everything not driven by DataStore flows. */
@@ -555,7 +560,20 @@ class SettingsViewModel(
     fun uploadAvatar(uri: Any) {
         viewModelScope.launch {
             _uiState.update { it.copy(isAvatarUploading = true) }
-            val bytes = contentReader.readBytes(uri)
+            // Reading bytes off the URI is blocking I/O — keep it off the Main
+            // dispatcher (viewModelScope = Main.immediate) to avoid an ANR on
+            // large images. Mirrors the #92 FileAttachmentDelegate fix.
+            val bytes = try {
+                withContext(ioDispatcher) { contentReader.readBytes(uri) }
+            } catch (e: CancellationException) {
+                // Cooperative cancellation must propagate (SKIE/iOS requirement).
+                throw e
+            } catch (e: Exception) {
+                _uiState.update {
+                    it.copy(isAvatarUploading = false, error = "Could not read selected image: ${e.message}")
+                }
+                return@launch
+            }
             if (bytes == null) {
                 _uiState.update {
                     it.copy(isAvatarUploading = false, error = "Could not read selected image")

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/delegate/DataManagementDelegate.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/delegate/DataManagementDelegate.kt
@@ -11,6 +11,7 @@ import com.garfiec.librechat.feature.settings.model.SharedLinkDisplayData
 import com.garfiec.librechat.feature.settings.util.PlatformCacheCleaner
 import com.garfiec.librechat.feature.settings.viewmodel.LogsExportPayload
 import com.garfiec.librechat.feature.settings.viewmodel.SettingsStateHandle
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
 import kotlin.time.Clock
 
@@ -217,6 +218,8 @@ class DataManagementDelegate(
             try {
                 cacheCleaner.clearCache()
                 stateHandle.update { copy(isCacheClearing = false) }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 stateHandle.update {
                     copy(

--- a/feature/settings/src/iosMain/kotlin/com/garfiec/librechat/feature/settings/di/SettingsPlatformModule.ios.kt
+++ b/feature/settings/src/iosMain/kotlin/com/garfiec/librechat/feature/settings/di/SettingsPlatformModule.ios.kt
@@ -8,6 +8,9 @@ import com.garfiec.librechat.feature.settings.viewmodel.delegate.SpeechSettingsF
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.addressOf
 import kotlinx.cinterop.usePinned
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import org.koin.core.module.Module
 import org.koin.dsl.bind
 import org.koin.dsl.module
@@ -48,27 +51,31 @@ actual val settingsPlatformModule: Module = module {
     single {
         @OptIn(ExperimentalForeignApi::class)
         object : PlatformCacheCleaner {
-            override fun clearCache() {
-                try {
-                    val paths = NSSearchPathForDirectoriesInDomains(
-                        NSCachesDirectory,
-                        NSUserDomainMask,
-                        true,
-                    )
-                    val cachePath = paths.firstOrNull() as? String
-                    if (cachePath == null) {
-                        Logger.w("CacheCleaner") { "Could not resolve caches directory" }
-                        return
+            override suspend fun clearCache() {
+                withContext(Dispatchers.Default) {
+                    try {
+                        val paths = NSSearchPathForDirectoriesInDomains(
+                            NSCachesDirectory,
+                            NSUserDomainMask,
+                            true,
+                        )
+                        val cachePath = paths.firstOrNull() as? String
+                        if (cachePath == null) {
+                            Logger.w("CacheCleaner") { "Could not resolve caches directory" }
+                            return@withContext
+                        }
+                        val fm = NSFileManager.defaultManager
+                        val contents = fm.contentsOfDirectoryAtPath(cachePath, null) as? List<*>
+                        contents?.forEach { item ->
+                            val name = item as? String ?: return@forEach
+                            fm.removeItemAtPath("$cachePath/$name", null)
+                        }
+                        Logger.i("CacheCleaner") { "Cleared iOS caches directory" }
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Exception) {
+                        Logger.w(e) { "Failed to clear caches" }
                     }
-                    val fm = NSFileManager.defaultManager
-                    val contents = fm.contentsOfDirectoryAtPath(cachePath, null) as? List<*>
-                    contents?.forEach { item ->
-                        val name = item as? String ?: return@forEach
-                        fm.removeItemAtPath("$cachePath/$name", null)
-                    }
-                    Logger.i("CacheCleaner") { "Cleared iOS caches directory" }
-                } catch (e: Exception) {
-                    Logger.w(e) { "Failed to clear caches" }
                 }
             }
         }

--- a/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/app/LibreChatApp.kt
+++ b/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/app/LibreChatApp.kt
@@ -50,6 +50,9 @@ fun LibreChatApp() {
     setSingletonImageLoaderFactory(imageLoaderFactory)
 
     val themeDataStore = koinInject<ThemeDataStore>()
+    // Hold off drawing themed content until the persisted theme has resolved, so a dark-mode
+    // user on a light-system device never sees a one-frame flash of the wrong theme.
+    val themeReady by themeDataStore.isReady.collectAsState()
     val themeMode by themeDataStore.themeMode.collectAsState(initial = themeDataStore.initialThemeMode)
     val systemDark = isSystemInDarkTheme()
     val darkTheme = when (themeMode) {
@@ -57,7 +60,9 @@ fun LibreChatApp() {
         ThemeMode.DARK -> true
         ThemeMode.SYSTEM -> systemDark
     }
-    LibreChatTheme(darkTheme = darkTheme) {
-        LibreChatNavHost()
+    if (themeReady) {
+        LibreChatTheme(darkTheme = darkTheme) {
+            LibreChatNavHost()
+        }
     }
 }

--- a/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/NavHostViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/NavHostViewModel.kt
@@ -3,7 +3,6 @@ package com.garfiec.librechat.shared.navigation
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import co.touchlab.kermit.Logger
-import com.garfiec.librechat.core.common.extensions.firstBlocking
 import com.garfiec.librechat.core.common.result.Result
 import com.garfiec.librechat.core.data.datastore.SettingsDataStore
 import com.garfiec.librechat.core.data.repository.AuthRepository
@@ -19,6 +18,7 @@ import com.garfiec.librechat.core.model.SAVED_TAG
 import com.garfiec.librechat.core.model.permissions.Permission
 import com.garfiec.librechat.core.model.permissions.PermissionType
 import com.garfiec.librechat.core.model.permissions.hasAccessOrPermissive
+import com.garfiec.librechat.core.network.client.ServerUrlProvider
 import com.garfiec.librechat.core.network.client.TokenManager
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -40,6 +40,7 @@ class NavHostViewModel(
     private val tagRepository: TagRepository,
     private val tokenManager: TokenManager,
     private val settingsDataStore: SettingsDataStore,
+    private val serverUrlProvider: ServerUrlProvider,
 ) : ViewModel() {
 
     private val bannerStateHolder = BannerStateHolder(bannerRepository, viewModelScope)
@@ -51,6 +52,14 @@ class NavHostViewModel(
             .map { list -> list.filter { SAVED_TAG in it.tags } }
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
 
+    // Seeded synchronously so first-frame routing (LibreChatNavHost reads isLoggedIn.value
+    // once in a LaunchedEffect to redirect to auth) gets the correct value with no flash.
+    // This is a non-blocking in-memory cache read: TokenManager decrypts the access token at
+    // its own construction (TokenDataStore.init -> initializeTokenCache), so by the time the
+    // VM is built the token is already cached and isAuthenticated is just a null check. The
+    // init{} block below re-resolves the same value asynchronously. (The Keychain/
+    // EncryptedSharedPreferences decrypt itself still runs on Main at TokenDataStore
+    // construction — see report follow-up; it is out of this stream's three files.)
     private val _isLoggedIn = MutableStateFlow(tokenManager.isAuthenticated)
     val isLoggedIn: StateFlow<Boolean> = _isLoggedIn.asStateFlow()
 
@@ -61,11 +70,17 @@ class NavHostViewModel(
 
     val sessionExpired: SharedFlow<Unit> = tokenManager.sessionExpiredFlow
 
-    val tabletSidebarOpen: StateFlow<Boolean> = settingsDataStore.tabletSidebarOpen
+    // Seeded `null` (= "not resolved yet") and warmed up by the Eagerly-started collector. The
+    // previous synchronous `firstBlocking` read blocked the Main thread Koin instantiates the VM
+    // on. The nullable seed lets TabletLayout distinguish "unknown" from "closed" so it can snap
+    // to the persisted state on first resolution instead of animating false -> true (a visible
+    // sidebar jump on every tablet cold start).
+    val tabletSidebarOpen: StateFlow<Boolean?> = settingsDataStore.tabletSidebarOpen
+        .map<Boolean, Boolean?> { it }
         .stateIn(
             viewModelScope,
             SharingStarted.Eagerly,
-            firstBlocking(settingsDataStore.tabletSidebarOpen, false),
+            null,
         )
 
     val tabletSidebarGestureEnabled: StateFlow<Boolean> = settingsDataStore.tabletSidebarGestureEnabled
@@ -144,6 +159,10 @@ class NavHostViewModel(
     init {
         viewModelScope.launch {
             try {
+                // Wait for the server URL's async warm-up before any startup network work, so a
+                // logged-in cold start can't fire requests (auth check, version/config fetch,
+                // session tasks) at an empty base URL while ServerDataStore is still resolving.
+                serverUrlProvider.awaitBaseUrl()
                 val loggedIn = authRepository.isLoggedIn()
                 _isLoggedIn.value = loggedIn
                 if (loggedIn) {

--- a/shared/src/iosMain/kotlin/com/garfiec/librechat/shared/IosSharedModule.kt
+++ b/shared/src/iosMain/kotlin/com/garfiec/librechat/shared/IosSharedModule.kt
@@ -29,6 +29,7 @@ import com.garfiec.librechat.core.network.api.TagsApi
 import com.garfiec.librechat.core.network.api.UserApi
 import com.garfiec.librechat.core.network.client.LibreChatHttpClient
 import com.garfiec.librechat.core.network.client.ServerUrlProvider
+import com.garfiec.librechat.core.network.client.ServerUrlReadyPlugin
 import com.garfiec.librechat.core.network.client.TokenManager
 import com.garfiec.librechat.core.network.sse.SseClient
 import com.garfiec.librechat.core.network.sse.SseHttpTransport
@@ -94,6 +95,9 @@ val iosSharedModule = module {
         val serverUrlProvider = get<ServerUrlProvider>()
         HttpClient(Darwin) {
             install(ContentNegotiation) { json(json) }
+            install(ServerUrlReadyPlugin) {
+                this.serverUrlProvider = serverUrlProvider
+            }
             install(HttpTimeout) {
                 requestTimeoutMillis = 15_000
                 connectTimeoutMillis = 10_000


### PR DESCRIPTION
## Summary

Audits and fixes ~30 sites that ran blocking I/O, CPU-heavy parsing, or large
allocations on the Main/UI dispatcher across Android and iOS. These cause dropped
frames during streaming and ANR-class freezes during uploads, PDF preview, and
voice playback. Closes #93.

## Changes

- **Streaming** — SSE parse and message-tree derivation moved off Main (`flowOn`);
  removed an O(N²) re-join in HTML-block extraction.
- **Cold start** — Theme/Server datastores warm up asynchronously instead of
  blocking the Koin-instantiation thread with `runBlocking`. First frame is gated
  on theme readiness (no wrong-theme flash) and the tablet sidebar snaps to its
  persisted state (no first-frame slide-in).
- **Network** — requests await server-URL readiness at the network layer, so a
  cold-start request can't be built against an empty base URL.
- **Uploads / export / PDF** — avatar uploads, conversation export/import, and
  PDF rendering run off Main.
- **Audio / voice** — recording, server-TTS playback, and audio rendering run off
  Main; the voice record start/stop path is race-free and releases the recorder
  deterministically.
- **iOS** — file/clipboard picker encode/copy, image/artifact share, and cache
  clear run off Main; the SSE transport awaits URL readiness.

## Testing

- Android unit tests + all module DI-verification tests + Koin graph verification.
- iOS `:shared` simulator-arm64 compile.
- detekt.
- On-device smoke pass (Pixel 9 Pro Fold): cold-start theme/auth routing, tablet
  sidebar restore, streaming, branch switching, voice record/TTS, cache clear.

## Notes for review

The network layer gains a suspension point (await server-URL readiness) before
each request's URL is applied; `defaultRequest`'s URL merge is unchanged. Worth a
look at the SSE, auth-refresh, and OAuth paths.