### PR TITLE
docs(readme): bump backend compatibility range to v0.8.6

### DIFF
--- a/.claude/skills/sync-upstream/SKILL.md
+++ b/.claude/skills/sync-upstream/SKILL.md
@@ -383,12 +383,17 @@ Create a task for the implementer with the approved change list:
 >    commit={full SHA of target_tag}
 >    date={today's date YYYY-MM-DD}
 >    ```
-> 4. Update `DISCOVERY.md` at the repo root: append newly-discovered endpoints, removed
+> 4. Update `README.md` at repo root: bump the compatibility badge and the
+>    "Backend compatibility" note's upper bound to the new `{target_tag}` (badge
+>    link target too). Leave the lower bound unless the floor was deliberately
+>    raised. Easy to forget — it's the only user-facing version surface not
+>    driven by `version.properties`. (Missed in the v0.8.6 sync; fixed in PR #125.)
+> 5. Update `DISCOVERY.md` at the repo root: append newly-discovered endpoints, removed
 >    endpoints, and revised response shapes. Keep it accurate — future syncs depend on it.
-> 5. Create/update `VERSION_GATES.md` at repo root: add a row for any code path
+> 6. Create/update `VERSION_GATES.md` at repo root: add a row for any code path
 >    that branches on `BackendVersion.isCompatible()` / `isCompatibleOrNewer()`.
 >    Keep backward-compat gates auditable so future floor-raises are mechanical.
-> 6. Report back the full list of files created or modified, grouped by module.
+> 7. Report back the full list of files created or modified, grouped by module.
 >
 > **DO NOT** run `git push`, `git push -u origin ...`, or `gh pr create`.
 > The branch stays local-only until the user device-tests and explicitly
@@ -422,8 +427,9 @@ After implementer reports done, create a task for the verifier:
 > **Version consistency:**
 > 7. `backendTargetVersion` in the root `version.properties` matches target (this drives the generated `SUPPORTED_BACKEND_VERSION`)
 > 8. `UPSTREAM_VERSION` file has correct tag, commit, date
-> 9. Submodule is at the correct tag: `cd upstream && git describe --tags`
-> 10. `DISCOVERY.md` reflects endpoint additions/removals
+> 9. `README.md` compatibility badge + note upper bound matches the new target tag
+> 10. Submodule is at the correct tag: `cd upstream && git describe --tags`
+> 11. `DISCOVERY.md` reflects endpoint additions/removals
 >
 > **If you find issues**, message the **implementer** directly to fix them.
 > The implementer retains context of what it changed.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # LibreChat Mobile
 
-[![LibreChat](https://img.shields.io/badge/LibreChat-v0.8.4_–_v0.8.5-blue)](https://github.com/danny-avila/LibreChat/releases/tag/v0.8.5)
+[![LibreChat](https://img.shields.io/badge/LibreChat-v0.8.4_–_v0.8.6-blue)](https://github.com/danny-avila/LibreChat/releases/tag/v0.8.6)
 
 A third-party native mobile client for [LibreChat](https://www.librechat.ai/) (Android & iOS). Not affiliated with the official LibreChat project — this is an independent app that connects to any self-hosted LibreChat server, no backend modifications required.
 
-> **Backend compatibility:** Tested against LibreChat **v0.8.4 – v0.8.5**. Older releases may work but are not guaranteed; newer releases are supported on a best-effort basis until the next sync.
+> **Backend compatibility:** Tested against LibreChat **v0.8.4 – v0.8.6**. Older releases may work but are not guaranteed; newer releases are supported on a best-effort basis until the next sync.
 
 ## Features
 


### PR DESCRIPTION
## Summary
The v0.8.6 sync bumped the backend target constant (`backendTargetVersion`, `UPSTREAM_VERSION`) to 0.8.6, but the README compatibility badge and note still advertised v0.8.4 – v0.8.5. This fast-follow updates both to **v0.8.4 – v0.8.6**.

## Changes
- README badge → `LibreChat-v0.8.4_–_v0.8.6`, link points at the v0.8.6 release tag
- Backend compatibility note → "Tested against LibreChat **v0.8.4 – v0.8.6**"