### PR TITLE
Gate chat options by server config, role, and endpoint capability

### DIFF
--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/FileRepository.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/FileRepository.kt
@@ -4,9 +4,14 @@ import com.garfiec.librechat.core.common.result.Result
 import com.garfiec.librechat.core.model.FileObject
 import com.garfiec.librechat.core.model.request.DeleteFileEntry
 import com.garfiec.librechat.core.model.response.FilePreviewResponse
+import com.garfiec.librechat.core.model.response.FileUploadConfig
 
 interface FileRepository {
     suspend fun getFiles(): Result<List<FileObject>>
+
+    /** Fetches the server's upload config (`GET /api/files/config`), including the
+     *  per-endpoint `endpoints` map. Used to gate the chat attach controls. */
+    suspend fun getFileConfig(): Result<FileUploadConfig>
     suspend fun uploadFile(
         bytes: ByteArray,
         filename: String,

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/FileRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/FileRepositoryImpl.kt
@@ -6,6 +6,7 @@ import com.garfiec.librechat.core.model.FileObject
 import com.garfiec.librechat.core.model.request.DeleteFileEntry
 import com.garfiec.librechat.core.model.request.DeleteFilesRequest
 import com.garfiec.librechat.core.model.response.FilePreviewResponse
+import com.garfiec.librechat.core.model.response.FileUploadConfig
 import com.garfiec.librechat.core.network.api.FilesApi
 import com.garfiec.librechat.core.network.api.FilesExtApi
 import kotlinx.coroutines.CancellationException
@@ -21,6 +22,9 @@ class FileRepositoryImpl(
 
     override suspend fun getFiles(): Result<List<FileObject>> =
         safeApiCall { filesApi.getFiles() }
+
+    override suspend fun getFileConfig(): Result<FileUploadConfig> =
+        safeApiCall { filesApi.getFileConfig() }
 
     override suspend fun uploadFile(
         bytes: ByteArray,

--- a/core/model/src/commonMain/kotlin/com/garfiec/librechat/core/model/response/FileUploadConfig.kt
+++ b/core/model/src/commonMain/kotlin/com/garfiec/librechat/core/model/response/FileUploadConfig.kt
@@ -9,4 +9,24 @@ data class FileUploadConfig(
     val totalSizeLimit: Long? = null,
     val supportedMimeTypes: List<String> = emptyList(),
     val disabled: Boolean = false,
+    /**
+     * Per-endpoint overrides keyed by endpoint name (plus a `"default"` entry).
+     * The server's `/api/files/config` returns this map; the web client resolves the
+     * effective config for the selected endpoint from it (see data-provider
+     * `getEndpointFileConfig`). Mobile uses it to gate the attach controls when an
+     * endpoint sets `disabled = true`. Absent on older backends — callers fail open.
+     */
+    val endpoints: Map<String, EndpointFileConfig> = emptyMap(),
+)
+
+/**
+ * Per-endpoint slice of the file-upload config. Only the fields mobile consults are
+ * modeled; the response may carry more which is ignored here.
+ */
+@Serializable
+data class EndpointFileConfig(
+    val disabled: Boolean = false,
+    val fileLimit: Int? = null,
+    val fileSizeLimit: Long? = null,
+    val supportedMimeTypes: List<String> = emptyList(),
 )

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/components/ChatInput.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/components/ChatInput.kt
@@ -52,6 +52,7 @@ import androidx.core.content.ContextCompat
 import androidx.core.content.FileProvider
 import com.garfiec.librechat.feature.chat.model.McpServerDisplayData
 import com.garfiec.librechat.feature.chat.model.PromptMentionDisplayData
+import com.garfiec.librechat.feature.chat.viewmodel.ChatInputGates
 import com.garfiec.librechat.feature.chat.resources.*
 import com.garfiec.librechat.feature.chat.resources.Res
 import org.jetbrains.compose.resources.stringResource
@@ -89,6 +90,7 @@ fun ChatInput(
     runCodeEnabled: Boolean = true,
     fileSearchEnabled: Boolean = true,
     mcpServersEnabled: Boolean = true,
+    gates: ChatInputGates = ChatInputGates(),
 ) {
     val cdOpenToolsMenu = stringResource(Res.string.cd_open_tools_menu)
     val cdPasteImage = stringResource(Res.string.cd_paste_image)
@@ -181,9 +183,10 @@ fun ChatInput(
         textFieldValue = TextFieldValue(inputText, selection = TextRange(inputText.length))
     }
 
-    val hasActiveTools by remember(enabledTools, selectedMcpServerNames) {
+    // Badge suppressed on agents endpoint (retained state restores on concrete models).
+    val hasActiveTools by remember(enabledTools, selectedMcpServerNames, gates.showEphemeralTools) {
         derivedStateOf {
-            enabledTools.isNotEmpty() || selectedMcpServerNames.isNotEmpty()
+            gates.showEphemeralTools && (enabledTools.isNotEmpty() || selectedMcpServerNames.isNotEmpty())
         }
     }
 
@@ -222,6 +225,7 @@ fun ChatInput(
         selectedModelDisplay = selectedModelDisplay,
         isCodeInterpreterAvailable = isCodeInterpreterAvailable,
         attachedFiles = attachedFiles,
+        gates = gates,
     )
 
     CommonChatInputCore(
@@ -404,6 +408,7 @@ fun ChatInput(
             runCodeEnabled = runCodeEnabled,
             fileSearchEnabled = fileSearchEnabled,
             mcpServersEnabled = mcpServersEnabled,
+            gates = gates,
         )
     }
 }

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatScreen.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatScreen.kt
@@ -338,6 +338,7 @@ actual fun ChatScreen(
                     onOpenSearch = viewModel::openSearch,
                     onOpenPromptsLibrary = onNavigateToPromptsLibrary,
                     promptsEnabled = uiState.promptsEnabled,
+                    presetsEnabled = uiState.presetsEnabled,
                     multiConvoEnabled = uiState.multiConvoEnabled,
                     isTemporaryChat = uiState.isTemporaryChat,
                     onToggleTemporaryChat = viewModel::toggleTemporaryChat,
@@ -684,6 +685,7 @@ actual fun ChatScreen(
                 runCodeEnabled = uiState.runCodeEnabled,
                 fileSearchEnabled = uiState.fileSearchEnabled,
                 mcpServersEnabled = uiState.mcpServersEnabled,
+                gates = uiState.chatInputGates,
                 modifier = Modifier.align(Alignment.BottomCenter),
             )
         }
@@ -844,6 +846,7 @@ private fun ChatTopBar(
     onOpenSearch: () -> Unit = {},
     onOpenPromptsLibrary: (() -> Unit)? = null,
     promptsEnabled: Boolean = true,
+    presetsEnabled: Boolean = true,
     multiConvoEnabled: Boolean = true,
     isTemporaryChat: Boolean = false,
     onToggleTemporaryChat: () -> Unit = {},
@@ -927,26 +930,30 @@ private fun ChatTopBar(
                         },
                     )
                 }
-                DropdownMenuItem(
-                    text = { Text(stringResource(Res.string.load_preset)) },
-                    onClick = {
-                        showOverflowMenu = false
-                        onLoadPreset()
-                    },
-                    leadingIcon = {
-                        Icon(Icons.Outlined.FileOpen, contentDescription = null)
-                    },
-                )
-                DropdownMenuItem(
-                    text = { Text(stringResource(Res.string.save_as_preset)) },
-                    onClick = {
-                        showOverflowMenu = false
-                        onSavePreset()
-                    },
-                    leadingIcon = {
-                        Icon(Icons.Outlined.SaveAs, contentDescription = null)
-                    },
-                )
+                // Preset load/save — hidden when the server disables `interface.presets`
+                // (or `interface.modelSelect`), matching web's Header.tsx presets menu.
+                if (presetsEnabled) {
+                    DropdownMenuItem(
+                        text = { Text(stringResource(Res.string.load_preset)) },
+                        onClick = {
+                            showOverflowMenu = false
+                            onLoadPreset()
+                        },
+                        leadingIcon = {
+                            Icon(Icons.Outlined.FileOpen, contentDescription = null)
+                        },
+                    )
+                    DropdownMenuItem(
+                        text = { Text(stringResource(Res.string.save_as_preset)) },
+                        onClick = {
+                            showOverflowMenu = false
+                            onSavePreset()
+                        },
+                        leadingIcon = {
+                            Icon(Icons.Outlined.SaveAs, contentDescription = null)
+                        },
+                    )
+                }
                 if (onOpenPromptsLibrary != null && promptsEnabled) {
                     DropdownMenuItem(
                         text = { Text(stringResource(Res.string.prompts_library)) },

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/AttachmentChipsRow.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/AttachmentChipsRow.kt
@@ -73,12 +73,33 @@ fun AttachmentChipsRow(
     modifier: Modifier = Modifier,
     mcpServers: List<McpServerDisplayData> = emptyList(),
     selectedMcpServerNames: Set<String> = emptySet(),
+    /**
+     * Whether ephemeral tool selections (web search / code / file search / MCP) should be
+     * shown as chips. False for the agents endpoint, where the underlying selections are
+     * retained but not sent (see [ChatUiState.showEphemeralTools]); only the display is
+     * suppressed so switching back to a concrete model restores the chips. File chips are
+     * unaffected — files aren't ephemeral tools.
+     */
+    showEphemeralTools: Boolean = true,
 ) {
     val hasFiles = attachedFiles.isNotEmpty()
-    val hasWebSearch = ToolConstants.WEB_SEARCH in enabledTools
-    val hasCode = ToolConstants.CODE_INTERPRETER in enabledTools
-    val hasFileSearch = ToolConstants.FILE_SEARCH in enabledTools
-    val selectedMcpServers = mcpServers.filter { it.name in selectedMcpServerNames }
+    // Memoize ephemeral state once to avoid repeated guards and per-recomposition MCP filtering when tools are hidden.
+    val ephemeral = remember(showEphemeralTools, enabledTools, mcpServers, selectedMcpServerNames) {
+        if (!showEphemeralTools) {
+            EphemeralChips()
+        } else {
+            EphemeralChips(
+                hasWebSearch = ToolConstants.WEB_SEARCH in enabledTools,
+                hasCode = ToolConstants.CODE_INTERPRETER in enabledTools,
+                hasFileSearch = ToolConstants.FILE_SEARCH in enabledTools,
+                selectedMcpServers = mcpServers.filter { it.name in selectedMcpServerNames },
+            )
+        }
+    }
+    val hasWebSearch = ephemeral.hasWebSearch
+    val hasCode = ephemeral.hasCode
+    val hasFileSearch = ephemeral.hasFileSearch
+    val selectedMcpServers = ephemeral.selectedMcpServers
     val hasMcp = selectedMcpServers.isNotEmpty()
     val hasAnyChip = hasFiles || hasWebSearch || hasCode || hasFileSearch || hasMcp
 
@@ -386,3 +407,10 @@ private fun FilePreviewItem(
         }
     }
 }
+
+private data class EphemeralChips(
+    val hasWebSearch: Boolean = false,
+    val hasCode: Boolean = false,
+    val hasFileSearch: Boolean = false,
+    val selectedMcpServers: List<McpServerDisplayData> = emptyList(),
+)

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ChatToolsBottomSheet.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ChatToolsBottomSheet.kt
@@ -56,6 +56,7 @@ import com.garfiec.librechat.core.common.ToolConstants
 import com.garfiec.librechat.feature.chat.model.McpServerDisplayData
 import com.garfiec.librechat.feature.chat.resources.*
 import com.garfiec.librechat.feature.chat.resources.Res
+import com.garfiec.librechat.feature.chat.viewmodel.ChatInputGates
 import org.jetbrains.compose.resources.stringResource
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -79,6 +80,12 @@ fun ChatToolsBottomSheet(
     runCodeEnabled: Boolean = true,
     fileSearchEnabled: Boolean = true,
     mcpServersEnabled: Boolean = true,
+    /**
+     * Server/endpoint feature gates for the sheet: model-select row, parameters row,
+     * ephemeral tool controls (web search / code / file search / MCP), and the
+     * Camera / Photos / Files attach controls. See [ChatInputGates].
+     */
+    gates: ChatInputGates = ChatInputGates(),
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     var showMcpServers by remember { mutableStateOf(false) }
@@ -95,120 +102,128 @@ fun ChatToolsBottomSheet(
                 .padding(horizontal = 16.dp)
                 .padding(bottom = 16.dp),
         ) {
-            // Top section: Camera, Photos, Files cards
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(12.dp),
-            ) {
-                AttachmentOptionCard(
-                    icon = Icons.Default.PhotoCamera,
-                    label = stringResource(Res.string.tool_camera),
-                    onClick = {
-                        onTakePhoto()
-                        onDismiss()
-                    },
-                )
-                AttachmentOptionCard(
-                    icon = Icons.Default.PhotoLibrary,
-                    label = stringResource(Res.string.tool_photos),
-                    onClick = {
-                        onPickPhotos()
-                        onDismiss()
-                    },
-                )
-                AttachmentOptionCard(
-                    icon = Icons.Default.AttachFile,
-                    label = stringResource(Res.string.tool_files),
-                    onClick = {
-                        onAttachFiles()
-                        onDismiss()
-                    },
-                )
+            // Top section: Camera, Photos, Files cards — hidden when the selected
+            // endpoint can't accept uploads (mirrors web's AttachFileChat gate).
+            if (gates.fileUploadEnabled) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    AttachmentOptionCard(
+                        icon = Icons.Default.PhotoCamera,
+                        label = stringResource(Res.string.tool_camera),
+                        onClick = {
+                            onTakePhoto()
+                            onDismiss()
+                        },
+                    )
+                    AttachmentOptionCard(
+                        icon = Icons.Default.PhotoLibrary,
+                        label = stringResource(Res.string.tool_photos),
+                        onClick = {
+                            onPickPhotos()
+                            onDismiss()
+                        },
+                    )
+                    AttachmentOptionCard(
+                        icon = Icons.Default.AttachFile,
+                        label = stringResource(Res.string.tool_files),
+                        onClick = {
+                            onAttachFiles()
+                            onDismiss()
+                        },
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(12.dp))
+                HorizontalDivider()
+                Spacer(modifier = Modifier.height(8.dp))
             }
 
-            Spacer(modifier = Modifier.height(12.dp))
+            // Model selector row — hidden when the server disables `interface.modelSelect`.
+            if (gates.modelSelectEnabled) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable {
+                            onOpenModelSelector()
+                            onDismiss()
+                        }
+                        .padding(vertical = 12.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.SmartToy,
+                        contentDescription = null,
+                        modifier = Modifier.size(24.dp),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Spacer(modifier = Modifier.width(16.dp))
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = stringResource(Res.string.tool_model),
+                            style = MaterialTheme.typography.bodyLarge,
+                        )
+                        Text(
+                            text = selectedModelDisplay ?: stringResource(Res.string.select_model),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    }
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+
+            // Model Parameters — hidden when the server disables `interface.parameters`.
+            if (gates.parametersEnabled) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable {
+                            onOpenModelParameters()
+                            onDismiss()
+                        }
+                        .padding(vertical = 12.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Tune,
+                        contentDescription = null,
+                        modifier = Modifier.size(24.dp),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Spacer(modifier = Modifier.width(16.dp))
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = stringResource(Res.string.tool_model_parameters),
+                            style = MaterialTheme.typography.bodyLarge,
+                        )
+                        Text(
+                            text = stringResource(Res.string.tool_model_parameters_desc),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+
             HorizontalDivider()
             Spacer(modifier = Modifier.height(8.dp))
 
-            // Model selector row
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clickable {
-                        onOpenModelSelector()
-                        onDismiss()
-                    }
-                    .padding(vertical = 12.dp),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Icon(
-                    imageVector = Icons.Default.SmartToy,
-                    contentDescription = null,
-                    modifier = Modifier.size(24.dp),
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-                Spacer(modifier = Modifier.width(16.dp))
-                Column(modifier = Modifier.weight(1f)) {
-                    Text(
-                        text = stringResource(Res.string.tool_model),
-                        style = MaterialTheme.typography.bodyLarge,
-                    )
-                    Text(
-                        text = selectedModelDisplay ?: stringResource(Res.string.select_model),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                    )
-                }
-                Icon(
-                    imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
-
-            // Model Parameters
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clickable {
-                        onOpenModelParameters()
-                        onDismiss()
-                    }
-                    .padding(vertical = 12.dp),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Icon(
-                    imageVector = Icons.Default.Tune,
-                    contentDescription = null,
-                    modifier = Modifier.size(24.dp),
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-                Spacer(modifier = Modifier.width(16.dp))
-                Column(modifier = Modifier.weight(1f)) {
-                    Text(
-                        text = stringResource(Res.string.tool_model_parameters),
-                        style = MaterialTheme.typography.bodyLarge,
-                    )
-                    Text(
-                        text = stringResource(Res.string.tool_model_parameters_desc),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
-                Icon(
-                    imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
-
-            HorizontalDivider()
-            Spacer(modifier = Modifier.height(8.dp))
-
-            // Tool toggle items
-            if (webSearchEnabled) {
+            // Tool toggle items — ephemeral tools are hidden for the agents endpoint
+            // (the agent uses its own configured tools), mirroring web's showEphemeralBadges.
+            if (gates.showEphemeralTools && webSearchEnabled) {
                 ToolToggleRow(
                     icon = Icons.Default.Search,
                     title = stringResource(Res.string.tool_web_search),
@@ -218,7 +233,7 @@ fun ChatToolsBottomSheet(
                 )
             }
 
-            if (isCodeInterpreterAvailable && runCodeEnabled) {
+            if (gates.showEphemeralTools && isCodeInterpreterAvailable && runCodeEnabled) {
                 ToolToggleRow(
                     icon = Icons.Default.Code,
                     title = stringResource(Res.string.tool_code),
@@ -228,7 +243,7 @@ fun ChatToolsBottomSheet(
                 )
             }
 
-            if (fileSearchEnabled) {
+            if (gates.showEphemeralTools && fileSearchEnabled) {
                 ToolToggleRow(
                     icon = Icons.Default.FindInPage,
                     title = stringResource(Res.string.tool_file_search),
@@ -238,8 +253,9 @@ fun ChatToolsBottomSheet(
                 )
             }
 
-            // MCP section — hidden entirely when role denies MCP_SERVERS.USE.
-            if (mcpServersEnabled && mcpServers.isNotEmpty()) {
+            // MCP section — hidden when role denies MCP_SERVERS.USE, and for the agents
+            // endpoint where dynamic MCP selections are silently ignored by the backend.
+            if (gates.showEphemeralTools && mcpServersEnabled && mcpServers.isNotEmpty()) {
                 val anyMcpSelected = selectedMcpServerNames.isNotEmpty()
                 Row(
                     modifier = Modifier

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/CommonChatInputCore.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/CommonChatInputCore.kt
@@ -50,6 +50,7 @@ import com.garfiec.librechat.feature.chat.resources.cd_stop_generation
 import com.garfiec.librechat.feature.chat.resources.hint_message
 import com.garfiec.librechat.feature.chat.resources.hint_message_model
 import com.garfiec.librechat.feature.chat.resources.recording
+import com.garfiec.librechat.feature.chat.viewmodel.ChatInputGates
 import org.jetbrains.compose.resources.stringResource
 
 @Immutable
@@ -64,6 +65,8 @@ data class ChatInputState(
     val selectedModelDisplay: String?,
     val isCodeInterpreterAvailable: Boolean,
     val attachedFiles: List<AttachedFile>,
+    /** Ephemeral-tools gate drives local chip display; remaining gates are threaded to the sheet. */
+    val gates: ChatInputGates = ChatInputGates(),
 )
 
 /**
@@ -111,6 +114,7 @@ fun CommonChatInputCore(
                 onRemoveFile = onRemoveFile,
                 mcpServers = state.mcpServers,
                 selectedMcpServerNames = state.selectedMcpServerNames,
+                showEphemeralTools = state.gates.showEphemeralTools,
             )
 
             Row(

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatUiState.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatUiState.kt
@@ -14,6 +14,7 @@ import com.garfiec.librechat.core.model.Message
 import com.garfiec.librechat.core.model.SubagentPhase
 import com.garfiec.librechat.core.model.content.MessageContentPart
 import com.garfiec.librechat.core.model.endpoint.KeyState
+import com.garfiec.librechat.core.model.response.FileUploadConfig
 import com.garfiec.librechat.core.ui.components.ModelParameters
 import com.garfiec.librechat.feature.chat.model.McpServerDisplayData
 import com.garfiec.librechat.feature.chat.model.PresetDisplayData
@@ -105,6 +106,22 @@ data class SubagentTrace(
     val parts: List<MessageContentPart> = emptyList(),
     /** True once the server reports a terminal phase (`stop`/`error`). */
     val isComplete: Boolean = false,
+)
+
+/**
+ * Feature gates that flow into the composer ([ChatInput] → [ChatToolsBottomSheet]),
+ * bundled so they thread as one value across Android and iOS. Each defaults to true
+ * (shown) so a default-constructed bundle is fully permissive. Built by
+ * [ChatUiState.chatInputGates]; see [ChatUiState.modelSelectEnabled] /
+ * [ChatUiState.parametersEnabled] / [ChatUiState.showEphemeralTools] /
+ * [ChatUiState.fileUploadEnabled] for the individual gating rules.
+ */
+@Immutable
+data class ChatInputGates(
+    val modelSelectEnabled: Boolean = true,
+    val parametersEnabled: Boolean = true,
+    val showEphemeralTools: Boolean = true,
+    val fileUploadEnabled: Boolean = true,
 )
 
 @Immutable
@@ -200,7 +217,10 @@ data class ChatUiState(
     val showModelSheet: Boolean = false,
     // Model comparison state
     val comparisonState: ComparisonState = ComparisonState(),
-    // Role-permission gates — default permissive; narrowed once RoleRepository emits.
+    // Feature gates — effective value is `interface.* flag AND role permission`,
+    // matching the web client. Default permissive (true); narrowed once both the
+    // RoleRepository and the server's interface config emit. Fails open when an
+    // interface flag is absent (older backends that don't send it).
     val promptsEnabled: Boolean = true,
     val promptsCreateEnabled: Boolean = true,
     val agentsEnabled: Boolean = true,
@@ -212,6 +232,15 @@ data class ChatUiState(
     val runCodeEnabled: Boolean = true,
     val fileSearchEnabled: Boolean = true,
     val bookmarksEnabled: Boolean = true,
+    /**
+     * Interface-only gates (no corresponding role permission on web). Driven solely by
+     * the server's `interface.*` config: presets on `interface.presets && interface.modelSelect`,
+     * model select on `interface.modelSelect`, parameters on `interface.parameters`.
+     * See web `Chat/Header.tsx` and `Chat/Input/HeaderOptions.tsx`.
+     */
+    val presetsEnabled: Boolean = true,
+    val modelSelectEnabled: Boolean = true,
+    val parametersEnabled: Boolean = true,
     /**
      * User-pinned agent IDs (v0.8.5 favorites). Pinned agents sort to the top
      * of the "My Agents" group in [ModelSelectorSheet] and get a filled star.
@@ -228,7 +257,35 @@ data class ChatUiState(
      * older or unknown servers (per VERSION_GATES.md guideline #2). See VERSION_GATES.md.
      */
     val extendedEffortSupported: Boolean = false,
+    /**
+     * Server upload config (`GET /api/files/config`).
+     * Null before fetch or on fetch failure; treated as no constraint (controls fail open).
+     */
+    val fileUploadConfig: FileUploadConfig? = null,
 ) {
+    /**
+     * Whether the chat attach controls (Camera / Photos / Files) should be offered for
+     * the current endpoint. Mirrors web's AttachFileChat gate:
+     *  - The agents endpoint always allows attaching (file tools are gated per-agent
+     *    inside the menu on web; mobile keeps the controls visible).
+     *  - Other endpoints allow it unless the server marks the endpoint's file config
+     *    `disabled` (or the global default disabled).
+     *
+     * Fails OPEN: a null/absent config (older backend, fetch not landed, or fetch failed)
+     * leaves attaching enabled to preserve current behavior.
+     */
+    val fileUploadEnabled: Boolean
+        get() {
+            if (selectedEndpoint == EndpointConstants.AGENTS) return true
+            val config = fileUploadConfig ?: return true
+            // Per-endpoint override wins; fall back to the global default `disabled`.
+            val endpointDisabled = config.endpoints[selectedEndpoint]?.disabled
+            return when {
+                endpointDisabled != null -> !endpointDisabled
+                else -> !config.disabled
+            }
+        }
+
     /**
      * Effective tool set that merges [enabledTools] with the web search state from
      * [modelParameters]. This ensures the toolbar, bottom sheet, and dropdown all
@@ -240,6 +297,31 @@ data class ChatUiState(
         } else {
             enabledTools - ToolConstants.WEB_SEARCH
         }
+
+    /**
+     * Whether the per-request ephemeral tool controls (dynamic MCP servers, web search,
+     * code interpreter, file search) should be offered. Mirrors web's `showEphemeralBadges`
+     * (ChatForm.tsx): a saved agent uses its own configured tools, so the backend ignores
+     * client-supplied ephemeral tools on agent runs. Mobile's only agent-type endpoint is
+     * [EndpointConstants.AGENTS], so the gate is simply "not the agents endpoint".
+     */
+    val showEphemeralTools: Boolean
+        get() = selectedEndpoint != EndpointConstants.AGENTS
+
+    /**
+     * Bundle of the feature gates that flow into the composer ([ChatInput] →
+     * [ChatToolsBottomSheet]), so the four are threaded as one value across both
+     * platforms instead of four parallel params. Built from the existing fields;
+     * see each property for its gating rule. (`presetsEnabled` is not included —
+     * it flows to the top bar, a different path.)
+     */
+    val chatInputGates: ChatInputGates
+        get() = ChatInputGates(
+            modelSelectEnabled = modelSelectEnabled,
+            parametersEnabled = parametersEnabled,
+            showEphemeralTools = showEphemeralTools,
+            fileUploadEnabled = fileUploadEnabled,
+        )
 
     /**
      * Whether code interpreter (execute_code) is available on this server.

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModel.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModel.kt
@@ -33,6 +33,7 @@ import com.garfiec.librechat.core.model.Attachment
 import com.garfiec.librechat.core.model.Message
 import com.garfiec.librechat.core.model.Preset
 import com.garfiec.librechat.core.model.StreamEvent
+import com.garfiec.librechat.core.model.config.InterfaceConfig
 import com.garfiec.librechat.core.model.error.UserKeyError
 import com.garfiec.librechat.core.model.error.parseUserKeyError
 import com.garfiec.librechat.core.model.permissions.Permission
@@ -378,6 +379,7 @@ class ChatViewModel(
         favoritesDelegate.load()
         loadUserProfile()
         loadFlags()
+        loadFileConfig()
         voiceDelegate.loadSpeechConfig()
 
         // Gated loads share a single 5-second role-await budget so offline/timeout
@@ -579,6 +581,10 @@ class ChatViewModel(
      */
     private fun buildEphemeralAgent(): EphemeralAgent? {
         val state = _uiState.value
+        // A saved agent uses its own configured tools; the backend ignores client-supplied
+        // ephemeral tools for agent runs. Mirror web's `showEphemeralBadges` (ChatForm.tsx)
+        // and never serialize leftover UI selections on the agents endpoint.
+        if (!state.showEphemeralTools) return null
         val mcpServers = state.selectedMcpServerNames.toList().ifEmpty { null }
         val enabledTools = state.enabledTools
         val webSearchEnabled = state.modelParameters.webSearch
@@ -1657,10 +1663,26 @@ class ChatViewModel(
                 }
             }
         }
-        // Role-permission-driven flags. Permissive default: null role (not loaded) → true;
-        // missing type/action in the map → true (see UserRolePermissions.hasAccess).
+        // Feature gates. The effective rule mirrors web: `interface.* flag AND role permission`.
+        // Combining the two flows lets us AND them in one place. Both inputs fail open:
+        //  - Role permissions: null role (not loaded) → true; missing type/action → true
+        //    (see UserRolePermissions.hasAccess).
+        //  - Interface flags: an absent `interface` block (older backend) → null → treated
+        //    as enabled, so we never hide a control just because config is missing.
+        // The `interface.*` booleans (modelSelect/parameters/presets/multiConvo/temporaryChat/
+        // runCode/webSearch/fileSearch/bookmarks) default to true in InterfaceConfig, so an
+        // omitted individual flag is also fail-open.
         viewModelScope.launch {
-            roleRepository.userPermissions.collect { role ->
+            combine(
+                roleRepository.userPermissions,
+                configRepository.startupConfig,
+            ) { role, config ->
+                role to config?.interfaceConfig
+            }.distinctUntilChanged().collect { (role, iface) ->
+                // Effective gate = role permission AND interface flag, both fail-open
+                // (null role → permissive; absent/omitted flag → enabled).
+                fun gate(type: PermissionType, action: Permission, flag: (InterfaceConfig) -> Boolean?) =
+                    role.hasAccessOrPermissive(type, action) && (iface?.let(flag) ?: true)
                 _uiState.update {
                     it.copy(
                         promptsEnabled = role.hasAccessOrPermissive(PermissionType.PROMPTS, Permission.USE),
@@ -1668,14 +1690,32 @@ class ChatViewModel(
                         agentsEnabled = role.hasAccessOrPermissive(PermissionType.AGENTS, Permission.USE),
                         agentsCreateEnabled = role.hasAccessOrPermissive(PermissionType.AGENTS, Permission.CREATE),
                         mcpServersEnabled = role.hasAccessOrPermissive(PermissionType.MCP_SERVERS, Permission.USE),
-                        multiConvoEnabled = role.hasAccessOrPermissive(PermissionType.MULTI_CONVO, Permission.USE),
-                        temporaryChatEnabled = role.hasAccessOrPermissive(PermissionType.TEMPORARY_CHAT, Permission.USE),
-                        webSearchEnabled = role.hasAccessOrPermissive(PermissionType.WEB_SEARCH, Permission.USE),
-                        runCodeEnabled = role.hasAccessOrPermissive(PermissionType.RUN_CODE, Permission.USE),
-                        fileSearchEnabled = role.hasAccessOrPermissive(PermissionType.FILE_SEARCH, Permission.USE),
-                        bookmarksEnabled = role.hasAccessOrPermissive(PermissionType.BOOKMARKS, Permission.USE),
+                        multiConvoEnabled = gate(PermissionType.MULTI_CONVO, Permission.USE) { it.multiConvo },
+                        temporaryChatEnabled = gate(PermissionType.TEMPORARY_CHAT, Permission.USE) { it.temporaryChat },
+                        webSearchEnabled = gate(PermissionType.WEB_SEARCH, Permission.USE) { it.webSearch },
+                        runCodeEnabled = gate(PermissionType.RUN_CODE, Permission.USE) { it.runCode },
+                        fileSearchEnabled = gate(PermissionType.FILE_SEARCH, Permission.USE) { it.fileSearch },
+                        bookmarksEnabled = gate(PermissionType.BOOKMARKS, Permission.USE) { it.bookmarks },
+                        // Interface-only gates (no role permission counterpart on web).
+                        modelSelectEnabled = iface?.modelSelect ?: true,
+                        parametersEnabled = iface?.parameters ?: true,
+                        // Web gates the presets menu on `presets && modelSelect` (Header.tsx).
+                        presetsEnabled = (iface?.presets ?: true) && (iface?.modelSelect ?: true),
                     )
                 }
+            }
+        }
+    }
+
+    /**
+     * Fetches the server's upload config once so the attach controls can be gated per
+     * endpoint (see [ChatUiState.fileUploadEnabled]). Fails open: on error the config
+     * stays null and attaching remains enabled.
+     */
+    private fun loadFileConfig() {
+        viewModelScope.launch {
+            fileRepository.getFileConfig().getOrNull()?.let { config ->
+                _uiState.update { it.copy(fileUploadConfig = config) }
             }
         }
     }

--- a/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/components/IosChatInput.kt
+++ b/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/components/IosChatInput.kt
@@ -30,6 +30,7 @@ import com.garfiec.librechat.feature.chat.model.McpServerDisplayData
 import com.garfiec.librechat.feature.chat.resources.Res
 import com.garfiec.librechat.feature.chat.resources.cd_attach_file
 import com.garfiec.librechat.feature.chat.resources.cd_paste_image
+import com.garfiec.librechat.feature.chat.viewmodel.ChatInputGates
 import org.jetbrains.compose.resources.stringResource
 
 @Composable
@@ -64,6 +65,7 @@ fun IosChatInput(
     runCodeEnabled: Boolean = true,
     fileSearchEnabled: Boolean = true,
     mcpServersEnabled: Boolean = true,
+    gates: ChatInputGates = ChatInputGates(),
 ) {
     val snackbarHostState = remember { SnackbarHostState() }
     var showToolsSheet by remember { mutableStateOf(false) }
@@ -79,6 +81,7 @@ fun IosChatInput(
         selectedModelDisplay = selectedModelDisplay,
         isCodeInterpreterAvailable = isCodeInterpreterAvailable,
         attachedFiles = attachedFiles,
+        gates = gates,
     )
 
     CommonChatInputCore(
@@ -216,6 +219,7 @@ fun IosChatInput(
             runCodeEnabled = runCodeEnabled,
             fileSearchEnabled = fileSearchEnabled,
             mcpServersEnabled = mcpServersEnabled,
+            gates = gates,
         )
     }
 }

--- a/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/screen/PlatformScreens.ios.kt
+++ b/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/screen/PlatformScreens.ios.kt
@@ -241,27 +241,30 @@ actual fun ChatScreen(
                                         },
                                     )
                                 }
-                                // Presets
-                                DropdownMenuItem(
-                                    text = { Text(stringResource(Res.string.load_preset)) },
-                                    onClick = {
-                                        showOptionsMenu = false
-                                        showPresetPicker = true
-                                    },
-                                    leadingIcon = {
-                                        Icon(Icons.Outlined.FileOpen, contentDescription = null)
-                                    },
-                                )
-                                DropdownMenuItem(
-                                    text = { Text(stringResource(Res.string.save_as_preset)) },
-                                    onClick = {
-                                        showOptionsMenu = false
-                                        showSavePresetDialog = true
-                                    },
-                                    leadingIcon = {
-                                        Icon(Icons.Outlined.SaveAs, contentDescription = null)
-                                    },
-                                )
+                                // Presets — hidden when the server disables `interface.presets`
+                                // (or `interface.modelSelect`), matching web's Header.tsx.
+                                if (uiState.presetsEnabled) {
+                                    DropdownMenuItem(
+                                        text = { Text(stringResource(Res.string.load_preset)) },
+                                        onClick = {
+                                            showOptionsMenu = false
+                                            showPresetPicker = true
+                                        },
+                                        leadingIcon = {
+                                            Icon(Icons.Outlined.FileOpen, contentDescription = null)
+                                        },
+                                    )
+                                    DropdownMenuItem(
+                                        text = { Text(stringResource(Res.string.save_as_preset)) },
+                                        onClick = {
+                                            showOptionsMenu = false
+                                            showSavePresetDialog = true
+                                        },
+                                        leadingIcon = {
+                                            Icon(Icons.Outlined.SaveAs, contentDescription = null)
+                                        },
+                                    )
+                                }
                                 // Prompts Library — gated on PROMPTS.USE
                                 if (onNavigateToPromptsLibrary != null && uiState.promptsEnabled) {
                                     DropdownMenuItem(
@@ -542,6 +545,7 @@ actual fun ChatScreen(
                 runCodeEnabled = uiState.runCodeEnabled,
                 fileSearchEnabled = uiState.fileSearchEnabled,
                 mcpServersEnabled = uiState.mcpServersEnabled,
+                gates = uiState.chatInputGates,
                 modifier = Modifier.align(Alignment.BottomCenter),
             )
         }


### PR DESCRIPTION
## Summary
The chat UI offered options the backend silently ignores or that the server's
config/role permissions don't allow. This gates the relevant controls so the UI
reflects what the selected endpoint and server actually support.

Closes #127, #128, #129.

## Changes
- **Server `interface.*` flags + role permissions (#128):** tool toggles
  (web search, file search, run code), multi-convo, temporary chat, bookmarks,
  model selector, parameters, and presets are now gated. The effective rule
  matches the web client: a control is shown only when the interface flag AND
  the role permission allow it. Presets additionally require model selection.
- **Agents endpoint (#127):** dynamic MCP servers, web search, code interpreter,
  and file search are per-request ("ephemeral") tools that the backend ignores
  on agent runs (a saved agent uses its own configured tools). These controls
  are now hidden when an agent is selected, their chips/active-tools badge are
  hidden, and the ephemeral payload is no longer sent — so a leftover selection
  can't be silently dropped. Switching back to a model restores the prior
  selection (state is preserved, only display is gated).
- **File upload (#129):** the attach controls are hidden when the selected
  endpoint is marked upload-disabled by the server's `/api/files/config`
  (per-endpoint override, then global default).

## Fail-open
Every gate fails open: when the relevant server config is absent, null, or not
yet loaded (older backends, cold start, or a failed fetch), the control stays
visible. Missing config never hides a control.

## Scope note (#129)
This lands the endpoint-level upload gate. Per-MIME-type picker filtering,
client-side size validation, agent-tool gating of file-search/code uploads, and
a document-vs-image attach split are tracked as follow-ups in #129. A per-model
vision-capability gate was evaluated and intentionally not included: the targeted
backend's web client does not gate image upload on a model capability.
