### PR TITLE
Remove model selector from the chat app bar

### DIFF
--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatScreen.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatScreen.kt
@@ -349,8 +349,6 @@ actual fun ChatScreen(
                     onToggleComparison = viewModel::toggleComparison,
                     conversationId = uiState.conversationId,
                     conversationTitle = uiState.conversationTitle,
-                    displayModel = displayModel,
-                    onOpenModelSelector = viewModel::openModelSheet,
                     sharedLinksEnabled = uiState.sharedLinksEnabled,
                     onShare = viewModel::shareConversation,
                     onRename = viewModel::showRenameDialog,
@@ -854,8 +852,6 @@ private fun ChatTopBar(
     onToggleComparison: () -> Unit = {},
     conversationId: String? = null,
     conversationTitle: String? = null,
-    displayModel: String? = null,
-    onOpenModelSelector: () -> Unit = {},
     sharedLinksEnabled: Boolean = false,
     onShare: () -> Unit = {},
     onRename: () -> Unit = {},
@@ -883,9 +879,10 @@ private fun ChatTopBar(
             }
         }
 
-        // Show conversation title when viewing an existing conversation, otherwise a
-        // tappable model selector so the model/params (thinkingLevel) sheet is reachable
-        // from the header — not only two taps deep in the composer "+" menu.
+        // Show the conversation title when viewing an existing conversation. The header
+        // intentionally has no model selector — model/params stay reachable from the
+        // composer "+" menu (tools sheet), a deliberate mobile decluttering choice that
+        // diverges from web's header model selector.
         if (conversationId != null && !conversationTitle.isNullOrBlank()) {
             Text(
                 text = conversationTitle,
@@ -897,11 +894,7 @@ private fun ChatTopBar(
             )
             Spacer(modifier = Modifier.width(4.dp))
         } else {
-            ModelSelectorButton(
-                modelName = displayModel,
-                onClick = onOpenModelSelector,
-                modifier = Modifier.weight(1f),
-            )
+            Spacer(modifier = Modifier.weight(1f))
         }
 
         if (showTempChatToggle) {

--- a/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/screen/PlatformScreens.ios.kt
+++ b/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/screen/PlatformScreens.ios.kt
@@ -66,7 +66,6 @@ import com.garfiec.librechat.feature.chat.components.IosChatInput
 import com.garfiec.librechat.feature.chat.components.LandingContent
 import com.garfiec.librechat.feature.chat.components.ChatRoot
 import com.garfiec.librechat.feature.chat.components.MessageList
-import com.garfiec.librechat.feature.chat.components.ModelSelectorButton
 import com.garfiec.librechat.feature.chat.components.ModelSelectorSheet
 import com.garfiec.librechat.feature.chat.components.PresetPicker
 import com.garfiec.librechat.feature.chat.components.SavePresetDialog
@@ -182,6 +181,10 @@ actual fun ChatScreen(
             Column {
                 TopAppBar(
                     title = {
+                        // Show the conversation title only. The header intentionally has no
+                        // model selector — model/params stay reachable from the composer "+"
+                        // menu (tools sheet), a deliberate mobile decluttering choice that
+                        // diverges from web's header model selector. Mirrors Android ChatTopBar.
                         val title = uiState.conversationTitle
                         if (!isLandingPage && title != null) {
                             Text(
@@ -189,14 +192,6 @@ actual fun ChatScreen(
                                 style = MaterialTheme.typography.titleSmall,
                                 maxLines = 1,
                                 overflow = TextOverflow.Ellipsis,
-                            )
-                        } else {
-                            // Model selector in the header (incl. the landing page) so the
-                            // model/params (thinkingLevel) sheet is reachable without digging
-                            // into the composer "+" menu. Mirrors the Android ChatTopBar.
-                            ModelSelectorButton(
-                                modelName = displayModel,
-                                onClick = viewModel::openModelSheet,
                             )
                         }
                     },


### PR DESCRIPTION
## Summary
Removes the model selector from the chat app bar. Mobile intentionally diverges
from the web client's header here — the selector added visual clutter to the top
bar, and model/parameter selection is already reachable from the composer.

## Background
The app-bar model selector was added during the v0.8.6 sync to mirror the web
client's header `ModelSelector` and keep model/params reachable. On mobile it
duplicates an entry point that already exists in the composer's tools sheet, so
the header button is redundant.

## Changes
- Chat header (Android `ChatScreen` / iOS `PlatformScreens`): the no-title branch
  no longer renders the model selector; the header shows the conversation title
  when present and nothing otherwise.
- Removed the now-unused header parameters and a dead import. The shared model
  label helper is retained — it's still used by comparison mode and the composer.

## Reachability
Model and parameter selection remain available via the composer "+" → tools
sheet (Model and Model Parameters rows), unchanged on both platforms.
