### PR TITLE
feat(chat): add Starred models display setting for the model picker

### DIFF
--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/SettingsDataStore.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/SettingsDataStore.kt
@@ -20,6 +20,10 @@ class SettingsDataStore(
         ChatFontSize.fromString(prefs[KEY_CHAT_FONT_SIZE])
     }
 
+    val starredModelsDisplay: Flow<StarredModelsDisplay> = dataStore.data.map { prefs ->
+        StarredModelsDisplay.fromString(prefs[KEY_STARRED_MODELS_DISPLAY])
+    }
+
     val autoScrollEnabled: Flow<Boolean> = dataStore.data.map { prefs ->
         prefs[KEY_AUTO_SCROLL_ENABLED] ?: true
     }
@@ -147,6 +151,12 @@ class SettingsDataStore(
     suspend fun setChatFontSize(size: ChatFontSize) {
         dataStore.edit { prefs ->
             prefs[KEY_CHAT_FONT_SIZE] = size.toStorageString()
+        }
+    }
+
+    suspend fun setStarredModelsDisplay(display: StarredModelsDisplay) {
+        dataStore.edit { prefs ->
+            prefs[KEY_STARRED_MODELS_DISPLAY] = display.toStorageString()
         }
     }
 
@@ -336,6 +346,7 @@ class SettingsDataStore(
     companion object {
         private val KEY_LATEX_RENDERER = stringPreferencesKey("latex_renderer")
         private val KEY_CHAT_FONT_SIZE = stringPreferencesKey("chat_font_size")
+        private val KEY_STARRED_MODELS_DISPLAY = stringPreferencesKey("starred_models_display")
         private val KEY_AUTO_SCROLL_ENABLED = booleanPreferencesKey("auto_scroll_enabled")
         private val KEY_SHOW_THINKING_BLOCKS = booleanPreferencesKey("show_thinking_blocks")
         private val KEY_AUTO_READ_ENABLED = booleanPreferencesKey("auto_read_enabled")

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/StarredModelsDisplay.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/StarredModelsDisplay.kt
@@ -1,0 +1,30 @@
+package com.garfiec.librechat.core.data.datastore
+
+/**
+ * Mobile-only preference controlling how pinned ("starred") models and agents are
+ * surfaced in the model-selection bottom sheet.
+ *
+ * - [OFF] — no dedicated section; favorites simply float to the top within their own
+ *   provider/agent group (the historical behavior).
+ * - [GROUPED] — a collapsible "Starred" group at the top of the sheet, styled like the
+ *   provider groups. Items still also appear in their original groups.
+ * - [TOP] — starred items listed flat at the very top, no header or collapse. Items still
+ *   also appear in their original groups.
+ */
+enum class StarredModelsDisplay {
+    OFF, GROUPED, TOP;
+
+    companion object {
+        fun fromString(value: String?): StarredModelsDisplay = when (value) {
+            "grouped" -> GROUPED
+            "top" -> TOP
+            else -> OFF
+        }
+    }
+
+    fun toStorageString(): String = when (this) {
+        OFF -> "off"
+        GROUPED -> "grouped"
+        TOP -> "top"
+    }
+}

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatScreen.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatScreen.kt
@@ -806,6 +806,7 @@ actual fun ChatScreen(
             favoriteModelKeys = uiState.favoriteModelKeys,
             onToggleAgentFavorite = viewModel::toggleAgentFavorite,
             onToggleModelFavorite = viewModel::toggleModelFavorite,
+            starredDisplay = uiState.starredModelsDisplay,
             endpointKeyStates = uiState.endpointKeyStates,
             onSetApiKey = { name -> onNavigateToProviderKeys(name) },
         )
@@ -829,6 +830,7 @@ actual fun ChatScreen(
             favoriteModelKeys = uiState.favoriteModelKeys,
             onToggleAgentFavorite = viewModel::toggleAgentFavorite,
             onToggleModelFavorite = viewModel::toggleModelFavorite,
+            starredDisplay = uiState.starredModelsDisplay,
             endpointKeyStates = uiState.endpointKeyStates,
             onSetApiKey = { name -> onNavigateToProviderKeys(name) },
         )

--- a/feature/chat/src/commonMain/composeResources/values/strings.xml
+++ b/feature/chat/src/commonMain/composeResources/values/strings.xml
@@ -33,6 +33,7 @@
     <string name="preview">Preview</string>
     <string name="select_model">Select model</string>
     <string name="select_a_model">Select a model</string>
+    <string name="starred_group">Starred</string>
     <!-- Neutral label for the active agent when its name hasn't resolved yet (never a model string). -->
     <string name="chat_agent_fallback_label">Agent</string>
     <string name="compare_models">Compare Models</string>

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ModelSelectorSheet.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ModelSelectorSheet.kt
@@ -25,6 +25,7 @@ import androidx.compose.material.icons.outlined.Create
 import androidx.compose.material.icons.outlined.Public
 import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -44,10 +45,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import com.garfiec.librechat.core.common.EndpointConstants
+import com.garfiec.librechat.core.data.datastore.StarredModelsDisplay
 import com.garfiec.librechat.core.model.Agent
 import com.garfiec.librechat.core.model.EndpointConfig
 import com.garfiec.librechat.core.model.endpoint.KeyState
@@ -56,11 +59,15 @@ import com.garfiec.librechat.core.ui.components.ErrorBanner
 import com.garfiec.librechat.feature.chat.resources.*
 import com.garfiec.librechat.feature.chat.resources.Res
 import com.garfiec.librechat.feature.chat.util.FuzzyMatch
+import com.garfiec.librechat.feature.chat.viewmodel.delegate.FavoritesDelegate
 import com.garfiec.librechat.feature.chat.viewmodel.delegate.filterModelsByEndpoint
 import org.jetbrains.compose.resources.stringResource
 
 private val IconSize = 20.dp
 private const val FUZZY_MATCH_THRESHOLD = 55
+
+/** Sentinel group key for the optional "Starred" section's expand/collapse state. */
+private const val STARRED_GROUP_KEY = "__starred__"
 
 private fun fuzzyMatches(candidate: String, query: String): Boolean {
     // Short queries (1-2 chars) use substring matching for better UX
@@ -98,6 +105,12 @@ fun ModelSelectorSheet(
     onToggleAgentFavorite: ((agentId: String) -> Unit)? = null,
     onToggleModelFavorite: ((endpoint: String, model: String) -> Unit)? = null,
     /**
+     * Mobile-only preference controlling whether pinned items also appear in a
+     * dedicated section at the top of the sheet. [StarredModelsDisplay.OFF] keeps the
+     * historical behavior (favorites float to the top within their own group).
+     */
+    starredDisplay: StarredModelsDisplay = StarredModelsDisplay.OFF,
+    /**
      * Per-endpoint user-provided-key state. Endpoints whose key is [KeyState.Unset]
      * or [KeyState.Expired] render a greyed group with a "Set API Key" CTA. Absent
      * keys (built-in endpoints) and [KeyState.Loading] / [KeyState.Set] all
@@ -116,6 +129,8 @@ fun ModelSelectorSheet(
         mutableStateMapOf<String, Boolean>().apply {
             availableModels.keys.forEach { put(it, false) }
             if (agents.isNotEmpty()) put(EndpointConstants.AGENTS, false)
+            // Starred group starts collapsed too, matching the provider groups.
+            put(STARRED_GROUP_KEY, false)
         }
     }
     val isSearching = searchQuery.isNotBlank()
@@ -150,6 +165,29 @@ fun ModelSelectorSheet(
             base.sortedByDescending { it.id in favoriteAgentIds }
         }
     }
+
+    // Optional dedicated "Starred" section (mobile-only). Shown only when not searching
+    // (search already reorders by relevance) and the preference is not OFF. Starred items
+    // are also still rendered within their own groups below — nothing is removed.
+    val showStarred = !isSearching && starredDisplay != StarredModelsDisplay.OFF
+    // favoriteAgentIds / favoriteModelKeys are LinkedHashSets from FavoritesDelegate.publish,
+    // so iterating them preserves the server-side pin order.
+    val agentsById = remember(agents) { agents.associateBy { it.id } }
+    val starredAgents = remember(agentsById, favoriteAgentIds, showStarred) {
+        if (!showStarred) emptyList() else favoriteAgentIds.mapNotNull { agentsById[it] }
+    }
+    val starredModels = remember(filteredByEndpoint, favoriteModelKeys, showStarred) {
+        if (!showStarred) {
+            emptyList()
+        } else {
+            favoriteModelKeys.mapNotNull { key ->
+                val (endpoint, model) = FavoritesDelegate.parseFavoriteModelKey(key) ?: return@mapNotNull null
+                // Only surface favorites whose endpoint+model are actually available.
+                if (filteredByEndpoint[endpoint]?.contains(model) == true) endpoint to model else null
+            }
+        }
+    }
+    val hasStarred = starredAgents.isNotEmpty() || starredModels.isNotEmpty()
 
     ModalBottomSheet(
         onDismissRequest = onDismiss,
@@ -201,6 +239,62 @@ fun ModelSelectorSheet(
                     .weight(1f)
                     .padding(horizontal = 16.dp),
             ) {
+                // Optional "Starred" section at the very top (mobile-only). Starred items
+                // are duplicated here — they still render in their own groups below.
+                if (showStarred && hasStarred) {
+                    // GROUPED renders a collapsible header and respects its toggle; TOP is a
+                    // flat, always-shown list closed off with a divider. OFF never reaches here.
+                    val starredItemsVisible = when (starredDisplay) {
+                        StarredModelsDisplay.GROUPED -> {
+                            val expanded = expandedGroups[STARRED_GROUP_KEY] != false
+                            item(key = "header_starred") {
+                                EndpointGroupHeader(
+                                    endpointName = STARRED_GROUP_KEY,
+                                    displayLabel = stringResource(Res.string.starred_group),
+                                    modelCount = starredAgents.size + starredModels.size,
+                                    isExpanded = expanded,
+                                    iconUrl = null,
+                                    leadingIcon = Icons.Default.Star,
+                                    onToggle = { expandedGroups[STARRED_GROUP_KEY] = !expanded },
+                                )
+                            }
+                            expanded
+                        }
+                        StarredModelsDisplay.TOP -> true
+                        StarredModelsDisplay.OFF -> false
+                    }
+                    if (starredItemsVisible) {
+                        items(starredAgents, key = { "starred_agent_${it.id}" }, contentType = { "agent" }) { agent ->
+                            AgentListItem(
+                                agent = agent,
+                                isSelected = selectedEndpoint == EndpointConstants.AGENTS && agent.id == selectedModel,
+                                serverUrl = serverUrl,
+                                onClick = { onModelSelect(EndpointConstants.AGENTS, agent.id) },
+                                isFavorite = true,
+                                onToggleFavorite = onToggleAgentFavorite?.let { toggle -> { toggle(agent.id) } },
+                            )
+                        }
+                        items(
+                            starredModels,
+                            key = { (endpoint, model) -> "starred_model_$endpoint::$model" },
+                            contentType = { "model" },
+                        ) { (endpoint, model) ->
+                            ModelListItem(
+                                model = model,
+                                isSelected = endpoint == selectedEndpoint && model == selectedModel,
+                                isFavorite = true,
+                                onClick = { onModelSelect(endpoint, model) },
+                                onToggleFavorite = onToggleModelFavorite?.let { toggle -> { toggle(endpoint, model) } },
+                            )
+                        }
+                    }
+                    if (starredDisplay == StarredModelsDisplay.TOP) {
+                        item(key = "starred_divider") {
+                            HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+                        }
+                    }
+                }
+
                 // "My Agents" group (shown first, like the web frontend)
                 if (filteredAgents.isNotEmpty()) {
                     val agentsExpanded = expandedGroups[EndpointConstants.AGENTS] != false
@@ -270,37 +364,13 @@ fun ModelSelectorSheet(
                         }
                         if (effectiveExpanded) {
                             items(filteredModels, key = { "${endpointName}_$it" }, contentType = { "model" }) { model ->
-                                val isSelected = endpointName == selectedEndpoint && model == selectedModel
-                                val isFavorite = "$endpointName::$model" in favoriteModelKeys
-                                Row(
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                        .clickable { onModelSelect(endpointName, model) }
-                                        .padding(vertical = 12.dp, horizontal = 8.dp)
-                                        .animateItem(),
-                                    verticalAlignment = Alignment.CenterVertically,
-                                ) {
-                                    Text(
-                                        text = model,
-                                        style = MaterialTheme.typography.bodyMedium,
-                                        modifier = Modifier.weight(1f),
-                                    )
-                                    if (isSelected) {
-                                        Spacer(modifier = Modifier.width(8.dp))
-                                        Icon(
-                                            Icons.Default.Check,
-                                            contentDescription = stringResource(Res.string.cd_selected),
-                                            tint = MaterialTheme.colorScheme.primary,
-                                        )
-                                    }
-                                    if (onToggleModelFavorite != null) {
-                                        Spacer(modifier = Modifier.width(4.dp))
-                                        FavoriteStarButton(
-                                            isFavorite = isFavorite,
-                                            onToggle = { onToggleModelFavorite(endpointName, model) },
-                                        )
-                                    }
-                                }
+                                ModelListItem(
+                                    model = model,
+                                    isSelected = endpointName == selectedEndpoint && model == selectedModel,
+                                    isFavorite = "$endpointName::$model" in favoriteModelKeys,
+                                    onClick = { onModelSelect(endpointName, model) },
+                                    onToggleFavorite = onToggleModelFavorite?.let { toggle -> { toggle(endpointName, model) } },
+                                )
                             }
                         }
                     }
@@ -320,6 +390,8 @@ private fun EndpointGroupHeader(
     onToggle: () -> Unit,
     needsKey: Boolean = false,
     onSetApiKey: () -> Unit = {},
+    /** When set, renders this vector instead of an [EndpointIcon] (used by the Starred group). */
+    leadingIcon: ImageVector? = null,
 ) {
     Row(
         modifier = Modifier
@@ -335,14 +407,25 @@ private fun EndpointGroupHeader(
         // Disabled icon + label use Material's standard 0.38 disabled alpha. The
         // CTA chip below stays full-opacity so the action remains discoverable.
         val labelAlpha = if (needsKey) 0.38f else 1f
-        EndpointIcon(
-            endpointName = endpointName,
-            iconUrl = iconUrl,
-            size = IconSize,
-            contentDescription = "$endpointName icon",
-            glyphTint = MaterialTheme.colorScheme.onSurface,
-            modifier = Modifier.alpha(labelAlpha),
-        )
+        if (leadingIcon != null) {
+            Icon(
+                imageVector = leadingIcon,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurface,
+                modifier = Modifier
+                    .size(IconSize)
+                    .alpha(labelAlpha),
+            )
+        } else {
+            EndpointIcon(
+                endpointName = endpointName,
+                iconUrl = iconUrl,
+                size = IconSize,
+                contentDescription = "$endpointName icon",
+                glyphTint = MaterialTheme.colorScheme.onSurface,
+                modifier = Modifier.alpha(labelAlpha),
+            )
+        }
         Spacer(modifier = Modifier.width(8.dp))
         Text(
             text = "$displayLabel ($modelCount)",
@@ -394,6 +477,45 @@ private fun SetApiKeyChip(
             style = MaterialTheme.typography.labelMedium,
             color = MaterialTheme.colorScheme.primary,
         )
+    }
+}
+
+@Composable
+private fun LazyItemScope.ModelListItem(
+    model: String,
+    isSelected: Boolean,
+    isFavorite: Boolean,
+    onClick: () -> Unit,
+    onToggleFavorite: (() -> Unit)?,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(vertical = 12.dp, horizontal = 8.dp)
+            .animateItem(),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = model,
+            style = MaterialTheme.typography.bodyMedium,
+            modifier = Modifier.weight(1f),
+        )
+        if (isSelected) {
+            Spacer(modifier = Modifier.width(8.dp))
+            Icon(
+                Icons.Default.Check,
+                contentDescription = stringResource(Res.string.cd_selected),
+                tint = MaterialTheme.colorScheme.primary,
+            )
+        }
+        if (onToggleFavorite != null) {
+            Spacer(modifier = Modifier.width(4.dp))
+            FavoriteStarButton(
+                isFavorite = isFavorite,
+                onToggle = onToggleFavorite,
+            )
+        }
     }
 }
 

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatUiState.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatUiState.kt
@@ -7,6 +7,7 @@ import com.garfiec.librechat.core.common.ToolConstants
 import com.garfiec.librechat.core.data.datastore.ChatFontSize
 import com.garfiec.librechat.core.data.datastore.InlineArtifactPrefs
 import com.garfiec.librechat.core.data.datastore.LatexRenderer
+import com.garfiec.librechat.core.data.datastore.StarredModelsDisplay
 import com.garfiec.librechat.core.model.Agent
 import com.garfiec.librechat.core.model.Attachment
 import com.garfiec.librechat.core.model.EndpointConfig
@@ -194,6 +195,12 @@ data class ChatUiState(
     // Merged from separate StateFlows
     val serverUrl: String = "",
     val chatFontSize: ChatFontSize = ChatFontSize.MEDIUM,
+    /**
+     * Mobile-only preference for how pinned models/agents are surfaced in
+     * [ModelSelectorSheet]: off (float within group), grouped (collapsible top
+     * section), or top (flat top list). Read from [SettingsDataStore].
+     */
+    val starredModelsDisplay: StarredModelsDisplay = StarredModelsDisplay.OFF,
     val forkedConversationId: String? = null,
     val showForkOptionsForMessageId: String? = null,
     val isForkInProgress: Boolean = false,

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModel.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModel.kt
@@ -221,10 +221,12 @@ class ChatViewModel(
         _uiState,
         serverDataStore.currentUrlFlow,
         settingsDataStore.chatFontSize,
-    ) { state, url, fontSize ->
+        settingsDataStore.starredModelsDisplay,
+    ) { state, url, fontSize, starredDisplay ->
         state.copy(
             serverUrl = url,
             chatFontSize = fontSize,
+            starredModelsDisplay = starredDisplay,
         )
     }.stateIn(viewModelScope, SharingStarted.Eagerly, ChatUiState())
 

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/FavoritesDelegate.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/FavoritesDelegate.kt
@@ -114,7 +114,16 @@ class FavoritesDelegate(
     }
 
     companion object {
+        private const val KEY_SEPARATOR = "::"
+
         /** Stable composite key for a (endpoint, model) favorite — used by pickers for membership checks and sorting. */
-        fun favoriteModelKey(endpoint: String, model: String): String = "$endpoint::$model"
+        fun favoriteModelKey(endpoint: String, model: String): String = "$endpoint$KEY_SEPARATOR$model"
+
+        /** Inverse of [favoriteModelKey]: splits a key back into (endpoint, model), or null if malformed. */
+        fun parseFavoriteModelKey(key: String): Pair<String, String>? {
+            val sep = key.indexOf(KEY_SEPARATOR)
+            if (sep < 0) return null
+            return key.substring(0, sep) to key.substring(sep + KEY_SEPARATOR.length)
+        }
     }
 }

--- a/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/screen/PlatformScreens.ios.kt
+++ b/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/screen/PlatformScreens.ios.kt
@@ -585,6 +585,7 @@ actual fun ChatScreen(
             favoriteModelKeys = uiState.favoriteModelKeys,
             onToggleAgentFavorite = viewModel::toggleAgentFavorite,
             onToggleModelFavorite = viewModel::toggleModelFavorite,
+            starredDisplay = uiState.starredModelsDisplay,
             endpointKeyStates = uiState.endpointKeyStates,
             onSetApiKey = { name -> onNavigateToProviderKeys(name) },
         )

--- a/feature/settings/src/commonMain/composeResources/values/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values/strings.xml
@@ -152,6 +152,11 @@
     <string name="show_bubbles_desc">Add rounded bubble backgrounds to messages</string>
     <string name="show_avatars">Show avatars</string>
     <string name="show_avatars_desc">Display user and agent avatars next to messages</string>
+    <string name="starred_models_title">Starred models</string>
+    <string name="starred_models_desc">Show your pinned models and agents at the top of the model picker</string>
+    <string name="starred_models_off">Off</string>
+    <string name="starred_models_grouped">Collapsible group at top</string>
+    <string name="starred_models_top">At top, no grouping</string>
     <string name="font_size">Font size</string>
     <string name="font_size_small">Small</string>
     <string name="font_size_medium">Medium</string>

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/ChatSettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/ChatSettingsScreen.kt
@@ -106,6 +106,7 @@ fun ChatSettingsContent(
                     showAvatars = uiState.showAvatars,
                     showBubbles = uiState.showBubbles,
                     latexRenderer = uiState.latexRenderer,
+                    starredModelsDisplay = uiState.starredModelsDisplay,
                     onFontSizeChange = viewModel::setChatFontSize,
                     onAutoScrollChange = viewModel::setAutoScrollEnabled,
                     onShowThinkingChange = viewModel::setShowThinkingBlocks,
@@ -115,6 +116,7 @@ fun ChatSettingsContent(
                     onShowAvatarsChange = viewModel::setShowAvatars,
                     onShowBubblesChange = viewModel::setShowBubbles,
                     onLatexRendererChange = viewModel::setLatexRenderer,
+                    onStarredModelsDisplayChange = viewModel::setStarredModelsDisplay,
                 )
             }
 

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/ChatSettingsSection.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/ChatSettingsSection.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.unit.dp
 import com.garfiec.librechat.core.common.ChatLayoutConstants
 import com.garfiec.librechat.core.data.datastore.ChatFontSize
 import com.garfiec.librechat.core.data.datastore.LatexRenderer
+import com.garfiec.librechat.core.data.datastore.StarredModelsDisplay
 import com.garfiec.librechat.feature.settings.resources.*
 import com.garfiec.librechat.feature.settings.resources.Res
 import org.jetbrains.compose.resources.stringResource
@@ -38,6 +39,7 @@ internal fun ChatSettingsSection(
     showAvatars: Boolean,
     showBubbles: Boolean,
     latexRenderer: LatexRenderer,
+    starredModelsDisplay: StarredModelsDisplay,
     onFontSizeChange: (ChatFontSize) -> Unit,
     onAutoScrollChange: (Boolean) -> Unit,
     onShowThinkingChange: (Boolean) -> Unit,
@@ -47,6 +49,7 @@ internal fun ChatSettingsSection(
     onShowAvatarsChange: (Boolean) -> Unit,
     onShowBubblesChange: (Boolean) -> Unit,
     onLatexRendererChange: (LatexRenderer) -> Unit,
+    onStarredModelsDisplayChange: (StarredModelsDisplay) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(modifier = modifier) {
@@ -329,6 +332,48 @@ internal fun ChatSettingsSection(
                     checked = dismissKeyboardOnSend,
                     onCheckedChange = onDismissKeyboardOnSendChange,
                 )
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            // Starred models display selector (mobile-only model-picker behavior)
+            Text(
+                text = stringResource(Res.string.starred_models_title),
+                style = MaterialTheme.typography.bodyLarge,
+            )
+            Text(
+                text = stringResource(Res.string.starred_models_desc),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            StarredModelsDisplay.entries.forEach { option ->
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clip(RoundedCornerShape(8.dp))
+                        .selectable(
+                            selected = starredModelsDisplay == option,
+                            onClick = { onStarredModelsDisplayChange(option) },
+                            role = Role.RadioButton,
+                        )
+                        .padding(vertical = 8.dp, horizontal = 4.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    RadioButton(
+                        selected = starredModelsDisplay == option,
+                        onClick = null,
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(
+                        text = when (option) {
+                            StarredModelsDisplay.OFF -> stringResource(Res.string.starred_models_off)
+                            StarredModelsDisplay.GROUPED -> stringResource(Res.string.starred_models_grouped)
+                            StarredModelsDisplay.TOP -> stringResource(Res.string.starred_models_top)
+                        },
+                        style = MaterialTheme.typography.bodyLarge,
+                    )
+                }
             }
         }
         HorizontalDivider(modifier = Modifier.padding(top = 8.dp))

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/SettingsViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/SettingsViewModel.kt
@@ -12,6 +12,7 @@ import com.garfiec.librechat.core.data.datastore.InlineArtifactPrefs
 import com.garfiec.librechat.core.data.datastore.LatexRenderer
 import com.garfiec.librechat.core.data.datastore.ServerDataStore
 import com.garfiec.librechat.core.data.datastore.SettingsDataStore
+import com.garfiec.librechat.core.data.datastore.StarredModelsDisplay
 import com.garfiec.librechat.core.data.datastore.ThemeDataStore
 import com.garfiec.librechat.core.data.datastore.ThemeMode
 import com.garfiec.librechat.core.data.repository.AuthRepository
@@ -225,6 +226,8 @@ data class SettingsUiState(
     val showAvatars: Boolean = true,
     val showBubbles: Boolean = false,
     val latexRenderer: LatexRenderer = LatexRenderer.KATEX,
+    // Mobile-only: how pinned models/agents surface in the model-selection sheet
+    val starredModelsDisplay: StarredModelsDisplay = StarredModelsDisplay.OFF,
     // Inline artifact rendering (per-type toggles)
     val inlineArtifactPrefs: InlineArtifactPrefs = InlineArtifactPrefs(),
     // Role-permission gates. `serverMemoriesEnabled` is the SERVER-level MEMORIES.USE
@@ -394,6 +397,9 @@ class SettingsViewModel(
     private val inlineArtifactPrefsFlow: StateFlow<InlineArtifactPrefs> = settingsDataStore.inlineArtifactPrefs
         .stateIn(viewModelScope, SharingStarted.Eagerly, InlineArtifactPrefs())
 
+    private val starredModelsDisplayPref: StateFlow<StarredModelsDisplay> = settingsDataStore.starredModelsDisplay
+        .stateIn(viewModelScope, SharingStarted.Eagerly, StarredModelsDisplay.OFF)
+
     /** Additional preferences combined separately to stay within the 5-arg combine limit. */
     private data class AdditionalPreferences(
         val tabletSidebarGestureEnabled: Boolean,
@@ -406,6 +412,7 @@ class SettingsViewModel(
         val showBubbles: Boolean = false,
         val latexRenderer: LatexRenderer = LatexRenderer.KATEX,
         val inlineArtifactPrefs: InlineArtifactPrefs = InlineArtifactPrefs(),
+        val starredModelsDisplay: StarredModelsDisplay = StarredModelsDisplay.OFF,
     )
 
     private val baseAdditionalPreferences = combine(
@@ -428,6 +435,8 @@ class SettingsViewModel(
         base.copy(chatLayoutStyle = layoutStyle, showAvatars = showAvatars, showBubbles = showBubbles, latexRenderer = latexRenderer)
     }.combine(inlineArtifactPrefsFlow) { additional, inlineArtifact ->
         additional.copy(inlineArtifactPrefs = inlineArtifact)
+    }.combine(starredModelsDisplayPref) { additional, starredDisplay ->
+        additional.copy(starredModelsDisplay = starredDisplay)
     }.stateIn(viewModelScope, SharingStarted.Eagerly, AdditionalPreferences(true, false, "", "", true))
 
     /** The single public UI state that merges DataStore preferences with imperative state. */
@@ -465,6 +474,7 @@ class SettingsViewModel(
             showBubbles = additional.showBubbles,
             latexRenderer = additional.latexRenderer,
             inlineArtifactPrefs = additional.inlineArtifactPrefs,
+            starredModelsDisplay = additional.starredModelsDisplay,
         )
     }.stateIn(viewModelScope, SharingStarted.Eagerly, SettingsUiState())
 
@@ -632,6 +642,10 @@ class SettingsViewModel(
 
     fun setChatFontSize(size: ChatFontSize) {
         viewModelScope.launch { settingsDataStore.setChatFontSize(size) }
+    }
+
+    fun setStarredModelsDisplay(display: StarredModelsDisplay) {
+        viewModelScope.launch { settingsDataStore.setStarredModelsDisplay(display) }
     }
 
     fun setAutoScrollEnabled(enabled: Boolean) {


### PR DESCRIPTION
## Summary

Adds a mobile-only **Starred models** preference (Settings → Chat) controlling how
pinned favorites surface in the model-selection bottom sheet. Builds on the existing
favorites system — no backend or protocol changes.

Three modes:

- **Off** (default) — unchanged behavior: favorites float to the top within their own
  provider/agent group; no dedicated section.
- **Collapsible group at top** — a "Starred (N)" group at the top, styled like the
  provider groups, collapsed by default.
- **At top, no grouping** — starred items listed flat above everything, closed off with
  a divider.

In both non-off modes, starred items also remain in their original groups (duplicated,
nothing is removed). The section is hidden while searching, since search already reorders
by relevance.

## Changes

- **core/data** — `StarredModelsDisplay` enum + `SettingsDataStore` flow/setter
  (`starred_models_display` key), following the existing `ChatFontSize` template.
- **feature/settings** — preference plumbed through `SettingsViewModel`/`SettingsUiState`;
  radio selector added to the Chat settings tab.
- **feature/chat** — `ModelSelectorSheet` renders the optional starred section; the inline
  model row was extracted into a reusable `ModelListItem`, and `EndpointGroupHeader` gained
  an optional `leadingIcon`. Wired at both Android call sites and the iOS screen.
- `FavoritesDelegate` gained `parseFavoriteModelKey()` (inverse of `favoriteModelKey()`) so
  the `endpoint::model` key format lives in one place.

## Notes

- Pin order is preserved via the `LinkedHashSet`s already published by `FavoritesDelegate`.
  Starred items render agents-then-models rather than true interleaved pin order.
- Mobile-only; no web equivalent.

## Screenshots

| Description | Screenshot |
| --- | --- |
| **Settings UI** — the new selector in Settings → Chat | <img width="485" height="1098" alt="image" src="https://github.com/user-attachments/assets/75e14f37-ba20-4cb5-91f6-d45351881a4a" /> |
| **Off** — no dedicated section; favorites float within their group | <img width="481" height="1095" alt="image" src="https://github.com/user-attachments/assets/25aa216b-572c-4d6b-a6a3-3729ef1b6ae1" /> |
| **Collapsible group at top** — "Starred (N)" group, collapsed by default | <img width="481" height="1097" alt="image" src="https://github.com/user-attachments/assets/4b11b1a7-9639-411f-8d29-f77bf1b7f7ea" /> |
| **At top, no grouping** — flat starred list above everything, with a divider | <img width="482" height="1099" alt="image" src="https://github.com/user-attachments/assets/9fa470e1-3c3f-49f9-a850-ae85bc9a0db3" /> |
