### PR TITLE
fix(conversations): stop drawer search field auto-focusing on open

### DIFF
--- a/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/DrawerContent.kt
+++ b/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/DrawerContent.kt
@@ -2,6 +2,7 @@ package com.garfiec.librechat.shared.navigation
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -46,6 +47,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.semantics.heading
@@ -121,6 +124,15 @@ fun DrawerContent(
     onRefresh: () -> Unit = {},
     onLoadMore: () -> Unit = {},
 ) {
+    // Invisible anchor that claims initial focus so the search field below
+    // doesn't auto-focus and pop the keyboard when the drawer opens. Tapping
+    // the search field still focuses it normally. See Android focus docs
+    // ("Change focus behavior"): redirect initial focus to a non-input element.
+    val focusAnchor = remember { FocusRequester() }
+    LaunchedEffect(Unit) {
+        runCatching { focusAnchor.requestFocus() }
+    }
+
     Column(
         modifier = modifier
             .fillMaxHeight()
@@ -128,6 +140,13 @@ fun DrawerContent(
             .statusBarsPadding()
             .padding(top = 16.dp),
     ) {
+        Spacer(
+            modifier = Modifier
+                .size(1.dp)
+                .focusRequester(focusAnchor)
+                .focusable(),
+        )
+
         // "New Chat" button at top
         Surface(
             onClick = onNewChat,


### PR DESCRIPTION
## Summary
Opening the conversation history drawer (hamburger menu) auto-focused the "Search conversations…" field, which popped the soft keyboard every time. This makes the keyboard opt-in: the drawer opens to the conversation list, and the keyboard appears only when the user taps the search field.

## Changes
- Add an invisible 1.dp `focusable()` `Spacer` at the top of the drawer `Column` in `DrawerContent.kt`, anchored with a `FocusRequester`, and request focus on it in a `LaunchedEffect`. It claims initial focus so the search `OutlinedTextField` no longer grabs it on open. Tap-to-focus on the search field is unchanged.

## Testing
- `:shared:compileDebugKotlinAndroid` compiles.
- Installed the debug build on a physical device and confirmed the drawer opens without the keyboard, and tapping the search field still focuses it and shows the keyboard.

## Notes
- Pure `commonMain` Compose; same behavior applies on iOS.
- Follows the Android "Change focus behavior" guidance (redirect initial focus to a non-input element) rather than `canFocus = false`, which would have broken tap-to-type.
