### PR TITLE
fix(chat): render in-progress tool calls when resuming a stream

### DIFF
--- a/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/sse/SseEventMapperTest.kt
+++ b/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/sse/SseEventMapperTest.kt
@@ -225,6 +225,52 @@ class SseEventMapperTest {
         assertThat(result.aggregatedContent[0].text).isEqualTo("Previously streamed text")
     }
 
+    @Test
+    fun `sync aggregatedContent carries in-progress and completed tool_call parts`() {
+        val event = SseEvent(
+            event = "",
+            data = """{"sync":true,"resumeState":{"aggregatedContent":[
+                {"type":"text","text":"Let me generate that now"},
+                {"type":"tool_call","tool_call":{"type":"tool_call","id":"call_done","name":"web_search","args":"{}","output":"results"}},
+                {"type":"tool_call","tool_call":{"type":"tool_call","id":"call_pending","name":"image_gen_oai","args":"{\"prompt\":\"a cat\"}"}}
+            ]}}""",
+        )
+        val result = mapper.map(event) as StreamEvent.Sync
+        val toolCalls = result.aggregatedContent.mapNotNull { it.toolCall }
+        assertThat(toolCalls).hasSize(2)
+        assertThat(toolCalls[0].id).isEqualTo("call_done")
+        assertThat(toolCalls[0].output).isEqualTo("results")
+        assertThat(toolCalls[1].id).isEqualTo("call_pending")
+        assertThat(toolCalls[1].output).isNull() // in-progress: drives the live card
+    }
+
+    @Test
+    fun `mapFrame expands sync frame into snapshot then buffered pendingEvents in order`() {
+        val event = SseEvent(
+            event = "",
+            data = """{"sync":true,"resumeState":{"aggregatedContent":[{"type":"text","text":"hi"}]},"pendingEvents":[
+                {"event":"on_message_delta","data":{"id":"s","delta":{"content":[{"type":"text","text":" there"}]}}},
+                {"event":"on_run_step_completed","data":{"result":{"id":"s","tool_call":{"id":"call_pending","output":"http://img/x.png"}}}}
+            ]}""",
+        )
+        val events = mapper.mapFrame(event)
+        assertThat(events).hasSize(3)
+        assertThat(events[0]).isInstanceOf(StreamEvent.Sync::class.java)
+        assertThat(events[1]).isInstanceOf(StreamEvent.ContentDelta::class.java)
+        assertThat((events[1] as StreamEvent.ContentDelta).chunk).isEqualTo(" there")
+        assertThat(events[2]).isInstanceOf(StreamEvent.ToolCallComplete::class.java)
+        assertThat((events[2] as StreamEvent.ToolCallComplete).toolCallId).isEqualTo("call_pending")
+    }
+
+    @Test
+    fun `mapFrame returns single-element list for an ordinary frame`() {
+        val event = SseEvent(
+            event = "",
+            data = """{"event":"on_message_delta","data":{"id":"s","delta":{"content":[{"type":"text","text":"x"}]}}}""",
+        )
+        assertThat(mapper.mapFrame(event)).hasSize(1)
+    }
+
     // --- Attachment Events ---
 
     @Test

--- a/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/sse/SseClient.kt
+++ b/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/sse/SseClient.kt
@@ -67,8 +67,10 @@ class SseClient(
                     }
                     try {
                         lineParser.parse(byteChannel).collect { sseEvent ->
-                            val streamEvent = mapper.map(sseEvent)
-                            if (streamEvent != null) {
+                            // One frame can carry multiple events (the resume `sync`
+                            // frame expands to a snapshot + its buffered pendingEvents),
+                            // so map to a list and emit each in order.
+                            mapper.mapFrame(sseEvent).forEach { streamEvent ->
                                 emit(streamEvent)
                                 if (streamEvent is StreamEvent.Final) {
                                     done = true

--- a/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/sse/SseEventMapper.kt
+++ b/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/sse/SseEventMapper.kt
@@ -68,8 +68,29 @@ class SseEventMapper(private val json: Json) {
         else -> toString()
     }
 
-    fun map(event: SseEvent): StreamEvent? {
-        if (event.data.isBlank() || event.data == "[DONE]") return null
+    /**
+     * Maps a single SSE frame to at-most-one [StreamEvent]. Retained for callers
+     * (and tests) that only ever produce one event per frame. The streaming
+     * pipeline uses [mapFrame] instead, because the resume `sync` frame expands
+     * into several events; this delegate keeps only the first and would drop a
+     * sync frame's buffered events — never route the live stream through it.
+     */
+    fun map(event: SseEvent): StreamEvent? = mapFrame(event).firstOrNull()
+
+    /**
+     * Maps a single SSE frame to the (possibly multiple) [StreamEvent]s it carries.
+     *
+     * Almost every frame yields one event. The exception is the resume `sync`
+     * frame, which is a composite: a state snapshot ([StreamEvent.Sync] built from
+     * `resumeState.aggregatedContent`) followed by `pendingEvents` — raw LangGraph
+     * events that occurred after the snapshot and are delivered here exactly once
+     * (the live continuation does not replay them). The pending events are mapped
+     * through the same [mapJsonObject] the live stream uses, so downstream they are
+     * indistinguishable from live events. List order is significant: the snapshot
+     * must be applied before the buffered deltas that build on it.
+     */
+    fun mapFrame(event: SseEvent): List<StreamEvent> {
+        if (event.data.isBlank() || event.data == "[DONE]") return emptyList()
 
         return try {
             val root = json.parseToJsonElement(event.data).jsonObject
@@ -77,9 +98,18 @@ class SseEventMapper(private val json: Json) {
             // `event: attachment\ndata: {...}` (the data object won't have
             // an "event" key — it's the raw attachment metadata).
             if (event.event == "attachment" || event.event == "librechat:attachment") {
-                return mapAttachment(root)
+                return listOfNotNull(mapAttachment(root))
             }
-            mapJsonObject(root)
+            // Resume sync frame: snapshot + buffered events. `pendingEvents` lives
+            // at the frame top level (alongside `sync`/`resumeState`), not inside it.
+            if (root["sync"]?.jsonPrimitive?.booleanOrNull == true) {
+                val sync = mapSyncEvent(root)
+                val pending = root["pendingEvents"]?.jsonArray.orEmpty()
+                    .filterIsInstance<JsonObject>()
+                    .mapNotNull(::mapJsonObject)
+                return listOfNotNull(sync) + pending
+            }
+            listOfNotNull(mapJsonObject(root))
         } catch (e: Exception) {
             Diag.w(
                 "SSE",
@@ -87,7 +117,7 @@ class SseEventMapper(private val json: Json) {
                 throwable = e,
                 attrs = mapOf("event" to event.event),
             ) { "SSE parse error" }
-            StreamEvent.Error(message = "Parse error: ${e.message}")
+            listOf(StreamEvent.Error(message = "Parse error: ${e.message}"))
         }
     }
 
@@ -102,24 +132,23 @@ class SseEventMapper(private val json: Json) {
             return mapCreatedEvent(root)
         }
 
-        // 3. Check for "sync" control event
-        if (root["sync"]?.jsonPrimitive?.booleanOrNull == true) {
-            return mapSyncEvent(root)
-        }
+        // The "sync" control event is handled in mapFrame (it expands to a snapshot
+        // plus its buffered pendingEvents) before any frame reaches here, so there is
+        // deliberately no sync branch in this per-event dispatcher.
 
-        // 4. Check for "error" field (may be a string or an object)
+        // 3. Check for "error" field (may be a string or an object)
         val errorText = root["error"]?.toStringValue()
         if (errorText != null) {
             return StreamEvent.Error(message = errorText)
         }
 
-        // 5. Check for LangGraph nested event (has "event" key)
+        // 4. Check for LangGraph nested event (has "event" key)
         val eventType = root["event"]?.jsonPrimitive?.contentOrNull
         if (eventType != null) {
             return mapLangGraphEvent(eventType, root)
         }
 
-        // 6. Legacy flat format fallback
+        // 5. Legacy flat format fallback
         return mapLegacyEvent(root)
     }
 
@@ -209,30 +238,24 @@ class SseEventMapper(private val json: Json) {
     private fun mapSyncEvent(root: JsonObject): StreamEvent? {
         val resumeState = root["resumeState"]?.jsonObject ?: return null
 
-        // Replay run steps as individual events first — the caller will handle them
-        // The web client replays these as on_run_step events; for our mapper we
-        // focus on the aggregatedContent snapshot that replaces current message state.
-        val runSteps = resumeState["runSteps"]?.jsonArray
+        // We intentionally do NOT replay `resumeState.runSteps`. The web client
+        // replays them as on_run_step events to seed its event-sourced step-index
+        // map; our client renders tool calls from a flat list keyed by id, and
+        // `aggregatedContent` already carries every tool_call part (in-progress
+        // with a null output, completed with its output merged in) in order — so
+        // it is the authoritative snapshot. runSteps would only duplicate it.
+        val aggregatedContent = resumeState["aggregatedContent"]?.jsonArray ?: return null
 
-        // Parse aggregatedContent — this is the full content array that replaces
-        // whatever the client currently has for this response message.
-        val aggregatedContent = resumeState["aggregatedContent"]?.jsonArray
-        if (aggregatedContent == null && runSteps == null) return null
-
-        val contentParts = if (aggregatedContent != null) {
-            aggregatedContent.mapNotNull { element ->
-                try {
-                    json.decodeFromJsonElement(
-                        MessageContentPart.serializer(),
-                        element,
-                    )
-                } catch (e: Exception) {
-                    Logger.w("SSE", e) { "Failed to parse sync aggregatedContent part" }
-                    null
-                }
+        val contentParts = aggregatedContent.mapNotNull { element ->
+            try {
+                json.decodeFromJsonElement(
+                    MessageContentPart.serializer(),
+                    element,
+                )
+            } catch (e: Exception) {
+                Logger.w("SSE", e) { "Failed to parse sync aggregatedContent part" }
+                null
             }
-        } else {
-            emptyList()
         }
 
         return StreamEvent.Sync(aggregatedContent = contentParts)

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModel.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModel.kt
@@ -1169,7 +1169,11 @@ class ChatViewModel(
                 }
             }
             is StreamEvent.Sync -> {
-                // State-snapshot protocol: replace streaming buffer with synced content
+                // Resume snapshot: `aggregatedContent` is the authoritative state of
+                // the response so far, so we REPLACE (not append) the streaming
+                // pipeline's fields from it — both the text buffer and the tool-call
+                // list. Any pendingEvents in the same frame arrive as their own
+                // StreamEvents after this and fold on top via the normal handlers.
                 if (lastErrorWasNetwork) {
                     lastErrorWasNetwork = false
                     cancelConnectivityObserver()
@@ -1183,6 +1187,24 @@ class ChatViewModel(
                 streamingBuffer.clear()
                 streamingBuffer.append(textContent)
                 streamingBufferDirty = true
+
+                // Rebuild active tool calls from the snapshot's tool_call parts so an
+                // in-progress image gen (or any tool call) started before we resumed
+                // still renders its live card. The same ActiveToolCall the live path
+                // produces, so the existing StreamingToolCallCard / ImageGenCard render
+                // it identically. A part with a non-blank output is already complete.
+                val syncedToolCalls = event.aggregatedContent
+                    .mapNotNull { part -> part.toolCall?.takeIf { !it.id.isNullOrBlank() } }
+                    .map { tc ->
+                        ActiveToolCall(
+                            id = tc.id.orEmpty(),
+                            name = tc.name.orEmpty(),
+                            input = tc.args?.toString(),
+                            isComplete = !tc.output.isNullOrBlank(),
+                            output = tc.output,
+                        )
+                    }
+                _uiState.update { it.copy(activeToolCalls = syncedToolCalls) }
                 flushStreamingBuffer()
             }
             is StreamEvent.Step -> { /* no-op */ }


### PR DESCRIPTION
## Summary
When a tool call is in progress on the server — most visibly an image generation — and the client connects to that stream via resume (e.g. the generation was started on the web, then the conversation is opened on mobile), the live card for that tool call did not appear. The assistant's text streamed in, but an in-progress image generation showed nothing until it finished.

The resume `sync` SSE frame is a composite: a state snapshot (`resumeState.aggregatedContent`) plus `pendingEvents` — events buffered server-side since the snapshot, delivered once. The mapper kept only the snapshot's text and dropped both its tool-call parts and the buffered events, so any tool call that started before the client resumed was never reflected in the streaming UI.

## Changes
- **`SseEventMapper`** — add `mapFrame(): List<StreamEvent>` as the pipeline entry point. A `sync` frame expands into the snapshot (`StreamEvent.Sync`) followed by its `pendingEvents`, each mapped through the same path as live events so they're handled identically downstream. `map()` is retained as a single-event delegate for tests. `runSteps` is intentionally not replayed — `aggregatedContent` already carries every tool-call part (in-progress and completed) in order, so it's the authoritative snapshot.
- **`SseClient`** — emit each event a frame yields, in order (was 1:1).
- **`ChatViewModel`** — the `Sync` handler now rebuilds the active tool-call list from the snapshot's content parts (a non-blank output marks a call complete), reusing the same `ActiveToolCall` the live path produces so the existing card renderers apply unchanged.

## Testing
- Device-verified: starting an image generation on the web, then opening the conversation on mobile while it's still generating, now shows the loading card and swaps to the image on completion.
- Added 3 unit tests covering the sync snapshot's tool-call parts, the frame-expansion ordering, and the ordinary single-event passthrough; existing `SseEventMapperTest` suite passes.
- Android and iOS targets compile.

## Notes
- Resume while model-comparison mode is active is not handled — the reconstruction writes only the single-stream tool-call lane, not the comparison panes. Narrow combination; deferred.
