### PR TITLE
feat(settings): in-app language selection with runtime locale switching

### DIFF
--- a/app/src/main/kotlin/com/garfiec/librechat/MainActivity.kt
+++ b/app/src/main/kotlin/com/garfiec/librechat/MainActivity.kt
@@ -40,6 +40,7 @@ import androidx.core.view.WindowCompat
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import co.touchlab.kermit.Logger
 import com.garfiec.librechat.core.common.network.ConnectivityObserver
+import com.garfiec.librechat.core.data.datastore.SettingsDataStore
 import com.garfiec.librechat.core.data.datastore.ThemeDataStore
 import com.garfiec.librechat.core.data.datastore.ThemeMode
 import com.garfiec.librechat.core.ui.theme.LibreChatTheme
@@ -52,6 +53,7 @@ class MainActivity : ComponentActivity() {
 
     private val connectivityObserver: ConnectivityObserver by inject()
     private val themeDataStore: ThemeDataStore by inject()
+    private val settingsDataStore: SettingsDataStore by inject()
 
     private var deepLinkUri by mutableStateOf<Uri?>(null)
 
@@ -83,6 +85,14 @@ class MainActivity : ComponentActivity() {
             val useDynamicColor by themeDataStore.useDynamicColor.collectAsStateWithLifecycle(
                 initialValue = themeDataStore.initialUseDynamicColor,
             )
+            // Gate on the language warm-up too so a persisted non-system language is applied
+            // before the first frame (no flash of the system locale before switching).
+            val localeReady by settingsDataStore.isReady.collectAsStateWithLifecycle()
+            val selectedLanguage by settingsDataStore.selectedLanguage.collectAsStateWithLifecycle(
+                initialValue = settingsDataStore.initialSelectedLanguage,
+            )
+            // The DEFAULT_LANGUAGE sentinel ("system") maps to no override → keep the device locale.
+            val appLocale = selectedLanguage.takeIf { it != SettingsDataStore.DEFAULT_LANGUAGE }
             val darkTheme = when (themeMode) {
                 ThemeMode.LIGHT -> false
                 ThemeMode.DARK -> true
@@ -99,7 +109,7 @@ class MainActivity : ComponentActivity() {
                 insetsController.isAppearanceLightNavigationBars = !darkTheme
             }
 
-            if (themeReady) {
+            if (themeReady && localeReady) {
                 LibreChatTheme(
                     darkTheme = darkTheme,
                     accentColor = Color(accentColorArgb),
@@ -132,6 +142,7 @@ class MainActivity : ComponentActivity() {
                                 deepLinkUri = deepLinkUri,
                                 onDeepLinkConsume = { deepLinkUri = null },
                                 shareNavigationTrigger = shareNavigationTrigger,
+                                appLocaleTag = appLocale,
                                 modifier = Modifier
                                     .weight(1f)
                                     .then(

--- a/app/src/main/kotlin/com/garfiec/librechat/navigation/LibreChatNavHost.kt
+++ b/app/src/main/kotlin/com/garfiec/librechat/navigation/LibreChatNavHost.kt
@@ -26,8 +26,9 @@ fun LibreChatNavHost(
     deepLinkUri: Uri? = null,
     onDeepLinkConsume: () -> Unit = {},
     shareNavigationTrigger: Int = 0,
+    appLocaleTag: String? = null,
 ) {
-    SharedLibreChatNavHost(modifier = modifier) { navigator, navHostViewModel, mod ->
+    SharedLibreChatNavHost(modifier = modifier, appLocaleTag = appLocaleTag) { navigator, navHostViewModel, mod ->
         // Handle deep links
         val currentOnDeepLinkConsume by rememberUpdatedState(onDeepLinkConsume)
         LaunchedEffect(deepLinkUri) {

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -173,3 +173,6 @@ formatting:
   ImportOrdering:
     excludes:
       - "**/build/generated/compose/resourceGenerator/**"
+  SpacingAroundParens:
+    excludes:
+      - "**/build/generated/compose/resourceGenerator/**"

--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/datastore/DataStoreRoundTripTest.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/datastore/DataStoreRoundTripTest.kt
@@ -108,7 +108,7 @@ class DataStoreRoundTripTest {
     @Test
     fun settingsDataStore_defaults() = runTest(testDispatcher) {
         val ds = createDataStore("settings")
-        val store = SettingsDataStore(ds)
+        val store = SettingsDataStore(ds, CoroutineScope(testDispatcher), testDispatcher)
 
         assertThat(store.autoScrollEnabled.first()).isTrue()
         assertThat(store.showThinkingBlocks.first()).isTrue()
@@ -118,12 +118,13 @@ class DataStoreRoundTripTest {
         assertThat(store.latexRenderer.first()).isEqualTo(LatexRenderer.KATEX)
         assertThat(store.showAvatars.first()).isTrue()
         assertThat(store.showBubbles.first()).isFalse()
+        assertThat(store.selectedLanguage.first()).isEqualTo("system")
     }
 
     @Test
     fun settingsDataStore_roundTrip_booleans() = runTest(testDispatcher) {
         val ds = createDataStore("settings-bool")
-        val store = SettingsDataStore(ds)
+        val store = SettingsDataStore(ds, CoroutineScope(testDispatcher), testDispatcher)
 
         store.setAutoScrollEnabled(false)
         store.setShowThinkingBlocks(false)
@@ -141,7 +142,7 @@ class DataStoreRoundTripTest {
     @Test
     fun settingsDataStore_roundTrip_enums() = runTest(testDispatcher) {
         val ds = createDataStore("settings-enums")
-        val store = SettingsDataStore(ds)
+        val store = SettingsDataStore(ds, CoroutineScope(testDispatcher), testDispatcher)
 
         store.setLatexRenderer(LatexRenderer.NATIVE)
         assertThat(store.latexRenderer.first()).isEqualTo(LatexRenderer.NATIVE)
@@ -156,7 +157,7 @@ class DataStoreRoundTripTest {
     @Test
     fun settingsDataStore_roundTrip_strings() = runTest(testDispatcher) {
         val ds = createDataStore("settings-strings")
-        val store = SettingsDataStore(ds)
+        val store = SettingsDataStore(ds, CoroutineScope(testDispatcher), testDispatcher)
 
         store.setLastUsedModel("anthropic", "claude-3.5-sonnet")
         assertThat(store.lastUsedEndpoint.first()).isEqualTo("anthropic")
@@ -164,12 +165,15 @@ class DataStoreRoundTripTest {
 
         store.setSelectedVoiceId("voice-en-us-001")
         assertThat(store.selectedVoiceId.first()).isEqualTo("voice-en-us-001")
+
+        store.setSelectedLanguage("zh-Hans")
+        assertThat(store.selectedLanguage.first()).isEqualTo("zh-Hans")
     }
 
     @Test
     fun settingsDataStore_roundTrip_floats() = runTest(testDispatcher) {
         val ds = createDataStore("settings-floats")
-        val store = SettingsDataStore(ds)
+        val store = SettingsDataStore(ds, CoroutineScope(testDispatcher), testDispatcher)
 
         store.setTtsSpeechRate(1.5f)
         store.setTtsPitch(0.8f)
@@ -180,7 +184,7 @@ class DataStoreRoundTripTest {
     @Test
     fun settingsDataStore_roundTrip_mcpServers() = runTest(testDispatcher) {
         val ds = createDataStore("settings-mcp")
-        val store = SettingsDataStore(ds)
+        val store = SettingsDataStore(ds, CoroutineScope(testDispatcher), testDispatcher)
 
         store.setSelectedMcpServers(setOf("server-a", "server-b"))
         assertThat(store.selectedMcpServers.first()).containsExactly("server-a", "server-b")

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/SettingsDataStore.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/SettingsDataStore.kt
@@ -24,8 +24,9 @@ class SettingsDataStore(
     ioDispatcher: CoroutineDispatcher,
 ) {
     /**
-     * Selected app language as a BCP-47/ISO code (e.g. "es", "zh-Hans"), or [DEFAULT_LANGUAGE]
-     * ("en") when the user hasn't chosen one. Drives the runtime locale applied at the app root.
+     * Selected app language as a BCP-47/ISO code (e.g. "es", "zh"), or [DEFAULT_LANGUAGE] (the
+     * "follow the device locale" sentinel) when the user hasn't chosen one. Drives the runtime
+     * locale applied at the app root.
      */
     val selectedLanguage: Flow<String> = dataStore.data.map { prefs ->
         prefs[KEY_SELECTED_LANGUAGE] ?: DEFAULT_LANGUAGE

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/SettingsDataStore.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/SettingsDataStore.kt
@@ -6,12 +6,61 @@ import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.floatPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+import kotlin.concurrent.Volatile
 
 class SettingsDataStore(
     private val dataStore: DataStore<Preferences>,
+    appScope: CoroutineScope,
+    ioDispatcher: CoroutineDispatcher,
 ) {
+    /**
+     * Selected app language as a BCP-47/ISO code (e.g. "es", "zh-Hans"), or [DEFAULT_LANGUAGE]
+     * ("en") when the user hasn't chosen one. Drives the runtime locale applied at the app root.
+     */
+    val selectedLanguage: Flow<String> = dataStore.data.map { prefs ->
+        prefs[KEY_SELECTED_LANGUAGE] ?: DEFAULT_LANGUAGE
+    }
+
+    /**
+     * Initial language seeded for the first compose frame, warmed up asynchronously off the Main
+     * thread (Koin instantiates this singleton on Main at startup, so the read must not block).
+     * Stays [DEFAULT_LANGUAGE] until [isReady] flips; the root composable gates on [isReady] so the
+     * persisted locale is applied before the first frame draws (no flash of the wrong language).
+     */
+    @Volatile
+    var initialSelectedLanguage: String = DEFAULT_LANGUAGE
+        private set
+
+    private val _isReady = MutableStateFlow(false)
+
+    /** Flips true once the async warm-up has resolved [initialSelectedLanguage]. */
+    val isReady: StateFlow<Boolean> = _isReady.asStateFlow()
+
+    init {
+        appScope.launch(ioDispatcher) {
+            try {
+                val prefs = dataStore.data.first()
+                initialSelectedLanguage = prefs[KEY_SELECTED_LANGUAGE] ?: DEFAULT_LANGUAGE
+            } catch (e: CancellationException) {
+                throw e
+            } catch (_: Exception) {
+                // Keep the default; the live flow still drives the UI value.
+            } finally {
+                _isReady.value = true
+            }
+        }
+    }
+
     val latexRenderer: Flow<LatexRenderer> = dataStore.data.map { prefs ->
         LatexRenderer.fromString(prefs[KEY_LATEX_RENDERER])
     }
@@ -140,6 +189,12 @@ class SettingsDataStore(
      */
     val dismissedVersionWarning: Flow<String?> = dataStore.data.map { prefs ->
         prefs[KEY_DISMISSED_VERSION_WARNING]
+    }
+
+    suspend fun setSelectedLanguage(languageCode: String) {
+        dataStore.edit { prefs ->
+            prefs[KEY_SELECTED_LANGUAGE] = languageCode
+        }
     }
 
     suspend fun setLatexRenderer(renderer: LatexRenderer) {
@@ -344,6 +399,14 @@ class SettingsDataStore(
     }
 
     companion object {
+        /**
+         * Sentinel meaning "follow the device locale" — the default until the user picks a
+         * specific language. Maps to a null locale override at the app root, so formatting and
+         * resource resolution keep following the system (current behavior preserved).
+         */
+        const val DEFAULT_LANGUAGE = "system"
+
+        private val KEY_SELECTED_LANGUAGE = stringPreferencesKey("selected_language")
         private val KEY_LATEX_RENDERER = stringPreferencesKey("latex_renderer")
         private val KEY_CHAT_FONT_SIZE = stringPreferencesKey("chat_font_size")
         private val KEY_STARRED_MODELS_DISPLAY = stringPreferencesKey("starred_models_display")

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/di/DataModule.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/di/DataModule.kt
@@ -108,7 +108,13 @@ val dataModule = module {
     }
     singleOf(::ConfigCacheDataStore)
     singleOf(::RoleCacheDataStore)
-    singleOf(::SettingsDataStore)
+    single {
+        SettingsDataStore(
+            dataStore = get(),
+            appScope = get<CoroutineScope>(KoinQualifiers.ApplicationScope),
+            ioDispatcher = get(KoinQualifiers.IO),
+        )
+    }
 
     // --- Repositories (special wiring) ---
 

--- a/core/ui/src/androidMain/kotlin/com/garfiec/librechat/core/ui/theme/LocalAppLocale.android.kt
+++ b/core/ui/src/androidMain/kotlin/com/garfiec/librechat/core/ui/theme/LocalAppLocale.android.kt
@@ -1,0 +1,33 @@
+package com.garfiec.librechat.core.ui.theme
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ProvidedValue
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
+import java.util.Locale
+
+actual object LocalAppLocale {
+    private var default: Locale? = null
+
+    actual val current: String
+        @Composable
+        get() = Locale.getDefault().toString()
+
+    @Composable
+    actual infix fun provides(value: String?): ProvidedValue<*> {
+        val configuration = LocalConfiguration.current
+        if (default == null) {
+            default = Locale.getDefault()
+        }
+        val new = when (value) {
+            null -> default!!
+            else -> Locale.forLanguageTag(value)
+        }
+        Locale.setDefault(new)
+        configuration.setLocale(new)
+        val resources = LocalContext.current.resources
+        @Suppress("DEPRECATION")
+        resources.updateConfiguration(configuration, resources.displayMetrics)
+        return LocalConfiguration provides configuration
+    }
+}

--- a/core/ui/src/commonMain/kotlin/com/garfiec/librechat/core/ui/theme/LocalAppLocale.kt
+++ b/core/ui/src/commonMain/kotlin/com/garfiec/librechat/core/ui/theme/LocalAppLocale.kt
@@ -1,0 +1,62 @@
+package com.garfiec.librechat.core.ui.theme
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.ProvidedValue
+import androidx.compose.runtime.key
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.unit.LayoutDirection
+
+/**
+ * Runtime app-locale override for Compose Multiplatform resources.
+ *
+ * CMP's `stringResource` resolves against the locale carried in the composition, and there is no
+ * public API yet to switch it at runtime. This is the official JetBrains workaround
+ * (https://kotlinlang.org/docs/multiplatform/compose-resource-environment.html): an expect/actual
+ * object that pushes the chosen locale into the platform + composition, applied through [AppLocale]
+ * which wraps the subtree in a `key(...)` so it fully recomposes and re-resolves resources whenever
+ * the locale changes.
+ */
+expect object LocalAppLocale {
+    val current: String
+        @Composable get
+
+    @Composable
+    infix fun provides(value: String?): ProvidedValue<*>
+}
+
+/** Language subtags that render right-to-left. We only ship Arabic today; the rest are listed
+ *  so a future locale addition mirrors correctly without revisiting this code. */
+private val RTL_LANGUAGE_SUBTAGS = setOf("ar", "he", "iw", "fa", "ur")
+
+/**
+ * Applies [tag] (a BCP-47 language code such as "es" or "zh") as the app locale for [content].
+ * Pass null to fall back to the system/source locale. The `key(tag)` forces a full recomposition
+ * of [content] when the locale changes so every `stringResource` re-resolves against the new
+ * locale without an app restart.
+ *
+ * Overriding the locale alone re-resolves strings and right-aligns text but does NOT flip Compose's
+ * [LocalLayoutDirection], so RTL languages would otherwise keep LTR-mirrored chrome (back arrow,
+ * row icons, chevrons). We therefore provide the layout direction explicitly for an overridden tag;
+ * for the system default (null) we leave the platform's current direction untouched.
+ *
+ * Because `key(tag)` tears down composition state on every locale change, callers must keep
+ * navigation state (the nav back stack) ABOVE this wrapper so it survives the swap — see
+ * `LibreChatNavHost`, which creates the back stack outside [AppLocale] and only wraps the rendering.
+ */
+@Composable
+fun AppLocale(tag: String?, content: @Composable () -> Unit) {
+    val layoutDirection = when {
+        tag == null -> LocalLayoutDirection.current
+        tag.substringBefore('-').lowercase() in RTL_LANGUAGE_SUBTAGS -> LayoutDirection.Rtl
+        else -> LayoutDirection.Ltr
+    }
+    CompositionLocalProvider(
+        LocalAppLocale provides tag,
+        LocalLayoutDirection provides layoutDirection,
+    ) {
+        key(tag) {
+            content()
+        }
+    }
+}

--- a/core/ui/src/iosMain/kotlin/com/garfiec/librechat/core/ui/theme/LocalAppLocale.ios.kt
+++ b/core/ui/src/iosMain/kotlin/com/garfiec/librechat/core/ui/theme/LocalAppLocale.ios.kt
@@ -1,0 +1,29 @@
+package com.garfiec.librechat.core.ui.theme
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ProvidedValue
+import androidx.compose.runtime.staticCompositionLocalOf
+import platform.Foundation.NSLocale
+import platform.Foundation.NSUserDefaults
+import platform.Foundation.preferredLanguages
+
+actual object LocalAppLocale {
+    private const val LANG_KEY = "AppleLanguages"
+    private val default: String = NSLocale.preferredLanguages.firstOrNull() as? String ?: "en"
+    private val LocalAppLocale = staticCompositionLocalOf { default }
+
+    actual val current: String
+        @Composable
+        get() = LocalAppLocale.current
+
+    @Composable
+    actual infix fun provides(value: String?): ProvidedValue<*> {
+        val new = value ?: default
+        if (value == null) {
+            NSUserDefaults.standardUserDefaults.removeObjectForKey(LANG_KEY)
+        } else {
+            NSUserDefaults.standardUserDefaults.setObject(listOf(new), LANG_KEY)
+        }
+        return LocalAppLocale provides new
+    }
+}

--- a/feature/agents/src/commonMain/composeResources/values-ar/strings.xml
+++ b/feature/agents/src/commonMain/composeResources/values-ar/strings.xml
@@ -1,0 +1,305 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Common actions -->
+    <string name="agents">الوكلاء</string>
+    <string name="marketplace">المتجر</string>
+    <string name="search_agents">البحث في الوكلاء…</string>
+    <string name="start_chat">بدء محادثة</string>
+    <string name="edit">تعديل</string>
+    <string name="delete">حذف</string>
+    <string name="cancel">إلغاء</string>
+    <string name="duplicate">تكرار</string>
+    <string name="save">حفظ</string>
+    <string name="create">إنشاء</string>
+    <string name="apply">تطبيق</string>
+    <string name="add">إضافة</string>
+    <string name="remove">إزالة</string>
+    <string name="revert">استرجاع</string>
+    <string name="close">إغلاق</string>
+
+    <!-- Content descriptions -->
+    <string name="cd_create_agent">إنشاء وكيل</string>
+    <string name="cd_search">بحث</string>
+    <string name="cd_back">رجوع</string>
+    <string name="cd_more_actions">إجراءات إضافية</string>
+    <string name="cd_more_options">خيارات إضافية</string>
+    <string name="cd_collapse">طي</string>
+    <string name="cd_expand">توسيع</string>
+    <string name="cd_remove_item">إزالة %1$s</string>
+    <string name="cd_edit_action">تعديل الإجراء</string>
+    <string name="cd_delete_action">حذف الإجراء</string>
+    <string name="cd_add_starter">إضافة محفّز محادثة</string>
+    <string name="cd_agent_avatar_tap">الصورة الرمزية للوكيل. انقر للتغيير.</string>
+    <string name="cd_agent_avatar_name">الصورة الرمزية لـ %1$s</string>
+    <string name="cd_tool_icon">أيقونة %1$s</string>
+
+    <!-- Marketplace screen -->
+    <string name="search_agents_hint">البحث في الوكلاء…</string>
+    <string name="no_agents_found">لم يتم العثور على وكلاء</string>
+    <string name="no_agents_available">لا يوجد وكلاء متاحون</string>
+    <string name="agents_not_available_title">الوكلاء غير متاحين</string>
+    <string name="agents_not_available_description">قام مسؤول الخادم بتعطيل الوكلاء لحسابك.</string>
+    <string name="try_different_search">جرّب مصطلح بحث مختلفًا</string>
+    <string name="check_back_later">تحقّق لاحقًا من وجود وكلاء جدد</string>
+    <string name="error_unknown">حدث خطأ غير معروف</string>
+    <string name="unknown_author">غير معروف</string>
+
+    <!-- Detail screen -->
+    <string name="agent_title">وكيل</string>
+    <string name="delete_agent">حذف الوكيل</string>
+    <string name="delete_agent_confirm">هل أنت متأكد أنك تريد حذف \"%1$s\"؟ لا يمكن التراجع عن ذلك.</string>
+    <string name="delete_this_agent">هذا الوكيل</string>
+    <string name="by_author">بواسطة %1$s</string>
+    <string name="label_description">الوصف</string>
+    <string name="no_description">لا يوجد وصف</string>
+    <string name="label_category">الفئة</string>
+    <string name="label_model">النموذج</string>
+    <string name="default_value">افتراضي</string>
+    <string name="label_tools">الأدوات</string>
+    <string name="label_conversation_starters">محفّزات المحادثة</string>
+
+    <!-- Editor screen -->
+    <string name="edit_agent">تعديل الوكيل</string>
+    <string name="create_agent">إنشاء وكيل</string>
+    <string name="duplicate_agent">تكرار الوكيل</string>
+    <string name="delete_agent_editor_confirm">هل أنت متأكد أنك تريد حذف هذا الوكيل؟ لا يمكن التراجع عن هذا الإجراء.</string>
+    <string name="duplicate_agent_confirm">إنشاء نسخة من هذا الوكيل؟</string>
+    <string name="version_history">سجل الإصدارات</string>
+    <string name="tap_to_change_avatar">انقر لتغيير الصورة الرمزية</string>
+    <string name="remove_avatar">إزالة الصورة الرمزية</string>
+    <string name="agent_name_label">الاسم *</string>
+    <string name="agent_name_placeholder">اختياري: اسم الوكيل</string>
+    <string name="agent_description_label">الوصف</string>
+    <string name="agent_description_placeholder">اختياري: صف وكيلك هنا</string>
+    <string name="agent_instructions_label">التعليمات</string>
+    <string name="agent_instructions_placeholder">تعليمات النظام التي يستخدمها الوكيل</string>
+    <string name="insert_variable">إدراج متغير</string>
+    <string name="cd_insert_variable">إدراج متغير</string>
+    <string name="special_var_current_date">التاريخ الحالي</string>
+    <string name="special_var_current_user">المستخدم الحالي</string>
+    <string name="special_var_iso_datetime">التاريخ والوقت بصيغة ISO</string>
+    <string name="special_var_current_datetime">التاريخ والوقت الحاليان</string>
+    <string name="label_capabilities">الإمكانات</string>
+    <string name="label_tools_and_actions">الأدوات والإجراءات</string>
+    <string name="add_tools">إضافة أدوات</string>
+    <string name="add_starter_hint">إضافة محفّز…</string>
+    <string name="save_changes">حفظ التغييرات</string>
+
+    <!-- Actions panel -->
+    <string name="openapi_actions_count">إجراءات OpenAPI (%1$d)</string>
+    <string name="no_actions_configured">لا توجد إجراءات مُهيأة. أضف إجراء OpenAPI للاتصال بواجهات API الخارجية.</string>
+    <string name="add_action">إضافة إجراء</string>
+    <string name="edit_action">تعديل الإجراء</string>
+    <string name="auth_api_key">مفتاح API</string>
+    <string name="auth_oauth">OAuth</string>
+    <string name="auth_none">بدون</string>
+    <string name="action_auth_info">المصادقة: %1$s | %2$d دالة (دوال)</string>
+    <string name="label_action">الإجراء</string>
+
+    <!-- Action editor dialog -->
+    <string name="label_authentication">المصادقة</string>
+    <string name="auth_api_key_full">مصادقة بمفتاح API</string>
+    <string name="auth_oauth_full">مصادقة OAuth</string>
+    <string name="auth_no_auth">بدون مصادقة</string>
+    <string name="label_openapi_schema">مخطط OpenAPI</string>
+    <string name="openapi_schema_hint">الصق مواصفات OpenAPI الخاصة بك بصيغة JSON أو YAML.</string>
+    <string name="label_openapi_spec">مواصفات OpenAPI (JSON أو YAML)</string>
+    <string name="validating">جارٍ التحقق…</string>
+    <string name="domain_prefix">النطاق: %1$s</string>
+    <string name="available_actions_count">الإجراءات المتاحة (%1$d)</string>
+    <string name="label_privacy_policy_url">رابط سياسة الخصوصية</string>
+    <string name="label_save_or_create">%1$s</string>
+
+    <!-- Auth config dialog -->
+    <string name="label_authentication_type">نوع المصادقة</string>
+    <string name="label_api_key_settings">إعدادات مفتاح API</string>
+    <string name="label_api_key">مفتاح API</string>
+    <string name="label_authorization_type">نوع التفويض</string>
+    <string name="auth_basic">Basic</string>
+    <string name="auth_bearer">Bearer</string>
+    <string name="auth_custom">مخصص</string>
+    <string name="label_custom_auth_header">ترويسة المصادقة المخصصة</string>
+    <string name="label_oauth_settings">إعدادات OAuth</string>
+    <string name="label_client_id">معرّف العميل</string>
+    <string name="label_client_secret">سر العميل</string>
+    <string name="label_authorization_url">رابط التفويض</string>
+    <string name="label_token_url">رابط الرمز المميز</string>
+    <string name="label_scope">النطاق</string>
+    <string name="label_token_exchange_method">طريقة تبادل الرمز المميز</string>
+    <string name="token_default_post">افتراضي (POST)</string>
+    <string name="token_basic_auth_header">ترويسة مصادقة Basic</string>
+
+    <!-- Function table -->
+    <string name="table_name">الاسم</string>
+    <string name="table_method">الطريقة</string>
+    <string name="table_path">المسار</string>
+
+    <!-- Advanced panel -->
+    <string name="advanced_settings">إعدادات النموذج</string>
+    <string name="label_temperature">درجة الحرارة</string>
+    <string name="temperature_description">تتحكم في العشوائية. أقل = أكثر تركيزًا.</string>
+    <string name="label_top_p">Top P</string>
+    <string name="top_p_description">حد أخذ عينات النواة.</string>
+    <string name="label_max_tokens">الحد الأقصى للرموز</string>
+    <string name="max_tokens_description">الحد الأقصى للرموز في الرد. اتركه فارغًا للقيمة الافتراضية.</string>
+
+    <!-- Avatar picker -->
+    <!-- (content descriptions above) -->
+
+    <!-- Capabilities section -->
+    <string name="label_artifacts">العناصر التفاعلية</string>
+    <string name="artifacts_description">تفعيل إنشاء العناصر التفاعلية</string>
+    <string name="artifacts_mode_off">إيقاف</string>
+    <string name="artifacts_mode_default">افتراضي</string>
+    <string name="artifacts_mode_shadcnui">shadcn/ui</string>
+    <string name="artifacts_mode_custom">مخصص</string>
+    <string name="label_end_after_tools">الإنهاء بعد الأدوات</string>
+    <string name="end_after_tools_description">التوقف بعد اكتمال تنفيذ الأداة</string>
+    <string name="label_hide_sequential_outputs">إخفاء المخرجات المتتابعة</string>
+    <string name="hide_sequential_description">إخفاء مخرجات الأدوات الوسيطة</string>
+    <string name="label_recursion_limit">حد التكرار العودي</string>
+    <string name="recursion_limit_description">الحد الأقصى لعدد استدعاءات الأدوات العودية</string>
+
+    <!-- Category selector -->
+    <string name="general">عام</string>
+
+    <!-- Code Interpreter section -->
+    <string name="label_code_interpreter">مفسّر الكود</string>
+    <string name="code_interpreter_description">السماح للوكيل بكتابة الكود وتنفيذه لحل المشكلات</string>
+
+    <!-- Web Search section -->
+    <string name="label_web_search">البحث على الويب</string>
+    <string name="web_search_description">السماح للوكيل بالبحث على الويب عن المعلومات الحالية</string>
+
+    <!-- Tool auth dialog -->
+    <string name="tool_auth_revoke">إبطال</string>
+    <string name="tool_auth_code_title">مفتاح API لمفسّر الكود</string>
+    <string name="tool_auth_code_description">أدخل مفتاح API الذي يجب أن يستخدمه الخادم لتشغيل الكود نيابة عنك. يُخزّن في حسابك، وليس في الوكيل.</string>
+    <string name="tool_auth_code_field">مفتاح LibreChat Code API</string>
+    <string name="tool_auth_required">المصادقة مطلوبة لتفعيل هذه الأداة</string>
+
+    <!-- File Context section -->
+    <string name="label_file_context">سياق الملفات</string>
+    <string name="file_context_description">إرفاق ملفات تُضمّن دائمًا كسياق للمحادثة</string>
+
+    <!-- File Search section -->
+    <string name="label_file_search">البحث في الملفات</string>
+    <string name="file_search_description">تمكين الوكيل من البحث في الملفات والمستندات المرفوعة</string>
+
+    <!-- Handoff config -->
+    <!-- Chain (sequential multi-agent) -->
+    <string name="chain_agents_count">وكلاء السلسلة (%1$d)</string>
+    <string name="chain_description">الوكلاء الذين يعملون بالتسلسل بعد هذا الوكيل. الحد الأقصى هو %1$d.</string>
+    <string name="no_chain_agents">لا توجد وكلاء سلسلة مُهيأون.</string>
+    <string name="add_chain_agent">إضافة وكيل سلسلة</string>
+    <string name="chain_full">تم الوصول إلى الحد الأقصى لعدد وكلاء السلسلة.</string>
+    <!-- Handoffs (graph edges) -->
+    <string name="handoff_edges_count">حواف التسليم (%1$d)</string>
+    <string name="handoff_edges_description">حواف توجيه الرسم البياني للتسليم الديناميكي متعدد الوكلاء.</string>
+    <string name="no_handoff_edges">لا توجد حواف تسليم مُهيأة.</string>
+    <string name="add_handoff_edge">إضافة حافة تسليم</string>
+    <string name="handoff_edge_from">من</string>
+    <string name="handoff_edge_to">إلى</string>
+    <string name="handoff_edge_description">الوصف (اختياري)</string>
+    <string name="handoff_edge_prompt">مطالبة النقل (اختياري)</string>
+    <string name="handoff_edge_prompt_key">اسم معامل المطالبة (اختياري)</string>
+    <string name="handoff_edge_exclude_results">استبعاد الرسائل السابقة</string>
+    <string name="handoff_edge_arrow">%1$s → %2$s</string>
+    <string name="handoff_edge_multi">%1$d وكلاء → %2$d وكلاء</string>
+    <string name="no_more_agents">لا يوجد المزيد من الوكلاء المتاحين للإضافة.</string>
+    <string name="select_agent">اختيار وكيل</string>
+
+    <!-- MCP Tools selector -->
+    <string name="mcp_tools_count">أدوات MCP (%1$d محددة)</string>
+    <string name="no_mcp_tools">لا توجد أدوات MCP متاحة. هيّئ خوادم MCP في الإعدادات.</string>
+    <string name="unknown_server">خادم غير معروف</string>
+
+    <!-- Model picker -->
+    <string name="model_required_label">النموذج *</string>
+    <string name="select_model_hint">اختر نموذجًا…</string>
+    <string name="no_models_found">لم يتم العثور على نماذج</string>
+
+    <!-- Sharing section -->
+    <string name="sharing_and_permissions">المشاركة والأذونات</string>
+    <string name="label_visibility">الظهور</string>
+    <string name="label_collaborative">تعاوني</string>
+    <string name="collaborative_description">السماح للمستخدمين الآخرين بتعديل هذا الوكيل</string>
+    <string name="collaborative_managed_server_side">تُدار أذونات الوصول على جانب الخادم في هذا الإصدار.</string>
+
+    <!-- Visibility labels -->
+    <string name="visibility_private">خاص</string>
+    <string name="visibility_team">فريق</string>
+    <string name="visibility_public">عام</string>
+
+    <!-- Support contact section -->
+    <string name="label_support_contact">جهة اتصال الدعم</string>
+    <string name="label_name">الاسم</string>
+    <string name="support_contact_placeholder">اسم جهة اتصال الدعم</string>
+    <string name="label_email">البريد الإلكتروني</string>
+
+    <!-- Version history -->
+    <string name="no_version_history">لا يوجد سجل إصدارات متاح</string>
+    <string name="version_number">الإصدار %1$d</string>
+    <string name="version_current">نشط</string>
+    <string name="version_no_date">لا يوجد تاريخ متاح</string>
+    <string name="version_unknown_date">تاريخ غير معروف</string>
+    <string name="version_snapshot_name">الاسم</string>
+    <string name="version_snapshot_description">الوصف</string>
+    <string name="version_snapshot_instructions">التعليمات</string>
+    <string name="version_snapshot_artifacts">العناصر التفاعلية</string>
+    <string name="version_snapshot_capabilities">الإمكانات</string>
+    <string name="version_snapshot_tools">الأدوات</string>
+    <string name="version_snapshot_empty">—</string>
+    <string name="version_restore_confirm">استرجاع هذا الوكيل إلى الإصدار المحدد؟ ستُفقد التغييرات الحالية غير المحفوظة.</string>
+
+    <!-- ACL sharing (v0.8.5+) -->
+    <string name="acl_sharing_title">المشاركة والوصول</string>
+    <string name="acl_add_principal">إضافة مستخدم أو مجموعة</string>
+    <string name="acl_no_grants">لم يُمنح أحد الوصول بعد.</string>
+    <string name="acl_public_label">عام</string>
+    <string name="acl_public_description">السماح لأي شخص لديه وصول إلى الخادم</string>
+    <string name="acl_role">الدور</string>
+    <string name="acl_revoke">إبطال</string>
+    <string name="acl_search_hint">البحث عن المستخدمين أو المجموعات…</string>
+    <string name="acl_search_empty">لا توجد تطابقات</string>
+    <string name="acl_grant_button">منح</string>
+    <string name="acl_grant_dialog_title">إضافة مستخدم أو مجموعة</string>
+    <string name="acl_principal_user">مستخدم</string>
+    <string name="acl_principal_group">مجموعة</string>
+    <string name="acl_principal_role">دور</string>
+    <string name="acl_create_mode_notice">تتوفر عناصر التحكم في المشاركة والوصول بعد حفظ الوكيل.</string>
+
+    <!-- Tool select dialog -->
+    <string name="agent_tools_title">أدوات الوكيل</string>
+    <string name="select_tools_description">اختر الأدوات التي سيستخدمها وكيلك</string>
+    <string name="search_tools_hint">البحث في الأدوات…</string>
+    <string name="no_tools_matching">لا توجد أدوات تطابق \"%1$s\"</string>
+    <string name="no_tools_available">لا توجد أدوات متاحة</string>
+
+    <!-- Per-capability file attachments -->
+    <string name="add_file">إضافة ملف</string>
+    <string name="agent_files_save_first">احفظ الوكيل قبل إرفاق الملفات</string>
+    <string name="agent_file_too_large">يجب أن يكون الملف %1$d ميغابايت أو أصغر</string>
+    <string name="agent_file_upload_failed">فشل رفع الملف</string>
+    <string name="agent_file_remove_failed">فشل إزالة الملف</string>
+    <string name="cd_remove_file">إزالة %1$s</string>
+
+    <!-- Skills selector (v0.8.6) -->
+    <string name="label_skills">المهارات</string>
+    <string name="skills_disabled_hint">المهارات معطّلة لهذا الوكيل.</string>
+    <string name="skills_enabled_all_hint">جميع المهارات التي يمكنك الوصول إليها متاحة لهذا الوكيل.</string>
+    <string name="skills_enabled_allowlist_hint">المهارات المحددة فقط متاحة لهذا الوكيل.</string>
+    <string name="add_skills">إضافة مهارات</string>
+    <string name="select_skills">اختيار المهارات</string>
+    <string name="search_skills_hint">البحث في المهارات…</string>
+    <string name="no_skills_matching">لا توجد مهارات تطابق \"%1$s\"</string>
+    <string name="no_skills_available">لا توجد مهارات متاحة</string>
+    <string name="skills_done">تم</string>
+
+    <!-- Subagents config (v0.8.6) -->
+    <string name="label_subagents">الوكلاء الفرعيون</string>
+    <string name="subagents_description">دع هذا الوكيل يفوّض العمل إلى وكلاء آخرين في سياقات معزولة.</string>
+    <string name="subagents_allow_self">السماح بإنشاء نسخة من نفسه</string>
+    <string name="add_subagent">إضافة وكيل فرعي</string>
+    <string name="subagents_full">تم الوصول إلى الحد الأقصى لعدد الوكلاء الفرعيين.</string>
+</resources>

--- a/feature/agents/src/commonMain/composeResources/values-de/strings.xml
+++ b/feature/agents/src/commonMain/composeResources/values-de/strings.xml
@@ -1,0 +1,305 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Common actions -->
+    <string name="agents">Agenten</string>
+    <string name="marketplace">Marketplace</string>
+    <string name="search_agents">Agenten suchen…</string>
+    <string name="start_chat">Chat starten</string>
+    <string name="edit">Bearbeiten</string>
+    <string name="delete">Löschen</string>
+    <string name="cancel">Abbrechen</string>
+    <string name="duplicate">Duplizieren</string>
+    <string name="save">Speichern</string>
+    <string name="create">Erstellen</string>
+    <string name="apply">Anwenden</string>
+    <string name="add">Hinzufügen</string>
+    <string name="remove">Entfernen</string>
+    <string name="revert">Zurücksetzen</string>
+    <string name="close">Schließen</string>
+
+    <!-- Content descriptions -->
+    <string name="cd_create_agent">Agent erstellen</string>
+    <string name="cd_search">Suchen</string>
+    <string name="cd_back">Zurück</string>
+    <string name="cd_more_actions">Weitere Aktionen</string>
+    <string name="cd_more_options">Weitere Optionen</string>
+    <string name="cd_collapse">Einklappen</string>
+    <string name="cd_expand">Ausklappen</string>
+    <string name="cd_remove_item">%1$s entfernen</string>
+    <string name="cd_edit_action">Aktion bearbeiten</string>
+    <string name="cd_delete_action">Aktion löschen</string>
+    <string name="cd_add_starter">Starter hinzufügen</string>
+    <string name="cd_agent_avatar_tap">Agent-Avatar. Zum Ändern tippen.</string>
+    <string name="cd_agent_avatar_name">%1$s-Avatar</string>
+    <string name="cd_tool_icon">%1$s-Symbol</string>
+
+    <!-- Marketplace screen -->
+    <string name="search_agents_hint">Agenten suchen…</string>
+    <string name="no_agents_found">Keine Agenten gefunden</string>
+    <string name="no_agents_available">Keine Agenten verfügbar</string>
+    <string name="agents_not_available_title">Agenten nicht verfügbar</string>
+    <string name="agents_not_available_description">Dein Serveradministrator hat Agenten für dein Konto deaktiviert.</string>
+    <string name="try_different_search">Versuche einen anderen Suchbegriff</string>
+    <string name="check_back_later">Schau später nach neuen Agenten</string>
+    <string name="error_unknown">Ein unbekannter Fehler ist aufgetreten</string>
+    <string name="unknown_author">Unbekannt</string>
+
+    <!-- Detail screen -->
+    <string name="agent_title">Agent</string>
+    <string name="delete_agent">Agent löschen</string>
+    <string name="delete_agent_confirm">Möchtest du \"%1$s\" wirklich löschen? Dies kann nicht rückgängig gemacht werden.</string>
+    <string name="delete_this_agent">diesen Agenten</string>
+    <string name="by_author">von %1$s</string>
+    <string name="label_description">Beschreibung</string>
+    <string name="no_description">Keine Beschreibung</string>
+    <string name="label_category">Kategorie</string>
+    <string name="label_model">Modell</string>
+    <string name="default_value">Standard</string>
+    <string name="label_tools">Tools</string>
+    <string name="label_conversation_starters">Gesprächseinstiege</string>
+
+    <!-- Editor screen -->
+    <string name="edit_agent">Agent bearbeiten</string>
+    <string name="create_agent">Agent erstellen</string>
+    <string name="duplicate_agent">Agent duplizieren</string>
+    <string name="delete_agent_editor_confirm">Möchtest du diesen Agenten wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden.</string>
+    <string name="duplicate_agent_confirm">Eine Kopie dieses Agenten erstellen?</string>
+    <string name="version_history">Versionsverlauf</string>
+    <string name="tap_to_change_avatar">Zum Ändern des Avatars tippen</string>
+    <string name="remove_avatar">Avatar entfernen</string>
+    <string name="agent_name_label">Name *</string>
+    <string name="agent_name_placeholder">Optional: Der Name des Agenten</string>
+    <string name="agent_description_label">Beschreibung</string>
+    <string name="agent_description_placeholder">Optional: Beschreibe deinen Agenten hier</string>
+    <string name="agent_instructions_label">Anweisungen</string>
+    <string name="agent_instructions_placeholder">Die Systemanweisungen, die der Agent verwendet</string>
+    <string name="insert_variable">Variable einfügen</string>
+    <string name="cd_insert_variable">Variable einfügen</string>
+    <string name="special_var_current_date">Aktuelles Datum</string>
+    <string name="special_var_current_user">Aktueller Benutzer</string>
+    <string name="special_var_iso_datetime">ISO-Datum/Uhrzeit</string>
+    <string name="special_var_current_datetime">Aktuelles Datum/Uhrzeit</string>
+    <string name="label_capabilities">Funktionen</string>
+    <string name="label_tools_and_actions">Tools &amp; Aktionen</string>
+    <string name="add_tools">Tools hinzufügen</string>
+    <string name="add_starter_hint">Starter hinzufügen…</string>
+    <string name="save_changes">Änderungen speichern</string>
+
+    <!-- Actions panel -->
+    <string name="openapi_actions_count">OpenAPI-Aktionen (%1$d)</string>
+    <string name="no_actions_configured">Keine Aktionen konfiguriert. Füge eine OpenAPI-Aktion hinzu, um externe APIs zu verbinden.</string>
+    <string name="add_action">Aktion hinzufügen</string>
+    <string name="edit_action">Aktion bearbeiten</string>
+    <string name="auth_api_key">API-Schlüssel</string>
+    <string name="auth_oauth">OAuth</string>
+    <string name="auth_none">Keine</string>
+    <string name="action_auth_info">Auth: %1$s | %2$d Funktion(en)</string>
+    <string name="label_action">Aktion</string>
+
+    <!-- Action editor dialog -->
+    <string name="label_authentication">Authentifizierung</string>
+    <string name="auth_api_key_full">API-Schlüssel-Authentifizierung</string>
+    <string name="auth_oauth_full">OAuth-Authentifizierung</string>
+    <string name="auth_no_auth">Keine Authentifizierung</string>
+    <string name="label_openapi_schema">OpenAPI-Schema</string>
+    <string name="openapi_schema_hint">Füge deine OpenAPI-Spezifikation im JSON- oder YAML-Format ein.</string>
+    <string name="label_openapi_spec">OpenAPI-Spec (JSON oder YAML)</string>
+    <string name="validating">Wird validiert…</string>
+    <string name="domain_prefix">Domain: %1$s</string>
+    <string name="available_actions_count">Verfügbare Aktionen (%1$d)</string>
+    <string name="label_privacy_policy_url">URL der Datenschutzerklärung</string>
+    <string name="label_save_or_create">%1$s</string>
+
+    <!-- Auth config dialog -->
+    <string name="label_authentication_type">Authentifizierungstyp</string>
+    <string name="label_api_key_settings">API-Schlüssel-Einstellungen</string>
+    <string name="label_api_key">API-Schlüssel</string>
+    <string name="label_authorization_type">Autorisierungstyp</string>
+    <string name="auth_basic">Basic</string>
+    <string name="auth_bearer">Bearer</string>
+    <string name="auth_custom">Benutzerdefiniert</string>
+    <string name="label_custom_auth_header">Benutzerdefinierter Auth-Header</string>
+    <string name="label_oauth_settings">OAuth-Einstellungen</string>
+    <string name="label_client_id">Client-ID</string>
+    <string name="label_client_secret">Client-Secret</string>
+    <string name="label_authorization_url">Autorisierungs-URL</string>
+    <string name="label_token_url">Token-URL</string>
+    <string name="label_scope">Scope</string>
+    <string name="label_token_exchange_method">Token-Austauschmethode</string>
+    <string name="token_default_post">Standard (POST)</string>
+    <string name="token_basic_auth_header">Basic-Auth-Header</string>
+
+    <!-- Function table -->
+    <string name="table_name">Name</string>
+    <string name="table_method">Methode</string>
+    <string name="table_path">Pfad</string>
+
+    <!-- Advanced panel -->
+    <string name="advanced_settings">Modelleinstellungen</string>
+    <string name="label_temperature">Temperatur</string>
+    <string name="temperature_description">Steuert die Zufälligkeit. Niedriger = fokussierter.</string>
+    <string name="label_top_p">Top P</string>
+    <string name="top_p_description">Cutoff für Nucleus-Sampling.</string>
+    <string name="label_max_tokens">Max. Tokens</string>
+    <string name="max_tokens_description">Maximale Anzahl Tokens in der Antwort. Leer lassen für Standard.</string>
+
+    <!-- Avatar picker -->
+    <!-- (content descriptions above) -->
+
+    <!-- Capabilities section -->
+    <string name="label_artifacts">Artefakte</string>
+    <string name="artifacts_description">Artefakt-Generierung aktivieren</string>
+    <string name="artifacts_mode_off">Aus</string>
+    <string name="artifacts_mode_default">Standard</string>
+    <string name="artifacts_mode_shadcnui">shadcn/ui</string>
+    <string name="artifacts_mode_custom">Benutzerdefiniert</string>
+    <string name="label_end_after_tools">Nach Tools beenden</string>
+    <string name="end_after_tools_description">Nach Abschluss der Tool-Ausführung stoppen</string>
+    <string name="label_hide_sequential_outputs">Sequenzielle Ausgaben ausblenden</string>
+    <string name="hide_sequential_description">Zwischenliegende Tool-Ausgaben ausblenden</string>
+    <string name="label_recursion_limit">Rekursionslimit</string>
+    <string name="recursion_limit_description">Maximale Anzahl rekursiver Tool-Aufrufe</string>
+
+    <!-- Category selector -->
+    <string name="general">Allgemein</string>
+
+    <!-- Code Interpreter section -->
+    <string name="label_code_interpreter">Code-Interpreter</string>
+    <string name="code_interpreter_description">Dem Agenten erlauben, Code zu schreiben und auszuführen, um Probleme zu lösen</string>
+
+    <!-- Web Search section -->
+    <string name="label_web_search">Websuche</string>
+    <string name="web_search_description">Dem Agenten erlauben, im Web nach aktuellen Informationen zu suchen</string>
+
+    <!-- Tool auth dialog -->
+    <string name="tool_auth_revoke">Widerrufen</string>
+    <string name="tool_auth_code_title">Code-Interpreter-API-Schlüssel</string>
+    <string name="tool_auth_code_description">Gib den API-Schlüssel ein, den der Server verwenden soll, um Code in deinem Namen auszuführen. In deinem Konto gespeichert, nicht im Agenten.</string>
+    <string name="tool_auth_code_field">LibreChat Code API-Schlüssel</string>
+    <string name="tool_auth_required">Authentifizierung erforderlich, um dieses Tool zu aktivieren</string>
+
+    <!-- File Context section -->
+    <string name="label_file_context">Dateikontext</string>
+    <string name="file_context_description">Dateien anhängen, die immer als Gesprächskontext einbezogen werden</string>
+
+    <!-- File Search section -->
+    <string name="label_file_search">Dateisuche</string>
+    <string name="file_search_description">Dem Agenten erlauben, hochgeladene Dateien und Dokumente zu durchsuchen</string>
+
+    <!-- Handoff config -->
+    <!-- Chain (sequential multi-agent) -->
+    <string name="chain_agents_count">Ketten-Agenten (%1$d)</string>
+    <string name="chain_description">Agenten, die nach diesem in Reihenfolge ausgeführt werden. Limit ist %1$d.</string>
+    <string name="no_chain_agents">Keine Ketten-Agenten konfiguriert.</string>
+    <string name="add_chain_agent">Ketten-Agent hinzufügen</string>
+    <string name="chain_full">Maximale Anzahl an Ketten-Agenten erreicht.</string>
+    <!-- Handoffs (graph edges) -->
+    <string name="handoff_edges_count">Übergabe-Kanten (%1$d)</string>
+    <string name="handoff_edges_description">Graph-Routing-Kanten für dynamische Multi-Agent-Übergabe.</string>
+    <string name="no_handoff_edges">Keine Übergabe-Kanten konfiguriert.</string>
+    <string name="add_handoff_edge">Übergabe-Kante hinzufügen</string>
+    <string name="handoff_edge_from">Von</string>
+    <string name="handoff_edge_to">Nach</string>
+    <string name="handoff_edge_description">Beschreibung (optional)</string>
+    <string name="handoff_edge_prompt">Übergabe-Prompt (optional)</string>
+    <string name="handoff_edge_prompt_key">Name des Prompt-Parameters (optional)</string>
+    <string name="handoff_edge_exclude_results">Vorherige Nachrichten ausschließen</string>
+    <string name="handoff_edge_arrow">%1$s → %2$s</string>
+    <string name="handoff_edge_multi">%1$d Agenten → %2$d Agenten</string>
+    <string name="no_more_agents">Keine weiteren Agenten zum Hinzufügen verfügbar.</string>
+    <string name="select_agent">Agent auswählen</string>
+
+    <!-- MCP Tools selector -->
+    <string name="mcp_tools_count">MCP-Tools (%1$d ausgewählt)</string>
+    <string name="no_mcp_tools">Keine MCP-Tools verfügbar. Konfiguriere MCP-Server in den Einstellungen.</string>
+    <string name="unknown_server">Unbekannter Server</string>
+
+    <!-- Model picker -->
+    <string name="model_required_label">Modell *</string>
+    <string name="select_model_hint">Ein Modell auswählen…</string>
+    <string name="no_models_found">Keine Modelle gefunden</string>
+
+    <!-- Sharing section -->
+    <string name="sharing_and_permissions">Teilen &amp; Berechtigungen</string>
+    <string name="label_visibility">Sichtbarkeit</string>
+    <string name="label_collaborative">Kollaborativ</string>
+    <string name="collaborative_description">Anderen Benutzern erlauben, diesen Agenten zu ändern</string>
+    <string name="collaborative_managed_server_side">Zugriffsberechtigungen werden in dieser Version serverseitig verwaltet.</string>
+
+    <!-- Visibility labels -->
+    <string name="visibility_private">Privat</string>
+    <string name="visibility_team">Team</string>
+    <string name="visibility_public">Öffentlich</string>
+
+    <!-- Support contact section -->
+    <string name="label_support_contact">Support-Kontakt</string>
+    <string name="label_name">Name</string>
+    <string name="support_contact_placeholder">Name des Support-Kontakts</string>
+    <string name="label_email">E-Mail</string>
+
+    <!-- Version history -->
+    <string name="no_version_history">Kein Versionsverlauf verfügbar</string>
+    <string name="version_number">Version %1$d</string>
+    <string name="version_current">Aktiv</string>
+    <string name="version_no_date">Kein Datum verfügbar</string>
+    <string name="version_unknown_date">Unbekanntes Datum</string>
+    <string name="version_snapshot_name">Name</string>
+    <string name="version_snapshot_description">Beschreibung</string>
+    <string name="version_snapshot_instructions">Anweisungen</string>
+    <string name="version_snapshot_artifacts">Artefakte</string>
+    <string name="version_snapshot_capabilities">Funktionen</string>
+    <string name="version_snapshot_tools">Tools</string>
+    <string name="version_snapshot_empty">—</string>
+    <string name="version_restore_confirm">Diesen Agenten auf die ausgewählte Version zurücksetzen? Aktuelle ungespeicherte Änderungen gehen verloren.</string>
+
+    <!-- ACL sharing (v0.8.5+) -->
+    <string name="acl_sharing_title">Teilen &amp; Zugriff</string>
+    <string name="acl_add_principal">Benutzer oder Gruppe hinzufügen</string>
+    <string name="acl_no_grants">Bisher wurde niemandem Zugriff gewährt.</string>
+    <string name="acl_public_label">Öffentlich</string>
+    <string name="acl_public_description">Jedem mit Zugriff auf den Server erlauben</string>
+    <string name="acl_role">Rolle</string>
+    <string name="acl_revoke">Widerrufen</string>
+    <string name="acl_search_hint">Benutzer oder Gruppen suchen…</string>
+    <string name="acl_search_empty">Keine Treffer</string>
+    <string name="acl_grant_button">Gewähren</string>
+    <string name="acl_grant_dialog_title">Benutzer oder Gruppe hinzufügen</string>
+    <string name="acl_principal_user">Benutzer</string>
+    <string name="acl_principal_group">Gruppe</string>
+    <string name="acl_principal_role">Rolle</string>
+    <string name="acl_create_mode_notice">Teilen- &amp; Zugriffssteuerungen sind verfügbar, nachdem der Agent gespeichert wurde.</string>
+
+    <!-- Tool select dialog -->
+    <string name="agent_tools_title">Agent-Tools</string>
+    <string name="select_tools_description">Wähle Tools aus, die dein Agent verwenden soll</string>
+    <string name="search_tools_hint">Tools suchen…</string>
+    <string name="no_tools_matching">Keine Tools passend zu \"%1$s\"</string>
+    <string name="no_tools_available">Keine Tools verfügbar</string>
+
+    <!-- Per-capability file attachments -->
+    <string name="add_file">Datei hinzufügen</string>
+    <string name="agent_files_save_first">Speichere den Agenten, bevor du Dateien anhängst</string>
+    <string name="agent_file_too_large">Datei darf höchstens %1$d MB groß sein</string>
+    <string name="agent_file_upload_failed">Datei konnte nicht hochgeladen werden</string>
+    <string name="agent_file_remove_failed">Datei konnte nicht entfernt werden</string>
+    <string name="cd_remove_file">%1$s entfernen</string>
+
+    <!-- Skills selector (v0.8.6) -->
+    <string name="label_skills">Skills</string>
+    <string name="skills_disabled_hint">Skills sind für diesen Agenten deaktiviert.</string>
+    <string name="skills_enabled_all_hint">Alle Skills, auf die du zugreifen kannst, stehen diesem Agenten zur Verfügung.</string>
+    <string name="skills_enabled_allowlist_hint">Nur die ausgewählten Skills stehen diesem Agenten zur Verfügung.</string>
+    <string name="add_skills">Skills hinzufügen</string>
+    <string name="select_skills">Skills auswählen</string>
+    <string name="search_skills_hint">Skills suchen…</string>
+    <string name="no_skills_matching">Keine Skills passend zu \"%1$s\"</string>
+    <string name="no_skills_available">Keine Skills verfügbar</string>
+    <string name="skills_done">Fertig</string>
+
+    <!-- Subagents config (v0.8.6) -->
+    <string name="label_subagents">Subagenten</string>
+    <string name="subagents_description">Diesem Agenten erlauben, Arbeit an andere Agenten in isolierten Kontexten zu delegieren.</string>
+    <string name="subagents_allow_self">Selbst-Erzeugung erlauben</string>
+    <string name="add_subagent">Subagent hinzufügen</string>
+    <string name="subagents_full">Maximale Anzahl an Subagenten erreicht.</string>
+</resources>

--- a/feature/agents/src/commonMain/composeResources/values-es/strings.xml
+++ b/feature/agents/src/commonMain/composeResources/values-es/strings.xml
@@ -1,0 +1,305 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Common actions -->
+    <string name="agents">Agentes</string>
+    <string name="marketplace">Mercado</string>
+    <string name="search_agents">Buscar agentes…</string>
+    <string name="start_chat">Iniciar chat</string>
+    <string name="edit">Editar</string>
+    <string name="delete">Eliminar</string>
+    <string name="cancel">Cancelar</string>
+    <string name="duplicate">Duplicar</string>
+    <string name="save">Guardar</string>
+    <string name="create">Crear</string>
+    <string name="apply">Aplicar</string>
+    <string name="add">Añadir</string>
+    <string name="remove">Quitar</string>
+    <string name="revert">Revertir</string>
+    <string name="close">Cerrar</string>
+
+    <!-- Content descriptions -->
+    <string name="cd_create_agent">Crear agente</string>
+    <string name="cd_search">Buscar</string>
+    <string name="cd_back">Atrás</string>
+    <string name="cd_more_actions">Más acciones</string>
+    <string name="cd_more_options">Más opciones</string>
+    <string name="cd_collapse">Contraer</string>
+    <string name="cd_expand">Expandir</string>
+    <string name="cd_remove_item">Quitar %1$s</string>
+    <string name="cd_edit_action">Editar acción</string>
+    <string name="cd_delete_action">Eliminar acción</string>
+    <string name="cd_add_starter">Añadir iniciador</string>
+    <string name="cd_agent_avatar_tap">Avatar del agente. Toca para cambiar.</string>
+    <string name="cd_agent_avatar_name">Avatar de %1$s</string>
+    <string name="cd_tool_icon">Icono de %1$s</string>
+
+    <!-- Marketplace screen -->
+    <string name="search_agents_hint">Buscar agentes…</string>
+    <string name="no_agents_found">No se encontraron agentes</string>
+    <string name="no_agents_available">No hay agentes disponibles</string>
+    <string name="agents_not_available_title">Agentes no disponibles</string>
+    <string name="agents_not_available_description">El administrador de tu servidor ha desactivado los agentes para tu cuenta.</string>
+    <string name="try_different_search">Prueba con otro término de búsqueda</string>
+    <string name="check_back_later">Vuelve más tarde para ver nuevos agentes</string>
+    <string name="error_unknown">Ocurrió un error desconocido</string>
+    <string name="unknown_author">Desconocido</string>
+
+    <!-- Detail screen -->
+    <string name="agent_title">Agente</string>
+    <string name="delete_agent">Eliminar agente</string>
+    <string name="delete_agent_confirm">¿Seguro que quieres eliminar \"%1$s\"? Esta acción no se puede deshacer.</string>
+    <string name="delete_this_agent">este agente</string>
+    <string name="by_author">por %1$s</string>
+    <string name="label_description">Descripción</string>
+    <string name="no_description">Sin descripción</string>
+    <string name="label_category">Categoría</string>
+    <string name="label_model">Modelo</string>
+    <string name="default_value">Predeterminado</string>
+    <string name="label_tools">Herramientas</string>
+    <string name="label_conversation_starters">Iniciadores de conversación</string>
+
+    <!-- Editor screen -->
+    <string name="edit_agent">Editar agente</string>
+    <string name="create_agent">Crear agente</string>
+    <string name="duplicate_agent">Duplicar agente</string>
+    <string name="delete_agent_editor_confirm">¿Seguro que quieres eliminar este agente? Esta acción no se puede deshacer.</string>
+    <string name="duplicate_agent_confirm">¿Crear una copia de este agente?</string>
+    <string name="version_history">Historial de versiones</string>
+    <string name="tap_to_change_avatar">Toca para cambiar el avatar</string>
+    <string name="remove_avatar">Quitar avatar</string>
+    <string name="agent_name_label">Nombre *</string>
+    <string name="agent_name_placeholder">Opcional: el nombre del agente</string>
+    <string name="agent_description_label">Descripción</string>
+    <string name="agent_description_placeholder">Opcional: describe tu agente aquí</string>
+    <string name="agent_instructions_label">Instrucciones</string>
+    <string name="agent_instructions_placeholder">Las instrucciones de sistema que usa el agente</string>
+    <string name="insert_variable">Insertar variable</string>
+    <string name="cd_insert_variable">Insertar variable</string>
+    <string name="special_var_current_date">Fecha actual</string>
+    <string name="special_var_current_user">Usuario actual</string>
+    <string name="special_var_iso_datetime">Fecha y hora ISO</string>
+    <string name="special_var_current_datetime">Fecha y hora actuales</string>
+    <string name="label_capabilities">Capacidades</string>
+    <string name="label_tools_and_actions">Herramientas y acciones</string>
+    <string name="add_tools">Añadir herramientas</string>
+    <string name="add_starter_hint">Añadir iniciador…</string>
+    <string name="save_changes">Guardar cambios</string>
+
+    <!-- Actions panel -->
+    <string name="openapi_actions_count">Acciones de OpenAPI (%1$d)</string>
+    <string name="no_actions_configured">No hay acciones configuradas. Añade una acción de OpenAPI para conectar APIs externas.</string>
+    <string name="add_action">Añadir acción</string>
+    <string name="edit_action">Editar acción</string>
+    <string name="auth_api_key">Clave de API</string>
+    <string name="auth_oauth">OAuth</string>
+    <string name="auth_none">Ninguna</string>
+    <string name="action_auth_info">Autenticación: %1$s | %2$d función(es)</string>
+    <string name="label_action">Acción</string>
+
+    <!-- Action editor dialog -->
+    <string name="label_authentication">Autenticación</string>
+    <string name="auth_api_key_full">Autenticación por clave de API</string>
+    <string name="auth_oauth_full">Autenticación OAuth</string>
+    <string name="auth_no_auth">Sin autenticación</string>
+    <string name="label_openapi_schema">Esquema OpenAPI</string>
+    <string name="openapi_schema_hint">Pega tu especificación OpenAPI en formato JSON o YAML.</string>
+    <string name="label_openapi_spec">Especificación OpenAPI (JSON o YAML)</string>
+    <string name="validating">Validando…</string>
+    <string name="domain_prefix">Dominio: %1$s</string>
+    <string name="available_actions_count">Acciones disponibles (%1$d)</string>
+    <string name="label_privacy_policy_url">URL de la política de privacidad</string>
+    <string name="label_save_or_create">%1$s</string>
+
+    <!-- Auth config dialog -->
+    <string name="label_authentication_type">Tipo de autenticación</string>
+    <string name="label_api_key_settings">Ajustes de la clave de API</string>
+    <string name="label_api_key">Clave de API</string>
+    <string name="label_authorization_type">Tipo de autorización</string>
+    <string name="auth_basic">Básica</string>
+    <string name="auth_bearer">Bearer</string>
+    <string name="auth_custom">Personalizada</string>
+    <string name="label_custom_auth_header">Encabezado de autenticación personalizado</string>
+    <string name="label_oauth_settings">Ajustes de OAuth</string>
+    <string name="label_client_id">ID de cliente</string>
+    <string name="label_client_secret">Secreto de cliente</string>
+    <string name="label_authorization_url">URL de autorización</string>
+    <string name="label_token_url">URL del token</string>
+    <string name="label_scope">Ámbito</string>
+    <string name="label_token_exchange_method">Método de intercambio de tokens</string>
+    <string name="token_default_post">Predeterminado (POST)</string>
+    <string name="token_basic_auth_header">Encabezado de autenticación básica</string>
+
+    <!-- Function table -->
+    <string name="table_name">Nombre</string>
+    <string name="table_method">Método</string>
+    <string name="table_path">Ruta</string>
+
+    <!-- Advanced panel -->
+    <string name="advanced_settings">Ajustes del modelo</string>
+    <string name="label_temperature">Temperatura</string>
+    <string name="temperature_description">Controla la aleatoriedad. Más baja = más enfocada.</string>
+    <string name="label_top_p">Top P</string>
+    <string name="top_p_description">Umbral de muestreo de núcleo.</string>
+    <string name="label_max_tokens">Máx. de tokens</string>
+    <string name="max_tokens_description">Máximo de tokens en la respuesta. Déjalo vacío para usar el valor predeterminado.</string>
+
+    <!-- Avatar picker -->
+    <!-- (content descriptions above) -->
+
+    <!-- Capabilities section -->
+    <string name="label_artifacts">Artefactos</string>
+    <string name="artifacts_description">Activar la generación de artefactos</string>
+    <string name="artifacts_mode_off">Desactivado</string>
+    <string name="artifacts_mode_default">Predeterminado</string>
+    <string name="artifacts_mode_shadcnui">shadcn/ui</string>
+    <string name="artifacts_mode_custom">Personalizado</string>
+    <string name="label_end_after_tools">Finalizar tras las herramientas</string>
+    <string name="end_after_tools_description">Detener cuando termine la ejecución de las herramientas</string>
+    <string name="label_hide_sequential_outputs">Ocultar salidas secuenciales</string>
+    <string name="hide_sequential_description">Ocultar las salidas intermedias de las herramientas</string>
+    <string name="label_recursion_limit">Límite de recursión</string>
+    <string name="recursion_limit_description">Número máximo de llamadas recursivas a herramientas</string>
+
+    <!-- Category selector -->
+    <string name="general">General</string>
+
+    <!-- Code Interpreter section -->
+    <string name="label_code_interpreter">Intérprete de código</string>
+    <string name="code_interpreter_description">Permitir que el agente escriba y ejecute código para resolver problemas</string>
+
+    <!-- Web Search section -->
+    <string name="label_web_search">Búsqueda web</string>
+    <string name="web_search_description">Permitir que el agente busque en la web información actualizada</string>
+
+    <!-- Tool auth dialog -->
+    <string name="tool_auth_revoke">Revocar</string>
+    <string name="tool_auth_code_title">Clave de API del intérprete de código</string>
+    <string name="tool_auth_code_description">Introduce la clave de API que el servidor debe usar para ejecutar código en tu nombre. Se almacena en tu cuenta, no en el agente.</string>
+    <string name="tool_auth_code_field">Clave de la API de Code de LibreChat</string>
+    <string name="tool_auth_required">Se requiere autenticación para activar esta herramienta</string>
+
+    <!-- File Context section -->
+    <string name="label_file_context">Contexto de archivos</string>
+    <string name="file_context_description">Adjunta archivos que se incluyan siempre como contexto de la conversación</string>
+
+    <!-- File Search section -->
+    <string name="label_file_search">Búsqueda en archivos</string>
+    <string name="file_search_description">Permitir que el agente busque en los archivos y documentos subidos</string>
+
+    <!-- Handoff config -->
+    <!-- Chain (sequential multi-agent) -->
+    <string name="chain_agents_count">Agentes en cadena (%1$d)</string>
+    <string name="chain_description">Agentes que se ejecutan en secuencia después de este. El límite es %1$d.</string>
+    <string name="no_chain_agents">No hay agentes en cadena configurados.</string>
+    <string name="add_chain_agent">Añadir agente en cadena</string>
+    <string name="chain_full">Se alcanzó el número máximo de agentes en cadena.</string>
+    <!-- Handoffs (graph edges) -->
+    <string name="handoff_edges_count">Conexiones de transferencia (%1$d)</string>
+    <string name="handoff_edges_description">Conexiones de enrutamiento del grafo para la transferencia dinámica entre varios agentes.</string>
+    <string name="no_handoff_edges">No hay conexiones de transferencia configuradas.</string>
+    <string name="add_handoff_edge">Añadir conexión de transferencia</string>
+    <string name="handoff_edge_from">De</string>
+    <string name="handoff_edge_to">A</string>
+    <string name="handoff_edge_description">Descripción (opcional)</string>
+    <string name="handoff_edge_prompt">Indicación de transferencia (opcional)</string>
+    <string name="handoff_edge_prompt_key">Nombre del parámetro de la indicación (opcional)</string>
+    <string name="handoff_edge_exclude_results">Excluir mensajes anteriores</string>
+    <string name="handoff_edge_arrow">%1$s → %2$s</string>
+    <string name="handoff_edge_multi">%1$d agentes → %2$d agentes</string>
+    <string name="no_more_agents">No hay más agentes disponibles para añadir.</string>
+    <string name="select_agent">Seleccionar agente</string>
+
+    <!-- MCP Tools selector -->
+    <string name="mcp_tools_count">Herramientas MCP (%1$d seleccionadas)</string>
+    <string name="no_mcp_tools">No hay herramientas MCP disponibles. Configura servidores MCP en los ajustes.</string>
+    <string name="unknown_server">Servidor desconocido</string>
+
+    <!-- Model picker -->
+    <string name="model_required_label">Modelo *</string>
+    <string name="select_model_hint">Selecciona un modelo…</string>
+    <string name="no_models_found">No se encontraron modelos</string>
+
+    <!-- Sharing section -->
+    <string name="sharing_and_permissions">Compartir y permisos</string>
+    <string name="label_visibility">Visibilidad</string>
+    <string name="label_collaborative">Colaborativo</string>
+    <string name="collaborative_description">Permitir que otros usuarios modifiquen este agente</string>
+    <string name="collaborative_managed_server_side">Los permisos de acceso se gestionan en el servidor en esta versión.</string>
+
+    <!-- Visibility labels -->
+    <string name="visibility_private">Privado</string>
+    <string name="visibility_team">Equipo</string>
+    <string name="visibility_public">Público</string>
+
+    <!-- Support contact section -->
+    <string name="label_support_contact">Contacto de soporte</string>
+    <string name="label_name">Nombre</string>
+    <string name="support_contact_placeholder">Nombre del contacto de soporte</string>
+    <string name="label_email">Correo electrónico</string>
+
+    <!-- Version history -->
+    <string name="no_version_history">No hay historial de versiones disponible</string>
+    <string name="version_number">Versión %1$d</string>
+    <string name="version_current">Activa</string>
+    <string name="version_no_date">No hay fecha disponible</string>
+    <string name="version_unknown_date">Fecha desconocida</string>
+    <string name="version_snapshot_name">Nombre</string>
+    <string name="version_snapshot_description">Descripción</string>
+    <string name="version_snapshot_instructions">Instrucciones</string>
+    <string name="version_snapshot_artifacts">Artefactos</string>
+    <string name="version_snapshot_capabilities">Capacidades</string>
+    <string name="version_snapshot_tools">Herramientas</string>
+    <string name="version_snapshot_empty">—</string>
+    <string name="version_restore_confirm">¿Revertir este agente a la versión seleccionada? Se perderán los cambios actuales sin guardar.</string>
+
+    <!-- ACL sharing (v0.8.5+) -->
+    <string name="acl_sharing_title">Compartir y acceso</string>
+    <string name="acl_add_principal">Añadir usuario o grupo</string>
+    <string name="acl_no_grants">Aún no se ha concedido acceso a nadie.</string>
+    <string name="acl_public_label">Público</string>
+    <string name="acl_public_description">Permitir a cualquier persona con acceso al servidor</string>
+    <string name="acl_role">Rol</string>
+    <string name="acl_revoke">Revocar</string>
+    <string name="acl_search_hint">Buscar usuarios o grupos…</string>
+    <string name="acl_search_empty">Sin coincidencias</string>
+    <string name="acl_grant_button">Conceder</string>
+    <string name="acl_grant_dialog_title">Añadir usuario o grupo</string>
+    <string name="acl_principal_user">Usuario</string>
+    <string name="acl_principal_group">Grupo</string>
+    <string name="acl_principal_role">Rol</string>
+    <string name="acl_create_mode_notice">Los controles de compartir y acceso están disponibles después de guardar el agente.</string>
+
+    <!-- Tool select dialog -->
+    <string name="agent_tools_title">Herramientas del agente</string>
+    <string name="select_tools_description">Selecciona las herramientas que usará tu agente</string>
+    <string name="search_tools_hint">Buscar herramientas…</string>
+    <string name="no_tools_matching">No hay herramientas que coincidan con \"%1$s\"</string>
+    <string name="no_tools_available">No hay herramientas disponibles</string>
+
+    <!-- Per-capability file attachments -->
+    <string name="add_file">Añadir archivo</string>
+    <string name="agent_files_save_first">Guarda el agente antes de adjuntar archivos</string>
+    <string name="agent_file_too_large">El archivo debe ser de %1$d MB o menos</string>
+    <string name="agent_file_upload_failed">Error al subir el archivo</string>
+    <string name="agent_file_remove_failed">Error al quitar el archivo</string>
+    <string name="cd_remove_file">Quitar %1$s</string>
+
+    <!-- Skills selector (v0.8.6) -->
+    <string name="label_skills">Habilidades</string>
+    <string name="skills_disabled_hint">Las habilidades están desactivadas para este agente.</string>
+    <string name="skills_enabled_all_hint">Todas las habilidades a las que puedes acceder están disponibles para este agente.</string>
+    <string name="skills_enabled_allowlist_hint">Solo las habilidades seleccionadas están disponibles para este agente.</string>
+    <string name="add_skills">Añadir habilidades</string>
+    <string name="select_skills">Seleccionar habilidades</string>
+    <string name="search_skills_hint">Buscar habilidades…</string>
+    <string name="no_skills_matching">No hay habilidades que coincidan con \"%1$s\"</string>
+    <string name="no_skills_available">No hay habilidades disponibles</string>
+    <string name="skills_done">Hecho</string>
+
+    <!-- Subagents config (v0.8.6) -->
+    <string name="label_subagents">Subagentes</string>
+    <string name="subagents_description">Permite que este agente delegue trabajo a otros agentes en contextos aislados.</string>
+    <string name="subagents_allow_self">Permitir que se genere a sí mismo</string>
+    <string name="add_subagent">Añadir subagente</string>
+    <string name="subagents_full">Se alcanzó el número máximo de subagentes.</string>
+</resources>

--- a/feature/agents/src/commonMain/composeResources/values-fr/strings.xml
+++ b/feature/agents/src/commonMain/composeResources/values-fr/strings.xml
@@ -1,0 +1,305 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Common actions -->
+    <string name="agents">Agents</string>
+    <string name="marketplace">Place de marché</string>
+    <string name="search_agents">Rechercher des agents…</string>
+    <string name="start_chat">Démarrer une discussion</string>
+    <string name="edit">Modifier</string>
+    <string name="delete">Supprimer</string>
+    <string name="cancel">Annuler</string>
+    <string name="duplicate">Dupliquer</string>
+    <string name="save">Enregistrer</string>
+    <string name="create">Créer</string>
+    <string name="apply">Appliquer</string>
+    <string name="add">Ajouter</string>
+    <string name="remove">Supprimer</string>
+    <string name="revert">Rétablir</string>
+    <string name="close">Fermer</string>
+
+    <!-- Content descriptions -->
+    <string name="cd_create_agent">Créer un agent</string>
+    <string name="cd_search">Rechercher</string>
+    <string name="cd_back">Retour</string>
+    <string name="cd_more_actions">Plus d\'actions</string>
+    <string name="cd_more_options">Plus d\'options</string>
+    <string name="cd_collapse">Réduire</string>
+    <string name="cd_expand">Développer</string>
+    <string name="cd_remove_item">Supprimer %1$s</string>
+    <string name="cd_edit_action">Modifier l\'action</string>
+    <string name="cd_delete_action">Supprimer l\'action</string>
+    <string name="cd_add_starter">Ajouter une amorce</string>
+    <string name="cd_agent_avatar_tap">Avatar de l\'agent. Appuyez pour le changer.</string>
+    <string name="cd_agent_avatar_name">Avatar de %1$s</string>
+    <string name="cd_tool_icon">Icône %1$s</string>
+
+    <!-- Marketplace screen -->
+    <string name="search_agents_hint">Rechercher des agents…</string>
+    <string name="no_agents_found">Aucun agent trouvé</string>
+    <string name="no_agents_available">Aucun agent disponible</string>
+    <string name="agents_not_available_title">Agents non disponibles</string>
+    <string name="agents_not_available_description">L\'administrateur de votre serveur a désactivé les agents pour votre compte.</string>
+    <string name="try_different_search">Essayez un autre terme de recherche</string>
+    <string name="check_back_later">Revenez plus tard pour de nouveaux agents</string>
+    <string name="error_unknown">Une erreur inconnue s\'est produite</string>
+    <string name="unknown_author">Inconnu</string>
+
+    <!-- Detail screen -->
+    <string name="agent_title">Agent</string>
+    <string name="delete_agent">Supprimer l\'agent</string>
+    <string name="delete_agent_confirm">Voulez-vous vraiment supprimer \"%1$s\" ? Cette action est irréversible.</string>
+    <string name="delete_this_agent">cet agent</string>
+    <string name="by_author">par %1$s</string>
+    <string name="label_description">Description</string>
+    <string name="no_description">Aucune description</string>
+    <string name="label_category">Catégorie</string>
+    <string name="label_model">Modèle</string>
+    <string name="default_value">Par défaut</string>
+    <string name="label_tools">Outils</string>
+    <string name="label_conversation_starters">Amorces de conversation</string>
+
+    <!-- Editor screen -->
+    <string name="edit_agent">Modifier l\'agent</string>
+    <string name="create_agent">Créer un agent</string>
+    <string name="duplicate_agent">Dupliquer l\'agent</string>
+    <string name="delete_agent_editor_confirm">Voulez-vous vraiment supprimer cet agent ? Cette action est irréversible.</string>
+    <string name="duplicate_agent_confirm">Créer une copie de cet agent ?</string>
+    <string name="version_history">Historique des versions</string>
+    <string name="tap_to_change_avatar">Appuyez pour changer l\'avatar</string>
+    <string name="remove_avatar">Supprimer l\'avatar</string>
+    <string name="agent_name_label">Nom *</string>
+    <string name="agent_name_placeholder">Facultatif : le nom de l\'agent</string>
+    <string name="agent_description_label">Description</string>
+    <string name="agent_description_placeholder">Facultatif : décrivez votre agent ici</string>
+    <string name="agent_instructions_label">Instructions</string>
+    <string name="agent_instructions_placeholder">Les instructions système que l\'agent utilise</string>
+    <string name="insert_variable">Insérer une variable</string>
+    <string name="cd_insert_variable">Insérer une variable</string>
+    <string name="special_var_current_date">Date actuelle</string>
+    <string name="special_var_current_user">Utilisateur actuel</string>
+    <string name="special_var_iso_datetime">Date-heure ISO</string>
+    <string name="special_var_current_datetime">Date-heure actuelle</string>
+    <string name="label_capabilities">Capacités</string>
+    <string name="label_tools_and_actions">Outils &amp; actions</string>
+    <string name="add_tools">Ajouter des outils</string>
+    <string name="add_starter_hint">Ajouter une amorce…</string>
+    <string name="save_changes">Enregistrer les modifications</string>
+
+    <!-- Actions panel -->
+    <string name="openapi_actions_count">Actions OpenAPI (%1$d)</string>
+    <string name="no_actions_configured">Aucune action configurée. Ajoutez une action OpenAPI pour connecter des API externes.</string>
+    <string name="add_action">Ajouter une action</string>
+    <string name="edit_action">Modifier l\'action</string>
+    <string name="auth_api_key">Clé API</string>
+    <string name="auth_oauth">OAuth</string>
+    <string name="auth_none">Aucune</string>
+    <string name="action_auth_info">Auth : %1$s | %2$d fonction(s)</string>
+    <string name="label_action">Action</string>
+
+    <!-- Action editor dialog -->
+    <string name="label_authentication">Authentification</string>
+    <string name="auth_api_key_full">Authentification par clé API</string>
+    <string name="auth_oauth_full">Authentification OAuth</string>
+    <string name="auth_no_auth">Aucune authentification</string>
+    <string name="label_openapi_schema">Schéma OpenAPI</string>
+    <string name="openapi_schema_hint">Collez votre spécification OpenAPI au format JSON ou YAML.</string>
+    <string name="label_openapi_spec">Spécification OpenAPI (JSON ou YAML)</string>
+    <string name="validating">Validation…</string>
+    <string name="domain_prefix">Domaine : %1$s</string>
+    <string name="available_actions_count">Actions disponibles (%1$d)</string>
+    <string name="label_privacy_policy_url">URL de la politique de confidentialité</string>
+    <string name="label_save_or_create">%1$s</string>
+
+    <!-- Auth config dialog -->
+    <string name="label_authentication_type">Type d\'authentification</string>
+    <string name="label_api_key_settings">Paramètres de la clé API</string>
+    <string name="label_api_key">Clé API</string>
+    <string name="label_authorization_type">Type d\'autorisation</string>
+    <string name="auth_basic">Basic</string>
+    <string name="auth_bearer">Bearer</string>
+    <string name="auth_custom">Personnalisé</string>
+    <string name="label_custom_auth_header">En-tête d\'authentification personnalisé</string>
+    <string name="label_oauth_settings">Paramètres OAuth</string>
+    <string name="label_client_id">ID client</string>
+    <string name="label_client_secret">Secret client</string>
+    <string name="label_authorization_url">URL d\'autorisation</string>
+    <string name="label_token_url">URL du jeton</string>
+    <string name="label_scope">Portée</string>
+    <string name="label_token_exchange_method">Méthode d\'échange de jeton</string>
+    <string name="token_default_post">Par défaut (POST)</string>
+    <string name="token_basic_auth_header">En-tête Basic Auth</string>
+
+    <!-- Function table -->
+    <string name="table_name">Nom</string>
+    <string name="table_method">Méthode</string>
+    <string name="table_path">Chemin</string>
+
+    <!-- Advanced panel -->
+    <string name="advanced_settings">Paramètres du modèle</string>
+    <string name="label_temperature">Température</string>
+    <string name="temperature_description">Contrôle l\'aléatoire. Plus bas = plus ciblé.</string>
+    <string name="label_top_p">Top P</string>
+    <string name="top_p_description">Seuil d\'échantillonnage par noyau.</string>
+    <string name="label_max_tokens">Jetons max</string>
+    <string name="max_tokens_description">Nombre maximal de jetons dans la réponse. Laissez vide pour la valeur par défaut.</string>
+
+    <!-- Avatar picker -->
+    <!-- (content descriptions above) -->
+
+    <!-- Capabilities section -->
+    <string name="label_artifacts">Artefacts</string>
+    <string name="artifacts_description">Activer la génération d\'artefacts</string>
+    <string name="artifacts_mode_off">Désactivé</string>
+    <string name="artifacts_mode_default">Par défaut</string>
+    <string name="artifacts_mode_shadcnui">shadcn/ui</string>
+    <string name="artifacts_mode_custom">Personnalisé</string>
+    <string name="label_end_after_tools">Terminer après les outils</string>
+    <string name="end_after_tools_description">S\'arrêter une fois l\'exécution des outils terminée</string>
+    <string name="label_hide_sequential_outputs">Masquer les sorties séquentielles</string>
+    <string name="hide_sequential_description">Masquer les sorties intermédiaires des outils</string>
+    <string name="label_recursion_limit">Limite de récursivité</string>
+    <string name="recursion_limit_description">Nombre maximal d\'appels d\'outils récursifs</string>
+
+    <!-- Category selector -->
+    <string name="general">Général</string>
+
+    <!-- Code Interpreter section -->
+    <string name="label_code_interpreter">Interpréteur de code</string>
+    <string name="code_interpreter_description">Permettre à l\'agent d\'écrire et d\'exécuter du code pour résoudre des problèmes</string>
+
+    <!-- Web Search section -->
+    <string name="label_web_search">Recherche web</string>
+    <string name="web_search_description">Permettre à l\'agent de rechercher sur le web des informations actuelles</string>
+
+    <!-- Tool auth dialog -->
+    <string name="tool_auth_revoke">Révoquer</string>
+    <string name="tool_auth_code_title">Clé API de l\'interpréteur de code</string>
+    <string name="tool_auth_code_description">Saisissez la clé API que le serveur doit utiliser pour exécuter du code en votre nom. Stockée sur votre compte, pas dans l\'agent.</string>
+    <string name="tool_auth_code_field">Clé API LibreChat Code</string>
+    <string name="tool_auth_required">Authentification requise pour activer cet outil</string>
+
+    <!-- File Context section -->
+    <string name="label_file_context">Contexte de fichier</string>
+    <string name="file_context_description">Joindre des fichiers toujours inclus comme contexte de conversation</string>
+
+    <!-- File Search section -->
+    <string name="label_file_search">Recherche de fichiers</string>
+    <string name="file_search_description">Permettre à l\'agent de rechercher dans les fichiers et documents téléversés</string>
+
+    <!-- Handoff config -->
+    <!-- Chain (sequential multi-agent) -->
+    <string name="chain_agents_count">Agents en chaîne (%1$d)</string>
+    <string name="chain_description">Agents qui s\'exécutent en séquence après celui-ci. La limite est de %1$d.</string>
+    <string name="no_chain_agents">Aucun agent en chaîne configuré.</string>
+    <string name="add_chain_agent">Ajouter un agent en chaîne</string>
+    <string name="chain_full">Nombre maximal d\'agents en chaîne atteint.</string>
+    <!-- Handoffs (graph edges) -->
+    <string name="handoff_edges_count">Arêtes de passation (%1$d)</string>
+    <string name="handoff_edges_description">Arêtes de routage du graphe pour la passation multi-agent dynamique.</string>
+    <string name="no_handoff_edges">Aucune arête de passation configurée.</string>
+    <string name="add_handoff_edge">Ajouter une arête de passation</string>
+    <string name="handoff_edge_from">De</string>
+    <string name="handoff_edge_to">À</string>
+    <string name="handoff_edge_description">Description (facultatif)</string>
+    <string name="handoff_edge_prompt">Invite de transfert (facultatif)</string>
+    <string name="handoff_edge_prompt_key">Nom du paramètre d\'invite (facultatif)</string>
+    <string name="handoff_edge_exclude_results">Exclure les messages précédents</string>
+    <string name="handoff_edge_arrow">%1$s → %2$s</string>
+    <string name="handoff_edge_multi">%1$d agents → %2$d agents</string>
+    <string name="no_more_agents">Plus aucun agent disponible à ajouter.</string>
+    <string name="select_agent">Sélectionner un agent</string>
+
+    <!-- MCP Tools selector -->
+    <string name="mcp_tools_count">Outils MCP (%1$d sélectionné(s))</string>
+    <string name="no_mcp_tools">Aucun outil MCP disponible. Configurez les serveurs MCP dans les paramètres.</string>
+    <string name="unknown_server">Serveur inconnu</string>
+
+    <!-- Model picker -->
+    <string name="model_required_label">Modèle *</string>
+    <string name="select_model_hint">Sélectionnez un modèle…</string>
+    <string name="no_models_found">Aucun modèle trouvé</string>
+
+    <!-- Sharing section -->
+    <string name="sharing_and_permissions">Partage &amp; autorisations</string>
+    <string name="label_visibility">Visibilité</string>
+    <string name="label_collaborative">Collaboratif</string>
+    <string name="collaborative_description">Permettre à d\'autres utilisateurs de modifier cet agent</string>
+    <string name="collaborative_managed_server_side">Les autorisations d\'accès sont gérées côté serveur dans cette version.</string>
+
+    <!-- Visibility labels -->
+    <string name="visibility_private">Privé</string>
+    <string name="visibility_team">Équipe</string>
+    <string name="visibility_public">Public</string>
+
+    <!-- Support contact section -->
+    <string name="label_support_contact">Contact d\'assistance</string>
+    <string name="label_name">Nom</string>
+    <string name="support_contact_placeholder">Nom du contact d\'assistance</string>
+    <string name="label_email">E-mail</string>
+
+    <!-- Version history -->
+    <string name="no_version_history">Aucun historique de versions disponible</string>
+    <string name="version_number">Version %1$d</string>
+    <string name="version_current">Active</string>
+    <string name="version_no_date">Aucune date disponible</string>
+    <string name="version_unknown_date">Date inconnue</string>
+    <string name="version_snapshot_name">Nom</string>
+    <string name="version_snapshot_description">Description</string>
+    <string name="version_snapshot_instructions">Instructions</string>
+    <string name="version_snapshot_artifacts">Artefacts</string>
+    <string name="version_snapshot_capabilities">Capacités</string>
+    <string name="version_snapshot_tools">Outils</string>
+    <string name="version_snapshot_empty">—</string>
+    <string name="version_restore_confirm">Rétablir cet agent à la version sélectionnée ? Les modifications non enregistrées seront perdues.</string>
+
+    <!-- ACL sharing (v0.8.5+) -->
+    <string name="acl_sharing_title">Partage &amp; accès</string>
+    <string name="acl_add_principal">Ajouter un utilisateur ou un groupe</string>
+    <string name="acl_no_grants">Personne n\'a encore reçu d\'accès.</string>
+    <string name="acl_public_label">Public</string>
+    <string name="acl_public_description">Autoriser toute personne ayant accès au serveur</string>
+    <string name="acl_role">Rôle</string>
+    <string name="acl_revoke">Révoquer</string>
+    <string name="acl_search_hint">Rechercher des utilisateurs ou des groupes…</string>
+    <string name="acl_search_empty">Aucune correspondance</string>
+    <string name="acl_grant_button">Accorder</string>
+    <string name="acl_grant_dialog_title">Ajouter un utilisateur ou un groupe</string>
+    <string name="acl_principal_user">Utilisateur</string>
+    <string name="acl_principal_group">Groupe</string>
+    <string name="acl_principal_role">Rôle</string>
+    <string name="acl_create_mode_notice">Les contrôles de partage &amp; d\'accès sont disponibles après l\'enregistrement de l\'agent.</string>
+
+    <!-- Tool select dialog -->
+    <string name="agent_tools_title">Outils de l\'agent</string>
+    <string name="select_tools_description">Sélectionnez les outils que votre agent peut utiliser</string>
+    <string name="search_tools_hint">Rechercher des outils…</string>
+    <string name="no_tools_matching">Aucun outil correspondant à \"%1$s\"</string>
+    <string name="no_tools_available">Aucun outil disponible</string>
+
+    <!-- Per-capability file attachments -->
+    <string name="add_file">Ajouter un fichier</string>
+    <string name="agent_files_save_first">Enregistrez l\'agent avant de joindre des fichiers</string>
+    <string name="agent_file_too_large">Le fichier doit faire %1$d Mo ou moins</string>
+    <string name="agent_file_upload_failed">Échec du téléversement du fichier</string>
+    <string name="agent_file_remove_failed">Échec de la suppression du fichier</string>
+    <string name="cd_remove_file">Supprimer %1$s</string>
+
+    <!-- Skills selector (v0.8.6) -->
+    <string name="label_skills">Compétences</string>
+    <string name="skills_disabled_hint">Les compétences sont désactivées pour cet agent.</string>
+    <string name="skills_enabled_all_hint">Toutes les compétences auxquelles vous avez accès sont disponibles pour cet agent.</string>
+    <string name="skills_enabled_allowlist_hint">Seules les compétences sélectionnées sont disponibles pour cet agent.</string>
+    <string name="add_skills">Ajouter des compétences</string>
+    <string name="select_skills">Sélectionner des compétences</string>
+    <string name="search_skills_hint">Rechercher des compétences…</string>
+    <string name="no_skills_matching">Aucune compétence correspondant à \"%1$s\"</string>
+    <string name="no_skills_available">Aucune compétence disponible</string>
+    <string name="skills_done">Terminé</string>
+
+    <!-- Subagents config (v0.8.6) -->
+    <string name="label_subagents">Sous-agents</string>
+    <string name="subagents_description">Permettre à cet agent de déléguer du travail à d\'autres agents dans des contextes isolés.</string>
+    <string name="subagents_allow_self">Autoriser à se générer lui-même</string>
+    <string name="add_subagent">Ajouter un sous-agent</string>
+    <string name="subagents_full">Nombre maximal de sous-agents atteint.</string>
+</resources>

--- a/feature/agents/src/commonMain/composeResources/values-ja/strings.xml
+++ b/feature/agents/src/commonMain/composeResources/values-ja/strings.xml
@@ -1,0 +1,305 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Common actions -->
+    <string name="agents">エージェント</string>
+    <string name="marketplace">マーケットプレイス</string>
+    <string name="search_agents">エージェントを検索…</string>
+    <string name="start_chat">チャットを開始</string>
+    <string name="edit">編集</string>
+    <string name="delete">削除</string>
+    <string name="cancel">キャンセル</string>
+    <string name="duplicate">複製</string>
+    <string name="save">保存</string>
+    <string name="create">作成</string>
+    <string name="apply">適用</string>
+    <string name="add">追加</string>
+    <string name="remove">削除</string>
+    <string name="revert">元に戻す</string>
+    <string name="close">閉じる</string>
+
+    <!-- Content descriptions -->
+    <string name="cd_create_agent">エージェントを作成</string>
+    <string name="cd_search">検索</string>
+    <string name="cd_back">戻る</string>
+    <string name="cd_more_actions">その他の操作</string>
+    <string name="cd_more_options">その他のオプション</string>
+    <string name="cd_collapse">折りたたむ</string>
+    <string name="cd_expand">展開</string>
+    <string name="cd_remove_item">%1$s を削除</string>
+    <string name="cd_edit_action">アクションを編集</string>
+    <string name="cd_delete_action">アクションを削除</string>
+    <string name="cd_add_starter">スターターを追加</string>
+    <string name="cd_agent_avatar_tap">エージェントのアバター。タップして変更します。</string>
+    <string name="cd_agent_avatar_name">%1$s のアバター</string>
+    <string name="cd_tool_icon">%1$s のアイコン</string>
+
+    <!-- Marketplace screen -->
+    <string name="search_agents_hint">エージェントを検索…</string>
+    <string name="no_agents_found">エージェントが見つかりません</string>
+    <string name="no_agents_available">利用可能なエージェントがありません</string>
+    <string name="agents_not_available_title">エージェントを利用できません</string>
+    <string name="agents_not_available_description">サーバー管理者がお使いのアカウントでエージェントを無効にしています。</string>
+    <string name="try_different_search">別の検索語をお試しください</string>
+    <string name="check_back_later">新しいエージェントについては後でもう一度ご確認ください</string>
+    <string name="error_unknown">不明なエラーが発生しました</string>
+    <string name="unknown_author">不明</string>
+
+    <!-- Detail screen -->
+    <string name="agent_title">エージェント</string>
+    <string name="delete_agent">エージェントを削除</string>
+    <string name="delete_agent_confirm">「%1$s」を削除してもよろしいですか？この操作は取り消せません。</string>
+    <string name="delete_this_agent">このエージェント</string>
+    <string name="by_author">作成者: %1$s</string>
+    <string name="label_description">説明</string>
+    <string name="no_description">説明なし</string>
+    <string name="label_category">カテゴリ</string>
+    <string name="label_model">モデル</string>
+    <string name="default_value">デフォルト</string>
+    <string name="label_tools">ツール</string>
+    <string name="label_conversation_starters">会話のきっかけ</string>
+
+    <!-- Editor screen -->
+    <string name="edit_agent">エージェントを編集</string>
+    <string name="create_agent">エージェントを作成</string>
+    <string name="duplicate_agent">エージェントを複製</string>
+    <string name="delete_agent_editor_confirm">このエージェントを削除してもよろしいですか？この操作は取り消せません。</string>
+    <string name="duplicate_agent_confirm">このエージェントのコピーを作成しますか？</string>
+    <string name="version_history">バージョン履歴</string>
+    <string name="tap_to_change_avatar">タップしてアバターを変更</string>
+    <string name="remove_avatar">アバターを削除</string>
+    <string name="agent_name_label">名前 *</string>
+    <string name="agent_name_placeholder">任意: エージェントの名前</string>
+    <string name="agent_description_label">説明</string>
+    <string name="agent_description_placeholder">任意: ここにエージェントの説明を入力</string>
+    <string name="agent_instructions_label">指示</string>
+    <string name="agent_instructions_placeholder">エージェントが使用するシステム指示</string>
+    <string name="insert_variable">変数を挿入</string>
+    <string name="cd_insert_variable">変数を挿入</string>
+    <string name="special_var_current_date">現在の日付</string>
+    <string name="special_var_current_user">現在のユーザー</string>
+    <string name="special_var_iso_datetime">ISO日時</string>
+    <string name="special_var_current_datetime">現在の日時</string>
+    <string name="label_capabilities">機能</string>
+    <string name="label_tools_and_actions">ツールとアクション</string>
+    <string name="add_tools">ツールを追加</string>
+    <string name="add_starter_hint">スターターを追加…</string>
+    <string name="save_changes">変更を保存</string>
+
+    <!-- Actions panel -->
+    <string name="openapi_actions_count">OpenAPIアクション（%1$d）</string>
+    <string name="no_actions_configured">アクションが設定されていません。OpenAPIアクションを追加して外部APIに接続します。</string>
+    <string name="add_action">アクションを追加</string>
+    <string name="edit_action">アクションを編集</string>
+    <string name="auth_api_key">APIキー</string>
+    <string name="auth_oauth">OAuth</string>
+    <string name="auth_none">なし</string>
+    <string name="action_auth_info">認証: %1$s | %2$d 個の関数</string>
+    <string name="label_action">アクション</string>
+
+    <!-- Action editor dialog -->
+    <string name="label_authentication">認証</string>
+    <string name="auth_api_key_full">APIキー認証</string>
+    <string name="auth_oauth_full">OAuth認証</string>
+    <string name="auth_no_auth">認証なし</string>
+    <string name="label_openapi_schema">OpenAPIスキーマ</string>
+    <string name="openapi_schema_hint">OpenAPI仕様をJSONまたはYAML形式で貼り付けてください。</string>
+    <string name="label_openapi_spec">OpenAPI仕様（JSONまたはYAML）</string>
+    <string name="validating">検証中…</string>
+    <string name="domain_prefix">ドメイン: %1$s</string>
+    <string name="available_actions_count">利用可能なアクション（%1$d）</string>
+    <string name="label_privacy_policy_url">プライバシーポリシーのURL</string>
+    <string name="label_save_or_create">%1$s</string>
+
+    <!-- Auth config dialog -->
+    <string name="label_authentication_type">認証の種類</string>
+    <string name="label_api_key_settings">APIキーの設定</string>
+    <string name="label_api_key">APIキー</string>
+    <string name="label_authorization_type">認可の種類</string>
+    <string name="auth_basic">Basic</string>
+    <string name="auth_bearer">Bearer</string>
+    <string name="auth_custom">カスタム</string>
+    <string name="label_custom_auth_header">カスタム認証ヘッダー</string>
+    <string name="label_oauth_settings">OAuthの設定</string>
+    <string name="label_client_id">クライアントID</string>
+    <string name="label_client_secret">クライアントシークレット</string>
+    <string name="label_authorization_url">認可URL</string>
+    <string name="label_token_url">トークンURL</string>
+    <string name="label_scope">スコープ</string>
+    <string name="label_token_exchange_method">トークン交換方式</string>
+    <string name="token_default_post">デフォルト（POST）</string>
+    <string name="token_basic_auth_header">Basic認証ヘッダー</string>
+
+    <!-- Function table -->
+    <string name="table_name">名前</string>
+    <string name="table_method">メソッド</string>
+    <string name="table_path">パス</string>
+
+    <!-- Advanced panel -->
+    <string name="advanced_settings">モデル設定</string>
+    <string name="label_temperature">Temperature</string>
+    <string name="temperature_description">ランダム性を制御します。低いほど焦点が絞られます。</string>
+    <string name="label_top_p">Top P</string>
+    <string name="top_p_description">核サンプリングのしきい値。</string>
+    <string name="label_max_tokens">最大トークン数</string>
+    <string name="max_tokens_description">応答の最大トークン数。デフォルトの場合は空のままにします。</string>
+
+    <!-- Avatar picker -->
+    <!-- (content descriptions above) -->
+
+    <!-- Capabilities section -->
+    <string name="label_artifacts">アーティファクト</string>
+    <string name="artifacts_description">アーティファクトの生成を有効にする</string>
+    <string name="artifacts_mode_off">オフ</string>
+    <string name="artifacts_mode_default">デフォルト</string>
+    <string name="artifacts_mode_shadcnui">shadcn/ui</string>
+    <string name="artifacts_mode_custom">カスタム</string>
+    <string name="label_end_after_tools">ツール後に終了</string>
+    <string name="end_after_tools_description">ツールの実行完了後に停止します</string>
+    <string name="label_hide_sequential_outputs">連続した出力を非表示</string>
+    <string name="hide_sequential_description">中間的なツールの出力を非表示にします</string>
+    <string name="label_recursion_limit">再帰の上限</string>
+    <string name="recursion_limit_description">再帰的なツール呼び出しの最大回数</string>
+
+    <!-- Category selector -->
+    <string name="general">一般</string>
+
+    <!-- Code Interpreter section -->
+    <string name="label_code_interpreter">コードインタープリター</string>
+    <string name="code_interpreter_description">問題を解決するためにエージェントがコードを記述・実行できるようにします</string>
+
+    <!-- Web Search section -->
+    <string name="label_web_search">ウェブ検索</string>
+    <string name="web_search_description">最新情報をウェブで検索することをエージェントに許可します</string>
+
+    <!-- Tool auth dialog -->
+    <string name="tool_auth_revoke">取り消す</string>
+    <string name="tool_auth_code_title">コードインタープリターのAPIキー</string>
+    <string name="tool_auth_code_description">サーバーがあなたの代わりにコードを実行するために使用するAPIキーを入力してください。エージェントではなくアカウントに保存されます。</string>
+    <string name="tool_auth_code_field">LibreChat Code APIキー</string>
+    <string name="tool_auth_required">このツールを有効にするには認証が必要です</string>
+
+    <!-- File Context section -->
+    <string name="label_file_context">ファイルコンテキスト</string>
+    <string name="file_context_description">常に会話のコンテキストに含めるファイルを添付します</string>
+
+    <!-- File Search section -->
+    <string name="label_file_search">ファイル検索</string>
+    <string name="file_search_description">アップロードされたファイルや文書をエージェントが検索できるようにします</string>
+
+    <!-- Handoff config -->
+    <!-- Chain (sequential multi-agent) -->
+    <string name="chain_agents_count">チェーンエージェント（%1$d）</string>
+    <string name="chain_description">このエージェントの後に順番に実行されるエージェント。上限は %1$d です。</string>
+    <string name="no_chain_agents">チェーンエージェントが設定されていません。</string>
+    <string name="add_chain_agent">チェーンエージェントを追加</string>
+    <string name="chain_full">チェーンエージェントの最大数に達しました。</string>
+    <!-- Handoffs (graph edges) -->
+    <string name="handoff_edges_count">引き継ぎエッジ（%1$d）</string>
+    <string name="handoff_edges_description">動的なマルチエージェント引き継ぎのためのグラフルーティングエッジ。</string>
+    <string name="no_handoff_edges">引き継ぎエッジが設定されていません。</string>
+    <string name="add_handoff_edge">引き継ぎエッジを追加</string>
+    <string name="handoff_edge_from">送信元</string>
+    <string name="handoff_edge_to">送信先</string>
+    <string name="handoff_edge_description">説明（任意）</string>
+    <string name="handoff_edge_prompt">転送プロンプト（任意）</string>
+    <string name="handoff_edge_prompt_key">プロンプトのパラメータ名（任意）</string>
+    <string name="handoff_edge_exclude_results">以前のメッセージを除外</string>
+    <string name="handoff_edge_arrow">%1$s → %2$s</string>
+    <string name="handoff_edge_multi">%1$d 個のエージェント → %2$d 個のエージェント</string>
+    <string name="no_more_agents">追加できるエージェントがありません。</string>
+    <string name="select_agent">エージェントを選択</string>
+
+    <!-- MCP Tools selector -->
+    <string name="mcp_tools_count">MCPツール（%1$d 個選択）</string>
+    <string name="no_mcp_tools">利用可能なMCPツールがありません。設定でMCPサーバーを構成してください。</string>
+    <string name="unknown_server">不明なサーバー</string>
+
+    <!-- Model picker -->
+    <string name="model_required_label">モデル *</string>
+    <string name="select_model_hint">モデルを選択…</string>
+    <string name="no_models_found">モデルが見つかりません</string>
+
+    <!-- Sharing section -->
+    <string name="sharing_and_permissions">共有と権限</string>
+    <string name="label_visibility">公開範囲</string>
+    <string name="label_collaborative">共同編集</string>
+    <string name="collaborative_description">他のユーザーがこのエージェントを変更できるようにします</string>
+    <string name="collaborative_managed_server_side">このバージョンではアクセス権限はサーバー側で管理されます。</string>
+
+    <!-- Visibility labels -->
+    <string name="visibility_private">非公開</string>
+    <string name="visibility_team">チーム</string>
+    <string name="visibility_public">公開</string>
+
+    <!-- Support contact section -->
+    <string name="label_support_contact">サポート連絡先</string>
+    <string name="label_name">名前</string>
+    <string name="support_contact_placeholder">サポート連絡先の名前</string>
+    <string name="label_email">メールアドレス</string>
+
+    <!-- Version history -->
+    <string name="no_version_history">利用可能なバージョン履歴がありません</string>
+    <string name="version_number">バージョン %1$d</string>
+    <string name="version_current">有効</string>
+    <string name="version_no_date">日付がありません</string>
+    <string name="version_unknown_date">不明な日付</string>
+    <string name="version_snapshot_name">名前</string>
+    <string name="version_snapshot_description">説明</string>
+    <string name="version_snapshot_instructions">指示</string>
+    <string name="version_snapshot_artifacts">アーティファクト</string>
+    <string name="version_snapshot_capabilities">機能</string>
+    <string name="version_snapshot_tools">ツール</string>
+    <string name="version_snapshot_empty">—</string>
+    <string name="version_restore_confirm">このエージェントを選択したバージョンに戻しますか？現在の未保存の変更は失われます。</string>
+
+    <!-- ACL sharing (v0.8.5+) -->
+    <string name="acl_sharing_title">共有とアクセス</string>
+    <string name="acl_add_principal">ユーザーまたはグループを追加</string>
+    <string name="acl_no_grants">まだ誰にもアクセスが許可されていません。</string>
+    <string name="acl_public_label">公開</string>
+    <string name="acl_public_description">サーバーにアクセスできるすべての人に許可します</string>
+    <string name="acl_role">ロール</string>
+    <string name="acl_revoke">取り消す</string>
+    <string name="acl_search_hint">ユーザーまたはグループを検索…</string>
+    <string name="acl_search_empty">一致するものがありません</string>
+    <string name="acl_grant_button">許可</string>
+    <string name="acl_grant_dialog_title">ユーザーまたはグループを追加</string>
+    <string name="acl_principal_user">ユーザー</string>
+    <string name="acl_principal_group">グループ</string>
+    <string name="acl_principal_role">ロール</string>
+    <string name="acl_create_mode_notice">共有とアクセス制御はエージェントの保存後に利用できます。</string>
+
+    <!-- Tool select dialog -->
+    <string name="agent_tools_title">エージェントツール</string>
+    <string name="select_tools_description">エージェントが使用するツールを選択します</string>
+    <string name="search_tools_hint">ツールを検索…</string>
+    <string name="no_tools_matching">「%1$s」に一致するツールがありません</string>
+    <string name="no_tools_available">利用可能なツールがありません</string>
+
+    <!-- Per-capability file attachments -->
+    <string name="add_file">ファイルを追加</string>
+    <string name="agent_files_save_first">ファイルを添付する前にエージェントを保存してください</string>
+    <string name="agent_file_too_large">ファイルは %1$d MB 以下にしてください</string>
+    <string name="agent_file_upload_failed">ファイルのアップロードに失敗しました</string>
+    <string name="agent_file_remove_failed">ファイルの削除に失敗しました</string>
+    <string name="cd_remove_file">%1$s を削除</string>
+
+    <!-- Skills selector (v0.8.6) -->
+    <string name="label_skills">スキル</string>
+    <string name="skills_disabled_hint">このエージェントではスキルがオフになっています。</string>
+    <string name="skills_enabled_all_hint">アクセスできるすべてのスキルがこのエージェントで利用できます。</string>
+    <string name="skills_enabled_allowlist_hint">選択したスキルのみがこのエージェントで利用できます。</string>
+    <string name="add_skills">スキルを追加</string>
+    <string name="select_skills">スキルを選択</string>
+    <string name="search_skills_hint">スキルを検索…</string>
+    <string name="no_skills_matching">「%1$s」に一致するスキルがありません</string>
+    <string name="no_skills_available">利用可能なスキルがありません</string>
+    <string name="skills_done">完了</string>
+
+    <!-- Subagents config (v0.8.6) -->
+    <string name="label_subagents">サブエージェント</string>
+    <string name="subagents_description">このエージェントが分離されたコンテキストで他のエージェントに作業を委任できるようにします。</string>
+    <string name="subagents_allow_self">自分自身の生成を許可</string>
+    <string name="add_subagent">サブエージェントを追加</string>
+    <string name="subagents_full">サブエージェントの最大数に達しました。</string>
+</resources>

--- a/feature/agents/src/commonMain/composeResources/values-ko/strings.xml
+++ b/feature/agents/src/commonMain/composeResources/values-ko/strings.xml
@@ -1,0 +1,305 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Common actions -->
+    <string name="agents">에이전트</string>
+    <string name="marketplace">마켓플레이스</string>
+    <string name="search_agents">에이전트 검색…</string>
+    <string name="start_chat">채팅 시작</string>
+    <string name="edit">편집</string>
+    <string name="delete">삭제</string>
+    <string name="cancel">취소</string>
+    <string name="duplicate">복제</string>
+    <string name="save">저장</string>
+    <string name="create">생성</string>
+    <string name="apply">적용</string>
+    <string name="add">추가</string>
+    <string name="remove">제거</string>
+    <string name="revert">되돌리기</string>
+    <string name="close">닫기</string>
+
+    <!-- Content descriptions -->
+    <string name="cd_create_agent">에이전트 생성</string>
+    <string name="cd_search">검색</string>
+    <string name="cd_back">뒤로</string>
+    <string name="cd_more_actions">추가 작업</string>
+    <string name="cd_more_options">추가 옵션</string>
+    <string name="cd_collapse">접기</string>
+    <string name="cd_expand">펼치기</string>
+    <string name="cd_remove_item">%1$s 제거</string>
+    <string name="cd_edit_action">작업 편집</string>
+    <string name="cd_delete_action">작업 삭제</string>
+    <string name="cd_add_starter">스타터 추가</string>
+    <string name="cd_agent_avatar_tap">에이전트 아바타. 탭하여 변경합니다.</string>
+    <string name="cd_agent_avatar_name">%1$s 아바타</string>
+    <string name="cd_tool_icon">%1$s 아이콘</string>
+
+    <!-- Marketplace screen -->
+    <string name="search_agents_hint">에이전트 검색…</string>
+    <string name="no_agents_found">에이전트를 찾을 수 없습니다</string>
+    <string name="no_agents_available">사용 가능한 에이전트가 없습니다</string>
+    <string name="agents_not_available_title">에이전트를 사용할 수 없습니다</string>
+    <string name="agents_not_available_description">서버 관리자가 계정에 대한 에이전트를 사용 중지했습니다.</string>
+    <string name="try_different_search">다른 검색어를 사용해 보세요</string>
+    <string name="check_back_later">나중에 새 에이전트를 확인하세요</string>
+    <string name="error_unknown">알 수 없는 오류가 발생했습니다</string>
+    <string name="unknown_author">알 수 없음</string>
+
+    <!-- Detail screen -->
+    <string name="agent_title">에이전트</string>
+    <string name="delete_agent">에이전트 삭제</string>
+    <string name="delete_agent_confirm">\"%1$s\"을(를) 삭제하시겠습니까? 되돌릴 수 없습니다.</string>
+    <string name="delete_this_agent">이 에이전트</string>
+    <string name="by_author">작성자: %1$s</string>
+    <string name="label_description">설명</string>
+    <string name="no_description">설명 없음</string>
+    <string name="label_category">카테고리</string>
+    <string name="label_model">모델</string>
+    <string name="default_value">기본값</string>
+    <string name="label_tools">도구</string>
+    <string name="label_conversation_starters">대화 스타터</string>
+
+    <!-- Editor screen -->
+    <string name="edit_agent">에이전트 편집</string>
+    <string name="create_agent">에이전트 생성</string>
+    <string name="duplicate_agent">에이전트 복제</string>
+    <string name="delete_agent_editor_confirm">이 에이전트를 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.</string>
+    <string name="duplicate_agent_confirm">이 에이전트의 사본을 만드시겠습니까?</string>
+    <string name="version_history">버전 기록</string>
+    <string name="tap_to_change_avatar">탭하여 아바타 변경</string>
+    <string name="remove_avatar">아바타 제거</string>
+    <string name="agent_name_label">이름 *</string>
+    <string name="agent_name_placeholder">선택 사항: 에이전트의 이름</string>
+    <string name="agent_description_label">설명</string>
+    <string name="agent_description_placeholder">선택 사항: 여기에 에이전트를 설명하세요</string>
+    <string name="agent_instructions_label">지침</string>
+    <string name="agent_instructions_placeholder">에이전트가 사용하는 시스템 지침</string>
+    <string name="insert_variable">변수 삽입</string>
+    <string name="cd_insert_variable">변수 삽입</string>
+    <string name="special_var_current_date">현재 날짜</string>
+    <string name="special_var_current_user">현재 사용자</string>
+    <string name="special_var_iso_datetime">ISO 날짜시간</string>
+    <string name="special_var_current_datetime">현재 날짜시간</string>
+    <string name="label_capabilities">기능</string>
+    <string name="label_tools_and_actions">도구 &amp; 작업</string>
+    <string name="add_tools">도구 추가</string>
+    <string name="add_starter_hint">스타터 추가…</string>
+    <string name="save_changes">변경 사항 저장</string>
+
+    <!-- Actions panel -->
+    <string name="openapi_actions_count">OpenAPI 작업 (%1$d)</string>
+    <string name="no_actions_configured">구성된 작업이 없습니다. OpenAPI 작업을 추가하여 외부 API를 연결하세요.</string>
+    <string name="add_action">작업 추가</string>
+    <string name="edit_action">작업 편집</string>
+    <string name="auth_api_key">API 키</string>
+    <string name="auth_oauth">OAuth</string>
+    <string name="auth_none">없음</string>
+    <string name="action_auth_info">인증: %1$s | 함수 %2$d개</string>
+    <string name="label_action">작업</string>
+
+    <!-- Action editor dialog -->
+    <string name="label_authentication">인증</string>
+    <string name="auth_api_key_full">API 키 인증</string>
+    <string name="auth_oauth_full">OAuth 인증</string>
+    <string name="auth_no_auth">인증 없음</string>
+    <string name="label_openapi_schema">OpenAPI 스키마</string>
+    <string name="openapi_schema_hint">OpenAPI 사양을 JSON 또는 YAML 형식으로 붙여넣으세요.</string>
+    <string name="label_openapi_spec">OpenAPI 사양 (JSON 또는 YAML)</string>
+    <string name="validating">검증 중…</string>
+    <string name="domain_prefix">도메인: %1$s</string>
+    <string name="available_actions_count">사용 가능한 작업 (%1$d)</string>
+    <string name="label_privacy_policy_url">개인정보처리방침 URL</string>
+    <string name="label_save_or_create">%1$s</string>
+
+    <!-- Auth config dialog -->
+    <string name="label_authentication_type">인증 유형</string>
+    <string name="label_api_key_settings">API 키 설정</string>
+    <string name="label_api_key">API 키</string>
+    <string name="label_authorization_type">권한 부여 유형</string>
+    <string name="auth_basic">Basic</string>
+    <string name="auth_bearer">Bearer</string>
+    <string name="auth_custom">사용자 지정</string>
+    <string name="label_custom_auth_header">사용자 지정 인증 헤더</string>
+    <string name="label_oauth_settings">OAuth 설정</string>
+    <string name="label_client_id">Client ID</string>
+    <string name="label_client_secret">Client Secret</string>
+    <string name="label_authorization_url">Authorization URL</string>
+    <string name="label_token_url">Token URL</string>
+    <string name="label_scope">Scope</string>
+    <string name="label_token_exchange_method">토큰 교환 방식</string>
+    <string name="token_default_post">기본값 (POST)</string>
+    <string name="token_basic_auth_header">Basic 인증 헤더</string>
+
+    <!-- Function table -->
+    <string name="table_name">이름</string>
+    <string name="table_method">메서드</string>
+    <string name="table_path">경로</string>
+
+    <!-- Advanced panel -->
+    <string name="advanced_settings">모델 설정</string>
+    <string name="label_temperature">Temperature</string>
+    <string name="temperature_description">무작위성을 제어합니다. 낮을수록 더 집중적입니다.</string>
+    <string name="label_top_p">Top P</string>
+    <string name="top_p_description">Nucleus 샘플링 컷오프.</string>
+    <string name="label_max_tokens">최대 토큰</string>
+    <string name="max_tokens_description">응답의 최대 토큰 수입니다. 기본값을 사용하려면 비워 두세요.</string>
+
+    <!-- Avatar picker -->
+    <!-- (content descriptions above) -->
+
+    <!-- Capabilities section -->
+    <string name="label_artifacts">아티팩트</string>
+    <string name="artifacts_description">아티팩트 생성 사용</string>
+    <string name="artifacts_mode_off">끔</string>
+    <string name="artifacts_mode_default">기본값</string>
+    <string name="artifacts_mode_shadcnui">shadcn/ui</string>
+    <string name="artifacts_mode_custom">사용자 지정</string>
+    <string name="label_end_after_tools">도구 실행 후 종료</string>
+    <string name="end_after_tools_description">도구 실행이 완료되면 중지합니다</string>
+    <string name="label_hide_sequential_outputs">순차 출력 숨기기</string>
+    <string name="hide_sequential_description">중간 도구 출력 숨기기</string>
+    <string name="label_recursion_limit">재귀 한도</string>
+    <string name="recursion_limit_description">재귀 도구 호출의 최대 횟수</string>
+
+    <!-- Category selector -->
+    <string name="general">일반</string>
+
+    <!-- Code Interpreter section -->
+    <string name="label_code_interpreter">코드 인터프리터</string>
+    <string name="code_interpreter_description">에이전트가 문제 해결을 위해 코드를 작성하고 실행하도록 허용합니다</string>
+
+    <!-- Web Search section -->
+    <string name="label_web_search">웹 검색</string>
+    <string name="web_search_description">에이전트가 최신 정보를 위해 웹을 검색하도록 허용합니다</string>
+
+    <!-- Tool auth dialog -->
+    <string name="tool_auth_revoke">해제</string>
+    <string name="tool_auth_code_title">코드 인터프리터 API 키</string>
+    <string name="tool_auth_code_description">서버가 사용자를 대신해 코드를 실행하는 데 사용할 API 키를 입력하세요. 에이전트가 아닌 계정에 저장됩니다.</string>
+    <string name="tool_auth_code_field">LibreChat Code API 키</string>
+    <string name="tool_auth_required">이 도구를 사용하려면 인증이 필요합니다</string>
+
+    <!-- File Context section -->
+    <string name="label_file_context">파일 컨텍스트</string>
+    <string name="file_context_description">항상 대화 컨텍스트로 포함되는 파일을 첨부합니다</string>
+
+    <!-- File Search section -->
+    <string name="label_file_search">파일 검색</string>
+    <string name="file_search_description">에이전트가 업로드한 파일과 문서를 검색하도록 사용 설정합니다</string>
+
+    <!-- Handoff config -->
+    <!-- Chain (sequential multi-agent) -->
+    <string name="chain_agents_count">체인 에이전트 (%1$d)</string>
+    <string name="chain_description">이 에이전트 이후에 순차적으로 실행되는 에이전트입니다. 한도는 %1$d개입니다.</string>
+    <string name="no_chain_agents">구성된 체인 에이전트가 없습니다.</string>
+    <string name="add_chain_agent">체인 에이전트 추가</string>
+    <string name="chain_full">체인 에이전트의 최대 수에 도달했습니다.</string>
+    <!-- Handoffs (graph edges) -->
+    <string name="handoff_edges_count">인계 엣지 (%1$d)</string>
+    <string name="handoff_edges_description">동적 다중 에이전트 인계를 위한 그래프 라우팅 엣지.</string>
+    <string name="no_handoff_edges">구성된 인계 엣지가 없습니다.</string>
+    <string name="add_handoff_edge">인계 엣지 추가</string>
+    <string name="handoff_edge_from">시작</string>
+    <string name="handoff_edge_to">대상</string>
+    <string name="handoff_edge_description">설명 (선택 사항)</string>
+    <string name="handoff_edge_prompt">전송 프롬프트 (선택 사항)</string>
+    <string name="handoff_edge_prompt_key">프롬프트 매개변수 이름 (선택 사항)</string>
+    <string name="handoff_edge_exclude_results">이전 메시지 제외</string>
+    <string name="handoff_edge_arrow">%1$s → %2$s</string>
+    <string name="handoff_edge_multi">에이전트 %1$d개 → 에이전트 %2$d개</string>
+    <string name="no_more_agents">추가할 수 있는 에이전트가 더 이상 없습니다.</string>
+    <string name="select_agent">에이전트 선택</string>
+
+    <!-- MCP Tools selector -->
+    <string name="mcp_tools_count">MCP 도구 (%1$d개 선택됨)</string>
+    <string name="no_mcp_tools">사용 가능한 MCP 도구가 없습니다. 설정에서 MCP 서버를 구성하세요.</string>
+    <string name="unknown_server">알 수 없는 서버</string>
+
+    <!-- Model picker -->
+    <string name="model_required_label">모델 *</string>
+    <string name="select_model_hint">모델을 선택하세요…</string>
+    <string name="no_models_found">모델을 찾을 수 없습니다</string>
+
+    <!-- Sharing section -->
+    <string name="sharing_and_permissions">공유 &amp; 권한</string>
+    <string name="label_visibility">공개 범위</string>
+    <string name="label_collaborative">공동 작업</string>
+    <string name="collaborative_description">다른 사용자가 이 에이전트를 수정하도록 허용합니다</string>
+    <string name="collaborative_managed_server_side">이 버전에서는 접근 권한이 서버 측에서 관리됩니다.</string>
+
+    <!-- Visibility labels -->
+    <string name="visibility_private">비공개</string>
+    <string name="visibility_team">팀</string>
+    <string name="visibility_public">공개</string>
+
+    <!-- Support contact section -->
+    <string name="label_support_contact">지원 연락처</string>
+    <string name="label_name">이름</string>
+    <string name="support_contact_placeholder">지원 연락처 이름</string>
+    <string name="label_email">이메일</string>
+
+    <!-- Version history -->
+    <string name="no_version_history">사용 가능한 버전 기록이 없습니다</string>
+    <string name="version_number">버전 %1$d</string>
+    <string name="version_current">활성</string>
+    <string name="version_no_date">날짜 없음</string>
+    <string name="version_unknown_date">알 수 없는 날짜</string>
+    <string name="version_snapshot_name">이름</string>
+    <string name="version_snapshot_description">설명</string>
+    <string name="version_snapshot_instructions">지침</string>
+    <string name="version_snapshot_artifacts">아티팩트</string>
+    <string name="version_snapshot_capabilities">기능</string>
+    <string name="version_snapshot_tools">도구</string>
+    <string name="version_snapshot_empty">—</string>
+    <string name="version_restore_confirm">이 에이전트를 선택한 버전으로 되돌리시겠습니까? 현재 저장되지 않은 변경 사항은 손실됩니다.</string>
+
+    <!-- ACL sharing (v0.8.5+) -->
+    <string name="acl_sharing_title">공유 &amp; 접근</string>
+    <string name="acl_add_principal">사용자 또는 그룹 추가</string>
+    <string name="acl_no_grants">아직 접근 권한이 부여된 사용자가 없습니다.</string>
+    <string name="acl_public_label">공개</string>
+    <string name="acl_public_description">서버에 접근할 수 있는 모든 사람에게 허용</string>
+    <string name="acl_role">역할</string>
+    <string name="acl_revoke">해제</string>
+    <string name="acl_search_hint">사용자 또는 그룹 검색…</string>
+    <string name="acl_search_empty">일치하는 항목 없음</string>
+    <string name="acl_grant_button">부여</string>
+    <string name="acl_grant_dialog_title">사용자 또는 그룹 추가</string>
+    <string name="acl_principal_user">사용자</string>
+    <string name="acl_principal_group">그룹</string>
+    <string name="acl_principal_role">역할</string>
+    <string name="acl_create_mode_notice">공유 &amp; 접근 제어는 에이전트를 저장한 후에 사용할 수 있습니다.</string>
+
+    <!-- Tool select dialog -->
+    <string name="agent_tools_title">에이전트 도구</string>
+    <string name="select_tools_description">에이전트가 사용할 도구를 선택하세요</string>
+    <string name="search_tools_hint">도구 검색…</string>
+    <string name="no_tools_matching">\"%1$s\"과(와) 일치하는 도구가 없습니다</string>
+    <string name="no_tools_available">사용 가능한 도구가 없습니다</string>
+
+    <!-- Per-capability file attachments -->
+    <string name="add_file">파일 추가</string>
+    <string name="agent_files_save_first">파일을 첨부하기 전에 에이전트를 저장하세요</string>
+    <string name="agent_file_too_large">파일은 %1$d MB 이하여야 합니다</string>
+    <string name="agent_file_upload_failed">파일 업로드에 실패했습니다</string>
+    <string name="agent_file_remove_failed">파일 제거에 실패했습니다</string>
+    <string name="cd_remove_file">%1$s 제거</string>
+
+    <!-- Skills selector (v0.8.6) -->
+    <string name="label_skills">스킬</string>
+    <string name="skills_disabled_hint">이 에이전트에는 스킬이 꺼져 있습니다.</string>
+    <string name="skills_enabled_all_hint">접근할 수 있는 모든 스킬을 이 에이전트가 사용할 수 있습니다.</string>
+    <string name="skills_enabled_allowlist_hint">선택한 스킬만 이 에이전트가 사용할 수 있습니다.</string>
+    <string name="add_skills">스킬 추가</string>
+    <string name="select_skills">스킬 선택</string>
+    <string name="search_skills_hint">스킬 검색…</string>
+    <string name="no_skills_matching">\"%1$s\"과(와) 일치하는 스킬이 없습니다</string>
+    <string name="no_skills_available">사용 가능한 스킬이 없습니다</string>
+    <string name="skills_done">완료</string>
+
+    <!-- Subagents config (v0.8.6) -->
+    <string name="label_subagents">서브에이전트</string>
+    <string name="subagents_description">이 에이전트가 격리된 컨텍스트에서 다른 에이전트에게 작업을 위임하도록 허용합니다.</string>
+    <string name="subagents_allow_self">자신을 생성하도록 허용</string>
+    <string name="add_subagent">서브에이전트 추가</string>
+    <string name="subagents_full">서브에이전트의 최대 수에 도달했습니다.</string>
+</resources>

--- a/feature/agents/src/commonMain/composeResources/values-pt/strings.xml
+++ b/feature/agents/src/commonMain/composeResources/values-pt/strings.xml
@@ -1,0 +1,305 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Common actions -->
+    <string name="agents">Agentes</string>
+    <string name="marketplace">Marketplace</string>
+    <string name="search_agents">Buscar agentes…</string>
+    <string name="start_chat">Iniciar conversa</string>
+    <string name="edit">Editar</string>
+    <string name="delete">Excluir</string>
+    <string name="cancel">Cancelar</string>
+    <string name="duplicate">Duplicar</string>
+    <string name="save">Salvar</string>
+    <string name="create">Criar</string>
+    <string name="apply">Aplicar</string>
+    <string name="add">Adicionar</string>
+    <string name="remove">Remover</string>
+    <string name="revert">Reverter</string>
+    <string name="close">Fechar</string>
+
+    <!-- Content descriptions -->
+    <string name="cd_create_agent">Criar agente</string>
+    <string name="cd_search">Buscar</string>
+    <string name="cd_back">Voltar</string>
+    <string name="cd_more_actions">Mais ações</string>
+    <string name="cd_more_options">Mais opções</string>
+    <string name="cd_collapse">Recolher</string>
+    <string name="cd_expand">Expandir</string>
+    <string name="cd_remove_item">Remover %1$s</string>
+    <string name="cd_edit_action">Editar ação</string>
+    <string name="cd_delete_action">Excluir ação</string>
+    <string name="cd_add_starter">Adicionar iniciador</string>
+    <string name="cd_agent_avatar_tap">Avatar do agente. Toque para alterar.</string>
+    <string name="cd_agent_avatar_name">Avatar de %1$s</string>
+    <string name="cd_tool_icon">Ícone de %1$s</string>
+
+    <!-- Marketplace screen -->
+    <string name="search_agents_hint">Buscar agentes…</string>
+    <string name="no_agents_found">Nenhum agente encontrado</string>
+    <string name="no_agents_available">Nenhum agente disponível</string>
+    <string name="agents_not_available_title">Agentes indisponíveis</string>
+    <string name="agents_not_available_description">O administrador do seu servidor desativou os agentes para sua conta.</string>
+    <string name="try_different_search">Tente um termo de busca diferente</string>
+    <string name="check_back_later">Volte mais tarde para ver novos agentes</string>
+    <string name="error_unknown">Ocorreu um erro desconhecido</string>
+    <string name="unknown_author">Desconhecido</string>
+
+    <!-- Detail screen -->
+    <string name="agent_title">Agente</string>
+    <string name="delete_agent">Excluir agente</string>
+    <string name="delete_agent_confirm">Tem certeza de que deseja excluir \"%1$s\"? Esta ação não pode ser desfeita.</string>
+    <string name="delete_this_agent">este agente</string>
+    <string name="by_author">por %1$s</string>
+    <string name="label_description">Descrição</string>
+    <string name="no_description">Sem descrição</string>
+    <string name="label_category">Categoria</string>
+    <string name="label_model">Modelo</string>
+    <string name="default_value">Padrão</string>
+    <string name="label_tools">Ferramentas</string>
+    <string name="label_conversation_starters">Iniciadores de conversa</string>
+
+    <!-- Editor screen -->
+    <string name="edit_agent">Editar agente</string>
+    <string name="create_agent">Criar agente</string>
+    <string name="duplicate_agent">Duplicar agente</string>
+    <string name="delete_agent_editor_confirm">Tem certeza de que deseja excluir este agente? Esta ação não pode ser desfeita.</string>
+    <string name="duplicate_agent_confirm">Criar uma cópia deste agente?</string>
+    <string name="version_history">Histórico de versões</string>
+    <string name="tap_to_change_avatar">Toque para alterar o avatar</string>
+    <string name="remove_avatar">Remover avatar</string>
+    <string name="agent_name_label">Nome *</string>
+    <string name="agent_name_placeholder">Opcional: o nome do agente</string>
+    <string name="agent_description_label">Descrição</string>
+    <string name="agent_description_placeholder">Opcional: descreva seu agente aqui</string>
+    <string name="agent_instructions_label">Instruções</string>
+    <string name="agent_instructions_placeholder">As instruções do sistema que o agente usa</string>
+    <string name="insert_variable">Inserir variável</string>
+    <string name="cd_insert_variable">Inserir variável</string>
+    <string name="special_var_current_date">Data atual</string>
+    <string name="special_var_current_user">Usuário atual</string>
+    <string name="special_var_iso_datetime">Data/hora ISO</string>
+    <string name="special_var_current_datetime">Data/hora atual</string>
+    <string name="label_capabilities">Recursos</string>
+    <string name="label_tools_and_actions">Ferramentas &amp; ações</string>
+    <string name="add_tools">Adicionar ferramentas</string>
+    <string name="add_starter_hint">Adicionar iniciador…</string>
+    <string name="save_changes">Salvar alterações</string>
+
+    <!-- Actions panel -->
+    <string name="openapi_actions_count">Ações OpenAPI (%1$d)</string>
+    <string name="no_actions_configured">Nenhuma ação configurada. Adicione uma ação OpenAPI para conectar APIs externas.</string>
+    <string name="add_action">Adicionar ação</string>
+    <string name="edit_action">Editar ação</string>
+    <string name="auth_api_key">Chave de API</string>
+    <string name="auth_oauth">OAuth</string>
+    <string name="auth_none">Nenhuma</string>
+    <string name="action_auth_info">Autenticação: %1$s | %2$d função(ões)</string>
+    <string name="label_action">Ação</string>
+
+    <!-- Action editor dialog -->
+    <string name="label_authentication">Autenticação</string>
+    <string name="auth_api_key_full">Autenticação por chave de API</string>
+    <string name="auth_oauth_full">Autenticação OAuth</string>
+    <string name="auth_no_auth">Sem autenticação</string>
+    <string name="label_openapi_schema">Esquema OpenAPI</string>
+    <string name="openapi_schema_hint">Cole sua especificação OpenAPI no formato JSON ou YAML.</string>
+    <string name="label_openapi_spec">Especificação OpenAPI (JSON ou YAML)</string>
+    <string name="validating">Validando…</string>
+    <string name="domain_prefix">Domínio: %1$s</string>
+    <string name="available_actions_count">Ações disponíveis (%1$d)</string>
+    <string name="label_privacy_policy_url">URL da política de privacidade</string>
+    <string name="label_save_or_create">%1$s</string>
+
+    <!-- Auth config dialog -->
+    <string name="label_authentication_type">Tipo de autenticação</string>
+    <string name="label_api_key_settings">Configurações da chave de API</string>
+    <string name="label_api_key">Chave de API</string>
+    <string name="label_authorization_type">Tipo de autorização</string>
+    <string name="auth_basic">Basic</string>
+    <string name="auth_bearer">Bearer</string>
+    <string name="auth_custom">Personalizado</string>
+    <string name="label_custom_auth_header">Cabeçalho de autenticação personalizado</string>
+    <string name="label_oauth_settings">Configurações OAuth</string>
+    <string name="label_client_id">Client ID</string>
+    <string name="label_client_secret">Client Secret</string>
+    <string name="label_authorization_url">URL de autorização</string>
+    <string name="label_token_url">URL do token</string>
+    <string name="label_scope">Escopo</string>
+    <string name="label_token_exchange_method">Método de troca de token</string>
+    <string name="token_default_post">Padrão (POST)</string>
+    <string name="token_basic_auth_header">Cabeçalho Basic Auth</string>
+
+    <!-- Function table -->
+    <string name="table_name">Nome</string>
+    <string name="table_method">Método</string>
+    <string name="table_path">Caminho</string>
+
+    <!-- Advanced panel -->
+    <string name="advanced_settings">Configurações do modelo</string>
+    <string name="label_temperature">Temperatura</string>
+    <string name="temperature_description">Controla a aleatoriedade. Menor = mais focado.</string>
+    <string name="label_top_p">Top P</string>
+    <string name="top_p_description">Corte de amostragem por núcleo.</string>
+    <string name="label_max_tokens">Máx. de tokens</string>
+    <string name="max_tokens_description">Máximo de tokens na resposta. Deixe em branco para o padrão.</string>
+
+    <!-- Avatar picker -->
+    <!-- (content descriptions above) -->
+
+    <!-- Capabilities section -->
+    <string name="label_artifacts">Artefatos</string>
+    <string name="artifacts_description">Ativar geração de artefatos</string>
+    <string name="artifacts_mode_off">Desativado</string>
+    <string name="artifacts_mode_default">Padrão</string>
+    <string name="artifacts_mode_shadcnui">shadcn/ui</string>
+    <string name="artifacts_mode_custom">Personalizado</string>
+    <string name="label_end_after_tools">Encerrar após ferramentas</string>
+    <string name="end_after_tools_description">Parar após a conclusão da execução das ferramentas</string>
+    <string name="label_hide_sequential_outputs">Ocultar saídas sequenciais</string>
+    <string name="hide_sequential_description">Ocultar saídas intermediárias das ferramentas</string>
+    <string name="label_recursion_limit">Limite de recursão</string>
+    <string name="recursion_limit_description">Número máximo de chamadas recursivas de ferramentas</string>
+
+    <!-- Category selector -->
+    <string name="general">Geral</string>
+
+    <!-- Code Interpreter section -->
+    <string name="label_code_interpreter">Interpretador de código</string>
+    <string name="code_interpreter_description">Permitir que o agente escreva e execute código para resolver problemas</string>
+
+    <!-- Web Search section -->
+    <string name="label_web_search">Busca na web</string>
+    <string name="web_search_description">Permitir que o agente pesquise na web por informações atuais</string>
+
+    <!-- Tool auth dialog -->
+    <string name="tool_auth_revoke">Revogar</string>
+    <string name="tool_auth_code_title">Chave de API do Interpretador de Código</string>
+    <string name="tool_auth_code_description">Digite a chave de API que o servidor deve usar para executar código em seu nome. Armazenada na sua conta, não no agente.</string>
+    <string name="tool_auth_code_field">Chave de API do LibreChat Code</string>
+    <string name="tool_auth_required">Autenticação necessária para ativar esta ferramenta</string>
+
+    <!-- File Context section -->
+    <string name="label_file_context">Contexto de arquivo</string>
+    <string name="file_context_description">Anexe arquivos que são sempre incluídos como contexto da conversa</string>
+
+    <!-- File Search section -->
+    <string name="label_file_search">Busca em arquivos</string>
+    <string name="file_search_description">Permitir que o agente pesquise em arquivos e documentos enviados</string>
+
+    <!-- Handoff config -->
+    <!-- Chain (sequential multi-agent) -->
+    <string name="chain_agents_count">Agentes em cadeia (%1$d)</string>
+    <string name="chain_description">Agentes que executam em sequência após este. O limite é %1$d.</string>
+    <string name="no_chain_agents">Nenhum agente em cadeia configurado.</string>
+    <string name="add_chain_agent">Adicionar agente em cadeia</string>
+    <string name="chain_full">Número máximo de agentes em cadeia atingido.</string>
+    <!-- Handoffs (graph edges) -->
+    <string name="handoff_edges_count">Arestas de transferência (%1$d)</string>
+    <string name="handoff_edges_description">Arestas de roteamento do grafo para transferência dinâmica entre múltiplos agentes.</string>
+    <string name="no_handoff_edges">Nenhuma aresta de transferência configurada.</string>
+    <string name="add_handoff_edge">Adicionar aresta de transferência</string>
+    <string name="handoff_edge_from">De</string>
+    <string name="handoff_edge_to">Para</string>
+    <string name="handoff_edge_description">Descrição (opcional)</string>
+    <string name="handoff_edge_prompt">Prompt de transferência (opcional)</string>
+    <string name="handoff_edge_prompt_key">Nome do parâmetro do prompt (opcional)</string>
+    <string name="handoff_edge_exclude_results">Excluir mensagens anteriores</string>
+    <string name="handoff_edge_arrow">%1$s → %2$s</string>
+    <string name="handoff_edge_multi">%1$d agentes → %2$d agentes</string>
+    <string name="no_more_agents">Nenhum outro agente disponível para adicionar.</string>
+    <string name="select_agent">Selecionar agente</string>
+
+    <!-- MCP Tools selector -->
+    <string name="mcp_tools_count">Ferramentas MCP (%1$d selecionada(s))</string>
+    <string name="no_mcp_tools">Nenhuma ferramenta MCP disponível. Configure servidores MCP nas configurações.</string>
+    <string name="unknown_server">Servidor desconhecido</string>
+
+    <!-- Model picker -->
+    <string name="model_required_label">Modelo *</string>
+    <string name="select_model_hint">Selecione um modelo…</string>
+    <string name="no_models_found">Nenhum modelo encontrado</string>
+
+    <!-- Sharing section -->
+    <string name="sharing_and_permissions">Compartilhamento &amp; permissões</string>
+    <string name="label_visibility">Visibilidade</string>
+    <string name="label_collaborative">Colaborativo</string>
+    <string name="collaborative_description">Permitir que outros usuários modifiquem este agente</string>
+    <string name="collaborative_managed_server_side">As permissões de acesso são gerenciadas no servidor nesta versão.</string>
+
+    <!-- Visibility labels -->
+    <string name="visibility_private">Privado</string>
+    <string name="visibility_team">Equipe</string>
+    <string name="visibility_public">Público</string>
+
+    <!-- Support contact section -->
+    <string name="label_support_contact">Contato de suporte</string>
+    <string name="label_name">Nome</string>
+    <string name="support_contact_placeholder">Nome do contato de suporte</string>
+    <string name="label_email">E-mail</string>
+
+    <!-- Version history -->
+    <string name="no_version_history">Nenhum histórico de versões disponível</string>
+    <string name="version_number">Versão %1$d</string>
+    <string name="version_current">Ativa</string>
+    <string name="version_no_date">Nenhuma data disponível</string>
+    <string name="version_unknown_date">Data desconhecida</string>
+    <string name="version_snapshot_name">Nome</string>
+    <string name="version_snapshot_description">Descrição</string>
+    <string name="version_snapshot_instructions">Instruções</string>
+    <string name="version_snapshot_artifacts">Artefatos</string>
+    <string name="version_snapshot_capabilities">Recursos</string>
+    <string name="version_snapshot_tools">Ferramentas</string>
+    <string name="version_snapshot_empty">—</string>
+    <string name="version_restore_confirm">Reverter este agente para a versão selecionada? As alterações não salvas serão perdidas.</string>
+
+    <!-- ACL sharing (v0.8.5+) -->
+    <string name="acl_sharing_title">Compartilhamento &amp; acesso</string>
+    <string name="acl_add_principal">Adicionar usuário ou grupo</string>
+    <string name="acl_no_grants">Ninguém recebeu acesso ainda.</string>
+    <string name="acl_public_label">Público</string>
+    <string name="acl_public_description">Permitir qualquer pessoa com acesso ao servidor</string>
+    <string name="acl_role">Função</string>
+    <string name="acl_revoke">Revogar</string>
+    <string name="acl_search_hint">Buscar usuários ou grupos…</string>
+    <string name="acl_search_empty">Nenhuma correspondência</string>
+    <string name="acl_grant_button">Conceder</string>
+    <string name="acl_grant_dialog_title">Adicionar usuário ou grupo</string>
+    <string name="acl_principal_user">Usuário</string>
+    <string name="acl_principal_group">Grupo</string>
+    <string name="acl_principal_role">Função</string>
+    <string name="acl_create_mode_notice">Os controles de compartilhamento &amp; acesso ficam disponíveis após o agente ser salvo.</string>
+
+    <!-- Tool select dialog -->
+    <string name="agent_tools_title">Ferramentas do agente</string>
+    <string name="select_tools_description">Selecione as ferramentas que seu agente vai usar</string>
+    <string name="search_tools_hint">Buscar ferramentas…</string>
+    <string name="no_tools_matching">Nenhuma ferramenta corresponde a \"%1$s\"</string>
+    <string name="no_tools_available">Nenhuma ferramenta disponível</string>
+
+    <!-- Per-capability file attachments -->
+    <string name="add_file">Adicionar arquivo</string>
+    <string name="agent_files_save_first">Salve o agente antes de anexar arquivos</string>
+    <string name="agent_file_too_large">O arquivo deve ter %1$d MB ou menos</string>
+    <string name="agent_file_upload_failed">Falha ao enviar o arquivo</string>
+    <string name="agent_file_remove_failed">Falha ao remover o arquivo</string>
+    <string name="cd_remove_file">Remover %1$s</string>
+
+    <!-- Skills selector (v0.8.6) -->
+    <string name="label_skills">Habilidades</string>
+    <string name="skills_disabled_hint">As habilidades estão desativadas para este agente.</string>
+    <string name="skills_enabled_all_hint">Todas as habilidades que você pode acessar estão disponíveis para este agente.</string>
+    <string name="skills_enabled_allowlist_hint">Apenas as habilidades selecionadas estão disponíveis para este agente.</string>
+    <string name="add_skills">Adicionar habilidades</string>
+    <string name="select_skills">Selecionar habilidades</string>
+    <string name="search_skills_hint">Buscar habilidades…</string>
+    <string name="no_skills_matching">Nenhuma habilidade corresponde a \"%1$s\"</string>
+    <string name="no_skills_available">Nenhuma habilidade disponível</string>
+    <string name="skills_done">Concluído</string>
+
+    <!-- Subagents config (v0.8.6) -->
+    <string name="label_subagents">Subagentes</string>
+    <string name="subagents_description">Permitir que este agente delegue trabalho a outros agentes em contextos isolados.</string>
+    <string name="subagents_allow_self">Permitir gerar a si mesmo</string>
+    <string name="add_subagent">Adicionar subagente</string>
+    <string name="subagents_full">Número máximo de subagentes atingido.</string>
+</resources>

--- a/feature/agents/src/commonMain/composeResources/values-ru/strings.xml
+++ b/feature/agents/src/commonMain/composeResources/values-ru/strings.xml
@@ -1,0 +1,305 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Common actions -->
+    <string name="agents">Агенты</string>
+    <string name="marketplace">Маркетплейс</string>
+    <string name="search_agents">Поиск агентов…</string>
+    <string name="start_chat">Начать чат</string>
+    <string name="edit">Изменить</string>
+    <string name="delete">Удалить</string>
+    <string name="cancel">Отмена</string>
+    <string name="duplicate">Дублировать</string>
+    <string name="save">Сохранить</string>
+    <string name="create">Создать</string>
+    <string name="apply">Применить</string>
+    <string name="add">Добавить</string>
+    <string name="remove">Удалить</string>
+    <string name="revert">Откатить</string>
+    <string name="close">Закрыть</string>
+
+    <!-- Content descriptions -->
+    <string name="cd_create_agent">Создать агента</string>
+    <string name="cd_search">Поиск</string>
+    <string name="cd_back">Назад</string>
+    <string name="cd_more_actions">Ещё действия</string>
+    <string name="cd_more_options">Дополнительно</string>
+    <string name="cd_collapse">Свернуть</string>
+    <string name="cd_expand">Развернуть</string>
+    <string name="cd_remove_item">Удалить %1$s</string>
+    <string name="cd_edit_action">Изменить действие</string>
+    <string name="cd_delete_action">Удалить действие</string>
+    <string name="cd_add_starter">Добавить начальную фразу</string>
+    <string name="cd_agent_avatar_tap">Аватар агента. Нажмите, чтобы изменить.</string>
+    <string name="cd_agent_avatar_name">Аватар %1$s</string>
+    <string name="cd_tool_icon">Значок %1$s</string>
+
+    <!-- Marketplace screen -->
+    <string name="search_agents_hint">Поиск агентов…</string>
+    <string name="no_agents_found">Агенты не найдены</string>
+    <string name="no_agents_available">Нет доступных агентов</string>
+    <string name="agents_not_available_title">Агенты недоступны</string>
+    <string name="agents_not_available_description">Администратор вашего сервера отключил агентов для вашего аккаунта.</string>
+    <string name="try_different_search">Попробуйте другой поисковый запрос</string>
+    <string name="check_back_later">Загляните позже за новыми агентами</string>
+    <string name="error_unknown">Произошла неизвестная ошибка</string>
+    <string name="unknown_author">Неизвестно</string>
+
+    <!-- Detail screen -->
+    <string name="agent_title">Агент</string>
+    <string name="delete_agent">Удалить агента</string>
+    <string name="delete_agent_confirm">Вы уверены, что хотите удалить \"%1$s\"? Это нельзя отменить.</string>
+    <string name="delete_this_agent">этого агента</string>
+    <string name="by_author">автор: %1$s</string>
+    <string name="label_description">Описание</string>
+    <string name="no_description">Без описания</string>
+    <string name="label_category">Категория</string>
+    <string name="label_model">Модель</string>
+    <string name="default_value">По умолчанию</string>
+    <string name="label_tools">Инструменты</string>
+    <string name="label_conversation_starters">Начальные фразы</string>
+
+    <!-- Editor screen -->
+    <string name="edit_agent">Изменить агента</string>
+    <string name="create_agent">Создать агента</string>
+    <string name="duplicate_agent">Дублировать агента</string>
+    <string name="delete_agent_editor_confirm">Вы уверены, что хотите удалить этого агента? Это действие нельзя отменить.</string>
+    <string name="duplicate_agent_confirm">Создать копию этого агента?</string>
+    <string name="version_history">История версий</string>
+    <string name="tap_to_change_avatar">Нажмите, чтобы изменить аватар</string>
+    <string name="remove_avatar">Удалить аватар</string>
+    <string name="agent_name_label">Имя *</string>
+    <string name="agent_name_placeholder">Необязательно: имя агента</string>
+    <string name="agent_description_label">Описание</string>
+    <string name="agent_description_placeholder">Необязательно: опишите вашего агента здесь</string>
+    <string name="agent_instructions_label">Инструкции</string>
+    <string name="agent_instructions_placeholder">Системные инструкции, которые использует агент</string>
+    <string name="insert_variable">Вставить переменную</string>
+    <string name="cd_insert_variable">Вставить переменную</string>
+    <string name="special_var_current_date">Текущая дата</string>
+    <string name="special_var_current_user">Текущий пользователь</string>
+    <string name="special_var_iso_datetime">Дата и время ISO</string>
+    <string name="special_var_current_datetime">Текущие дата и время</string>
+    <string name="label_capabilities">Возможности</string>
+    <string name="label_tools_and_actions">Инструменты и действия</string>
+    <string name="add_tools">Добавить инструменты</string>
+    <string name="add_starter_hint">Добавить начальную фразу…</string>
+    <string name="save_changes">Сохранить изменения</string>
+
+    <!-- Actions panel -->
+    <string name="openapi_actions_count">Действия OpenAPI (%1$d)</string>
+    <string name="no_actions_configured">Действия не настроены. Добавьте действие OpenAPI для подключения внешних API.</string>
+    <string name="add_action">Добавить действие</string>
+    <string name="edit_action">Изменить действие</string>
+    <string name="auth_api_key">API-ключ</string>
+    <string name="auth_oauth">OAuth</string>
+    <string name="auth_none">Нет</string>
+    <string name="action_auth_info">Аутентификация: %1$s | %2$d функц.</string>
+    <string name="label_action">Действие</string>
+
+    <!-- Action editor dialog -->
+    <string name="label_authentication">Аутентификация</string>
+    <string name="auth_api_key_full">Аутентификация по API-ключу</string>
+    <string name="auth_oauth_full">Аутентификация OAuth</string>
+    <string name="auth_no_auth">Без аутентификации</string>
+    <string name="label_openapi_schema">Схема OpenAPI</string>
+    <string name="openapi_schema_hint">Вставьте вашу спецификацию OpenAPI в формате JSON или YAML.</string>
+    <string name="label_openapi_spec">Спецификация OpenAPI (JSON или YAML)</string>
+    <string name="validating">Проверка…</string>
+    <string name="domain_prefix">Домен: %1$s</string>
+    <string name="available_actions_count">Доступные действия (%1$d)</string>
+    <string name="label_privacy_policy_url">URL политики конфиденциальности</string>
+    <string name="label_save_or_create">%1$s</string>
+
+    <!-- Auth config dialog -->
+    <string name="label_authentication_type">Тип аутентификации</string>
+    <string name="label_api_key_settings">Настройки API-ключа</string>
+    <string name="label_api_key">API-ключ</string>
+    <string name="label_authorization_type">Тип авторизации</string>
+    <string name="auth_basic">Basic</string>
+    <string name="auth_bearer">Bearer</string>
+    <string name="auth_custom">Свой</string>
+    <string name="label_custom_auth_header">Свой заголовок авторизации</string>
+    <string name="label_oauth_settings">Настройки OAuth</string>
+    <string name="label_client_id">Client ID</string>
+    <string name="label_client_secret">Client Secret</string>
+    <string name="label_authorization_url">URL авторизации</string>
+    <string name="label_token_url">URL токена</string>
+    <string name="label_scope">Область</string>
+    <string name="label_token_exchange_method">Способ обмена токенами</string>
+    <string name="token_default_post">По умолчанию (POST)</string>
+    <string name="token_basic_auth_header">Заголовок Basic Auth</string>
+
+    <!-- Function table -->
+    <string name="table_name">Имя</string>
+    <string name="table_method">Метод</string>
+    <string name="table_path">Путь</string>
+
+    <!-- Advanced panel -->
+    <string name="advanced_settings">Настройки модели</string>
+    <string name="label_temperature">Температура</string>
+    <string name="temperature_description">Управляет случайностью. Ниже = более сфокусированно.</string>
+    <string name="label_top_p">Top P</string>
+    <string name="top_p_description">Порог сэмплирования по ядру.</string>
+    <string name="label_max_tokens">Макс. токенов</string>
+    <string name="max_tokens_description">Максимальное число токенов в ответе. Оставьте пустым для значения по умолчанию.</string>
+
+    <!-- Avatar picker -->
+    <!-- (content descriptions above) -->
+
+    <!-- Capabilities section -->
+    <string name="label_artifacts">Артефакты</string>
+    <string name="artifacts_description">Включить генерацию артефактов</string>
+    <string name="artifacts_mode_off">Выключено</string>
+    <string name="artifacts_mode_default">По умолчанию</string>
+    <string name="artifacts_mode_shadcnui">shadcn/ui</string>
+    <string name="artifacts_mode_custom">Свой</string>
+    <string name="label_end_after_tools">Завершать после инструментов</string>
+    <string name="end_after_tools_description">Останавливаться после завершения выполнения инструментов</string>
+    <string name="label_hide_sequential_outputs">Скрывать промежуточные результаты</string>
+    <string name="hide_sequential_description">Скрывать промежуточные результаты инструментов</string>
+    <string name="label_recursion_limit">Лимит рекурсии</string>
+    <string name="recursion_limit_description">Максимальное число рекурсивных вызовов инструментов</string>
+
+    <!-- Category selector -->
+    <string name="general">Общие</string>
+
+    <!-- Code Interpreter section -->
+    <string name="label_code_interpreter">Интерпретатор кода</string>
+    <string name="code_interpreter_description">Разрешить агенту писать и выполнять код для решения задач</string>
+
+    <!-- Web Search section -->
+    <string name="label_web_search">Веб-поиск</string>
+    <string name="web_search_description">Разрешить агенту искать в интернете актуальную информацию</string>
+
+    <!-- Tool auth dialog -->
+    <string name="tool_auth_revoke">Отозвать</string>
+    <string name="tool_auth_code_title">API-ключ интерпретатора кода</string>
+    <string name="tool_auth_code_description">Введите API-ключ, который сервер должен использовать для выполнения кода от вашего имени. Хранится в вашем аккаунте, а не в агенте.</string>
+    <string name="tool_auth_code_field">API-ключ LibreChat Code</string>
+    <string name="tool_auth_required">Для включения этого инструмента требуется аутентификация</string>
+
+    <!-- File Context section -->
+    <string name="label_file_context">Файловый контекст</string>
+    <string name="file_context_description">Прикрепите файлы, которые всегда включаются как контекст беседы</string>
+
+    <!-- File Search section -->
+    <string name="label_file_search">Поиск по файлам</string>
+    <string name="file_search_description">Разрешить агенту искать по загруженным файлам и документам</string>
+
+    <!-- Handoff config -->
+    <!-- Chain (sequential multi-agent) -->
+    <string name="chain_agents_count">Агенты в цепочке (%1$d)</string>
+    <string name="chain_description">Агенты, выполняющиеся последовательно после этого. Предел — %1$d.</string>
+    <string name="no_chain_agents">Агенты в цепочке не настроены.</string>
+    <string name="add_chain_agent">Добавить агента в цепочку</string>
+    <string name="chain_full">Достигнуто максимальное число агентов в цепочке.</string>
+    <!-- Handoffs (graph edges) -->
+    <string name="handoff_edges_count">Рёбра передачи (%1$d)</string>
+    <string name="handoff_edges_description">Рёбра маршрутизации графа для динамической передачи между агентами.</string>
+    <string name="no_handoff_edges">Рёбра передачи не настроены.</string>
+    <string name="add_handoff_edge">Добавить ребро передачи</string>
+    <string name="handoff_edge_from">От</string>
+    <string name="handoff_edge_to">К</string>
+    <string name="handoff_edge_description">Описание (необязательно)</string>
+    <string name="handoff_edge_prompt">Промпт передачи (необязательно)</string>
+    <string name="handoff_edge_prompt_key">Имя параметра промпта (необязательно)</string>
+    <string name="handoff_edge_exclude_results">Исключить предыдущие сообщения</string>
+    <string name="handoff_edge_arrow">%1$s → %2$s</string>
+    <string name="handoff_edge_multi">%1$d агентов → %2$d агентов</string>
+    <string name="no_more_agents">Больше нет агентов для добавления.</string>
+    <string name="select_agent">Выбрать агента</string>
+
+    <!-- MCP Tools selector -->
+    <string name="mcp_tools_count">Инструменты MCP (выбрано: %1$d)</string>
+    <string name="no_mcp_tools">Нет доступных инструментов MCP. Настройте серверы MCP в настройках.</string>
+    <string name="unknown_server">Неизвестный сервер</string>
+
+    <!-- Model picker -->
+    <string name="model_required_label">Модель *</string>
+    <string name="select_model_hint">Выберите модель…</string>
+    <string name="no_models_found">Модели не найдены</string>
+
+    <!-- Sharing section -->
+    <string name="sharing_and_permissions">Доступ и разрешения</string>
+    <string name="label_visibility">Видимость</string>
+    <string name="label_collaborative">Совместный</string>
+    <string name="collaborative_description">Разрешить другим пользователям изменять этого агента</string>
+    <string name="collaborative_managed_server_side">В этой версии разрешения доступа управляются на стороне сервера.</string>
+
+    <!-- Visibility labels -->
+    <string name="visibility_private">Приватный</string>
+    <string name="visibility_team">Команда</string>
+    <string name="visibility_public">Публичный</string>
+
+    <!-- Support contact section -->
+    <string name="label_support_contact">Контакт поддержки</string>
+    <string name="label_name">Имя</string>
+    <string name="support_contact_placeholder">Имя контакта поддержки</string>
+    <string name="label_email">Эл. почта</string>
+
+    <!-- Version history -->
+    <string name="no_version_history">История версий недоступна</string>
+    <string name="version_number">Версия %1$d</string>
+    <string name="version_current">Активная</string>
+    <string name="version_no_date">Дата недоступна</string>
+    <string name="version_unknown_date">Неизвестная дата</string>
+    <string name="version_snapshot_name">Имя</string>
+    <string name="version_snapshot_description">Описание</string>
+    <string name="version_snapshot_instructions">Инструкции</string>
+    <string name="version_snapshot_artifacts">Артефакты</string>
+    <string name="version_snapshot_capabilities">Возможности</string>
+    <string name="version_snapshot_tools">Инструменты</string>
+    <string name="version_snapshot_empty">—</string>
+    <string name="version_restore_confirm">Откатить этого агента к выбранной версии? Текущие несохранённые изменения будут потеряны.</string>
+
+    <!-- ACL sharing (v0.8.5+) -->
+    <string name="acl_sharing_title">Доступ и совместное использование</string>
+    <string name="acl_add_principal">Добавить пользователя или группу</string>
+    <string name="acl_no_grants">Доступ пока никому не предоставлен.</string>
+    <string name="acl_public_label">Публичный</string>
+    <string name="acl_public_description">Разрешить всем, у кого есть доступ к серверу</string>
+    <string name="acl_role">Роль</string>
+    <string name="acl_revoke">Отозвать</string>
+    <string name="acl_search_hint">Поиск пользователей или групп…</string>
+    <string name="acl_search_empty">Совпадений нет</string>
+    <string name="acl_grant_button">Предоставить</string>
+    <string name="acl_grant_dialog_title">Добавить пользователя или группу</string>
+    <string name="acl_principal_user">Пользователь</string>
+    <string name="acl_principal_group">Группа</string>
+    <string name="acl_principal_role">Роль</string>
+    <string name="acl_create_mode_notice">Управление доступом и совместным использованием доступно после сохранения агента.</string>
+
+    <!-- Tool select dialog -->
+    <string name="agent_tools_title">Инструменты агента</string>
+    <string name="select_tools_description">Выберите инструменты, которые сможет использовать ваш агент</string>
+    <string name="search_tools_hint">Поиск инструментов…</string>
+    <string name="no_tools_matching">Нет инструментов, соответствующих \"%1$s\"</string>
+    <string name="no_tools_available">Нет доступных инструментов</string>
+
+    <!-- Per-capability file attachments -->
+    <string name="add_file">Добавить файл</string>
+    <string name="agent_files_save_first">Сохраните агента перед прикреплением файлов</string>
+    <string name="agent_file_too_large">Файл должен быть не больше %1$d МБ</string>
+    <string name="agent_file_upload_failed">Не удалось загрузить файл</string>
+    <string name="agent_file_remove_failed">Не удалось удалить файл</string>
+    <string name="cd_remove_file">Удалить %1$s</string>
+
+    <!-- Skills selector (v0.8.6) -->
+    <string name="label_skills">Навыки</string>
+    <string name="skills_disabled_hint">Навыки отключены для этого агента.</string>
+    <string name="skills_enabled_all_hint">Все доступные вам навыки доступны этому агенту.</string>
+    <string name="skills_enabled_allowlist_hint">Этому агенту доступны только выбранные навыки.</string>
+    <string name="add_skills">Добавить навыки</string>
+    <string name="select_skills">Выбрать навыки</string>
+    <string name="search_skills_hint">Поиск навыков…</string>
+    <string name="no_skills_matching">Нет навыков, соответствующих \"%1$s\"</string>
+    <string name="no_skills_available">Нет доступных навыков</string>
+    <string name="skills_done">Готово</string>
+
+    <!-- Subagents config (v0.8.6) -->
+    <string name="label_subagents">Субагенты</string>
+    <string name="subagents_description">Позвольте этому агенту делегировать работу другим агентам в изолированных контекстах.</string>
+    <string name="subagents_allow_self">Разрешить порождать самого себя</string>
+    <string name="add_subagent">Добавить субагента</string>
+    <string name="subagents_full">Достигнуто максимальное число субагентов.</string>
+</resources>

--- a/feature/agents/src/commonMain/composeResources/values-zh/strings.xml
+++ b/feature/agents/src/commonMain/composeResources/values-zh/strings.xml
@@ -1,0 +1,305 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Common actions -->
+    <string name="agents">智能体</string>
+    <string name="marketplace">市场</string>
+    <string name="search_agents">搜索智能体…</string>
+    <string name="start_chat">开始聊天</string>
+    <string name="edit">编辑</string>
+    <string name="delete">删除</string>
+    <string name="cancel">取消</string>
+    <string name="duplicate">复制副本</string>
+    <string name="save">保存</string>
+    <string name="create">创建</string>
+    <string name="apply">应用</string>
+    <string name="add">添加</string>
+    <string name="remove">移除</string>
+    <string name="revert">还原</string>
+    <string name="close">关闭</string>
+
+    <!-- Content descriptions -->
+    <string name="cd_create_agent">创建智能体</string>
+    <string name="cd_search">搜索</string>
+    <string name="cd_back">返回</string>
+    <string name="cd_more_actions">更多操作</string>
+    <string name="cd_more_options">更多选项</string>
+    <string name="cd_collapse">收起</string>
+    <string name="cd_expand">展开</string>
+    <string name="cd_remove_item">移除 %1$s</string>
+    <string name="cd_edit_action">编辑操作</string>
+    <string name="cd_delete_action">删除操作</string>
+    <string name="cd_add_starter">添加开场白</string>
+    <string name="cd_agent_avatar_tap">智能体头像。点击更换。</string>
+    <string name="cd_agent_avatar_name">%1$s 头像</string>
+    <string name="cd_tool_icon">%1$s 图标</string>
+
+    <!-- Marketplace screen -->
+    <string name="search_agents_hint">搜索智能体…</string>
+    <string name="no_agents_found">未找到智能体</string>
+    <string name="no_agents_available">没有可用的智能体</string>
+    <string name="agents_not_available_title">智能体不可用</string>
+    <string name="agents_not_available_description">你的服务器管理员已为你的账户禁用智能体。</string>
+    <string name="try_different_search">尝试其他搜索关键词</string>
+    <string name="check_back_later">稍后再来看看新的智能体</string>
+    <string name="error_unknown">发生未知错误</string>
+    <string name="unknown_author">未知</string>
+
+    <!-- Detail screen -->
+    <string name="agent_title">智能体</string>
+    <string name="delete_agent">删除智能体</string>
+    <string name="delete_agent_confirm">确定要删除 \"%1$s\" 吗？此操作无法撤销。</string>
+    <string name="delete_this_agent">此智能体</string>
+    <string name="by_author">作者：%1$s</string>
+    <string name="label_description">描述</string>
+    <string name="no_description">无描述</string>
+    <string name="label_category">类别</string>
+    <string name="label_model">模型</string>
+    <string name="default_value">默认</string>
+    <string name="label_tools">工具</string>
+    <string name="label_conversation_starters">对话开场白</string>
+
+    <!-- Editor screen -->
+    <string name="edit_agent">编辑智能体</string>
+    <string name="create_agent">创建智能体</string>
+    <string name="duplicate_agent">复制智能体</string>
+    <string name="delete_agent_editor_confirm">确定要删除此智能体吗？此操作无法撤销。</string>
+    <string name="duplicate_agent_confirm">创建此智能体的副本？</string>
+    <string name="version_history">版本历史</string>
+    <string name="tap_to_change_avatar">点击更换头像</string>
+    <string name="remove_avatar">移除头像</string>
+    <string name="agent_name_label">名称 *</string>
+    <string name="agent_name_placeholder">可选：智能体的名称</string>
+    <string name="agent_description_label">描述</string>
+    <string name="agent_description_placeholder">可选：在此描述你的智能体</string>
+    <string name="agent_instructions_label">指令</string>
+    <string name="agent_instructions_placeholder">智能体使用的系统指令</string>
+    <string name="insert_variable">插入变量</string>
+    <string name="cd_insert_variable">插入变量</string>
+    <string name="special_var_current_date">当前日期</string>
+    <string name="special_var_current_user">当前用户</string>
+    <string name="special_var_iso_datetime">ISO 日期时间</string>
+    <string name="special_var_current_datetime">当前日期时间</string>
+    <string name="label_capabilities">能力</string>
+    <string name="label_tools_and_actions">工具与操作</string>
+    <string name="add_tools">添加工具</string>
+    <string name="add_starter_hint">添加开场白…</string>
+    <string name="save_changes">保存更改</string>
+
+    <!-- Actions panel -->
+    <string name="openapi_actions_count">OpenAPI 操作（%1$d）</string>
+    <string name="no_actions_configured">未配置操作。添加一个 OpenAPI 操作以连接外部 API。</string>
+    <string name="add_action">添加操作</string>
+    <string name="edit_action">编辑操作</string>
+    <string name="auth_api_key">API 密钥</string>
+    <string name="auth_oauth">OAuth</string>
+    <string name="auth_none">无</string>
+    <string name="action_auth_info">身份验证：%1$s | %2$d 个函数</string>
+    <string name="label_action">操作</string>
+
+    <!-- Action editor dialog -->
+    <string name="label_authentication">身份验证</string>
+    <string name="auth_api_key_full">API 密钥身份验证</string>
+    <string name="auth_oauth_full">OAuth 身份验证</string>
+    <string name="auth_no_auth">无身份验证</string>
+    <string name="label_openapi_schema">OpenAPI Schema</string>
+    <string name="openapi_schema_hint">以 JSON 或 YAML 格式粘贴你的 OpenAPI 规范。</string>
+    <string name="label_openapi_spec">OpenAPI 规范（JSON 或 YAML）</string>
+    <string name="validating">验证中…</string>
+    <string name="domain_prefix">域名：%1$s</string>
+    <string name="available_actions_count">可用操作（%1$d）</string>
+    <string name="label_privacy_policy_url">隐私政策 URL</string>
+    <string name="label_save_or_create">%1$s</string>
+
+    <!-- Auth config dialog -->
+    <string name="label_authentication_type">身份验证类型</string>
+    <string name="label_api_key_settings">API 密钥设置</string>
+    <string name="label_api_key">API 密钥</string>
+    <string name="label_authorization_type">授权类型</string>
+    <string name="auth_basic">Basic</string>
+    <string name="auth_bearer">Bearer</string>
+    <string name="auth_custom">自定义</string>
+    <string name="label_custom_auth_header">自定义认证请求头</string>
+    <string name="label_oauth_settings">OAuth 设置</string>
+    <string name="label_client_id">Client ID</string>
+    <string name="label_client_secret">Client Secret</string>
+    <string name="label_authorization_url">授权 URL</string>
+    <string name="label_token_url">Token URL</string>
+    <string name="label_scope">作用域</string>
+    <string name="label_token_exchange_method">Token 交换方式</string>
+    <string name="token_default_post">默认（POST）</string>
+    <string name="token_basic_auth_header">Basic 认证请求头</string>
+
+    <!-- Function table -->
+    <string name="table_name">名称</string>
+    <string name="table_method">方法</string>
+    <string name="table_path">路径</string>
+
+    <!-- Advanced panel -->
+    <string name="advanced_settings">模型设置</string>
+    <string name="label_temperature">温度</string>
+    <string name="temperature_description">控制随机性。越低越聚焦。</string>
+    <string name="label_top_p">Top P</string>
+    <string name="top_p_description">核采样截断值。</string>
+    <string name="label_max_tokens">最大 Token 数</string>
+    <string name="max_tokens_description">回复中的最大 token 数。留空则使用默认值。</string>
+
+    <!-- Avatar picker -->
+    <!-- (content descriptions above) -->
+
+    <!-- Capabilities section -->
+    <string name="label_artifacts">Artifacts</string>
+    <string name="artifacts_description">启用 artifact 生成</string>
+    <string name="artifacts_mode_off">关闭</string>
+    <string name="artifacts_mode_default">默认</string>
+    <string name="artifacts_mode_shadcnui">shadcn/ui</string>
+    <string name="artifacts_mode_custom">自定义</string>
+    <string name="label_end_after_tools">工具执行后结束</string>
+    <string name="end_after_tools_description">在工具执行完成后停止</string>
+    <string name="label_hide_sequential_outputs">隐藏顺序输出</string>
+    <string name="hide_sequential_description">隐藏中间的工具输出</string>
+    <string name="label_recursion_limit">递归上限</string>
+    <string name="recursion_limit_description">递归工具调用的最大次数</string>
+
+    <!-- Category selector -->
+    <string name="general">通用</string>
+
+    <!-- Code Interpreter section -->
+    <string name="label_code_interpreter">代码解释器</string>
+    <string name="code_interpreter_description">允许智能体编写并执行代码以解决问题</string>
+
+    <!-- Web Search section -->
+    <string name="label_web_search">网络搜索</string>
+    <string name="web_search_description">允许智能体在网络上搜索最新信息</string>
+
+    <!-- Tool auth dialog -->
+    <string name="tool_auth_revoke">吊销</string>
+    <string name="tool_auth_code_title">代码解释器 API 密钥</string>
+    <string name="tool_auth_code_description">输入服务器应使用的 API 密钥，以代你运行代码。该密钥存储在你的账户中，而非智能体中。</string>
+    <string name="tool_auth_code_field">LibreChat Code API 密钥</string>
+    <string name="tool_auth_required">启用此工具需要进行身份验证</string>
+
+    <!-- File Context section -->
+    <string name="label_file_context">文件上下文</string>
+    <string name="file_context_description">附加始终作为对话上下文的文件</string>
+
+    <!-- File Search section -->
+    <string name="label_file_search">文件搜索</string>
+    <string name="file_search_description">让智能体能够在已上传的文件和文档中搜索</string>
+
+    <!-- Handoff config -->
+    <!-- Chain (sequential multi-agent) -->
+    <string name="chain_agents_count">链式智能体（%1$d）</string>
+    <string name="chain_description">在此智能体之后依次运行的智能体。上限为 %1$d。</string>
+    <string name="no_chain_agents">未配置链式智能体。</string>
+    <string name="add_chain_agent">添加链式智能体</string>
+    <string name="chain_full">已达到链式智能体的最大数量。</string>
+    <!-- Handoffs (graph edges) -->
+    <string name="handoff_edges_count">交接边（%1$d）</string>
+    <string name="handoff_edges_description">用于动态多智能体交接的图路由边。</string>
+    <string name="no_handoff_edges">未配置交接边。</string>
+    <string name="add_handoff_edge">添加交接边</string>
+    <string name="handoff_edge_from">从</string>
+    <string name="handoff_edge_to">到</string>
+    <string name="handoff_edge_description">描述（可选）</string>
+    <string name="handoff_edge_prompt">转交提示词（可选）</string>
+    <string name="handoff_edge_prompt_key">提示词参数名（可选）</string>
+    <string name="handoff_edge_exclude_results">排除先前的消息</string>
+    <string name="handoff_edge_arrow">%1$s → %2$s</string>
+    <string name="handoff_edge_multi">%1$d 个智能体 → %2$d 个智能体</string>
+    <string name="no_more_agents">没有更多可添加的智能体。</string>
+    <string name="select_agent">选择智能体</string>
+
+    <!-- MCP Tools selector -->
+    <string name="mcp_tools_count">MCP 工具（已选 %1$d 个）</string>
+    <string name="no_mcp_tools">没有可用的 MCP 工具。请在设置中配置 MCP 服务器。</string>
+    <string name="unknown_server">未知服务器</string>
+
+    <!-- Model picker -->
+    <string name="model_required_label">模型 *</string>
+    <string name="select_model_hint">选择一个模型…</string>
+    <string name="no_models_found">未找到模型</string>
+
+    <!-- Sharing section -->
+    <string name="sharing_and_permissions">分享与权限</string>
+    <string name="label_visibility">可见性</string>
+    <string name="label_collaborative">协作</string>
+    <string name="collaborative_description">允许其他用户修改此智能体</string>
+    <string name="collaborative_managed_server_side">在此版本中，访问权限由服务器端管理。</string>
+
+    <!-- Visibility labels -->
+    <string name="visibility_private">私有</string>
+    <string name="visibility_team">团队</string>
+    <string name="visibility_public">公开</string>
+
+    <!-- Support contact section -->
+    <string name="label_support_contact">支持联系人</string>
+    <string name="label_name">名称</string>
+    <string name="support_contact_placeholder">支持联系人姓名</string>
+    <string name="label_email">电子邮箱</string>
+
+    <!-- Version history -->
+    <string name="no_version_history">没有可用的版本历史</string>
+    <string name="version_number">版本 %1$d</string>
+    <string name="version_current">当前</string>
+    <string name="version_no_date">无可用日期</string>
+    <string name="version_unknown_date">日期未知</string>
+    <string name="version_snapshot_name">名称</string>
+    <string name="version_snapshot_description">描述</string>
+    <string name="version_snapshot_instructions">指令</string>
+    <string name="version_snapshot_artifacts">Artifacts</string>
+    <string name="version_snapshot_capabilities">能力</string>
+    <string name="version_snapshot_tools">工具</string>
+    <string name="version_snapshot_empty">—</string>
+    <string name="version_restore_confirm">将此智能体还原到所选版本？当前未保存的更改将丢失。</string>
+
+    <!-- ACL sharing (v0.8.5+) -->
+    <string name="acl_sharing_title">分享与访问</string>
+    <string name="acl_add_principal">添加用户或群组</string>
+    <string name="acl_no_grants">尚未授予任何人访问权限。</string>
+    <string name="acl_public_label">公开</string>
+    <string name="acl_public_description">允许任何能访问服务器的人</string>
+    <string name="acl_role">角色</string>
+    <string name="acl_revoke">吊销</string>
+    <string name="acl_search_hint">搜索用户或群组…</string>
+    <string name="acl_search_empty">无匹配项</string>
+    <string name="acl_grant_button">授予</string>
+    <string name="acl_grant_dialog_title">添加用户或群组</string>
+    <string name="acl_principal_user">用户</string>
+    <string name="acl_principal_group">群组</string>
+    <string name="acl_principal_role">角色</string>
+    <string name="acl_create_mode_notice">分享与访问控制在智能体保存后可用。</string>
+
+    <!-- Tool select dialog -->
+    <string name="agent_tools_title">智能体工具</string>
+    <string name="select_tools_description">为你的智能体选择要使用的工具</string>
+    <string name="search_tools_hint">搜索工具…</string>
+    <string name="no_tools_matching">没有与 \"%1$s\" 匹配的工具</string>
+    <string name="no_tools_available">没有可用的工具</string>
+
+    <!-- Per-capability file attachments -->
+    <string name="add_file">添加文件</string>
+    <string name="agent_files_save_first">附加文件前请先保存智能体</string>
+    <string name="agent_file_too_large">文件大小必须为 %1$d MB 或更小</string>
+    <string name="agent_file_upload_failed">文件上传失败</string>
+    <string name="agent_file_remove_failed">移除文件失败</string>
+    <string name="cd_remove_file">移除 %1$s</string>
+
+    <!-- Skills selector (v0.8.6) -->
+    <string name="label_skills">技能</string>
+    <string name="skills_disabled_hint">此智能体的技能已关闭。</string>
+    <string name="skills_enabled_all_hint">你能访问的所有技能都对此智能体可用。</string>
+    <string name="skills_enabled_allowlist_hint">仅所选技能对此智能体可用。</string>
+    <string name="add_skills">添加技能</string>
+    <string name="select_skills">选择技能</string>
+    <string name="search_skills_hint">搜索技能…</string>
+    <string name="no_skills_matching">没有与 \"%1$s\" 匹配的技能</string>
+    <string name="no_skills_available">没有可用的技能</string>
+    <string name="skills_done">完成</string>
+
+    <!-- Subagents config (v0.8.6) -->
+    <string name="label_subagents">子智能体</string>
+    <string name="subagents_description">让此智能体在隔离的上下文中将工作委派给其他智能体。</string>
+    <string name="subagents_allow_self">允许生成自身</string>
+    <string name="add_subagent">添加子智能体</string>
+    <string name="subagents_full">已达到子智能体的最大数量。</string>
+</resources>

--- a/feature/auth/src/commonMain/composeResources/values-ar/strings.xml
+++ b/feature/auth/src/commonMain/composeResources/values-ar/strings.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Server URL -->
+    <string name="server_url_label">رابط الخادم</string>
+    <string name="server_url_placeholder">https://your-server.com</string>
+    <string name="server_url_connect">اتصال</string>
+    <string name="connect_to_librechat">الاتصال بـ LibreChat</string>
+    <string name="enter_server_url_hint">أدخل رابط خادمك للبدء</string>
+    <string name="insecure_connection_title">اتصال غير آمن</string>
+    <string name="insecure_connection_message">أنت تتصل عبر HTTP. سيتم إرسال بيانات تسجيل الدخول والرسائل الخاصة بك دون تشفير وقد يعترضها آخرون على الشبكة.\n\nاستخدم HTTP فقط لخوادم التطوير المحلية.</string>
+    <string name="connect_anyway">الاتصال على أي حال</string>
+    <string name="cancel">إلغاء</string>
+
+    <!-- Login -->
+    <string name="login_title">تسجيل الدخول</string>
+    <string name="email_label">البريد الإلكتروني</string>
+    <string name="password_label">كلمة المرور</string>
+    <string name="continue_button">متابعة</string>
+    <string name="forgot_password">هل نسيت كلمة المرور؟</string>
+    <string name="no_account_sign_up">ليس لديك حساب؟ سجّل الآن</string>
+    <string name="or_continue_with">أو تابع باستخدام</string>
+
+    <!-- OAuth provider labels -->
+    <string name="oauth_google">المتابعة باستخدام Google</string>
+    <string name="oauth_github">المتابعة باستخدام GitHub</string>
+    <string name="oauth_discord">المتابعة باستخدام Discord</string>
+    <string name="oauth_facebook">المتابعة باستخدام Facebook</string>
+    <string name="oauth_apple">المتابعة باستخدام Apple</string>
+    <string name="oauth_openid">المتابعة باستخدام OpenID</string>
+    <string name="oauth_generic">المتابعة باستخدام %1$s</string>
+
+    <!-- Register -->
+    <string name="register_title">إنشاء حساب</string>
+    <string name="full_name_label">الاسم الكامل</string>
+    <string name="username_label">اسم المستخدم</string>
+    <string name="confirm_password_label">تأكيد كلمة المرور</string>
+    <string name="sign_up">سجّل الآن</string>
+    <string name="have_account_sign_in">لديك حساب بالفعل؟ سجّل الدخول</string>
+
+    <!-- Forgot Password -->
+    <string name="reset_password_title">إعادة تعيين كلمة المرور</string>
+    <string name="forgot_your_password">هل نسيت كلمة المرور؟</string>
+    <string name="enter_email_for_reset">أدخل بريدك الإلكتروني لتلقّي رابط إعادة التعيين</string>
+    <string name="send_reset_link">إرسال رابط إعادة التعيين</string>
+    <string name="check_your_email">تحقّق من بريدك الإلكتروني</string>
+    <string name="reset_link_sent">لقد أرسلنا رابط إعادة تعيين كلمة المرور إلى %1$s</string>
+    <string name="back_to_sign_in">العودة إلى تسجيل الدخول</string>
+
+    <!-- Reset Password -->
+    <string name="reset_password_screen_title">إعادة تعيين كلمة المرور</string>
+    <string name="password_reset_successful">تمت إعادة تعيين كلمة المرور بنجاح</string>
+    <string name="password_reset_message">تم تحديث كلمة المرور الخاصة بك. يمكنك الآن تسجيل الدخول بكلمة المرور الجديدة.</string>
+    <string name="set_new_password">تعيين كلمة مرور جديدة</string>
+    <string name="enter_new_password_hint">أدخل كلمة المرور الجديدة أدناه</string>
+    <string name="new_password_label">كلمة المرور الجديدة</string>
+    <string name="confirm_new_password_label">تأكيد كلمة المرور الجديدة</string>
+    <string name="reset_password_button">إعادة تعيين كلمة المرور</string>
+
+    <!-- Two-Factor -->
+    <string name="two_factor_title">المصادقة الثنائية</string>
+    <string name="enter_verification_code">أدخل رمز التحقق</string>
+    <string name="enter_backup_code">أدخل رمز النسخ الاحتياطي</string>
+    <string name="authenticator_prompt">أدخل الرمز المكوّن من 6 أرقام من تطبيق المصادقة الخاص بك</string>
+    <string name="backup_code_prompt">أدخل أحد رموز النسخ الاحتياطي الخاصة بك</string>
+    <string name="verify">تحقّق</string>
+    <string name="use_authenticator_code">استخدام رمز المصادقة</string>
+    <string name="use_backup_code">استخدام رمز النسخ الاحتياطي</string>
+    <string name="backup_code_label">رمز النسخ الاحتياطي</string>
+
+    <!-- Verify Email -->
+    <string name="verify_email_title">التحقق من البريد الإلكتروني</string>
+    <string name="verification_link_sent">لقد أرسلنا رابط تحقق إلى</string>
+    <string name="click_link_to_verify">انقر على الرابط الموجود في البريد الإلكتروني للتحقق من حسابك.</string>
+    <string name="verification_email_sent">تم إرسال بريد التحقق!</string>
+    <string name="resend_verification_email">إعادة إرسال بريد التحقق</string>
+    <string name="resend_in_seconds">إعادة الإرسال خلال %1$d ثانية</string>
+
+    <!-- Terms -->
+    <string name="terms_title">شروط الخدمة</string>
+    <string name="i_accept">أوافق</string>
+    <string name="retry">إعادة المحاولة</string>
+
+    <!-- Common -->
+    <string name="back">رجوع</string>
+</resources>

--- a/feature/auth/src/commonMain/composeResources/values-de/strings.xml
+++ b/feature/auth/src/commonMain/composeResources/values-de/strings.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Server URL -->
+    <string name="server_url_label">Server-URL</string>
+    <string name="server_url_placeholder">https://dein-server.com</string>
+    <string name="server_url_connect">Verbinden</string>
+    <string name="connect_to_librechat">Mit LibreChat verbinden</string>
+    <string name="enter_server_url_hint">Gib deine Server-URL ein, um zu beginnen</string>
+    <string name="insecure_connection_title">Unsichere Verbindung</string>
+    <string name="insecure_connection_message">Du verbindest dich über HTTP. Deine Anmeldedaten und Nachrichten werden unverschlüsselt gesendet und könnten von anderen im Netzwerk abgefangen werden.\n\nVerwende HTTP nur für lokale Entwicklungsserver.</string>
+    <string name="connect_anyway">Trotzdem verbinden</string>
+    <string name="cancel">Abbrechen</string>
+
+    <!-- Login -->
+    <string name="login_title">Anmelden</string>
+    <string name="email_label">E-Mail</string>
+    <string name="password_label">Passwort</string>
+    <string name="continue_button">Weiter</string>
+    <string name="forgot_password">Passwort vergessen?</string>
+    <string name="no_account_sign_up">Noch kein Konto? Registrieren</string>
+    <string name="or_continue_with">Oder fortfahren mit</string>
+
+    <!-- OAuth provider labels -->
+    <string name="oauth_google">Mit Google fortfahren</string>
+    <string name="oauth_github">Mit GitHub fortfahren</string>
+    <string name="oauth_discord">Mit Discord fortfahren</string>
+    <string name="oauth_facebook">Mit Facebook fortfahren</string>
+    <string name="oauth_apple">Mit Apple fortfahren</string>
+    <string name="oauth_openid">Mit OpenID fortfahren</string>
+    <string name="oauth_generic">Mit %1$s fortfahren</string>
+
+    <!-- Register -->
+    <string name="register_title">Konto erstellen</string>
+    <string name="full_name_label">Vollständiger Name</string>
+    <string name="username_label">Benutzername</string>
+    <string name="confirm_password_label">Passwort bestätigen</string>
+    <string name="sign_up">Registrieren</string>
+    <string name="have_account_sign_in">Bereits ein Konto? Anmelden</string>
+
+    <!-- Forgot Password -->
+    <string name="reset_password_title">Passwort zurücksetzen</string>
+    <string name="forgot_your_password">Passwort vergessen?</string>
+    <string name="enter_email_for_reset">Gib deine E-Mail ein, um einen Zurücksetzungs-Link zu erhalten</string>
+    <string name="send_reset_link">Zurücksetzungs-Link senden</string>
+    <string name="check_your_email">Überprüfe deine E-Mails</string>
+    <string name="reset_link_sent">Wir haben einen Link zum Zurücksetzen des Passworts an %1$s gesendet</string>
+    <string name="back_to_sign_in">Zurück zur Anmeldung</string>
+
+    <!-- Reset Password -->
+    <string name="reset_password_screen_title">Passwort zurücksetzen</string>
+    <string name="password_reset_successful">Passwort erfolgreich zurückgesetzt</string>
+    <string name="password_reset_message">Dein Passwort wurde aktualisiert. Du kannst dich jetzt mit deinem neuen Passwort anmelden.</string>
+    <string name="set_new_password">Neues Passwort festlegen</string>
+    <string name="enter_new_password_hint">Gib unten dein neues Passwort ein</string>
+    <string name="new_password_label">Neues Passwort</string>
+    <string name="confirm_new_password_label">Neues Passwort bestätigen</string>
+    <string name="reset_password_button">Passwort zurücksetzen</string>
+
+    <!-- Two-Factor -->
+    <string name="two_factor_title">Zwei-Faktor-Authentifizierung</string>
+    <string name="enter_verification_code">Bestätigungscode eingeben</string>
+    <string name="enter_backup_code">Backup-Code eingeben</string>
+    <string name="authenticator_prompt">Gib den 6-stelligen Code aus deiner Authenticator-App ein</string>
+    <string name="backup_code_prompt">Gib einen deiner Backup-Codes ein</string>
+    <string name="verify">Überprüfen</string>
+    <string name="use_authenticator_code">Authenticator-Code verwenden</string>
+    <string name="use_backup_code">Backup-Code verwenden</string>
+    <string name="backup_code_label">Backup-Code</string>
+
+    <!-- Verify Email -->
+    <string name="verify_email_title">E-Mail bestätigen</string>
+    <string name="verification_link_sent">Wir haben einen Bestätigungslink gesendet an</string>
+    <string name="click_link_to_verify">Klicke auf den Link in der E-Mail, um dein Konto zu bestätigen.</string>
+    <string name="verification_email_sent">Bestätigungs-E-Mail gesendet!</string>
+    <string name="resend_verification_email">Bestätigungs-E-Mail erneut senden</string>
+    <string name="resend_in_seconds">Erneut senden in %1$ds</string>
+
+    <!-- Terms -->
+    <string name="terms_title">Nutzungsbedingungen</string>
+    <string name="i_accept">Ich akzeptiere</string>
+    <string name="retry">Erneut versuchen</string>
+
+    <!-- Common -->
+    <string name="back">Zurück</string>
+</resources>

--- a/feature/auth/src/commonMain/composeResources/values-es/strings.xml
+++ b/feature/auth/src/commonMain/composeResources/values-es/strings.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Server URL -->
+    <string name="server_url_label">URL del servidor</string>
+    <string name="server_url_placeholder">https://tu-servidor.com</string>
+    <string name="server_url_connect">Conectar</string>
+    <string name="connect_to_librechat">Conectar a LibreChat</string>
+    <string name="enter_server_url_hint">Introduce la URL de tu servidor para empezar</string>
+    <string name="insecure_connection_title">Conexión no segura</string>
+    <string name="insecure_connection_message">Te estás conectando mediante HTTP. Tus credenciales de inicio de sesión y mensajes se enviarán sin cifrar y podrían ser interceptados por otras personas en la red.\n\nUsa HTTP solo para servidores de desarrollo local.</string>
+    <string name="connect_anyway">Conectar de todos modos</string>
+    <string name="cancel">Cancelar</string>
+
+    <!-- Login -->
+    <string name="login_title">Iniciar sesión</string>
+    <string name="email_label">Correo electrónico</string>
+    <string name="password_label">Contraseña</string>
+    <string name="continue_button">Continuar</string>
+    <string name="forgot_password">¿Olvidaste tu contraseña?</string>
+    <string name="no_account_sign_up">¿No tienes una cuenta? Regístrate</string>
+    <string name="or_continue_with">O continúa con</string>
+
+    <!-- OAuth provider labels -->
+    <string name="oauth_google">Continuar con Google</string>
+    <string name="oauth_github">Continuar con GitHub</string>
+    <string name="oauth_discord">Continuar con Discord</string>
+    <string name="oauth_facebook">Continuar con Facebook</string>
+    <string name="oauth_apple">Continuar con Apple</string>
+    <string name="oauth_openid">Continuar con OpenID</string>
+    <string name="oauth_generic">Continuar con %1$s</string>
+
+    <!-- Register -->
+    <string name="register_title">Crear cuenta</string>
+    <string name="full_name_label">Nombre completo</string>
+    <string name="username_label">Nombre de usuario</string>
+    <string name="confirm_password_label">Confirmar contraseña</string>
+    <string name="sign_up">Regístrate</string>
+    <string name="have_account_sign_in">¿Ya tienes una cuenta? Inicia sesión</string>
+
+    <!-- Forgot Password -->
+    <string name="reset_password_title">Restablecer contraseña</string>
+    <string name="forgot_your_password">¿Olvidaste tu contraseña?</string>
+    <string name="enter_email_for_reset">Introduce tu correo para recibir un enlace de restablecimiento</string>
+    <string name="send_reset_link">Enviar enlace de restablecimiento</string>
+    <string name="check_your_email">Revisa tu correo</string>
+    <string name="reset_link_sent">Hemos enviado un enlace para restablecer la contraseña a %1$s</string>
+    <string name="back_to_sign_in">Volver a iniciar sesión</string>
+
+    <!-- Reset Password -->
+    <string name="reset_password_screen_title">Restablecer contraseña</string>
+    <string name="password_reset_successful">Contraseña restablecida correctamente</string>
+    <string name="password_reset_message">Tu contraseña se ha actualizado. Ahora puedes iniciar sesión con tu nueva contraseña.</string>
+    <string name="set_new_password">Establecer nueva contraseña</string>
+    <string name="enter_new_password_hint">Introduce tu nueva contraseña a continuación</string>
+    <string name="new_password_label">Nueva contraseña</string>
+    <string name="confirm_new_password_label">Confirmar nueva contraseña</string>
+    <string name="reset_password_button">Restablecer contraseña</string>
+
+    <!-- Two-Factor -->
+    <string name="two_factor_title">Autenticación de dos factores</string>
+    <string name="enter_verification_code">Introduce el código de verificación</string>
+    <string name="enter_backup_code">Introduce el código de respaldo</string>
+    <string name="authenticator_prompt">Introduce el código de 6 dígitos de tu app de autenticación</string>
+    <string name="backup_code_prompt">Introduce uno de tus códigos de respaldo</string>
+    <string name="verify">Verificar</string>
+    <string name="use_authenticator_code">Usar código de autenticación</string>
+    <string name="use_backup_code">Usar código de respaldo</string>
+    <string name="backup_code_label">Código de respaldo</string>
+
+    <!-- Verify Email -->
+    <string name="verify_email_title">Verificar correo</string>
+    <string name="verification_link_sent">Hemos enviado un enlace de verificación a</string>
+    <string name="click_link_to_verify">Haz clic en el enlace del correo para verificar tu cuenta.</string>
+    <string name="verification_email_sent">¡Correo de verificación enviado!</string>
+    <string name="resend_verification_email">Reenviar correo de verificación</string>
+    <string name="resend_in_seconds">Reenviar en %1$ds</string>
+
+    <!-- Terms -->
+    <string name="terms_title">Términos del servicio</string>
+    <string name="i_accept">Acepto</string>
+    <string name="retry">Reintentar</string>
+
+    <!-- Common -->
+    <string name="back">Atrás</string>
+</resources>

--- a/feature/auth/src/commonMain/composeResources/values-fr/strings.xml
+++ b/feature/auth/src/commonMain/composeResources/values-fr/strings.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Server URL -->
+    <string name="server_url_label">URL du serveur</string>
+    <string name="server_url_placeholder">https://votre-serveur.com</string>
+    <string name="server_url_connect">Se connecter</string>
+    <string name="connect_to_librechat">Se connecter à LibreChat</string>
+    <string name="enter_server_url_hint">Saisissez l\'URL de votre serveur pour commencer</string>
+    <string name="insecure_connection_title">Connexion non sécurisée</string>
+    <string name="insecure_connection_message">Vous vous connectez via HTTP. Vos identifiants de connexion et vos messages seront envoyés sans chiffrement et pourraient être interceptés par d\'autres personnes sur le réseau.\n\nN\'utilisez HTTP que pour les serveurs de développement local.</string>
+    <string name="connect_anyway">Se connecter quand même</string>
+    <string name="cancel">Annuler</string>
+
+    <!-- Login -->
+    <string name="login_title">Se connecter</string>
+    <string name="email_label">E-mail</string>
+    <string name="password_label">Mot de passe</string>
+    <string name="continue_button">Continuer</string>
+    <string name="forgot_password">Mot de passe oublié ?</string>
+    <string name="no_account_sign_up">Vous n\'avez pas de compte ? Inscrivez-vous</string>
+    <string name="or_continue_with">Ou continuer avec</string>
+
+    <!-- OAuth provider labels -->
+    <string name="oauth_google">Continuer avec Google</string>
+    <string name="oauth_github">Continuer avec GitHub</string>
+    <string name="oauth_discord">Continuer avec Discord</string>
+    <string name="oauth_facebook">Continuer avec Facebook</string>
+    <string name="oauth_apple">Continuer avec Apple</string>
+    <string name="oauth_openid">Continuer avec OpenID</string>
+    <string name="oauth_generic">Continuer avec %1$s</string>
+
+    <!-- Register -->
+    <string name="register_title">Créer un compte</string>
+    <string name="full_name_label">Nom complet</string>
+    <string name="username_label">Nom d\'utilisateur</string>
+    <string name="confirm_password_label">Confirmer le mot de passe</string>
+    <string name="sign_up">S\'inscrire</string>
+    <string name="have_account_sign_in">Vous avez déjà un compte ? Connectez-vous</string>
+
+    <!-- Forgot Password -->
+    <string name="reset_password_title">Réinitialiser le mot de passe</string>
+    <string name="forgot_your_password">Mot de passe oublié ?</string>
+    <string name="enter_email_for_reset">Saisissez votre e-mail pour recevoir un lien de réinitialisation</string>
+    <string name="send_reset_link">Envoyer le lien de réinitialisation</string>
+    <string name="check_your_email">Consultez votre e-mail</string>
+    <string name="reset_link_sent">Nous avons envoyé un lien de réinitialisation du mot de passe à %1$s</string>
+    <string name="back_to_sign_in">Retour à la connexion</string>
+
+    <!-- Reset Password -->
+    <string name="reset_password_screen_title">Réinitialiser le mot de passe</string>
+    <string name="password_reset_successful">Mot de passe réinitialisé avec succès</string>
+    <string name="password_reset_message">Votre mot de passe a été mis à jour. Vous pouvez désormais vous connecter avec votre nouveau mot de passe.</string>
+    <string name="set_new_password">Définir un nouveau mot de passe</string>
+    <string name="enter_new_password_hint">Saisissez votre nouveau mot de passe ci-dessous</string>
+    <string name="new_password_label">Nouveau mot de passe</string>
+    <string name="confirm_new_password_label">Confirmer le nouveau mot de passe</string>
+    <string name="reset_password_button">Réinitialiser le mot de passe</string>
+
+    <!-- Two-Factor -->
+    <string name="two_factor_title">Authentification à deux facteurs</string>
+    <string name="enter_verification_code">Saisissez le code de vérification</string>
+    <string name="enter_backup_code">Saisissez le code de secours</string>
+    <string name="authenticator_prompt">Saisissez le code à 6 chiffres de votre application d\'authentification</string>
+    <string name="backup_code_prompt">Saisissez l\'un de vos codes de secours</string>
+    <string name="verify">Vérifier</string>
+    <string name="use_authenticator_code">Utiliser le code de l\'application d\'authentification</string>
+    <string name="use_backup_code">Utiliser un code de secours</string>
+    <string name="backup_code_label">Code de secours</string>
+
+    <!-- Verify Email -->
+    <string name="verify_email_title">Vérifier l\'e-mail</string>
+    <string name="verification_link_sent">Nous avons envoyé un lien de vérification à</string>
+    <string name="click_link_to_verify">Cliquez sur le lien dans l\'e-mail pour vérifier votre compte.</string>
+    <string name="verification_email_sent">E-mail de vérification envoyé !</string>
+    <string name="resend_verification_email">Renvoyer l\'e-mail de vérification</string>
+    <string name="resend_in_seconds">Renvoyer dans %1$ds</string>
+
+    <!-- Terms -->
+    <string name="terms_title">Conditions d\'utilisation</string>
+    <string name="i_accept">J\'accepte</string>
+    <string name="retry">Réessayer</string>
+
+    <!-- Common -->
+    <string name="back">Retour</string>
+</resources>

--- a/feature/auth/src/commonMain/composeResources/values-ja/strings.xml
+++ b/feature/auth/src/commonMain/composeResources/values-ja/strings.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Server URL -->
+    <string name="server_url_label">サーバーURL</string>
+    <string name="server_url_placeholder">https://your-server.com</string>
+    <string name="server_url_connect">接続</string>
+    <string name="connect_to_librechat">LibreChatに接続</string>
+    <string name="enter_server_url_hint">開始するにはサーバーURLを入力してください</string>
+    <string name="insecure_connection_title">安全でない接続</string>
+    <string name="insecure_connection_message">HTTPで接続しようとしています。ログイン情報やメッセージは暗号化されずに送信され、ネットワーク上の他者に傍受される可能性があります。\n\nHTTPはローカル開発サーバーにのみ使用してください。</string>
+    <string name="connect_anyway">それでも接続</string>
+    <string name="cancel">キャンセル</string>
+
+    <!-- Login -->
+    <string name="login_title">サインイン</string>
+    <string name="email_label">メールアドレス</string>
+    <string name="password_label">パスワード</string>
+    <string name="continue_button">続行</string>
+    <string name="forgot_password">パスワードをお忘れですか？</string>
+    <string name="no_account_sign_up">アカウントをお持ちでないですか？サインアップ</string>
+    <string name="or_continue_with">または次で続行</string>
+
+    <!-- OAuth provider labels -->
+    <string name="oauth_google">Googleで続行</string>
+    <string name="oauth_github">GitHubで続行</string>
+    <string name="oauth_discord">Discordで続行</string>
+    <string name="oauth_facebook">Facebookで続行</string>
+    <string name="oauth_apple">Appleで続行</string>
+    <string name="oauth_openid">OpenIDで続行</string>
+    <string name="oauth_generic">%1$s で続行</string>
+
+    <!-- Register -->
+    <string name="register_title">アカウントを作成</string>
+    <string name="full_name_label">氏名</string>
+    <string name="username_label">ユーザー名</string>
+    <string name="confirm_password_label">パスワードの確認</string>
+    <string name="sign_up">サインアップ</string>
+    <string name="have_account_sign_in">すでにアカウントをお持ちですか？サインイン</string>
+
+    <!-- Forgot Password -->
+    <string name="reset_password_title">パスワードをリセット</string>
+    <string name="forgot_your_password">パスワードをお忘れですか？</string>
+    <string name="enter_email_for_reset">リセットリンクを受け取るにはメールアドレスを入力してください</string>
+    <string name="send_reset_link">リセットリンクを送信</string>
+    <string name="check_your_email">メールをご確認ください</string>
+    <string name="reset_link_sent">%1$s にパスワードリセットリンクを送信しました</string>
+    <string name="back_to_sign_in">サインインに戻る</string>
+
+    <!-- Reset Password -->
+    <string name="reset_password_screen_title">パスワードをリセット</string>
+    <string name="password_reset_successful">パスワードのリセットに成功しました</string>
+    <string name="password_reset_message">パスワードが更新されました。新しいパスワードでサインインできます。</string>
+    <string name="set_new_password">新しいパスワードを設定</string>
+    <string name="enter_new_password_hint">新しいパスワードを下に入力してください</string>
+    <string name="new_password_label">新しいパスワード</string>
+    <string name="confirm_new_password_label">新しいパスワードの確認</string>
+    <string name="reset_password_button">パスワードをリセット</string>
+
+    <!-- Two-Factor -->
+    <string name="two_factor_title">二要素認証</string>
+    <string name="enter_verification_code">確認コードを入力</string>
+    <string name="enter_backup_code">バックアップコードを入力</string>
+    <string name="authenticator_prompt">認証アプリの6桁のコードを入力してください</string>
+    <string name="backup_code_prompt">バックアップコードのいずれかを入力してください</string>
+    <string name="verify">確認</string>
+    <string name="use_authenticator_code">認証アプリのコードを使用</string>
+    <string name="use_backup_code">バックアップコードを使用</string>
+    <string name="backup_code_label">バックアップコード</string>
+
+    <!-- Verify Email -->
+    <string name="verify_email_title">メールアドレスを確認</string>
+    <string name="verification_link_sent">次のアドレスに確認リンクを送信しました</string>
+    <string name="click_link_to_verify">メール内のリンクをクリックしてアカウントを確認してください。</string>
+    <string name="verification_email_sent">確認メールを送信しました！</string>
+    <string name="resend_verification_email">確認メールを再送信</string>
+    <string name="resend_in_seconds">%1$d 秒後に再送信</string>
+
+    <!-- Terms -->
+    <string name="terms_title">利用規約</string>
+    <string name="i_accept">同意します</string>
+    <string name="retry">再試行</string>
+
+    <!-- Common -->
+    <string name="back">戻る</string>
+</resources>

--- a/feature/auth/src/commonMain/composeResources/values-ko/strings.xml
+++ b/feature/auth/src/commonMain/composeResources/values-ko/strings.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Server URL -->
+    <string name="server_url_label">서버 URL</string>
+    <string name="server_url_placeholder">https://your-server.com</string>
+    <string name="server_url_connect">연결</string>
+    <string name="connect_to_librechat">LibreChat에 연결</string>
+    <string name="enter_server_url_hint">시작하려면 서버 URL을 입력하세요</string>
+    <string name="insecure_connection_title">안전하지 않은 연결</string>
+    <string name="insecure_connection_message">HTTP로 연결하고 있습니다. 로그인 자격 증명과 메시지가 암호화되지 않은 채 전송되어 네트워크상의 다른 사람에게 가로채일 수 있습니다.\n\nHTTP는 로컬 개발 서버에만 사용하세요.</string>
+    <string name="connect_anyway">계속 연결</string>
+    <string name="cancel">취소</string>
+
+    <!-- Login -->
+    <string name="login_title">로그인</string>
+    <string name="email_label">이메일</string>
+    <string name="password_label">비밀번호</string>
+    <string name="continue_button">계속</string>
+    <string name="forgot_password">비밀번호를 잊으셨나요?</string>
+    <string name="no_account_sign_up">계정이 없으신가요? 회원가입</string>
+    <string name="or_continue_with">또는 다음으로 계속</string>
+
+    <!-- OAuth provider labels -->
+    <string name="oauth_google">Google로 계속</string>
+    <string name="oauth_github">GitHub로 계속</string>
+    <string name="oauth_discord">Discord로 계속</string>
+    <string name="oauth_facebook">Facebook으로 계속</string>
+    <string name="oauth_apple">Apple로 계속</string>
+    <string name="oauth_openid">OpenID로 계속</string>
+    <string name="oauth_generic">%1$s(으)로 계속</string>
+
+    <!-- Register -->
+    <string name="register_title">계정 만들기</string>
+    <string name="full_name_label">이름</string>
+    <string name="username_label">사용자 이름</string>
+    <string name="confirm_password_label">비밀번호 확인</string>
+    <string name="sign_up">회원가입</string>
+    <string name="have_account_sign_in">이미 계정이 있으신가요? 로그인</string>
+
+    <!-- Forgot Password -->
+    <string name="reset_password_title">비밀번호 재설정</string>
+    <string name="forgot_your_password">비밀번호를 잊으셨나요?</string>
+    <string name="enter_email_for_reset">재설정 링크를 받으려면 이메일을 입력하세요</string>
+    <string name="send_reset_link">재설정 링크 보내기</string>
+    <string name="check_your_email">이메일을 확인하세요</string>
+    <string name="reset_link_sent">%1$s(으)로 비밀번호 재설정 링크를 보냈습니다</string>
+    <string name="back_to_sign_in">로그인으로 돌아가기</string>
+
+    <!-- Reset Password -->
+    <string name="reset_password_screen_title">비밀번호 재설정</string>
+    <string name="password_reset_successful">비밀번호 재설정 완료</string>
+    <string name="password_reset_message">비밀번호가 업데이트되었습니다. 이제 새 비밀번호로 로그인할 수 있습니다.</string>
+    <string name="set_new_password">새 비밀번호 설정</string>
+    <string name="enter_new_password_hint">아래에 새 비밀번호를 입력하세요</string>
+    <string name="new_password_label">새 비밀번호</string>
+    <string name="confirm_new_password_label">새 비밀번호 확인</string>
+    <string name="reset_password_button">비밀번호 재설정</string>
+
+    <!-- Two-Factor -->
+    <string name="two_factor_title">2단계 인증</string>
+    <string name="enter_verification_code">인증 코드 입력</string>
+    <string name="enter_backup_code">백업 코드 입력</string>
+    <string name="authenticator_prompt">인증 앱의 6자리 코드를 입력하세요</string>
+    <string name="backup_code_prompt">백업 코드 중 하나를 입력하세요</string>
+    <string name="verify">확인</string>
+    <string name="use_authenticator_code">인증 앱 코드 사용</string>
+    <string name="use_backup_code">백업 코드 사용</string>
+    <string name="backup_code_label">백업 코드</string>
+
+    <!-- Verify Email -->
+    <string name="verify_email_title">이메일 인증</string>
+    <string name="verification_link_sent">인증 링크를 다음 주소로 보냈습니다</string>
+    <string name="click_link_to_verify">계정을 인증하려면 이메일의 링크를 클릭하세요.</string>
+    <string name="verification_email_sent">인증 이메일을 보냈습니다!</string>
+    <string name="resend_verification_email">인증 이메일 다시 보내기</string>
+    <string name="resend_in_seconds">%1$d초 후 다시 보내기</string>
+
+    <!-- Terms -->
+    <string name="terms_title">서비스 약관</string>
+    <string name="i_accept">동의합니다</string>
+    <string name="retry">다시 시도</string>
+
+    <!-- Common -->
+    <string name="back">뒤로</string>
+</resources>

--- a/feature/auth/src/commonMain/composeResources/values-pt/strings.xml
+++ b/feature/auth/src/commonMain/composeResources/values-pt/strings.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Server URL -->
+    <string name="server_url_label">URL do servidor</string>
+    <string name="server_url_placeholder">https://seu-servidor.com</string>
+    <string name="server_url_connect">Conectar</string>
+    <string name="connect_to_librechat">Conectar ao LibreChat</string>
+    <string name="enter_server_url_hint">Digite a URL do seu servidor para começar</string>
+    <string name="insecure_connection_title">Conexão insegura</string>
+    <string name="insecure_connection_message">Você está se conectando por HTTP. Suas credenciais de login e mensagens serão enviadas sem criptografia e poderão ser interceptadas por outras pessoas na rede.\n\nUse HTTP apenas para servidores de desenvolvimento local.</string>
+    <string name="connect_anyway">Conectar mesmo assim</string>
+    <string name="cancel">Cancelar</string>
+
+    <!-- Login -->
+    <string name="login_title">Entrar</string>
+    <string name="email_label">E-mail</string>
+    <string name="password_label">Senha</string>
+    <string name="continue_button">Continuar</string>
+    <string name="forgot_password">Esqueceu a senha?</string>
+    <string name="no_account_sign_up">Não tem uma conta? Cadastre-se</string>
+    <string name="or_continue_with">Ou continue com</string>
+
+    <!-- OAuth provider labels -->
+    <string name="oauth_google">Continuar com Google</string>
+    <string name="oauth_github">Continuar com GitHub</string>
+    <string name="oauth_discord">Continuar com Discord</string>
+    <string name="oauth_facebook">Continuar com Facebook</string>
+    <string name="oauth_apple">Continuar com Apple</string>
+    <string name="oauth_openid">Continuar com OpenID</string>
+    <string name="oauth_generic">Continuar com %1$s</string>
+
+    <!-- Register -->
+    <string name="register_title">Criar conta</string>
+    <string name="full_name_label">Nome completo</string>
+    <string name="username_label">Nome de usuário</string>
+    <string name="confirm_password_label">Confirmar senha</string>
+    <string name="sign_up">Cadastrar-se</string>
+    <string name="have_account_sign_in">Já tem uma conta? Entre</string>
+
+    <!-- Forgot Password -->
+    <string name="reset_password_title">Redefinir senha</string>
+    <string name="forgot_your_password">Esqueceu sua senha?</string>
+    <string name="enter_email_for_reset">Digite seu e-mail para receber um link de redefinição</string>
+    <string name="send_reset_link">Enviar link de redefinição</string>
+    <string name="check_your_email">Verifique seu e-mail</string>
+    <string name="reset_link_sent">Enviamos um link de redefinição de senha para %1$s</string>
+    <string name="back_to_sign_in">Voltar para entrar</string>
+
+    <!-- Reset Password -->
+    <string name="reset_password_screen_title">Redefinir senha</string>
+    <string name="password_reset_successful">Senha redefinida com sucesso</string>
+    <string name="password_reset_message">Sua senha foi atualizada. Agora você pode entrar com sua nova senha.</string>
+    <string name="set_new_password">Definir nova senha</string>
+    <string name="enter_new_password_hint">Digite sua nova senha abaixo</string>
+    <string name="new_password_label">Nova senha</string>
+    <string name="confirm_new_password_label">Confirmar nova senha</string>
+    <string name="reset_password_button">Redefinir senha</string>
+
+    <!-- Two-Factor -->
+    <string name="two_factor_title">Autenticação de dois fatores</string>
+    <string name="enter_verification_code">Digite o código de verificação</string>
+    <string name="enter_backup_code">Digite o código de backup</string>
+    <string name="authenticator_prompt">Digite o código de 6 dígitos do seu app autenticador</string>
+    <string name="backup_code_prompt">Digite um dos seus códigos de backup</string>
+    <string name="verify">Verificar</string>
+    <string name="use_authenticator_code">Usar código do autenticador</string>
+    <string name="use_backup_code">Usar código de backup</string>
+    <string name="backup_code_label">Código de backup</string>
+
+    <!-- Verify Email -->
+    <string name="verify_email_title">Verificar e-mail</string>
+    <string name="verification_link_sent">Enviamos um link de verificação para</string>
+    <string name="click_link_to_verify">Clique no link do e-mail para verificar sua conta.</string>
+    <string name="verification_email_sent">E-mail de verificação enviado!</string>
+    <string name="resend_verification_email">Reenviar e-mail de verificação</string>
+    <string name="resend_in_seconds">Reenviar em %1$ds</string>
+
+    <!-- Terms -->
+    <string name="terms_title">Termos de Serviço</string>
+    <string name="i_accept">Eu aceito</string>
+    <string name="retry">Tentar novamente</string>
+
+    <!-- Common -->
+    <string name="back">Voltar</string>
+</resources>

--- a/feature/auth/src/commonMain/composeResources/values-ru/strings.xml
+++ b/feature/auth/src/commonMain/composeResources/values-ru/strings.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Server URL -->
+    <string name="server_url_label">URL сервера</string>
+    <string name="server_url_placeholder">https://your-server.com</string>
+    <string name="server_url_connect">Подключиться</string>
+    <string name="connect_to_librechat">Подключиться к LibreChat</string>
+    <string name="enter_server_url_hint">Введите URL вашего сервера, чтобы начать</string>
+    <string name="insecure_connection_title">Незащищённое соединение</string>
+    <string name="insecure_connection_message">Вы подключаетесь по HTTP. Ваши учётные данные и сообщения будут отправлены в незашифрованном виде и могут быть перехвачены другими в сети.\n\nИспользуйте HTTP только для локальных серверов разработки.</string>
+    <string name="connect_anyway">Всё равно подключиться</string>
+    <string name="cancel">Отмена</string>
+
+    <!-- Login -->
+    <string name="login_title">Вход</string>
+    <string name="email_label">Эл. почта</string>
+    <string name="password_label">Пароль</string>
+    <string name="continue_button">Продолжить</string>
+    <string name="forgot_password">Забыли пароль?</string>
+    <string name="no_account_sign_up">Нет аккаунта? Зарегистрироваться</string>
+    <string name="or_continue_with">Или продолжить через</string>
+
+    <!-- OAuth provider labels -->
+    <string name="oauth_google">Продолжить через Google</string>
+    <string name="oauth_github">Продолжить через GitHub</string>
+    <string name="oauth_discord">Продолжить через Discord</string>
+    <string name="oauth_facebook">Продолжить через Facebook</string>
+    <string name="oauth_apple">Продолжить через Apple</string>
+    <string name="oauth_openid">Продолжить через OpenID</string>
+    <string name="oauth_generic">Продолжить через %1$s</string>
+
+    <!-- Register -->
+    <string name="register_title">Создать аккаунт</string>
+    <string name="full_name_label">Полное имя</string>
+    <string name="username_label">Имя пользователя</string>
+    <string name="confirm_password_label">Подтвердите пароль</string>
+    <string name="sign_up">Зарегистрироваться</string>
+    <string name="have_account_sign_in">Уже есть аккаунт? Войти</string>
+
+    <!-- Forgot Password -->
+    <string name="reset_password_title">Сброс пароля</string>
+    <string name="forgot_your_password">Забыли пароль?</string>
+    <string name="enter_email_for_reset">Введите эл. почту, чтобы получить ссылку для сброса</string>
+    <string name="send_reset_link">Отправить ссылку для сброса</string>
+    <string name="check_your_email">Проверьте почту</string>
+    <string name="reset_link_sent">Мы отправили ссылку для сброса пароля на %1$s</string>
+    <string name="back_to_sign_in">Назад к входу</string>
+
+    <!-- Reset Password -->
+    <string name="reset_password_screen_title">Сброс пароля</string>
+    <string name="password_reset_successful">Пароль успешно сброшен</string>
+    <string name="password_reset_message">Ваш пароль обновлён. Теперь вы можете войти с новым паролем.</string>
+    <string name="set_new_password">Задать новый пароль</string>
+    <string name="enter_new_password_hint">Введите новый пароль ниже</string>
+    <string name="new_password_label">Новый пароль</string>
+    <string name="confirm_new_password_label">Подтвердите новый пароль</string>
+    <string name="reset_password_button">Сбросить пароль</string>
+
+    <!-- Two-Factor -->
+    <string name="two_factor_title">Двухфакторная аутентификация</string>
+    <string name="enter_verification_code">Введите код подтверждения</string>
+    <string name="enter_backup_code">Введите резервный код</string>
+    <string name="authenticator_prompt">Введите 6-значный код из приложения-аутентификатора</string>
+    <string name="backup_code_prompt">Введите один из ваших резервных кодов</string>
+    <string name="verify">Проверить</string>
+    <string name="use_authenticator_code">Использовать код аутентификатора</string>
+    <string name="use_backup_code">Использовать резервный код</string>
+    <string name="backup_code_label">Резервный код</string>
+
+    <!-- Verify Email -->
+    <string name="verify_email_title">Подтверждение почты</string>
+    <string name="verification_link_sent">Мы отправили ссылку для подтверждения на</string>
+    <string name="click_link_to_verify">Нажмите ссылку в письме, чтобы подтвердить аккаунт.</string>
+    <string name="verification_email_sent">Письмо с подтверждением отправлено!</string>
+    <string name="resend_verification_email">Отправить письмо повторно</string>
+    <string name="resend_in_seconds">Повтор через %1$d с</string>
+
+    <!-- Terms -->
+    <string name="terms_title">Условия использования</string>
+    <string name="i_accept">Я принимаю</string>
+    <string name="retry">Повторить</string>
+
+    <!-- Common -->
+    <string name="back">Назад</string>
+</resources>

--- a/feature/auth/src/commonMain/composeResources/values-zh/strings.xml
+++ b/feature/auth/src/commonMain/composeResources/values-zh/strings.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Server URL -->
+    <string name="server_url_label">服务器 URL</string>
+    <string name="server_url_placeholder">https://your-server.com</string>
+    <string name="server_url_connect">连接</string>
+    <string name="connect_to_librechat">连接到 LibreChat</string>
+    <string name="enter_server_url_hint">输入你的服务器 URL 以开始</string>
+    <string name="insecure_connection_title">不安全的连接</string>
+    <string name="insecure_connection_message">你正在通过 HTTP 连接。你的登录凭据和消息将以未加密方式发送，可能被网络上的其他人截获。\n\n仅在本地开发服务器上使用 HTTP。</string>
+    <string name="connect_anyway">仍然连接</string>
+    <string name="cancel">取消</string>
+
+    <!-- Login -->
+    <string name="login_title">登录</string>
+    <string name="email_label">电子邮箱</string>
+    <string name="password_label">密码</string>
+    <string name="continue_button">继续</string>
+    <string name="forgot_password">忘记密码？</string>
+    <string name="no_account_sign_up">还没有账户？注册</string>
+    <string name="or_continue_with">或使用以下方式继续</string>
+
+    <!-- OAuth provider labels -->
+    <string name="oauth_google">使用 Google 继续</string>
+    <string name="oauth_github">使用 GitHub 继续</string>
+    <string name="oauth_discord">使用 Discord 继续</string>
+    <string name="oauth_facebook">使用 Facebook 继续</string>
+    <string name="oauth_apple">使用 Apple 继续</string>
+    <string name="oauth_openid">使用 OpenID 继续</string>
+    <string name="oauth_generic">使用 %1$s 继续</string>
+
+    <!-- Register -->
+    <string name="register_title">创建账户</string>
+    <string name="full_name_label">全名</string>
+    <string name="username_label">用户名</string>
+    <string name="confirm_password_label">确认密码</string>
+    <string name="sign_up">注册</string>
+    <string name="have_account_sign_in">已有账户？登录</string>
+
+    <!-- Forgot Password -->
+    <string name="reset_password_title">重置密码</string>
+    <string name="forgot_your_password">忘记密码了？</string>
+    <string name="enter_email_for_reset">输入你的电子邮箱以接收重置链接</string>
+    <string name="send_reset_link">发送重置链接</string>
+    <string name="check_your_email">请查收你的邮箱</string>
+    <string name="reset_link_sent">我们已向 %1$s 发送了密码重置链接</string>
+    <string name="back_to_sign_in">返回登录</string>
+
+    <!-- Reset Password -->
+    <string name="reset_password_screen_title">重置密码</string>
+    <string name="password_reset_successful">密码重置成功</string>
+    <string name="password_reset_message">你的密码已更新。现在可以使用新密码登录了。</string>
+    <string name="set_new_password">设置新密码</string>
+    <string name="enter_new_password_hint">在下方输入你的新密码</string>
+    <string name="new_password_label">新密码</string>
+    <string name="confirm_new_password_label">确认新密码</string>
+    <string name="reset_password_button">重置密码</string>
+
+    <!-- Two-Factor -->
+    <string name="two_factor_title">两步验证</string>
+    <string name="enter_verification_code">输入验证码</string>
+    <string name="enter_backup_code">输入备用码</string>
+    <string name="authenticator_prompt">输入身份验证器应用中的 6 位验证码</string>
+    <string name="backup_code_prompt">输入你的某个备用码</string>
+    <string name="verify">验证</string>
+    <string name="use_authenticator_code">使用身份验证器验证码</string>
+    <string name="use_backup_code">使用备用码</string>
+    <string name="backup_code_label">备用码</string>
+
+    <!-- Verify Email -->
+    <string name="verify_email_title">验证电子邮箱</string>
+    <string name="verification_link_sent">我们已发送验证链接至</string>
+    <string name="click_link_to_verify">点击邮件中的链接以验证你的账户。</string>
+    <string name="verification_email_sent">验证邮件已发送！</string>
+    <string name="resend_verification_email">重新发送验证邮件</string>
+    <string name="resend_in_seconds">%1$d 秒后可重新发送</string>
+
+    <!-- Terms -->
+    <string name="terms_title">服务条款</string>
+    <string name="i_accept">我接受</string>
+    <string name="retry">重试</string>
+
+    <!-- Common -->
+    <string name="back">返回</string>
+</resources>

--- a/feature/chat/src/commonMain/composeResources/values-ar/strings.xml
+++ b/feature/chat/src/commonMain/composeResources/values-ar/strings.xml
@@ -1,0 +1,369 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Common actions -->
+    <string name="cancel">إلغاء</string>
+    <string name="save">حفظ</string>
+    <string name="delete">حذف</string>
+    <string name="copy">نسخ</string>
+    <string name="edit">تعديل</string>
+    <string name="regenerate">إعادة إنشاء</string>
+    <string name="action_rename">إعادة تسمية</string>
+    <string name="action_submit">إرسال</string>
+    <string name="action_insert">إدراج</string>
+    <string name="action_open">فتح</string>
+    <string name="action_close">إغلاق</string>
+    <string name="action_share">مشاركة</string>
+    <string name="action_search">بحث</string>
+    <string name="action_archive">أرشفة</string>
+    <string name="action_duplicate">تكرار</string>
+    <string name="action_copy_link">نسخ الرابط</string>
+
+    <!-- Chat screen -->
+    <string name="new_chat">محادثة جديدة</string>
+    <string name="send_message">إرسال</string>
+    <string name="stop_generating">إيقاف</string>
+    <string name="message_hint">اكتب رسالة…</string>
+    <string name="model_parameters">معاملات النموذج</string>
+    <string name="load_preset">تحميل إعداد مسبق</string>
+    <string name="save_as_preset">الحفظ كإعداد مسبق</string>
+    <string name="search_models">البحث في النماذج…</string>
+    <string name="save_and_submit">حفظ وإرسال</string>
+    <string name="preset_name_label">اسم الإعداد المسبق</string>
+    <string name="code">الكود</string>
+    <string name="preview">معاينة</string>
+    <string name="select_model">اختيار النموذج</string>
+    <string name="select_a_model">اختر نموذجًا</string>
+    <string name="starred_group">المميزة بنجمة</string>
+    <!-- Neutral label for the active agent when its name hasn't resolved yet (never a model string). -->
+    <string name="chat_agent_fallback_label">وكيل</string>
+    <string name="compare_models">مقارنة النماذج</string>
+    <string name="how_can_i_help">كيف يمكنني مساعدتك اليوم؟</string>
+    <string name="recording">جارٍ التسجيل…</string>
+    <string name="hint_message_model">رسالة إلى %1$s</string>
+    <string name="hint_message">رسالة…</string>
+
+    <!-- Content descriptions - Chat -->
+    <string name="cd_open_tools_menu">فتح قائمة الأدوات</string>
+    <string name="cd_paste_image">لصق صورة من الحافظة</string>
+    <string name="cd_message_input">حقل إدخال الرسالة</string>
+    <string name="cd_stop_voice_recording">إيقاف التسجيل الصوتي</string>
+    <string name="cd_start_voice_recording">بدء التسجيل الصوتي</string>
+    <string name="cd_stop_generation">إيقاف الإنشاء</string>
+    <string name="cd_send_message">إرسال الرسالة</string>
+    <string name="cd_open_drawer">فتح درج التنقل</string>
+    <string name="cd_more_options">خيارات إضافية</string>
+    <string name="cd_more_tools">أدوات إضافية</string>
+    <string name="cd_scroll_to_bottom">التمرير إلى الأسفل</string>
+    <string name="cd_select_model">اختيار النموذج</string>
+    <string name="cd_librechat">LibreChat</string>
+    <string name="cd_comparison_enabled">المقارنة مُفعّلة</string>
+
+    <!-- Content descriptions - Messages -->
+    <string name="cd_thumbs_up">إعجاب</string>
+    <string name="cd_thumbs_down">عدم إعجاب</string>
+    <string name="cd_copy_message">نسخ الرسالة</string>
+    <string name="cd_edit_message">تعديل الرسالة</string>
+    <string name="cd_regenerate_response">إعادة إنشاء الرد</string>
+    <string name="cd_stop_reading">إيقاف القراءة</string>
+    <string name="cd_read_aloud">قراءة بصوت عالٍ</string>
+    <string name="cd_fork_conversation">تفريع المحادثة من هنا</string>
+    <string name="cd_previous_response">الرد السابق</string>
+    <string name="cd_next_response">الرد التالي</string>
+    <string name="cd_generating_response">جارٍ إنشاء الرد</string>
+
+    <!-- Content descriptions - Images -->
+    <string name="cd_fullscreen_image">صورة بملء الشاشة</string>
+    <string name="cd_close">إغلاق</string>
+    <string name="cd_save_to_device">الحفظ في الجهاز</string>
+    <string name="cd_share_image">مشاركة الصورة</string>
+    <string name="cd_failed_to_load_image">فشل تحميل الصورة</string>
+    <string name="cd_failed_to_load_generated_image">فشل تحميل الصورة المُنشأة</string>
+    <string name="cd_embedded_image">صورة مضمّنة في الرسالة</string>
+
+    <!-- Content descriptions - Search -->
+    <string name="cd_search_in_conversation">البحث في المحادثة</string>
+    <string name="cd_previous_match">التطابق السابق</string>
+    <string name="cd_next_match">التطابق التالي</string>
+    <string name="cd_close_search">إغلاق البحث</string>
+    <string name="cd_clear_search">مسح البحث</string>
+    <string name="hint_find_in_conversation">البحث في المحادثة…</string>
+
+    <!-- Content descriptions - Code -->
+    <string name="cd_copy_code">نسخ الكود</string>
+    <string name="cd_copied">تم النسخ</string>
+    <string name="action_copy_code">نسخ</string>
+    <string name="action_copied">تم النسخ!</string>
+    <string name="cd_code_execution_result">نتيجة تنفيذ الكود</string>
+    <string name="cd_exit_code_success">رمز الخروج 0 (نجاح)</string>
+    <string name="cd_exit_code_failure">رمز الخروج %1$d (فشل)</string>
+    <string name="exit_code">خروج %1$d</string>
+    <string name="label_code">الكود</string>
+    <string name="label_output">المخرجات:</string>
+    <string name="label_error">خطأ:</string>
+    <string name="label_input">المدخلات:</string>
+    <string name="cd_collapse_code">طي الكود</string>
+    <string name="cd_expand_code">توسيع الكود</string>
+
+    <!-- Content descriptions - Thinking -->
+    <string name="cd_thinking_indicator">مؤشر التفكير</string>
+    <string name="label_thinking">جارٍ التفكير</string>
+    <string name="cd_collapse">طي</string>
+    <string name="cd_expand">توسيع</string>
+    <string name="cd_collapse_thinking">طي كتلة التفكير</string>
+    <string name="cd_expand_thinking">توسيع كتلة التفكير</string>
+
+    <!-- Content descriptions - Summary (context compaction, v0.8.5+) -->
+    <string name="label_summary">ملخص الرسائل السابقة</string>
+    <string name="cd_summary_indicator">مؤشر الملخص</string>
+    <string name="cd_collapse_summary">طي كتلة الملخص</string>
+    <string name="cd_expand_summary">توسيع كتلة الملخص</string>
+
+    <!-- Content descriptions - Subagent trace (subagents, v0.8.6+) -->
+    <string name="label_subagent">وكيل فرعي</string>
+    <string name="cd_collapse_subagent">طي الوكيل الفرعي %1$s</string>
+    <string name="cd_expand_subagent">توسيع الوكيل الفرعي %1$s</string>
+
+    <!-- Office-doc preview attachments (deferred preview, v0.8.6+) -->
+    <string name="office_preview_preparing">جارٍ تحضير معاينة %1$s…</string>
+    <string name="office_preview_failed">تعذّرت معاينة %1$s (%2$s)</string>
+    <string name="office_preview_unavailable">%1$s — المعاينة غير متاحة</string>
+
+    <!-- Content descriptions - Tool calls -->
+    <string name="cd_tool_call">استدعاء أداة</string>
+    <string name="cd_collapse_tool_call">طي استدعاء الأداة %1$s</string>
+    <string name="cd_expand_tool_call">توسيع استدعاء الأداة %1$s</string>
+    <string name="cd_tool_complete">مكتمل</string>
+    <string name="cd_tool_enabled">مُفعّل</string>
+    <string name="video_not_supported">محتوى الفيديو غير مدعوم</string>
+
+    <!-- Tools bottom sheet -->
+    <string name="tool_camera">الكاميرا</string>
+    <string name="tool_photos">الصور</string>
+    <string name="tool_files">الملفات</string>
+    <string name="tool_model">النموذج</string>
+    <string name="tool_model_parameters">معاملات النموذج</string>
+    <string name="tool_model_parameters_desc">ضبط درجة الحرارة والرموز والمزيد</string>
+    <string name="tool_web_search">البحث على الويب</string>
+    <string name="tool_web_search_desc">البحث على الويب عن المعلومات</string>
+    <string name="tool_code">الكود</string>
+    <string name="tool_code_desc">تشغيل الكود وتحليله</string>
+    <string name="tool_file_search">البحث في الملفات</string>
+    <string name="tool_file_search_desc">البحث في الملفات المرفوعة</string>
+    <string name="tool_mcp">MCP</string>
+    <string name="tool_mcp_desc">خوادم بروتوكول سياق النموذج (MCP)</string>
+    <string name="cd_web_search_enabled">البحث على الويب مُفعّل</string>
+    <string name="cd_code_enabled">مفسّر الكود مُفعّل</string>
+    <string name="cd_file_search_enabled">البحث في الملفات مُفعّل</string>
+
+    <!-- Attachments -->
+    <string name="cd_attach_file">إرفاق ملف</string>
+    <string name="toast_file_attach_unavailable">مرفقات الملفات غير متاحة على iOS بعد</string>
+    <string name="files_count">الملفات (%1$d)</string>
+    <string name="cd_attached_file">ملف مرفق: %1$s</string>
+    <string name="cd_preview_file">معاينة %1$s</string>
+    <string name="cd_remove_file">إزالة %1$s</string>
+
+    <!-- Agent handoff -->
+    <string name="cd_agent_handoff">تسليم الوكيل من %1$s إلى %2$s</string>
+    <string name="cd_handed_off_to">تم التسليم إلى</string>
+    <string name="agent_unknown">غير معروف</string>
+    <string name="agent_previous">الوكيل السابق</string>
+    <string name="agent_next">الوكيل التالي</string>
+
+    <!-- Audio/Video -->
+    <string name="cd_pause">إيقاف مؤقت</string>
+    <string name="cd_play">تشغيل</string>
+    <string name="cd_play_video">تشغيل الفيديو</string>
+    <string name="audio_no_data">لا توجد بيانات صوتية</string>
+    <string name="audio_decode_failed">فشل فك ترميز الصوت</string>
+
+    <!-- Citation -->
+    <string name="citation_number">الاستشهاد %1$d</string>
+    <string name="cd_open_citation_url">فتح رابط الاستشهاد</string>
+
+    <!-- Fork options -->
+    <string name="fork_conversation">تفريع المحادثة</string>
+    <string name="fork_visible_messages">الرسائل المرئية</string>
+    <string name="fork_visible_messages_desc">المسار المباشر للرسائل فقط</string>
+    <string name="fork_include_branches">تضمين الفروع</string>
+    <string name="fork_include_branches_desc">المسار المباشر بالإضافة إلى الرسائل الشقيقة</string>
+    <string name="fork_all_to_target">الكل حتى المستوى المستهدف</string>
+    <string name="fork_all_to_target_desc">جميع الرسائل والفروع حتى هذا المستوى</string>
+    <string name="fork_start_new">بدء محادثة جديدة من الهدف</string>
+    <string name="fork_start_new_desc">ابدأ التفريع من الرسالة المحددة بدلًا من الجذر</string>
+
+    <!-- Image viewer toasts -->
+    <string name="toast_failed_to_load_image">فشل تحميل الصورة</string>
+    <string name="toast_failed_to_save_image">فشل حفظ الصورة</string>
+    <string name="toast_image_saved">تم حفظ الصورة في المعرض</string>
+    <string name="toast_failed_to_save_with_error">فشل حفظ الصورة: %1$s</string>
+    <string name="toast_storage_permission_required">إذن التخزين مطلوب لحفظ الصور</string>
+
+    <!-- Image generation -->
+    <string name="generating_image">جارٍ إنشاء الصورة…</string>
+    <string name="image_generated">تم إنشاء الصورة</string>
+    <string name="cd_generated_image">صورة مُنشأة</string>
+
+    <!-- Landing page greetings -->
+    <string name="greeting_late_night">سهرة سعيدة</string>
+    <string name="greeting_weekend_morning">صباح عطلة سعيد</string>
+    <string name="greeting_weekend_afternoon">ظهيرة عطلة سعيدة</string>
+    <string name="greeting_weekend_evening">مساء عطلة سعيد</string>
+    <string name="greeting_early_morning">صباح الخير المبكر</string>
+    <string name="greeting_morning">صباح الخير</string>
+    <string name="greeting_afternoon">طاب يومك</string>
+    <string name="greeting_evening">مساء الخير</string>
+
+    <!-- Log content -->
+    <string name="log_output">مخرجات السجل</string>
+    <string name="cd_collapse_log">طي %1$s</string>
+    <string name="cd_expand_log">توسيع %1$s</string>
+
+    <!-- Table dialog -->
+    <string name="cd_expand_table">توسيع الجدول</string>
+    <string name="dialog_table">جدول</string>
+
+    <!-- MCP -->
+    <string name="cd_select_mcp_servers">اختيار خوادم MCP</string>
+    <string name="cd_mcp_resources">موارد MCP: %1$d عنصر</string>
+    <string name="cd_mcp_resource">مورد MCP: %1$s</string>
+
+    <!-- Memory artifact -->
+    <string name="cd_memory_artifact">عنصر الذاكرة: %1$s</string>
+    <string name="memory_artifact_untitled">بدون عنوان</string>
+    <string name="label_memory">الذاكرة</string>
+
+    <!-- Mermaid diagram -->
+    <string name="label_mermaid">mermaid</string>
+    <string name="cd_show_diagram">إظهار المخطط</string>
+    <string name="cd_view_code">عرض الكود</string>
+    <string name="label_diagram">المخطط</string>
+    <string name="cd_fullscreen">ملء الشاشة</string>
+    <string name="cd_close_fullscreen">إغلاق ملء الشاشة</string>
+
+    <!-- Message bubble -->
+    <string name="sender_you">أنت</string>
+    <string name="sender_assistant">المساعد</string>
+
+    <!-- Message files -->
+    <string name="file_fallback">ملف</string>
+
+    <!-- Model selector sheet -->
+    <string name="cd_selected">محدد</string>
+    <string name="cd_public_agent">وكيل عام</string>
+    <string name="cd_pin_favorite">التثبيت كمفضلة</string>
+    <string name="cd_unpin_favorite">إلغاء تثبيت المفضلة</string>
+    <string name="cd_collapse_section">طي %1$s</string>
+    <string name="cd_expand_section">توسيع %1$s</string>
+    <string name="set_api_key_action">تعيين مفتاح API</string>
+    <string name="cd_set_api_key">إعداد مفتاح API لـ %1$s</string>
+
+    <!-- Preset picker -->
+    <string name="select_preset">اختيار إعداد مسبق</string>
+    <string name="no_presets_saved">لا توجد إعدادات مسبقة محفوظة بعد</string>
+    <string name="cd_edit_preset">تعديل %1$s</string>
+    <string name="cd_delete_preset">حذف %1$s</string>
+    <string name="preset_endpoint">نقطة النهاية: %1$s</string>
+    <string name="preset_model">النموذج: %1$s</string>
+
+    <!-- Feedback dialog -->
+    <string name="dialog_title_feedback">تقديم ملاحظات</string>
+    <string name="feedback_question">ما المشكلة في هذا الرد؟</string>
+    <string name="hint_optional_comment">تعليق اختياري…</string>
+
+    <!-- Streaming tool call -->
+    <string name="tool_call_output">المخرجات:</string>
+
+    <!-- Web search result -->
+    <string name="cd_search_result">نتيجة البحث: %1$s</string>
+
+    <!-- Rename dialog -->
+    <string name="dialog_title_rename">إعادة تسمية المحادثة</string>
+    <string name="hint_title">العنوان</string>
+
+    <!-- Delete dialog -->
+    <string name="dialog_title_delete_conversation">حذف المحادثة</string>
+    <string name="dialog_delete_conversation_message">سيؤدي هذا إلى حذف هذه المحادثة نهائيًا. لا يمكن التراجع عن ذلك.</string>
+
+    <!-- Chat menu options -->
+    <string name="menu_search">بحث</string>
+    <string name="menu_rename">إعادة تسمية</string>
+
+    <!-- Artifacts -->
+    <string name="cd_open_artifact">فتح العنصر التفاعلي</string>
+    <string name="cd_share_artifact">مشاركة العنصر التفاعلي</string>
+    <string name="cd_previous_version">الإصدار السابق</string>
+    <string name="cd_next_version">الإصدار التالي</string>
+    <string name="artifact_version">الإصدار %1$d/%2$d</string>
+    <string name="label_resource">المورد</string>
+
+    <!-- Prompts -->
+    <string name="prompts_library">مكتبة المطالبات</string>
+    <string name="use_in_chat">استخدام في المحادثة</string>
+    <string name="set_production">تعيين كإنتاج</string>
+    <string name="prompt_name_label">الاسم</string>
+    <string name="prompt_description_label">الوصف</string>
+    <string name="prompt_command_label">الأمر</string>
+    <string name="prompt_text_label">نص المطالبة</string>
+    <string name="prompt_content">محتوى المطالبة</string>
+    <string name="cd_share_prompt">مشاركة المطالبة</string>
+    <string name="cd_edit_prompt">تعديل المطالبة</string>
+    <string name="cd_delete_prompt">حذف المطالبة</string>
+    <string name="cd_back">رجوع</string>
+    <string name="cd_version_history">سجل الإصدارات</string>
+    <string name="cd_filter_sort">التصفية والترتيب</string>
+    <string name="cd_create_prompt">إنشاء مطالبة</string>
+    <string name="cd_remove_filter">إزالة التصفية</string>
+    <string name="cd_reset_sort">إعادة تعيين الترتيب</string>
+    <string name="cd_share">مشاركة</string>
+    <string name="prompt_author">بواسطة %1$s</string>
+    <string name="prompt_sort_label">الترتيب: %1$s</string>
+
+    <!-- Prompt versions -->
+    <string name="version_history">سجل الإصدارات</string>
+    <string name="no_versions">لا توجد إصدارات متاحة</string>
+    <string name="label_production">الإنتاج</string>
+    <string name="version_number">الإصدار %1$d</string>
+
+    <!-- Prompt variables -->
+    <string name="label_variables">المتغيرات</string>
+
+    <!-- Prompt filter sheet -->
+    <string name="label_category">الفئة</string>
+    <string name="label_all">الكل</string>
+    <string name="label_sort_by">ترتيب حسب</string>
+
+    <!-- Prompt share dialog -->
+    <string name="dialog_title_share_prompt">مشاركة المطالبة</string>
+    <string name="label_permission">الإذن</string>
+
+    <!-- Variable input dialog -->
+    <string name="dialog_title_fill_variables">تعبئة المتغيرات</string>
+
+    <!-- Temp chat toggle -->
+    <string name="cd_temp_chat">محادثة مؤقتة</string>
+    <string name="label_temp_chat">مؤقتة</string>
+
+    <!-- Comparison mode -->
+    <string name="continue_with_response">المتابعة بهذا الرد</string>
+    <string name="waiting_for_response">في انتظار الرد…</string>
+
+    <!-- Slash command menu -->
+    <string name="slash_command_title">/%1$s</string>
+
+    <!-- Provider Keys chat-time errors. -->
+    <string name="provider_keys_chat_error_no_key">لم يتم العثور على مفتاح. يرجى تقديم مفتاح والمحاولة مرة أخرى.</string>
+    <!-- {0} = endpoint name, {1} = expiredAt (server-locale string, NOT ISO) -->
+    <string name="provider_keys_chat_error_expired">انتهت صلاحية المفتاح المقدّم لـ %1$s في %2$s. يرجى تقديم مفتاح جديد والمحاولة مرة أخرى.</string>
+    <string name="provider_keys_chat_error_invalid">المفتاح المقدّم غير صالح. يرجى تقديم مفتاح صالح والمحاولة مرة أخرى.</string>
+    <!-- Snackbar action label that deep-links to Settings → Provider Keys -->
+    <string name="provider_keys_chat_error_cta">فتح إعدادات المفاتيح</string>
+
+    <!-- Send block reasons (shown in error snackbar when send can't proceed) -->
+    <string name="send_block_select_agent">اختر وكيلًا قبل إرسال رسالتك.</string>
+    <string name="send_block_select_model">اختر نموذجًا قبل إرسال رسالتك.</string>
+    <string name="send_block_agents_unavailable">الوكلاء غير متاحين على هذا الخادم. يرجى اختيار نموذج مختلف.</string>
+    <string name="send_block_agent_not_available">الوكيل المحدد غير متاح على هذا الخادم. يرجى اختيار وكيل مختلف.</string>
+    <string name="send_block_model_not_available">النموذج المحدد غير متاح على هذا الخادم. يرجى اختيار نموذج مختلف.</string>
+    <string name="send_block_model_load_failed">تعذّر تحميل النموذج المحدد بعد. يرجى المحاولة مرة أخرى أو اختيار نموذج مختلف.</string>
+</resources>

--- a/feature/chat/src/commonMain/composeResources/values-de/strings.xml
+++ b/feature/chat/src/commonMain/composeResources/values-de/strings.xml
@@ -1,0 +1,369 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Common actions -->
+    <string name="cancel">Abbrechen</string>
+    <string name="save">Speichern</string>
+    <string name="delete">Löschen</string>
+    <string name="copy">Kopieren</string>
+    <string name="edit">Bearbeiten</string>
+    <string name="regenerate">Neu generieren</string>
+    <string name="action_rename">Umbenennen</string>
+    <string name="action_submit">Senden</string>
+    <string name="action_insert">Einfügen</string>
+    <string name="action_open">Öffnen</string>
+    <string name="action_close">Schließen</string>
+    <string name="action_share">Teilen</string>
+    <string name="action_search">Suchen</string>
+    <string name="action_archive">Archivieren</string>
+    <string name="action_duplicate">Duplizieren</string>
+    <string name="action_copy_link">Link kopieren</string>
+
+    <!-- Chat screen -->
+    <string name="new_chat">Neuer Chat</string>
+    <string name="send_message">Senden</string>
+    <string name="stop_generating">Stopp</string>
+    <string name="message_hint">Nachricht eingeben…</string>
+    <string name="model_parameters">Modellparameter</string>
+    <string name="load_preset">Vorlage laden</string>
+    <string name="save_as_preset">Als Vorlage speichern</string>
+    <string name="search_models">Modelle suchen…</string>
+    <string name="save_and_submit">Speichern &amp; senden</string>
+    <string name="preset_name_label">Vorlagenname</string>
+    <string name="code">Code</string>
+    <string name="preview">Vorschau</string>
+    <string name="select_model">Modell auswählen</string>
+    <string name="select_a_model">Ein Modell auswählen</string>
+    <string name="starred_group">Markiert</string>
+    <!-- Neutral label for the active agent when its name hasn't resolved yet (never a model string). -->
+    <string name="chat_agent_fallback_label">Agent</string>
+    <string name="compare_models">Modelle vergleichen</string>
+    <string name="how_can_i_help">Wie kann ich dir heute helfen?</string>
+    <string name="recording">Aufnahme läuft…</string>
+    <string name="hint_message_model">Nachricht an %1$s</string>
+    <string name="hint_message">Nachricht…</string>
+
+    <!-- Content descriptions - Chat -->
+    <string name="cd_open_tools_menu">Tools-Menü öffnen</string>
+    <string name="cd_paste_image">Bild aus Zwischenablage einfügen</string>
+    <string name="cd_message_input">Nachrichteneingabefeld</string>
+    <string name="cd_stop_voice_recording">Sprachaufnahme stoppen</string>
+    <string name="cd_start_voice_recording">Sprachaufnahme starten</string>
+    <string name="cd_stop_generation">Generierung stoppen</string>
+    <string name="cd_send_message">Nachricht senden</string>
+    <string name="cd_open_drawer">Navigationsleiste öffnen</string>
+    <string name="cd_more_options">Weitere Optionen</string>
+    <string name="cd_more_tools">Weitere Tools</string>
+    <string name="cd_scroll_to_bottom">Nach unten scrollen</string>
+    <string name="cd_select_model">Modell auswählen</string>
+    <string name="cd_librechat">LibreChat</string>
+    <string name="cd_comparison_enabled">Vergleich aktiviert</string>
+
+    <!-- Content descriptions - Messages -->
+    <string name="cd_thumbs_up">Daumen hoch</string>
+    <string name="cd_thumbs_down">Daumen runter</string>
+    <string name="cd_copy_message">Nachricht kopieren</string>
+    <string name="cd_edit_message">Nachricht bearbeiten</string>
+    <string name="cd_regenerate_response">Antwort neu generieren</string>
+    <string name="cd_stop_reading">Vorlesen stoppen</string>
+    <string name="cd_read_aloud">Vorlesen</string>
+    <string name="cd_fork_conversation">Unterhaltung ab hier verzweigen</string>
+    <string name="cd_previous_response">Vorherige Antwort</string>
+    <string name="cd_next_response">Nächste Antwort</string>
+    <string name="cd_generating_response">Antwort wird generiert</string>
+
+    <!-- Content descriptions - Images -->
+    <string name="cd_fullscreen_image">Vollbild-Bild</string>
+    <string name="cd_close">Schließen</string>
+    <string name="cd_save_to_device">Auf Gerät speichern</string>
+    <string name="cd_share_image">Bild teilen</string>
+    <string name="cd_failed_to_load_image">Bild konnte nicht geladen werden</string>
+    <string name="cd_failed_to_load_generated_image">Generiertes Bild konnte nicht geladen werden</string>
+    <string name="cd_embedded_image">Eingebettetes Bild in Nachricht</string>
+
+    <!-- Content descriptions - Search -->
+    <string name="cd_search_in_conversation">In Unterhaltung suchen</string>
+    <string name="cd_previous_match">Vorheriger Treffer</string>
+    <string name="cd_next_match">Nächster Treffer</string>
+    <string name="cd_close_search">Suche schließen</string>
+    <string name="cd_clear_search">Suche löschen</string>
+    <string name="hint_find_in_conversation">In Unterhaltung suchen…</string>
+
+    <!-- Content descriptions - Code -->
+    <string name="cd_copy_code">Code kopieren</string>
+    <string name="cd_copied">Kopiert</string>
+    <string name="action_copy_code">Kopieren</string>
+    <string name="action_copied">Kopiert!</string>
+    <string name="cd_code_execution_result">Ergebnis der Code-Ausführung</string>
+    <string name="cd_exit_code_success">Exit-Code 0 (Erfolg)</string>
+    <string name="cd_exit_code_failure">Exit-Code %1$d (Fehler)</string>
+    <string name="exit_code">Exit %1$d</string>
+    <string name="label_code">Code</string>
+    <string name="label_output">Ausgabe:</string>
+    <string name="label_error">Fehler:</string>
+    <string name="label_input">Eingabe:</string>
+    <string name="cd_collapse_code">Code einklappen</string>
+    <string name="cd_expand_code">Code ausklappen</string>
+
+    <!-- Content descriptions - Thinking -->
+    <string name="cd_thinking_indicator">Denkanzeige</string>
+    <string name="label_thinking">Denkt nach</string>
+    <string name="cd_collapse">Einklappen</string>
+    <string name="cd_expand">Ausklappen</string>
+    <string name="cd_collapse_thinking">Denkblock einklappen</string>
+    <string name="cd_expand_thinking">Denkblock ausklappen</string>
+
+    <!-- Content descriptions - Summary (context compaction, v0.8.5+) -->
+    <string name="label_summary">Frühere Nachrichten zusammengefasst</string>
+    <string name="cd_summary_indicator">Zusammenfassungsanzeige</string>
+    <string name="cd_collapse_summary">Zusammenfassungsblock einklappen</string>
+    <string name="cd_expand_summary">Zusammenfassungsblock ausklappen</string>
+
+    <!-- Content descriptions - Subagent trace (subagents, v0.8.6+) -->
+    <string name="label_subagent">Subagent</string>
+    <string name="cd_collapse_subagent">Subagent %1$s einklappen</string>
+    <string name="cd_expand_subagent">Subagent %1$s ausklappen</string>
+
+    <!-- Office-doc preview attachments (deferred preview, v0.8.6+) -->
+    <string name="office_preview_preparing">Vorschau von %1$s wird vorbereitet…</string>
+    <string name="office_preview_failed">Vorschau von %1$s nicht möglich (%2$s)</string>
+    <string name="office_preview_unavailable">%1$s — Vorschau nicht verfügbar</string>
+
+    <!-- Content descriptions - Tool calls -->
+    <string name="cd_tool_call">Tool-Aufruf</string>
+    <string name="cd_collapse_tool_call">Tool-Aufruf %1$s einklappen</string>
+    <string name="cd_expand_tool_call">Tool-Aufruf %1$s ausklappen</string>
+    <string name="cd_tool_complete">Abgeschlossen</string>
+    <string name="cd_tool_enabled">Aktiviert</string>
+    <string name="video_not_supported">Videoinhalt nicht unterstützt</string>
+
+    <!-- Tools bottom sheet -->
+    <string name="tool_camera">Kamera</string>
+    <string name="tool_photos">Fotos</string>
+    <string name="tool_files">Dateien</string>
+    <string name="tool_model">Modell</string>
+    <string name="tool_model_parameters">Modellparameter</string>
+    <string name="tool_model_parameters_desc">Temperatur, Tokens und mehr anpassen</string>
+    <string name="tool_web_search">Websuche</string>
+    <string name="tool_web_search_desc">Im Web nach Informationen suchen</string>
+    <string name="tool_code">Code</string>
+    <string name="tool_code_desc">Code ausführen und analysieren</string>
+    <string name="tool_file_search">Dateisuche</string>
+    <string name="tool_file_search_desc">In hochgeladenen Dateien suchen</string>
+    <string name="tool_mcp">MCP</string>
+    <string name="tool_mcp_desc">Model-Context-Protocol-Server</string>
+    <string name="cd_web_search_enabled">Websuche aktiviert</string>
+    <string name="cd_code_enabled">Code-Interpreter aktiviert</string>
+    <string name="cd_file_search_enabled">Dateisuche aktiviert</string>
+
+    <!-- Attachments -->
+    <string name="cd_attach_file">Datei anhängen</string>
+    <string name="toast_file_attach_unavailable">Dateianhänge sind unter iOS noch nicht verfügbar</string>
+    <string name="files_count">Dateien (%1$d)</string>
+    <string name="cd_attached_file">Angehängte Datei: %1$s</string>
+    <string name="cd_preview_file">Vorschau von %1$s</string>
+    <string name="cd_remove_file">%1$s entfernen</string>
+
+    <!-- Agent handoff -->
+    <string name="cd_agent_handoff">Agent-Übergabe von %1$s an %2$s</string>
+    <string name="cd_handed_off_to">übergeben an</string>
+    <string name="agent_unknown">unbekannt</string>
+    <string name="agent_previous">Vorheriger Agent</string>
+    <string name="agent_next">Nächster Agent</string>
+
+    <!-- Audio/Video -->
+    <string name="cd_pause">Pause</string>
+    <string name="cd_play">Abspielen</string>
+    <string name="cd_play_video">Video abspielen</string>
+    <string name="audio_no_data">Keine Audiodaten</string>
+    <string name="audio_decode_failed">Audio konnte nicht dekodiert werden</string>
+
+    <!-- Citation -->
+    <string name="citation_number">Quelle %1$d</string>
+    <string name="cd_open_citation_url">Quellen-URL öffnen</string>
+
+    <!-- Fork options -->
+    <string name="fork_conversation">Unterhaltung verzweigen</string>
+    <string name="fork_visible_messages">Sichtbare Nachrichten</string>
+    <string name="fork_visible_messages_desc">Nur der direkte Pfad der Nachrichten</string>
+    <string name="fork_include_branches">Verzweigungen einschließen</string>
+    <string name="fork_include_branches_desc">Direkter Pfad plus benachbarte Nachrichten</string>
+    <string name="fork_all_to_target">Alles bis zur Zielebene</string>
+    <string name="fork_all_to_target_desc">Alle Nachrichten und Verzweigungen bis zu dieser Ebene</string>
+    <string name="fork_start_new">Neue Unterhaltung ab Ziel beginnen</string>
+    <string name="fork_start_new_desc">Die Verzweigung bei der ausgewählten Nachricht statt am Anfang beginnen</string>
+
+    <!-- Image viewer toasts -->
+    <string name="toast_failed_to_load_image">Bild konnte nicht geladen werden</string>
+    <string name="toast_failed_to_save_image">Bild konnte nicht gespeichert werden</string>
+    <string name="toast_image_saved">Bild in Galerie gespeichert</string>
+    <string name="toast_failed_to_save_with_error">Bild konnte nicht gespeichert werden: %1$s</string>
+    <string name="toast_storage_permission_required">Speicherberechtigung ist zum Speichern von Bildern erforderlich</string>
+
+    <!-- Image generation -->
+    <string name="generating_image">Bild wird generiert…</string>
+    <string name="image_generated">Bild generiert</string>
+    <string name="cd_generated_image">Generiertes Bild</string>
+
+    <!-- Landing page greetings -->
+    <string name="greeting_late_night">Schöne späte Nacht</string>
+    <string name="greeting_weekend_morning">Schönen Wochenendmorgen</string>
+    <string name="greeting_weekend_afternoon">Schönen Wochenendnachmittag</string>
+    <string name="greeting_weekend_evening">Schönen Wochenendabend</string>
+    <string name="greeting_early_morning">Guten frühen Morgen</string>
+    <string name="greeting_morning">Guten Morgen</string>
+    <string name="greeting_afternoon">Guten Tag</string>
+    <string name="greeting_evening">Guten Abend</string>
+
+    <!-- Log content -->
+    <string name="log_output">Protokollausgabe</string>
+    <string name="cd_collapse_log">%1$s einklappen</string>
+    <string name="cd_expand_log">%1$s ausklappen</string>
+
+    <!-- Table dialog -->
+    <string name="cd_expand_table">Tabelle ausklappen</string>
+    <string name="dialog_table">Tabelle</string>
+
+    <!-- MCP -->
+    <string name="cd_select_mcp_servers">MCP-Server auswählen</string>
+    <string name="cd_mcp_resources">MCP-Ressourcen: %1$d Elemente</string>
+    <string name="cd_mcp_resource">MCP-Ressource: %1$s</string>
+
+    <!-- Memory artifact -->
+    <string name="cd_memory_artifact">Erinnerungsartefakt: %1$s</string>
+    <string name="memory_artifact_untitled">Ohne Titel</string>
+    <string name="label_memory">Erinnerung</string>
+
+    <!-- Mermaid diagram -->
+    <string name="label_mermaid">mermaid</string>
+    <string name="cd_show_diagram">Diagramm anzeigen</string>
+    <string name="cd_view_code">Code anzeigen</string>
+    <string name="label_diagram">Diagramm</string>
+    <string name="cd_fullscreen">Vollbild</string>
+    <string name="cd_close_fullscreen">Vollbild schließen</string>
+
+    <!-- Message bubble -->
+    <string name="sender_you">Du</string>
+    <string name="sender_assistant">Assistent</string>
+
+    <!-- Message files -->
+    <string name="file_fallback">Datei</string>
+
+    <!-- Model selector sheet -->
+    <string name="cd_selected">Ausgewählt</string>
+    <string name="cd_public_agent">Öffentlicher Agent</string>
+    <string name="cd_pin_favorite">Als Favorit anheften</string>
+    <string name="cd_unpin_favorite">Favorit lösen</string>
+    <string name="cd_collapse_section">%1$s einklappen</string>
+    <string name="cd_expand_section">%1$s ausklappen</string>
+    <string name="set_api_key_action">API-Schlüssel festlegen</string>
+    <string name="cd_set_api_key">API-Schlüssel für %1$s konfigurieren</string>
+
+    <!-- Preset picker -->
+    <string name="select_preset">Vorlage auswählen</string>
+    <string name="no_presets_saved">Noch keine Vorlagen gespeichert</string>
+    <string name="cd_edit_preset">%1$s bearbeiten</string>
+    <string name="cd_delete_preset">%1$s löschen</string>
+    <string name="preset_endpoint">Endpunkt: %1$s</string>
+    <string name="preset_model">Modell: %1$s</string>
+
+    <!-- Feedback dialog -->
+    <string name="dialog_title_feedback">Feedback geben</string>
+    <string name="feedback_question">Was war das Problem mit dieser Antwort?</string>
+    <string name="hint_optional_comment">Optionaler Kommentar…</string>
+
+    <!-- Streaming tool call -->
+    <string name="tool_call_output">Ausgabe:</string>
+
+    <!-- Web search result -->
+    <string name="cd_search_result">Suchergebnis: %1$s</string>
+
+    <!-- Rename dialog -->
+    <string name="dialog_title_rename">Unterhaltung umbenennen</string>
+    <string name="hint_title">Titel</string>
+
+    <!-- Delete dialog -->
+    <string name="dialog_title_delete_conversation">Unterhaltung löschen</string>
+    <string name="dialog_delete_conversation_message">Dies löscht diese Unterhaltung dauerhaft. Dies kann nicht rückgängig gemacht werden.</string>
+
+    <!-- Chat menu options -->
+    <string name="menu_search">Suchen</string>
+    <string name="menu_rename">Umbenennen</string>
+
+    <!-- Artifacts -->
+    <string name="cd_open_artifact">Artefakt öffnen</string>
+    <string name="cd_share_artifact">Artefakt teilen</string>
+    <string name="cd_previous_version">Vorherige Version</string>
+    <string name="cd_next_version">Nächste Version</string>
+    <string name="artifact_version">v%1$d/%2$d</string>
+    <string name="label_resource">Ressource</string>
+
+    <!-- Prompts -->
+    <string name="prompts_library">Prompt-Bibliothek</string>
+    <string name="use_in_chat">Im Chat verwenden</string>
+    <string name="set_production">Als Produktiv festlegen</string>
+    <string name="prompt_name_label">Name</string>
+    <string name="prompt_description_label">Beschreibung</string>
+    <string name="prompt_command_label">Befehl</string>
+    <string name="prompt_text_label">Prompt-Text</string>
+    <string name="prompt_content">Prompt-Inhalt</string>
+    <string name="cd_share_prompt">Prompt teilen</string>
+    <string name="cd_edit_prompt">Prompt bearbeiten</string>
+    <string name="cd_delete_prompt">Prompt löschen</string>
+    <string name="cd_back">Zurück</string>
+    <string name="cd_version_history">Versionsverlauf</string>
+    <string name="cd_filter_sort">Filtern und sortieren</string>
+    <string name="cd_create_prompt">Prompt erstellen</string>
+    <string name="cd_remove_filter">Filter entfernen</string>
+    <string name="cd_reset_sort">Sortierung zurücksetzen</string>
+    <string name="cd_share">Teilen</string>
+    <string name="prompt_author">von %1$s</string>
+    <string name="prompt_sort_label">Sortieren: %1$s</string>
+
+    <!-- Prompt versions -->
+    <string name="version_history">Versionsverlauf</string>
+    <string name="no_versions">Keine Versionen verfügbar</string>
+    <string name="label_production">Produktiv</string>
+    <string name="version_number">v%1$d</string>
+
+    <!-- Prompt variables -->
+    <string name="label_variables">Variablen</string>
+
+    <!-- Prompt filter sheet -->
+    <string name="label_category">Kategorie</string>
+    <string name="label_all">Alle</string>
+    <string name="label_sort_by">Sortieren nach</string>
+
+    <!-- Prompt share dialog -->
+    <string name="dialog_title_share_prompt">Prompt teilen</string>
+    <string name="label_permission">Berechtigung</string>
+
+    <!-- Variable input dialog -->
+    <string name="dialog_title_fill_variables">Variablen ausfüllen</string>
+
+    <!-- Temp chat toggle -->
+    <string name="cd_temp_chat">Temporärer Chat</string>
+    <string name="label_temp_chat">Temp</string>
+
+    <!-- Comparison mode -->
+    <string name="continue_with_response">Mit dieser Antwort fortfahren</string>
+    <string name="waiting_for_response">Warten auf Antwort…</string>
+
+    <!-- Slash command menu -->
+    <string name="slash_command_title">/%1$s</string>
+
+    <!-- Provider Keys chat-time errors. -->
+    <string name="provider_keys_chat_error_no_key">Kein Schlüssel gefunden. Bitte gib einen Schlüssel an und versuche es erneut.</string>
+    <!-- {0} = endpoint name, {1} = expiredAt (server-locale string, NOT ISO) -->
+    <string name="provider_keys_chat_error_expired">Der angegebene Schlüssel für %1$s ist am %2$s abgelaufen. Bitte gib einen neuen Schlüssel an und versuche es erneut.</string>
+    <string name="provider_keys_chat_error_invalid">Ungültiger Schlüssel angegeben. Bitte gib einen gültigen Schlüssel an und versuche es erneut.</string>
+    <!-- Snackbar action label that deep-links to Settings → Provider Keys -->
+    <string name="provider_keys_chat_error_cta">Schlüsseleinstellungen öffnen</string>
+
+    <!-- Send block reasons (shown in error snackbar when send can't proceed) -->
+    <string name="send_block_select_agent">Wähle einen Agenten aus, bevor du deine Nachricht sendest.</string>
+    <string name="send_block_select_model">Wähle ein Modell aus, bevor du deine Nachricht sendest.</string>
+    <string name="send_block_agents_unavailable">Agenten sind auf diesem Server nicht verfügbar. Bitte wähle ein anderes Modell.</string>
+    <string name="send_block_agent_not_available">Der ausgewählte Agent ist auf diesem Server nicht verfügbar. Bitte wähle einen anderen Agenten.</string>
+    <string name="send_block_model_not_available">Das ausgewählte Modell ist auf diesem Server nicht verfügbar. Bitte wähle ein anderes Modell.</string>
+    <string name="send_block_model_load_failed">Das ausgewählte Modell konnte noch nicht geladen werden. Bitte versuche es erneut oder wähle ein anderes Modell.</string>
+</resources>

--- a/feature/chat/src/commonMain/composeResources/values-es/strings.xml
+++ b/feature/chat/src/commonMain/composeResources/values-es/strings.xml
@@ -1,0 +1,369 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Common actions -->
+    <string name="cancel">Cancelar</string>
+    <string name="save">Guardar</string>
+    <string name="delete">Eliminar</string>
+    <string name="copy">Copiar</string>
+    <string name="edit">Editar</string>
+    <string name="regenerate">Regenerar</string>
+    <string name="action_rename">Renombrar</string>
+    <string name="action_submit">Enviar</string>
+    <string name="action_insert">Insertar</string>
+    <string name="action_open">Abrir</string>
+    <string name="action_close">Cerrar</string>
+    <string name="action_share">Compartir</string>
+    <string name="action_search">Buscar</string>
+    <string name="action_archive">Archivar</string>
+    <string name="action_duplicate">Duplicar</string>
+    <string name="action_copy_link">Copiar enlace</string>
+
+    <!-- Chat screen -->
+    <string name="new_chat">Nuevo chat</string>
+    <string name="send_message">Enviar</string>
+    <string name="stop_generating">Detener</string>
+    <string name="message_hint">Escribe un mensaje…</string>
+    <string name="model_parameters">Parámetros del modelo</string>
+    <string name="load_preset">Cargar preajuste</string>
+    <string name="save_as_preset">Guardar como preajuste</string>
+    <string name="search_models">Buscar modelos…</string>
+    <string name="save_and_submit">Guardar y enviar</string>
+    <string name="preset_name_label">Nombre del preajuste</string>
+    <string name="code">Código</string>
+    <string name="preview">Vista previa</string>
+    <string name="select_model">Seleccionar modelo</string>
+    <string name="select_a_model">Selecciona un modelo</string>
+    <string name="starred_group">Destacados</string>
+    <!-- Neutral label for the active agent when its name hasn't resolved yet (never a model string). -->
+    <string name="chat_agent_fallback_label">Agente</string>
+    <string name="compare_models">Comparar modelos</string>
+    <string name="how_can_i_help">¿En qué puedo ayudarte hoy?</string>
+    <string name="recording">Grabando…</string>
+    <string name="hint_message_model">Mensaje para %1$s</string>
+    <string name="hint_message">Mensaje…</string>
+
+    <!-- Content descriptions - Chat -->
+    <string name="cd_open_tools_menu">Abrir menú de herramientas</string>
+    <string name="cd_paste_image">Pegar imagen desde el portapapeles</string>
+    <string name="cd_message_input">Campo de entrada de mensaje</string>
+    <string name="cd_stop_voice_recording">Detener grabación de voz</string>
+    <string name="cd_start_voice_recording">Iniciar grabación de voz</string>
+    <string name="cd_stop_generation">Detener generación</string>
+    <string name="cd_send_message">Enviar mensaje</string>
+    <string name="cd_open_drawer">Abrir el panel de navegación</string>
+    <string name="cd_more_options">Más opciones</string>
+    <string name="cd_more_tools">Más herramientas</string>
+    <string name="cd_scroll_to_bottom">Desplazar al final</string>
+    <string name="cd_select_model">Seleccionar modelo</string>
+    <string name="cd_librechat">LibreChat</string>
+    <string name="cd_comparison_enabled">Comparación activada</string>
+
+    <!-- Content descriptions - Messages -->
+    <string name="cd_thumbs_up">Me gusta</string>
+    <string name="cd_thumbs_down">No me gusta</string>
+    <string name="cd_copy_message">Copiar mensaje</string>
+    <string name="cd_edit_message">Editar mensaje</string>
+    <string name="cd_regenerate_response">Regenerar respuesta</string>
+    <string name="cd_stop_reading">Detener lectura</string>
+    <string name="cd_read_aloud">Leer en voz alta</string>
+    <string name="cd_fork_conversation">Bifurcar conversación desde aquí</string>
+    <string name="cd_previous_response">Respuesta anterior</string>
+    <string name="cd_next_response">Respuesta siguiente</string>
+    <string name="cd_generating_response">Generando respuesta</string>
+
+    <!-- Content descriptions - Images -->
+    <string name="cd_fullscreen_image">Imagen a pantalla completa</string>
+    <string name="cd_close">Cerrar</string>
+    <string name="cd_save_to_device">Guardar en el dispositivo</string>
+    <string name="cd_share_image">Compartir imagen</string>
+    <string name="cd_failed_to_load_image">Error al cargar la imagen</string>
+    <string name="cd_failed_to_load_generated_image">Error al cargar la imagen generada</string>
+    <string name="cd_embedded_image">Imagen incrustada en el mensaje</string>
+
+    <!-- Content descriptions - Search -->
+    <string name="cd_search_in_conversation">Buscar en la conversación</string>
+    <string name="cd_previous_match">Coincidencia anterior</string>
+    <string name="cd_next_match">Coincidencia siguiente</string>
+    <string name="cd_close_search">Cerrar búsqueda</string>
+    <string name="cd_clear_search">Borrar búsqueda</string>
+    <string name="hint_find_in_conversation">Buscar en la conversación…</string>
+
+    <!-- Content descriptions - Code -->
+    <string name="cd_copy_code">Copiar código</string>
+    <string name="cd_copied">Copiado</string>
+    <string name="action_copy_code">Copiar</string>
+    <string name="action_copied">¡Copiado!</string>
+    <string name="cd_code_execution_result">Resultado de la ejecución de código</string>
+    <string name="cd_exit_code_success">Código de salida 0 (correcto)</string>
+    <string name="cd_exit_code_failure">Código de salida %1$d (error)</string>
+    <string name="exit_code">salida %1$d</string>
+    <string name="label_code">Código</string>
+    <string name="label_output">Salida:</string>
+    <string name="label_error">Error:</string>
+    <string name="label_input">Entrada:</string>
+    <string name="cd_collapse_code">Contraer código</string>
+    <string name="cd_expand_code">Expandir código</string>
+
+    <!-- Content descriptions - Thinking -->
+    <string name="cd_thinking_indicator">Indicador de razonamiento</string>
+    <string name="label_thinking">Pensando</string>
+    <string name="cd_collapse">Contraer</string>
+    <string name="cd_expand">Expandir</string>
+    <string name="cd_collapse_thinking">Contraer bloque de razonamiento</string>
+    <string name="cd_expand_thinking">Expandir bloque de razonamiento</string>
+
+    <!-- Content descriptions - Summary (context compaction, v0.8.5+) -->
+    <string name="label_summary">Mensajes anteriores resumidos</string>
+    <string name="cd_summary_indicator">Indicador de resumen</string>
+    <string name="cd_collapse_summary">Contraer bloque de resumen</string>
+    <string name="cd_expand_summary">Expandir bloque de resumen</string>
+
+    <!-- Content descriptions - Subagent trace (subagents, v0.8.6+) -->
+    <string name="label_subagent">Subagente</string>
+    <string name="cd_collapse_subagent">Contraer subagente %1$s</string>
+    <string name="cd_expand_subagent">Expandir subagente %1$s</string>
+
+    <!-- Office-doc preview attachments (deferred preview, v0.8.6+) -->
+    <string name="office_preview_preparing">Preparando la vista previa de %1$s…</string>
+    <string name="office_preview_failed">No se pudo previsualizar %1$s (%2$s)</string>
+    <string name="office_preview_unavailable">%1$s — vista previa no disponible</string>
+
+    <!-- Content descriptions - Tool calls -->
+    <string name="cd_tool_call">Llamada a herramienta</string>
+    <string name="cd_collapse_tool_call">Contraer llamada a herramienta %1$s</string>
+    <string name="cd_expand_tool_call">Expandir llamada a herramienta %1$s</string>
+    <string name="cd_tool_complete">Completada</string>
+    <string name="cd_tool_enabled">Activada</string>
+    <string name="video_not_supported">Contenido de vídeo no compatible</string>
+
+    <!-- Tools bottom sheet -->
+    <string name="tool_camera">Cámara</string>
+    <string name="tool_photos">Fotos</string>
+    <string name="tool_files">Archivos</string>
+    <string name="tool_model">Modelo</string>
+    <string name="tool_model_parameters">Parámetros del modelo</string>
+    <string name="tool_model_parameters_desc">Ajusta la temperatura, los tokens y más</string>
+    <string name="tool_web_search">Búsqueda web</string>
+    <string name="tool_web_search_desc">Busca información en la web</string>
+    <string name="tool_code">Código</string>
+    <string name="tool_code_desc">Ejecuta y analiza código</string>
+    <string name="tool_file_search">Búsqueda en archivos</string>
+    <string name="tool_file_search_desc">Busca en los archivos subidos</string>
+    <string name="tool_mcp">MCP</string>
+    <string name="tool_mcp_desc">Servidores de Model Context Protocol</string>
+    <string name="cd_web_search_enabled">Búsqueda web activada</string>
+    <string name="cd_code_enabled">Intérprete de código activado</string>
+    <string name="cd_file_search_enabled">Búsqueda en archivos activada</string>
+
+    <!-- Attachments -->
+    <string name="cd_attach_file">Adjuntar archivo</string>
+    <string name="toast_file_attach_unavailable">Los archivos adjuntos aún no están disponibles en iOS</string>
+    <string name="files_count">Archivos (%1$d)</string>
+    <string name="cd_attached_file">Archivo adjunto: %1$s</string>
+    <string name="cd_preview_file">Vista previa de %1$s</string>
+    <string name="cd_remove_file">Quitar %1$s</string>
+
+    <!-- Agent handoff -->
+    <string name="cd_agent_handoff">Transferencia de agente de %1$s a %2$s</string>
+    <string name="cd_handed_off_to">transferido a</string>
+    <string name="agent_unknown">desconocido</string>
+    <string name="agent_previous">Agente anterior</string>
+    <string name="agent_next">Agente siguiente</string>
+
+    <!-- Audio/Video -->
+    <string name="cd_pause">Pausar</string>
+    <string name="cd_play">Reproducir</string>
+    <string name="cd_play_video">Reproducir vídeo</string>
+    <string name="audio_no_data">No hay datos de audio</string>
+    <string name="audio_decode_failed">Error al decodificar el audio</string>
+
+    <!-- Citation -->
+    <string name="citation_number">Cita %1$d</string>
+    <string name="cd_open_citation_url">Abrir la URL de la cita</string>
+
+    <!-- Fork options -->
+    <string name="fork_conversation">Bifurcar conversación</string>
+    <string name="fork_visible_messages">Mensajes visibles</string>
+    <string name="fork_visible_messages_desc">Solo la ruta directa de los mensajes</string>
+    <string name="fork_include_branches">Incluir ramas</string>
+    <string name="fork_include_branches_desc">Ruta directa más los mensajes hermanos</string>
+    <string name="fork_all_to_target">Todo hasta el nivel objetivo</string>
+    <string name="fork_all_to_target_desc">Todos los mensajes y ramas hasta este nivel</string>
+    <string name="fork_start_new">Iniciar nueva conversación desde el objetivo</string>
+    <string name="fork_start_new_desc">Comienza la bifurcación desde el mensaje seleccionado en lugar de la raíz</string>
+
+    <!-- Image viewer toasts -->
+    <string name="toast_failed_to_load_image">Error al cargar la imagen</string>
+    <string name="toast_failed_to_save_image">Error al guardar la imagen</string>
+    <string name="toast_image_saved">Imagen guardada en la galería</string>
+    <string name="toast_failed_to_save_with_error">Error al guardar la imagen: %1$s</string>
+    <string name="toast_storage_permission_required">Se requiere permiso de almacenamiento para guardar imágenes</string>
+
+    <!-- Image generation -->
+    <string name="generating_image">Generando imagen…</string>
+    <string name="image_generated">Imagen generada</string>
+    <string name="cd_generated_image">Imagen generada</string>
+
+    <!-- Landing page greetings -->
+    <string name="greeting_late_night">Feliz madrugada</string>
+    <string name="greeting_weekend_morning">Feliz mañana de fin de semana</string>
+    <string name="greeting_weekend_afternoon">Feliz tarde de fin de semana</string>
+    <string name="greeting_weekend_evening">Feliz noche de fin de semana</string>
+    <string name="greeting_early_morning">Buenos días tempraneros</string>
+    <string name="greeting_morning">Buenos días</string>
+    <string name="greeting_afternoon">Buenas tardes</string>
+    <string name="greeting_evening">Buenas noches</string>
+
+    <!-- Log content -->
+    <string name="log_output">Salida del registro</string>
+    <string name="cd_collapse_log">Contraer %1$s</string>
+    <string name="cd_expand_log">Expandir %1$s</string>
+
+    <!-- Table dialog -->
+    <string name="cd_expand_table">Expandir tabla</string>
+    <string name="dialog_table">Tabla</string>
+
+    <!-- MCP -->
+    <string name="cd_select_mcp_servers">Seleccionar servidores MCP</string>
+    <string name="cd_mcp_resources">Recursos MCP: %1$d elementos</string>
+    <string name="cd_mcp_resource">Recurso MCP: %1$s</string>
+
+    <!-- Memory artifact -->
+    <string name="cd_memory_artifact">Artefacto de memoria: %1$s</string>
+    <string name="memory_artifact_untitled">Sin título</string>
+    <string name="label_memory">Memoria</string>
+
+    <!-- Mermaid diagram -->
+    <string name="label_mermaid">mermaid</string>
+    <string name="cd_show_diagram">Mostrar diagrama</string>
+    <string name="cd_view_code">Ver código</string>
+    <string name="label_diagram">Diagrama</string>
+    <string name="cd_fullscreen">Pantalla completa</string>
+    <string name="cd_close_fullscreen">Cerrar pantalla completa</string>
+
+    <!-- Message bubble -->
+    <string name="sender_you">Tú</string>
+    <string name="sender_assistant">Asistente</string>
+
+    <!-- Message files -->
+    <string name="file_fallback">Archivo</string>
+
+    <!-- Model selector sheet -->
+    <string name="cd_selected">Seleccionado</string>
+    <string name="cd_public_agent">Agente público</string>
+    <string name="cd_pin_favorite">Fijar como favorito</string>
+    <string name="cd_unpin_favorite">Quitar de favoritos</string>
+    <string name="cd_collapse_section">Contraer %1$s</string>
+    <string name="cd_expand_section">Expandir %1$s</string>
+    <string name="set_api_key_action">Establecer clave de API</string>
+    <string name="cd_set_api_key">Configurar la clave de API de %1$s</string>
+
+    <!-- Preset picker -->
+    <string name="select_preset">Seleccionar preajuste</string>
+    <string name="no_presets_saved">Aún no hay preajustes guardados</string>
+    <string name="cd_edit_preset">Editar %1$s</string>
+    <string name="cd_delete_preset">Eliminar %1$s</string>
+    <string name="preset_endpoint">Endpoint: %1$s</string>
+    <string name="preset_model">Modelo: %1$s</string>
+
+    <!-- Feedback dialog -->
+    <string name="dialog_title_feedback">Enviar comentarios</string>
+    <string name="feedback_question">¿Cuál fue el problema con esta respuesta?</string>
+    <string name="hint_optional_comment">Comentario opcional…</string>
+
+    <!-- Streaming tool call -->
+    <string name="tool_call_output">Salida:</string>
+
+    <!-- Web search result -->
+    <string name="cd_search_result">Resultado de búsqueda: %1$s</string>
+
+    <!-- Rename dialog -->
+    <string name="dialog_title_rename">Renombrar conversación</string>
+    <string name="hint_title">Título</string>
+
+    <!-- Delete dialog -->
+    <string name="dialog_title_delete_conversation">Eliminar conversación</string>
+    <string name="dialog_delete_conversation_message">Esto eliminará permanentemente esta conversación. Esta acción no se puede deshacer.</string>
+
+    <!-- Chat menu options -->
+    <string name="menu_search">Buscar</string>
+    <string name="menu_rename">Renombrar</string>
+
+    <!-- Artifacts -->
+    <string name="cd_open_artifact">Abrir artefacto</string>
+    <string name="cd_share_artifact">Compartir artefacto</string>
+    <string name="cd_previous_version">Versión anterior</string>
+    <string name="cd_next_version">Versión siguiente</string>
+    <string name="artifact_version">v%1$d/%2$d</string>
+    <string name="label_resource">Recurso</string>
+
+    <!-- Prompts -->
+    <string name="prompts_library">Biblioteca de prompts</string>
+    <string name="use_in_chat">Usar en el chat</string>
+    <string name="set_production">Establecer como producción</string>
+    <string name="prompt_name_label">Nombre</string>
+    <string name="prompt_description_label">Descripción</string>
+    <string name="prompt_command_label">Comando</string>
+    <string name="prompt_text_label">Texto del prompt</string>
+    <string name="prompt_content">Contenido del prompt</string>
+    <string name="cd_share_prompt">Compartir prompt</string>
+    <string name="cd_edit_prompt">Editar prompt</string>
+    <string name="cd_delete_prompt">Eliminar prompt</string>
+    <string name="cd_back">Atrás</string>
+    <string name="cd_version_history">Historial de versiones</string>
+    <string name="cd_filter_sort">Filtrar y ordenar</string>
+    <string name="cd_create_prompt">Crear prompt</string>
+    <string name="cd_remove_filter">Quitar filtro</string>
+    <string name="cd_reset_sort">Restablecer orden</string>
+    <string name="cd_share">Compartir</string>
+    <string name="prompt_author">por %1$s</string>
+    <string name="prompt_sort_label">Ordenar: %1$s</string>
+
+    <!-- Prompt versions -->
+    <string name="version_history">Historial de versiones</string>
+    <string name="no_versions">No hay versiones disponibles</string>
+    <string name="label_production">Producción</string>
+    <string name="version_number">v%1$d</string>
+
+    <!-- Prompt variables -->
+    <string name="label_variables">Variables</string>
+
+    <!-- Prompt filter sheet -->
+    <string name="label_category">Categoría</string>
+    <string name="label_all">Todas</string>
+    <string name="label_sort_by">Ordenar por</string>
+
+    <!-- Prompt share dialog -->
+    <string name="dialog_title_share_prompt">Compartir prompt</string>
+    <string name="label_permission">Permiso</string>
+
+    <!-- Variable input dialog -->
+    <string name="dialog_title_fill_variables">Completar variables</string>
+
+    <!-- Temp chat toggle -->
+    <string name="cd_temp_chat">Chat temporal</string>
+    <string name="label_temp_chat">Temp</string>
+
+    <!-- Comparison mode -->
+    <string name="continue_with_response">Continuar con esta respuesta</string>
+    <string name="waiting_for_response">Esperando respuesta…</string>
+
+    <!-- Slash command menu -->
+    <string name="slash_command_title">/%1$s</string>
+
+    <!-- Provider Keys chat-time errors. -->
+    <string name="provider_keys_chat_error_no_key">No se encontró ninguna clave. Proporciona una clave e inténtalo de nuevo.</string>
+    <!-- {0} = endpoint name, {1} = expiredAt (server-locale string, NOT ISO) -->
+    <string name="provider_keys_chat_error_expired">La clave proporcionada para %1$s caducó el %2$s. Proporciona una nueva clave e inténtalo de nuevo.</string>
+    <string name="provider_keys_chat_error_invalid">Clave proporcionada no válida. Proporciona una clave válida e inténtalo de nuevo.</string>
+    <!-- Snackbar action label that deep-links to Settings → Provider Keys -->
+    <string name="provider_keys_chat_error_cta">Abrir ajustes de claves</string>
+
+    <!-- Send block reasons (shown in error snackbar when send can't proceed) -->
+    <string name="send_block_select_agent">Selecciona un agente antes de enviar tu mensaje.</string>
+    <string name="send_block_select_model">Selecciona un modelo antes de enviar tu mensaje.</string>
+    <string name="send_block_agents_unavailable">Los agentes no están disponibles en este servidor. Elige un modelo diferente.</string>
+    <string name="send_block_agent_not_available">El agente seleccionado no está disponible en este servidor. Elige un agente diferente.</string>
+    <string name="send_block_model_not_available">El modelo seleccionado no está disponible en este servidor. Elige un modelo diferente.</string>
+    <string name="send_block_model_load_failed">Aún no se pudo cargar el modelo seleccionado. Inténtalo de nuevo o elige un modelo diferente.</string>
+</resources>

--- a/feature/chat/src/commonMain/composeResources/values-fr/strings.xml
+++ b/feature/chat/src/commonMain/composeResources/values-fr/strings.xml
@@ -1,0 +1,369 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Common actions -->
+    <string name="cancel">Annuler</string>
+    <string name="save">Enregistrer</string>
+    <string name="delete">Supprimer</string>
+    <string name="copy">Copier</string>
+    <string name="edit">Modifier</string>
+    <string name="regenerate">Régénérer</string>
+    <string name="action_rename">Renommer</string>
+    <string name="action_submit">Envoyer</string>
+    <string name="action_insert">Insérer</string>
+    <string name="action_open">Ouvrir</string>
+    <string name="action_close">Fermer</string>
+    <string name="action_share">Partager</string>
+    <string name="action_search">Rechercher</string>
+    <string name="action_archive">Archiver</string>
+    <string name="action_duplicate">Dupliquer</string>
+    <string name="action_copy_link">Copier le lien</string>
+
+    <!-- Chat screen -->
+    <string name="new_chat">Nouvelle discussion</string>
+    <string name="send_message">Envoyer</string>
+    <string name="stop_generating">Arrêter</string>
+    <string name="message_hint">Saisissez un message…</string>
+    <string name="model_parameters">Paramètres du modèle</string>
+    <string name="load_preset">Charger un préréglage</string>
+    <string name="save_as_preset">Enregistrer comme préréglage</string>
+    <string name="search_models">Rechercher des modèles…</string>
+    <string name="save_and_submit">Enregistrer &amp; envoyer</string>
+    <string name="preset_name_label">Nom du préréglage</string>
+    <string name="code">Code</string>
+    <string name="preview">Aperçu</string>
+    <string name="select_model">Sélectionner un modèle</string>
+    <string name="select_a_model">Sélectionnez un modèle</string>
+    <string name="starred_group">Favoris</string>
+    <!-- Neutral label for the active agent when its name hasn't resolved yet (never a model string). -->
+    <string name="chat_agent_fallback_label">Agent</string>
+    <string name="compare_models">Comparer les modèles</string>
+    <string name="how_can_i_help">Comment puis-je vous aider aujourd\'hui ?</string>
+    <string name="recording">Enregistrement…</string>
+    <string name="hint_message_model">Message à %1$s</string>
+    <string name="hint_message">Message…</string>
+
+    <!-- Content descriptions - Chat -->
+    <string name="cd_open_tools_menu">Ouvrir le menu des outils</string>
+    <string name="cd_paste_image">Coller une image depuis le presse-papiers</string>
+    <string name="cd_message_input">Champ de saisie de message</string>
+    <string name="cd_stop_voice_recording">Arrêter l\'enregistrement vocal</string>
+    <string name="cd_start_voice_recording">Démarrer l\'enregistrement vocal</string>
+    <string name="cd_stop_generation">Arrêter la génération</string>
+    <string name="cd_send_message">Envoyer le message</string>
+    <string name="cd_open_drawer">Ouvrir le tiroir de navigation</string>
+    <string name="cd_more_options">Plus d\'options</string>
+    <string name="cd_more_tools">Plus d\'outils</string>
+    <string name="cd_scroll_to_bottom">Défiler vers le bas</string>
+    <string name="cd_select_model">Sélectionner un modèle</string>
+    <string name="cd_librechat">LibreChat</string>
+    <string name="cd_comparison_enabled">Comparaison activée</string>
+
+    <!-- Content descriptions - Messages -->
+    <string name="cd_thumbs_up">Pouce levé</string>
+    <string name="cd_thumbs_down">Pouce baissé</string>
+    <string name="cd_copy_message">Copier le message</string>
+    <string name="cd_edit_message">Modifier le message</string>
+    <string name="cd_regenerate_response">Régénérer la réponse</string>
+    <string name="cd_stop_reading">Arrêter la lecture</string>
+    <string name="cd_read_aloud">Lire à voix haute</string>
+    <string name="cd_fork_conversation">Bifurquer la conversation à partir d\'ici</string>
+    <string name="cd_previous_response">Réponse précédente</string>
+    <string name="cd_next_response">Réponse suivante</string>
+    <string name="cd_generating_response">Génération de la réponse</string>
+
+    <!-- Content descriptions - Images -->
+    <string name="cd_fullscreen_image">Image en plein écran</string>
+    <string name="cd_close">Fermer</string>
+    <string name="cd_save_to_device">Enregistrer sur l\'appareil</string>
+    <string name="cd_share_image">Partager l\'image</string>
+    <string name="cd_failed_to_load_image">Échec du chargement de l\'image</string>
+    <string name="cd_failed_to_load_generated_image">Échec du chargement de l\'image générée</string>
+    <string name="cd_embedded_image">Image intégrée dans le message</string>
+
+    <!-- Content descriptions - Search -->
+    <string name="cd_search_in_conversation">Rechercher dans la conversation</string>
+    <string name="cd_previous_match">Correspondance précédente</string>
+    <string name="cd_next_match">Correspondance suivante</string>
+    <string name="cd_close_search">Fermer la recherche</string>
+    <string name="cd_clear_search">Effacer la recherche</string>
+    <string name="hint_find_in_conversation">Rechercher dans la conversation…</string>
+
+    <!-- Content descriptions - Code -->
+    <string name="cd_copy_code">Copier le code</string>
+    <string name="cd_copied">Copié</string>
+    <string name="action_copy_code">Copier</string>
+    <string name="action_copied">Copié !</string>
+    <string name="cd_code_execution_result">Résultat de l\'exécution du code</string>
+    <string name="cd_exit_code_success">Code de sortie 0 (succès)</string>
+    <string name="cd_exit_code_failure">Code de sortie %1$d (échec)</string>
+    <string name="exit_code">sortie %1$d</string>
+    <string name="label_code">Code</string>
+    <string name="label_output">Sortie :</string>
+    <string name="label_error">Erreur :</string>
+    <string name="label_input">Entrée :</string>
+    <string name="cd_collapse_code">Réduire le code</string>
+    <string name="cd_expand_code">Développer le code</string>
+
+    <!-- Content descriptions - Thinking -->
+    <string name="cd_thinking_indicator">Indicateur de réflexion</string>
+    <string name="label_thinking">Réflexion</string>
+    <string name="cd_collapse">Réduire</string>
+    <string name="cd_expand">Développer</string>
+    <string name="cd_collapse_thinking">Réduire le bloc de réflexion</string>
+    <string name="cd_expand_thinking">Développer le bloc de réflexion</string>
+
+    <!-- Content descriptions - Summary (context compaction, v0.8.5+) -->
+    <string name="label_summary">Messages antérieurs résumés</string>
+    <string name="cd_summary_indicator">Indicateur de résumé</string>
+    <string name="cd_collapse_summary">Réduire le bloc de résumé</string>
+    <string name="cd_expand_summary">Développer le bloc de résumé</string>
+
+    <!-- Content descriptions - Subagent trace (subagents, v0.8.6+) -->
+    <string name="label_subagent">Sous-agent</string>
+    <string name="cd_collapse_subagent">Réduire le sous-agent %1$s</string>
+    <string name="cd_expand_subagent">Développer le sous-agent %1$s</string>
+
+    <!-- Office-doc preview attachments (deferred preview, v0.8.6+) -->
+    <string name="office_preview_preparing">Préparation de l\'aperçu de %1$s…</string>
+    <string name="office_preview_failed">Impossible d\'afficher l\'aperçu de %1$s (%2$s)</string>
+    <string name="office_preview_unavailable">%1$s — aperçu non disponible</string>
+
+    <!-- Content descriptions - Tool calls -->
+    <string name="cd_tool_call">Appel d\'outil</string>
+    <string name="cd_collapse_tool_call">Réduire l\'appel d\'outil %1$s</string>
+    <string name="cd_expand_tool_call">Développer l\'appel d\'outil %1$s</string>
+    <string name="cd_tool_complete">Terminé</string>
+    <string name="cd_tool_enabled">Activé</string>
+    <string name="video_not_supported">Contenu vidéo non pris en charge</string>
+
+    <!-- Tools bottom sheet -->
+    <string name="tool_camera">Appareil photo</string>
+    <string name="tool_photos">Photos</string>
+    <string name="tool_files">Fichiers</string>
+    <string name="tool_model">Modèle</string>
+    <string name="tool_model_parameters">Paramètres du modèle</string>
+    <string name="tool_model_parameters_desc">Ajuster la température, les jetons et plus encore</string>
+    <string name="tool_web_search">Recherche web</string>
+    <string name="tool_web_search_desc">Rechercher des informations sur le web</string>
+    <string name="tool_code">Code</string>
+    <string name="tool_code_desc">Exécuter et analyser du code</string>
+    <string name="tool_file_search">Recherche de fichiers</string>
+    <string name="tool_file_search_desc">Rechercher dans les fichiers téléversés</string>
+    <string name="tool_mcp">MCP</string>
+    <string name="tool_mcp_desc">Serveurs Model Context Protocol</string>
+    <string name="cd_web_search_enabled">Recherche web activée</string>
+    <string name="cd_code_enabled">Interpréteur de code activé</string>
+    <string name="cd_file_search_enabled">Recherche de fichiers activée</string>
+
+    <!-- Attachments -->
+    <string name="cd_attach_file">Joindre un fichier</string>
+    <string name="toast_file_attach_unavailable">Les pièces jointes ne sont pas encore disponibles sur iOS</string>
+    <string name="files_count">Fichiers (%1$d)</string>
+    <string name="cd_attached_file">Fichier joint : %1$s</string>
+    <string name="cd_preview_file">Aperçu de %1$s</string>
+    <string name="cd_remove_file">Supprimer %1$s</string>
+
+    <!-- Agent handoff -->
+    <string name="cd_agent_handoff">Passation d\'agent de %1$s à %2$s</string>
+    <string name="cd_handed_off_to">a transmis à</string>
+    <string name="agent_unknown">inconnu</string>
+    <string name="agent_previous">Agent précédent</string>
+    <string name="agent_next">Agent suivant</string>
+
+    <!-- Audio/Video -->
+    <string name="cd_pause">Pause</string>
+    <string name="cd_play">Lecture</string>
+    <string name="cd_play_video">Lire la vidéo</string>
+    <string name="audio_no_data">Aucune donnée audio</string>
+    <string name="audio_decode_failed">Échec du décodage de l\'audio</string>
+
+    <!-- Citation -->
+    <string name="citation_number">Citation %1$d</string>
+    <string name="cd_open_citation_url">Ouvrir l\'URL de la citation</string>
+
+    <!-- Fork options -->
+    <string name="fork_conversation">Bifurquer la conversation</string>
+    <string name="fork_visible_messages">Messages visibles</string>
+    <string name="fork_visible_messages_desc">Uniquement le chemin direct des messages</string>
+    <string name="fork_include_branches">Inclure les branches</string>
+    <string name="fork_include_branches_desc">Chemin direct plus les messages frères</string>
+    <string name="fork_all_to_target">Tout jusqu\'au niveau cible</string>
+    <string name="fork_all_to_target_desc">Tous les messages et branches jusqu\'à ce niveau</string>
+    <string name="fork_start_new">Démarrer une nouvelle conversation à partir de la cible</string>
+    <string name="fork_start_new_desc">Commencer la bifurcation à partir du message sélectionné au lieu de la racine</string>
+
+    <!-- Image viewer toasts -->
+    <string name="toast_failed_to_load_image">Échec du chargement de l\'image</string>
+    <string name="toast_failed_to_save_image">Échec de l\'enregistrement de l\'image</string>
+    <string name="toast_image_saved">Image enregistrée dans la galerie</string>
+    <string name="toast_failed_to_save_with_error">Échec de l\'enregistrement de l\'image : %1$s</string>
+    <string name="toast_storage_permission_required">L\'autorisation de stockage est requise pour enregistrer des images</string>
+
+    <!-- Image generation -->
+    <string name="generating_image">Génération de l\'image…</string>
+    <string name="image_generated">Image générée</string>
+    <string name="cd_generated_image">Image générée</string>
+
+    <!-- Landing page greetings -->
+    <string name="greeting_late_night">Bonne nuit blanche</string>
+    <string name="greeting_weekend_morning">Bon week-end matin</string>
+    <string name="greeting_weekend_afternoon">Bon week-end après-midi</string>
+    <string name="greeting_weekend_evening">Bonne soirée de week-end</string>
+    <string name="greeting_early_morning">Bonne aube</string>
+    <string name="greeting_morning">Bonjour</string>
+    <string name="greeting_afternoon">Bon après-midi</string>
+    <string name="greeting_evening">Bonsoir</string>
+
+    <!-- Log content -->
+    <string name="log_output">Sortie du journal</string>
+    <string name="cd_collapse_log">Réduire %1$s</string>
+    <string name="cd_expand_log">Développer %1$s</string>
+
+    <!-- Table dialog -->
+    <string name="cd_expand_table">Développer le tableau</string>
+    <string name="dialog_table">Tableau</string>
+
+    <!-- MCP -->
+    <string name="cd_select_mcp_servers">Sélectionner les serveurs MCP</string>
+    <string name="cd_mcp_resources">Ressources MCP : %1$d éléments</string>
+    <string name="cd_mcp_resource">Ressource MCP : %1$s</string>
+
+    <!-- Memory artifact -->
+    <string name="cd_memory_artifact">Artefact de mémoire : %1$s</string>
+    <string name="memory_artifact_untitled">Sans titre</string>
+    <string name="label_memory">Mémoire</string>
+
+    <!-- Mermaid diagram -->
+    <string name="label_mermaid">mermaid</string>
+    <string name="cd_show_diagram">Afficher le diagramme</string>
+    <string name="cd_view_code">Voir le code</string>
+    <string name="label_diagram">Diagramme</string>
+    <string name="cd_fullscreen">Plein écran</string>
+    <string name="cd_close_fullscreen">Fermer le plein écran</string>
+
+    <!-- Message bubble -->
+    <string name="sender_you">Vous</string>
+    <string name="sender_assistant">Assistant</string>
+
+    <!-- Message files -->
+    <string name="file_fallback">Fichier</string>
+
+    <!-- Model selector sheet -->
+    <string name="cd_selected">Sélectionné</string>
+    <string name="cd_public_agent">Agent public</string>
+    <string name="cd_pin_favorite">Épingler comme favori</string>
+    <string name="cd_unpin_favorite">Désépingler le favori</string>
+    <string name="cd_collapse_section">Réduire %1$s</string>
+    <string name="cd_expand_section">Développer %1$s</string>
+    <string name="set_api_key_action">Définir la clé API</string>
+    <string name="cd_set_api_key">Configurer la clé API pour %1$s</string>
+
+    <!-- Preset picker -->
+    <string name="select_preset">Sélectionner un préréglage</string>
+    <string name="no_presets_saved">Aucun préréglage enregistré pour l\'instant</string>
+    <string name="cd_edit_preset">Modifier %1$s</string>
+    <string name="cd_delete_preset">Supprimer %1$s</string>
+    <string name="preset_endpoint">Point de terminaison : %1$s</string>
+    <string name="preset_model">Modèle : %1$s</string>
+
+    <!-- Feedback dialog -->
+    <string name="dialog_title_feedback">Donner un avis</string>
+    <string name="feedback_question">Quel était le problème avec cette réponse ?</string>
+    <string name="hint_optional_comment">Commentaire facultatif…</string>
+
+    <!-- Streaming tool call -->
+    <string name="tool_call_output">Sortie :</string>
+
+    <!-- Web search result -->
+    <string name="cd_search_result">Résultat de recherche : %1$s</string>
+
+    <!-- Rename dialog -->
+    <string name="dialog_title_rename">Renommer la conversation</string>
+    <string name="hint_title">Titre</string>
+
+    <!-- Delete dialog -->
+    <string name="dialog_title_delete_conversation">Supprimer la conversation</string>
+    <string name="dialog_delete_conversation_message">Ceci supprimera définitivement cette conversation. Cette action est irréversible.</string>
+
+    <!-- Chat menu options -->
+    <string name="menu_search">Rechercher</string>
+    <string name="menu_rename">Renommer</string>
+
+    <!-- Artifacts -->
+    <string name="cd_open_artifact">Ouvrir l\'artefact</string>
+    <string name="cd_share_artifact">Partager l\'artefact</string>
+    <string name="cd_previous_version">Version précédente</string>
+    <string name="cd_next_version">Version suivante</string>
+    <string name="artifact_version">v%1$d/%2$d</string>
+    <string name="label_resource">Ressource</string>
+
+    <!-- Prompts -->
+    <string name="prompts_library">Bibliothèque d\'invites</string>
+    <string name="use_in_chat">Utiliser dans la discussion</string>
+    <string name="set_production">Définir comme production</string>
+    <string name="prompt_name_label">Nom</string>
+    <string name="prompt_description_label">Description</string>
+    <string name="prompt_command_label">Commande</string>
+    <string name="prompt_text_label">Texte de l\'invite</string>
+    <string name="prompt_content">Contenu de l\'invite</string>
+    <string name="cd_share_prompt">Partager l\'invite</string>
+    <string name="cd_edit_prompt">Modifier l\'invite</string>
+    <string name="cd_delete_prompt">Supprimer l\'invite</string>
+    <string name="cd_back">Retour</string>
+    <string name="cd_version_history">Historique des versions</string>
+    <string name="cd_filter_sort">Filtrer et trier</string>
+    <string name="cd_create_prompt">Créer une invite</string>
+    <string name="cd_remove_filter">Supprimer le filtre</string>
+    <string name="cd_reset_sort">Réinitialiser le tri</string>
+    <string name="cd_share">Partager</string>
+    <string name="prompt_author">par %1$s</string>
+    <string name="prompt_sort_label">Tri : %1$s</string>
+
+    <!-- Prompt versions -->
+    <string name="version_history">Historique des versions</string>
+    <string name="no_versions">Aucune version disponible</string>
+    <string name="label_production">Production</string>
+    <string name="version_number">v%1$d</string>
+
+    <!-- Prompt variables -->
+    <string name="label_variables">Variables</string>
+
+    <!-- Prompt filter sheet -->
+    <string name="label_category">Catégorie</string>
+    <string name="label_all">Tout</string>
+    <string name="label_sort_by">Trier par</string>
+
+    <!-- Prompt share dialog -->
+    <string name="dialog_title_share_prompt">Partager l\'invite</string>
+    <string name="label_permission">Autorisation</string>
+
+    <!-- Variable input dialog -->
+    <string name="dialog_title_fill_variables">Renseigner les variables</string>
+
+    <!-- Temp chat toggle -->
+    <string name="cd_temp_chat">Discussion temporaire</string>
+    <string name="label_temp_chat">Temp</string>
+
+    <!-- Comparison mode -->
+    <string name="continue_with_response">Continuer avec cette réponse</string>
+    <string name="waiting_for_response">En attente d\'une réponse…</string>
+
+    <!-- Slash command menu -->
+    <string name="slash_command_title">/%1$s</string>
+
+    <!-- Provider Keys chat-time errors. -->
+    <string name="provider_keys_chat_error_no_key">Aucune clé trouvée. Veuillez fournir une clé et réessayer.</string>
+    <!-- {0} = endpoint name, {1} = expiredAt (server-locale string, NOT ISO) -->
+    <string name="provider_keys_chat_error_expired">La clé fournie pour %1$s a expiré le %2$s. Veuillez fournir une nouvelle clé et réessayer.</string>
+    <string name="provider_keys_chat_error_invalid">Clé fournie invalide. Veuillez fournir une clé valide et réessayer.</string>
+    <!-- Snackbar action label that deep-links to Settings → Provider Keys -->
+    <string name="provider_keys_chat_error_cta">Ouvrir les paramètres des clés</string>
+
+    <!-- Send block reasons (shown in error snackbar when send can't proceed) -->
+    <string name="send_block_select_agent">Sélectionnez un agent avant d\'envoyer votre message.</string>
+    <string name="send_block_select_model">Sélectionnez un modèle avant d\'envoyer votre message.</string>
+    <string name="send_block_agents_unavailable">Les agents ne sont pas disponibles sur ce serveur. Veuillez choisir un autre modèle.</string>
+    <string name="send_block_agent_not_available">L\'agent sélectionné n\'est pas disponible sur ce serveur. Veuillez choisir un autre agent.</string>
+    <string name="send_block_model_not_available">Le modèle sélectionné n\'est pas disponible sur ce serveur. Veuillez choisir un autre modèle.</string>
+    <string name="send_block_model_load_failed">Impossible de charger le modèle sélectionné pour l\'instant. Veuillez réessayer ou choisir un autre modèle.</string>
+</resources>

--- a/feature/chat/src/commonMain/composeResources/values-ja/strings.xml
+++ b/feature/chat/src/commonMain/composeResources/values-ja/strings.xml
@@ -1,0 +1,369 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Common actions -->
+    <string name="cancel">キャンセル</string>
+    <string name="save">保存</string>
+    <string name="delete">削除</string>
+    <string name="copy">コピー</string>
+    <string name="edit">編集</string>
+    <string name="regenerate">再生成</string>
+    <string name="action_rename">名前を変更</string>
+    <string name="action_submit">送信</string>
+    <string name="action_insert">挿入</string>
+    <string name="action_open">開く</string>
+    <string name="action_close">閉じる</string>
+    <string name="action_share">共有</string>
+    <string name="action_search">検索</string>
+    <string name="action_archive">アーカイブ</string>
+    <string name="action_duplicate">複製</string>
+    <string name="action_copy_link">リンクをコピー</string>
+
+    <!-- Chat screen -->
+    <string name="new_chat">新しいチャット</string>
+    <string name="send_message">送信</string>
+    <string name="stop_generating">停止</string>
+    <string name="message_hint">メッセージを入力…</string>
+    <string name="model_parameters">モデルパラメータ</string>
+    <string name="load_preset">プリセットを読み込む</string>
+    <string name="save_as_preset">プリセットとして保存</string>
+    <string name="search_models">モデルを検索…</string>
+    <string name="save_and_submit">保存して送信</string>
+    <string name="preset_name_label">プリセット名</string>
+    <string name="code">コード</string>
+    <string name="preview">プレビュー</string>
+    <string name="select_model">モデルを選択</string>
+    <string name="select_a_model">モデルを選択してください</string>
+    <string name="starred_group">スター付き</string>
+    <!-- Neutral label for the active agent when its name hasn't resolved yet (never a model string). -->
+    <string name="chat_agent_fallback_label">エージェント</string>
+    <string name="compare_models">モデルを比較</string>
+    <string name="how_can_i_help">今日は何をお手伝いしましょうか？</string>
+    <string name="recording">録音中…</string>
+    <string name="hint_message_model">%1$s にメッセージ</string>
+    <string name="hint_message">メッセージ…</string>
+
+    <!-- Content descriptions - Chat -->
+    <string name="cd_open_tools_menu">ツールメニューを開く</string>
+    <string name="cd_paste_image">クリップボードから画像を貼り付け</string>
+    <string name="cd_message_input">メッセージ入力欄</string>
+    <string name="cd_stop_voice_recording">音声録音を停止</string>
+    <string name="cd_start_voice_recording">音声録音を開始</string>
+    <string name="cd_stop_generation">生成を停止</string>
+    <string name="cd_send_message">メッセージを送信</string>
+    <string name="cd_open_drawer">ナビゲーションドロワーを開く</string>
+    <string name="cd_more_options">その他のオプション</string>
+    <string name="cd_more_tools">その他のツール</string>
+    <string name="cd_scroll_to_bottom">一番下までスクロール</string>
+    <string name="cd_select_model">モデルを選択</string>
+    <string name="cd_librechat">LibreChat</string>
+    <string name="cd_comparison_enabled">比較が有効</string>
+
+    <!-- Content descriptions - Messages -->
+    <string name="cd_thumbs_up">高評価</string>
+    <string name="cd_thumbs_down">低評価</string>
+    <string name="cd_copy_message">メッセージをコピー</string>
+    <string name="cd_edit_message">メッセージを編集</string>
+    <string name="cd_regenerate_response">応答を再生成</string>
+    <string name="cd_stop_reading">読み上げを停止</string>
+    <string name="cd_read_aloud">読み上げ</string>
+    <string name="cd_fork_conversation">ここから会話をフォーク</string>
+    <string name="cd_previous_response">前の応答</string>
+    <string name="cd_next_response">次の応答</string>
+    <string name="cd_generating_response">応答を生成中</string>
+
+    <!-- Content descriptions - Images -->
+    <string name="cd_fullscreen_image">全画面画像</string>
+    <string name="cd_close">閉じる</string>
+    <string name="cd_save_to_device">デバイスに保存</string>
+    <string name="cd_share_image">画像を共有</string>
+    <string name="cd_failed_to_load_image">画像の読み込みに失敗しました</string>
+    <string name="cd_failed_to_load_generated_image">生成された画像の読み込みに失敗しました</string>
+    <string name="cd_embedded_image">メッセージ内の埋め込み画像</string>
+
+    <!-- Content descriptions - Search -->
+    <string name="cd_search_in_conversation">会話内を検索</string>
+    <string name="cd_previous_match">前の一致</string>
+    <string name="cd_next_match">次の一致</string>
+    <string name="cd_close_search">検索を閉じる</string>
+    <string name="cd_clear_search">検索をクリア</string>
+    <string name="hint_find_in_conversation">会話内を検索…</string>
+
+    <!-- Content descriptions - Code -->
+    <string name="cd_copy_code">コードをコピー</string>
+    <string name="cd_copied">コピー済み</string>
+    <string name="action_copy_code">コピー</string>
+    <string name="action_copied">コピーしました！</string>
+    <string name="cd_code_execution_result">コードの実行結果</string>
+    <string name="cd_exit_code_success">終了コード 0（成功）</string>
+    <string name="cd_exit_code_failure">終了コード %1$d（失敗）</string>
+    <string name="exit_code">終了 %1$d</string>
+    <string name="label_code">コード</string>
+    <string name="label_output">出力:</string>
+    <string name="label_error">エラー:</string>
+    <string name="label_input">入力:</string>
+    <string name="cd_collapse_code">コードを折りたたむ</string>
+    <string name="cd_expand_code">コードを展開</string>
+
+    <!-- Content descriptions - Thinking -->
+    <string name="cd_thinking_indicator">思考インジケーター</string>
+    <string name="label_thinking">思考中</string>
+    <string name="cd_collapse">折りたたむ</string>
+    <string name="cd_expand">展開</string>
+    <string name="cd_collapse_thinking">思考ブロックを折りたたむ</string>
+    <string name="cd_expand_thinking">思考ブロックを展開</string>
+
+    <!-- Content descriptions - Summary (context compaction, v0.8.5+) -->
+    <string name="label_summary">以前のメッセージの要約</string>
+    <string name="cd_summary_indicator">要約インジケーター</string>
+    <string name="cd_collapse_summary">要約ブロックを折りたたむ</string>
+    <string name="cd_expand_summary">要約ブロックを展開</string>
+
+    <!-- Content descriptions - Subagent trace (subagents, v0.8.6+) -->
+    <string name="label_subagent">サブエージェント</string>
+    <string name="cd_collapse_subagent">サブエージェント %1$s を折りたたむ</string>
+    <string name="cd_expand_subagent">サブエージェント %1$s を展開</string>
+
+    <!-- Office-doc preview attachments (deferred preview, v0.8.6+) -->
+    <string name="office_preview_preparing">%1$s のプレビューを準備中…</string>
+    <string name="office_preview_failed">%1$s をプレビューできませんでした（%2$s）</string>
+    <string name="office_preview_unavailable">%1$s — プレビューは利用できません</string>
+
+    <!-- Content descriptions - Tool calls -->
+    <string name="cd_tool_call">ツール呼び出し</string>
+    <string name="cd_collapse_tool_call">ツール呼び出し %1$s を折りたたむ</string>
+    <string name="cd_expand_tool_call">ツール呼び出し %1$s を展開</string>
+    <string name="cd_tool_complete">完了</string>
+    <string name="cd_tool_enabled">有効</string>
+    <string name="video_not_supported">動画コンテンツはサポートされていません</string>
+
+    <!-- Tools bottom sheet -->
+    <string name="tool_camera">カメラ</string>
+    <string name="tool_photos">写真</string>
+    <string name="tool_files">ファイル</string>
+    <string name="tool_model">モデル</string>
+    <string name="tool_model_parameters">モデルパラメータ</string>
+    <string name="tool_model_parameters_desc">温度やトークンなどを調整</string>
+    <string name="tool_web_search">ウェブ検索</string>
+    <string name="tool_web_search_desc">ウェブで情報を検索</string>
+    <string name="tool_code">コード</string>
+    <string name="tool_code_desc">コードを実行・分析</string>
+    <string name="tool_file_search">ファイル検索</string>
+    <string name="tool_file_search_desc">アップロード済みのファイルを検索</string>
+    <string name="tool_mcp">MCP</string>
+    <string name="tool_mcp_desc">Model Context Protocolサーバー</string>
+    <string name="cd_web_search_enabled">ウェブ検索が有効</string>
+    <string name="cd_code_enabled">コードインタープリターが有効</string>
+    <string name="cd_file_search_enabled">ファイル検索が有効</string>
+
+    <!-- Attachments -->
+    <string name="cd_attach_file">ファイルを添付</string>
+    <string name="toast_file_attach_unavailable">ファイル添付はまだiOSでは利用できません</string>
+    <string name="files_count">ファイル（%1$d）</string>
+    <string name="cd_attached_file">添付ファイル: %1$s</string>
+    <string name="cd_preview_file">%1$s のプレビュー</string>
+    <string name="cd_remove_file">%1$s を削除</string>
+
+    <!-- Agent handoff -->
+    <string name="cd_agent_handoff">%1$s から %2$s へのエージェント引き継ぎ</string>
+    <string name="cd_handed_off_to">引き継ぎ先</string>
+    <string name="agent_unknown">不明</string>
+    <string name="agent_previous">前のエージェント</string>
+    <string name="agent_next">次のエージェント</string>
+
+    <!-- Audio/Video -->
+    <string name="cd_pause">一時停止</string>
+    <string name="cd_play">再生</string>
+    <string name="cd_play_video">動画を再生</string>
+    <string name="audio_no_data">音声データがありません</string>
+    <string name="audio_decode_failed">音声のデコードに失敗しました</string>
+
+    <!-- Citation -->
+    <string name="citation_number">引用 %1$d</string>
+    <string name="cd_open_citation_url">引用URLを開く</string>
+
+    <!-- Fork options -->
+    <string name="fork_conversation">会話をフォーク</string>
+    <string name="fork_visible_messages">表示中のメッセージ</string>
+    <string name="fork_visible_messages_desc">メッセージの直接の経路のみ</string>
+    <string name="fork_include_branches">分岐を含める</string>
+    <string name="fork_include_branches_desc">直接の経路に加えて兄弟メッセージ</string>
+    <string name="fork_all_to_target">対象の階層まですべて</string>
+    <string name="fork_all_to_target_desc">この階層までのすべてのメッセージと分岐</string>
+    <string name="fork_start_new">対象から新しい会話を開始</string>
+    <string name="fork_start_new_desc">ルートではなく選択したメッセージからフォークを開始します</string>
+
+    <!-- Image viewer toasts -->
+    <string name="toast_failed_to_load_image">画像の読み込みに失敗しました</string>
+    <string name="toast_failed_to_save_image">画像の保存に失敗しました</string>
+    <string name="toast_image_saved">画像をギャラリーに保存しました</string>
+    <string name="toast_failed_to_save_with_error">画像の保存に失敗しました: %1$s</string>
+    <string name="toast_storage_permission_required">画像を保存するにはストレージの権限が必要です</string>
+
+    <!-- Image generation -->
+    <string name="generating_image">画像を生成中…</string>
+    <string name="image_generated">画像を生成しました</string>
+    <string name="cd_generated_image">生成された画像</string>
+
+    <!-- Landing page greetings -->
+    <string name="greeting_late_night">こんばんは、夜更かしですね</string>
+    <string name="greeting_weekend_morning">楽しい週末の朝を</string>
+    <string name="greeting_weekend_afternoon">楽しい週末の午後を</string>
+    <string name="greeting_weekend_evening">楽しい週末の夜を</string>
+    <string name="greeting_early_morning">おはようございます、早起きですね</string>
+    <string name="greeting_morning">おはようございます</string>
+    <string name="greeting_afternoon">こんにちは</string>
+    <string name="greeting_evening">こんばんは</string>
+
+    <!-- Log content -->
+    <string name="log_output">ログ出力</string>
+    <string name="cd_collapse_log">%1$s を折りたたむ</string>
+    <string name="cd_expand_log">%1$s を展開</string>
+
+    <!-- Table dialog -->
+    <string name="cd_expand_table">表を展開</string>
+    <string name="dialog_table">表</string>
+
+    <!-- MCP -->
+    <string name="cd_select_mcp_servers">MCPサーバーを選択</string>
+    <string name="cd_mcp_resources">MCPリソース: %1$d 件</string>
+    <string name="cd_mcp_resource">MCPリソース: %1$s</string>
+
+    <!-- Memory artifact -->
+    <string name="cd_memory_artifact">メモリアーティファクト: %1$s</string>
+    <string name="memory_artifact_untitled">無題</string>
+    <string name="label_memory">メモリ</string>
+
+    <!-- Mermaid diagram -->
+    <string name="label_mermaid">mermaid</string>
+    <string name="cd_show_diagram">図を表示</string>
+    <string name="cd_view_code">コードを表示</string>
+    <string name="label_diagram">図</string>
+    <string name="cd_fullscreen">全画面</string>
+    <string name="cd_close_fullscreen">全画面を閉じる</string>
+
+    <!-- Message bubble -->
+    <string name="sender_you">あなた</string>
+    <string name="sender_assistant">アシスタント</string>
+
+    <!-- Message files -->
+    <string name="file_fallback">ファイル</string>
+
+    <!-- Model selector sheet -->
+    <string name="cd_selected">選択済み</string>
+    <string name="cd_public_agent">公開エージェント</string>
+    <string name="cd_pin_favorite">お気に入りにピン留め</string>
+    <string name="cd_unpin_favorite">お気に入りのピンを外す</string>
+    <string name="cd_collapse_section">%1$s を折りたたむ</string>
+    <string name="cd_expand_section">%1$s を展開</string>
+    <string name="set_api_key_action">APIキーを設定</string>
+    <string name="cd_set_api_key">%1$s のAPIキーを設定</string>
+
+    <!-- Preset picker -->
+    <string name="select_preset">プリセットを選択</string>
+    <string name="no_presets_saved">保存されたプリセットはまだありません</string>
+    <string name="cd_edit_preset">%1$s を編集</string>
+    <string name="cd_delete_preset">%1$s を削除</string>
+    <string name="preset_endpoint">エンドポイント: %1$s</string>
+    <string name="preset_model">モデル: %1$s</string>
+
+    <!-- Feedback dialog -->
+    <string name="dialog_title_feedback">フィードバックを送る</string>
+    <string name="feedback_question">この応答の問題点は何でしたか？</string>
+    <string name="hint_optional_comment">任意のコメント…</string>
+
+    <!-- Streaming tool call -->
+    <string name="tool_call_output">出力:</string>
+
+    <!-- Web search result -->
+    <string name="cd_search_result">検索結果: %1$s</string>
+
+    <!-- Rename dialog -->
+    <string name="dialog_title_rename">会話の名前を変更</string>
+    <string name="hint_title">タイトル</string>
+
+    <!-- Delete dialog -->
+    <string name="dialog_title_delete_conversation">会話を削除</string>
+    <string name="dialog_delete_conversation_message">この会話を完全に削除します。この操作は取り消せません。</string>
+
+    <!-- Chat menu options -->
+    <string name="menu_search">検索</string>
+    <string name="menu_rename">名前を変更</string>
+
+    <!-- Artifacts -->
+    <string name="cd_open_artifact">アーティファクトを開く</string>
+    <string name="cd_share_artifact">アーティファクトを共有</string>
+    <string name="cd_previous_version">前のバージョン</string>
+    <string name="cd_next_version">次のバージョン</string>
+    <string name="artifact_version">v%1$d/%2$d</string>
+    <string name="label_resource">リソース</string>
+
+    <!-- Prompts -->
+    <string name="prompts_library">プロンプトライブラリ</string>
+    <string name="use_in_chat">チャットで使用</string>
+    <string name="set_production">本番に設定</string>
+    <string name="prompt_name_label">名前</string>
+    <string name="prompt_description_label">説明</string>
+    <string name="prompt_command_label">コマンド</string>
+    <string name="prompt_text_label">プロンプトテキスト</string>
+    <string name="prompt_content">プロンプトの内容</string>
+    <string name="cd_share_prompt">プロンプトを共有</string>
+    <string name="cd_edit_prompt">プロンプトを編集</string>
+    <string name="cd_delete_prompt">プロンプトを削除</string>
+    <string name="cd_back">戻る</string>
+    <string name="cd_version_history">バージョン履歴</string>
+    <string name="cd_filter_sort">フィルターと並べ替え</string>
+    <string name="cd_create_prompt">プロンプトを作成</string>
+    <string name="cd_remove_filter">フィルターを削除</string>
+    <string name="cd_reset_sort">並べ替えをリセット</string>
+    <string name="cd_share">共有</string>
+    <string name="prompt_author">作成者: %1$s</string>
+    <string name="prompt_sort_label">並べ替え: %1$s</string>
+
+    <!-- Prompt versions -->
+    <string name="version_history">バージョン履歴</string>
+    <string name="no_versions">利用可能なバージョンがありません</string>
+    <string name="label_production">本番</string>
+    <string name="version_number">v%1$d</string>
+
+    <!-- Prompt variables -->
+    <string name="label_variables">変数</string>
+
+    <!-- Prompt filter sheet -->
+    <string name="label_category">カテゴリ</string>
+    <string name="label_all">すべて</string>
+    <string name="label_sort_by">並べ替え基準</string>
+
+    <!-- Prompt share dialog -->
+    <string name="dialog_title_share_prompt">プロンプトを共有</string>
+    <string name="label_permission">権限</string>
+
+    <!-- Variable input dialog -->
+    <string name="dialog_title_fill_variables">変数を入力</string>
+
+    <!-- Temp chat toggle -->
+    <string name="cd_temp_chat">一時的なチャット</string>
+    <string name="label_temp_chat">一時</string>
+
+    <!-- Comparison mode -->
+    <string name="continue_with_response">この応答で続ける</string>
+    <string name="waiting_for_response">応答を待っています…</string>
+
+    <!-- Slash command menu -->
+    <string name="slash_command_title">/%1$s</string>
+
+    <!-- Provider Keys chat-time errors. -->
+    <string name="provider_keys_chat_error_no_key">キーが見つかりません。キーを入力してもう一度お試しください。</string>
+    <!-- {0} = endpoint name, {1} = expiredAt (server-locale string, NOT ISO) -->
+    <string name="provider_keys_chat_error_expired">%1$s に提供されたキーは %2$s に期限切れになりました。新しいキーを入力してもう一度お試しください。</string>
+    <string name="provider_keys_chat_error_invalid">無効なキーが提供されました。有効なキーを入力してもう一度お試しください。</string>
+    <!-- Snackbar action label that deep-links to Settings → Provider Keys -->
+    <string name="provider_keys_chat_error_cta">キー設定を開く</string>
+
+    <!-- Send block reasons (shown in error snackbar when send can't proceed) -->
+    <string name="send_block_select_agent">メッセージを送信する前にエージェントを選択してください。</string>
+    <string name="send_block_select_model">メッセージを送信する前にモデルを選択してください。</string>
+    <string name="send_block_agents_unavailable">このサーバーではエージェントを利用できません。別のモデルを選択してください。</string>
+    <string name="send_block_agent_not_available">選択したエージェントはこのサーバーで利用できません。別のエージェントを選択してください。</string>
+    <string name="send_block_model_not_available">選択したモデルはこのサーバーで利用できません。別のモデルを選択してください。</string>
+    <string name="send_block_model_load_failed">選択したモデルをまだ読み込めませんでした。もう一度お試しいただくか、別のモデルを選択してください。</string>
+</resources>

--- a/feature/chat/src/commonMain/composeResources/values-ko/strings.xml
+++ b/feature/chat/src/commonMain/composeResources/values-ko/strings.xml
@@ -1,0 +1,369 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Common actions -->
+    <string name="cancel">취소</string>
+    <string name="save">저장</string>
+    <string name="delete">삭제</string>
+    <string name="copy">복사</string>
+    <string name="edit">편집</string>
+    <string name="regenerate">다시 생성</string>
+    <string name="action_rename">이름 변경</string>
+    <string name="action_submit">제출</string>
+    <string name="action_insert">삽입</string>
+    <string name="action_open">열기</string>
+    <string name="action_close">닫기</string>
+    <string name="action_share">공유</string>
+    <string name="action_search">검색</string>
+    <string name="action_archive">보관</string>
+    <string name="action_duplicate">복제</string>
+    <string name="action_copy_link">링크 복사</string>
+
+    <!-- Chat screen -->
+    <string name="new_chat">새 채팅</string>
+    <string name="send_message">전송</string>
+    <string name="stop_generating">중지</string>
+    <string name="message_hint">메시지를 입력하세요…</string>
+    <string name="model_parameters">모델 매개변수</string>
+    <string name="load_preset">프리셋 불러오기</string>
+    <string name="save_as_preset">프리셋으로 저장</string>
+    <string name="search_models">모델 검색…</string>
+    <string name="save_and_submit">저장 &amp; 제출</string>
+    <string name="preset_name_label">프리셋 이름</string>
+    <string name="code">코드</string>
+    <string name="preview">미리보기</string>
+    <string name="select_model">모델 선택</string>
+    <string name="select_a_model">모델을 선택하세요</string>
+    <string name="starred_group">즐겨찾기</string>
+    <!-- Neutral label for the active agent when its name hasn't resolved yet (never a model string). -->
+    <string name="chat_agent_fallback_label">에이전트</string>
+    <string name="compare_models">모델 비교</string>
+    <string name="how_can_i_help">오늘 무엇을 도와드릴까요?</string>
+    <string name="recording">녹음 중…</string>
+    <string name="hint_message_model">%1$s에게 메시지</string>
+    <string name="hint_message">메시지…</string>
+
+    <!-- Content descriptions - Chat -->
+    <string name="cd_open_tools_menu">도구 메뉴 열기</string>
+    <string name="cd_paste_image">클립보드에서 이미지 붙여넣기</string>
+    <string name="cd_message_input">메시지 입력 필드</string>
+    <string name="cd_stop_voice_recording">음성 녹음 중지</string>
+    <string name="cd_start_voice_recording">음성 녹음 시작</string>
+    <string name="cd_stop_generation">생성 중지</string>
+    <string name="cd_send_message">메시지 전송</string>
+    <string name="cd_open_drawer">탐색 서랍 열기</string>
+    <string name="cd_more_options">추가 옵션</string>
+    <string name="cd_more_tools">추가 도구</string>
+    <string name="cd_scroll_to_bottom">맨 아래로 스크롤</string>
+    <string name="cd_select_model">모델 선택</string>
+    <string name="cd_librechat">LibreChat</string>
+    <string name="cd_comparison_enabled">비교 사용</string>
+
+    <!-- Content descriptions - Messages -->
+    <string name="cd_thumbs_up">좋아요</string>
+    <string name="cd_thumbs_down">싫어요</string>
+    <string name="cd_copy_message">메시지 복사</string>
+    <string name="cd_edit_message">메시지 편집</string>
+    <string name="cd_regenerate_response">응답 다시 생성</string>
+    <string name="cd_stop_reading">읽기 중지</string>
+    <string name="cd_read_aloud">소리 내어 읽기</string>
+    <string name="cd_fork_conversation">여기서 대화 분기</string>
+    <string name="cd_previous_response">이전 응답</string>
+    <string name="cd_next_response">다음 응답</string>
+    <string name="cd_generating_response">응답 생성 중</string>
+
+    <!-- Content descriptions - Images -->
+    <string name="cd_fullscreen_image">전체 화면 이미지</string>
+    <string name="cd_close">닫기</string>
+    <string name="cd_save_to_device">기기에 저장</string>
+    <string name="cd_share_image">이미지 공유</string>
+    <string name="cd_failed_to_load_image">이미지를 불러오지 못했습니다</string>
+    <string name="cd_failed_to_load_generated_image">생성된 이미지를 불러오지 못했습니다</string>
+    <string name="cd_embedded_image">메시지에 포함된 이미지</string>
+
+    <!-- Content descriptions - Search -->
+    <string name="cd_search_in_conversation">대화에서 검색</string>
+    <string name="cd_previous_match">이전 검색 결과</string>
+    <string name="cd_next_match">다음 검색 결과</string>
+    <string name="cd_close_search">검색 닫기</string>
+    <string name="cd_clear_search">검색 지우기</string>
+    <string name="hint_find_in_conversation">대화에서 찾기…</string>
+
+    <!-- Content descriptions - Code -->
+    <string name="cd_copy_code">코드 복사</string>
+    <string name="cd_copied">복사됨</string>
+    <string name="action_copy_code">복사</string>
+    <string name="action_copied">복사됨!</string>
+    <string name="cd_code_execution_result">코드 실행 결과</string>
+    <string name="cd_exit_code_success">종료 코드 0 (성공)</string>
+    <string name="cd_exit_code_failure">종료 코드 %1$d (실패)</string>
+    <string name="exit_code">종료 %1$d</string>
+    <string name="label_code">코드</string>
+    <string name="label_output">출력:</string>
+    <string name="label_error">오류:</string>
+    <string name="label_input">입력:</string>
+    <string name="cd_collapse_code">코드 접기</string>
+    <string name="cd_expand_code">코드 펼치기</string>
+
+    <!-- Content descriptions - Thinking -->
+    <string name="cd_thinking_indicator">사고 과정 표시</string>
+    <string name="label_thinking">사고 중</string>
+    <string name="cd_collapse">접기</string>
+    <string name="cd_expand">펼치기</string>
+    <string name="cd_collapse_thinking">사고 과정 블록 접기</string>
+    <string name="cd_expand_thinking">사고 과정 블록 펼치기</string>
+
+    <!-- Content descriptions - Summary (context compaction, v0.8.5+) -->
+    <string name="label_summary">이전 메시지 요약됨</string>
+    <string name="cd_summary_indicator">요약 표시</string>
+    <string name="cd_collapse_summary">요약 블록 접기</string>
+    <string name="cd_expand_summary">요약 블록 펼치기</string>
+
+    <!-- Content descriptions - Subagent trace (subagents, v0.8.6+) -->
+    <string name="label_subagent">서브에이전트</string>
+    <string name="cd_collapse_subagent">서브에이전트 %1$s 접기</string>
+    <string name="cd_expand_subagent">서브에이전트 %1$s 펼치기</string>
+
+    <!-- Office-doc preview attachments (deferred preview, v0.8.6+) -->
+    <string name="office_preview_preparing">%1$s 미리보기 준비 중…</string>
+    <string name="office_preview_failed">%1$s을(를) 미리볼 수 없습니다 (%2$s)</string>
+    <string name="office_preview_unavailable">%1$s — 미리보기를 사용할 수 없습니다</string>
+
+    <!-- Content descriptions - Tool calls -->
+    <string name="cd_tool_call">도구 호출</string>
+    <string name="cd_collapse_tool_call">도구 호출 %1$s 접기</string>
+    <string name="cd_expand_tool_call">도구 호출 %1$s 펼치기</string>
+    <string name="cd_tool_complete">완료</string>
+    <string name="cd_tool_enabled">사용</string>
+    <string name="video_not_supported">동영상 콘텐츠는 지원되지 않습니다</string>
+
+    <!-- Tools bottom sheet -->
+    <string name="tool_camera">카메라</string>
+    <string name="tool_photos">사진</string>
+    <string name="tool_files">파일</string>
+    <string name="tool_model">모델</string>
+    <string name="tool_model_parameters">모델 매개변수</string>
+    <string name="tool_model_parameters_desc">온도, 토큰 등 조정</string>
+    <string name="tool_web_search">웹 검색</string>
+    <string name="tool_web_search_desc">웹에서 정보 검색</string>
+    <string name="tool_code">코드</string>
+    <string name="tool_code_desc">코드 실행 및 분석</string>
+    <string name="tool_file_search">파일 검색</string>
+    <string name="tool_file_search_desc">업로드한 파일에서 검색</string>
+    <string name="tool_mcp">MCP</string>
+    <string name="tool_mcp_desc">Model Context Protocol 서버</string>
+    <string name="cd_web_search_enabled">웹 검색 사용</string>
+    <string name="cd_code_enabled">코드 인터프리터 사용</string>
+    <string name="cd_file_search_enabled">파일 검색 사용</string>
+
+    <!-- Attachments -->
+    <string name="cd_attach_file">파일 첨부</string>
+    <string name="toast_file_attach_unavailable">파일 첨부는 아직 iOS에서 사용할 수 없습니다</string>
+    <string name="files_count">파일 (%1$d)</string>
+    <string name="cd_attached_file">첨부된 파일: %1$s</string>
+    <string name="cd_preview_file">%1$s 미리보기</string>
+    <string name="cd_remove_file">%1$s 제거</string>
+
+    <!-- Agent handoff -->
+    <string name="cd_agent_handoff">%1$s에서 %2$s(으)로 에이전트 인계</string>
+    <string name="cd_handed_off_to">인계 대상</string>
+    <string name="agent_unknown">알 수 없음</string>
+    <string name="agent_previous">이전 에이전트</string>
+    <string name="agent_next">다음 에이전트</string>
+
+    <!-- Audio/Video -->
+    <string name="cd_pause">일시정지</string>
+    <string name="cd_play">재생</string>
+    <string name="cd_play_video">동영상 재생</string>
+    <string name="audio_no_data">오디오 데이터가 없습니다</string>
+    <string name="audio_decode_failed">오디오를 디코딩하지 못했습니다</string>
+
+    <!-- Citation -->
+    <string name="citation_number">인용 %1$d</string>
+    <string name="cd_open_citation_url">인용 URL 열기</string>
+
+    <!-- Fork options -->
+    <string name="fork_conversation">대화 분기</string>
+    <string name="fork_visible_messages">표시된 메시지</string>
+    <string name="fork_visible_messages_desc">직접 경로의 메시지만</string>
+    <string name="fork_include_branches">분기 포함</string>
+    <string name="fork_include_branches_desc">직접 경로와 형제 메시지</string>
+    <string name="fork_all_to_target">대상 단계까지 전체</string>
+    <string name="fork_all_to_target_desc">이 단계까지의 모든 메시지와 분기</string>
+    <string name="fork_start_new">대상에서 새 대화 시작</string>
+    <string name="fork_start_new_desc">루트 대신 선택한 메시지에서 분기를 시작합니다</string>
+
+    <!-- Image viewer toasts -->
+    <string name="toast_failed_to_load_image">이미지를 불러오지 못했습니다</string>
+    <string name="toast_failed_to_save_image">이미지를 저장하지 못했습니다</string>
+    <string name="toast_image_saved">이미지를 갤러리에 저장했습니다</string>
+    <string name="toast_failed_to_save_with_error">이미지를 저장하지 못했습니다: %1$s</string>
+    <string name="toast_storage_permission_required">이미지를 저장하려면 저장소 권한이 필요합니다</string>
+
+    <!-- Image generation -->
+    <string name="generating_image">이미지 생성 중…</string>
+    <string name="image_generated">이미지 생성됨</string>
+    <string name="cd_generated_image">생성된 이미지</string>
+
+    <!-- Landing page greetings -->
+    <string name="greeting_late_night">늦은 밤이네요</string>
+    <string name="greeting_weekend_morning">즐거운 주말 아침입니다</string>
+    <string name="greeting_weekend_afternoon">즐거운 주말 오후입니다</string>
+    <string name="greeting_weekend_evening">즐거운 주말 저녁입니다</string>
+    <string name="greeting_early_morning">상쾌한 이른 아침입니다</string>
+    <string name="greeting_morning">좋은 아침입니다</string>
+    <string name="greeting_afternoon">좋은 오후입니다</string>
+    <string name="greeting_evening">좋은 저녁입니다</string>
+
+    <!-- Log content -->
+    <string name="log_output">로그 출력</string>
+    <string name="cd_collapse_log">%1$s 접기</string>
+    <string name="cd_expand_log">%1$s 펼치기</string>
+
+    <!-- Table dialog -->
+    <string name="cd_expand_table">표 펼치기</string>
+    <string name="dialog_table">표</string>
+
+    <!-- MCP -->
+    <string name="cd_select_mcp_servers">MCP 서버 선택</string>
+    <string name="cd_mcp_resources">MCP 리소스: %1$d개 항목</string>
+    <string name="cd_mcp_resource">MCP 리소스: %1$s</string>
+
+    <!-- Memory artifact -->
+    <string name="cd_memory_artifact">메모리 아티팩트: %1$s</string>
+    <string name="memory_artifact_untitled">제목 없음</string>
+    <string name="label_memory">메모리</string>
+
+    <!-- Mermaid diagram -->
+    <string name="label_mermaid">mermaid</string>
+    <string name="cd_show_diagram">다이어그램 표시</string>
+    <string name="cd_view_code">코드 보기</string>
+    <string name="label_diagram">다이어그램</string>
+    <string name="cd_fullscreen">전체 화면</string>
+    <string name="cd_close_fullscreen">전체 화면 닫기</string>
+
+    <!-- Message bubble -->
+    <string name="sender_you">나</string>
+    <string name="sender_assistant">어시스턴트</string>
+
+    <!-- Message files -->
+    <string name="file_fallback">파일</string>
+
+    <!-- Model selector sheet -->
+    <string name="cd_selected">선택됨</string>
+    <string name="cd_public_agent">공개 에이전트</string>
+    <string name="cd_pin_favorite">즐겨찾기로 고정</string>
+    <string name="cd_unpin_favorite">즐겨찾기 고정 해제</string>
+    <string name="cd_collapse_section">%1$s 접기</string>
+    <string name="cd_expand_section">%1$s 펼치기</string>
+    <string name="set_api_key_action">API 키 설정</string>
+    <string name="cd_set_api_key">%1$s의 API 키 구성</string>
+
+    <!-- Preset picker -->
+    <string name="select_preset">프리셋 선택</string>
+    <string name="no_presets_saved">아직 저장된 프리셋이 없습니다</string>
+    <string name="cd_edit_preset">%1$s 편집</string>
+    <string name="cd_delete_preset">%1$s 삭제</string>
+    <string name="preset_endpoint">엔드포인트: %1$s</string>
+    <string name="preset_model">모델: %1$s</string>
+
+    <!-- Feedback dialog -->
+    <string name="dialog_title_feedback">피드백 제공</string>
+    <string name="feedback_question">이 응답의 문제점은 무엇이었나요?</string>
+    <string name="hint_optional_comment">선택 사항 의견…</string>
+
+    <!-- Streaming tool call -->
+    <string name="tool_call_output">출력:</string>
+
+    <!-- Web search result -->
+    <string name="cd_search_result">검색 결과: %1$s</string>
+
+    <!-- Rename dialog -->
+    <string name="dialog_title_rename">대화 이름 변경</string>
+    <string name="hint_title">제목</string>
+
+    <!-- Delete dialog -->
+    <string name="dialog_title_delete_conversation">대화 삭제</string>
+    <string name="dialog_delete_conversation_message">이 대화를 영구적으로 삭제합니다. 되돌릴 수 없습니다.</string>
+
+    <!-- Chat menu options -->
+    <string name="menu_search">검색</string>
+    <string name="menu_rename">이름 변경</string>
+
+    <!-- Artifacts -->
+    <string name="cd_open_artifact">아티팩트 열기</string>
+    <string name="cd_share_artifact">아티팩트 공유</string>
+    <string name="cd_previous_version">이전 버전</string>
+    <string name="cd_next_version">다음 버전</string>
+    <string name="artifact_version">v%1$d/%2$d</string>
+    <string name="label_resource">리소스</string>
+
+    <!-- Prompts -->
+    <string name="prompts_library">프롬프트 라이브러리</string>
+    <string name="use_in_chat">채팅에서 사용</string>
+    <string name="set_production">프로덕션으로 설정</string>
+    <string name="prompt_name_label">이름</string>
+    <string name="prompt_description_label">설명</string>
+    <string name="prompt_command_label">명령어</string>
+    <string name="prompt_text_label">프롬프트 텍스트</string>
+    <string name="prompt_content">프롬프트 내용</string>
+    <string name="cd_share_prompt">프롬프트 공유</string>
+    <string name="cd_edit_prompt">프롬프트 편집</string>
+    <string name="cd_delete_prompt">프롬프트 삭제</string>
+    <string name="cd_back">뒤로</string>
+    <string name="cd_version_history">버전 기록</string>
+    <string name="cd_filter_sort">필터 및 정렬</string>
+    <string name="cd_create_prompt">프롬프트 생성</string>
+    <string name="cd_remove_filter">필터 제거</string>
+    <string name="cd_reset_sort">정렬 초기화</string>
+    <string name="cd_share">공유</string>
+    <string name="prompt_author">작성자: %1$s</string>
+    <string name="prompt_sort_label">정렬: %1$s</string>
+
+    <!-- Prompt versions -->
+    <string name="version_history">버전 기록</string>
+    <string name="no_versions">사용 가능한 버전이 없습니다</string>
+    <string name="label_production">프로덕션</string>
+    <string name="version_number">v%1$d</string>
+
+    <!-- Prompt variables -->
+    <string name="label_variables">변수</string>
+
+    <!-- Prompt filter sheet -->
+    <string name="label_category">카테고리</string>
+    <string name="label_all">전체</string>
+    <string name="label_sort_by">정렬 기준</string>
+
+    <!-- Prompt share dialog -->
+    <string name="dialog_title_share_prompt">프롬프트 공유</string>
+    <string name="label_permission">권한</string>
+
+    <!-- Variable input dialog -->
+    <string name="dialog_title_fill_variables">변수 입력</string>
+
+    <!-- Temp chat toggle -->
+    <string name="cd_temp_chat">임시 채팅</string>
+    <string name="label_temp_chat">임시</string>
+
+    <!-- Comparison mode -->
+    <string name="continue_with_response">이 응답으로 계속하기</string>
+    <string name="waiting_for_response">응답 대기 중…</string>
+
+    <!-- Slash command menu -->
+    <string name="slash_command_title">/%1$s</string>
+
+    <!-- Provider Keys chat-time errors. -->
+    <string name="provider_keys_chat_error_no_key">키를 찾을 수 없습니다. 키를 입력한 후 다시 시도하세요.</string>
+    <!-- {0} = endpoint name, {1} = expiredAt (server-locale string, NOT ISO) -->
+    <string name="provider_keys_chat_error_expired">%1$s에 제공된 키가 %2$s에 만료되었습니다. 새 키를 입력한 후 다시 시도하세요.</string>
+    <string name="provider_keys_chat_error_invalid">유효하지 않은 키입니다. 유효한 키를 입력한 후 다시 시도하세요.</string>
+    <!-- Snackbar action label that deep-links to Settings → Provider Keys -->
+    <string name="provider_keys_chat_error_cta">키 설정 열기</string>
+
+    <!-- Send block reasons (shown in error snackbar when send can't proceed) -->
+    <string name="send_block_select_agent">메시지를 보내기 전에 에이전트를 선택하세요.</string>
+    <string name="send_block_select_model">메시지를 보내기 전에 모델을 선택하세요.</string>
+    <string name="send_block_agents_unavailable">이 서버에서는 에이전트를 사용할 수 없습니다. 다른 모델을 선택하세요.</string>
+    <string name="send_block_agent_not_available">선택한 에이전트를 이 서버에서 사용할 수 없습니다. 다른 에이전트를 선택하세요.</string>
+    <string name="send_block_model_not_available">선택한 모델을 이 서버에서 사용할 수 없습니다. 다른 모델을 선택하세요.</string>
+    <string name="send_block_model_load_failed">선택한 모델을 아직 불러올 수 없습니다. 다시 시도하거나 다른 모델을 선택하세요.</string>
+</resources>

--- a/feature/chat/src/commonMain/composeResources/values-pt/strings.xml
+++ b/feature/chat/src/commonMain/composeResources/values-pt/strings.xml
@@ -1,0 +1,369 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Common actions -->
+    <string name="cancel">Cancelar</string>
+    <string name="save">Salvar</string>
+    <string name="delete">Excluir</string>
+    <string name="copy">Copiar</string>
+    <string name="edit">Editar</string>
+    <string name="regenerate">Regenerar</string>
+    <string name="action_rename">Renomear</string>
+    <string name="action_submit">Enviar</string>
+    <string name="action_insert">Inserir</string>
+    <string name="action_open">Abrir</string>
+    <string name="action_close">Fechar</string>
+    <string name="action_share">Compartilhar</string>
+    <string name="action_search">Buscar</string>
+    <string name="action_archive">Arquivar</string>
+    <string name="action_duplicate">Duplicar</string>
+    <string name="action_copy_link">Copiar link</string>
+
+    <!-- Chat screen -->
+    <string name="new_chat">Nova conversa</string>
+    <string name="send_message">Enviar</string>
+    <string name="stop_generating">Parar</string>
+    <string name="message_hint">Digite uma mensagem…</string>
+    <string name="model_parameters">Parâmetros do modelo</string>
+    <string name="load_preset">Carregar predefinição</string>
+    <string name="save_as_preset">Salvar como predefinição</string>
+    <string name="search_models">Buscar modelos…</string>
+    <string name="save_and_submit">Salvar &amp; enviar</string>
+    <string name="preset_name_label">Nome da predefinição</string>
+    <string name="code">Código</string>
+    <string name="preview">Visualizar</string>
+    <string name="select_model">Selecionar modelo</string>
+    <string name="select_a_model">Selecione um modelo</string>
+    <string name="starred_group">Favoritos</string>
+    <!-- Neutral label for the active agent when its name hasn't resolved yet (never a model string). -->
+    <string name="chat_agent_fallback_label">Agente</string>
+    <string name="compare_models">Comparar modelos</string>
+    <string name="how_can_i_help">Como posso ajudar você hoje?</string>
+    <string name="recording">Gravando…</string>
+    <string name="hint_message_model">Mensagem para %1$s</string>
+    <string name="hint_message">Mensagem…</string>
+
+    <!-- Content descriptions - Chat -->
+    <string name="cd_open_tools_menu">Abrir menu de ferramentas</string>
+    <string name="cd_paste_image">Colar imagem da área de transferência</string>
+    <string name="cd_message_input">Campo de entrada de mensagem</string>
+    <string name="cd_stop_voice_recording">Parar gravação de voz</string>
+    <string name="cd_start_voice_recording">Iniciar gravação de voz</string>
+    <string name="cd_stop_generation">Parar geração</string>
+    <string name="cd_send_message">Enviar mensagem</string>
+    <string name="cd_open_drawer">Abrir menu de navegação</string>
+    <string name="cd_more_options">Mais opções</string>
+    <string name="cd_more_tools">Mais ferramentas</string>
+    <string name="cd_scroll_to_bottom">Rolar até o final</string>
+    <string name="cd_select_model">Selecionar modelo</string>
+    <string name="cd_librechat">LibreChat</string>
+    <string name="cd_comparison_enabled">Comparação ativada</string>
+
+    <!-- Content descriptions - Messages -->
+    <string name="cd_thumbs_up">Gostei</string>
+    <string name="cd_thumbs_down">Não gostei</string>
+    <string name="cd_copy_message">Copiar mensagem</string>
+    <string name="cd_edit_message">Editar mensagem</string>
+    <string name="cd_regenerate_response">Regenerar resposta</string>
+    <string name="cd_stop_reading">Parar leitura</string>
+    <string name="cd_read_aloud">Ler em voz alta</string>
+    <string name="cd_fork_conversation">Bifurcar conversa a partir daqui</string>
+    <string name="cd_previous_response">Resposta anterior</string>
+    <string name="cd_next_response">Próxima resposta</string>
+    <string name="cd_generating_response">Gerando resposta</string>
+
+    <!-- Content descriptions - Images -->
+    <string name="cd_fullscreen_image">Imagem em tela cheia</string>
+    <string name="cd_close">Fechar</string>
+    <string name="cd_save_to_device">Salvar no dispositivo</string>
+    <string name="cd_share_image">Compartilhar imagem</string>
+    <string name="cd_failed_to_load_image">Falha ao carregar a imagem</string>
+    <string name="cd_failed_to_load_generated_image">Falha ao carregar a imagem gerada</string>
+    <string name="cd_embedded_image">Imagem incorporada na mensagem</string>
+
+    <!-- Content descriptions - Search -->
+    <string name="cd_search_in_conversation">Buscar na conversa</string>
+    <string name="cd_previous_match">Correspondência anterior</string>
+    <string name="cd_next_match">Próxima correspondência</string>
+    <string name="cd_close_search">Fechar busca</string>
+    <string name="cd_clear_search">Limpar busca</string>
+    <string name="hint_find_in_conversation">Localizar na conversa…</string>
+
+    <!-- Content descriptions - Code -->
+    <string name="cd_copy_code">Copiar código</string>
+    <string name="cd_copied">Copiado</string>
+    <string name="action_copy_code">Copiar</string>
+    <string name="action_copied">Copiado!</string>
+    <string name="cd_code_execution_result">Resultado da execução do código</string>
+    <string name="cd_exit_code_success">Código de saída 0 (sucesso)</string>
+    <string name="cd_exit_code_failure">Código de saída %1$d (falha)</string>
+    <string name="exit_code">saída %1$d</string>
+    <string name="label_code">Código</string>
+    <string name="label_output">Saída:</string>
+    <string name="label_error">Erro:</string>
+    <string name="label_input">Entrada:</string>
+    <string name="cd_collapse_code">Recolher código</string>
+    <string name="cd_expand_code">Expandir código</string>
+
+    <!-- Content descriptions - Thinking -->
+    <string name="cd_thinking_indicator">Indicador de raciocínio</string>
+    <string name="label_thinking">Raciocinando</string>
+    <string name="cd_collapse">Recolher</string>
+    <string name="cd_expand">Expandir</string>
+    <string name="cd_collapse_thinking">Recolher bloco de raciocínio</string>
+    <string name="cd_expand_thinking">Expandir bloco de raciocínio</string>
+
+    <!-- Content descriptions - Summary (context compaction, v0.8.5+) -->
+    <string name="label_summary">Mensagens anteriores resumidas</string>
+    <string name="cd_summary_indicator">Indicador de resumo</string>
+    <string name="cd_collapse_summary">Recolher bloco de resumo</string>
+    <string name="cd_expand_summary">Expandir bloco de resumo</string>
+
+    <!-- Content descriptions - Subagent trace (subagents, v0.8.6+) -->
+    <string name="label_subagent">Subagente</string>
+    <string name="cd_collapse_subagent">Recolher subagente %1$s</string>
+    <string name="cd_expand_subagent">Expandir subagente %1$s</string>
+
+    <!-- Office-doc preview attachments (deferred preview, v0.8.6+) -->
+    <string name="office_preview_preparing">Preparando visualização de %1$s…</string>
+    <string name="office_preview_failed">Não foi possível visualizar %1$s (%2$s)</string>
+    <string name="office_preview_unavailable">%1$s — visualização indisponível</string>
+
+    <!-- Content descriptions - Tool calls -->
+    <string name="cd_tool_call">Chamada de ferramenta</string>
+    <string name="cd_collapse_tool_call">Recolher chamada de ferramenta %1$s</string>
+    <string name="cd_expand_tool_call">Expandir chamada de ferramenta %1$s</string>
+    <string name="cd_tool_complete">Concluída</string>
+    <string name="cd_tool_enabled">Ativada</string>
+    <string name="video_not_supported">Conteúdo de vídeo não suportado</string>
+
+    <!-- Tools bottom sheet -->
+    <string name="tool_camera">Câmera</string>
+    <string name="tool_photos">Fotos</string>
+    <string name="tool_files">Arquivos</string>
+    <string name="tool_model">Modelo</string>
+    <string name="tool_model_parameters">Parâmetros do modelo</string>
+    <string name="tool_model_parameters_desc">Ajuste temperatura, tokens e mais</string>
+    <string name="tool_web_search">Busca na web</string>
+    <string name="tool_web_search_desc">Pesquise informações na web</string>
+    <string name="tool_code">Código</string>
+    <string name="tool_code_desc">Executar e analisar código</string>
+    <string name="tool_file_search">Busca em arquivos</string>
+    <string name="tool_file_search_desc">Pesquise nos arquivos enviados</string>
+    <string name="tool_mcp">MCP</string>
+    <string name="tool_mcp_desc">Servidores Model Context Protocol</string>
+    <string name="cd_web_search_enabled">Busca na web ativada</string>
+    <string name="cd_code_enabled">Interpretador de código ativado</string>
+    <string name="cd_file_search_enabled">Busca em arquivos ativada</string>
+
+    <!-- Attachments -->
+    <string name="cd_attach_file">Anexar arquivo</string>
+    <string name="toast_file_attach_unavailable">Anexos de arquivo ainda não disponíveis no iOS</string>
+    <string name="files_count">Arquivos (%1$d)</string>
+    <string name="cd_attached_file">Arquivo anexado: %1$s</string>
+    <string name="cd_preview_file">Visualização de %1$s</string>
+    <string name="cd_remove_file">Remover %1$s</string>
+
+    <!-- Agent handoff -->
+    <string name="cd_agent_handoff">Transferência de agente de %1$s para %2$s</string>
+    <string name="cd_handed_off_to">transferido para</string>
+    <string name="agent_unknown">desconhecido</string>
+    <string name="agent_previous">Agente anterior</string>
+    <string name="agent_next">Próximo agente</string>
+
+    <!-- Audio/Video -->
+    <string name="cd_pause">Pausar</string>
+    <string name="cd_play">Reproduzir</string>
+    <string name="cd_play_video">Reproduzir vídeo</string>
+    <string name="audio_no_data">Nenhum dado de áudio</string>
+    <string name="audio_decode_failed">Falha ao decodificar o áudio</string>
+
+    <!-- Citation -->
+    <string name="citation_number">Citação %1$d</string>
+    <string name="cd_open_citation_url">Abrir URL da citação</string>
+
+    <!-- Fork options -->
+    <string name="fork_conversation">Bifurcar conversa</string>
+    <string name="fork_visible_messages">Mensagens visíveis</string>
+    <string name="fork_visible_messages_desc">Apenas o caminho direto de mensagens</string>
+    <string name="fork_include_branches">Incluir ramificações</string>
+    <string name="fork_include_branches_desc">Caminho direto mais mensagens irmãs</string>
+    <string name="fork_all_to_target">Tudo até o nível alvo</string>
+    <string name="fork_all_to_target_desc">Todas as mensagens e ramificações até este nível</string>
+    <string name="fork_start_new">Iniciar nova conversa a partir do alvo</string>
+    <string name="fork_start_new_desc">Começar a bifurcação a partir da mensagem selecionada, em vez da raiz</string>
+
+    <!-- Image viewer toasts -->
+    <string name="toast_failed_to_load_image">Falha ao carregar a imagem</string>
+    <string name="toast_failed_to_save_image">Falha ao salvar a imagem</string>
+    <string name="toast_image_saved">Imagem salva na galeria</string>
+    <string name="toast_failed_to_save_with_error">Falha ao salvar a imagem: %1$s</string>
+    <string name="toast_storage_permission_required">É necessária permissão de armazenamento para salvar imagens</string>
+
+    <!-- Image generation -->
+    <string name="generating_image">Gerando imagem…</string>
+    <string name="image_generated">Imagem gerada</string>
+    <string name="cd_generated_image">Imagem gerada</string>
+
+    <!-- Landing page greetings -->
+    <string name="greeting_late_night">Boa madrugada</string>
+    <string name="greeting_weekend_morning">Bom fim de semana de manhã</string>
+    <string name="greeting_weekend_afternoon">Bom fim de semana à tarde</string>
+    <string name="greeting_weekend_evening">Bom fim de semana à noite</string>
+    <string name="greeting_early_morning">Bom amanhecer</string>
+    <string name="greeting_morning">Bom dia</string>
+    <string name="greeting_afternoon">Boa tarde</string>
+    <string name="greeting_evening">Boa noite</string>
+
+    <!-- Log content -->
+    <string name="log_output">Saída do log</string>
+    <string name="cd_collapse_log">Recolher %1$s</string>
+    <string name="cd_expand_log">Expandir %1$s</string>
+
+    <!-- Table dialog -->
+    <string name="cd_expand_table">Expandir tabela</string>
+    <string name="dialog_table">Tabela</string>
+
+    <!-- MCP -->
+    <string name="cd_select_mcp_servers">Selecionar servidores MCP</string>
+    <string name="cd_mcp_resources">Recursos MCP: %1$d itens</string>
+    <string name="cd_mcp_resource">Recurso MCP: %1$s</string>
+
+    <!-- Memory artifact -->
+    <string name="cd_memory_artifact">Artefato de memória: %1$s</string>
+    <string name="memory_artifact_untitled">Sem título</string>
+    <string name="label_memory">Memória</string>
+
+    <!-- Mermaid diagram -->
+    <string name="label_mermaid">mermaid</string>
+    <string name="cd_show_diagram">Mostrar diagrama</string>
+    <string name="cd_view_code">Ver código</string>
+    <string name="label_diagram">Diagrama</string>
+    <string name="cd_fullscreen">Tela cheia</string>
+    <string name="cd_close_fullscreen">Fechar tela cheia</string>
+
+    <!-- Message bubble -->
+    <string name="sender_you">Você</string>
+    <string name="sender_assistant">Assistente</string>
+
+    <!-- Message files -->
+    <string name="file_fallback">Arquivo</string>
+
+    <!-- Model selector sheet -->
+    <string name="cd_selected">Selecionado</string>
+    <string name="cd_public_agent">Agente público</string>
+    <string name="cd_pin_favorite">Fixar como favorito</string>
+    <string name="cd_unpin_favorite">Desafixar favorito</string>
+    <string name="cd_collapse_section">Recolher %1$s</string>
+    <string name="cd_expand_section">Expandir %1$s</string>
+    <string name="set_api_key_action">Definir chave de API</string>
+    <string name="cd_set_api_key">Configurar chave de API para %1$s</string>
+
+    <!-- Preset picker -->
+    <string name="select_preset">Selecionar predefinição</string>
+    <string name="no_presets_saved">Nenhuma predefinição salva ainda</string>
+    <string name="cd_edit_preset">Editar %1$s</string>
+    <string name="cd_delete_preset">Excluir %1$s</string>
+    <string name="preset_endpoint">Endpoint: %1$s</string>
+    <string name="preset_model">Modelo: %1$s</string>
+
+    <!-- Feedback dialog -->
+    <string name="dialog_title_feedback">Enviar feedback</string>
+    <string name="feedback_question">Qual foi o problema com esta resposta?</string>
+    <string name="hint_optional_comment">Comentário opcional…</string>
+
+    <!-- Streaming tool call -->
+    <string name="tool_call_output">Saída:</string>
+
+    <!-- Web search result -->
+    <string name="cd_search_result">Resultado da busca: %1$s</string>
+
+    <!-- Rename dialog -->
+    <string name="dialog_title_rename">Renomear conversa</string>
+    <string name="hint_title">Título</string>
+
+    <!-- Delete dialog -->
+    <string name="dialog_title_delete_conversation">Excluir conversa</string>
+    <string name="dialog_delete_conversation_message">Isso excluirá permanentemente esta conversa. Esta ação não pode ser desfeita.</string>
+
+    <!-- Chat menu options -->
+    <string name="menu_search">Buscar</string>
+    <string name="menu_rename">Renomear</string>
+
+    <!-- Artifacts -->
+    <string name="cd_open_artifact">Abrir artefato</string>
+    <string name="cd_share_artifact">Compartilhar artefato</string>
+    <string name="cd_previous_version">Versão anterior</string>
+    <string name="cd_next_version">Próxima versão</string>
+    <string name="artifact_version">v%1$d/%2$d</string>
+    <string name="label_resource">Recurso</string>
+
+    <!-- Prompts -->
+    <string name="prompts_library">Biblioteca de prompts</string>
+    <string name="use_in_chat">Usar na conversa</string>
+    <string name="set_production">Definir como produção</string>
+    <string name="prompt_name_label">Nome</string>
+    <string name="prompt_description_label">Descrição</string>
+    <string name="prompt_command_label">Comando</string>
+    <string name="prompt_text_label">Texto do prompt</string>
+    <string name="prompt_content">Conteúdo do prompt</string>
+    <string name="cd_share_prompt">Compartilhar prompt</string>
+    <string name="cd_edit_prompt">Editar prompt</string>
+    <string name="cd_delete_prompt">Excluir prompt</string>
+    <string name="cd_back">Voltar</string>
+    <string name="cd_version_history">Histórico de versões</string>
+    <string name="cd_filter_sort">Filtrar e ordenar</string>
+    <string name="cd_create_prompt">Criar prompt</string>
+    <string name="cd_remove_filter">Remover filtro</string>
+    <string name="cd_reset_sort">Redefinir ordenação</string>
+    <string name="cd_share">Compartilhar</string>
+    <string name="prompt_author">por %1$s</string>
+    <string name="prompt_sort_label">Ordenar: %1$s</string>
+
+    <!-- Prompt versions -->
+    <string name="version_history">Histórico de versões</string>
+    <string name="no_versions">Nenhuma versão disponível</string>
+    <string name="label_production">Produção</string>
+    <string name="version_number">v%1$d</string>
+
+    <!-- Prompt variables -->
+    <string name="label_variables">Variáveis</string>
+
+    <!-- Prompt filter sheet -->
+    <string name="label_category">Categoria</string>
+    <string name="label_all">Todas</string>
+    <string name="label_sort_by">Ordenar por</string>
+
+    <!-- Prompt share dialog -->
+    <string name="dialog_title_share_prompt">Compartilhar prompt</string>
+    <string name="label_permission">Permissão</string>
+
+    <!-- Variable input dialog -->
+    <string name="dialog_title_fill_variables">Preencher variáveis</string>
+
+    <!-- Temp chat toggle -->
+    <string name="cd_temp_chat">Conversa temporária</string>
+    <string name="label_temp_chat">Temp</string>
+
+    <!-- Comparison mode -->
+    <string name="continue_with_response">Continuar com esta resposta</string>
+    <string name="waiting_for_response">Aguardando resposta…</string>
+
+    <!-- Slash command menu -->
+    <string name="slash_command_title">/%1$s</string>
+
+    <!-- Provider Keys chat-time errors. -->
+    <string name="provider_keys_chat_error_no_key">Nenhuma chave encontrada. Forneça uma chave e tente novamente.</string>
+    <!-- {0} = endpoint name, {1} = expiredAt (server-locale string, NOT ISO) -->
+    <string name="provider_keys_chat_error_expired">A chave fornecida para %1$s expirou em %2$s. Forneça uma nova chave e tente novamente.</string>
+    <string name="provider_keys_chat_error_invalid">Chave inválida fornecida. Forneça uma chave válida e tente novamente.</string>
+    <!-- Snackbar action label that deep-links to Settings → Provider Keys -->
+    <string name="provider_keys_chat_error_cta">Abrir configurações de chaves</string>
+
+    <!-- Send block reasons (shown in error snackbar when send can't proceed) -->
+    <string name="send_block_select_agent">Selecione um agente antes de enviar sua mensagem.</string>
+    <string name="send_block_select_model">Selecione um modelo antes de enviar sua mensagem.</string>
+    <string name="send_block_agents_unavailable">Os agentes não estão disponíveis neste servidor. Escolha um modelo diferente.</string>
+    <string name="send_block_agent_not_available">O agente selecionado não está disponível neste servidor. Escolha um agente diferente.</string>
+    <string name="send_block_model_not_available">O modelo selecionado não está disponível neste servidor. Escolha um modelo diferente.</string>
+    <string name="send_block_model_load_failed">Ainda não foi possível carregar o modelo selecionado. Tente novamente ou escolha um modelo diferente.</string>
+</resources>

--- a/feature/chat/src/commonMain/composeResources/values-ru/strings.xml
+++ b/feature/chat/src/commonMain/composeResources/values-ru/strings.xml
@@ -1,0 +1,369 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Common actions -->
+    <string name="cancel">Отмена</string>
+    <string name="save">Сохранить</string>
+    <string name="delete">Удалить</string>
+    <string name="copy">Копировать</string>
+    <string name="edit">Изменить</string>
+    <string name="regenerate">Сгенерировать заново</string>
+    <string name="action_rename">Переименовать</string>
+    <string name="action_submit">Отправить</string>
+    <string name="action_insert">Вставить</string>
+    <string name="action_open">Открыть</string>
+    <string name="action_close">Закрыть</string>
+    <string name="action_share">Поделиться</string>
+    <string name="action_search">Поиск</string>
+    <string name="action_archive">В архив</string>
+    <string name="action_duplicate">Дублировать</string>
+    <string name="action_copy_link">Скопировать ссылку</string>
+
+    <!-- Chat screen -->
+    <string name="new_chat">Новый чат</string>
+    <string name="send_message">Отправить</string>
+    <string name="stop_generating">Стоп</string>
+    <string name="message_hint">Введите сообщение…</string>
+    <string name="model_parameters">Параметры модели</string>
+    <string name="load_preset">Загрузить пресет</string>
+    <string name="save_as_preset">Сохранить как пресет</string>
+    <string name="search_models">Поиск моделей…</string>
+    <string name="save_and_submit">Сохранить и отправить</string>
+    <string name="preset_name_label">Имя пресета</string>
+    <string name="code">Код</string>
+    <string name="preview">Предпросмотр</string>
+    <string name="select_model">Выбрать модель</string>
+    <string name="select_a_model">Выберите модель</string>
+    <string name="starred_group">Избранное</string>
+    <!-- Neutral label for the active agent when its name hasn't resolved yet (never a model string). -->
+    <string name="chat_agent_fallback_label">Агент</string>
+    <string name="compare_models">Сравнить модели</string>
+    <string name="how_can_i_help">Чем я могу помочь вам сегодня?</string>
+    <string name="recording">Запись…</string>
+    <string name="hint_message_model">Сообщение для %1$s</string>
+    <string name="hint_message">Сообщение…</string>
+
+    <!-- Content descriptions - Chat -->
+    <string name="cd_open_tools_menu">Открыть меню инструментов</string>
+    <string name="cd_paste_image">Вставить изображение из буфера обмена</string>
+    <string name="cd_message_input">Поле ввода сообщения</string>
+    <string name="cd_stop_voice_recording">Остановить запись голоса</string>
+    <string name="cd_start_voice_recording">Начать запись голоса</string>
+    <string name="cd_stop_generation">Остановить генерацию</string>
+    <string name="cd_send_message">Отправить сообщение</string>
+    <string name="cd_open_drawer">Открыть панель навигации</string>
+    <string name="cd_more_options">Дополнительно</string>
+    <string name="cd_more_tools">Ещё инструменты</string>
+    <string name="cd_scroll_to_bottom">Прокрутить вниз</string>
+    <string name="cd_select_model">Выбрать модель</string>
+    <string name="cd_librechat">LibreChat</string>
+    <string name="cd_comparison_enabled">Сравнение включено</string>
+
+    <!-- Content descriptions - Messages -->
+    <string name="cd_thumbs_up">Нравится</string>
+    <string name="cd_thumbs_down">Не нравится</string>
+    <string name="cd_copy_message">Скопировать сообщение</string>
+    <string name="cd_edit_message">Изменить сообщение</string>
+    <string name="cd_regenerate_response">Сгенерировать ответ заново</string>
+    <string name="cd_stop_reading">Остановить озвучивание</string>
+    <string name="cd_read_aloud">Озвучить</string>
+    <string name="cd_fork_conversation">Ответвить беседу отсюда</string>
+    <string name="cd_previous_response">Предыдущий ответ</string>
+    <string name="cd_next_response">Следующий ответ</string>
+    <string name="cd_generating_response">Генерация ответа</string>
+
+    <!-- Content descriptions - Images -->
+    <string name="cd_fullscreen_image">Изображение во весь экран</string>
+    <string name="cd_close">Закрыть</string>
+    <string name="cd_save_to_device">Сохранить на устройство</string>
+    <string name="cd_share_image">Поделиться изображением</string>
+    <string name="cd_failed_to_load_image">Не удалось загрузить изображение</string>
+    <string name="cd_failed_to_load_generated_image">Не удалось загрузить сгенерированное изображение</string>
+    <string name="cd_embedded_image">Встроенное изображение в сообщении</string>
+
+    <!-- Content descriptions - Search -->
+    <string name="cd_search_in_conversation">Поиск в беседе</string>
+    <string name="cd_previous_match">Предыдущее совпадение</string>
+    <string name="cd_next_match">Следующее совпадение</string>
+    <string name="cd_close_search">Закрыть поиск</string>
+    <string name="cd_clear_search">Очистить поиск</string>
+    <string name="hint_find_in_conversation">Найти в беседе…</string>
+
+    <!-- Content descriptions - Code -->
+    <string name="cd_copy_code">Скопировать код</string>
+    <string name="cd_copied">Скопировано</string>
+    <string name="action_copy_code">Копировать</string>
+    <string name="action_copied">Скопировано!</string>
+    <string name="cd_code_execution_result">Результат выполнения кода</string>
+    <string name="cd_exit_code_success">Код выхода 0 (успех)</string>
+    <string name="cd_exit_code_failure">Код выхода %1$d (ошибка)</string>
+    <string name="exit_code">выход %1$d</string>
+    <string name="label_code">Код</string>
+    <string name="label_output">Вывод:</string>
+    <string name="label_error">Ошибка:</string>
+    <string name="label_input">Ввод:</string>
+    <string name="cd_collapse_code">Свернуть код</string>
+    <string name="cd_expand_code">Развернуть код</string>
+
+    <!-- Content descriptions - Thinking -->
+    <string name="cd_thinking_indicator">Индикатор размышления</string>
+    <string name="label_thinking">Размышление</string>
+    <string name="cd_collapse">Свернуть</string>
+    <string name="cd_expand">Развернуть</string>
+    <string name="cd_collapse_thinking">Свернуть блок размышлений</string>
+    <string name="cd_expand_thinking">Развернуть блок размышлений</string>
+
+    <!-- Content descriptions - Summary (context compaction, v0.8.5+) -->
+    <string name="label_summary">Сводка предыдущих сообщений</string>
+    <string name="cd_summary_indicator">Индикатор сводки</string>
+    <string name="cd_collapse_summary">Свернуть блок сводки</string>
+    <string name="cd_expand_summary">Развернуть блок сводки</string>
+
+    <!-- Content descriptions - Subagent trace (subagents, v0.8.6+) -->
+    <string name="label_subagent">Субагент</string>
+    <string name="cd_collapse_subagent">Свернуть субагента %1$s</string>
+    <string name="cd_expand_subagent">Развернуть субагента %1$s</string>
+
+    <!-- Office-doc preview attachments (deferred preview, v0.8.6+) -->
+    <string name="office_preview_preparing">Подготовка предпросмотра %1$s…</string>
+    <string name="office_preview_failed">Не удалось показать предпросмотр %1$s (%2$s)</string>
+    <string name="office_preview_unavailable">%1$s — предпросмотр недоступен</string>
+
+    <!-- Content descriptions - Tool calls -->
+    <string name="cd_tool_call">Вызов инструмента</string>
+    <string name="cd_collapse_tool_call">Свернуть вызов инструмента %1$s</string>
+    <string name="cd_expand_tool_call">Развернуть вызов инструмента %1$s</string>
+    <string name="cd_tool_complete">Завершено</string>
+    <string name="cd_tool_enabled">Включено</string>
+    <string name="video_not_supported">Видеоконтент не поддерживается</string>
+
+    <!-- Tools bottom sheet -->
+    <string name="tool_camera">Камера</string>
+    <string name="tool_photos">Фото</string>
+    <string name="tool_files">Файлы</string>
+    <string name="tool_model">Модель</string>
+    <string name="tool_model_parameters">Параметры модели</string>
+    <string name="tool_model_parameters_desc">Настройте температуру, токены и другое</string>
+    <string name="tool_web_search">Веб-поиск</string>
+    <string name="tool_web_search_desc">Искать информацию в интернете</string>
+    <string name="tool_code">Код</string>
+    <string name="tool_code_desc">Запуск и анализ кода</string>
+    <string name="tool_file_search">Поиск по файлам</string>
+    <string name="tool_file_search_desc">Поиск по загруженным файлам</string>
+    <string name="tool_mcp">MCP</string>
+    <string name="tool_mcp_desc">Серверы Model Context Protocol</string>
+    <string name="cd_web_search_enabled">Веб-поиск включён</string>
+    <string name="cd_code_enabled">Интерпретатор кода включён</string>
+    <string name="cd_file_search_enabled">Поиск по файлам включён</string>
+
+    <!-- Attachments -->
+    <string name="cd_attach_file">Прикрепить файл</string>
+    <string name="toast_file_attach_unavailable">Вложения файлов пока недоступны на iOS</string>
+    <string name="files_count">Файлы (%1$d)</string>
+    <string name="cd_attached_file">Прикреплённый файл: %1$s</string>
+    <string name="cd_preview_file">Предпросмотр %1$s</string>
+    <string name="cd_remove_file">Удалить %1$s</string>
+
+    <!-- Agent handoff -->
+    <string name="cd_agent_handoff">Передача от агента %1$s к %2$s</string>
+    <string name="cd_handed_off_to">передано</string>
+    <string name="agent_unknown">неизвестно</string>
+    <string name="agent_previous">Предыдущий агент</string>
+    <string name="agent_next">Следующий агент</string>
+
+    <!-- Audio/Video -->
+    <string name="cd_pause">Пауза</string>
+    <string name="cd_play">Воспроизвести</string>
+    <string name="cd_play_video">Воспроизвести видео</string>
+    <string name="audio_no_data">Нет аудиоданных</string>
+    <string name="audio_decode_failed">Не удалось декодировать аудио</string>
+
+    <!-- Citation -->
+    <string name="citation_number">Источник %1$d</string>
+    <string name="cd_open_citation_url">Открыть URL источника</string>
+
+    <!-- Fork options -->
+    <string name="fork_conversation">Ответвить беседу</string>
+    <string name="fork_visible_messages">Видимые сообщения</string>
+    <string name="fork_visible_messages_desc">Только прямой путь сообщений</string>
+    <string name="fork_include_branches">Включить ветви</string>
+    <string name="fork_include_branches_desc">Прямой путь плюс соседние сообщения</string>
+    <string name="fork_all_to_target">Все до уровня цели</string>
+    <string name="fork_all_to_target_desc">Все сообщения и ветви до этого уровня</string>
+    <string name="fork_start_new">Начать новую беседу с цели</string>
+    <string name="fork_start_new_desc">Начать ответвление с выбранного сообщения, а не с корня</string>
+
+    <!-- Image viewer toasts -->
+    <string name="toast_failed_to_load_image">Не удалось загрузить изображение</string>
+    <string name="toast_failed_to_save_image">Не удалось сохранить изображение</string>
+    <string name="toast_image_saved">Изображение сохранено в галерею</string>
+    <string name="toast_failed_to_save_with_error">Не удалось сохранить изображение: %1$s</string>
+    <string name="toast_storage_permission_required">Для сохранения изображений требуется разрешение на доступ к хранилищу</string>
+
+    <!-- Image generation -->
+    <string name="generating_image">Генерация изображения…</string>
+    <string name="image_generated">Изображение сгенерировано</string>
+    <string name="cd_generated_image">Сгенерированное изображение</string>
+
+    <!-- Landing page greetings -->
+    <string name="greeting_late_night">Доброй ночи</string>
+    <string name="greeting_weekend_morning">Приятного утра выходного</string>
+    <string name="greeting_weekend_afternoon">Приятного дня выходного</string>
+    <string name="greeting_weekend_evening">Приятного вечера выходного</string>
+    <string name="greeting_early_morning">Доброго раннего утра</string>
+    <string name="greeting_morning">Доброе утро</string>
+    <string name="greeting_afternoon">Добрый день</string>
+    <string name="greeting_evening">Добрый вечер</string>
+
+    <!-- Log content -->
+    <string name="log_output">Вывод журнала</string>
+    <string name="cd_collapse_log">Свернуть %1$s</string>
+    <string name="cd_expand_log">Развернуть %1$s</string>
+
+    <!-- Table dialog -->
+    <string name="cd_expand_table">Развернуть таблицу</string>
+    <string name="dialog_table">Таблица</string>
+
+    <!-- MCP -->
+    <string name="cd_select_mcp_servers">Выбрать серверы MCP</string>
+    <string name="cd_mcp_resources">Ресурсы MCP: %1$d элементов</string>
+    <string name="cd_mcp_resource">Ресурс MCP: %1$s</string>
+
+    <!-- Memory artifact -->
+    <string name="cd_memory_artifact">Артефакт памяти: %1$s</string>
+    <string name="memory_artifact_untitled">Без названия</string>
+    <string name="label_memory">Память</string>
+
+    <!-- Mermaid diagram -->
+    <string name="label_mermaid">mermaid</string>
+    <string name="cd_show_diagram">Показать диаграмму</string>
+    <string name="cd_view_code">Показать код</string>
+    <string name="label_diagram">Диаграмма</string>
+    <string name="cd_fullscreen">Во весь экран</string>
+    <string name="cd_close_fullscreen">Закрыть полноэкранный режим</string>
+
+    <!-- Message bubble -->
+    <string name="sender_you">Вы</string>
+    <string name="sender_assistant">Ассистент</string>
+
+    <!-- Message files -->
+    <string name="file_fallback">Файл</string>
+
+    <!-- Model selector sheet -->
+    <string name="cd_selected">Выбрано</string>
+    <string name="cd_public_agent">Публичный агент</string>
+    <string name="cd_pin_favorite">Закрепить в избранном</string>
+    <string name="cd_unpin_favorite">Открепить из избранного</string>
+    <string name="cd_collapse_section">Свернуть %1$s</string>
+    <string name="cd_expand_section">Развернуть %1$s</string>
+    <string name="set_api_key_action">Задать API-ключ</string>
+    <string name="cd_set_api_key">Настроить API-ключ для %1$s</string>
+
+    <!-- Preset picker -->
+    <string name="select_preset">Выбрать пресет</string>
+    <string name="no_presets_saved">Пока нет сохранённых пресетов</string>
+    <string name="cd_edit_preset">Изменить %1$s</string>
+    <string name="cd_delete_preset">Удалить %1$s</string>
+    <string name="preset_endpoint">Конечная точка: %1$s</string>
+    <string name="preset_model">Модель: %1$s</string>
+
+    <!-- Feedback dialog -->
+    <string name="dialog_title_feedback">Оставить отзыв</string>
+    <string name="feedback_question">В чём была проблема с этим ответом?</string>
+    <string name="hint_optional_comment">Необязательный комментарий…</string>
+
+    <!-- Streaming tool call -->
+    <string name="tool_call_output">Вывод:</string>
+
+    <!-- Web search result -->
+    <string name="cd_search_result">Результат поиска: %1$s</string>
+
+    <!-- Rename dialog -->
+    <string name="dialog_title_rename">Переименовать беседу</string>
+    <string name="hint_title">Название</string>
+
+    <!-- Delete dialog -->
+    <string name="dialog_title_delete_conversation">Удалить беседу</string>
+    <string name="dialog_delete_conversation_message">Это безвозвратно удалит эту беседу. Это нельзя отменить.</string>
+
+    <!-- Chat menu options -->
+    <string name="menu_search">Поиск</string>
+    <string name="menu_rename">Переименовать</string>
+
+    <!-- Artifacts -->
+    <string name="cd_open_artifact">Открыть артефакт</string>
+    <string name="cd_share_artifact">Поделиться артефактом</string>
+    <string name="cd_previous_version">Предыдущая версия</string>
+    <string name="cd_next_version">Следующая версия</string>
+    <string name="artifact_version">v%1$d/%2$d</string>
+    <string name="label_resource">Ресурс</string>
+
+    <!-- Prompts -->
+    <string name="prompts_library">Библиотека промптов</string>
+    <string name="use_in_chat">Использовать в чате</string>
+    <string name="set_production">Сделать рабочей</string>
+    <string name="prompt_name_label">Имя</string>
+    <string name="prompt_description_label">Описание</string>
+    <string name="prompt_command_label">Команда</string>
+    <string name="prompt_text_label">Текст промпта</string>
+    <string name="prompt_content">Содержимое промпта</string>
+    <string name="cd_share_prompt">Поделиться промптом</string>
+    <string name="cd_edit_prompt">Изменить промпт</string>
+    <string name="cd_delete_prompt">Удалить промпт</string>
+    <string name="cd_back">Назад</string>
+    <string name="cd_version_history">История версий</string>
+    <string name="cd_filter_sort">Фильтр и сортировка</string>
+    <string name="cd_create_prompt">Создать промпт</string>
+    <string name="cd_remove_filter">Убрать фильтр</string>
+    <string name="cd_reset_sort">Сбросить сортировку</string>
+    <string name="cd_share">Поделиться</string>
+    <string name="prompt_author">автор: %1$s</string>
+    <string name="prompt_sort_label">Сортировка: %1$s</string>
+
+    <!-- Prompt versions -->
+    <string name="version_history">История версий</string>
+    <string name="no_versions">Нет доступных версий</string>
+    <string name="label_production">Рабочая</string>
+    <string name="version_number">v%1$d</string>
+
+    <!-- Prompt variables -->
+    <string name="label_variables">Переменные</string>
+
+    <!-- Prompt filter sheet -->
+    <string name="label_category">Категория</string>
+    <string name="label_all">Все</string>
+    <string name="label_sort_by">Сортировать по</string>
+
+    <!-- Prompt share dialog -->
+    <string name="dialog_title_share_prompt">Поделиться промптом</string>
+    <string name="label_permission">Разрешение</string>
+
+    <!-- Variable input dialog -->
+    <string name="dialog_title_fill_variables">Заполнить переменные</string>
+
+    <!-- Temp chat toggle -->
+    <string name="cd_temp_chat">Временный чат</string>
+    <string name="label_temp_chat">Врем.</string>
+
+    <!-- Comparison mode -->
+    <string name="continue_with_response">Продолжить с этим ответом</string>
+    <string name="waiting_for_response">Ожидание ответа…</string>
+
+    <!-- Slash command menu -->
+    <string name="slash_command_title">/%1$s</string>
+
+    <!-- Provider Keys chat-time errors. -->
+    <string name="provider_keys_chat_error_no_key">Ключ не найден. Укажите ключ и попробуйте снова.</string>
+    <!-- {0} = endpoint name, {1} = expiredAt (server-locale string, NOT ISO) -->
+    <string name="provider_keys_chat_error_expired">Указанный ключ для %1$s истёк %2$s. Укажите новый ключ и попробуйте снова.</string>
+    <string name="provider_keys_chat_error_invalid">Указан недействительный ключ. Укажите действительный ключ и попробуйте снова.</string>
+    <!-- Snackbar action label that deep-links to Settings → Provider Keys -->
+    <string name="provider_keys_chat_error_cta">Открыть настройки ключей</string>
+
+    <!-- Send block reasons (shown in error snackbar when send can't proceed) -->
+    <string name="send_block_select_agent">Выберите агента перед отправкой сообщения.</string>
+    <string name="send_block_select_model">Выберите модель перед отправкой сообщения.</string>
+    <string name="send_block_agents_unavailable">Агенты недоступны на этом сервере. Выберите другую модель.</string>
+    <string name="send_block_agent_not_available">Выбранный агент недоступен на этом сервере. Выберите другого агента.</string>
+    <string name="send_block_model_not_available">Выбранная модель недоступна на этом сервере. Выберите другую модель.</string>
+    <string name="send_block_model_load_failed">Пока не удалось загрузить выбранную модель. Попробуйте снова или выберите другую модель.</string>
+</resources>

--- a/feature/chat/src/commonMain/composeResources/values-zh/strings.xml
+++ b/feature/chat/src/commonMain/composeResources/values-zh/strings.xml
@@ -1,0 +1,369 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Common actions -->
+    <string name="cancel">取消</string>
+    <string name="save">保存</string>
+    <string name="delete">删除</string>
+    <string name="copy">复制</string>
+    <string name="edit">编辑</string>
+    <string name="regenerate">重新生成</string>
+    <string name="action_rename">重命名</string>
+    <string name="action_submit">提交</string>
+    <string name="action_insert">插入</string>
+    <string name="action_open">打开</string>
+    <string name="action_close">关闭</string>
+    <string name="action_share">分享</string>
+    <string name="action_search">搜索</string>
+    <string name="action_archive">归档</string>
+    <string name="action_duplicate">复制副本</string>
+    <string name="action_copy_link">复制链接</string>
+
+    <!-- Chat screen -->
+    <string name="new_chat">新建聊天</string>
+    <string name="send_message">发送</string>
+    <string name="stop_generating">停止</string>
+    <string name="message_hint">输入消息…</string>
+    <string name="model_parameters">模型参数</string>
+    <string name="load_preset">加载预设</string>
+    <string name="save_as_preset">另存为预设</string>
+    <string name="search_models">搜索模型…</string>
+    <string name="save_and_submit">保存并提交</string>
+    <string name="preset_name_label">预设名称</string>
+    <string name="code">代码</string>
+    <string name="preview">预览</string>
+    <string name="select_model">选择模型</string>
+    <string name="select_a_model">选择一个模型</string>
+    <string name="starred_group">已星标</string>
+    <!-- Neutral label for the active agent when its name hasn't resolved yet (never a model string). -->
+    <string name="chat_agent_fallback_label">智能体</string>
+    <string name="compare_models">对比模型</string>
+    <string name="how_can_i_help">今天我能帮你做些什么？</string>
+    <string name="recording">录音中…</string>
+    <string name="hint_message_model">向 %1$s 发送消息</string>
+    <string name="hint_message">发送消息…</string>
+
+    <!-- Content descriptions - Chat -->
+    <string name="cd_open_tools_menu">打开工具菜单</string>
+    <string name="cd_paste_image">从剪贴板粘贴图片</string>
+    <string name="cd_message_input">消息输入框</string>
+    <string name="cd_stop_voice_recording">停止录音</string>
+    <string name="cd_start_voice_recording">开始录音</string>
+    <string name="cd_stop_generation">停止生成</string>
+    <string name="cd_send_message">发送消息</string>
+    <string name="cd_open_drawer">打开导航抽屉</string>
+    <string name="cd_more_options">更多选项</string>
+    <string name="cd_more_tools">更多工具</string>
+    <string name="cd_scroll_to_bottom">滚动到底部</string>
+    <string name="cd_select_model">选择模型</string>
+    <string name="cd_librechat">LibreChat</string>
+    <string name="cd_comparison_enabled">已启用对比</string>
+
+    <!-- Content descriptions - Messages -->
+    <string name="cd_thumbs_up">点赞</string>
+    <string name="cd_thumbs_down">点踩</string>
+    <string name="cd_copy_message">复制消息</string>
+    <string name="cd_edit_message">编辑消息</string>
+    <string name="cd_regenerate_response">重新生成回复</string>
+    <string name="cd_stop_reading">停止朗读</string>
+    <string name="cd_read_aloud">朗读</string>
+    <string name="cd_fork_conversation">从此处分叉对话</string>
+    <string name="cd_previous_response">上一条回复</string>
+    <string name="cd_next_response">下一条回复</string>
+    <string name="cd_generating_response">正在生成回复</string>
+
+    <!-- Content descriptions - Images -->
+    <string name="cd_fullscreen_image">全屏图片</string>
+    <string name="cd_close">关闭</string>
+    <string name="cd_save_to_device">保存到设备</string>
+    <string name="cd_share_image">分享图片</string>
+    <string name="cd_failed_to_load_image">图片加载失败</string>
+    <string name="cd_failed_to_load_generated_image">生成的图片加载失败</string>
+    <string name="cd_embedded_image">消息中的内嵌图片</string>
+
+    <!-- Content descriptions - Search -->
+    <string name="cd_search_in_conversation">在对话中搜索</string>
+    <string name="cd_previous_match">上一个匹配项</string>
+    <string name="cd_next_match">下一个匹配项</string>
+    <string name="cd_close_search">关闭搜索</string>
+    <string name="cd_clear_search">清除搜索</string>
+    <string name="hint_find_in_conversation">在对话中查找…</string>
+
+    <!-- Content descriptions - Code -->
+    <string name="cd_copy_code">复制代码</string>
+    <string name="cd_copied">已复制</string>
+    <string name="action_copy_code">复制</string>
+    <string name="action_copied">已复制！</string>
+    <string name="cd_code_execution_result">代码执行结果</string>
+    <string name="cd_exit_code_success">退出码 0（成功）</string>
+    <string name="cd_exit_code_failure">退出码 %1$d（失败）</string>
+    <string name="exit_code">退出码 %1$d</string>
+    <string name="label_code">代码</string>
+    <string name="label_output">输出：</string>
+    <string name="label_error">错误：</string>
+    <string name="label_input">输入：</string>
+    <string name="cd_collapse_code">收起代码</string>
+    <string name="cd_expand_code">展开代码</string>
+
+    <!-- Content descriptions - Thinking -->
+    <string name="cd_thinking_indicator">思考指示器</string>
+    <string name="label_thinking">思考中</string>
+    <string name="cd_collapse">收起</string>
+    <string name="cd_expand">展开</string>
+    <string name="cd_collapse_thinking">收起思考块</string>
+    <string name="cd_expand_thinking">展开思考块</string>
+
+    <!-- Content descriptions - Summary (context compaction, v0.8.5+) -->
+    <string name="label_summary">已总结较早的消息</string>
+    <string name="cd_summary_indicator">摘要指示器</string>
+    <string name="cd_collapse_summary">收起摘要块</string>
+    <string name="cd_expand_summary">展开摘要块</string>
+
+    <!-- Content descriptions - Subagent trace (subagents, v0.8.6+) -->
+    <string name="label_subagent">子智能体</string>
+    <string name="cd_collapse_subagent">收起子智能体 %1$s</string>
+    <string name="cd_expand_subagent">展开子智能体 %1$s</string>
+
+    <!-- Office-doc preview attachments (deferred preview, v0.8.6+) -->
+    <string name="office_preview_preparing">正在准备 %1$s 的预览…</string>
+    <string name="office_preview_failed">无法预览 %1$s（%2$s）</string>
+    <string name="office_preview_unavailable">%1$s — 预览不可用</string>
+
+    <!-- Content descriptions - Tool calls -->
+    <string name="cd_tool_call">工具调用</string>
+    <string name="cd_collapse_tool_call">收起工具调用 %1$s</string>
+    <string name="cd_expand_tool_call">展开工具调用 %1$s</string>
+    <string name="cd_tool_complete">已完成</string>
+    <string name="cd_tool_enabled">已启用</string>
+    <string name="video_not_supported">不支持视频内容</string>
+
+    <!-- Tools bottom sheet -->
+    <string name="tool_camera">相机</string>
+    <string name="tool_photos">照片</string>
+    <string name="tool_files">文件</string>
+    <string name="tool_model">模型</string>
+    <string name="tool_model_parameters">模型参数</string>
+    <string name="tool_model_parameters_desc">调整温度、token 等参数</string>
+    <string name="tool_web_search">网络搜索</string>
+    <string name="tool_web_search_desc">在网络上搜索信息</string>
+    <string name="tool_code">代码</string>
+    <string name="tool_code_desc">运行和分析代码</string>
+    <string name="tool_file_search">文件搜索</string>
+    <string name="tool_file_search_desc">在已上传的文件中搜索</string>
+    <string name="tool_mcp">MCP</string>
+    <string name="tool_mcp_desc">Model Context Protocol 服务器</string>
+    <string name="cd_web_search_enabled">已启用网络搜索</string>
+    <string name="cd_code_enabled">已启用代码解释器</string>
+    <string name="cd_file_search_enabled">已启用文件搜索</string>
+
+    <!-- Attachments -->
+    <string name="cd_attach_file">附加文件</string>
+    <string name="toast_file_attach_unavailable">iOS 上暂不支持附加文件</string>
+    <string name="files_count">文件（%1$d）</string>
+    <string name="cd_attached_file">已附加文件：%1$s</string>
+    <string name="cd_preview_file">%1$s 的预览</string>
+    <string name="cd_remove_file">移除 %1$s</string>
+
+    <!-- Agent handoff -->
+    <string name="cd_agent_handoff">智能体从 %1$s 交接给 %2$s</string>
+    <string name="cd_handed_off_to">交接给</string>
+    <string name="agent_unknown">未知</string>
+    <string name="agent_previous">上一个智能体</string>
+    <string name="agent_next">下一个智能体</string>
+
+    <!-- Audio/Video -->
+    <string name="cd_pause">暂停</string>
+    <string name="cd_play">播放</string>
+    <string name="cd_play_video">播放视频</string>
+    <string name="audio_no_data">无音频数据</string>
+    <string name="audio_decode_failed">音频解码失败</string>
+
+    <!-- Citation -->
+    <string name="citation_number">引用 %1$d</string>
+    <string name="cd_open_citation_url">打开引用 URL</string>
+
+    <!-- Fork options -->
+    <string name="fork_conversation">分叉对话</string>
+    <string name="fork_visible_messages">可见消息</string>
+    <string name="fork_visible_messages_desc">仅包含直接的消息路径</string>
+    <string name="fork_include_branches">包含分支</string>
+    <string name="fork_include_branches_desc">直接路径以及同级消息</string>
+    <string name="fork_all_to_target">直到目标层级的全部</string>
+    <string name="fork_all_to_target_desc">直到此层级的所有消息和分支</string>
+    <string name="fork_start_new">从目标处开始新对话</string>
+    <string name="fork_start_new_desc">从所选消息而非根消息开始分叉</string>
+
+    <!-- Image viewer toasts -->
+    <string name="toast_failed_to_load_image">图片加载失败</string>
+    <string name="toast_failed_to_save_image">图片保存失败</string>
+    <string name="toast_image_saved">图片已保存到相册</string>
+    <string name="toast_failed_to_save_with_error">图片保存失败：%1$s</string>
+    <string name="toast_storage_permission_required">保存图片需要存储权限</string>
+
+    <!-- Image generation -->
+    <string name="generating_image">正在生成图片…</string>
+    <string name="image_generated">图片已生成</string>
+    <string name="cd_generated_image">生成的图片</string>
+
+    <!-- Landing page greetings -->
+    <string name="greeting_late_night">夜深了</string>
+    <string name="greeting_weekend_morning">周末早上好</string>
+    <string name="greeting_weekend_afternoon">周末下午好</string>
+    <string name="greeting_weekend_evening">周末晚上好</string>
+    <string name="greeting_early_morning">清晨好</string>
+    <string name="greeting_morning">早上好</string>
+    <string name="greeting_afternoon">下午好</string>
+    <string name="greeting_evening">晚上好</string>
+
+    <!-- Log content -->
+    <string name="log_output">日志输出</string>
+    <string name="cd_collapse_log">收起 %1$s</string>
+    <string name="cd_expand_log">展开 %1$s</string>
+
+    <!-- Table dialog -->
+    <string name="cd_expand_table">展开表格</string>
+    <string name="dialog_table">表格</string>
+
+    <!-- MCP -->
+    <string name="cd_select_mcp_servers">选择 MCP 服务器</string>
+    <string name="cd_mcp_resources">MCP 资源：%1$d 项</string>
+    <string name="cd_mcp_resource">MCP 资源：%1$s</string>
+
+    <!-- Memory artifact -->
+    <string name="cd_memory_artifact">记忆 artifact：%1$s</string>
+    <string name="memory_artifact_untitled">无标题</string>
+    <string name="label_memory">记忆</string>
+
+    <!-- Mermaid diagram -->
+    <string name="label_mermaid">mermaid</string>
+    <string name="cd_show_diagram">显示图表</string>
+    <string name="cd_view_code">查看代码</string>
+    <string name="label_diagram">图表</string>
+    <string name="cd_fullscreen">全屏</string>
+    <string name="cd_close_fullscreen">退出全屏</string>
+
+    <!-- Message bubble -->
+    <string name="sender_you">你</string>
+    <string name="sender_assistant">助手</string>
+
+    <!-- Message files -->
+    <string name="file_fallback">文件</string>
+
+    <!-- Model selector sheet -->
+    <string name="cd_selected">已选择</string>
+    <string name="cd_public_agent">公开智能体</string>
+    <string name="cd_pin_favorite">固定为收藏</string>
+    <string name="cd_unpin_favorite">取消固定收藏</string>
+    <string name="cd_collapse_section">收起 %1$s</string>
+    <string name="cd_expand_section">展开 %1$s</string>
+    <string name="set_api_key_action">设置 API 密钥</string>
+    <string name="cd_set_api_key">为 %1$s 配置 API 密钥</string>
+
+    <!-- Preset picker -->
+    <string name="select_preset">选择预设</string>
+    <string name="no_presets_saved">尚未保存任何预设</string>
+    <string name="cd_edit_preset">编辑 %1$s</string>
+    <string name="cd_delete_preset">删除 %1$s</string>
+    <string name="preset_endpoint">端点：%1$s</string>
+    <string name="preset_model">模型：%1$s</string>
+
+    <!-- Feedback dialog -->
+    <string name="dialog_title_feedback">提供反馈</string>
+    <string name="feedback_question">这条回复有什么问题？</string>
+    <string name="hint_optional_comment">可选评论…</string>
+
+    <!-- Streaming tool call -->
+    <string name="tool_call_output">输出：</string>
+
+    <!-- Web search result -->
+    <string name="cd_search_result">搜索结果：%1$s</string>
+
+    <!-- Rename dialog -->
+    <string name="dialog_title_rename">重命名对话</string>
+    <string name="hint_title">标题</string>
+
+    <!-- Delete dialog -->
+    <string name="dialog_title_delete_conversation">删除对话</string>
+    <string name="dialog_delete_conversation_message">这将永久删除此对话。此操作无法撤销。</string>
+
+    <!-- Chat menu options -->
+    <string name="menu_search">搜索</string>
+    <string name="menu_rename">重命名</string>
+
+    <!-- Artifacts -->
+    <string name="cd_open_artifact">打开 artifact</string>
+    <string name="cd_share_artifact">分享 artifact</string>
+    <string name="cd_previous_version">上一个版本</string>
+    <string name="cd_next_version">下一个版本</string>
+    <string name="artifact_version">v%1$d/%2$d</string>
+    <string name="label_resource">资源</string>
+
+    <!-- Prompts -->
+    <string name="prompts_library">提示词库</string>
+    <string name="use_in_chat">在聊天中使用</string>
+    <string name="set_production">设为正式版</string>
+    <string name="prompt_name_label">名称</string>
+    <string name="prompt_description_label">描述</string>
+    <string name="prompt_command_label">命令</string>
+    <string name="prompt_text_label">提示词文本</string>
+    <string name="prompt_content">提示词内容</string>
+    <string name="cd_share_prompt">分享提示词</string>
+    <string name="cd_edit_prompt">编辑提示词</string>
+    <string name="cd_delete_prompt">删除提示词</string>
+    <string name="cd_back">返回</string>
+    <string name="cd_version_history">版本历史</string>
+    <string name="cd_filter_sort">筛选和排序</string>
+    <string name="cd_create_prompt">创建提示词</string>
+    <string name="cd_remove_filter">移除筛选</string>
+    <string name="cd_reset_sort">重置排序</string>
+    <string name="cd_share">分享</string>
+    <string name="prompt_author">作者：%1$s</string>
+    <string name="prompt_sort_label">排序：%1$s</string>
+
+    <!-- Prompt versions -->
+    <string name="version_history">版本历史</string>
+    <string name="no_versions">没有可用的版本</string>
+    <string name="label_production">正式版</string>
+    <string name="version_number">v%1$d</string>
+
+    <!-- Prompt variables -->
+    <string name="label_variables">变量</string>
+
+    <!-- Prompt filter sheet -->
+    <string name="label_category">类别</string>
+    <string name="label_all">全部</string>
+    <string name="label_sort_by">排序方式</string>
+
+    <!-- Prompt share dialog -->
+    <string name="dialog_title_share_prompt">分享提示词</string>
+    <string name="label_permission">权限</string>
+
+    <!-- Variable input dialog -->
+    <string name="dialog_title_fill_variables">填写变量</string>
+
+    <!-- Temp chat toggle -->
+    <string name="cd_temp_chat">临时聊天</string>
+    <string name="label_temp_chat">临时</string>
+
+    <!-- Comparison mode -->
+    <string name="continue_with_response">使用此回复继续</string>
+    <string name="waiting_for_response">等待回复…</string>
+
+    <!-- Slash command menu -->
+    <string name="slash_command_title">/%1$s</string>
+
+    <!-- Provider Keys chat-time errors. -->
+    <string name="provider_keys_chat_error_no_key">未找到密钥。请提供密钥后重试。</string>
+    <!-- {0} = endpoint name, {1} = expiredAt (server-locale string, NOT ISO) -->
+    <string name="provider_keys_chat_error_expired">为 %1$s 提供的密钥已于 %2$s 过期。请提供新密钥后重试。</string>
+    <string name="provider_keys_chat_error_invalid">提供的密钥无效。请提供有效的密钥后重试。</string>
+    <!-- Snackbar action label that deep-links to Settings → Provider Keys -->
+    <string name="provider_keys_chat_error_cta">打开密钥设置</string>
+
+    <!-- Send block reasons (shown in error snackbar when send can't proceed) -->
+    <string name="send_block_select_agent">发送消息前请先选择一个智能体。</string>
+    <string name="send_block_select_model">发送消息前请先选择一个模型。</string>
+    <string name="send_block_agents_unavailable">此服务器不支持智能体。请选择其他模型。</string>
+    <string name="send_block_agent_not_available">所选智能体在此服务器上不可用。请选择其他智能体。</string>
+    <string name="send_block_model_not_available">所选模型在此服务器上不可用。请选择其他模型。</string>
+    <string name="send_block_model_load_failed">尚无法加载所选模型。请重试或选择其他模型。</string>
+</resources>

--- a/feature/conversations/src/commonMain/composeResources/values-ar/strings.xml
+++ b/feature/conversations/src/commonMain/composeResources/values-ar/strings.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Common actions -->
+    <string name="rename">إعادة تسمية</string>
+    <string name="cancel">إلغاء</string>
+    <string name="delete">حذف</string>
+    <string name="archive">أرشفة</string>
+    <string name="unarchive">إلغاء الأرشفة</string>
+    <string name="export">تصدير</string>
+    <string name="share">مشاركة</string>
+    <string name="duplicate">تكرار</string>
+    <string name="clear">مسح</string>
+    <string name="back">رجوع</string>
+    <string name="new_chat">محادثة جديدة</string>
+
+    <!-- Content descriptions -->
+    <string name="cd_new_chat">محادثة جديدة</string>
+    <string name="cd_archived_conversations">المحادثات المؤرشفة</string>
+    <string name="cd_search">بحث</string>
+    <string name="cd_clear_search">مسح البحث</string>
+    <string name="cd_bookmarked">مُعلّم بإشارة مرجعية</string>
+    <string name="cd_conversation_actions">إجراءات المحادثة</string>
+    <string name="cd_add_tag">إضافة وسم</string>
+    <string name="cd_hide_tags">إخفاء الوسوم</string>
+    <string name="cd_show_tags">إظهار الوسوم</string>
+    <string name="cd_clear_filter">مسح التصفية</string>
+    <string name="cd_unarchive">إلغاء الأرشفة</string>
+    <string name="cd_delete">حذف</string>
+
+    <!-- Conversation list screen -->
+    <string name="conversations">المحادثات</string>
+    <string name="search_conversations">البحث في المحادثات…</string>
+    <string name="could_not_load_conversations">تعذّر تحميل المحادثات</string>
+    <string name="no_results_found">لم يتم العثور على نتائج</string>
+    <string name="no_conversations_yet">لا توجد محادثات بعد</string>
+    <string name="try_different_search">جرّب مصطلح بحث مختلفًا</string>
+    <string name="start_new_chat">ابدأ محادثة جديدة للبدء</string>
+    <string name="unknown_error">حدث خطأ غير معروف</string>
+    <string name="conversation_exported">تم تصدير المحادثة</string>
+    <string name="export_failed">فشل التصدير: %1$s</string>
+    <string name="import_failed">فشل الاستيراد: %1$s</string>
+    <string name="link_copied">تم نسخ الرابط!</string>
+    <string name="imported_title">تم الاستيراد: %1$s</string>
+    <string name="copy_of">نسخة من %1$s</string>
+
+    <!-- Conversation actions -->
+    <string name="remove_bookmark">إزالة الإشارة المرجعية</string>
+    <string name="bookmark">إشارة مرجعية</string>
+    <string name="tags">الوسوم</string>
+    <string name="rename_conversation">إعادة تسمية المحادثة</string>
+    <string name="rename_dialog_message">أدخل عنوانًا جديدًا لهذه المحادثة.</string>
+    <string name="title_label">العنوان</string>
+    <string name="delete_conversation">حذف المحادثة</string>
+    <string name="delete_confirmation_message">هل أنت متأكد أنك تريد حذف \"%1$s\"؟ لا يمكن التراجع عن هذا الإجراء.</string>
+    <string name="this_conversation">هذه المحادثة</string>
+
+    <!-- Tag picker -->
+    <string name="no_tags_yet">لا توجد وسوم بعد. أضف وسمًا أدناه.</string>
+    <string name="add_new_tag">إضافة وسم جديد</string>
+
+    <!-- Tag filter bar -->
+    <string name="tags_active_count">%1$d وسم%2$s نشط</string>
+
+    <!-- Export format picker -->
+    <string name="export_format">صيغة التصدير</string>
+    <string name="format_json">JSON</string>
+    <string name="format_json_description">تصدير كامل للبيانات، يمكن استيراده مرة أخرى</string>
+    <string name="format_markdown">Markdown</string>
+    <string name="format_markdown_description">صيغة نصية قابلة للقراءة</string>
+
+    <!-- Archived conversations screen -->
+    <string name="archived_conversations">المحادثات المؤرشفة</string>
+    <string name="could_not_load_archived">تعذّر تحميل المحادثات المؤرشفة</string>
+    <string name="no_archived_conversations">لا توجد محادثات مؤرشفة</string>
+    <string name="archived_will_appear_here">ستظهر المحادثات المؤرشفة هنا</string>
+
+    <!-- Conversation item fallback -->
+    <string name="chat">محادثة</string>
+</resources>

--- a/feature/conversations/src/commonMain/composeResources/values-de/strings.xml
+++ b/feature/conversations/src/commonMain/composeResources/values-de/strings.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Common actions -->
+    <string name="rename">Umbenennen</string>
+    <string name="cancel">Abbrechen</string>
+    <string name="delete">Löschen</string>
+    <string name="archive">Archivieren</string>
+    <string name="unarchive">Aus Archiv holen</string>
+    <string name="export">Exportieren</string>
+    <string name="share">Teilen</string>
+    <string name="duplicate">Duplizieren</string>
+    <string name="clear">Löschen</string>
+    <string name="back">Zurück</string>
+    <string name="new_chat">Neuer Chat</string>
+
+    <!-- Content descriptions -->
+    <string name="cd_new_chat">Neuer Chat</string>
+    <string name="cd_archived_conversations">Archivierte Unterhaltungen</string>
+    <string name="cd_search">Suchen</string>
+    <string name="cd_clear_search">Suche löschen</string>
+    <string name="cd_bookmarked">Mit Lesezeichen versehen</string>
+    <string name="cd_conversation_actions">Unterhaltungsaktionen</string>
+    <string name="cd_add_tag">Tag hinzufügen</string>
+    <string name="cd_hide_tags">Tags ausblenden</string>
+    <string name="cd_show_tags">Tags anzeigen</string>
+    <string name="cd_clear_filter">Filter löschen</string>
+    <string name="cd_unarchive">Aus Archiv holen</string>
+    <string name="cd_delete">Löschen</string>
+
+    <!-- Conversation list screen -->
+    <string name="conversations">Unterhaltungen</string>
+    <string name="search_conversations">Unterhaltungen suchen…</string>
+    <string name="could_not_load_conversations">Unterhaltungen konnten nicht geladen werden</string>
+    <string name="no_results_found">Keine Ergebnisse gefunden</string>
+    <string name="no_conversations_yet">Noch keine Unterhaltungen</string>
+    <string name="try_different_search">Versuche einen anderen Suchbegriff</string>
+    <string name="start_new_chat">Starte einen neuen Chat, um zu beginnen</string>
+    <string name="unknown_error">Ein unbekannter Fehler ist aufgetreten</string>
+    <string name="conversation_exported">Unterhaltung exportiert</string>
+    <string name="export_failed">Export fehlgeschlagen: %1$s</string>
+    <string name="import_failed">Import fehlgeschlagen: %1$s</string>
+    <string name="link_copied">Link kopiert!</string>
+    <string name="imported_title">Importiert: %1$s</string>
+    <string name="copy_of">Kopie von %1$s</string>
+
+    <!-- Conversation actions -->
+    <string name="remove_bookmark">Lesezeichen entfernen</string>
+    <string name="bookmark">Lesezeichen</string>
+    <string name="tags">Tags</string>
+    <string name="rename_conversation">Unterhaltung umbenennen</string>
+    <string name="rename_dialog_message">Gib einen neuen Titel für diese Unterhaltung ein.</string>
+    <string name="title_label">Titel</string>
+    <string name="delete_conversation">Unterhaltung löschen</string>
+    <string name="delete_confirmation_message">Möchtest du \"%1$s\" wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden.</string>
+    <string name="this_conversation">diese Unterhaltung</string>
+
+    <!-- Tag picker -->
+    <string name="no_tags_yet">Noch keine Tags. Füge unten eines hinzu.</string>
+    <string name="add_new_tag">Neues Tag hinzufügen</string>
+
+    <!-- Tag filter bar -->
+    <string name="tags_active_count">%1$d Tag%2$s aktiv</string>
+
+    <!-- Export format picker -->
+    <string name="export_format">Exportformat</string>
+    <string name="format_json">JSON</string>
+    <string name="format_json_description">Vollständiger Datenexport, kann zurückimportiert werden</string>
+    <string name="format_markdown">Markdown</string>
+    <string name="format_markdown_description">Lesbares Textformat</string>
+
+    <!-- Archived conversations screen -->
+    <string name="archived_conversations">Archivierte Unterhaltungen</string>
+    <string name="could_not_load_archived">Archivierte Unterhaltungen konnten nicht geladen werden</string>
+    <string name="no_archived_conversations">Keine archivierten Unterhaltungen</string>
+    <string name="archived_will_appear_here">Archivierte Unterhaltungen erscheinen hier</string>
+
+    <!-- Conversation item fallback -->
+    <string name="chat">Chat</string>
+</resources>

--- a/feature/conversations/src/commonMain/composeResources/values-es/strings.xml
+++ b/feature/conversations/src/commonMain/composeResources/values-es/strings.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Common actions -->
+    <string name="rename">Renombrar</string>
+    <string name="cancel">Cancelar</string>
+    <string name="delete">Eliminar</string>
+    <string name="archive">Archivar</string>
+    <string name="unarchive">Desarchivar</string>
+    <string name="export">Exportar</string>
+    <string name="share">Compartir</string>
+    <string name="duplicate">Duplicar</string>
+    <string name="clear">Borrar</string>
+    <string name="back">Atrás</string>
+    <string name="new_chat">Nuevo chat</string>
+
+    <!-- Content descriptions -->
+    <string name="cd_new_chat">Nuevo chat</string>
+    <string name="cd_archived_conversations">Conversaciones archivadas</string>
+    <string name="cd_search">Buscar</string>
+    <string name="cd_clear_search">Borrar búsqueda</string>
+    <string name="cd_bookmarked">Guardado en marcadores</string>
+    <string name="cd_conversation_actions">Acciones de conversación</string>
+    <string name="cd_add_tag">Añadir etiqueta</string>
+    <string name="cd_hide_tags">Ocultar etiquetas</string>
+    <string name="cd_show_tags">Mostrar etiquetas</string>
+    <string name="cd_clear_filter">Borrar filtro</string>
+    <string name="cd_unarchive">Desarchivar</string>
+    <string name="cd_delete">Eliminar</string>
+
+    <!-- Conversation list screen -->
+    <string name="conversations">Conversaciones</string>
+    <string name="search_conversations">Buscar conversaciones…</string>
+    <string name="could_not_load_conversations">No se pudieron cargar las conversaciones</string>
+    <string name="no_results_found">No se encontraron resultados</string>
+    <string name="no_conversations_yet">Aún no hay conversaciones</string>
+    <string name="try_different_search">Prueba con otro término de búsqueda</string>
+    <string name="start_new_chat">Inicia un nuevo chat para empezar</string>
+    <string name="unknown_error">Ocurrió un error desconocido</string>
+    <string name="conversation_exported">Conversación exportada</string>
+    <string name="export_failed">Error al exportar: %1$s</string>
+    <string name="import_failed">Error al importar: %1$s</string>
+    <string name="link_copied">¡Enlace copiado!</string>
+    <string name="imported_title">Importada: %1$s</string>
+    <string name="copy_of">Copia de %1$s</string>
+
+    <!-- Conversation actions -->
+    <string name="remove_bookmark">Quitar marcador</string>
+    <string name="bookmark">Marcador</string>
+    <string name="tags">Etiquetas</string>
+    <string name="rename_conversation">Renombrar conversación</string>
+    <string name="rename_dialog_message">Introduce un nuevo título para esta conversación.</string>
+    <string name="title_label">Título</string>
+    <string name="delete_conversation">Eliminar conversación</string>
+    <string name="delete_confirmation_message">¿Seguro que quieres eliminar \"%1$s\"? Esta acción no se puede deshacer.</string>
+    <string name="this_conversation">esta conversación</string>
+
+    <!-- Tag picker -->
+    <string name="no_tags_yet">Aún no hay etiquetas. Añade una abajo.</string>
+    <string name="add_new_tag">Añadir nueva etiqueta</string>
+
+    <!-- Tag filter bar -->
+    <string name="tags_active_count">%1$d etiqueta%2$s activa</string>
+
+    <!-- Export format picker -->
+    <string name="export_format">Formato de exportación</string>
+    <string name="format_json">JSON</string>
+    <string name="format_json_description">Exportación completa de datos, se puede volver a importar</string>
+    <string name="format_markdown">Markdown</string>
+    <string name="format_markdown_description">Formato de texto legible</string>
+
+    <!-- Archived conversations screen -->
+    <string name="archived_conversations">Conversaciones archivadas</string>
+    <string name="could_not_load_archived">No se pudieron cargar las conversaciones archivadas</string>
+    <string name="no_archived_conversations">No hay conversaciones archivadas</string>
+    <string name="archived_will_appear_here">Las conversaciones archivadas aparecerán aquí</string>
+
+    <!-- Conversation item fallback -->
+    <string name="chat">Chat</string>
+</resources>

--- a/feature/conversations/src/commonMain/composeResources/values-fr/strings.xml
+++ b/feature/conversations/src/commonMain/composeResources/values-fr/strings.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Common actions -->
+    <string name="rename">Renommer</string>
+    <string name="cancel">Annuler</string>
+    <string name="delete">Supprimer</string>
+    <string name="archive">Archiver</string>
+    <string name="unarchive">Désarchiver</string>
+    <string name="export">Exporter</string>
+    <string name="share">Partager</string>
+    <string name="duplicate">Dupliquer</string>
+    <string name="clear">Effacer</string>
+    <string name="back">Retour</string>
+    <string name="new_chat">Nouvelle discussion</string>
+
+    <!-- Content descriptions -->
+    <string name="cd_new_chat">Nouvelle discussion</string>
+    <string name="cd_archived_conversations">Conversations archivées</string>
+    <string name="cd_search">Rechercher</string>
+    <string name="cd_clear_search">Effacer la recherche</string>
+    <string name="cd_bookmarked">Marqué d\'un signet</string>
+    <string name="cd_conversation_actions">Actions de conversation</string>
+    <string name="cd_add_tag">Ajouter une étiquette</string>
+    <string name="cd_hide_tags">Masquer les étiquettes</string>
+    <string name="cd_show_tags">Afficher les étiquettes</string>
+    <string name="cd_clear_filter">Effacer le filtre</string>
+    <string name="cd_unarchive">Désarchiver</string>
+    <string name="cd_delete">Supprimer</string>
+
+    <!-- Conversation list screen -->
+    <string name="conversations">Conversations</string>
+    <string name="search_conversations">Rechercher des conversations…</string>
+    <string name="could_not_load_conversations">Impossible de charger les conversations</string>
+    <string name="no_results_found">Aucun résultat trouvé</string>
+    <string name="no_conversations_yet">Aucune conversation pour l\'instant</string>
+    <string name="try_different_search">Essayez un autre terme de recherche</string>
+    <string name="start_new_chat">Démarrez une nouvelle discussion pour commencer</string>
+    <string name="unknown_error">Une erreur inconnue s\'est produite</string>
+    <string name="conversation_exported">Conversation exportée</string>
+    <string name="export_failed">Échec de l\'exportation : %1$s</string>
+    <string name="import_failed">Échec de l\'importation : %1$s</string>
+    <string name="link_copied">Lien copié !</string>
+    <string name="imported_title">Importée : %1$s</string>
+    <string name="copy_of">Copie de %1$s</string>
+
+    <!-- Conversation actions -->
+    <string name="remove_bookmark">Supprimer le signet</string>
+    <string name="bookmark">Signet</string>
+    <string name="tags">Étiquettes</string>
+    <string name="rename_conversation">Renommer la conversation</string>
+    <string name="rename_dialog_message">Saisissez un nouveau titre pour cette conversation.</string>
+    <string name="title_label">Titre</string>
+    <string name="delete_conversation">Supprimer la conversation</string>
+    <string name="delete_confirmation_message">Voulez-vous vraiment supprimer \"%1$s\" ? Cette action est irréversible.</string>
+    <string name="this_conversation">cette conversation</string>
+
+    <!-- Tag picker -->
+    <string name="no_tags_yet">Aucune étiquette pour l\'instant. Ajoutez-en une ci-dessous.</string>
+    <string name="add_new_tag">Ajouter une nouvelle étiquette</string>
+
+    <!-- Tag filter bar -->
+    <string name="tags_active_count">%1$d étiquette%2$s active(s)</string>
+
+    <!-- Export format picker -->
+    <string name="export_format">Format d\'exportation</string>
+    <string name="format_json">JSON</string>
+    <string name="format_json_description">Exportation complète des données, réimportable</string>
+    <string name="format_markdown">Markdown</string>
+    <string name="format_markdown_description">Format texte lisible</string>
+
+    <!-- Archived conversations screen -->
+    <string name="archived_conversations">Conversations archivées</string>
+    <string name="could_not_load_archived">Impossible de charger les conversations archivées</string>
+    <string name="no_archived_conversations">Aucune conversation archivée</string>
+    <string name="archived_will_appear_here">Les conversations archivées apparaîtront ici</string>
+
+    <!-- Conversation item fallback -->
+    <string name="chat">Discussion</string>
+</resources>

--- a/feature/conversations/src/commonMain/composeResources/values-ja/strings.xml
+++ b/feature/conversations/src/commonMain/composeResources/values-ja/strings.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Common actions -->
+    <string name="rename">名前を変更</string>
+    <string name="cancel">キャンセル</string>
+    <string name="delete">削除</string>
+    <string name="archive">アーカイブ</string>
+    <string name="unarchive">アーカイブを解除</string>
+    <string name="export">エクスポート</string>
+    <string name="share">共有</string>
+    <string name="duplicate">複製</string>
+    <string name="clear">クリア</string>
+    <string name="back">戻る</string>
+    <string name="new_chat">新しいチャット</string>
+
+    <!-- Content descriptions -->
+    <string name="cd_new_chat">新しいチャット</string>
+    <string name="cd_archived_conversations">アーカイブ済みの会話</string>
+    <string name="cd_search">検索</string>
+    <string name="cd_clear_search">検索をクリア</string>
+    <string name="cd_bookmarked">ブックマーク済み</string>
+    <string name="cd_conversation_actions">会話の操作</string>
+    <string name="cd_add_tag">タグを追加</string>
+    <string name="cd_hide_tags">タグを非表示</string>
+    <string name="cd_show_tags">タグを表示</string>
+    <string name="cd_clear_filter">フィルターをクリア</string>
+    <string name="cd_unarchive">アーカイブを解除</string>
+    <string name="cd_delete">削除</string>
+
+    <!-- Conversation list screen -->
+    <string name="conversations">会話</string>
+    <string name="search_conversations">会話を検索…</string>
+    <string name="could_not_load_conversations">会話を読み込めませんでした</string>
+    <string name="no_results_found">結果が見つかりません</string>
+    <string name="no_conversations_yet">会話はまだありません</string>
+    <string name="try_different_search">別の検索語をお試しください</string>
+    <string name="start_new_chat">新しいチャットを開始しましょう</string>
+    <string name="unknown_error">不明なエラーが発生しました</string>
+    <string name="conversation_exported">会話をエクスポートしました</string>
+    <string name="export_failed">エクスポートに失敗しました: %1$s</string>
+    <string name="import_failed">インポートに失敗しました: %1$s</string>
+    <string name="link_copied">リンクをコピーしました！</string>
+    <string name="imported_title">インポート済み: %1$s</string>
+    <string name="copy_of">%1$s のコピー</string>
+
+    <!-- Conversation actions -->
+    <string name="remove_bookmark">ブックマークを解除</string>
+    <string name="bookmark">ブックマーク</string>
+    <string name="tags">タグ</string>
+    <string name="rename_conversation">会話の名前を変更</string>
+    <string name="rename_dialog_message">この会話の新しいタイトルを入力してください。</string>
+    <string name="title_label">タイトル</string>
+    <string name="delete_conversation">会話を削除</string>
+    <string name="delete_confirmation_message">「%1$s」を削除してもよろしいですか？この操作は取り消せません。</string>
+    <string name="this_conversation">この会話</string>
+
+    <!-- Tag picker -->
+    <string name="no_tags_yet">タグはまだありません。下から追加してください。</string>
+    <string name="add_new_tag">新しいタグを追加</string>
+
+    <!-- Tag filter bar -->
+    <string name="tags_active_count">%1$d 個のタグ%2$sが有効</string>
+
+    <!-- Export format picker -->
+    <string name="export_format">エクスポート形式</string>
+    <string name="format_json">JSON</string>
+    <string name="format_json_description">完全なデータエクスポート、再インポート可能</string>
+    <string name="format_markdown">Markdown</string>
+    <string name="format_markdown_description">読みやすいテキスト形式</string>
+
+    <!-- Archived conversations screen -->
+    <string name="archived_conversations">アーカイブ済みの会話</string>
+    <string name="could_not_load_archived">アーカイブ済みの会話を読み込めませんでした</string>
+    <string name="no_archived_conversations">アーカイブ済みの会話がありません</string>
+    <string name="archived_will_appear_here">アーカイブした会話はここに表示されます</string>
+
+    <!-- Conversation item fallback -->
+    <string name="chat">チャット</string>
+</resources>

--- a/feature/conversations/src/commonMain/composeResources/values-ko/strings.xml
+++ b/feature/conversations/src/commonMain/composeResources/values-ko/strings.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Common actions -->
+    <string name="rename">이름 변경</string>
+    <string name="cancel">취소</string>
+    <string name="delete">삭제</string>
+    <string name="archive">보관</string>
+    <string name="unarchive">보관 해제</string>
+    <string name="export">내보내기</string>
+    <string name="share">공유</string>
+    <string name="duplicate">복제</string>
+    <string name="clear">지우기</string>
+    <string name="back">뒤로</string>
+    <string name="new_chat">새 채팅</string>
+
+    <!-- Content descriptions -->
+    <string name="cd_new_chat">새 채팅</string>
+    <string name="cd_archived_conversations">보관된 대화</string>
+    <string name="cd_search">검색</string>
+    <string name="cd_clear_search">검색 지우기</string>
+    <string name="cd_bookmarked">북마크됨</string>
+    <string name="cd_conversation_actions">대화 작업</string>
+    <string name="cd_add_tag">태그 추가</string>
+    <string name="cd_hide_tags">태그 숨기기</string>
+    <string name="cd_show_tags">태그 표시</string>
+    <string name="cd_clear_filter">필터 지우기</string>
+    <string name="cd_unarchive">보관 해제</string>
+    <string name="cd_delete">삭제</string>
+
+    <!-- Conversation list screen -->
+    <string name="conversations">대화</string>
+    <string name="search_conversations">대화 검색…</string>
+    <string name="could_not_load_conversations">대화를 불러올 수 없습니다</string>
+    <string name="no_results_found">결과를 찾을 수 없습니다</string>
+    <string name="no_conversations_yet">아직 대화가 없습니다</string>
+    <string name="try_different_search">다른 검색어를 사용해 보세요</string>
+    <string name="start_new_chat">새 채팅을 시작하세요</string>
+    <string name="unknown_error">알 수 없는 오류가 발생했습니다</string>
+    <string name="conversation_exported">대화를 내보냈습니다</string>
+    <string name="export_failed">내보내기 실패: %1$s</string>
+    <string name="import_failed">가져오기 실패: %1$s</string>
+    <string name="link_copied">링크가 복사되었습니다!</string>
+    <string name="imported_title">가져옴: %1$s</string>
+    <string name="copy_of">%1$s의 사본</string>
+
+    <!-- Conversation actions -->
+    <string name="remove_bookmark">북마크 제거</string>
+    <string name="bookmark">북마크</string>
+    <string name="tags">태그</string>
+    <string name="rename_conversation">대화 이름 변경</string>
+    <string name="rename_dialog_message">이 대화의 새 제목을 입력하세요.</string>
+    <string name="title_label">제목</string>
+    <string name="delete_conversation">대화 삭제</string>
+    <string name="delete_confirmation_message">\"%1$s\"을(를) 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.</string>
+    <string name="this_conversation">이 대화</string>
+
+    <!-- Tag picker -->
+    <string name="no_tags_yet">아직 태그가 없습니다. 아래에서 추가하세요.</string>
+    <string name="add_new_tag">새 태그 추가</string>
+
+    <!-- Tag filter bar -->
+    <string name="tags_active_count">태그 %1$d개%2$s 활성</string>
+
+    <!-- Export format picker -->
+    <string name="export_format">내보내기 형식</string>
+    <string name="format_json">JSON</string>
+    <string name="format_json_description">전체 데이터 내보내기, 다시 가져올 수 있습니다</string>
+    <string name="format_markdown">Markdown</string>
+    <string name="format_markdown_description">읽기 쉬운 텍스트 형식</string>
+
+    <!-- Archived conversations screen -->
+    <string name="archived_conversations">보관된 대화</string>
+    <string name="could_not_load_archived">보관된 대화를 불러올 수 없습니다</string>
+    <string name="no_archived_conversations">보관된 대화가 없습니다</string>
+    <string name="archived_will_appear_here">보관된 대화가 여기에 표시됩니다</string>
+
+    <!-- Conversation item fallback -->
+    <string name="chat">채팅</string>
+</resources>

--- a/feature/conversations/src/commonMain/composeResources/values-pt/strings.xml
+++ b/feature/conversations/src/commonMain/composeResources/values-pt/strings.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Common actions -->
+    <string name="rename">Renomear</string>
+    <string name="cancel">Cancelar</string>
+    <string name="delete">Excluir</string>
+    <string name="archive">Arquivar</string>
+    <string name="unarchive">Desarquivar</string>
+    <string name="export">Exportar</string>
+    <string name="share">Compartilhar</string>
+    <string name="duplicate">Duplicar</string>
+    <string name="clear">Limpar</string>
+    <string name="back">Voltar</string>
+    <string name="new_chat">Nova conversa</string>
+
+    <!-- Content descriptions -->
+    <string name="cd_new_chat">Nova conversa</string>
+    <string name="cd_archived_conversations">Conversas arquivadas</string>
+    <string name="cd_search">Buscar</string>
+    <string name="cd_clear_search">Limpar busca</string>
+    <string name="cd_bookmarked">Marcada</string>
+    <string name="cd_conversation_actions">Ações da conversa</string>
+    <string name="cd_add_tag">Adicionar etiqueta</string>
+    <string name="cd_hide_tags">Ocultar etiquetas</string>
+    <string name="cd_show_tags">Mostrar etiquetas</string>
+    <string name="cd_clear_filter">Limpar filtro</string>
+    <string name="cd_unarchive">Desarquivar</string>
+    <string name="cd_delete">Excluir</string>
+
+    <!-- Conversation list screen -->
+    <string name="conversations">Conversas</string>
+    <string name="search_conversations">Buscar conversas…</string>
+    <string name="could_not_load_conversations">Não foi possível carregar as conversas</string>
+    <string name="no_results_found">Nenhum resultado encontrado</string>
+    <string name="no_conversations_yet">Nenhuma conversa ainda</string>
+    <string name="try_different_search">Tente um termo de busca diferente</string>
+    <string name="start_new_chat">Inicie uma nova conversa para começar</string>
+    <string name="unknown_error">Ocorreu um erro desconhecido</string>
+    <string name="conversation_exported">Conversa exportada</string>
+    <string name="export_failed">Falha na exportação: %1$s</string>
+    <string name="import_failed">Falha na importação: %1$s</string>
+    <string name="link_copied">Link copiado!</string>
+    <string name="imported_title">Importada: %1$s</string>
+    <string name="copy_of">Cópia de %1$s</string>
+
+    <!-- Conversation actions -->
+    <string name="remove_bookmark">Remover marcador</string>
+    <string name="bookmark">Marcar</string>
+    <string name="tags">Etiquetas</string>
+    <string name="rename_conversation">Renomear conversa</string>
+    <string name="rename_dialog_message">Digite um novo título para esta conversa.</string>
+    <string name="title_label">Título</string>
+    <string name="delete_conversation">Excluir conversa</string>
+    <string name="delete_confirmation_message">Tem certeza de que deseja excluir \"%1$s\"? Esta ação não pode ser desfeita.</string>
+    <string name="this_conversation">esta conversa</string>
+
+    <!-- Tag picker -->
+    <string name="no_tags_yet">Nenhuma etiqueta ainda. Adicione uma abaixo.</string>
+    <string name="add_new_tag">Adicionar nova etiqueta</string>
+
+    <!-- Tag filter bar -->
+    <string name="tags_active_count">%1$d etiqueta%2$s ativa(s)</string>
+
+    <!-- Export format picker -->
+    <string name="export_format">Formato de exportação</string>
+    <string name="format_json">JSON</string>
+    <string name="format_json_description">Exportação completa dos dados, pode ser importada novamente</string>
+    <string name="format_markdown">Markdown</string>
+    <string name="format_markdown_description">Formato de texto legível</string>
+
+    <!-- Archived conversations screen -->
+    <string name="archived_conversations">Conversas arquivadas</string>
+    <string name="could_not_load_archived">Não foi possível carregar as conversas arquivadas</string>
+    <string name="no_archived_conversations">Nenhuma conversa arquivada</string>
+    <string name="archived_will_appear_here">As conversas arquivadas aparecerão aqui</string>
+
+    <!-- Conversation item fallback -->
+    <string name="chat">Conversa</string>
+</resources>

--- a/feature/conversations/src/commonMain/composeResources/values-ru/strings.xml
+++ b/feature/conversations/src/commonMain/composeResources/values-ru/strings.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Common actions -->
+    <string name="rename">Переименовать</string>
+    <string name="cancel">Отмена</string>
+    <string name="delete">Удалить</string>
+    <string name="archive">В архив</string>
+    <string name="unarchive">Из архива</string>
+    <string name="export">Экспорт</string>
+    <string name="share">Поделиться</string>
+    <string name="duplicate">Дублировать</string>
+    <string name="clear">Очистить</string>
+    <string name="back">Назад</string>
+    <string name="new_chat">Новый чат</string>
+
+    <!-- Content descriptions -->
+    <string name="cd_new_chat">Новый чат</string>
+    <string name="cd_archived_conversations">Архивированные беседы</string>
+    <string name="cd_search">Поиск</string>
+    <string name="cd_clear_search">Очистить поиск</string>
+    <string name="cd_bookmarked">В закладках</string>
+    <string name="cd_conversation_actions">Действия с беседой</string>
+    <string name="cd_add_tag">Добавить тег</string>
+    <string name="cd_hide_tags">Скрыть теги</string>
+    <string name="cd_show_tags">Показать теги</string>
+    <string name="cd_clear_filter">Сбросить фильтр</string>
+    <string name="cd_unarchive">Из архива</string>
+    <string name="cd_delete">Удалить</string>
+
+    <!-- Conversation list screen -->
+    <string name="conversations">Беседы</string>
+    <string name="search_conversations">Поиск бесед…</string>
+    <string name="could_not_load_conversations">Не удалось загрузить беседы</string>
+    <string name="no_results_found">Ничего не найдено</string>
+    <string name="no_conversations_yet">Пока нет бесед</string>
+    <string name="try_different_search">Попробуйте другой поисковый запрос</string>
+    <string name="start_new_chat">Начните новый чат, чтобы приступить</string>
+    <string name="unknown_error">Произошла неизвестная ошибка</string>
+    <string name="conversation_exported">Беседа экспортирована</string>
+    <string name="export_failed">Сбой экспорта: %1$s</string>
+    <string name="import_failed">Сбой импорта: %1$s</string>
+    <string name="link_copied">Ссылка скопирована!</string>
+    <string name="imported_title">Импортировано: %1$s</string>
+    <string name="copy_of">Копия %1$s</string>
+
+    <!-- Conversation actions -->
+    <string name="remove_bookmark">Убрать закладку</string>
+    <string name="bookmark">В закладки</string>
+    <string name="tags">Теги</string>
+    <string name="rename_conversation">Переименовать беседу</string>
+    <string name="rename_dialog_message">Введите новое название для этой беседы.</string>
+    <string name="title_label">Название</string>
+    <string name="delete_conversation">Удалить беседу</string>
+    <string name="delete_confirmation_message">Вы уверены, что хотите удалить \"%1$s\"? Это действие нельзя отменить.</string>
+    <string name="this_conversation">эту беседу</string>
+
+    <!-- Tag picker -->
+    <string name="no_tags_yet">Пока нет тегов. Добавьте один ниже.</string>
+    <string name="add_new_tag">Добавить новый тег</string>
+
+    <!-- Tag filter bar -->
+    <string name="tags_active_count">Активных тегов: %1$d%2$s</string>
+
+    <!-- Export format picker -->
+    <string name="export_format">Формат экспорта</string>
+    <string name="format_json">JSON</string>
+    <string name="format_json_description">Полный экспорт данных, можно импортировать обратно</string>
+    <string name="format_markdown">Markdown</string>
+    <string name="format_markdown_description">Удобочитаемый текстовый формат</string>
+
+    <!-- Archived conversations screen -->
+    <string name="archived_conversations">Архивированные беседы</string>
+    <string name="could_not_load_archived">Не удалось загрузить архивированные беседы</string>
+    <string name="no_archived_conversations">Нет архивированных бесед</string>
+    <string name="archived_will_appear_here">Архивированные беседы появятся здесь</string>
+
+    <!-- Conversation item fallback -->
+    <string name="chat">Чат</string>
+</resources>

--- a/feature/conversations/src/commonMain/composeResources/values-zh/strings.xml
+++ b/feature/conversations/src/commonMain/composeResources/values-zh/strings.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Common actions -->
+    <string name="rename">重命名</string>
+    <string name="cancel">取消</string>
+    <string name="delete">删除</string>
+    <string name="archive">归档</string>
+    <string name="unarchive">取消归档</string>
+    <string name="export">导出</string>
+    <string name="share">分享</string>
+    <string name="duplicate">复制副本</string>
+    <string name="clear">清除</string>
+    <string name="back">返回</string>
+    <string name="new_chat">新建聊天</string>
+
+    <!-- Content descriptions -->
+    <string name="cd_new_chat">新建聊天</string>
+    <string name="cd_archived_conversations">已归档对话</string>
+    <string name="cd_search">搜索</string>
+    <string name="cd_clear_search">清除搜索</string>
+    <string name="cd_bookmarked">已收藏</string>
+    <string name="cd_conversation_actions">对话操作</string>
+    <string name="cd_add_tag">添加标签</string>
+    <string name="cd_hide_tags">隐藏标签</string>
+    <string name="cd_show_tags">显示标签</string>
+    <string name="cd_clear_filter">清除筛选</string>
+    <string name="cd_unarchive">取消归档</string>
+    <string name="cd_delete">删除</string>
+
+    <!-- Conversation list screen -->
+    <string name="conversations">对话</string>
+    <string name="search_conversations">搜索对话…</string>
+    <string name="could_not_load_conversations">无法加载对话</string>
+    <string name="no_results_found">未找到结果</string>
+    <string name="no_conversations_yet">暂无对话</string>
+    <string name="try_different_search">尝试其他搜索关键词</string>
+    <string name="start_new_chat">开始新聊天</string>
+    <string name="unknown_error">发生未知错误</string>
+    <string name="conversation_exported">对话已导出</string>
+    <string name="export_failed">导出失败：%1$s</string>
+    <string name="import_failed">导入失败：%1$s</string>
+    <string name="link_copied">链接已复制！</string>
+    <string name="imported_title">已导入：%1$s</string>
+    <string name="copy_of">%1$s 的副本</string>
+
+    <!-- Conversation actions -->
+    <string name="remove_bookmark">取消收藏</string>
+    <string name="bookmark">收藏</string>
+    <string name="tags">标签</string>
+    <string name="rename_conversation">重命名对话</string>
+    <string name="rename_dialog_message">为此对话输入新标题。</string>
+    <string name="title_label">标题</string>
+    <string name="delete_conversation">删除对话</string>
+    <string name="delete_confirmation_message">确定要删除 \"%1$s\" 吗？此操作无法撤销。</string>
+    <string name="this_conversation">此对话</string>
+
+    <!-- Tag picker -->
+    <string name="no_tags_yet">暂无标签。在下方添加一个。</string>
+    <string name="add_new_tag">添加新标签</string>
+
+    <!-- Tag filter bar -->
+    <string name="tags_active_count">%1$d 个标签%2$s已启用</string>
+
+    <!-- Export format picker -->
+    <string name="export_format">导出格式</string>
+    <string name="format_json">JSON</string>
+    <string name="format_json_description">完整数据导出，可重新导入</string>
+    <string name="format_markdown">Markdown</string>
+    <string name="format_markdown_description">易读的文本格式</string>
+
+    <!-- Archived conversations screen -->
+    <string name="archived_conversations">已归档对话</string>
+    <string name="could_not_load_archived">无法加载已归档对话</string>
+    <string name="no_archived_conversations">没有已归档对话</string>
+    <string name="archived_will_appear_here">已归档的对话将显示在此处</string>
+
+    <!-- Conversation item fallback -->
+    <string name="chat">聊天</string>
+</resources>

--- a/feature/files/src/commonMain/composeResources/values-ar/strings.xml
+++ b/feature/files/src/commonMain/composeResources/values-ar/strings.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Common actions -->
+    <string name="files">الملفات</string>
+    <string name="upload">رفع</string>
+    <string name="delete">حذف</string>
+    <string name="cancel">إلغاء</string>
+    <string name="done">تم</string>
+
+    <!-- Content descriptions -->
+    <string name="cd_exit_edit_mode">الخروج من وضع التعديل</string>
+    <string name="cd_select_all">تحديد الكل</string>
+    <string name="cd_delete_selected">حذف المحدد</string>
+    <string name="cd_edit_files">تعديل الملفات</string>
+    <string name="cd_switch_to_grid">التبديل إلى عرض الشبكة</string>
+    <string name="cd_switch_to_list">التبديل إلى عرض القائمة</string>
+    <string name="cd_sort_files">ترتيب الملفات</string>
+    <string name="cd_upload_file">رفع ملف</string>
+    <string name="cd_delete_file">حذف %1$s</string>
+    <string name="cd_thumbnail">صورة مصغّرة لـ %1$s</string>
+    <string name="cd_close_preview">إغلاق المعاينة</string>
+    <string name="cd_cancel_upload">إلغاء الرفع</string>
+    <string name="cd_ascending">تصاعدي</string>
+    <string name="cd_descending">تنازلي</string>
+
+    <!-- Selection mode -->
+    <string name="select_files">تحديد الملفات</string>
+    <string name="selected_count">%1$d محدد</string>
+
+    <!-- Empty states -->
+    <string name="no_files">لا توجد ملفات</string>
+    <string name="upload_to_get_started">ارفع ملفات للبدء</string>
+    <string name="no_filter_files">لا توجد %1$s</string>
+    <string name="no_filter_files_found">لم يتم العثور على ملفات %1$s</string>
+    <string name="could_not_load_files">تعذّر تحميل الملفات</string>
+
+    <!-- Delete dialogs -->
+    <string name="delete_count_files">حذف %1$d ملف%2$s؟</string>
+    <string name="action_cannot_be_undone">لا يمكن التراجع عن هذا الإجراء.</string>
+    <string name="delete_file_question">حذف الملف؟</string>
+    <string name="delete_file_message">حذف "%1$s"؟ لا يمكن التراجع عن هذا الإجراء.</string>
+    <string name="this_file">هذا الملف</string>
+
+    <!-- File preview -->
+    <string name="image_preview_unavailable">معاينة الصورة غير متاحة</string>
+    <string name="preview_of">معاينة %1$s</string>
+    <string name="loading_pdf">جارٍ تحميل PDF…</string>
+    <string name="page_of">الصفحة %1$d من %2$d</string>
+    <string name="page_cd">الصفحة %1$d من %2$s</string>
+    <string name="could_not_render_pdf">تعذّر عرض معاينة PDF</string>
+    <string name="failed_to_download_pdf">فشل تنزيل PDF</string>
+    <string name="failed_to_render_pdf">فشل عرض PDF</string>
+    <string name="loading_file_content">جارٍ تحميل محتوى الملف…</string>
+    <string name="could_not_load_file_content">تعذّر تحميل محتوى الملف</string>
+    <string name="failed_to_download_file">فشل تنزيل الملف</string>
+    <string name="failed_to_load_content">فشل تحميل محتوى الملف</string>
+    <string name="content_truncated">\n\n--- تم اقتطاع المحتوى (الملف كبير جدًا) ---</string>
+
+    <!-- Info row labels -->
+    <string name="info_type">النوع</string>
+    <string name="info_size">الحجم</string>
+    <string name="info_created">تاريخ الإنشاء</string>
+    <string name="info_source">المصدر</string>
+
+    <!-- Upload progress -->
+    <string name="uploading">جارٍ الرفع…</string>
+</resources>

--- a/feature/files/src/commonMain/composeResources/values-de/strings.xml
+++ b/feature/files/src/commonMain/composeResources/values-de/strings.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Common actions -->
+    <string name="files">Dateien</string>
+    <string name="upload">Hochladen</string>
+    <string name="delete">Löschen</string>
+    <string name="cancel">Abbrechen</string>
+    <string name="done">Fertig</string>
+
+    <!-- Content descriptions -->
+    <string name="cd_exit_edit_mode">Bearbeitungsmodus verlassen</string>
+    <string name="cd_select_all">Alle auswählen</string>
+    <string name="cd_delete_selected">Ausgewählte löschen</string>
+    <string name="cd_edit_files">Dateien bearbeiten</string>
+    <string name="cd_switch_to_grid">Zur Rasteransicht wechseln</string>
+    <string name="cd_switch_to_list">Zur Listenansicht wechseln</string>
+    <string name="cd_sort_files">Dateien sortieren</string>
+    <string name="cd_upload_file">Datei hochladen</string>
+    <string name="cd_delete_file">%1$s löschen</string>
+    <string name="cd_thumbnail">Miniaturansicht von %1$s</string>
+    <string name="cd_close_preview">Vorschau schließen</string>
+    <string name="cd_cancel_upload">Upload abbrechen</string>
+    <string name="cd_ascending">Aufsteigend</string>
+    <string name="cd_descending">Absteigend</string>
+
+    <!-- Selection mode -->
+    <string name="select_files">Dateien auswählen</string>
+    <string name="selected_count">%1$d ausgewählt</string>
+
+    <!-- Empty states -->
+    <string name="no_files">Keine Dateien</string>
+    <string name="upload_to_get_started">Lade Dateien hoch, um zu beginnen</string>
+    <string name="no_filter_files">Keine %1$s</string>
+    <string name="no_filter_files_found">Keine %1$s-Dateien gefunden</string>
+    <string name="could_not_load_files">Dateien konnten nicht geladen werden</string>
+
+    <!-- Delete dialogs -->
+    <string name="delete_count_files">%1$d Datei%2$s löschen?</string>
+    <string name="action_cannot_be_undone">Diese Aktion kann nicht rückgängig gemacht werden.</string>
+    <string name="delete_file_question">Datei löschen?</string>
+    <string name="delete_file_message">\"%1$s\" löschen? Diese Aktion kann nicht rückgängig gemacht werden.</string>
+    <string name="this_file">diese Datei</string>
+
+    <!-- File preview -->
+    <string name="image_preview_unavailable">Bildvorschau nicht verfügbar</string>
+    <string name="preview_of">Vorschau von %1$s</string>
+    <string name="loading_pdf">PDF wird geladen…</string>
+    <string name="page_of">Seite %1$d von %2$d</string>
+    <string name="page_cd">Seite %1$d von %2$s</string>
+    <string name="could_not_render_pdf">PDF-Vorschau konnte nicht gerendert werden</string>
+    <string name="failed_to_download_pdf">PDF konnte nicht heruntergeladen werden</string>
+    <string name="failed_to_render_pdf">PDF konnte nicht gerendert werden</string>
+    <string name="loading_file_content">Dateiinhalt wird geladen…</string>
+    <string name="could_not_load_file_content">Dateiinhalt konnte nicht geladen werden</string>
+    <string name="failed_to_download_file">Datei konnte nicht heruntergeladen werden</string>
+    <string name="failed_to_load_content">Dateiinhalt konnte nicht geladen werden</string>
+    <string name="content_truncated">\n\n--- Inhalt gekürzt (Datei zu groß) ---</string>
+
+    <!-- Info row labels -->
+    <string name="info_type">Typ</string>
+    <string name="info_size">Größe</string>
+    <string name="info_created">Erstellt</string>
+    <string name="info_source">Quelle</string>
+
+    <!-- Upload progress -->
+    <string name="uploading">Wird hochgeladen…</string>
+</resources>

--- a/feature/files/src/commonMain/composeResources/values-es/strings.xml
+++ b/feature/files/src/commonMain/composeResources/values-es/strings.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Common actions -->
+    <string name="files">Archivos</string>
+    <string name="upload">Subir</string>
+    <string name="delete">Eliminar</string>
+    <string name="cancel">Cancelar</string>
+    <string name="done">Hecho</string>
+
+    <!-- Content descriptions -->
+    <string name="cd_exit_edit_mode">Salir del modo de edición</string>
+    <string name="cd_select_all">Seleccionar todo</string>
+    <string name="cd_delete_selected">Eliminar seleccionados</string>
+    <string name="cd_edit_files">Editar archivos</string>
+    <string name="cd_switch_to_grid">Cambiar a vista de cuadrícula</string>
+    <string name="cd_switch_to_list">Cambiar a vista de lista</string>
+    <string name="cd_sort_files">Ordenar archivos</string>
+    <string name="cd_upload_file">Subir archivo</string>
+    <string name="cd_delete_file">Eliminar %1$s</string>
+    <string name="cd_thumbnail">Miniatura de %1$s</string>
+    <string name="cd_close_preview">Cerrar vista previa</string>
+    <string name="cd_cancel_upload">Cancelar subida</string>
+    <string name="cd_ascending">Ascendente</string>
+    <string name="cd_descending">Descendente</string>
+
+    <!-- Selection mode -->
+    <string name="select_files">Seleccionar archivos</string>
+    <string name="selected_count">%1$d seleccionados</string>
+
+    <!-- Empty states -->
+    <string name="no_files">No hay archivos</string>
+    <string name="upload_to_get_started">Sube archivos para empezar</string>
+    <string name="no_filter_files">Sin %1$s</string>
+    <string name="no_filter_files_found">No se encontraron archivos de %1$s</string>
+    <string name="could_not_load_files">No se pudieron cargar los archivos</string>
+
+    <!-- Delete dialogs -->
+    <string name="delete_count_files">¿Eliminar %1$d archivo%2$s?</string>
+    <string name="action_cannot_be_undone">Esta acción no se puede deshacer.</string>
+    <string name="delete_file_question">¿Eliminar archivo?</string>
+    <string name="delete_file_message">¿Eliminar \"%1$s\"? Esta acción no se puede deshacer.</string>
+    <string name="this_file">este archivo</string>
+
+    <!-- File preview -->
+    <string name="image_preview_unavailable">Vista previa de imagen no disponible</string>
+    <string name="preview_of">Vista previa de %1$s</string>
+    <string name="loading_pdf">Cargando PDF…</string>
+    <string name="page_of">Página %1$d de %2$d</string>
+    <string name="page_cd">Página %1$d de %2$s</string>
+    <string name="could_not_render_pdf">No se pudo mostrar la vista previa del PDF</string>
+    <string name="failed_to_download_pdf">Error al descargar el PDF</string>
+    <string name="failed_to_render_pdf">Error al mostrar el PDF</string>
+    <string name="loading_file_content">Cargando contenido del archivo…</string>
+    <string name="could_not_load_file_content">No se pudo cargar el contenido del archivo</string>
+    <string name="failed_to_download_file">Error al descargar el archivo</string>
+    <string name="failed_to_load_content">Error al cargar el contenido del archivo</string>
+    <string name="content_truncated">\n\n--- Contenido truncado (archivo demasiado grande) ---</string>
+
+    <!-- Info row labels -->
+    <string name="info_type">Tipo</string>
+    <string name="info_size">Tamaño</string>
+    <string name="info_created">Creado</string>
+    <string name="info_source">Origen</string>
+
+    <!-- Upload progress -->
+    <string name="uploading">Subiendo…</string>
+</resources>

--- a/feature/files/src/commonMain/composeResources/values-fr/strings.xml
+++ b/feature/files/src/commonMain/composeResources/values-fr/strings.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Common actions -->
+    <string name="files">Fichiers</string>
+    <string name="upload">Téléverser</string>
+    <string name="delete">Supprimer</string>
+    <string name="cancel">Annuler</string>
+    <string name="done">Terminé</string>
+
+    <!-- Content descriptions -->
+    <string name="cd_exit_edit_mode">Quitter le mode édition</string>
+    <string name="cd_select_all">Tout sélectionner</string>
+    <string name="cd_delete_selected">Supprimer la sélection</string>
+    <string name="cd_edit_files">Modifier les fichiers</string>
+    <string name="cd_switch_to_grid">Passer en vue grille</string>
+    <string name="cd_switch_to_list">Passer en vue liste</string>
+    <string name="cd_sort_files">Trier les fichiers</string>
+    <string name="cd_upload_file">Téléverser un fichier</string>
+    <string name="cd_delete_file">Supprimer %1$s</string>
+    <string name="cd_thumbnail">Miniature de %1$s</string>
+    <string name="cd_close_preview">Fermer l\'aperçu</string>
+    <string name="cd_cancel_upload">Annuler le téléversement</string>
+    <string name="cd_ascending">Croissant</string>
+    <string name="cd_descending">Décroissant</string>
+
+    <!-- Selection mode -->
+    <string name="select_files">Sélectionner des fichiers</string>
+    <string name="selected_count">%1$d sélectionné(s)</string>
+
+    <!-- Empty states -->
+    <string name="no_files">Aucun fichier</string>
+    <string name="upload_to_get_started">Téléversez des fichiers pour commencer</string>
+    <string name="no_filter_files">Aucun %1$s</string>
+    <string name="no_filter_files_found">Aucun fichier %1$s trouvé</string>
+    <string name="could_not_load_files">Impossible de charger les fichiers</string>
+
+    <!-- Delete dialogs -->
+    <string name="delete_count_files">Supprimer %1$d fichier%2$s ?</string>
+    <string name="action_cannot_be_undone">Cette action est irréversible.</string>
+    <string name="delete_file_question">Supprimer le fichier ?</string>
+    <string name="delete_file_message">Supprimer "%1$s" ? Cette action est irréversible.</string>
+    <string name="this_file">ce fichier</string>
+
+    <!-- File preview -->
+    <string name="image_preview_unavailable">Aperçu de l\'image non disponible</string>
+    <string name="preview_of">Aperçu de %1$s</string>
+    <string name="loading_pdf">Chargement du PDF…</string>
+    <string name="page_of">Page %1$d sur %2$d</string>
+    <string name="page_cd">Page %1$d sur %2$s</string>
+    <string name="could_not_render_pdf">Impossible d\'afficher l\'aperçu du PDF</string>
+    <string name="failed_to_download_pdf">Échec du téléchargement du PDF</string>
+    <string name="failed_to_render_pdf">Échec de l\'affichage du PDF</string>
+    <string name="loading_file_content">Chargement du contenu du fichier…</string>
+    <string name="could_not_load_file_content">Impossible de charger le contenu du fichier</string>
+    <string name="failed_to_download_file">Échec du téléchargement du fichier</string>
+    <string name="failed_to_load_content">Échec du chargement du contenu du fichier</string>
+    <string name="content_truncated">\n\n--- Contenu tronqué (fichier trop volumineux) ---</string>
+
+    <!-- Info row labels -->
+    <string name="info_type">Type</string>
+    <string name="info_size">Taille</string>
+    <string name="info_created">Créé</string>
+    <string name="info_source">Source</string>
+
+    <!-- Upload progress -->
+    <string name="uploading">Téléversement…</string>
+</resources>

--- a/feature/files/src/commonMain/composeResources/values-ja/strings.xml
+++ b/feature/files/src/commonMain/composeResources/values-ja/strings.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Common actions -->
+    <string name="files">ファイル</string>
+    <string name="upload">アップロード</string>
+    <string name="delete">削除</string>
+    <string name="cancel">キャンセル</string>
+    <string name="done">完了</string>
+
+    <!-- Content descriptions -->
+    <string name="cd_exit_edit_mode">編集モードを終了</string>
+    <string name="cd_select_all">すべて選択</string>
+    <string name="cd_delete_selected">選択項目を削除</string>
+    <string name="cd_edit_files">ファイルを編集</string>
+    <string name="cd_switch_to_grid">グリッド表示に切り替え</string>
+    <string name="cd_switch_to_list">リスト表示に切り替え</string>
+    <string name="cd_sort_files">ファイルを並べ替え</string>
+    <string name="cd_upload_file">ファイルをアップロード</string>
+    <string name="cd_delete_file">%1$s を削除</string>
+    <string name="cd_thumbnail">%1$s のサムネイル</string>
+    <string name="cd_close_preview">プレビューを閉じる</string>
+    <string name="cd_cancel_upload">アップロードをキャンセル</string>
+    <string name="cd_ascending">昇順</string>
+    <string name="cd_descending">降順</string>
+
+    <!-- Selection mode -->
+    <string name="select_files">ファイルを選択</string>
+    <string name="selected_count">%1$d 件選択</string>
+
+    <!-- Empty states -->
+    <string name="no_files">ファイルがありません</string>
+    <string name="upload_to_get_started">ファイルをアップロードして始めましょう</string>
+    <string name="no_filter_files">%1$s はありません</string>
+    <string name="no_filter_files_found">%1$s のファイルが見つかりません</string>
+    <string name="could_not_load_files">ファイルを読み込めませんでした</string>
+
+    <!-- Delete dialogs -->
+    <string name="delete_count_files">%1$d 件のファイル%2$sを削除しますか？</string>
+    <string name="action_cannot_be_undone">この操作は取り消せません。</string>
+    <string name="delete_file_question">ファイルを削除しますか？</string>
+    <string name="delete_file_message">「%1$s」を削除しますか？この操作は取り消せません。</string>
+    <string name="this_file">このファイル</string>
+
+    <!-- File preview -->
+    <string name="image_preview_unavailable">画像のプレビューは利用できません</string>
+    <string name="preview_of">%1$s のプレビュー</string>
+    <string name="loading_pdf">PDFを読み込み中…</string>
+    <string name="page_of">%2$d ページ中 %1$d ページ</string>
+    <string name="page_cd">%2$s ページ中 %1$d ページ</string>
+    <string name="could_not_render_pdf">PDFのプレビューを表示できませんでした</string>
+    <string name="failed_to_download_pdf">PDFのダウンロードに失敗しました</string>
+    <string name="failed_to_render_pdf">PDFの表示に失敗しました</string>
+    <string name="loading_file_content">ファイルの内容を読み込み中…</string>
+    <string name="could_not_load_file_content">ファイルの内容を読み込めませんでした</string>
+    <string name="failed_to_download_file">ファイルのダウンロードに失敗しました</string>
+    <string name="failed_to_load_content">ファイルの内容の読み込みに失敗しました</string>
+    <string name="content_truncated">\n\n--- 内容が切り詰められました（ファイルが大きすぎます）---</string>
+
+    <!-- Info row labels -->
+    <string name="info_type">種類</string>
+    <string name="info_size">サイズ</string>
+    <string name="info_created">作成日</string>
+    <string name="info_source">ソース</string>
+
+    <!-- Upload progress -->
+    <string name="uploading">アップロード中…</string>
+</resources>

--- a/feature/files/src/commonMain/composeResources/values-ko/strings.xml
+++ b/feature/files/src/commonMain/composeResources/values-ko/strings.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Common actions -->
+    <string name="files">파일</string>
+    <string name="upload">업로드</string>
+    <string name="delete">삭제</string>
+    <string name="cancel">취소</string>
+    <string name="done">완료</string>
+
+    <!-- Content descriptions -->
+    <string name="cd_exit_edit_mode">편집 모드 종료</string>
+    <string name="cd_select_all">전체 선택</string>
+    <string name="cd_delete_selected">선택 항목 삭제</string>
+    <string name="cd_edit_files">파일 편집</string>
+    <string name="cd_switch_to_grid">그리드 보기로 전환</string>
+    <string name="cd_switch_to_list">목록 보기로 전환</string>
+    <string name="cd_sort_files">파일 정렬</string>
+    <string name="cd_upload_file">파일 업로드</string>
+    <string name="cd_delete_file">%1$s 삭제</string>
+    <string name="cd_thumbnail">%1$s 썸네일</string>
+    <string name="cd_close_preview">미리보기 닫기</string>
+    <string name="cd_cancel_upload">업로드 취소</string>
+    <string name="cd_ascending">오름차순</string>
+    <string name="cd_descending">내림차순</string>
+
+    <!-- Selection mode -->
+    <string name="select_files">파일 선택</string>
+    <string name="selected_count">%1$d개 선택됨</string>
+
+    <!-- Empty states -->
+    <string name="no_files">파일 없음</string>
+    <string name="upload_to_get_started">시작하려면 파일을 업로드하세요</string>
+    <string name="no_filter_files">%1$s 없음</string>
+    <string name="no_filter_files_found">%1$s 파일을 찾을 수 없습니다</string>
+    <string name="could_not_load_files">파일을 불러올 수 없습니다</string>
+
+    <!-- Delete dialogs -->
+    <string name="delete_count_files">파일 %1$d개%2$s를 삭제하시겠습니까?</string>
+    <string name="action_cannot_be_undone">이 작업은 되돌릴 수 없습니다.</string>
+    <string name="delete_file_question">파일을 삭제하시겠습니까?</string>
+    <string name="delete_file_message">"%1$s"을(를) 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.</string>
+    <string name="this_file">이 파일</string>
+
+    <!-- File preview -->
+    <string name="image_preview_unavailable">이미지 미리보기를 사용할 수 없습니다</string>
+    <string name="preview_of">%1$s 미리보기</string>
+    <string name="loading_pdf">PDF 불러오는 중…</string>
+    <string name="page_of">%2$d페이지 중 %1$d페이지</string>
+    <string name="page_cd">%2$s페이지 중 %1$d페이지</string>
+    <string name="could_not_render_pdf">PDF 미리보기를 렌더링할 수 없습니다</string>
+    <string name="failed_to_download_pdf">PDF 다운로드에 실패했습니다</string>
+    <string name="failed_to_render_pdf">PDF 렌더링에 실패했습니다</string>
+    <string name="loading_file_content">파일 내용 불러오는 중…</string>
+    <string name="could_not_load_file_content">파일 내용을 불러올 수 없습니다</string>
+    <string name="failed_to_download_file">파일 다운로드에 실패했습니다</string>
+    <string name="failed_to_load_content">파일 내용을 불러오지 못했습니다</string>
+    <string name="content_truncated">\n\n--- 내용이 잘렸습니다 (파일이 너무 큼) ---</string>
+
+    <!-- Info row labels -->
+    <string name="info_type">유형</string>
+    <string name="info_size">크기</string>
+    <string name="info_created">생성됨</string>
+    <string name="info_source">소스</string>
+
+    <!-- Upload progress -->
+    <string name="uploading">업로드 중…</string>
+</resources>

--- a/feature/files/src/commonMain/composeResources/values-pt/strings.xml
+++ b/feature/files/src/commonMain/composeResources/values-pt/strings.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Common actions -->
+    <string name="files">Arquivos</string>
+    <string name="upload">Enviar</string>
+    <string name="delete">Excluir</string>
+    <string name="cancel">Cancelar</string>
+    <string name="done">Concluído</string>
+
+    <!-- Content descriptions -->
+    <string name="cd_exit_edit_mode">Sair do modo de edição</string>
+    <string name="cd_select_all">Selecionar tudo</string>
+    <string name="cd_delete_selected">Excluir selecionados</string>
+    <string name="cd_edit_files">Editar arquivos</string>
+    <string name="cd_switch_to_grid">Alternar para visualização em grade</string>
+    <string name="cd_switch_to_list">Alternar para visualização em lista</string>
+    <string name="cd_sort_files">Ordenar arquivos</string>
+    <string name="cd_upload_file">Enviar arquivo</string>
+    <string name="cd_delete_file">Excluir %1$s</string>
+    <string name="cd_thumbnail">Miniatura de %1$s</string>
+    <string name="cd_close_preview">Fechar visualização</string>
+    <string name="cd_cancel_upload">Cancelar envio</string>
+    <string name="cd_ascending">Crescente</string>
+    <string name="cd_descending">Decrescente</string>
+
+    <!-- Selection mode -->
+    <string name="select_files">Selecionar arquivos</string>
+    <string name="selected_count">%1$d selecionado(s)</string>
+
+    <!-- Empty states -->
+    <string name="no_files">Nenhum arquivo</string>
+    <string name="upload_to_get_started">Envie arquivos para começar</string>
+    <string name="no_filter_files">Nenhum %1$s</string>
+    <string name="no_filter_files_found">Nenhum arquivo de %1$s encontrado</string>
+    <string name="could_not_load_files">Não foi possível carregar os arquivos</string>
+
+    <!-- Delete dialogs -->
+    <string name="delete_count_files">Excluir %1$d arquivo%2$s?</string>
+    <string name="action_cannot_be_undone">Esta ação não pode ser desfeita.</string>
+    <string name="delete_file_question">Excluir arquivo?</string>
+    <string name="delete_file_message">Excluir \"%1$s\"? Esta ação não pode ser desfeita.</string>
+    <string name="this_file">este arquivo</string>
+
+    <!-- File preview -->
+    <string name="image_preview_unavailable">Visualização da imagem indisponível</string>
+    <string name="preview_of">Visualização de %1$s</string>
+    <string name="loading_pdf">Carregando PDF…</string>
+    <string name="page_of">Página %1$d de %2$d</string>
+    <string name="page_cd">Página %1$d de %2$s</string>
+    <string name="could_not_render_pdf">Não foi possível renderizar a visualização do PDF</string>
+    <string name="failed_to_download_pdf">Falha ao baixar o PDF</string>
+    <string name="failed_to_render_pdf">Falha ao renderizar o PDF</string>
+    <string name="loading_file_content">Carregando conteúdo do arquivo…</string>
+    <string name="could_not_load_file_content">Não foi possível carregar o conteúdo do arquivo</string>
+    <string name="failed_to_download_file">Falha ao baixar o arquivo</string>
+    <string name="failed_to_load_content">Falha ao carregar o conteúdo do arquivo</string>
+    <string name="content_truncated">\n\n--- Conteúdo truncado (arquivo muito grande) ---</string>
+
+    <!-- Info row labels -->
+    <string name="info_type">Tipo</string>
+    <string name="info_size">Tamanho</string>
+    <string name="info_created">Criado em</string>
+    <string name="info_source">Origem</string>
+
+    <!-- Upload progress -->
+    <string name="uploading">Enviando…</string>
+</resources>

--- a/feature/files/src/commonMain/composeResources/values-ru/strings.xml
+++ b/feature/files/src/commonMain/composeResources/values-ru/strings.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Common actions -->
+    <string name="files">Файлы</string>
+    <string name="upload">Загрузить</string>
+    <string name="delete">Удалить</string>
+    <string name="cancel">Отмена</string>
+    <string name="done">Готово</string>
+
+    <!-- Content descriptions -->
+    <string name="cd_exit_edit_mode">Выйти из режима редактирования</string>
+    <string name="cd_select_all">Выбрать все</string>
+    <string name="cd_delete_selected">Удалить выбранные</string>
+    <string name="cd_edit_files">Редактировать файлы</string>
+    <string name="cd_switch_to_grid">Переключить на сетку</string>
+    <string name="cd_switch_to_list">Переключить на список</string>
+    <string name="cd_sort_files">Сортировать файлы</string>
+    <string name="cd_upload_file">Загрузить файл</string>
+    <string name="cd_delete_file">Удалить %1$s</string>
+    <string name="cd_thumbnail">Миниатюра %1$s</string>
+    <string name="cd_close_preview">Закрыть предпросмотр</string>
+    <string name="cd_cancel_upload">Отменить загрузку</string>
+    <string name="cd_ascending">По возрастанию</string>
+    <string name="cd_descending">По убыванию</string>
+
+    <!-- Selection mode -->
+    <string name="select_files">Выбрать файлы</string>
+    <string name="selected_count">Выбрано: %1$d</string>
+
+    <!-- Empty states -->
+    <string name="no_files">Нет файлов</string>
+    <string name="upload_to_get_started">Загрузите файлы, чтобы начать</string>
+    <string name="no_filter_files">Нет: %1$s</string>
+    <string name="no_filter_files_found">Файлы «%1$s» не найдены</string>
+    <string name="could_not_load_files">Не удалось загрузить файлы</string>
+
+    <!-- Delete dialogs -->
+    <string name="delete_count_files">Удалить файлов: %1$d%2$s?</string>
+    <string name="action_cannot_be_undone">Это действие нельзя отменить.</string>
+    <string name="delete_file_question">Удалить файл?</string>
+    <string name="delete_file_message">Удалить "%1$s"? Это действие нельзя отменить.</string>
+    <string name="this_file">этот файл</string>
+
+    <!-- File preview -->
+    <string name="image_preview_unavailable">Предпросмотр изображения недоступен</string>
+    <string name="preview_of">Предпросмотр %1$s</string>
+    <string name="loading_pdf">Загрузка PDF…</string>
+    <string name="page_of">Страница %1$d из %2$d</string>
+    <string name="page_cd">Страница %1$d из %2$s</string>
+    <string name="could_not_render_pdf">Не удалось отобразить предпросмотр PDF</string>
+    <string name="failed_to_download_pdf">Не удалось скачать PDF</string>
+    <string name="failed_to_render_pdf">Не удалось отобразить PDF</string>
+    <string name="loading_file_content">Загрузка содержимого файла…</string>
+    <string name="could_not_load_file_content">Не удалось загрузить содержимое файла</string>
+    <string name="failed_to_download_file">Не удалось скачать файл</string>
+    <string name="failed_to_load_content">Не удалось загрузить содержимое файла</string>
+    <string name="content_truncated">\n\n--- Содержимое усечено (файл слишком большой) ---</string>
+
+    <!-- Info row labels -->
+    <string name="info_type">Тип</string>
+    <string name="info_size">Размер</string>
+    <string name="info_created">Создан</string>
+    <string name="info_source">Источник</string>
+
+    <!-- Upload progress -->
+    <string name="uploading">Загрузка…</string>
+</resources>

--- a/feature/files/src/commonMain/composeResources/values-zh/strings.xml
+++ b/feature/files/src/commonMain/composeResources/values-zh/strings.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Common actions -->
+    <string name="files">文件</string>
+    <string name="upload">上传</string>
+    <string name="delete">删除</string>
+    <string name="cancel">取消</string>
+    <string name="done">完成</string>
+
+    <!-- Content descriptions -->
+    <string name="cd_exit_edit_mode">退出编辑模式</string>
+    <string name="cd_select_all">全选</string>
+    <string name="cd_delete_selected">删除所选项</string>
+    <string name="cd_edit_files">编辑文件</string>
+    <string name="cd_switch_to_grid">切换到网格视图</string>
+    <string name="cd_switch_to_list">切换到列表视图</string>
+    <string name="cd_sort_files">排序文件</string>
+    <string name="cd_upload_file">上传文件</string>
+    <string name="cd_delete_file">删除 %1$s</string>
+    <string name="cd_thumbnail">%1$s 的缩略图</string>
+    <string name="cd_close_preview">关闭预览</string>
+    <string name="cd_cancel_upload">取消上传</string>
+    <string name="cd_ascending">升序</string>
+    <string name="cd_descending">降序</string>
+
+    <!-- Selection mode -->
+    <string name="select_files">选择文件</string>
+    <string name="selected_count">已选 %1$d 项</string>
+
+    <!-- Empty states -->
+    <string name="no_files">没有文件</string>
+    <string name="upload_to_get_started">上传文件以开始</string>
+    <string name="no_filter_files">没有%1$s</string>
+    <string name="no_filter_files_found">未找到%1$s文件</string>
+    <string name="could_not_load_files">无法加载文件</string>
+
+    <!-- Delete dialogs -->
+    <string name="delete_count_files">删除 %1$d 个文件%2$s？</string>
+    <string name="action_cannot_be_undone">此操作无法撤销。</string>
+    <string name="delete_file_question">删除文件？</string>
+    <string name="delete_file_message">删除 "%1$s"？此操作无法撤销。</string>
+    <string name="this_file">此文件</string>
+
+    <!-- File preview -->
+    <string name="image_preview_unavailable">图片预览不可用</string>
+    <string name="preview_of">%1$s 的预览</string>
+    <string name="loading_pdf">正在加载 PDF…</string>
+    <string name="page_of">第 %1$d 页，共 %2$d 页</string>
+    <string name="page_cd">第 %1$d 页，共 %2$s 页</string>
+    <string name="could_not_render_pdf">无法渲染 PDF 预览</string>
+    <string name="failed_to_download_pdf">PDF 下载失败</string>
+    <string name="failed_to_render_pdf">PDF 渲染失败</string>
+    <string name="loading_file_content">正在加载文件内容…</string>
+    <string name="could_not_load_file_content">无法加载文件内容</string>
+    <string name="failed_to_download_file">文件下载失败</string>
+    <string name="failed_to_load_content">文件内容加载失败</string>
+    <string name="content_truncated">\n\n--- 内容已截断（文件过大）---</string>
+
+    <!-- Info row labels -->
+    <string name="info_type">类型</string>
+    <string name="info_size">大小</string>
+    <string name="info_created">创建时间</string>
+    <string name="info_source">来源</string>
+
+    <!-- Upload progress -->
+    <string name="uploading">上传中…</string>
+</resources>

--- a/feature/settings/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/settings/viewmodel/SettingsViewModelTest.kt
+++ b/feature/settings/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/settings/viewmodel/SettingsViewModelTest.kt
@@ -60,6 +60,7 @@ class SettingsViewModelTest {
     private val themeDataStore = mockk<ThemeDataStore>(relaxed = true)
     private val serverDataStore = mockk<ServerDataStore>(relaxed = true)
     private val settingsDataStore = mockk<SettingsDataStore>(relaxed = true)
+    private val selectedLanguageFlow = MutableStateFlow(SettingsDataStore.DEFAULT_LANGUAGE)
     private val mcpRepository = mockk<McpRepository>(relaxed = true)
     private val memoryRepository = mockk<MemoryRepository>(relaxed = true)
     private val speechRepository = mockk<SpeechRepository>(relaxed = true)
@@ -110,6 +111,8 @@ class SettingsViewModelTest {
         every { settingsDataStore.showAvatars } returns MutableStateFlow(true)
         every { settingsDataStore.showBubbles } returns MutableStateFlow(false)
         every { settingsDataStore.latexRenderer } returns MutableStateFlow(LatexRenderer.KATEX)
+        every { settingsDataStore.selectedLanguage } returns selectedLanguageFlow
+        coEvery { settingsDataStore.setSelectedLanguage(any()) } answers { selectedLanguageFlow.value = firstArg() }
 
         // Setup default API responses
         coEvery { userRepository.getUser() } returns Result.Success(testUser)
@@ -370,6 +373,7 @@ class SettingsViewModelTest {
         viewModel.setLanguage("fr")
         advanceUntilIdle()
 
+        coVerify { settingsDataStore.setSelectedLanguage("fr") }
         assertThat(viewModel.uiState.value.selectedLanguage).isEqualTo("fr")
         assertThat(viewModel.uiState.value.showLanguageDialog).isFalse()
     }

--- a/feature/settings/src/commonMain/composeResources/values-ar/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-ar/strings.xml
@@ -1,0 +1,488 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Common actions -->
+    <string name="action_add">إضافة</string>
+    <string name="action_cancel">إلغاء</string>
+    <string name="action_clear">مسح</string>
+    <string name="action_confirm">تأكيد</string>
+    <string name="action_creating">جارٍ الإنشاء…</string>
+    <string name="action_create">إنشاء</string>
+    <string name="action_delete">حذف</string>
+    <string name="action_done">تم</string>
+    <string name="action_retry">إعادة المحاولة</string>
+    <string name="action_revoke_all">إبطال الكل</string>
+    <string name="action_save">حفظ</string>
+    <string name="action_sign_out">تسجيل الخروج</string>
+    <string name="action_upload">رفع</string>
+    <string name="action_uploading">جارٍ الرفع…</string>
+    <string name="action_verify">تحقّق</string>
+    <string name="action_verifying">جارٍ التحقّق…</string>
+
+    <!-- Content descriptions -->
+    <string name="cd_add_memory">إضافة ذاكرة</string>
+    <string name="cd_add_server">إضافة خادم</string>
+    <string name="cd_back">رجوع</string>
+    <string name="cd_change_avatar">تغيير الصورة الرمزية</string>
+    <string name="cd_choose_image">اختيار صورة</string>
+    <string name="cd_collapse_tools">طي الأدوات</string>
+    <string name="cd_copy_api_key">نسخ مفتاح API</string>
+    <string name="cd_copy_link">نسخ الرابط</string>
+    <string name="cd_create_api_key">إنشاء مفتاح API</string>
+    <string name="cd_current_avatar">الصورة الرمزية الحالية</string>
+    <string name="cd_delete">حذف</string>
+    <string name="cd_delete_api_key">حذف مفتاح API</string>
+    <string name="cd_delete_memory">حذف الذاكرة</string>
+    <string name="cd_delete_preset">حذف الإعداد المسبق</string>
+    <string name="cd_delete_server">حذف الخادم</string>
+    <string name="cd_delete_shared_link">حذف الرابط المشترك</string>
+    <string name="cd_edit">تعديل</string>
+    <string name="cd_edit_memory">تعديل الذاكرة</string>
+    <string name="cd_edit_server">تعديل الخادم</string>
+    <string name="cd_expand_tools">توسيع الأدوات</string>
+    <string name="cd_loading_profile">جارٍ تحميل الملف الشخصي</string>
+    <string name="cd_make_private">جعله خاصًا</string>
+    <string name="cd_make_public">جعله عامًا</string>
+    <string name="cd_preview_voice">معاينة الصوت</string>
+    <string name="cd_qr_code">رمز QR لتطبيق المصادقة</string>
+    <string name="cd_reinitialize">إعادة التهيئة</string>
+    <string name="cd_avatar_preview">معاينة الصورة الرمزية</string>
+    <string name="cd_selected">محدد</string>
+    <string name="cd_selected_avatar">الصورة الرمزية المحددة</string>
+    <string name="cd_stop_voice_preview">إيقاف معاينة الصوت</string>
+    <string name="cd_test_tts_voice">اختبار صوت تحويل النص إلى كلام المحدد</string>
+    <string name="cd_toggle_auto_read">تبديل القراءة التلقائية للردود</string>
+    <string name="cd_toggle_auto_send_stt">تبديل الإرسال التلقائي بعد الكلام</string>
+    <string name="cd_toggle_memories">تبديل الذكريات</string>
+    <string name="cd_tts_voice_selector">اختيار صوت تحويل النص إلى كلام. الحالي %1$s</string>
+    <string name="cd_user_avatar">الصورة الرمزية للمستخدم</string>
+    <string name="cd_view_all_tools">عرض جميع الأدوات</string>
+    <string name="cd_view_tools">عرض الأدوات</string>
+
+    <!-- Section headers -->
+    <string name="section_about">حول</string>
+    <string name="section_account">الحساب</string>
+    <string name="section_advanced">متقدم</string>
+    <string name="section_appearance">المظهر</string>
+    <string name="section_balance">الرصيد</string>
+    <string name="section_chat_preferences">تفضيلات المحادثة</string>
+    <string name="section_conversations">المحادثات</string>
+    <string name="section_danger_zone">منطقة الخطر</string>
+    <string name="section_data_management">إدارة البيانات</string>
+    <string name="section_general">عام</string>
+    <string name="section_language">اللغة</string>
+    <string name="section_layout">التخطيط</string>
+    <string name="section_mcp_servers">خوادم MCP</string>
+    <string name="section_memories">الذكريات</string>
+    <string name="section_personalization">التخصيص</string>
+    <string name="section_presets">الإعدادات المسبقة</string>
+    <string name="section_profile">الملف الشخصي</string>
+    <string name="section_security">الأمان</string>
+    <string name="section_speech">الكلام</string>
+    <string name="section_tablet">الجهاز اللوحي</string>
+
+    <!-- Screen titles -->
+    <string name="title_account">الحساب</string>
+    <string name="title_api_keys">مفاتيح API</string>
+    <string name="title_chat">المحادثة</string>
+    <string name="title_commands">الأوامر</string>
+    <string name="title_data">البيانات</string>
+    <string name="title_general">عام</string>
+    <string name="title_memories">الذكريات</string>
+    <string name="title_mcp_servers">خوادم MCP</string>
+    <string name="title_presets">الإعدادات المسبقة</string>
+    <string name="title_settings">الإعدادات</string>
+    <string name="title_shared_links">الروابط المشتركة</string>
+
+    <!-- Tabbed settings tabs -->
+    <string name="tab_general">عام</string>
+    <string name="tab_chat">المحادثة</string>
+    <string name="tab_account">الحساب</string>
+    <string name="tab_data">البيانات</string>
+
+    <!-- Theme -->
+    <string name="theme_system">افتراضي النظام</string>
+    <string name="theme_light">فاتح</string>
+    <string name="theme_dark">داكن</string>
+
+    <!-- Accent color -->
+    <string name="accent_color">اللون المميز</string>
+    <string name="accent_color_custom">مخصص</string>
+    <string name="accent_color_hex">سداسي عشري</string>
+    <string name="use_wallpaper_colors">استخدام ألوان الخلفية</string>
+    <string name="use_wallpaper_colors_desc">مطابقة لون التطبيق المميز مع خلفية نظامك (Material You)</string>
+
+    <!-- Settings rows -->
+    <string name="language">اللغة</string>
+    <string name="language_system_default">افتراضي النظام</string>
+    <string name="personalization">التخصيص</string>
+    <string name="status_enabled">مُفعّل</string>
+    <string name="status_disabled">مُعطّل</string>
+    <string name="fork_behavior">سلوك التفريع</string>
+    <string name="commands">الأوامر</string>
+    <string name="commands_enabled_count">%1$d مُفعّل</string>
+    <string name="api_keys">مفاتيح API</string>
+    <string name="api_keys_subtitle">إدارة مفاتيح API للوصول البرمجي</string>
+    <string name="presets">الإعدادات المسبقة</string>
+    <string name="presets_subtitle">إدارة الإعدادات المسبقة للمحادثات</string>
+    <string name="favorites">المفضلة</string>
+    <string name="favorites_subtitle">إدارة الوكلاء والنماذج المثبتة</string>
+    <string name="favorites_title">المفضلة</string>
+    <string name="favorites_empty_title">لا توجد مفضلة بعد</string>
+    <string name="favorites_empty_message">ثبّت الوكلاء أو النماذج من محدد النموذج لرؤيتها هنا.</string>
+    <string name="favorites_count_of">%1$d من %2$d</string>
+    <string name="favorites_unpin_cd">إلغاء تثبيت المفضلة</string>
+
+    <!-- About info -->
+    <string name="app_version_label">إصدار التطبيق</string>
+    <string name="app_build_label">الإصدار البنائي</string>
+    <string name="server_label">الخادم</string>
+    <string name="server_not_configured">غير مُهيأ</string>
+    <string name="server_build_commit_label">إصدار الخادم (Commit)</string>
+    <string name="server_build_branch_label">فرع الخادم</string>
+    <string name="server_build_date_label">تاريخ بناء الخادم</string>
+
+    <!-- Tablet settings -->
+    <string name="sidebar_swipe_gesture">إيماءة السحب للشريط الجانبي</string>
+    <string name="sidebar_swipe_gesture_desc">اسحب من الحافة اليسرى لفتح الشريط الجانبي في تخطيطات الأجهزة اللوحية</string>
+
+    <!-- Balance -->
+    <string name="token_credits">أرصدة الرموز</string>
+    <string name="available_balance">الرصيد المتاح</string>
+    <string name="cd_token_balance">رصيد الرموز: %1$s رصيد</string>
+
+    <!-- Chat settings -->
+    <string name="chat_layout">تخطيط المحادثة</string>
+    <string name="chat_layout_thread">سلسلة</string>
+    <string name="chat_layout_two_sided">محادثة ثنائية الجانب</string>
+    <string name="chat_layout_thread_desc">جميع الرسائل محاذاة لليسار مع الصورة الرمزية والاسم</string>
+    <string name="chat_layout_two_sided_desc">رسائل المستخدم على اليمين والوكيل على اليسار</string>
+    <string name="show_bubbles">إظهار الفقاعات</string>
+    <string name="show_bubbles_desc">إضافة خلفيات فقاعية دائرية للرسائل</string>
+    <string name="show_avatars">إظهار الصور الرمزية</string>
+    <string name="show_avatars_desc">عرض الصور الرمزية للمستخدم والوكيل بجوار الرسائل</string>
+    <string name="starred_models_title">النماذج المميزة بنجمة</string>
+    <string name="starred_models_desc">إظهار نماذجك ووكلائك المثبتين في أعلى محدد النموذج</string>
+    <string name="starred_models_off">إيقاف</string>
+    <string name="starred_models_grouped">مجموعة قابلة للطي في الأعلى</string>
+    <string name="starred_models_top">في الأعلى بدون تجميع</string>
+    <string name="font_size">حجم الخط</string>
+    <string name="font_size_small">صغير</string>
+    <string name="font_size_medium">متوسط</string>
+    <string name="font_size_large">كبير</string>
+    <string name="latex_renderer">عارض LaTeX</string>
+    <string name="latex_katex">KaTeX (معروض)</string>
+    <string name="latex_katex_desc">عرض LaTeX كامل عبر WebView</string>
+    <string name="latex_native">نص عادي (سريع)</string>
+    <string name="latex_native_desc">يعرض مصدر LaTeX الخام لأداء تمرير أفضل</string>
+    <string name="auto_scroll">التمرير التلقائي أثناء البث</string>
+    <string name="auto_scroll_desc">التمرير تلقائيًا إلى المحتوى الجديد أثناء إنشاء الرد</string>
+    <string name="show_thinking_blocks">إظهار كتل التفكير</string>
+    <string name="show_thinking_blocks_desc">عرض خطوات استدلال النموذج عند توفّرها</string>
+    <string name="show_image_descriptions">إظهار أوصاف الصور</string>
+    <string name="show_image_descriptions_desc">عرض مطالبات الصور المُنشأة بالذكاء الاصطناعي أسفل الصور</string>
+    <string name="dismiss_keyboard_on_send">إخفاء لوحة المفاتيح بعد الإرسال</string>
+    <string name="dismiss_keyboard_on_send_desc">إخفاء لوحة المفاتيح تلقائيًا بعد إرسال رسالة</string>
+
+    <!-- Artifacts -->
+    <string name="section_artifacts">العناصر التفاعلية</string>
+    <string name="artifacts_section_desc">عرض العناصر التفاعلية مباشرة في المحادثة بدلًا من خلف بطاقة تُفتح بالنقر. انقر على عنصر تفاعلي مضمّن لفتح العرض بملء الشاشة.</string>
+    <string name="inline_artifact_mermaid">مخططات Mermaid</string>
+    <string name="inline_artifact_mermaid_desc">عرض مخططات ومنظومات Mermaid الانسيابية بشكل مضمّن</string>
+    <string name="inline_artifact_svg">صور SVG</string>
+    <string name="inline_artifact_svg_desc">عرض رسومات SVG المتجهة بشكل مضمّن</string>
+    <string name="inline_artifact_html">HTML</string>
+    <string name="inline_artifact_html_desc">عرض صفحات HTML بشكل مضمّن (يحمّل Tailwind من CDN)</string>
+    <string name="inline_artifact_react">مكوّنات React</string>
+    <string name="inline_artifact_react_desc">عرض مكوّنات React بشكل مضمّن (يحمّل React + Babel من CDN)</string>
+    <string name="inline_artifact_markdown">مستندات Markdown</string>
+    <string name="inline_artifact_markdown_desc">عرض عناصر Markdown التفاعلية بشكل مضمّن مع كتل أكواد مميزة بالتلوين النحوي</string>
+
+    <!-- Security -->
+    <string name="two_factor_auth">المصادقة الثنائية</string>
+    <string name="enable_two_factor">تفعيل المصادقة الثنائية</string>
+    <string name="disable_two_factor">تعطيل المصادقة الثنائية</string>
+    <string name="view_backup_codes">عرض رموز النسخ الاحتياطي</string>
+
+    <!-- 2FA setup dialog -->
+    <string name="dialog_title_enable_2fa">تفعيل المصادقة الثنائية</string>
+    <string name="dialog_title_disable_2fa">تعطيل المصادقة الثنائية</string>
+    <string name="twofa_scan_instructions">انسخ الرابط أدناه والصقه في تطبيق المصادقة الخاص بك (مثل Google Authenticator أو Authy)، ثم أدخل رمز التحقق.</string>
+    <string name="twofa_disable_instructions">أدخل رمز المصادقة لتعطيل المصادقة الثنائية.</string>
+    <string name="hint_verification_code">رمز التحقق</string>
+
+    <!-- OTP verification dialogs -->
+    <string name="otp_title_verify_identity">التحقق من الهوية</string>
+    <string name="otp_desc_delete_account">أدخل رمز المصادقة الثنائية لحذف حسابك.</string>
+    <string name="otp_desc_reenroll_2fa">أدخل رمز المصادقة الثنائية الحالي لإعادة التسجيل.</string>
+    <string name="otp_desc_regenerate_backup_codes">أدخل رمز المصادقة الثنائية لإعادة إنشاء رموز النسخ الاحتياطي.</string>
+    <string name="otp_verify">تحقّق</string>
+    <string name="otp_cancel">إلغاء</string>
+    <string name="otp_backup_code_label">رمز النسخ الاحتياطي</string>
+    <string name="otp_use_backup_code">استخدام رمز نسخ احتياطي بدلًا من ذلك</string>
+    <string name="otp_use_otp_code">استخدام رمز OTP بدلًا من ذلك</string>
+
+    <!-- Backup codes dialog -->
+    <string name="dialog_title_backup_codes">رموز النسخ الاحتياطي</string>
+    <string name="backup_codes_instructions">احفظ رموز النسخ الاحتياطي هذه في مكان آمن. يمكن استخدام كل رمز مرة واحدة فقط.</string>
+
+    <!-- Danger zone -->
+    <string name="delete_account">حذف الحساب</string>
+    <string name="dialog_title_sign_out">تسجيل الخروج</string>
+    <string name="dialog_sign_out_message">هل أنت متأكد أنك تريد تسجيل الخروج؟</string>
+    <string name="dialog_title_delete_account">حذف الحساب</string>
+    <string name="dialog_delete_account_message">لا يمكن التراجع عن هذا الإجراء. سيتم حذف جميع بياناتك نهائيًا.</string>
+
+    <!-- Clear cache dialog -->
+    <string name="dialog_title_clear_cache">مسح ذاكرة التخزين المؤقت</string>
+    <string name="dialog_clear_cache_message">سيؤدي هذا إلى مسح الصور المخزّنة مؤقتًا والبيانات المؤقتة. لن تتأثر بيانات حسابك.</string>
+
+    <!-- Revoke keys dialog -->
+    <string name="dialog_title_revoke_keys">إبطال جميع مفاتيح API</string>
+    <string name="dialog_revoke_keys_message">سيؤدي هذا إلى إبطال جميع مفاتيح API المخزّنة لديك. ستحتاج إلى إعادة إدخالها لمتابعة استخدام الخدمات الخارجية.</string>
+
+    <!-- Data settings -->
+    <string name="clear_all_conversations">مسح جميع المحادثات</string>
+    <string name="clearing">جارٍ المسح…</string>
+    <string name="archived_conversations">المحادثات المؤرشفة</string>
+    <string name="export_all_data">تصدير جميع البيانات</string>
+    <string name="shared_links">الروابط المشتركة</string>
+    <string name="clear_cache">مسح ذاكرة التخزين المؤقت</string>
+    <string name="revoke_all_api_keys">إبطال جميع مفاتيح API</string>
+    <string name="revoking">جارٍ الإبطال…</string>
+    <string name="dialog_title_clear_conversations">مسح جميع المحادثات</string>
+    <string name="dialog_clear_conversations_message">سيؤدي هذا إلى حذف جميع محادثاتك نهائيًا. لا يمكن التراجع عن هذا الإجراء.</string>
+    <string name="clear_all">مسح الكل</string>
+    <string name="export_coming_soon">التصدير قادم قريبًا</string>
+    <string name="error_could_not_load_settings">تعذّر تحميل الإعدادات</string>
+
+    <!-- Diagnostic logs (issue #96) -->
+    <string name="section_diagnostic_logs">سجلات التشخيص</string>
+    <string name="export_diagnostic_logs">تصدير سجلات التشخيص</string>
+    <string name="export_diagnostic_logs_with_size">تصدير سجلات التشخيص (%1$s)</string>
+    <string name="exporting_logs">جارٍ التصدير…</string>
+    <string name="clear_diagnostic_logs">مسح سجلات التشخيص</string>
+    <string name="clearing_logs">جارٍ المسح…</string>
+    <string name="logs_exported">تم تصدير سجلات التشخيص</string>
+    <string name="dialog_title_clear_logs">مسح سجلات التشخيص</string>
+    <string name="dialog_clear_logs_message">سيؤدي هذا إلى حذف جميع سجلات التشخيص المخزّنة من هذا الجهاز نهائيًا. لا يمكن التراجع عن هذا الإجراء.</string>
+
+    <!-- Speech settings -->
+    <string name="auto_send_after_speech">الإرسال التلقائي بعد الكلام</string>
+    <string name="auto_send_after_speech_desc">إرسال الرسالة تلقائيًا بعد انتهاء تحويل الكلام إلى نص</string>
+    <string name="auto_read_responses">القراءة التلقائية للردود</string>
+    <string name="auto_read_responses_desc">قراءة ردود الذكاء الاصطناعي بصوت عالٍ تلقائيًا باستخدام تحويل النص إلى كلام</string>
+    <string name="tts_voice">صوت تحويل النص إلى كلام</string>
+    <string name="test_voice">اختبار الصوت</string>
+    <string name="no_server_tts_voices">لا تتوفر أصوات تحويل النص إلى كلام في الخادم. قد لا تكون ميزات الكلام مُهيأة على الخادم.</string>
+    <string name="using_device_tts">استخدام محرك تحويل النص إلى كلام في الجهاز. اضبط الصوت والسرعة في إعدادات تحويل النص إلى كلام أدناه.</string>
+    <string name="speech_to_text_settings">إعدادات تحويل الكلام إلى نص</string>
+    <string name="text_to_speech_settings">إعدادات تحويل النص إلى كلام</string>
+
+    <!-- STT detail dialog -->
+    <string name="stt_engine_label">المحرك</string>
+    <string name="stt_language_label">اللغة</string>
+    <string name="stt_on_device">على الجهاز</string>
+    <string name="stt_default">افتراضي</string>
+    <string name="stt_hint_whisper">يستخدم Whisper النسخ على جانب الخادم. يجب أن يكون تحويل الكلام إلى نص مُفعّلًا في خادمك.</string>
+    <string name="stt_hint_device">يستخدم مُتعرّف الكلام المدمج في جهازك. يعمل دون اتصال على الأجهزة المدعومة.</string>
+    <string name="stt_hint_google">يستخدم مُتعرّف الكلام من Google. يتطلب تثبيت تطبيق Google.</string>
+    <string name="stt_hint_default">يستخدم النسخ على الخادم (Whisper) عند توفّره، وإلا يعود إلى التعرّف على الجهاز.</string>
+    <string name="stt_auto_detect">كشف تلقائي</string>
+
+    <!-- TTS detail dialog -->
+    <string name="tts_source_label">المصدر</string>
+    <string name="tts_source_device">الجهاز (مدمج)</string>
+    <string name="tts_source_server">الخادم</string>
+    <string name="tts_voice_label">الصوت</string>
+    <string name="tts_engine_label">المحرك</string>
+    <string name="tts_system_default">افتراضي النظام</string>
+    <string name="tts_speech_rate">سرعة الكلام: %1$.1fx</string>
+    <string name="tts_pitch">طبقة الصوت: %1$.1f</string>
+    <string name="tts_cache_audio">تخزين الصوت مؤقتًا</string>
+    <string name="tts_preview_text">هذه معاينة للصوت المحدد.</string>
+    <string name="tts_stop_preview">إيقاف المعاينة</string>
+    <string name="tts_preview_voice">معاينة الصوت</string>
+
+    <!-- Memories -->
+    <string name="enable_memories">تفعيل الذكريات</string>
+    <string name="enable_memories_desc">السماح للذكاء الاصطناعي بتذكّر المعلومات عبر المحادثات</string>
+    <string name="no_memories_saved">لا توجد ذكريات محفوظة بعد</string>
+    <string name="memories_add_hint">انقر على زر + لإضافة ذاكرة</string>
+    <string name="add_memory">إضافة ذاكرة</string>
+    <string name="edit_memory">تعديل الذاكرة</string>
+    <string name="dialog_title_delete_memory">حذف الذاكرة</string>
+    <string name="dialog_delete_memory_message">هل أنت متأكد أنك تريد حذف الذاكرة \"%1$s\"؟</string>
+    <string name="memory_key_label">المفتاح</string>
+    <string name="memory_value_label">القيمة</string>
+
+    <!-- MCP -->
+    <string name="add_mcp_server">إضافة خادم MCP</string>
+    <string name="edit_mcp_server">تعديل خادم MCP</string>
+    <string name="mcp_not_available">MCP غير متاح على هذا الخادم</string>
+    <string name="no_mcp_servers">لا توجد خوادم MCP مُهيأة</string>
+    <string name="mcp_add_hint">انقر على زر + لإضافة خادم</string>
+    <string name="mcp_name_label">الاسم</string>
+    <string name="mcp_description_label">الوصف</string>
+    <string name="mcp_description_optional">اختياري</string>
+    <string name="mcp_url_label">الرابط</string>
+    <string name="mcp_type_label">النوع</string>
+    <string name="mcp_type_sse">SSE</string>
+    <string name="mcp_type_streamable_http">Streamable HTTP</string>
+    <string name="mcp_auth_label">المصادقة</string>
+    <string name="mcp_auth_none">بدون</string>
+    <string name="mcp_auth_api_key">مفتاح API</string>
+    <string name="mcp_auth_oauth">OAuth</string>
+    <string name="mcp_auth_key_type">نوع المفتاح</string>
+    <string name="mcp_auth_bearer">Bearer</string>
+    <string name="mcp_auth_basic">Basic</string>
+    <string name="mcp_auth_custom">مخصص</string>
+    <string name="mcp_header_name_label">اسم الترويسة</string>
+    <string name="mcp_header_name_placeholder">X-API-Key</string>
+    <string name="mcp_api_key_label">مفتاح API</string>
+    <string name="mcp_oauth_client_id">معرّف العميل</string>
+    <string name="mcp_oauth_client_secret">سر العميل</string>
+    <string name="mcp_oauth_auth_url">رابط التفويض</string>
+    <string name="mcp_oauth_token_url">رابط الرمز المميز</string>
+    <string name="mcp_oauth_scope">النطاق</string>
+    <string name="mcp_oauth_scope_placeholder">read execute</string>
+    <string name="dialog_title_delete_server">حذف الخادم</string>
+    <string name="dialog_delete_server_message">هل أنت متأكد أنك تريد حذف \"%1$s\"؟</string>
+    <string name="error_failed_to_load_servers">فشل تحميل الخوادم</string>
+    <string name="mcp_tools_count">%1$d أداة%2$s</string>
+    <string name="mcp_tools_available">%1$d أداة%2$s متاحة</string>
+    <string name="mcp_all_tools">جميع أدوات MCP</string>
+    <string name="mcp_tools_for_server">الأدوات: %1$s</string>
+    <string name="no_tools_available">لا توجد أدوات متاحة</string>
+    <string name="mcp_tool_server">الخادم: %1$s</string>
+
+    <!-- MCP tools sheet -->
+    <string name="mcp_server_unknown">غير معروف</string>
+
+    <!-- Fork settings -->
+    <string name="fork_mode_direct_path">الرسائل المرئية</string>
+    <string name="fork_mode_direct_path_desc">المسار المباشر للرسائل إلى الرسالة المحددة فقط</string>
+    <string name="fork_mode_include_branches">تضمين الفروع</string>
+    <string name="fork_mode_include_branches_desc">المسار المباشر بالإضافة إلى الرسائل الشقيقة في كل مستوى</string>
+    <string name="fork_mode_target_level">الكل حتى المستوى المستهدف</string>
+    <string name="fork_mode_target_level_desc">جميع الرسائل والفروع حتى مستوى الرسالة المستهدفة (افتراضي)</string>
+
+    <!-- Language selector -->
+    <string name="hint_search_languages">البحث في اللغات</string>
+
+    <!-- Personalization dialog -->
+    <string name="enable_personalization">تفعيل التخصيص</string>
+    <string name="about_you_label">نبذة عنك</string>
+    <string name="about_you_hint">ما الذي ينبغي أن يعرفه الذكاء الاصطناعي عنك للسياق؟</string>
+    <string name="response_style_label">كيف ينبغي أن يرد الذكاء الاصطناعي؟</string>
+    <string name="response_style_hint">النبرة أو التنسيق أو الأسلوب المفضل للردود</string>
+
+    <!-- Commands screen -->
+    <string name="no_commands_available">لا توجد أوامر متاحة</string>
+
+    <!-- Avatar upload dialog -->
+    <string name="dialog_title_update_avatar">تحديث الصورة الرمزية</string>
+    <string name="avatar_choose_hint">انقر على أيقونة الكاميرا لاختيار صورة</string>
+
+    <!-- API Keys screen -->
+    <string name="api_keys_not_available">مفاتيح API غير متاحة</string>
+    <string name="api_keys_not_supported">هذه الميزة غير مدعومة في إصدار خادمك.</string>
+    <string name="no_api_keys">لا توجد مفاتيح API</string>
+    <string name="no_api_keys_desc">أنشئ مفتاح API للوصول إلى API برمجيًا.</string>
+    <string name="dialog_title_delete_api_key">حذف مفتاح API</string>
+    <string name="dialog_delete_api_key_message">هل أنت متأكد أنك تريد حذف مفتاح API \"%1$s\"؟ لا يمكن التراجع عن هذا الإجراء.</string>
+    <string name="created_prefix">تم الإنشاء: %1$s</string>
+
+    <!-- API Key create dialog -->
+    <string name="dialog_title_create_api_key">إنشاء مفتاح API</string>
+    <string name="api_key_name_hint">امنح مفتاح API الخاص بك اسمًا وصفيًا للمساعدة في تحديد غرضه.</string>
+    <string name="hint_key_name">اسم المفتاح</string>
+    <string name="hint_key_name_placeholder">مثال: تطبيقي</string>
+    <string name="dialog_title_api_key_created">تم إنشاء مفتاح API</string>
+    <string name="api_key_created_warning">تم إنشاء مفتاح API الخاص بك. انسخه الآن — لن تتمكن من رؤيته مرة أخرى.</string>
+    <string name="copied_to_clipboard">تم النسخ إلى الحافظة</string>
+
+    <!-- Preset manager -->
+    <string name="no_presets">لا توجد إعدادات مسبقة</string>
+    <string name="no_presets_desc">احفظ الإعدادات المسبقة من شاشة المحادثة لإدارتها هنا</string>
+    <string name="dialog_title_delete_preset">حذف الإعداد المسبق</string>
+    <string name="dialog_delete_preset_message">هل أنت متأكد أنك تريد حذف \"%1$s\"؟</string>
+
+    <!-- Shared links -->
+    <string name="no_shared_links">لا توجد روابط مشتركة</string>
+    <string name="no_shared_links_desc">شارك محادثة لرؤيتها هنا</string>
+    <string name="dialog_title_delete_shared_link">حذف الرابط المشترك</string>
+    <string name="dialog_delete_shared_link_message">سيؤدي هذا إلى إزالة الرابط المشترك لـ \"%1$s\". لن يتمكن أي شخص لديه الرابط من الوصول إليه بعد الآن.</string>
+    <string name="visibility_public">عام</string>
+    <string name="visibility_private">خاص</string>
+    <string name="error_failed_to_load_memories">فشل تحميل الذكريات</string>
+
+    <!-- Provider API Keys -->
+    <string name="provider_keys_title">مفاتيح API للمزودين</string>
+    <string name="provider_keys_subtitle">عيّن مفاتيحك الخاصة لنقاط النهاية التي تتطلبها</string>
+    <string name="provider_keys_dialog_title">تعيين مفتاح API لـ %1$s</string>
+    <string name="provider_keys_status_set_expires">ينتهي خلال %1$s</string>
+    <string name="provider_keys_status_set_never">لن ينتهي مفتاحك أبدًا</string>
+    <string name="provider_keys_status_unset">غير مُعيّن</string>
+    <string name="provider_keys_status_expired">منتهي الصلاحية</string>
+    <string name="provider_keys_status_loading">جارٍ التحقق من حالة المفتاح…</string>
+    <string name="provider_keys_field_api_key_label">المفتاح</string>
+    <string name="provider_keys_field_base_url_label">الرابط الأساسي</string>
+    <string name="provider_keys_field_base_url_optional_suffix">(اختياري)</string>
+    <string name="provider_keys_field_api_key_for_endpoint">مفتاح API لـ %1$s</string>
+    <string name="provider_keys_field_api_url_for_endpoint">رابط API لـ %1$s</string>
+
+    <string name="provider_keys_field_azure_api_key">مفتاح Azure OpenAI API</string>
+    <string name="provider_keys_field_azure_instance">اسم مثيل Azure</string>
+    <string name="provider_keys_field_azure_deployment">اسم نشر Azure</string>
+    <string name="provider_keys_field_azure_api_version">إصدار Azure API</string>
+
+    <string name="provider_keys_field_google_api_key">مفتاح Google API</string>
+    <string name="provider_keys_field_google_gemini_api">(Gemini API)</string>
+    <string name="provider_keys_field_google_service_key">مفتاح حساب خدمة Google</string>
+    <string name="provider_keys_field_google_import">استيراد مفتاح حساب الخدمة JSON.</string>
+    <string name="provider_keys_field_google_invalid">مفتاح حساب الخدمة JSON غير صالح، هل استوردت الملف الصحيح؟</string>
+    <string name="provider_keys_field_google_imported">تم استيراد مفتاح حساب الخدمة JSON بنجاح</string>
+    <string name="provider_keys_field_google_paste_label">أو الصق ملف JSON لحساب الخدمة</string>
+    <string name="provider_keys_field_google_paste_only_hint">الصق ملف JSON لحساب الخدمة أدناه.</string>
+    <string name="provider_keys_field_google_service_key_or_gemini">مفتاح خدمة Google أو مفتاح Gemini API</string>
+
+    <string name="provider_keys_field_bedrock_access_key_id">معرّف مفتاح الوصول</string>
+    <string name="provider_keys_field_bedrock_secret_access_key">مفتاح الوصول السري</string>
+    <string name="provider_keys_field_bedrock_session_token">رمز الجلسة المميز</string>
+    <string name="provider_keys_field_bedrock_session_token_optional_suffix">(اختياري)</string>
+
+    <string name="provider_keys_required_fields">الحقول التالية مطلوبة: %1$s</string>
+    <string name="provider_keys_revoke">إبطال</string>
+    <string name="provider_keys_revoke_failed">فشل إبطال مفتاح API. يرجى المحاولة مرة أخرى.</string>
+    <string name="provider_keys_revoke_success">تم إبطال مفتاح API بنجاح</string>
+    <string name="provider_keys_revoke_all">إبطال المفاتيح</string>
+    <string name="provider_keys_revoke_all_confirm">هل أنت متأكد أنك تريد إبطال جميع المفاتيح؟</string>
+    <string name="provider_keys_revoke_all_failed">فشل إبطال جميع المفاتيح</string>
+    <string name="provider_keys_save_failed">فشل حفظ مفتاح API. يرجى المحاولة مرة أخرى.</string>
+    <string name="provider_keys_save_success">تم حفظ مفتاح API بنجاح</string>
+
+    <string name="provider_keys_expiry_label">ينتهي</string>
+    <string name="provider_keys_expiry_30m">خلال 30 دقيقة</string>
+    <string name="provider_keys_expiry_2h">خلال ساعتين</string>
+    <string name="provider_keys_expiry_12h">خلال 12 ساعة</string>
+    <string name="provider_keys_expiry_1d">خلال يوم واحد</string>
+    <string name="provider_keys_expiry_7d">خلال 7 أيام</string>
+    <string name="provider_keys_expiry_30d">خلال 30 يومًا</string>
+    <string name="provider_keys_expiry_never">أبدًا</string>
+
+    <string name="provider_keys_empty_title">لا توجد نقاط نهاية تتطلب مفاتيح يوفرها المستخدم</string>
+    <string name="provider_keys_empty_desc">ستظهر هنا نقاط النهاية التي تحتاج إلى مفتاح API الخاص بك.</string>
+    <string name="provider_keys_revoke_all_action">إبطال الكل</string>
+
+    <!-- Admin: role skill access -->
+    <string name="role_skills_settings_row">الوصول إلى المهارات (المسؤول)</string>
+    <string name="role_skills_title">الوصول إلى المهارات</string>
+    <string name="role_skills_back">رجوع</string>
+    <string name="role_skills_description">تحكّم في إمكانات المهارات التي يملكها كل دور. تُطبّق التغييرات على جميع المستخدمين ذوي الدور المحدد.</string>
+    <string name="role_skills_role_label">الدور</string>
+    <string name="role_skills_use">استخدام المهارات</string>
+    <string name="role_skills_create">إنشاء المهارات وتعديلها</string>
+    <string name="role_skills_share">مشاركة المهارات</string>
+    <string name="role_skills_share_public">مشاركة المهارات علنًا</string>
+    <string name="role_skills_save">حفظ</string>
+</resources>

--- a/feature/settings/src/commonMain/composeResources/values-de/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-de/strings.xml
@@ -1,0 +1,488 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Common actions -->
+    <string name="action_add">Hinzufügen</string>
+    <string name="action_cancel">Abbrechen</string>
+    <string name="action_clear">Löschen</string>
+    <string name="action_confirm">Bestätigen</string>
+    <string name="action_creating">Wird erstellt…</string>
+    <string name="action_create">Erstellen</string>
+    <string name="action_delete">Löschen</string>
+    <string name="action_done">Fertig</string>
+    <string name="action_retry">Erneut versuchen</string>
+    <string name="action_revoke_all">Alle widerrufen</string>
+    <string name="action_save">Speichern</string>
+    <string name="action_sign_out">Abmelden</string>
+    <string name="action_upload">Hochladen</string>
+    <string name="action_uploading">Wird hochgeladen…</string>
+    <string name="action_verify">Überprüfen</string>
+    <string name="action_verifying">Wird überprüft…</string>
+
+    <!-- Content descriptions -->
+    <string name="cd_add_memory">Erinnerung hinzufügen</string>
+    <string name="cd_add_server">Server hinzufügen</string>
+    <string name="cd_back">Zurück</string>
+    <string name="cd_change_avatar">Avatar ändern</string>
+    <string name="cd_choose_image">Bild auswählen</string>
+    <string name="cd_collapse_tools">Tools einklappen</string>
+    <string name="cd_copy_api_key">API-Schlüssel kopieren</string>
+    <string name="cd_copy_link">Link kopieren</string>
+    <string name="cd_create_api_key">API-Schlüssel erstellen</string>
+    <string name="cd_current_avatar">Aktueller Avatar</string>
+    <string name="cd_delete">Löschen</string>
+    <string name="cd_delete_api_key">API-Schlüssel löschen</string>
+    <string name="cd_delete_memory">Erinnerung löschen</string>
+    <string name="cd_delete_preset">Vorlage löschen</string>
+    <string name="cd_delete_server">Server löschen</string>
+    <string name="cd_delete_shared_link">Geteilten Link löschen</string>
+    <string name="cd_edit">Bearbeiten</string>
+    <string name="cd_edit_memory">Erinnerung bearbeiten</string>
+    <string name="cd_edit_server">Server bearbeiten</string>
+    <string name="cd_expand_tools">Tools ausklappen</string>
+    <string name="cd_loading_profile">Profil wird geladen</string>
+    <string name="cd_make_private">Privat machen</string>
+    <string name="cd_make_public">Öffentlich machen</string>
+    <string name="cd_preview_voice">Stimme anhören</string>
+    <string name="cd_qr_code">QR-Code für Authenticator-App</string>
+    <string name="cd_reinitialize">Neu initialisieren</string>
+    <string name="cd_avatar_preview">Avatar-Vorschau</string>
+    <string name="cd_selected">Ausgewählt</string>
+    <string name="cd_selected_avatar">Ausgewählter Avatar</string>
+    <string name="cd_stop_voice_preview">Stimmenvorschau stoppen</string>
+    <string name="cd_test_tts_voice">Ausgewählte TTS-Stimme testen</string>
+    <string name="cd_toggle_auto_read">Automatisches Vorlesen von Antworten umschalten</string>
+    <string name="cd_toggle_auto_send_stt">Automatisches Senden nach Sprache umschalten</string>
+    <string name="cd_toggle_memories">Erinnerungen umschalten</string>
+    <string name="cd_tts_voice_selector">TTS-Stimme auswählen. Aktuell %1$s</string>
+    <string name="cd_user_avatar">Benutzer-Avatar</string>
+    <string name="cd_view_all_tools">Alle Tools anzeigen</string>
+    <string name="cd_view_tools">Tools anzeigen</string>
+
+    <!-- Section headers -->
+    <string name="section_about">Info</string>
+    <string name="section_account">Konto</string>
+    <string name="section_advanced">Erweitert</string>
+    <string name="section_appearance">Darstellung</string>
+    <string name="section_balance">Guthaben</string>
+    <string name="section_chat_preferences">Chat-Einstellungen</string>
+    <string name="section_conversations">Unterhaltungen</string>
+    <string name="section_danger_zone">Gefahrenzone</string>
+    <string name="section_data_management">Datenverwaltung</string>
+    <string name="section_general">Allgemein</string>
+    <string name="section_language">Sprache</string>
+    <string name="section_layout">Layout</string>
+    <string name="section_mcp_servers">MCP-Server</string>
+    <string name="section_memories">Erinnerungen</string>
+    <string name="section_personalization">Personalisierung</string>
+    <string name="section_presets">Vorlagen</string>
+    <string name="section_profile">Profil</string>
+    <string name="section_security">Sicherheit</string>
+    <string name="section_speech">Sprache</string>
+    <string name="section_tablet">Tablet</string>
+
+    <!-- Screen titles -->
+    <string name="title_account">Konto</string>
+    <string name="title_api_keys">API-Schlüssel</string>
+    <string name="title_chat">Chat</string>
+    <string name="title_commands">Befehle</string>
+    <string name="title_data">Daten</string>
+    <string name="title_general">Allgemein</string>
+    <string name="title_memories">Erinnerungen</string>
+    <string name="title_mcp_servers">MCP-Server</string>
+    <string name="title_presets">Vorlagen</string>
+    <string name="title_settings">Einstellungen</string>
+    <string name="title_shared_links">Geteilte Links</string>
+
+    <!-- Tabbed settings tabs -->
+    <string name="tab_general">Allgemein</string>
+    <string name="tab_chat">Chat</string>
+    <string name="tab_account">Konto</string>
+    <string name="tab_data">Daten</string>
+
+    <!-- Theme -->
+    <string name="theme_system">Systemstandard</string>
+    <string name="theme_light">Hell</string>
+    <string name="theme_dark">Dunkel</string>
+
+    <!-- Accent color -->
+    <string name="accent_color">Akzentfarbe</string>
+    <string name="accent_color_custom">Benutzerdefiniert</string>
+    <string name="accent_color_hex">Hex</string>
+    <string name="use_wallpaper_colors">Hintergrundfarben verwenden</string>
+    <string name="use_wallpaper_colors_desc">Den App-Akzent an dein System-Hintergrundbild anpassen (Material You)</string>
+
+    <!-- Settings rows -->
+    <string name="language">Sprache</string>
+    <string name="language_system_default">Systemstandard</string>
+    <string name="personalization">Personalisierung</string>
+    <string name="status_enabled">Aktiviert</string>
+    <string name="status_disabled">Deaktiviert</string>
+    <string name="fork_behavior">Verzweigungsverhalten</string>
+    <string name="commands">Befehle</string>
+    <string name="commands_enabled_count">%1$d aktiviert</string>
+    <string name="api_keys">API-Schlüssel</string>
+    <string name="api_keys_subtitle">API-Schlüssel für programmatischen Zugriff verwalten</string>
+    <string name="presets">Vorlagen</string>
+    <string name="presets_subtitle">Unterhaltungsvorlagen verwalten</string>
+    <string name="favorites">Favoriten</string>
+    <string name="favorites_subtitle">Angeheftete Agenten und Modelle verwalten</string>
+    <string name="favorites_title">Favoriten</string>
+    <string name="favorites_empty_title">Noch keine Favoriten</string>
+    <string name="favorites_empty_message">Hefte Agenten oder Modelle aus der Modellauswahl an, um sie hier zu sehen.</string>
+    <string name="favorites_count_of">%1$d von %2$d</string>
+    <string name="favorites_unpin_cd">Favorit lösen</string>
+
+    <!-- About info -->
+    <string name="app_version_label">App-Version</string>
+    <string name="app_build_label">Build</string>
+    <string name="server_label">Server</string>
+    <string name="server_not_configured">Nicht konfiguriert</string>
+    <string name="server_build_commit_label">Server-Commit</string>
+    <string name="server_build_branch_label">Server-Branch</string>
+    <string name="server_build_date_label">Server-Build-Datum</string>
+
+    <!-- Tablet settings -->
+    <string name="sidebar_swipe_gesture">Wischgeste für Seitenleiste</string>
+    <string name="sidebar_swipe_gesture_desc">Vom linken Rand wischen, um die Seitenleiste in Tablet-Layouts zu öffnen</string>
+
+    <!-- Balance -->
+    <string name="token_credits">Token-Guthaben</string>
+    <string name="available_balance">Verfügbares Guthaben</string>
+    <string name="cd_token_balance">Token-Guthaben: %1$s Credits</string>
+
+    <!-- Chat settings -->
+    <string name="chat_layout">Chat-Layout</string>
+    <string name="chat_layout_thread">Thread</string>
+    <string name="chat_layout_two_sided">Zweiseitiger Chat</string>
+    <string name="chat_layout_thread_desc">Alle Nachrichten links ausgerichtet mit Avatar und Name</string>
+    <string name="chat_layout_two_sided_desc">Benutzernachrichten rechts, Agent links</string>
+    <string name="show_bubbles">Sprechblasen anzeigen</string>
+    <string name="show_bubbles_desc">Nachrichten mit abgerundeten Sprechblasen-Hintergründen versehen</string>
+    <string name="show_avatars">Avatare anzeigen</string>
+    <string name="show_avatars_desc">Benutzer- und Agent-Avatare neben Nachrichten anzeigen</string>
+    <string name="starred_models_title">Markierte Modelle</string>
+    <string name="starred_models_desc">Deine angehefteten Modelle und Agenten oben in der Modellauswahl anzeigen</string>
+    <string name="starred_models_off">Aus</string>
+    <string name="starred_models_grouped">Einklappbare Gruppe oben</string>
+    <string name="starred_models_top">Oben, ohne Gruppierung</string>
+    <string name="font_size">Schriftgröße</string>
+    <string name="font_size_small">Klein</string>
+    <string name="font_size_medium">Mittel</string>
+    <string name="font_size_large">Groß</string>
+    <string name="latex_renderer">LaTeX-Renderer</string>
+    <string name="latex_katex">KaTeX (gerendert)</string>
+    <string name="latex_katex_desc">Vollständiges LaTeX-Rendering über WebView</string>
+    <string name="latex_native">Reiner Text (schnell)</string>
+    <string name="latex_native_desc">Zeigt rohen LaTeX-Quelltext für bessere Scroll-Leistung</string>
+    <string name="auto_scroll">Automatisches Scrollen beim Streaming</string>
+    <string name="auto_scroll_desc">Automatisch zu neuen Inhalten scrollen, während eine Antwort generiert wird</string>
+    <string name="show_thinking_blocks">Denkblöcke anzeigen</string>
+    <string name="show_thinking_blocks_desc">Schritte des Modell-Reasonings anzeigen, sofern verfügbar</string>
+    <string name="show_image_descriptions">Bildbeschreibungen anzeigen</string>
+    <string name="show_image_descriptions_desc">KI-generierte Bild-Prompts unter Bildern anzeigen</string>
+    <string name="dismiss_keyboard_on_send">Tastatur nach dem Senden ausblenden</string>
+    <string name="dismiss_keyboard_on_send_desc">Die Tastatur nach dem Senden einer Nachricht automatisch ausblenden</string>
+
+    <!-- Artifacts -->
+    <string name="section_artifacts">Artefakte</string>
+    <string name="artifacts_section_desc">Artefakte direkt im Chat rendern, statt hinter einer Karte zum Antippen. Tippe auf ein eingebettetes Artefakt, um die Vollbildansicht zu öffnen.</string>
+    <string name="inline_artifact_mermaid">Mermaid-Diagramme</string>
+    <string name="inline_artifact_mermaid_desc">Mermaid-Flussdiagramme und -Diagramme eingebettet rendern</string>
+    <string name="inline_artifact_svg">SVG-Bilder</string>
+    <string name="inline_artifact_svg_desc">SVG-Vektorgrafiken eingebettet rendern</string>
+    <string name="inline_artifact_html">HTML</string>
+    <string name="inline_artifact_html_desc">HTML-Seiten eingebettet rendern (lädt Tailwind vom CDN)</string>
+    <string name="inline_artifact_react">React-Komponenten</string>
+    <string name="inline_artifact_react_desc">React-Komponenten eingebettet rendern (lädt React + Babel vom CDN)</string>
+    <string name="inline_artifact_markdown">Markdown-Dokumente</string>
+    <string name="inline_artifact_markdown_desc">Markdown-Artefakte eingebettet mit syntaxhervorgehobenen Codeblöcken rendern</string>
+
+    <!-- Security -->
+    <string name="two_factor_auth">Zwei-Faktor-Authentifizierung</string>
+    <string name="enable_two_factor">Zwei-Faktor-Authentifizierung aktivieren</string>
+    <string name="disable_two_factor">Zwei-Faktor-Authentifizierung deaktivieren</string>
+    <string name="view_backup_codes">Backup-Codes anzeigen</string>
+
+    <!-- 2FA setup dialog -->
+    <string name="dialog_title_enable_2fa">Zwei-Faktor-Authentifizierung aktivieren</string>
+    <string name="dialog_title_disable_2fa">Zwei-Faktor-Authentifizierung deaktivieren</string>
+    <string name="twofa_scan_instructions">Kopiere die untenstehende URI und füge sie in deine Authenticator-App ein (z. B. Google Authenticator, Authy), und gib dann den Bestätigungscode ein.</string>
+    <string name="twofa_disable_instructions">Gib deinen Authenticator-Code ein, um 2FA zu deaktivieren.</string>
+    <string name="hint_verification_code">Bestätigungscode</string>
+
+    <!-- OTP verification dialogs -->
+    <string name="otp_title_verify_identity">Identität bestätigen</string>
+    <string name="otp_desc_delete_account">Gib deinen 2FA-Code ein, um dein Konto zu löschen.</string>
+    <string name="otp_desc_reenroll_2fa">Gib deinen aktuellen 2FA-Code ein, um dich neu zu registrieren.</string>
+    <string name="otp_desc_regenerate_backup_codes">Gib deinen 2FA-Code ein, um Backup-Codes neu zu generieren.</string>
+    <string name="otp_verify">Überprüfen</string>
+    <string name="otp_cancel">Abbrechen</string>
+    <string name="otp_backup_code_label">Backup-Code</string>
+    <string name="otp_use_backup_code">Stattdessen Backup-Code verwenden</string>
+    <string name="otp_use_otp_code">Stattdessen OTP-Code verwenden</string>
+
+    <!-- Backup codes dialog -->
+    <string name="dialog_title_backup_codes">Backup-Codes</string>
+    <string name="backup_codes_instructions">Bewahre diese Backup-Codes an einem sicheren Ort auf. Jeder Code kann nur einmal verwendet werden.</string>
+
+    <!-- Danger zone -->
+    <string name="delete_account">Konto löschen</string>
+    <string name="dialog_title_sign_out">Abmelden</string>
+    <string name="dialog_sign_out_message">Möchtest du dich wirklich abmelden?</string>
+    <string name="dialog_title_delete_account">Konto löschen</string>
+    <string name="dialog_delete_account_message">Diese Aktion kann nicht rückgängig gemacht werden. Alle deine Daten werden dauerhaft gelöscht.</string>
+
+    <!-- Clear cache dialog -->
+    <string name="dialog_title_clear_cache">Cache leeren</string>
+    <string name="dialog_clear_cache_message">Dies löscht zwischengespeicherte Bilder und temporäre Daten. Deine Kontodaten sind nicht betroffen.</string>
+
+    <!-- Revoke keys dialog -->
+    <string name="dialog_title_revoke_keys">Alle API-Schlüssel widerrufen</string>
+    <string name="dialog_revoke_keys_message">Dies widerruft alle deine gespeicherten API-Schlüssel. Du musst sie erneut eingeben, um externe Dienste weiter zu nutzen.</string>
+
+    <!-- Data settings -->
+    <string name="clear_all_conversations">Alle Unterhaltungen löschen</string>
+    <string name="clearing">Wird gelöscht…</string>
+    <string name="archived_conversations">Archivierte Unterhaltungen</string>
+    <string name="export_all_data">Alle Daten exportieren</string>
+    <string name="shared_links">Geteilte Links</string>
+    <string name="clear_cache">Cache leeren</string>
+    <string name="revoke_all_api_keys">Alle API-Schlüssel widerrufen</string>
+    <string name="revoking">Wird widerrufen…</string>
+    <string name="dialog_title_clear_conversations">Alle Unterhaltungen löschen</string>
+    <string name="dialog_clear_conversations_message">Dies löscht alle deine Unterhaltungen dauerhaft. Diese Aktion kann nicht rückgängig gemacht werden.</string>
+    <string name="clear_all">Alle löschen</string>
+    <string name="export_coming_soon">Export ist bald verfügbar</string>
+    <string name="error_could_not_load_settings">Einstellungen konnten nicht geladen werden</string>
+
+    <!-- Diagnostic logs (issue #96) -->
+    <string name="section_diagnostic_logs">Diagnoseprotokolle</string>
+    <string name="export_diagnostic_logs">Diagnoseprotokolle exportieren</string>
+    <string name="export_diagnostic_logs_with_size">Diagnoseprotokolle exportieren (%1$s)</string>
+    <string name="exporting_logs">Wird exportiert…</string>
+    <string name="clear_diagnostic_logs">Diagnoseprotokolle löschen</string>
+    <string name="clearing_logs">Wird gelöscht…</string>
+    <string name="logs_exported">Diagnoseprotokolle exportiert</string>
+    <string name="dialog_title_clear_logs">Diagnoseprotokolle löschen</string>
+    <string name="dialog_clear_logs_message">Dies löscht alle auf diesem Gerät gespeicherten Diagnoseprotokolle dauerhaft. Diese Aktion kann nicht rückgängig gemacht werden.</string>
+
+    <!-- Speech settings -->
+    <string name="auto_send_after_speech">Automatisch nach Sprache senden</string>
+    <string name="auto_send_after_speech_desc">Die Nachricht automatisch senden, sobald die Spr-zu-Text-Erkennung abgeschlossen ist</string>
+    <string name="auto_read_responses">Antworten automatisch vorlesen</string>
+    <string name="auto_read_responses_desc">KI-Antworten automatisch per Text-zu-Sprache vorlesen</string>
+    <string name="tts_voice">TTS-Stimme</string>
+    <string name="test_voice">Stimme testen</string>
+    <string name="no_server_tts_voices">Keine Server-TTS-Stimmen verfügbar. Sprachfunktionen sind auf dem Server möglicherweise nicht konfiguriert.</string>
+    <string name="using_device_tts">Verwendet die Text-zu-Sprache-Engine des Geräts. Stimme und Geschwindigkeit kannst du unten in den Text-zu-Sprache-Einstellungen konfigurieren.</string>
+    <string name="speech_to_text_settings">Sprache-zu-Text-Einstellungen</string>
+    <string name="text_to_speech_settings">Text-zu-Sprache-Einstellungen</string>
+
+    <!-- STT detail dialog -->
+    <string name="stt_engine_label">Engine</string>
+    <string name="stt_language_label">Sprache</string>
+    <string name="stt_on_device">Auf dem Gerät</string>
+    <string name="stt_default">Standard</string>
+    <string name="stt_hint_whisper">Whisper verwendet serverseitige Transkription. Auf deinem Server muss STT aktiviert sein.</string>
+    <string name="stt_hint_device">Verwendet die integrierte Spracherkennung deines Geräts. Funktioniert offline auf unterstützten Geräten.</string>
+    <string name="stt_hint_google">Verwendet die Spracherkennung von Google. Erfordert die installierte Google-App.</string>
+    <string name="stt_hint_default">Verwendet die Server-Transkription (Whisper), sofern verfügbar, andernfalls die Erkennung auf dem Gerät.</string>
+    <string name="stt_auto_detect">Automatisch erkennen</string>
+
+    <!-- TTS detail dialog -->
+    <string name="tts_source_label">Quelle</string>
+    <string name="tts_source_device">Gerät (integriert)</string>
+    <string name="tts_source_server">Server</string>
+    <string name="tts_voice_label">Stimme</string>
+    <string name="tts_engine_label">Engine</string>
+    <string name="tts_system_default">Systemstandard</string>
+    <string name="tts_speech_rate">Sprechgeschwindigkeit: %1$.1fx</string>
+    <string name="tts_pitch">Tonhöhe: %1$.1f</string>
+    <string name="tts_cache_audio">Audio zwischenspeichern</string>
+    <string name="tts_preview_text">Dies ist eine Vorschau der ausgewählten Stimme.</string>
+    <string name="tts_stop_preview">Vorschau stoppen</string>
+    <string name="tts_preview_voice">Stimme anhören</string>
+
+    <!-- Memories -->
+    <string name="enable_memories">Erinnerungen aktivieren</string>
+    <string name="enable_memories_desc">Der KI erlauben, Informationen über Unterhaltungen hinweg zu merken</string>
+    <string name="no_memories_saved">Noch keine Erinnerungen gespeichert</string>
+    <string name="memories_add_hint">Tippe auf die +-Schaltfläche, um eine Erinnerung hinzuzufügen</string>
+    <string name="add_memory">Erinnerung hinzufügen</string>
+    <string name="edit_memory">Erinnerung bearbeiten</string>
+    <string name="dialog_title_delete_memory">Erinnerung löschen</string>
+    <string name="dialog_delete_memory_message">Möchtest du die Erinnerung \"%1$s\" wirklich löschen?</string>
+    <string name="memory_key_label">Schlüssel</string>
+    <string name="memory_value_label">Wert</string>
+
+    <!-- MCP -->
+    <string name="add_mcp_server">MCP-Server hinzufügen</string>
+    <string name="edit_mcp_server">MCP-Server bearbeiten</string>
+    <string name="mcp_not_available">MCP ist auf diesem Server nicht verfügbar</string>
+    <string name="no_mcp_servers">Keine MCP-Server konfiguriert</string>
+    <string name="mcp_add_hint">Tippe auf die +-Schaltfläche, um einen Server hinzuzufügen</string>
+    <string name="mcp_name_label">Name</string>
+    <string name="mcp_description_label">Beschreibung</string>
+    <string name="mcp_description_optional">Optional</string>
+    <string name="mcp_url_label">URL</string>
+    <string name="mcp_type_label">Typ</string>
+    <string name="mcp_type_sse">SSE</string>
+    <string name="mcp_type_streamable_http">Streamable HTTP</string>
+    <string name="mcp_auth_label">Authentifizierung</string>
+    <string name="mcp_auth_none">Keine</string>
+    <string name="mcp_auth_api_key">API-Schlüssel</string>
+    <string name="mcp_auth_oauth">OAuth</string>
+    <string name="mcp_auth_key_type">Schlüsseltyp</string>
+    <string name="mcp_auth_bearer">Bearer</string>
+    <string name="mcp_auth_basic">Basic</string>
+    <string name="mcp_auth_custom">Benutzerdefiniert</string>
+    <string name="mcp_header_name_label">Header-Name</string>
+    <string name="mcp_header_name_placeholder">X-API-Key</string>
+    <string name="mcp_api_key_label">API-Schlüssel</string>
+    <string name="mcp_oauth_client_id">Client-ID</string>
+    <string name="mcp_oauth_client_secret">Client-Secret</string>
+    <string name="mcp_oauth_auth_url">Autorisierungs-URL</string>
+    <string name="mcp_oauth_token_url">Token-URL</string>
+    <string name="mcp_oauth_scope">Scope</string>
+    <string name="mcp_oauth_scope_placeholder">read execute</string>
+    <string name="dialog_title_delete_server">Server löschen</string>
+    <string name="dialog_delete_server_message">Möchtest du \"%1$s\" wirklich löschen?</string>
+    <string name="error_failed_to_load_servers">Server konnten nicht geladen werden</string>
+    <string name="mcp_tools_count">%1$d Tool%2$s</string>
+    <string name="mcp_tools_available">%1$d Tool%2$s verfügbar</string>
+    <string name="mcp_all_tools">Alle MCP-Tools</string>
+    <string name="mcp_tools_for_server">Tools: %1$s</string>
+    <string name="no_tools_available">Keine Tools verfügbar</string>
+    <string name="mcp_tool_server">Server: %1$s</string>
+
+    <!-- MCP tools sheet -->
+    <string name="mcp_server_unknown">Unbekannt</string>
+
+    <!-- Fork settings -->
+    <string name="fork_mode_direct_path">Sichtbare Nachrichten</string>
+    <string name="fork_mode_direct_path_desc">Nur der direkte Pfad der Nachrichten bis zur ausgewählten Nachricht</string>
+    <string name="fork_mode_include_branches">Verzweigungen einschließen</string>
+    <string name="fork_mode_include_branches_desc">Direkter Pfad plus benachbarte Nachrichten auf jeder Ebene</string>
+    <string name="fork_mode_target_level">Alles bis zur Zielebene</string>
+    <string name="fork_mode_target_level_desc">Alle Nachrichten und Verzweigungen bis zur Ebene der Zielnachricht (Standard)</string>
+
+    <!-- Language selector -->
+    <string name="hint_search_languages">Sprachen suchen</string>
+
+    <!-- Personalization dialog -->
+    <string name="enable_personalization">Personalisierung aktivieren</string>
+    <string name="about_you_label">Über dich</string>
+    <string name="about_you_hint">Was sollte die KI für den Kontext über dich wissen?</string>
+    <string name="response_style_label">Wie soll die KI antworten?</string>
+    <string name="response_style_hint">Bevorzugter Ton, Format oder Stil für Antworten</string>
+
+    <!-- Commands screen -->
+    <string name="no_commands_available">Keine Befehle verfügbar</string>
+
+    <!-- Avatar upload dialog -->
+    <string name="dialog_title_update_avatar">Avatar aktualisieren</string>
+    <string name="avatar_choose_hint">Tippe auf das Kamerasymbol, um ein Bild auszuwählen</string>
+
+    <!-- API Keys screen -->
+    <string name="api_keys_not_available">API-Schlüssel nicht verfügbar</string>
+    <string name="api_keys_not_supported">Diese Funktion wird von deiner Server-Version nicht unterstützt.</string>
+    <string name="no_api_keys">Keine API-Schlüssel</string>
+    <string name="no_api_keys_desc">Erstelle einen API-Schlüssel, um programmatisch auf die API zuzugreifen.</string>
+    <string name="dialog_title_delete_api_key">API-Schlüssel löschen</string>
+    <string name="dialog_delete_api_key_message">Möchtest du den API-Schlüssel \"%1$s\" wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden.</string>
+    <string name="created_prefix">Erstellt: %1$s</string>
+
+    <!-- API Key create dialog -->
+    <string name="dialog_title_create_api_key">API-Schlüssel erstellen</string>
+    <string name="api_key_name_hint">Gib deinem API-Schlüssel einen aussagekräftigen Namen, um seinen Zweck leichter zu erkennen.</string>
+    <string name="hint_key_name">Schlüsselname</string>
+    <string name="hint_key_name_placeholder">z. B. Meine App</string>
+    <string name="dialog_title_api_key_created">API-Schlüssel erstellt</string>
+    <string name="api_key_created_warning">Dein API-Schlüssel wurde erstellt. Kopiere ihn jetzt — du kannst ihn später nicht mehr einsehen.</string>
+    <string name="copied_to_clipboard">In Zwischenablage kopiert</string>
+
+    <!-- Preset manager -->
+    <string name="no_presets">Keine Vorlagen</string>
+    <string name="no_presets_desc">Speichere Vorlagen über den Chat-Bildschirm, um sie hier zu verwalten</string>
+    <string name="dialog_title_delete_preset">Vorlage löschen</string>
+    <string name="dialog_delete_preset_message">Möchtest du \"%1$s\" wirklich löschen?</string>
+
+    <!-- Shared links -->
+    <string name="no_shared_links">Keine geteilten Links</string>
+    <string name="no_shared_links_desc">Teile eine Unterhaltung, um sie hier zu sehen</string>
+    <string name="dialog_title_delete_shared_link">Geteilten Link löschen</string>
+    <string name="dialog_delete_shared_link_message">Dies entfernt den geteilten Link für \"%1$s\". Niemand mit dem Link kann mehr darauf zugreifen.</string>
+    <string name="visibility_public">Öffentlich</string>
+    <string name="visibility_private">Privat</string>
+    <string name="error_failed_to_load_memories">Erinnerungen konnten nicht geladen werden</string>
+
+    <!-- Provider API Keys -->
+    <string name="provider_keys_title">Anbieter-API-Schlüssel</string>
+    <string name="provider_keys_subtitle">Lege eigene Schlüssel für Endpunkte fest, die sie benötigen</string>
+    <string name="provider_keys_dialog_title">API-Schlüssel für %1$s festlegen</string>
+    <string name="provider_keys_status_set_expires">Läuft ab in %1$s</string>
+    <string name="provider_keys_status_set_never">Dein Schlüssel läuft nie ab</string>
+    <string name="provider_keys_status_unset">Nicht festgelegt</string>
+    <string name="provider_keys_status_expired">Abgelaufen</string>
+    <string name="provider_keys_status_loading">Schlüsselstatus wird geprüft…</string>
+    <string name="provider_keys_field_api_key_label">Schlüssel</string>
+    <string name="provider_keys_field_base_url_label">Basis-URL</string>
+    <string name="provider_keys_field_base_url_optional_suffix">(Optional)</string>
+    <string name="provider_keys_field_api_key_for_endpoint">%1$s API-Schlüssel</string>
+    <string name="provider_keys_field_api_url_for_endpoint">%1$s API-URL</string>
+
+    <string name="provider_keys_field_azure_api_key">Azure OpenAI API-Schlüssel</string>
+    <string name="provider_keys_field_azure_instance">Azure-Instanzname</string>
+    <string name="provider_keys_field_azure_deployment">Azure-Deployment-Name</string>
+    <string name="provider_keys_field_azure_api_version">Azure-API-Version</string>
+
+    <string name="provider_keys_field_google_api_key">Google API-Schlüssel</string>
+    <string name="provider_keys_field_google_gemini_api">(Gemini API)</string>
+    <string name="provider_keys_field_google_service_key">Google-Dienstkonto-Schlüssel</string>
+    <string name="provider_keys_field_google_import">Dienstkonto-JSON-Schlüssel importieren.</string>
+    <string name="provider_keys_field_google_invalid">Ungültiger Dienstkonto-JSON-Schlüssel. Hast du die richtige Datei importiert?</string>
+    <string name="provider_keys_field_google_imported">Dienstkonto-JSON-Schlüssel erfolgreich importiert</string>
+    <string name="provider_keys_field_google_paste_label">Oder Dienstkonto-JSON einfügen</string>
+    <string name="provider_keys_field_google_paste_only_hint">Füge das Dienstkonto-JSON unten ein.</string>
+    <string name="provider_keys_field_google_service_key_or_gemini">Google-Dienstschlüssel oder Gemini API-Schlüssel</string>
+
+    <string name="provider_keys_field_bedrock_access_key_id">Access Key ID</string>
+    <string name="provider_keys_field_bedrock_secret_access_key">Secret Access Key</string>
+    <string name="provider_keys_field_bedrock_session_token">Session Token</string>
+    <string name="provider_keys_field_bedrock_session_token_optional_suffix">(Optional)</string>
+
+    <string name="provider_keys_required_fields">Die folgenden Felder sind erforderlich: %1$s</string>
+    <string name="provider_keys_revoke">Widerrufen</string>
+    <string name="provider_keys_revoke_failed">API-Schlüssel konnte nicht widerrufen werden. Bitte versuche es erneut.</string>
+    <string name="provider_keys_revoke_success">API-Schlüssel erfolgreich widerrufen</string>
+    <string name="provider_keys_revoke_all">Schlüssel widerrufen</string>
+    <string name="provider_keys_revoke_all_confirm">Möchtest du wirklich alle Schlüssel widerrufen?</string>
+    <string name="provider_keys_revoke_all_failed">Alle Schlüssel konnten nicht widerrufen werden</string>
+    <string name="provider_keys_save_failed">API-Schlüssel konnte nicht gespeichert werden. Bitte versuche es erneut.</string>
+    <string name="provider_keys_save_success">API-Schlüssel erfolgreich gespeichert</string>
+
+    <string name="provider_keys_expiry_label">Läuft ab</string>
+    <string name="provider_keys_expiry_30m">in 30 Minuten</string>
+    <string name="provider_keys_expiry_2h">in 2 Stunden</string>
+    <string name="provider_keys_expiry_12h">in 12 Stunden</string>
+    <string name="provider_keys_expiry_1d">in 1 Tag</string>
+    <string name="provider_keys_expiry_7d">in 7 Tagen</string>
+    <string name="provider_keys_expiry_30d">in 30 Tagen</string>
+    <string name="provider_keys_expiry_never">nie</string>
+
+    <string name="provider_keys_empty_title">Keine Endpunkte benötigen vom Benutzer bereitgestellte Schlüssel</string>
+    <string name="provider_keys_empty_desc">Endpunkte, die deinen eigenen API-Schlüssel benötigen, erscheinen hier.</string>
+    <string name="provider_keys_revoke_all_action">Alle widerrufen</string>
+
+    <!-- Admin: role skill access -->
+    <string name="role_skills_settings_row">Skill-Zugriff (Admin)</string>
+    <string name="role_skills_title">Skill-Zugriff</string>
+    <string name="role_skills_back">Zurück</string>
+    <string name="role_skills_description">Steuere, welche Skill-Funktionen jede Rolle hat. Änderungen gelten für alle Benutzer mit der ausgewählten Rolle.</string>
+    <string name="role_skills_role_label">Rolle</string>
+    <string name="role_skills_use">Skills verwenden</string>
+    <string name="role_skills_create">Skills erstellen &amp; bearbeiten</string>
+    <string name="role_skills_share">Skills teilen</string>
+    <string name="role_skills_share_public">Skills öffentlich teilen</string>
+    <string name="role_skills_save">Speichern</string>
+</resources>

--- a/feature/settings/src/commonMain/composeResources/values-es/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-es/strings.xml
@@ -1,0 +1,488 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Common actions -->
+    <string name="action_add">Añadir</string>
+    <string name="action_cancel">Cancelar</string>
+    <string name="action_clear">Borrar</string>
+    <string name="action_confirm">Confirmar</string>
+    <string name="action_creating">Creando…</string>
+    <string name="action_create">Crear</string>
+    <string name="action_delete">Eliminar</string>
+    <string name="action_done">Hecho</string>
+    <string name="action_retry">Reintentar</string>
+    <string name="action_revoke_all">Revocar todo</string>
+    <string name="action_save">Guardar</string>
+    <string name="action_sign_out">Cerrar sesión</string>
+    <string name="action_upload">Subir</string>
+    <string name="action_uploading">Subiendo…</string>
+    <string name="action_verify">Verificar</string>
+    <string name="action_verifying">Verificando…</string>
+
+    <!-- Content descriptions -->
+    <string name="cd_add_memory">Añadir recuerdo</string>
+    <string name="cd_add_server">Añadir servidor</string>
+    <string name="cd_back">Atrás</string>
+    <string name="cd_change_avatar">Cambiar avatar</string>
+    <string name="cd_choose_image">Elegir imagen</string>
+    <string name="cd_collapse_tools">Contraer herramientas</string>
+    <string name="cd_copy_api_key">Copiar clave de API</string>
+    <string name="cd_copy_link">Copiar enlace</string>
+    <string name="cd_create_api_key">Crear clave de API</string>
+    <string name="cd_current_avatar">Avatar actual</string>
+    <string name="cd_delete">Eliminar</string>
+    <string name="cd_delete_api_key">Eliminar clave de API</string>
+    <string name="cd_delete_memory">Eliminar recuerdo</string>
+    <string name="cd_delete_preset">Eliminar preajuste</string>
+    <string name="cd_delete_server">Eliminar servidor</string>
+    <string name="cd_delete_shared_link">Eliminar enlace compartido</string>
+    <string name="cd_edit">Editar</string>
+    <string name="cd_edit_memory">Editar recuerdo</string>
+    <string name="cd_edit_server">Editar servidor</string>
+    <string name="cd_expand_tools">Expandir herramientas</string>
+    <string name="cd_loading_profile">Cargando perfil</string>
+    <string name="cd_make_private">Hacer privado</string>
+    <string name="cd_make_public">Hacer público</string>
+    <string name="cd_preview_voice">Previsualizar voz</string>
+    <string name="cd_qr_code">Código QR para la app de autenticación</string>
+    <string name="cd_reinitialize">Reinicializar</string>
+    <string name="cd_avatar_preview">Vista previa del avatar</string>
+    <string name="cd_selected">Seleccionado</string>
+    <string name="cd_selected_avatar">Avatar seleccionado</string>
+    <string name="cd_stop_voice_preview">Detener vista previa de voz</string>
+    <string name="cd_test_tts_voice">Probar la voz de TTS seleccionada</string>
+    <string name="cd_toggle_auto_read">Activar o desactivar la lectura automática de respuestas</string>
+    <string name="cd_toggle_auto_send_stt">Activar o desactivar el envío automático tras el habla</string>
+    <string name="cd_toggle_memories">Activar o desactivar recuerdos</string>
+    <string name="cd_tts_voice_selector">Seleccionar voz de TTS. Actualmente %1$s</string>
+    <string name="cd_user_avatar">Avatar de usuario</string>
+    <string name="cd_view_all_tools">Ver todas las herramientas</string>
+    <string name="cd_view_tools">Ver herramientas</string>
+
+    <!-- Section headers -->
+    <string name="section_about">Acerca de</string>
+    <string name="section_account">Cuenta</string>
+    <string name="section_advanced">Avanzado</string>
+    <string name="section_appearance">Apariencia</string>
+    <string name="section_balance">Saldo</string>
+    <string name="section_chat_preferences">Preferencias de chat</string>
+    <string name="section_conversations">Conversaciones</string>
+    <string name="section_danger_zone">Zona de peligro</string>
+    <string name="section_data_management">Gestión de datos</string>
+    <string name="section_general">General</string>
+    <string name="section_language">Idioma</string>
+    <string name="section_layout">Diseño</string>
+    <string name="section_mcp_servers">Servidores MCP</string>
+    <string name="section_memories">Recuerdos</string>
+    <string name="section_personalization">Personalización</string>
+    <string name="section_presets">Preajustes</string>
+    <string name="section_profile">Perfil</string>
+    <string name="section_security">Seguridad</string>
+    <string name="section_speech">Voz</string>
+    <string name="section_tablet">Tableta</string>
+
+    <!-- Screen titles -->
+    <string name="title_account">Cuenta</string>
+    <string name="title_api_keys">Claves de API</string>
+    <string name="title_chat">Chat</string>
+    <string name="title_commands">Comandos</string>
+    <string name="title_data">Datos</string>
+    <string name="title_general">General</string>
+    <string name="title_memories">Recuerdos</string>
+    <string name="title_mcp_servers">Servidores MCP</string>
+    <string name="title_presets">Preajustes</string>
+    <string name="title_settings">Ajustes</string>
+    <string name="title_shared_links">Enlaces compartidos</string>
+
+    <!-- Tabbed settings tabs -->
+    <string name="tab_general">General</string>
+    <string name="tab_chat">Chat</string>
+    <string name="tab_account">Cuenta</string>
+    <string name="tab_data">Datos</string>
+
+    <!-- Theme -->
+    <string name="theme_system">Predeterminado del sistema</string>
+    <string name="theme_light">Claro</string>
+    <string name="theme_dark">Oscuro</string>
+
+    <!-- Accent color -->
+    <string name="accent_color">Color de acento</string>
+    <string name="accent_color_custom">Personalizado</string>
+    <string name="accent_color_hex">Hex</string>
+    <string name="use_wallpaper_colors">Usar colores del fondo de pantalla</string>
+    <string name="use_wallpaper_colors_desc">Hacer coincidir el acento de la app con el fondo de pantalla del sistema (Material You)</string>
+
+    <!-- Settings rows -->
+    <string name="language">Idioma</string>
+    <string name="language_system_default">Predeterminado del sistema</string>
+    <string name="personalization">Personalización</string>
+    <string name="status_enabled">Activado</string>
+    <string name="status_disabled">Desactivado</string>
+    <string name="fork_behavior">Comportamiento de bifurcación</string>
+    <string name="commands">Comandos</string>
+    <string name="commands_enabled_count">%1$d activados</string>
+    <string name="api_keys">Claves de API</string>
+    <string name="api_keys_subtitle">Gestiona las claves de API para el acceso programático</string>
+    <string name="presets">Preajustes</string>
+    <string name="presets_subtitle">Gestiona los preajustes de conversación</string>
+    <string name="favorites">Favoritos</string>
+    <string name="favorites_subtitle">Gestiona los agentes y modelos fijados</string>
+    <string name="favorites_title">Favoritos</string>
+    <string name="favorites_empty_title">Aún no hay favoritos</string>
+    <string name="favorites_empty_message">Fija agentes o modelos desde el selector de modelos para verlos aquí.</string>
+    <string name="favorites_count_of">%1$d de %2$d</string>
+    <string name="favorites_unpin_cd">Quitar favorito</string>
+
+    <!-- About info -->
+    <string name="app_version_label">Versión de la app</string>
+    <string name="app_build_label">Compilación</string>
+    <string name="server_label">Servidor</string>
+    <string name="server_not_configured">No configurado</string>
+    <string name="server_build_commit_label">Commit del servidor</string>
+    <string name="server_build_branch_label">Rama del servidor</string>
+    <string name="server_build_date_label">Fecha de compilación del servidor</string>
+
+    <!-- Tablet settings -->
+    <string name="sidebar_swipe_gesture">Gesto de deslizar para la barra lateral</string>
+    <string name="sidebar_swipe_gesture_desc">Desliza desde el borde izquierdo para abrir la barra lateral en diseños de tableta</string>
+
+    <!-- Balance -->
+    <string name="token_credits">Créditos de tokens</string>
+    <string name="available_balance">Saldo disponible</string>
+    <string name="cd_token_balance">Saldo de tokens: %1$s créditos</string>
+
+    <!-- Chat settings -->
+    <string name="chat_layout">Diseño del chat</string>
+    <string name="chat_layout_thread">Hilo</string>
+    <string name="chat_layout_two_sided">Chat de dos lados</string>
+    <string name="chat_layout_thread_desc">Todos los mensajes alineados a la izquierda con avatar y nombre</string>
+    <string name="chat_layout_two_sided_desc">Mensajes del usuario a la derecha, del agente a la izquierda</string>
+    <string name="show_bubbles">Mostrar burbujas</string>
+    <string name="show_bubbles_desc">Añade fondos de burbuja redondeados a los mensajes</string>
+    <string name="show_avatars">Mostrar avatares</string>
+    <string name="show_avatars_desc">Muestra los avatares del usuario y del agente junto a los mensajes</string>
+    <string name="starred_models_title">Modelos destacados</string>
+    <string name="starred_models_desc">Muestra tus modelos y agentes fijados en la parte superior del selector de modelos</string>
+    <string name="starred_models_off">Desactivado</string>
+    <string name="starred_models_grouped">Grupo plegable en la parte superior</string>
+    <string name="starred_models_top">En la parte superior, sin agrupar</string>
+    <string name="font_size">Tamaño de fuente</string>
+    <string name="font_size_small">Pequeño</string>
+    <string name="font_size_medium">Mediano</string>
+    <string name="font_size_large">Grande</string>
+    <string name="latex_renderer">Renderizador de LaTeX</string>
+    <string name="latex_katex">KaTeX (renderizado)</string>
+    <string name="latex_katex_desc">Renderizado completo de LaTeX mediante WebView</string>
+    <string name="latex_native">Texto sin formato (rápido)</string>
+    <string name="latex_native_desc">Muestra el código fuente de LaTeX para un mejor rendimiento de desplazamiento</string>
+    <string name="auto_scroll">Desplazamiento automático durante la transmisión</string>
+    <string name="auto_scroll_desc">Desplazarse automáticamente al nuevo contenido mientras se genera una respuesta</string>
+    <string name="show_thinking_blocks">Mostrar bloques de razonamiento</string>
+    <string name="show_thinking_blocks_desc">Muestra los pasos de razonamiento del modelo cuando estén disponibles</string>
+    <string name="show_image_descriptions">Mostrar descripciones de imágenes</string>
+    <string name="show_image_descriptions_desc">Muestra los prompts de imagen generados por IA debajo de las imágenes</string>
+    <string name="dismiss_keyboard_on_send">Ocultar el teclado al enviar</string>
+    <string name="dismiss_keyboard_on_send_desc">Oculta automáticamente el teclado después de enviar un mensaje</string>
+
+    <!-- Artifacts -->
+    <string name="section_artifacts">Artefactos</string>
+    <string name="artifacts_section_desc">Renderiza los artefactos directamente en el chat en lugar de detrás de una tarjeta que se abre al tocar. Toca un artefacto en línea para abrir la vista a pantalla completa.</string>
+    <string name="inline_artifact_mermaid">Diagramas de Mermaid</string>
+    <string name="inline_artifact_mermaid_desc">Renderiza diagramas de flujo y diagramas de Mermaid en línea</string>
+    <string name="inline_artifact_svg">Imágenes SVG</string>
+    <string name="inline_artifact_svg_desc">Renderiza gráficos vectoriales SVG en línea</string>
+    <string name="inline_artifact_html">HTML</string>
+    <string name="inline_artifact_html_desc">Renderiza páginas HTML en línea (carga Tailwind desde la CDN)</string>
+    <string name="inline_artifact_react">Componentes de React</string>
+    <string name="inline_artifact_react_desc">Renderiza componentes de React en línea (carga React + Babel desde la CDN)</string>
+    <string name="inline_artifact_markdown">Documentos de Markdown</string>
+    <string name="inline_artifact_markdown_desc">Renderiza artefactos de Markdown en línea con bloques de código con resaltado de sintaxis</string>
+
+    <!-- Security -->
+    <string name="two_factor_auth">Autenticación de dos factores</string>
+    <string name="enable_two_factor">Activar la autenticación de dos factores</string>
+    <string name="disable_two_factor">Desactivar la autenticación de dos factores</string>
+    <string name="view_backup_codes">Ver códigos de respaldo</string>
+
+    <!-- 2FA setup dialog -->
+    <string name="dialog_title_enable_2fa">Activar la autenticación de dos factores</string>
+    <string name="dialog_title_disable_2fa">Desactivar la autenticación de dos factores</string>
+    <string name="twofa_scan_instructions">Copia el URI de abajo y pégalo en tu app de autenticación (p. ej. Google Authenticator, Authy), luego introduce el código de verificación.</string>
+    <string name="twofa_disable_instructions">Introduce el código de tu autenticador para desactivar la 2FA.</string>
+    <string name="hint_verification_code">Código de verificación</string>
+
+    <!-- OTP verification dialogs -->
+    <string name="otp_title_verify_identity">Verificar identidad</string>
+    <string name="otp_desc_delete_account">Introduce tu código de 2FA para eliminar tu cuenta.</string>
+    <string name="otp_desc_reenroll_2fa">Introduce tu código de 2FA actual para volver a registrarte.</string>
+    <string name="otp_desc_regenerate_backup_codes">Introduce tu código de 2FA para regenerar los códigos de respaldo.</string>
+    <string name="otp_verify">Verificar</string>
+    <string name="otp_cancel">Cancelar</string>
+    <string name="otp_backup_code_label">Código de respaldo</string>
+    <string name="otp_use_backup_code">Usar un código de respaldo en su lugar</string>
+    <string name="otp_use_otp_code">Usar un código OTP en su lugar</string>
+
+    <!-- Backup codes dialog -->
+    <string name="dialog_title_backup_codes">Códigos de respaldo</string>
+    <string name="backup_codes_instructions">Guarda estos códigos de respaldo en un lugar seguro. Cada código solo se puede usar una vez.</string>
+
+    <!-- Danger zone -->
+    <string name="delete_account">Eliminar cuenta</string>
+    <string name="dialog_title_sign_out">Cerrar sesión</string>
+    <string name="dialog_sign_out_message">¿Seguro que quieres cerrar sesión?</string>
+    <string name="dialog_title_delete_account">Eliminar cuenta</string>
+    <string name="dialog_delete_account_message">Esta acción no se puede deshacer. Todos tus datos se eliminarán de forma permanente.</string>
+
+    <!-- Clear cache dialog -->
+    <string name="dialog_title_clear_cache">Borrar caché</string>
+    <string name="dialog_clear_cache_message">Esto borrará las imágenes en caché y los datos temporales. Los datos de tu cuenta no se verán afectados.</string>
+
+    <!-- Revoke keys dialog -->
+    <string name="dialog_title_revoke_keys">Revocar todas las claves de API</string>
+    <string name="dialog_revoke_keys_message">Esto revocará todas las claves de API que tienes almacenadas. Tendrás que volver a introducirlas para seguir usando los servicios externos.</string>
+
+    <!-- Data settings -->
+    <string name="clear_all_conversations">Borrar todas las conversaciones</string>
+    <string name="clearing">Borrando…</string>
+    <string name="archived_conversations">Conversaciones archivadas</string>
+    <string name="export_all_data">Exportar todos los datos</string>
+    <string name="shared_links">Enlaces compartidos</string>
+    <string name="clear_cache">Borrar caché</string>
+    <string name="revoke_all_api_keys">Revocar todas las claves de API</string>
+    <string name="revoking">Revocando…</string>
+    <string name="dialog_title_clear_conversations">Borrar todas las conversaciones</string>
+    <string name="dialog_clear_conversations_message">Esto eliminará permanentemente todas tus conversaciones. Esta acción no se puede deshacer.</string>
+    <string name="clear_all">Borrar todo</string>
+    <string name="export_coming_soon">La exportación estará disponible próximamente</string>
+    <string name="error_could_not_load_settings">No se pudieron cargar los ajustes</string>
+
+    <!-- Diagnostic logs (issue #96) -->
+    <string name="section_diagnostic_logs">Registros de diagnóstico</string>
+    <string name="export_diagnostic_logs">Exportar registros de diagnóstico</string>
+    <string name="export_diagnostic_logs_with_size">Exportar registros de diagnóstico (%1$s)</string>
+    <string name="exporting_logs">Exportando…</string>
+    <string name="clear_diagnostic_logs">Borrar registros de diagnóstico</string>
+    <string name="clearing_logs">Borrando…</string>
+    <string name="logs_exported">Registros de diagnóstico exportados</string>
+    <string name="dialog_title_clear_logs">Borrar registros de diagnóstico</string>
+    <string name="dialog_clear_logs_message">Esto eliminará permanentemente todos los registros de diagnóstico almacenados en este dispositivo. Esta acción no se puede deshacer.</string>
+
+    <!-- Speech settings -->
+    <string name="auto_send_after_speech">Envío automático tras el habla</string>
+    <string name="auto_send_after_speech_desc">Envía automáticamente el mensaje cuando termina la conversión de voz a texto</string>
+    <string name="auto_read_responses">Lectura automática de respuestas</string>
+    <string name="auto_read_responses_desc">Lee automáticamente en voz alta las respuestas de la IA mediante texto a voz</string>
+    <string name="tts_voice">Voz de TTS</string>
+    <string name="test_voice">Probar voz</string>
+    <string name="no_server_tts_voices">No hay voces de TTS del servidor disponibles. Es posible que las funciones de voz no estén configuradas en el servidor.</string>
+    <string name="using_device_tts">Usando el motor de texto a voz del dispositivo. Configura la voz y la velocidad en los ajustes de texto a voz de abajo.</string>
+    <string name="speech_to_text_settings">Ajustes de voz a texto</string>
+    <string name="text_to_speech_settings">Ajustes de texto a voz</string>
+
+    <!-- STT detail dialog -->
+    <string name="stt_engine_label">Motor</string>
+    <string name="stt_language_label">Idioma</string>
+    <string name="stt_on_device">En el dispositivo</string>
+    <string name="stt_default">Predeterminado</string>
+    <string name="stt_hint_whisper">Whisper usa transcripción del lado del servidor. Tu servidor debe tener el STT activado.</string>
+    <string name="stt_hint_device">Usa el reconocedor de voz integrado de tu dispositivo. Funciona sin conexión en los dispositivos compatibles.</string>
+    <string name="stt_hint_google">Usa el reconocedor de voz de Google. Requiere que la app de Google esté instalada.</string>
+    <string name="stt_hint_default">Usa la transcripción del servidor (Whisper) cuando esté disponible; de lo contrario, recurre al reconocimiento en el dispositivo.</string>
+    <string name="stt_auto_detect">Detección automática</string>
+
+    <!-- TTS detail dialog -->
+    <string name="tts_source_label">Origen</string>
+    <string name="tts_source_device">Dispositivo (integrado)</string>
+    <string name="tts_source_server">Servidor</string>
+    <string name="tts_voice_label">Voz</string>
+    <string name="tts_engine_label">Motor</string>
+    <string name="tts_system_default">Predeterminado del sistema</string>
+    <string name="tts_speech_rate">Velocidad de habla: %1$.1fx</string>
+    <string name="tts_pitch">Tono: %1$.1f</string>
+    <string name="tts_cache_audio">Almacenar audio en caché</string>
+    <string name="tts_preview_text">Esta es una vista previa de la voz seleccionada.</string>
+    <string name="tts_stop_preview">Detener vista previa</string>
+    <string name="tts_preview_voice">Previsualizar voz</string>
+
+    <!-- Memories -->
+    <string name="enable_memories">Activar recuerdos</string>
+    <string name="enable_memories_desc">Permitir que la IA recuerde información entre conversaciones</string>
+    <string name="no_memories_saved">Aún no hay recuerdos guardados</string>
+    <string name="memories_add_hint">Toca el botón + para añadir un recuerdo</string>
+    <string name="add_memory">Añadir recuerdo</string>
+    <string name="edit_memory">Editar recuerdo</string>
+    <string name="dialog_title_delete_memory">Eliminar recuerdo</string>
+    <string name="dialog_delete_memory_message">¿Seguro que quieres eliminar el recuerdo \"%1$s\"?</string>
+    <string name="memory_key_label">Clave</string>
+    <string name="memory_value_label">Valor</string>
+
+    <!-- MCP -->
+    <string name="add_mcp_server">Añadir servidor MCP</string>
+    <string name="edit_mcp_server">Editar servidor MCP</string>
+    <string name="mcp_not_available">MCP no está disponible en este servidor</string>
+    <string name="no_mcp_servers">No hay servidores MCP configurados</string>
+    <string name="mcp_add_hint">Toca el botón + para añadir un servidor</string>
+    <string name="mcp_name_label">Nombre</string>
+    <string name="mcp_description_label">Descripción</string>
+    <string name="mcp_description_optional">Opcional</string>
+    <string name="mcp_url_label">URL</string>
+    <string name="mcp_type_label">Tipo</string>
+    <string name="mcp_type_sse">SSE</string>
+    <string name="mcp_type_streamable_http">HTTP transmisible</string>
+    <string name="mcp_auth_label">Autenticación</string>
+    <string name="mcp_auth_none">Ninguna</string>
+    <string name="mcp_auth_api_key">Clave de API</string>
+    <string name="mcp_auth_oauth">OAuth</string>
+    <string name="mcp_auth_key_type">Tipo de clave</string>
+    <string name="mcp_auth_bearer">Bearer</string>
+    <string name="mcp_auth_basic">Básica</string>
+    <string name="mcp_auth_custom">Personalizada</string>
+    <string name="mcp_header_name_label">Nombre del encabezado</string>
+    <string name="mcp_header_name_placeholder">X-API-Key</string>
+    <string name="mcp_api_key_label">Clave de API</string>
+    <string name="mcp_oauth_client_id">ID de cliente</string>
+    <string name="mcp_oauth_client_secret">Secreto de cliente</string>
+    <string name="mcp_oauth_auth_url">URL de autorización</string>
+    <string name="mcp_oauth_token_url">URL del token</string>
+    <string name="mcp_oauth_scope">Ámbito</string>
+    <string name="mcp_oauth_scope_placeholder">read execute</string>
+    <string name="dialog_title_delete_server">Eliminar servidor</string>
+    <string name="dialog_delete_server_message">¿Seguro que quieres eliminar \"%1$s\"?</string>
+    <string name="error_failed_to_load_servers">Error al cargar los servidores</string>
+    <string name="mcp_tools_count">%1$d herramienta%2$s</string>
+    <string name="mcp_tools_available">%1$d herramienta%2$s disponible</string>
+    <string name="mcp_all_tools">Todas las herramientas MCP</string>
+    <string name="mcp_tools_for_server">Herramientas: %1$s</string>
+    <string name="no_tools_available">No hay herramientas disponibles</string>
+    <string name="mcp_tool_server">Servidor: %1$s</string>
+
+    <!-- MCP tools sheet -->
+    <string name="mcp_server_unknown">Desconocido</string>
+
+    <!-- Fork settings -->
+    <string name="fork_mode_direct_path">Mensajes visibles</string>
+    <string name="fork_mode_direct_path_desc">Solo la ruta directa de mensajes hasta el mensaje seleccionado</string>
+    <string name="fork_mode_include_branches">Incluir ramas</string>
+    <string name="fork_mode_include_branches_desc">Ruta directa más los mensajes hermanos en cada nivel</string>
+    <string name="fork_mode_target_level">Todo hasta el nivel objetivo</string>
+    <string name="fork_mode_target_level_desc">Todos los mensajes y ramas hasta el nivel del mensaje objetivo (predeterminado)</string>
+
+    <!-- Language selector -->
+    <string name="hint_search_languages">Buscar idiomas</string>
+
+    <!-- Personalization dialog -->
+    <string name="enable_personalization">Activar personalización</string>
+    <string name="about_you_label">Sobre ti</string>
+    <string name="about_you_hint">¿Qué debería saber la IA sobre ti para tener contexto?</string>
+    <string name="response_style_label">¿Cómo debería responder la IA?</string>
+    <string name="response_style_hint">Tono, formato o estilo preferido para las respuestas</string>
+
+    <!-- Commands screen -->
+    <string name="no_commands_available">No hay comandos disponibles</string>
+
+    <!-- Avatar upload dialog -->
+    <string name="dialog_title_update_avatar">Actualizar avatar</string>
+    <string name="avatar_choose_hint">Toca el icono de la cámara para elegir una imagen</string>
+
+    <!-- API Keys screen -->
+    <string name="api_keys_not_available">Claves de API no disponibles</string>
+    <string name="api_keys_not_supported">Esta función no es compatible con la versión de tu servidor.</string>
+    <string name="no_api_keys">No hay claves de API</string>
+    <string name="no_api_keys_desc">Crea una clave de API para acceder a la API de forma programática.</string>
+    <string name="dialog_title_delete_api_key">Eliminar clave de API</string>
+    <string name="dialog_delete_api_key_message">¿Seguro que quieres eliminar la clave de API \"%1$s\"? Esta acción no se puede deshacer.</string>
+    <string name="created_prefix">Creada: %1$s</string>
+
+    <!-- API Key create dialog -->
+    <string name="dialog_title_create_api_key">Crear clave de API</string>
+    <string name="api_key_name_hint">Asigna a tu clave de API un nombre descriptivo para ayudar a identificar su propósito.</string>
+    <string name="hint_key_name">Nombre de la clave</string>
+    <string name="hint_key_name_placeholder">p. ej. Mi app</string>
+    <string name="dialog_title_api_key_created">Clave de API creada</string>
+    <string name="api_key_created_warning">Tu clave de API se ha creado. Cópiala ahora — no podrás volver a verla.</string>
+    <string name="copied_to_clipboard">Copiado al portapapeles</string>
+
+    <!-- Preset manager -->
+    <string name="no_presets">No hay preajustes</string>
+    <string name="no_presets_desc">Guarda preajustes desde la pantalla de chat para gestionarlos aquí</string>
+    <string name="dialog_title_delete_preset">Eliminar preajuste</string>
+    <string name="dialog_delete_preset_message">¿Seguro que quieres eliminar \"%1$s\"?</string>
+
+    <!-- Shared links -->
+    <string name="no_shared_links">No hay enlaces compartidos</string>
+    <string name="no_shared_links_desc">Comparte una conversación para verla aquí</string>
+    <string name="dialog_title_delete_shared_link">Eliminar enlace compartido</string>
+    <string name="dialog_delete_shared_link_message">Esto eliminará el enlace compartido de \"%1$s\". Las personas que tengan el enlace ya no podrán acceder a él.</string>
+    <string name="visibility_public">Público</string>
+    <string name="visibility_private">Privado</string>
+    <string name="error_failed_to_load_memories">Error al cargar los recuerdos</string>
+
+    <!-- Provider API Keys -->
+    <string name="provider_keys_title">Claves de API de proveedores</string>
+    <string name="provider_keys_subtitle">Establece tus propias claves para los endpoints que las requieran</string>
+    <string name="provider_keys_dialog_title">Establecer clave de API para %1$s</string>
+    <string name="provider_keys_status_set_expires">Caduca en %1$s</string>
+    <string name="provider_keys_status_set_never">Tu clave nunca caducará</string>
+    <string name="provider_keys_status_unset">No establecida</string>
+    <string name="provider_keys_status_expired">Caducada</string>
+    <string name="provider_keys_status_loading">Comprobando el estado de la clave…</string>
+    <string name="provider_keys_field_api_key_label">Clave</string>
+    <string name="provider_keys_field_base_url_label">URL base</string>
+    <string name="provider_keys_field_base_url_optional_suffix">(Opcional)</string>
+    <string name="provider_keys_field_api_key_for_endpoint">Clave de API de %1$s</string>
+    <string name="provider_keys_field_api_url_for_endpoint">URL de API de %1$s</string>
+
+    <string name="provider_keys_field_azure_api_key">Clave de API de Azure OpenAI</string>
+    <string name="provider_keys_field_azure_instance">Nombre de instancia de Azure</string>
+    <string name="provider_keys_field_azure_deployment">Nombre de implementación de Azure</string>
+    <string name="provider_keys_field_azure_api_version">Versión de API de Azure</string>
+
+    <string name="provider_keys_field_google_api_key">Clave de API de Google</string>
+    <string name="provider_keys_field_google_gemini_api">(API de Gemini)</string>
+    <string name="provider_keys_field_google_service_key">Clave de cuenta de servicio de Google</string>
+    <string name="provider_keys_field_google_import">Importar clave JSON de cuenta de servicio.</string>
+    <string name="provider_keys_field_google_invalid">Clave JSON de cuenta de servicio no válida. ¿Importaste el archivo correcto?</string>
+    <string name="provider_keys_field_google_imported">Clave JSON de cuenta de servicio importada correctamente</string>
+    <string name="provider_keys_field_google_paste_label">O pega el JSON de la cuenta de servicio</string>
+    <string name="provider_keys_field_google_paste_only_hint">Pega abajo el JSON de la cuenta de servicio.</string>
+    <string name="provider_keys_field_google_service_key_or_gemini">Clave de servicio de Google o clave de API de Gemini</string>
+
+    <string name="provider_keys_field_bedrock_access_key_id">ID de clave de acceso</string>
+    <string name="provider_keys_field_bedrock_secret_access_key">Clave de acceso secreta</string>
+    <string name="provider_keys_field_bedrock_session_token">Token de sesión</string>
+    <string name="provider_keys_field_bedrock_session_token_optional_suffix">(Opcional)</string>
+
+    <string name="provider_keys_required_fields">Los siguientes campos son obligatorios: %1$s</string>
+    <string name="provider_keys_revoke">Revocar</string>
+    <string name="provider_keys_revoke_failed">Error al revocar la clave de API. Inténtalo de nuevo.</string>
+    <string name="provider_keys_revoke_success">Clave de API revocada correctamente</string>
+    <string name="provider_keys_revoke_all">Revocar claves</string>
+    <string name="provider_keys_revoke_all_confirm">¿Seguro que quieres revocar todas las claves?</string>
+    <string name="provider_keys_revoke_all_failed">Error al revocar todas las claves</string>
+    <string name="provider_keys_save_failed">Error al guardar la clave de API. Inténtalo de nuevo.</string>
+    <string name="provider_keys_save_success">Clave de API guardada correctamente</string>
+
+    <string name="provider_keys_expiry_label">Caduca</string>
+    <string name="provider_keys_expiry_30m">en 30 minutos</string>
+    <string name="provider_keys_expiry_2h">en 2 horas</string>
+    <string name="provider_keys_expiry_12h">en 12 horas</string>
+    <string name="provider_keys_expiry_1d">en 1 día</string>
+    <string name="provider_keys_expiry_7d">en 7 días</string>
+    <string name="provider_keys_expiry_30d">en 30 días</string>
+    <string name="provider_keys_expiry_never">nunca</string>
+
+    <string name="provider_keys_empty_title">Ningún endpoint requiere claves proporcionadas por el usuario</string>
+    <string name="provider_keys_empty_desc">Los endpoints que necesiten tu propia clave de API aparecerán aquí.</string>
+    <string name="provider_keys_revoke_all_action">Revocar todo</string>
+
+    <!-- Admin: role skill access -->
+    <string name="role_skills_settings_row">Acceso a habilidades (admin)</string>
+    <string name="role_skills_title">Acceso a habilidades</string>
+    <string name="role_skills_back">Atrás</string>
+    <string name="role_skills_description">Controla qué capacidades de habilidades tiene cada rol. Los cambios se aplican a todos los usuarios con el rol seleccionado.</string>
+    <string name="role_skills_role_label">Rol</string>
+    <string name="role_skills_use">Usar habilidades</string>
+    <string name="role_skills_create">Crear y editar habilidades</string>
+    <string name="role_skills_share">Compartir habilidades</string>
+    <string name="role_skills_share_public">Compartir habilidades públicamente</string>
+    <string name="role_skills_save">Guardar</string>
+</resources>

--- a/feature/settings/src/commonMain/composeResources/values-fr/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-fr/strings.xml
@@ -1,0 +1,488 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Common actions -->
+    <string name="action_add">Ajouter</string>
+    <string name="action_cancel">Annuler</string>
+    <string name="action_clear">Effacer</string>
+    <string name="action_confirm">Confirmer</string>
+    <string name="action_creating">Création…</string>
+    <string name="action_create">Créer</string>
+    <string name="action_delete">Supprimer</string>
+    <string name="action_done">Terminé</string>
+    <string name="action_retry">Réessayer</string>
+    <string name="action_revoke_all">Tout révoquer</string>
+    <string name="action_save">Enregistrer</string>
+    <string name="action_sign_out">Se déconnecter</string>
+    <string name="action_upload">Téléverser</string>
+    <string name="action_uploading">Téléversement…</string>
+    <string name="action_verify">Vérifier</string>
+    <string name="action_verifying">Vérification…</string>
+
+    <!-- Content descriptions -->
+    <string name="cd_add_memory">Ajouter une mémoire</string>
+    <string name="cd_add_server">Ajouter un serveur</string>
+    <string name="cd_back">Retour</string>
+    <string name="cd_change_avatar">Changer l\'avatar</string>
+    <string name="cd_choose_image">Choisir une image</string>
+    <string name="cd_collapse_tools">Réduire les outils</string>
+    <string name="cd_copy_api_key">Copier la clé API</string>
+    <string name="cd_copy_link">Copier le lien</string>
+    <string name="cd_create_api_key">Créer une clé API</string>
+    <string name="cd_current_avatar">Avatar actuel</string>
+    <string name="cd_delete">Supprimer</string>
+    <string name="cd_delete_api_key">Supprimer la clé API</string>
+    <string name="cd_delete_memory">Supprimer la mémoire</string>
+    <string name="cd_delete_preset">Supprimer le préréglage</string>
+    <string name="cd_delete_server">Supprimer le serveur</string>
+    <string name="cd_delete_shared_link">Supprimer le lien partagé</string>
+    <string name="cd_edit">Modifier</string>
+    <string name="cd_edit_memory">Modifier la mémoire</string>
+    <string name="cd_edit_server">Modifier le serveur</string>
+    <string name="cd_expand_tools">Développer les outils</string>
+    <string name="cd_loading_profile">Chargement du profil</string>
+    <string name="cd_make_private">Rendre privé</string>
+    <string name="cd_make_public">Rendre public</string>
+    <string name="cd_preview_voice">Aperçu de la voix</string>
+    <string name="cd_qr_code">Code QR pour l\'application d\'authentification</string>
+    <string name="cd_reinitialize">Réinitialiser</string>
+    <string name="cd_avatar_preview">Aperçu de l\'avatar</string>
+    <string name="cd_selected">Sélectionné</string>
+    <string name="cd_selected_avatar">Avatar sélectionné</string>
+    <string name="cd_stop_voice_preview">Arrêter l\'aperçu de la voix</string>
+    <string name="cd_test_tts_voice">Tester la voix TTS sélectionnée</string>
+    <string name="cd_toggle_auto_read">Activer/désactiver la lecture automatique des réponses</string>
+    <string name="cd_toggle_auto_send_stt">Activer/désactiver l\'envoi automatique après la dictée</string>
+    <string name="cd_toggle_memories">Activer/désactiver les mémoires</string>
+    <string name="cd_tts_voice_selector">Sélectionner la voix TTS. Actuellement %1$s</string>
+    <string name="cd_user_avatar">Avatar de l\'utilisateur</string>
+    <string name="cd_view_all_tools">Voir tous les outils</string>
+    <string name="cd_view_tools">Voir les outils</string>
+
+    <!-- Section headers -->
+    <string name="section_about">À propos</string>
+    <string name="section_account">Compte</string>
+    <string name="section_advanced">Avancé</string>
+    <string name="section_appearance">Apparence</string>
+    <string name="section_balance">Solde</string>
+    <string name="section_chat_preferences">Préférences de discussion</string>
+    <string name="section_conversations">Conversations</string>
+    <string name="section_danger_zone">Zone de danger</string>
+    <string name="section_data_management">Gestion des données</string>
+    <string name="section_general">Général</string>
+    <string name="section_language">Langue</string>
+    <string name="section_layout">Disposition</string>
+    <string name="section_mcp_servers">Serveurs MCP</string>
+    <string name="section_memories">Mémoires</string>
+    <string name="section_personalization">Personnalisation</string>
+    <string name="section_presets">Préréglages</string>
+    <string name="section_profile">Profil</string>
+    <string name="section_security">Sécurité</string>
+    <string name="section_speech">Voix</string>
+    <string name="section_tablet">Tablette</string>
+
+    <!-- Screen titles -->
+    <string name="title_account">Compte</string>
+    <string name="title_api_keys">Clés API</string>
+    <string name="title_chat">Discussion</string>
+    <string name="title_commands">Commandes</string>
+    <string name="title_data">Données</string>
+    <string name="title_general">Général</string>
+    <string name="title_memories">Mémoires</string>
+    <string name="title_mcp_servers">Serveurs MCP</string>
+    <string name="title_presets">Préréglages</string>
+    <string name="title_settings">Paramètres</string>
+    <string name="title_shared_links">Liens partagés</string>
+
+    <!-- Tabbed settings tabs -->
+    <string name="tab_general">Général</string>
+    <string name="tab_chat">Discussion</string>
+    <string name="tab_account">Compte</string>
+    <string name="tab_data">Données</string>
+
+    <!-- Theme -->
+    <string name="theme_system">Par défaut du système</string>
+    <string name="theme_light">Clair</string>
+    <string name="theme_dark">Sombre</string>
+
+    <!-- Accent color -->
+    <string name="accent_color">Couleur d\'accentuation</string>
+    <string name="accent_color_custom">Personnalisée</string>
+    <string name="accent_color_hex">Hex</string>
+    <string name="use_wallpaper_colors">Utiliser les couleurs du fond d\'écran</string>
+    <string name="use_wallpaper_colors_desc">Adapter l\'accentuation de l\'application au fond d\'écran du système (Material You)</string>
+
+    <!-- Settings rows -->
+    <string name="language">Langue</string>
+    <string name="language_system_default">Par défaut du système</string>
+    <string name="personalization">Personnalisation</string>
+    <string name="status_enabled">Activé</string>
+    <string name="status_disabled">Désactivé</string>
+    <string name="fork_behavior">Comportement de bifurcation</string>
+    <string name="commands">Commandes</string>
+    <string name="commands_enabled_count">%1$d activée(s)</string>
+    <string name="api_keys">Clés API</string>
+    <string name="api_keys_subtitle">Gérer les clés API pour l\'accès programmatique</string>
+    <string name="presets">Préréglages</string>
+    <string name="presets_subtitle">Gérer les préréglages de conversation</string>
+    <string name="favorites">Favoris</string>
+    <string name="favorites_subtitle">Gérer les agents et modèles épinglés</string>
+    <string name="favorites_title">Favoris</string>
+    <string name="favorites_empty_title">Aucun favori pour l\'instant</string>
+    <string name="favorites_empty_message">Épinglez des agents ou des modèles depuis le sélecteur de modèle pour les voir ici.</string>
+    <string name="favorites_count_of">%1$d sur %2$d</string>
+    <string name="favorites_unpin_cd">Désépingler le favori</string>
+
+    <!-- About info -->
+    <string name="app_version_label">Version de l\'application</string>
+    <string name="app_build_label">Build</string>
+    <string name="server_label">Serveur</string>
+    <string name="server_not_configured">Non configuré</string>
+    <string name="server_build_commit_label">Commit du serveur</string>
+    <string name="server_build_branch_label">Branche du serveur</string>
+    <string name="server_build_date_label">Date de build du serveur</string>
+
+    <!-- Tablet settings -->
+    <string name="sidebar_swipe_gesture">Geste de balayage de la barre latérale</string>
+    <string name="sidebar_swipe_gesture_desc">Balayez depuis le bord gauche pour ouvrir la barre latérale sur les dispositions de tablette</string>
+
+    <!-- Balance -->
+    <string name="token_credits">Crédits de jetons</string>
+    <string name="available_balance">Solde disponible</string>
+    <string name="cd_token_balance">Solde de jetons : %1$s crédits</string>
+
+    <!-- Chat settings -->
+    <string name="chat_layout">Disposition de la discussion</string>
+    <string name="chat_layout_thread">Fil</string>
+    <string name="chat_layout_two_sided">Discussion à deux côtés</string>
+    <string name="chat_layout_thread_desc">Tous les messages alignés à gauche avec avatar et nom</string>
+    <string name="chat_layout_two_sided_desc">Messages de l\'utilisateur à droite, agent à gauche</string>
+    <string name="show_bubbles">Afficher les bulles</string>
+    <string name="show_bubbles_desc">Ajouter des arrière-plans en bulles arrondies aux messages</string>
+    <string name="show_avatars">Afficher les avatars</string>
+    <string name="show_avatars_desc">Afficher les avatars de l\'utilisateur et de l\'agent à côté des messages</string>
+    <string name="starred_models_title">Modèles favoris</string>
+    <string name="starred_models_desc">Afficher vos modèles et agents épinglés en haut du sélecteur de modèle</string>
+    <string name="starred_models_off">Désactivé</string>
+    <string name="starred_models_grouped">Groupe repliable en haut</string>
+    <string name="starred_models_top">En haut, sans regroupement</string>
+    <string name="font_size">Taille de police</string>
+    <string name="font_size_small">Petite</string>
+    <string name="font_size_medium">Moyenne</string>
+    <string name="font_size_large">Grande</string>
+    <string name="latex_renderer">Moteur de rendu LaTeX</string>
+    <string name="latex_katex">KaTeX (rendu)</string>
+    <string name="latex_katex_desc">Rendu LaTeX complet via WebView</string>
+    <string name="latex_native">Texte brut (rapide)</string>
+    <string name="latex_native_desc">Affiche la source LaTeX brute pour de meilleures performances de défilement</string>
+    <string name="auto_scroll">Défilement automatique pendant le streaming</string>
+    <string name="auto_scroll_desc">Faire défiler automatiquement vers le nouveau contenu pendant la génération d\'une réponse</string>
+    <string name="show_thinking_blocks">Afficher les blocs de réflexion</string>
+    <string name="show_thinking_blocks_desc">Afficher les étapes de raisonnement du modèle lorsqu\'elles sont disponibles</string>
+    <string name="show_image_descriptions">Afficher les descriptions d\'images</string>
+    <string name="show_image_descriptions_desc">Afficher les invites d\'image générées par l\'IA sous les images</string>
+    <string name="dismiss_keyboard_on_send">Masquer le clavier après l\'envoi</string>
+    <string name="dismiss_keyboard_on_send_desc">Masquer automatiquement le clavier après l\'envoi d\'un message</string>
+
+    <!-- Artifacts -->
+    <string name="section_artifacts">Artefacts</string>
+    <string name="artifacts_section_desc">Afficher les artefacts directement dans la discussion au lieu d\'une carte à ouvrir d\'une pression. Appuyez sur un artefact intégré pour ouvrir l\'affichage plein écran.</string>
+    <string name="inline_artifact_mermaid">Diagrammes Mermaid</string>
+    <string name="inline_artifact_mermaid_desc">Afficher les organigrammes et diagrammes Mermaid en ligne</string>
+    <string name="inline_artifact_svg">Images SVG</string>
+    <string name="inline_artifact_svg_desc">Afficher les images vectorielles SVG en ligne</string>
+    <string name="inline_artifact_html">HTML</string>
+    <string name="inline_artifact_html_desc">Afficher les pages HTML en ligne (charge Tailwind depuis le CDN)</string>
+    <string name="inline_artifact_react">Composants React</string>
+    <string name="inline_artifact_react_desc">Afficher les composants React en ligne (charge React + Babel depuis le CDN)</string>
+    <string name="inline_artifact_markdown">Documents Markdown</string>
+    <string name="inline_artifact_markdown_desc">Afficher les artefacts Markdown en ligne avec des blocs de code à coloration syntaxique</string>
+
+    <!-- Security -->
+    <string name="two_factor_auth">Authentification à deux facteurs</string>
+    <string name="enable_two_factor">Activer l\'authentification à deux facteurs</string>
+    <string name="disable_two_factor">Désactiver l\'authentification à deux facteurs</string>
+    <string name="view_backup_codes">Voir les codes de secours</string>
+
+    <!-- 2FA setup dialog -->
+    <string name="dialog_title_enable_2fa">Activer l\'authentification à deux facteurs</string>
+    <string name="dialog_title_disable_2fa">Désactiver l\'authentification à deux facteurs</string>
+    <string name="twofa_scan_instructions">Copiez l\'URI ci-dessous et collez-le dans votre application d\'authentification (par ex. Google Authenticator, Authy), puis saisissez le code de vérification.</string>
+    <string name="twofa_disable_instructions">Saisissez le code de votre application d\'authentification pour désactiver la 2FA.</string>
+    <string name="hint_verification_code">Code de vérification</string>
+
+    <!-- OTP verification dialogs -->
+    <string name="otp_title_verify_identity">Vérifier l\'identité</string>
+    <string name="otp_desc_delete_account">Saisissez votre code 2FA pour supprimer votre compte.</string>
+    <string name="otp_desc_reenroll_2fa">Saisissez votre code 2FA actuel pour vous réinscrire.</string>
+    <string name="otp_desc_regenerate_backup_codes">Saisissez votre code 2FA pour régénérer les codes de secours.</string>
+    <string name="otp_verify">Vérifier</string>
+    <string name="otp_cancel">Annuler</string>
+    <string name="otp_backup_code_label">Code de secours</string>
+    <string name="otp_use_backup_code">Utiliser plutôt un code de secours</string>
+    <string name="otp_use_otp_code">Utiliser plutôt un code OTP</string>
+
+    <!-- Backup codes dialog -->
+    <string name="dialog_title_backup_codes">Codes de secours</string>
+    <string name="backup_codes_instructions">Conservez ces codes de secours en lieu sûr. Chaque code ne peut être utilisé qu\'une seule fois.</string>
+
+    <!-- Danger zone -->
+    <string name="delete_account">Supprimer le compte</string>
+    <string name="dialog_title_sign_out">Se déconnecter</string>
+    <string name="dialog_sign_out_message">Voulez-vous vraiment vous déconnecter ?</string>
+    <string name="dialog_title_delete_account">Supprimer le compte</string>
+    <string name="dialog_delete_account_message">Cette action est irréversible. Toutes vos données seront définitivement supprimées.</string>
+
+    <!-- Clear cache dialog -->
+    <string name="dialog_title_clear_cache">Vider le cache</string>
+    <string name="dialog_clear_cache_message">Ceci effacera les images en cache et les données temporaires. Les données de votre compte ne seront pas affectées.</string>
+
+    <!-- Revoke keys dialog -->
+    <string name="dialog_title_revoke_keys">Révoquer toutes les clés API</string>
+    <string name="dialog_revoke_keys_message">Ceci révoquera toutes vos clés API enregistrées. Vous devrez les saisir à nouveau pour continuer à utiliser les services externes.</string>
+
+    <!-- Data settings -->
+    <string name="clear_all_conversations">Effacer toutes les conversations</string>
+    <string name="clearing">Effacement…</string>
+    <string name="archived_conversations">Conversations archivées</string>
+    <string name="export_all_data">Exporter toutes les données</string>
+    <string name="shared_links">Liens partagés</string>
+    <string name="clear_cache">Vider le cache</string>
+    <string name="revoke_all_api_keys">Révoquer toutes les clés API</string>
+    <string name="revoking">Révocation…</string>
+    <string name="dialog_title_clear_conversations">Effacer toutes les conversations</string>
+    <string name="dialog_clear_conversations_message">Ceci supprimera définitivement toutes vos conversations. Cette action est irréversible.</string>
+    <string name="clear_all">Tout effacer</string>
+    <string name="export_coming_soon">L\'exportation arrive bientôt</string>
+    <string name="error_could_not_load_settings">Impossible de charger les paramètres</string>
+
+    <!-- Diagnostic logs (issue #96) -->
+    <string name="section_diagnostic_logs">Journaux de diagnostic</string>
+    <string name="export_diagnostic_logs">Exporter les journaux de diagnostic</string>
+    <string name="export_diagnostic_logs_with_size">Exporter les journaux de diagnostic (%1$s)</string>
+    <string name="exporting_logs">Exportation…</string>
+    <string name="clear_diagnostic_logs">Effacer les journaux de diagnostic</string>
+    <string name="clearing_logs">Effacement…</string>
+    <string name="logs_exported">Journaux de diagnostic exportés</string>
+    <string name="dialog_title_clear_logs">Effacer les journaux de diagnostic</string>
+    <string name="dialog_clear_logs_message">Ceci supprimera définitivement tous les journaux de diagnostic stockés sur cet appareil. Cette action est irréversible.</string>
+
+    <!-- Speech settings -->
+    <string name="auto_send_after_speech">Envoi automatique après la dictée</string>
+    <string name="auto_send_after_speech_desc">Envoyer automatiquement le message après la fin de la reconnaissance vocale</string>
+    <string name="auto_read_responses">Lecture automatique des réponses</string>
+    <string name="auto_read_responses_desc">Lire automatiquement les réponses de l\'IA à voix haute via la synthèse vocale</string>
+    <string name="tts_voice">Voix TTS</string>
+    <string name="test_voice">Tester la voix</string>
+    <string name="no_server_tts_voices">Aucune voix TTS de serveur disponible. Les fonctions vocales ne sont peut-être pas configurées sur le serveur.</string>
+    <string name="using_device_tts">Utilisation du moteur de synthèse vocale de l\'appareil. Configurez la voix et la vitesse dans les Paramètres de synthèse vocale ci-dessous.</string>
+    <string name="speech_to_text_settings">Paramètres de reconnaissance vocale</string>
+    <string name="text_to_speech_settings">Paramètres de synthèse vocale</string>
+
+    <!-- STT detail dialog -->
+    <string name="stt_engine_label">Moteur</string>
+    <string name="stt_language_label">Langue</string>
+    <string name="stt_on_device">Sur l\'appareil</string>
+    <string name="stt_default">Par défaut</string>
+    <string name="stt_hint_whisper">Whisper utilise la transcription côté serveur. La reconnaissance vocale doit être activée sur votre serveur.</string>
+    <string name="stt_hint_device">Utilise le système de reconnaissance vocale intégré de votre appareil. Fonctionne hors ligne sur les appareils pris en charge.</string>
+    <string name="stt_hint_google">Utilise le système de reconnaissance vocale de Google. Nécessite l\'installation de l\'application Google.</string>
+    <string name="stt_hint_default">Utilise la transcription du serveur (Whisper) lorsqu\'elle est disponible, sinon revient à la reconnaissance sur l\'appareil.</string>
+    <string name="stt_auto_detect">Détection automatique</string>
+
+    <!-- TTS detail dialog -->
+    <string name="tts_source_label">Source</string>
+    <string name="tts_source_device">Appareil (intégré)</string>
+    <string name="tts_source_server">Serveur</string>
+    <string name="tts_voice_label">Voix</string>
+    <string name="tts_engine_label">Moteur</string>
+    <string name="tts_system_default">Par défaut du système</string>
+    <string name="tts_speech_rate">Débit de parole : %1$.1fx</string>
+    <string name="tts_pitch">Hauteur : %1$.1f</string>
+    <string name="tts_cache_audio">Mettre l\'audio en cache</string>
+    <string name="tts_preview_text">Ceci est un aperçu de la voix sélectionnée.</string>
+    <string name="tts_stop_preview">Arrêter l\'aperçu</string>
+    <string name="tts_preview_voice">Aperçu de la voix</string>
+
+    <!-- Memories -->
+    <string name="enable_memories">Activer les mémoires</string>
+    <string name="enable_memories_desc">Permettre à l\'IA de mémoriser des informations entre les conversations</string>
+    <string name="no_memories_saved">Aucune mémoire enregistrée pour l\'instant</string>
+    <string name="memories_add_hint">Appuyez sur le bouton + pour ajouter une mémoire</string>
+    <string name="add_memory">Ajouter une mémoire</string>
+    <string name="edit_memory">Modifier la mémoire</string>
+    <string name="dialog_title_delete_memory">Supprimer la mémoire</string>
+    <string name="dialog_delete_memory_message">Voulez-vous vraiment supprimer la mémoire \"%1$s\" ?</string>
+    <string name="memory_key_label">Clé</string>
+    <string name="memory_value_label">Valeur</string>
+
+    <!-- MCP -->
+    <string name="add_mcp_server">Ajouter un serveur MCP</string>
+    <string name="edit_mcp_server">Modifier le serveur MCP</string>
+    <string name="mcp_not_available">MCP n\'est pas disponible sur ce serveur</string>
+    <string name="no_mcp_servers">Aucun serveur MCP configuré</string>
+    <string name="mcp_add_hint">Appuyez sur le bouton + pour ajouter un serveur</string>
+    <string name="mcp_name_label">Nom</string>
+    <string name="mcp_description_label">Description</string>
+    <string name="mcp_description_optional">Facultatif</string>
+    <string name="mcp_url_label">URL</string>
+    <string name="mcp_type_label">Type</string>
+    <string name="mcp_type_sse">SSE</string>
+    <string name="mcp_type_streamable_http">Streamable HTTP</string>
+    <string name="mcp_auth_label">Authentification</string>
+    <string name="mcp_auth_none">Aucune</string>
+    <string name="mcp_auth_api_key">Clé API</string>
+    <string name="mcp_auth_oauth">OAuth</string>
+    <string name="mcp_auth_key_type">Type de clé</string>
+    <string name="mcp_auth_bearer">Bearer</string>
+    <string name="mcp_auth_basic">Basic</string>
+    <string name="mcp_auth_custom">Personnalisé</string>
+    <string name="mcp_header_name_label">Nom de l\'en-tête</string>
+    <string name="mcp_header_name_placeholder">X-API-Key</string>
+    <string name="mcp_api_key_label">Clé API</string>
+    <string name="mcp_oauth_client_id">ID client</string>
+    <string name="mcp_oauth_client_secret">Secret client</string>
+    <string name="mcp_oauth_auth_url">URL d\'autorisation</string>
+    <string name="mcp_oauth_token_url">URL du jeton</string>
+    <string name="mcp_oauth_scope">Portée</string>
+    <string name="mcp_oauth_scope_placeholder">read execute</string>
+    <string name="dialog_title_delete_server">Supprimer le serveur</string>
+    <string name="dialog_delete_server_message">Voulez-vous vraiment supprimer \"%1$s\" ?</string>
+    <string name="error_failed_to_load_servers">Échec du chargement des serveurs</string>
+    <string name="mcp_tools_count">%1$d outil%2$s</string>
+    <string name="mcp_tools_available">%1$d outil%2$s disponible(s)</string>
+    <string name="mcp_all_tools">Tous les outils MCP</string>
+    <string name="mcp_tools_for_server">Outils : %1$s</string>
+    <string name="no_tools_available">Aucun outil disponible</string>
+    <string name="mcp_tool_server">Serveur : %1$s</string>
+
+    <!-- MCP tools sheet -->
+    <string name="mcp_server_unknown">Inconnu</string>
+
+    <!-- Fork settings -->
+    <string name="fork_mode_direct_path">Messages visibles</string>
+    <string name="fork_mode_direct_path_desc">Uniquement le chemin direct des messages jusqu\'au message sélectionné</string>
+    <string name="fork_mode_include_branches">Inclure les branches</string>
+    <string name="fork_mode_include_branches_desc">Chemin direct plus les messages frères à chaque niveau</string>
+    <string name="fork_mode_target_level">Tout jusqu\'au niveau cible</string>
+    <string name="fork_mode_target_level_desc">Tous les messages et branches jusqu\'au niveau du message cible (par défaut)</string>
+
+    <!-- Language selector -->
+    <string name="hint_search_languages">Rechercher des langues</string>
+
+    <!-- Personalization dialog -->
+    <string name="enable_personalization">Activer la personnalisation</string>
+    <string name="about_you_label">À propos de vous</string>
+    <string name="about_you_hint">Que doit savoir l\'IA à votre sujet pour le contexte ?</string>
+    <string name="response_style_label">Comment l\'IA doit-elle répondre ?</string>
+    <string name="response_style_hint">Ton, format ou style préféré pour les réponses</string>
+
+    <!-- Commands screen -->
+    <string name="no_commands_available">Aucune commande disponible</string>
+
+    <!-- Avatar upload dialog -->
+    <string name="dialog_title_update_avatar">Mettre à jour l\'avatar</string>
+    <string name="avatar_choose_hint">Appuyez sur l\'icône de l\'appareil photo pour choisir une image</string>
+
+    <!-- API Keys screen -->
+    <string name="api_keys_not_available">Clés API non disponibles</string>
+    <string name="api_keys_not_supported">Cette fonctionnalité n\'est pas prise en charge sur la version de votre serveur.</string>
+    <string name="no_api_keys">Aucune clé API</string>
+    <string name="no_api_keys_desc">Créez une clé API pour accéder à l\'API de manière programmatique.</string>
+    <string name="dialog_title_delete_api_key">Supprimer la clé API</string>
+    <string name="dialog_delete_api_key_message">Voulez-vous vraiment supprimer la clé API \"%1$s\" ? Cette action est irréversible.</string>
+    <string name="created_prefix">Créée le : %1$s</string>
+
+    <!-- API Key create dialog -->
+    <string name="dialog_title_create_api_key">Créer une clé API</string>
+    <string name="api_key_name_hint">Donnez à votre clé API un nom descriptif pour mieux identifier son usage.</string>
+    <string name="hint_key_name">Nom de la clé</string>
+    <string name="hint_key_name_placeholder">par ex. Mon application</string>
+    <string name="dialog_title_api_key_created">Clé API créée</string>
+    <string name="api_key_created_warning">Votre clé API a été créée. Copiez-la maintenant — vous ne pourrez plus la revoir.</string>
+    <string name="copied_to_clipboard">Copié dans le presse-papiers</string>
+
+    <!-- Preset manager -->
+    <string name="no_presets">Aucun préréglage</string>
+    <string name="no_presets_desc">Enregistrez des préréglages depuis l\'écran de discussion pour les gérer ici</string>
+    <string name="dialog_title_delete_preset">Supprimer le préréglage</string>
+    <string name="dialog_delete_preset_message">Voulez-vous vraiment supprimer \"%1$s\" ?</string>
+
+    <!-- Shared links -->
+    <string name="no_shared_links">Aucun lien partagé</string>
+    <string name="no_shared_links_desc">Partagez une conversation pour la voir ici</string>
+    <string name="dialog_title_delete_shared_link">Supprimer le lien partagé</string>
+    <string name="dialog_delete_shared_link_message">Ceci supprimera le lien partagé pour \"%1$s\". Quiconque possède le lien ne pourra plus y accéder.</string>
+    <string name="visibility_public">Public</string>
+    <string name="visibility_private">Privé</string>
+    <string name="error_failed_to_load_memories">Échec du chargement des mémoires</string>
+
+    <!-- Provider API Keys -->
+    <string name="provider_keys_title">Clés API des fournisseurs</string>
+    <string name="provider_keys_subtitle">Définissez vos propres clés pour les points de terminaison qui les nécessitent</string>
+    <string name="provider_keys_dialog_title">Définir la clé API pour %1$s</string>
+    <string name="provider_keys_status_set_expires">Expire dans %1$s</string>
+    <string name="provider_keys_status_set_never">Votre clé n\'expirera jamais</string>
+    <string name="provider_keys_status_unset">Non définie</string>
+    <string name="provider_keys_status_expired">Expirée</string>
+    <string name="provider_keys_status_loading">Vérification du statut de la clé…</string>
+    <string name="provider_keys_field_api_key_label">Clé</string>
+    <string name="provider_keys_field_base_url_label">URL de base</string>
+    <string name="provider_keys_field_base_url_optional_suffix">(Facultatif)</string>
+    <string name="provider_keys_field_api_key_for_endpoint">Clé API %1$s</string>
+    <string name="provider_keys_field_api_url_for_endpoint">URL de l\'API %1$s</string>
+
+    <string name="provider_keys_field_azure_api_key">Clé API Azure OpenAI</string>
+    <string name="provider_keys_field_azure_instance">Nom de l\'instance Azure</string>
+    <string name="provider_keys_field_azure_deployment">Nom du déploiement Azure</string>
+    <string name="provider_keys_field_azure_api_version">Version de l\'API Azure</string>
+
+    <string name="provider_keys_field_google_api_key">Clé API Google</string>
+    <string name="provider_keys_field_google_gemini_api">(API Gemini)</string>
+    <string name="provider_keys_field_google_service_key">Clé de compte de service Google</string>
+    <string name="provider_keys_field_google_import">Importer la clé JSON du compte de service.</string>
+    <string name="provider_keys_field_google_invalid">Clé JSON de compte de service invalide. Avez-vous importé le bon fichier ?</string>
+    <string name="provider_keys_field_google_imported">Clé JSON de compte de service importée avec succès</string>
+    <string name="provider_keys_field_google_paste_label">Ou collez le JSON du compte de service</string>
+    <string name="provider_keys_field_google_paste_only_hint">Collez le JSON du compte de service ci-dessous.</string>
+    <string name="provider_keys_field_google_service_key_or_gemini">Clé de service Google ou clé API Gemini</string>
+
+    <string name="provider_keys_field_bedrock_access_key_id">ID de clé d\'accès</string>
+    <string name="provider_keys_field_bedrock_secret_access_key">Clé d\'accès secrète</string>
+    <string name="provider_keys_field_bedrock_session_token">Jeton de session</string>
+    <string name="provider_keys_field_bedrock_session_token_optional_suffix">(Facultatif)</string>
+
+    <string name="provider_keys_required_fields">Les champs suivants sont requis : %1$s</string>
+    <string name="provider_keys_revoke">Révoquer</string>
+    <string name="provider_keys_revoke_failed">Échec de la révocation de la clé API. Veuillez réessayer.</string>
+    <string name="provider_keys_revoke_success">Clé API révoquée avec succès</string>
+    <string name="provider_keys_revoke_all">Révoquer les clés</string>
+    <string name="provider_keys_revoke_all_confirm">Voulez-vous vraiment révoquer toutes les clés ?</string>
+    <string name="provider_keys_revoke_all_failed">Échec de la révocation de toutes les clés</string>
+    <string name="provider_keys_save_failed">Échec de l\'enregistrement de la clé API. Veuillez réessayer.</string>
+    <string name="provider_keys_save_success">Clé API enregistrée avec succès</string>
+
+    <string name="provider_keys_expiry_label">Expire</string>
+    <string name="provider_keys_expiry_30m">dans 30 minutes</string>
+    <string name="provider_keys_expiry_2h">dans 2 heures</string>
+    <string name="provider_keys_expiry_12h">dans 12 heures</string>
+    <string name="provider_keys_expiry_1d">dans 1 jour</string>
+    <string name="provider_keys_expiry_7d">dans 7 jours</string>
+    <string name="provider_keys_expiry_30d">dans 30 jours</string>
+    <string name="provider_keys_expiry_never">jamais</string>
+
+    <string name="provider_keys_empty_title">Aucun point de terminaison ne nécessite de clés fournies par l\'utilisateur</string>
+    <string name="provider_keys_empty_desc">Les points de terminaison qui nécessitent votre propre clé API apparaîtront ici.</string>
+    <string name="provider_keys_revoke_all_action">Tout révoquer</string>
+
+    <!-- Admin: role skill access -->
+    <string name="role_skills_settings_row">Accès aux compétences (admin)</string>
+    <string name="role_skills_title">Accès aux compétences</string>
+    <string name="role_skills_back">Retour</string>
+    <string name="role_skills_description">Contrôlez les capacités de compétences dont dispose chaque rôle. Les modifications s\'appliquent à tous les utilisateurs ayant le rôle sélectionné.</string>
+    <string name="role_skills_role_label">Rôle</string>
+    <string name="role_skills_use">Utiliser les compétences</string>
+    <string name="role_skills_create">Créer &amp; modifier des compétences</string>
+    <string name="role_skills_share">Partager des compétences</string>
+    <string name="role_skills_share_public">Partager des compétences publiquement</string>
+    <string name="role_skills_save">Enregistrer</string>
+</resources>

--- a/feature/settings/src/commonMain/composeResources/values-ja/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-ja/strings.xml
@@ -1,0 +1,488 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Common actions -->
+    <string name="action_add">追加</string>
+    <string name="action_cancel">キャンセル</string>
+    <string name="action_clear">クリア</string>
+    <string name="action_confirm">確認</string>
+    <string name="action_creating">作成中…</string>
+    <string name="action_create">作成</string>
+    <string name="action_delete">削除</string>
+    <string name="action_done">完了</string>
+    <string name="action_retry">再試行</string>
+    <string name="action_revoke_all">すべて取り消す</string>
+    <string name="action_save">保存</string>
+    <string name="action_sign_out">サインアウト</string>
+    <string name="action_upload">アップロード</string>
+    <string name="action_uploading">アップロード中…</string>
+    <string name="action_verify">確認</string>
+    <string name="action_verifying">確認中…</string>
+
+    <!-- Content descriptions -->
+    <string name="cd_add_memory">メモリを追加</string>
+    <string name="cd_add_server">サーバーを追加</string>
+    <string name="cd_back">戻る</string>
+    <string name="cd_change_avatar">アバターを変更</string>
+    <string name="cd_choose_image">画像を選択</string>
+    <string name="cd_collapse_tools">ツールを折りたたむ</string>
+    <string name="cd_copy_api_key">APIキーをコピー</string>
+    <string name="cd_copy_link">リンクをコピー</string>
+    <string name="cd_create_api_key">APIキーを作成</string>
+    <string name="cd_current_avatar">現在のアバター</string>
+    <string name="cd_delete">削除</string>
+    <string name="cd_delete_api_key">APIキーを削除</string>
+    <string name="cd_delete_memory">メモリを削除</string>
+    <string name="cd_delete_preset">プリセットを削除</string>
+    <string name="cd_delete_server">サーバーを削除</string>
+    <string name="cd_delete_shared_link">共有リンクを削除</string>
+    <string name="cd_edit">編集</string>
+    <string name="cd_edit_memory">メモリを編集</string>
+    <string name="cd_edit_server">サーバーを編集</string>
+    <string name="cd_expand_tools">ツールを展開</string>
+    <string name="cd_loading_profile">プロフィールを読み込み中</string>
+    <string name="cd_make_private">非公開にする</string>
+    <string name="cd_make_public">公開にする</string>
+    <string name="cd_preview_voice">音声をプレビュー</string>
+    <string name="cd_qr_code">認証アプリ用のQRコード</string>
+    <string name="cd_reinitialize">再初期化</string>
+    <string name="cd_avatar_preview">アバターのプレビュー</string>
+    <string name="cd_selected">選択済み</string>
+    <string name="cd_selected_avatar">選択されたアバター</string>
+    <string name="cd_stop_voice_preview">音声プレビューを停止</string>
+    <string name="cd_test_tts_voice">選択したTTS音声をテスト</string>
+    <string name="cd_toggle_auto_read">応答の自動読み上げを切り替え</string>
+    <string name="cd_toggle_auto_send_stt">音声入力後の自動送信を切り替え</string>
+    <string name="cd_toggle_memories">メモリを切り替え</string>
+    <string name="cd_tts_voice_selector">TTS音声を選択。現在は %1$s</string>
+    <string name="cd_user_avatar">ユーザーのアバター</string>
+    <string name="cd_view_all_tools">すべてのツールを表示</string>
+    <string name="cd_view_tools">ツールを表示</string>
+
+    <!-- Section headers -->
+    <string name="section_about">情報</string>
+    <string name="section_account">アカウント</string>
+    <string name="section_advanced">詳細設定</string>
+    <string name="section_appearance">外観</string>
+    <string name="section_balance">残高</string>
+    <string name="section_chat_preferences">チャット設定</string>
+    <string name="section_conversations">会話</string>
+    <string name="section_danger_zone">危険な操作</string>
+    <string name="section_data_management">データ管理</string>
+    <string name="section_general">一般</string>
+    <string name="section_language">言語</string>
+    <string name="section_layout">レイアウト</string>
+    <string name="section_mcp_servers">MCPサーバー</string>
+    <string name="section_memories">メモリ</string>
+    <string name="section_personalization">パーソナライズ</string>
+    <string name="section_presets">プリセット</string>
+    <string name="section_profile">プロフィール</string>
+    <string name="section_security">セキュリティ</string>
+    <string name="section_speech">音声</string>
+    <string name="section_tablet">タブレット</string>
+
+    <!-- Screen titles -->
+    <string name="title_account">アカウント</string>
+    <string name="title_api_keys">APIキー</string>
+    <string name="title_chat">チャット</string>
+    <string name="title_commands">コマンド</string>
+    <string name="title_data">データ</string>
+    <string name="title_general">一般</string>
+    <string name="title_memories">メモリ</string>
+    <string name="title_mcp_servers">MCPサーバー</string>
+    <string name="title_presets">プリセット</string>
+    <string name="title_settings">設定</string>
+    <string name="title_shared_links">共有リンク</string>
+
+    <!-- Tabbed settings tabs -->
+    <string name="tab_general">一般</string>
+    <string name="tab_chat">チャット</string>
+    <string name="tab_account">アカウント</string>
+    <string name="tab_data">データ</string>
+
+    <!-- Theme -->
+    <string name="theme_system">システムのデフォルト</string>
+    <string name="theme_light">ライト</string>
+    <string name="theme_dark">ダーク</string>
+
+    <!-- Accent color -->
+    <string name="accent_color">アクセントカラー</string>
+    <string name="accent_color_custom">カスタム</string>
+    <string name="accent_color_hex">16進数</string>
+    <string name="use_wallpaper_colors">壁紙の色を使用</string>
+    <string name="use_wallpaper_colors_desc">アプリのアクセントをシステムの壁紙に合わせます（Material You）</string>
+
+    <!-- Settings rows -->
+    <string name="language">言語</string>
+    <string name="language_system_default">システムのデフォルト</string>
+    <string name="personalization">パーソナライズ</string>
+    <string name="status_enabled">有効</string>
+    <string name="status_disabled">無効</string>
+    <string name="fork_behavior">フォークの動作</string>
+    <string name="commands">コマンド</string>
+    <string name="commands_enabled_count">%1$d 件有効</string>
+    <string name="api_keys">APIキー</string>
+    <string name="api_keys_subtitle">プログラムによるアクセス用のAPIキーを管理</string>
+    <string name="presets">プリセット</string>
+    <string name="presets_subtitle">会話のプリセットを管理</string>
+    <string name="favorites">お気に入り</string>
+    <string name="favorites_subtitle">ピン留めしたエージェントとモデルを管理</string>
+    <string name="favorites_title">お気に入り</string>
+    <string name="favorites_empty_title">お気に入りはまだありません</string>
+    <string name="favorites_empty_message">モデルセレクターからエージェントやモデルをピン留めすると、ここに表示されます。</string>
+    <string name="favorites_count_of">%2$d 件中 %1$d 件</string>
+    <string name="favorites_unpin_cd">お気に入りのピンを外す</string>
+
+    <!-- About info -->
+    <string name="app_version_label">アプリのバージョン</string>
+    <string name="app_build_label">ビルド</string>
+    <string name="server_label">サーバー</string>
+    <string name="server_not_configured">未設定</string>
+    <string name="server_build_commit_label">サーバーのコミット</string>
+    <string name="server_build_branch_label">サーバーのブランチ</string>
+    <string name="server_build_date_label">サーバーのビルド日</string>
+
+    <!-- Tablet settings -->
+    <string name="sidebar_swipe_gesture">サイドバーのスワイプ操作</string>
+    <string name="sidebar_swipe_gesture_desc">タブレットレイアウトで左端からスワイプしてサイドバーを開きます</string>
+
+    <!-- Balance -->
+    <string name="token_credits">トークンクレジット</string>
+    <string name="available_balance">利用可能な残高</string>
+    <string name="cd_token_balance">トークン残高: %1$s クレジット</string>
+
+    <!-- Chat settings -->
+    <string name="chat_layout">チャットレイアウト</string>
+    <string name="chat_layout_thread">スレッド</string>
+    <string name="chat_layout_two_sided">左右に分かれたチャット</string>
+    <string name="chat_layout_thread_desc">すべてのメッセージをアバターと名前付きで左揃えに表示</string>
+    <string name="chat_layout_two_sided_desc">ユーザーのメッセージを右、エージェントを左に表示</string>
+    <string name="show_bubbles">吹き出しを表示</string>
+    <string name="show_bubbles_desc">メッセージに角丸の吹き出し背景を追加します</string>
+    <string name="show_avatars">アバターを表示</string>
+    <string name="show_avatars_desc">メッセージの横にユーザーとエージェントのアバターを表示します</string>
+    <string name="starred_models_title">スター付きモデル</string>
+    <string name="starred_models_desc">ピン留めしたモデルとエージェントをモデルピッカーの上部に表示します</string>
+    <string name="starred_models_off">オフ</string>
+    <string name="starred_models_grouped">上部に折りたたみ可能なグループ</string>
+    <string name="starred_models_top">上部に表示、グループ化なし</string>
+    <string name="font_size">フォントサイズ</string>
+    <string name="font_size_small">小</string>
+    <string name="font_size_medium">中</string>
+    <string name="font_size_large">大</string>
+    <string name="latex_renderer">LaTeXレンダラー</string>
+    <string name="latex_katex">KaTeX（レンダリング）</string>
+    <string name="latex_katex_desc">WebView経由で完全なLaTeXをレンダリング</string>
+    <string name="latex_native">プレーンテキスト（高速）</string>
+    <string name="latex_native_desc">スクロール性能向上のため生のLaTeXソースを表示します</string>
+    <string name="auto_scroll">ストリーミング中に自動スクロール</string>
+    <string name="auto_scroll_desc">応答の生成中に新しいコンテンツへ自動でスクロールします</string>
+    <string name="show_thinking_blocks">思考ブロックを表示</string>
+    <string name="show_thinking_blocks_desc">利用可能な場合にモデルの推論ステップを表示します</string>
+    <string name="show_image_descriptions">画像の説明を表示</string>
+    <string name="show_image_descriptions_desc">画像の下にAIが生成したプロンプトを表示します</string>
+    <string name="dismiss_keyboard_on_send">送信後にキーボードを閉じる</string>
+    <string name="dismiss_keyboard_on_send_desc">メッセージ送信後にキーボードを自動で非表示にします</string>
+
+    <!-- Artifacts -->
+    <string name="section_artifacts">アーティファクト</string>
+    <string name="artifacts_section_desc">タップして開くカードの代わりに、アーティファクトをチャット内に直接レンダリングします。インラインのアーティファクトをタップすると全画面表示が開きます。</string>
+    <string name="inline_artifact_mermaid">Mermaid図</string>
+    <string name="inline_artifact_mermaid_desc">Mermaidのフローチャートや図をインラインでレンダリング</string>
+    <string name="inline_artifact_svg">SVG画像</string>
+    <string name="inline_artifact_svg_desc">SVGベクター画像をインラインでレンダリング</string>
+    <string name="inline_artifact_html">HTML</string>
+    <string name="inline_artifact_html_desc">HTMLページをインラインでレンダリング（TailwindをCDNから読み込み）</string>
+    <string name="inline_artifact_react">Reactコンポーネント</string>
+    <string name="inline_artifact_react_desc">Reactコンポーネントをインラインでレンダリング（React + BabelをCDNから読み込み）</string>
+    <string name="inline_artifact_markdown">Markdownドキュメント</string>
+    <string name="inline_artifact_markdown_desc">構文ハイライト付きのコードブロックでMarkdownアーティファクトをインラインでレンダリング</string>
+
+    <!-- Security -->
+    <string name="two_factor_auth">二要素認証</string>
+    <string name="enable_two_factor">二要素認証を有効にする</string>
+    <string name="disable_two_factor">二要素認証を無効にする</string>
+    <string name="view_backup_codes">バックアップコードを表示</string>
+
+    <!-- 2FA setup dialog -->
+    <string name="dialog_title_enable_2fa">二要素認証を有効にする</string>
+    <string name="dialog_title_disable_2fa">二要素認証を無効にする</string>
+    <string name="twofa_scan_instructions">以下のURIをコピーして認証アプリ（例: Google Authenticator、Authy）に貼り付け、確認コードを入力してください。</string>
+    <string name="twofa_disable_instructions">2FAを無効にするには認証アプリのコードを入力してください。</string>
+    <string name="hint_verification_code">確認コード</string>
+
+    <!-- OTP verification dialogs -->
+    <string name="otp_title_verify_identity">本人確認</string>
+    <string name="otp_desc_delete_account">アカウントを削除するには2FAコードを入力してください。</string>
+    <string name="otp_desc_reenroll_2fa">再登録するには現在の2FAコードを入力してください。</string>
+    <string name="otp_desc_regenerate_backup_codes">バックアップコードを再生成するには2FAコードを入力してください。</string>
+    <string name="otp_verify">確認</string>
+    <string name="otp_cancel">キャンセル</string>
+    <string name="otp_backup_code_label">バックアップコード</string>
+    <string name="otp_use_backup_code">代わりにバックアップコードを使用</string>
+    <string name="otp_use_otp_code">代わりにOTPコードを使用</string>
+
+    <!-- Backup codes dialog -->
+    <string name="dialog_title_backup_codes">バックアップコード</string>
+    <string name="backup_codes_instructions">これらのバックアップコードを安全な場所に保管してください。各コードは一度しか使用できません。</string>
+
+    <!-- Danger zone -->
+    <string name="delete_account">アカウントを削除</string>
+    <string name="dialog_title_sign_out">サインアウト</string>
+    <string name="dialog_sign_out_message">サインアウトしてもよろしいですか？</string>
+    <string name="dialog_title_delete_account">アカウントを削除</string>
+    <string name="dialog_delete_account_message">この操作は取り消せません。すべてのデータが完全に削除されます。</string>
+
+    <!-- Clear cache dialog -->
+    <string name="dialog_title_clear_cache">キャッシュをクリア</string>
+    <string name="dialog_clear_cache_message">キャッシュされた画像と一時データをクリアします。アカウントのデータには影響しません。</string>
+
+    <!-- Revoke keys dialog -->
+    <string name="dialog_title_revoke_keys">すべてのAPIキーを取り消す</string>
+    <string name="dialog_revoke_keys_message">保存されているすべてのAPIキーを取り消します。外部サービスを引き続き使用するには再入力が必要になります。</string>
+
+    <!-- Data settings -->
+    <string name="clear_all_conversations">すべての会話をクリア</string>
+    <string name="clearing">クリア中…</string>
+    <string name="archived_conversations">アーカイブ済みの会話</string>
+    <string name="export_all_data">すべてのデータをエクスポート</string>
+    <string name="shared_links">共有リンク</string>
+    <string name="clear_cache">キャッシュをクリア</string>
+    <string name="revoke_all_api_keys">すべてのAPIキーを取り消す</string>
+    <string name="revoking">取り消し中…</string>
+    <string name="dialog_title_clear_conversations">すべての会話をクリア</string>
+    <string name="dialog_clear_conversations_message">すべての会話を完全に削除します。この操作は取り消せません。</string>
+    <string name="clear_all">すべてクリア</string>
+    <string name="export_coming_soon">エクスポートは近日対応予定です</string>
+    <string name="error_could_not_load_settings">設定を読み込めませんでした</string>
+
+    <!-- Diagnostic logs (issue #96) -->
+    <string name="section_diagnostic_logs">診断ログ</string>
+    <string name="export_diagnostic_logs">診断ログをエクスポート</string>
+    <string name="export_diagnostic_logs_with_size">診断ログをエクスポート（%1$s）</string>
+    <string name="exporting_logs">エクスポート中…</string>
+    <string name="clear_diagnostic_logs">診断ログをクリア</string>
+    <string name="clearing_logs">クリア中…</string>
+    <string name="logs_exported">診断ログをエクスポートしました</string>
+    <string name="dialog_title_clear_logs">診断ログをクリア</string>
+    <string name="dialog_clear_logs_message">このデバイスに保存されているすべての診断ログを完全に削除します。この操作は取り消せません。</string>
+
+    <!-- Speech settings -->
+    <string name="auto_send_after_speech">音声入力後に自動送信</string>
+    <string name="auto_send_after_speech_desc">音声からテキストへの変換が完了した後にメッセージを自動送信します</string>
+    <string name="auto_read_responses">応答を自動読み上げ</string>
+    <string name="auto_read_responses_desc">テキスト読み上げを使ってAIの応答を自動で読み上げます</string>
+    <string name="tts_voice">TTS音声</string>
+    <string name="test_voice">音声をテスト</string>
+    <string name="no_server_tts_voices">利用可能なサーバーTTS音声がありません。サーバーで音声機能が設定されていない可能性があります。</string>
+    <string name="using_device_tts">デバイスのテキスト読み上げエンジンを使用しています。下の「テキスト読み上げ設定」で音声と速度を設定してください。</string>
+    <string name="speech_to_text_settings">音声入力の設定</string>
+    <string name="text_to_speech_settings">テキスト読み上げの設定</string>
+
+    <!-- STT detail dialog -->
+    <string name="stt_engine_label">エンジン</string>
+    <string name="stt_language_label">言語</string>
+    <string name="stt_on_device">オンデバイス</string>
+    <string name="stt_default">デフォルト</string>
+    <string name="stt_hint_whisper">Whisperはサーバー側の文字起こしを使用します。サーバーでSTTを有効にする必要があります。</string>
+    <string name="stt_hint_device">デバイス内蔵の音声認識を使用します。対応デバイスではオフラインで動作します。</string>
+    <string name="stt_hint_google">Googleの音声認識を使用します。Googleアプリがインストールされている必要があります。</string>
+    <string name="stt_hint_default">利用可能な場合はサーバーの文字起こし（Whisper）を使用し、そうでない場合はオンデバイス認識にフォールバックします。</string>
+    <string name="stt_auto_detect">自動検出</string>
+
+    <!-- TTS detail dialog -->
+    <string name="tts_source_label">ソース</string>
+    <string name="tts_source_device">デバイス（内蔵）</string>
+    <string name="tts_source_server">サーバー</string>
+    <string name="tts_voice_label">音声</string>
+    <string name="tts_engine_label">エンジン</string>
+    <string name="tts_system_default">システムのデフォルト</string>
+    <string name="tts_speech_rate">読み上げ速度: %1$.1fx</string>
+    <string name="tts_pitch">ピッチ: %1$.1f</string>
+    <string name="tts_cache_audio">音声をキャッシュ</string>
+    <string name="tts_preview_text">これは選択した音声のプレビューです。</string>
+    <string name="tts_stop_preview">プレビューを停止</string>
+    <string name="tts_preview_voice">音声をプレビュー</string>
+
+    <!-- Memories -->
+    <string name="enable_memories">メモリを有効にする</string>
+    <string name="enable_memories_desc">会話をまたいで情報を記憶することをAIに許可します</string>
+    <string name="no_memories_saved">保存されたメモリはまだありません</string>
+    <string name="memories_add_hint">＋ボタンをタップしてメモリを追加</string>
+    <string name="add_memory">メモリを追加</string>
+    <string name="edit_memory">メモリを編集</string>
+    <string name="dialog_title_delete_memory">メモリを削除</string>
+    <string name="dialog_delete_memory_message">メモリ「%1$s」を削除してもよろしいですか？</string>
+    <string name="memory_key_label">キー</string>
+    <string name="memory_value_label">値</string>
+
+    <!-- MCP -->
+    <string name="add_mcp_server">MCPサーバーを追加</string>
+    <string name="edit_mcp_server">MCPサーバーを編集</string>
+    <string name="mcp_not_available">このサーバーではMCPを利用できません</string>
+    <string name="no_mcp_servers">MCPサーバーが設定されていません</string>
+    <string name="mcp_add_hint">＋ボタンをタップしてサーバーを追加</string>
+    <string name="mcp_name_label">名前</string>
+    <string name="mcp_description_label">説明</string>
+    <string name="mcp_description_optional">任意</string>
+    <string name="mcp_url_label">URL</string>
+    <string name="mcp_type_label">種類</string>
+    <string name="mcp_type_sse">SSE</string>
+    <string name="mcp_type_streamable_http">Streamable HTTP</string>
+    <string name="mcp_auth_label">認証</string>
+    <string name="mcp_auth_none">なし</string>
+    <string name="mcp_auth_api_key">APIキー</string>
+    <string name="mcp_auth_oauth">OAuth</string>
+    <string name="mcp_auth_key_type">キーの種類</string>
+    <string name="mcp_auth_bearer">Bearer</string>
+    <string name="mcp_auth_basic">Basic</string>
+    <string name="mcp_auth_custom">カスタム</string>
+    <string name="mcp_header_name_label">ヘッダー名</string>
+    <string name="mcp_header_name_placeholder">X-API-Key</string>
+    <string name="mcp_api_key_label">APIキー</string>
+    <string name="mcp_oauth_client_id">クライアントID</string>
+    <string name="mcp_oauth_client_secret">クライアントシークレット</string>
+    <string name="mcp_oauth_auth_url">認可URL</string>
+    <string name="mcp_oauth_token_url">トークンURL</string>
+    <string name="mcp_oauth_scope">スコープ</string>
+    <string name="mcp_oauth_scope_placeholder">read execute</string>
+    <string name="dialog_title_delete_server">サーバーを削除</string>
+    <string name="dialog_delete_server_message">「%1$s」を削除してもよろしいですか？</string>
+    <string name="error_failed_to_load_servers">サーバーの読み込みに失敗しました</string>
+    <string name="mcp_tools_count">%1$d 個のツール%2$s</string>
+    <string name="mcp_tools_available">%1$d 個のツール%2$sが利用可能</string>
+    <string name="mcp_all_tools">すべてのMCPツール</string>
+    <string name="mcp_tools_for_server">ツール: %1$s</string>
+    <string name="no_tools_available">利用可能なツールがありません</string>
+    <string name="mcp_tool_server">サーバー: %1$s</string>
+
+    <!-- MCP tools sheet -->
+    <string name="mcp_server_unknown">不明</string>
+
+    <!-- Fork settings -->
+    <string name="fork_mode_direct_path">表示中のメッセージ</string>
+    <string name="fork_mode_direct_path_desc">選択したメッセージまでの直接の経路のみ</string>
+    <string name="fork_mode_include_branches">分岐を含める</string>
+    <string name="fork_mode_include_branches_desc">直接の経路に加え、各階層の兄弟メッセージ</string>
+    <string name="fork_mode_target_level">対象の階層まですべて</string>
+    <string name="fork_mode_target_level_desc">対象メッセージの階層までのすべてのメッセージと分岐（デフォルト）</string>
+
+    <!-- Language selector -->
+    <string name="hint_search_languages">言語を検索</string>
+
+    <!-- Personalization dialog -->
+    <string name="enable_personalization">パーソナライズを有効にする</string>
+    <string name="about_you_label">あなたについて</string>
+    <string name="about_you_hint">文脈としてAIが知っておくべきあなたの情報は何ですか？</string>
+    <string name="response_style_label">AIはどのように応答すべきですか？</string>
+    <string name="response_style_hint">応答に好みのトーン、形式、スタイル</string>
+
+    <!-- Commands screen -->
+    <string name="no_commands_available">利用可能なコマンドがありません</string>
+
+    <!-- Avatar upload dialog -->
+    <string name="dialog_title_update_avatar">アバターを更新</string>
+    <string name="avatar_choose_hint">カメラアイコンをタップして画像を選択</string>
+
+    <!-- API Keys screen -->
+    <string name="api_keys_not_available">APIキーを利用できません</string>
+    <string name="api_keys_not_supported">この機能はお使いのサーバーバージョンではサポートされていません。</string>
+    <string name="no_api_keys">APIキーがありません</string>
+    <string name="no_api_keys_desc">APIにプログラムでアクセスするためのAPIキーを作成してください。</string>
+    <string name="dialog_title_delete_api_key">APIキーを削除</string>
+    <string name="dialog_delete_api_key_message">APIキー「%1$s」を削除してもよろしいですか？この操作は取り消せません。</string>
+    <string name="created_prefix">作成日: %1$s</string>
+
+    <!-- API Key create dialog -->
+    <string name="dialog_title_create_api_key">APIキーを作成</string>
+    <string name="api_key_name_hint">用途を識別しやすいように、APIキーにわかりやすい名前を付けてください。</string>
+    <string name="hint_key_name">キー名</string>
+    <string name="hint_key_name_placeholder">例: My App</string>
+    <string name="dialog_title_api_key_created">APIキーを作成しました</string>
+    <string name="api_key_created_warning">APIキーを作成しました。今すぐコピーしてください。後で再表示することはできません。</string>
+    <string name="copied_to_clipboard">クリップボードにコピーしました</string>
+
+    <!-- Preset manager -->
+    <string name="no_presets">プリセットがありません</string>
+    <string name="no_presets_desc">チャット画面からプリセットを保存すると、ここで管理できます</string>
+    <string name="dialog_title_delete_preset">プリセットを削除</string>
+    <string name="dialog_delete_preset_message">「%1$s」を削除してもよろしいですか？</string>
+
+    <!-- Shared links -->
+    <string name="no_shared_links">共有リンクがありません</string>
+    <string name="no_shared_links_desc">会話を共有すると、ここに表示されます</string>
+    <string name="dialog_title_delete_shared_link">共有リンクを削除</string>
+    <string name="dialog_delete_shared_link_message">「%1$s」の共有リンクを削除します。リンクを持つ人はアクセスできなくなります。</string>
+    <string name="visibility_public">公開</string>
+    <string name="visibility_private">非公開</string>
+    <string name="error_failed_to_load_memories">メモリの読み込みに失敗しました</string>
+
+    <!-- Provider API Keys -->
+    <string name="provider_keys_title">プロバイダーAPIキー</string>
+    <string name="provider_keys_subtitle">キーが必要なエンドポイント向けに独自のキーを設定</string>
+    <string name="provider_keys_dialog_title">%1$s のAPIキーを設定</string>
+    <string name="provider_keys_status_set_expires">%1$s 後に期限切れ</string>
+    <string name="provider_keys_status_set_never">キーは期限切れになりません</string>
+    <string name="provider_keys_status_unset">未設定</string>
+    <string name="provider_keys_status_expired">期限切れ</string>
+    <string name="provider_keys_status_loading">キーの状態を確認中…</string>
+    <string name="provider_keys_field_api_key_label">キー</string>
+    <string name="provider_keys_field_base_url_label">ベースURL</string>
+    <string name="provider_keys_field_base_url_optional_suffix">（任意）</string>
+    <string name="provider_keys_field_api_key_for_endpoint">%1$s APIキー</string>
+    <string name="provider_keys_field_api_url_for_endpoint">%1$s API URL</string>
+
+    <string name="provider_keys_field_azure_api_key">Azure OpenAI APIキー</string>
+    <string name="provider_keys_field_azure_instance">Azureインスタンス名</string>
+    <string name="provider_keys_field_azure_deployment">Azureデプロイメント名</string>
+    <string name="provider_keys_field_azure_api_version">Azure APIバージョン</string>
+
+    <string name="provider_keys_field_google_api_key">Google APIキー</string>
+    <string name="provider_keys_field_google_gemini_api">(Gemini API)</string>
+    <string name="provider_keys_field_google_service_key">Googleサービスアカウントキー</string>
+    <string name="provider_keys_field_google_import">サービスアカウントのJSONキーをインポート。</string>
+    <string name="provider_keys_field_google_invalid">サービスアカウントのJSONキーが無効です。正しいファイルをインポートしましたか？</string>
+    <string name="provider_keys_field_google_imported">サービスアカウントのJSONキーを正常にインポートしました</string>
+    <string name="provider_keys_field_google_paste_label">またはサービスアカウントのJSONを貼り付け</string>
+    <string name="provider_keys_field_google_paste_only_hint">サービスアカウントのJSONを下に貼り付けてください。</string>
+    <string name="provider_keys_field_google_service_key_or_gemini">GoogleサービスキーまたはGemini APIキー</string>
+
+    <string name="provider_keys_field_bedrock_access_key_id">アクセスキーID</string>
+    <string name="provider_keys_field_bedrock_secret_access_key">シークレットアクセスキー</string>
+    <string name="provider_keys_field_bedrock_session_token">セッショントークン</string>
+    <string name="provider_keys_field_bedrock_session_token_optional_suffix">（任意）</string>
+
+    <string name="provider_keys_required_fields">次のフィールドは必須です: %1$s</string>
+    <string name="provider_keys_revoke">取り消す</string>
+    <string name="provider_keys_revoke_failed">APIキーの取り消しに失敗しました。もう一度お試しください。</string>
+    <string name="provider_keys_revoke_success">APIキーを取り消しました</string>
+    <string name="provider_keys_revoke_all">キーを取り消す</string>
+    <string name="provider_keys_revoke_all_confirm">すべてのキーを取り消してもよろしいですか？</string>
+    <string name="provider_keys_revoke_all_failed">すべてのキーの取り消しに失敗しました</string>
+    <string name="provider_keys_save_failed">APIキーの保存に失敗しました。もう一度お試しください。</string>
+    <string name="provider_keys_save_success">APIキーを保存しました</string>
+
+    <string name="provider_keys_expiry_label">有効期限</string>
+    <string name="provider_keys_expiry_30m">30分後</string>
+    <string name="provider_keys_expiry_2h">2時間後</string>
+    <string name="provider_keys_expiry_12h">12時間後</string>
+    <string name="provider_keys_expiry_1d">1日後</string>
+    <string name="provider_keys_expiry_7d">7日後</string>
+    <string name="provider_keys_expiry_30d">30日後</string>
+    <string name="provider_keys_expiry_never">なし</string>
+
+    <string name="provider_keys_empty_title">ユーザー提供のキーが必要なエンドポイントはありません</string>
+    <string name="provider_keys_empty_desc">独自のAPIキーが必要なエンドポイントがここに表示されます。</string>
+    <string name="provider_keys_revoke_all_action">すべて取り消す</string>
+
+    <!-- Admin: role skill access -->
+    <string name="role_skills_settings_row">スキルへのアクセス（管理者）</string>
+    <string name="role_skills_title">スキルへのアクセス</string>
+    <string name="role_skills_back">戻る</string>
+    <string name="role_skills_description">各ロールが持つスキル機能を制御します。変更は選択したロールのすべてのユーザーに適用されます。</string>
+    <string name="role_skills_role_label">ロール</string>
+    <string name="role_skills_use">スキルを使用</string>
+    <string name="role_skills_create">スキルの作成と編集</string>
+    <string name="role_skills_share">スキルを共有</string>
+    <string name="role_skills_share_public">スキルを公開で共有</string>
+    <string name="role_skills_save">保存</string>
+</resources>

--- a/feature/settings/src/commonMain/composeResources/values-ko/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-ko/strings.xml
@@ -1,0 +1,488 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Common actions -->
+    <string name="action_add">추가</string>
+    <string name="action_cancel">취소</string>
+    <string name="action_clear">지우기</string>
+    <string name="action_confirm">확인</string>
+    <string name="action_creating">생성 중…</string>
+    <string name="action_create">생성</string>
+    <string name="action_delete">삭제</string>
+    <string name="action_done">완료</string>
+    <string name="action_retry">다시 시도</string>
+    <string name="action_revoke_all">모두 해제</string>
+    <string name="action_save">저장</string>
+    <string name="action_sign_out">로그아웃</string>
+    <string name="action_upload">업로드</string>
+    <string name="action_uploading">업로드 중…</string>
+    <string name="action_verify">확인</string>
+    <string name="action_verifying">확인 중…</string>
+
+    <!-- Content descriptions -->
+    <string name="cd_add_memory">메모리 추가</string>
+    <string name="cd_add_server">서버 추가</string>
+    <string name="cd_back">뒤로</string>
+    <string name="cd_change_avatar">아바타 변경</string>
+    <string name="cd_choose_image">이미지 선택</string>
+    <string name="cd_collapse_tools">도구 접기</string>
+    <string name="cd_copy_api_key">API 키 복사</string>
+    <string name="cd_copy_link">링크 복사</string>
+    <string name="cd_create_api_key">API 키 생성</string>
+    <string name="cd_current_avatar">현재 아바타</string>
+    <string name="cd_delete">삭제</string>
+    <string name="cd_delete_api_key">API 키 삭제</string>
+    <string name="cd_delete_memory">메모리 삭제</string>
+    <string name="cd_delete_preset">프리셋 삭제</string>
+    <string name="cd_delete_server">서버 삭제</string>
+    <string name="cd_delete_shared_link">공유 링크 삭제</string>
+    <string name="cd_edit">편집</string>
+    <string name="cd_edit_memory">메모리 편집</string>
+    <string name="cd_edit_server">서버 편집</string>
+    <string name="cd_expand_tools">도구 펼치기</string>
+    <string name="cd_loading_profile">프로필 불러오는 중</string>
+    <string name="cd_make_private">비공개로 전환</string>
+    <string name="cd_make_public">공개로 전환</string>
+    <string name="cd_preview_voice">음성 미리듣기</string>
+    <string name="cd_qr_code">인증 앱용 QR 코드</string>
+    <string name="cd_reinitialize">다시 초기화</string>
+    <string name="cd_avatar_preview">아바타 미리보기</string>
+    <string name="cd_selected">선택됨</string>
+    <string name="cd_selected_avatar">선택된 아바타</string>
+    <string name="cd_stop_voice_preview">음성 미리듣기 중지</string>
+    <string name="cd_test_tts_voice">선택한 TTS 음성 테스트</string>
+    <string name="cd_toggle_auto_read">응답 자동 읽기 전환</string>
+    <string name="cd_toggle_auto_send_stt">음성 입력 후 자동 전송 전환</string>
+    <string name="cd_toggle_memories">메모리 전환</string>
+    <string name="cd_tts_voice_selector">TTS 음성 선택. 현재 %1$s</string>
+    <string name="cd_user_avatar">사용자 아바타</string>
+    <string name="cd_view_all_tools">모든 도구 보기</string>
+    <string name="cd_view_tools">도구 보기</string>
+
+    <!-- Section headers -->
+    <string name="section_about">정보</string>
+    <string name="section_account">계정</string>
+    <string name="section_advanced">고급</string>
+    <string name="section_appearance">화면 설정</string>
+    <string name="section_balance">잔액</string>
+    <string name="section_chat_preferences">채팅 환경설정</string>
+    <string name="section_conversations">대화</string>
+    <string name="section_danger_zone">위험 구역</string>
+    <string name="section_data_management">데이터 관리</string>
+    <string name="section_general">일반</string>
+    <string name="section_language">언어</string>
+    <string name="section_layout">레이아웃</string>
+    <string name="section_mcp_servers">MCP 서버</string>
+    <string name="section_memories">메모리</string>
+    <string name="section_personalization">개인화</string>
+    <string name="section_presets">프리셋</string>
+    <string name="section_profile">프로필</string>
+    <string name="section_security">보안</string>
+    <string name="section_speech">음성</string>
+    <string name="section_tablet">태블릿</string>
+
+    <!-- Screen titles -->
+    <string name="title_account">계정</string>
+    <string name="title_api_keys">API 키</string>
+    <string name="title_chat">채팅</string>
+    <string name="title_commands">명령어</string>
+    <string name="title_data">데이터</string>
+    <string name="title_general">일반</string>
+    <string name="title_memories">메모리</string>
+    <string name="title_mcp_servers">MCP 서버</string>
+    <string name="title_presets">프리셋</string>
+    <string name="title_settings">설정</string>
+    <string name="title_shared_links">공유 링크</string>
+
+    <!-- Tabbed settings tabs -->
+    <string name="tab_general">일반</string>
+    <string name="tab_chat">채팅</string>
+    <string name="tab_account">계정</string>
+    <string name="tab_data">데이터</string>
+
+    <!-- Theme -->
+    <string name="theme_system">시스템 기본값</string>
+    <string name="theme_light">라이트</string>
+    <string name="theme_dark">다크</string>
+
+    <!-- Accent color -->
+    <string name="accent_color">강조 색상</string>
+    <string name="accent_color_custom">사용자 지정</string>
+    <string name="accent_color_hex">Hex</string>
+    <string name="use_wallpaper_colors">배경화면 색상 사용</string>
+    <string name="use_wallpaper_colors_desc">앱 강조 색상을 시스템 배경화면에 맞춥니다 (Material You)</string>
+
+    <!-- Settings rows -->
+    <string name="language">언어</string>
+    <string name="language_system_default">시스템 기본값</string>
+    <string name="personalization">개인화</string>
+    <string name="status_enabled">사용</string>
+    <string name="status_disabled">사용 안 함</string>
+    <string name="fork_behavior">분기 동작</string>
+    <string name="commands">명령어</string>
+    <string name="commands_enabled_count">%1$d개 사용</string>
+    <string name="api_keys">API 키</string>
+    <string name="api_keys_subtitle">프로그래밍 방식 접근을 위한 API 키 관리</string>
+    <string name="presets">프리셋</string>
+    <string name="presets_subtitle">대화 프리셋 관리</string>
+    <string name="favorites">즐겨찾기</string>
+    <string name="favorites_subtitle">고정한 에이전트와 모델 관리</string>
+    <string name="favorites_title">즐겨찾기</string>
+    <string name="favorites_empty_title">아직 즐겨찾기가 없습니다</string>
+    <string name="favorites_empty_message">모델 선택기에서 에이전트나 모델을 고정하면 여기에 표시됩니다.</string>
+    <string name="favorites_count_of">%2$d개 중 %1$d개</string>
+    <string name="favorites_unpin_cd">즐겨찾기 고정 해제</string>
+
+    <!-- About info -->
+    <string name="app_version_label">앱 버전</string>
+    <string name="app_build_label">빌드</string>
+    <string name="server_label">서버</string>
+    <string name="server_not_configured">구성되지 않음</string>
+    <string name="server_build_commit_label">서버 커밋</string>
+    <string name="server_build_branch_label">서버 브랜치</string>
+    <string name="server_build_date_label">서버 빌드 날짜</string>
+
+    <!-- Tablet settings -->
+    <string name="sidebar_swipe_gesture">사이드바 스와이프 제스처</string>
+    <string name="sidebar_swipe_gesture_desc">태블릿 레이아웃에서 왼쪽 가장자리를 스와이프하여 사이드바 열기</string>
+
+    <!-- Balance -->
+    <string name="token_credits">토큰 크레딧</string>
+    <string name="available_balance">사용 가능 잔액</string>
+    <string name="cd_token_balance">토큰 잔액: %1$s 크레딧</string>
+
+    <!-- Chat settings -->
+    <string name="chat_layout">채팅 레이아웃</string>
+    <string name="chat_layout_thread">스레드</string>
+    <string name="chat_layout_two_sided">양방향 채팅</string>
+    <string name="chat_layout_thread_desc">모든 메시지가 아바타와 이름과 함께 왼쪽에 정렬됩니다</string>
+    <string name="chat_layout_two_sided_desc">사용자 메시지는 오른쪽, 에이전트는 왼쪽에 표시</string>
+    <string name="show_bubbles">말풍선 표시</string>
+    <string name="show_bubbles_desc">메시지에 둥근 말풍선 배경 추가</string>
+    <string name="show_avatars">아바타 표시</string>
+    <string name="show_avatars_desc">메시지 옆에 사용자와 에이전트 아바타 표시</string>
+    <string name="starred_models_title">즐겨찾기한 모델</string>
+    <string name="starred_models_desc">고정한 모델과 에이전트를 모델 선택기 상단에 표시</string>
+    <string name="starred_models_off">끔</string>
+    <string name="starred_models_grouped">상단에 접을 수 있는 그룹</string>
+    <string name="starred_models_top">상단에 표시, 그룹화 없음</string>
+    <string name="font_size">글자 크기</string>
+    <string name="font_size_small">작게</string>
+    <string name="font_size_medium">보통</string>
+    <string name="font_size_large">크게</string>
+    <string name="latex_renderer">LaTeX 렌더러</string>
+    <string name="latex_katex">KaTeX (렌더링)</string>
+    <string name="latex_katex_desc">WebView를 통한 완전한 LaTeX 렌더링</string>
+    <string name="latex_native">일반 텍스트 (빠름)</string>
+    <string name="latex_native_desc">스크롤 성능 향상을 위해 LaTeX 원본을 그대로 표시</string>
+    <string name="auto_scroll">스트리밍 중 자동 스크롤</string>
+    <string name="auto_scroll_desc">응답이 생성되는 동안 새 콘텐츠로 자동 스크롤</string>
+    <string name="show_thinking_blocks">사고 과정 블록 표시</string>
+    <string name="show_thinking_blocks_desc">가능한 경우 모델의 추론 단계 표시</string>
+    <string name="show_image_descriptions">이미지 설명 표시</string>
+    <string name="show_image_descriptions_desc">AI가 생성한 이미지 프롬프트를 이미지 아래에 표시</string>
+    <string name="dismiss_keyboard_on_send">전송 후 키보드 닫기</string>
+    <string name="dismiss_keyboard_on_send_desc">메시지를 전송한 후 키보드를 자동으로 숨깁니다</string>
+
+    <!-- Artifacts -->
+    <string name="section_artifacts">아티팩트</string>
+    <string name="artifacts_section_desc">아티팩트를 탭하여 여는 카드 대신 채팅에 직접 렌더링합니다. 인라인 아티팩트를 탭하면 전체 화면 보기가 열립니다.</string>
+    <string name="inline_artifact_mermaid">Mermaid 다이어그램</string>
+    <string name="inline_artifact_mermaid_desc">Mermaid 흐름도와 다이어그램을 인라인으로 렌더링</string>
+    <string name="inline_artifact_svg">SVG 이미지</string>
+    <string name="inline_artifact_svg_desc">SVG 벡터 그래픽을 인라인으로 렌더링</string>
+    <string name="inline_artifact_html">HTML</string>
+    <string name="inline_artifact_html_desc">HTML 페이지를 인라인으로 렌더링 (CDN에서 Tailwind 로드)</string>
+    <string name="inline_artifact_react">React 컴포넌트</string>
+    <string name="inline_artifact_react_desc">React 컴포넌트를 인라인으로 렌더링 (CDN에서 React + Babel 로드)</string>
+    <string name="inline_artifact_markdown">Markdown 문서</string>
+    <string name="inline_artifact_markdown_desc">구문 강조된 코드 블록과 함께 Markdown 아티팩트를 인라인으로 렌더링</string>
+
+    <!-- Security -->
+    <string name="two_factor_auth">2단계 인증</string>
+    <string name="enable_two_factor">2단계 인증 사용</string>
+    <string name="disable_two_factor">2단계 인증 사용 안 함</string>
+    <string name="view_backup_codes">백업 코드 보기</string>
+
+    <!-- 2FA setup dialog -->
+    <string name="dialog_title_enable_2fa">2단계 인증 사용</string>
+    <string name="dialog_title_disable_2fa">2단계 인증 사용 안 함</string>
+    <string name="twofa_scan_instructions">아래 URI를 복사하여 인증 앱(예: Google Authenticator, Authy)에 붙여넣은 후 인증 코드를 입력하세요.</string>
+    <string name="twofa_disable_instructions">2FA를 사용 중지하려면 인증 앱 코드를 입력하세요.</string>
+    <string name="hint_verification_code">인증 코드</string>
+
+    <!-- OTP verification dialogs -->
+    <string name="otp_title_verify_identity">본인 확인</string>
+    <string name="otp_desc_delete_account">계정을 삭제하려면 2FA 코드를 입력하세요.</string>
+    <string name="otp_desc_reenroll_2fa">다시 등록하려면 현재 2FA 코드를 입력하세요.</string>
+    <string name="otp_desc_regenerate_backup_codes">백업 코드를 재생성하려면 2FA 코드를 입력하세요.</string>
+    <string name="otp_verify">확인</string>
+    <string name="otp_cancel">취소</string>
+    <string name="otp_backup_code_label">백업 코드</string>
+    <string name="otp_use_backup_code">백업 코드 사용</string>
+    <string name="otp_use_otp_code">OTP 코드 사용</string>
+
+    <!-- Backup codes dialog -->
+    <string name="dialog_title_backup_codes">백업 코드</string>
+    <string name="backup_codes_instructions">이 백업 코드를 안전한 곳에 보관하세요. 각 코드는 한 번만 사용할 수 있습니다.</string>
+
+    <!-- Danger zone -->
+    <string name="delete_account">계정 삭제</string>
+    <string name="dialog_title_sign_out">로그아웃</string>
+    <string name="dialog_sign_out_message">로그아웃하시겠습니까?</string>
+    <string name="dialog_title_delete_account">계정 삭제</string>
+    <string name="dialog_delete_account_message">이 작업은 되돌릴 수 없습니다. 모든 데이터가 영구적으로 삭제됩니다.</string>
+
+    <!-- Clear cache dialog -->
+    <string name="dialog_title_clear_cache">캐시 지우기</string>
+    <string name="dialog_clear_cache_message">캐시된 이미지와 임시 데이터를 지웁니다. 계정 데이터에는 영향을 주지 않습니다.</string>
+
+    <!-- Revoke keys dialog -->
+    <string name="dialog_title_revoke_keys">모든 API 키 해제</string>
+    <string name="dialog_revoke_keys_message">저장된 모든 API 키를 해제합니다. 외부 서비스를 계속 사용하려면 다시 입력해야 합니다.</string>
+
+    <!-- Data settings -->
+    <string name="clear_all_conversations">모든 대화 지우기</string>
+    <string name="clearing">지우는 중…</string>
+    <string name="archived_conversations">보관된 대화</string>
+    <string name="export_all_data">모든 데이터 내보내기</string>
+    <string name="shared_links">공유 링크</string>
+    <string name="clear_cache">캐시 지우기</string>
+    <string name="revoke_all_api_keys">모든 API 키 해제</string>
+    <string name="revoking">해제하는 중…</string>
+    <string name="dialog_title_clear_conversations">모든 대화 지우기</string>
+    <string name="dialog_clear_conversations_message">모든 대화를 영구적으로 삭제합니다. 이 작업은 되돌릴 수 없습니다.</string>
+    <string name="clear_all">모두 지우기</string>
+    <string name="export_coming_soon">내보내기 기능은 곧 제공됩니다</string>
+    <string name="error_could_not_load_settings">설정을 불러올 수 없습니다</string>
+
+    <!-- Diagnostic logs (issue #96) -->
+    <string name="section_diagnostic_logs">진단 로그</string>
+    <string name="export_diagnostic_logs">진단 로그 내보내기</string>
+    <string name="export_diagnostic_logs_with_size">진단 로그 내보내기 (%1$s)</string>
+    <string name="exporting_logs">내보내는 중…</string>
+    <string name="clear_diagnostic_logs">진단 로그 지우기</string>
+    <string name="clearing_logs">지우는 중…</string>
+    <string name="logs_exported">진단 로그를 내보냈습니다</string>
+    <string name="dialog_title_clear_logs">진단 로그 지우기</string>
+    <string name="dialog_clear_logs_message">이 기기에 저장된 모든 진단 로그를 영구적으로 삭제합니다. 이 작업은 되돌릴 수 없습니다.</string>
+
+    <!-- Speech settings -->
+    <string name="auto_send_after_speech">음성 입력 후 자동 전송</string>
+    <string name="auto_send_after_speech_desc">음성-텍스트 변환이 끝나면 메시지를 자동으로 전송합니다</string>
+    <string name="auto_read_responses">응답 자동 읽기</string>
+    <string name="auto_read_responses_desc">텍스트-음성 변환으로 AI 응답을 자동으로 읽어줍니다</string>
+    <string name="tts_voice">TTS 음성</string>
+    <string name="test_voice">음성 테스트</string>
+    <string name="no_server_tts_voices">사용 가능한 서버 TTS 음성이 없습니다. 서버에 음성 기능이 구성되지 않았을 수 있습니다.</string>
+    <string name="using_device_tts">기기의 텍스트-음성 변환 엔진을 사용 중입니다. 아래 텍스트-음성 변환 설정에서 음성과 속도를 구성하세요.</string>
+    <string name="speech_to_text_settings">음성-텍스트 변환 설정</string>
+    <string name="text_to_speech_settings">텍스트-음성 변환 설정</string>
+
+    <!-- STT detail dialog -->
+    <string name="stt_engine_label">엔진</string>
+    <string name="stt_language_label">언어</string>
+    <string name="stt_on_device">기기 내</string>
+    <string name="stt_default">기본값</string>
+    <string name="stt_hint_whisper">Whisper는 서버 측 전사를 사용합니다. 서버에 STT가 사용 설정되어 있어야 합니다.</string>
+    <string name="stt_hint_device">기기에 내장된 음성 인식기를 사용합니다. 지원되는 기기에서는 오프라인으로 작동합니다.</string>
+    <string name="stt_hint_google">Google 음성 인식기를 사용합니다. Google 앱이 설치되어 있어야 합니다.</string>
+    <string name="stt_hint_default">가능한 경우 서버 전사(Whisper)를 사용하고, 그렇지 않으면 기기 내 인식으로 대체합니다.</string>
+    <string name="stt_auto_detect">자동 감지</string>
+
+    <!-- TTS detail dialog -->
+    <string name="tts_source_label">소스</string>
+    <string name="tts_source_device">기기 (내장)</string>
+    <string name="tts_source_server">서버</string>
+    <string name="tts_voice_label">음성</string>
+    <string name="tts_engine_label">엔진</string>
+    <string name="tts_system_default">시스템 기본값</string>
+    <string name="tts_speech_rate">말하기 속도: %1$.1fx</string>
+    <string name="tts_pitch">음높이: %1$.1f</string>
+    <string name="tts_cache_audio">오디오 캐시</string>
+    <string name="tts_preview_text">선택한 음성의 미리듣기입니다.</string>
+    <string name="tts_stop_preview">미리듣기 중지</string>
+    <string name="tts_preview_voice">음성 미리듣기</string>
+
+    <!-- Memories -->
+    <string name="enable_memories">메모리 사용</string>
+    <string name="enable_memories_desc">AI가 여러 대화에 걸쳐 정보를 기억하도록 허용합니다</string>
+    <string name="no_memories_saved">아직 저장된 메모리가 없습니다</string>
+    <string name="memories_add_hint">+ 버튼을 탭하여 메모리를 추가하세요</string>
+    <string name="add_memory">메모리 추가</string>
+    <string name="edit_memory">메모리 편집</string>
+    <string name="dialog_title_delete_memory">메모리 삭제</string>
+    <string name="dialog_delete_memory_message">메모리 \"%1$s\"을(를) 삭제하시겠습니까?</string>
+    <string name="memory_key_label">키</string>
+    <string name="memory_value_label">값</string>
+
+    <!-- MCP -->
+    <string name="add_mcp_server">MCP 서버 추가</string>
+    <string name="edit_mcp_server">MCP 서버 편집</string>
+    <string name="mcp_not_available">이 서버에서는 MCP를 사용할 수 없습니다</string>
+    <string name="no_mcp_servers">구성된 MCP 서버가 없습니다</string>
+    <string name="mcp_add_hint">+ 버튼을 탭하여 서버를 추가하세요</string>
+    <string name="mcp_name_label">이름</string>
+    <string name="mcp_description_label">설명</string>
+    <string name="mcp_description_optional">선택 사항</string>
+    <string name="mcp_url_label">URL</string>
+    <string name="mcp_type_label">유형</string>
+    <string name="mcp_type_sse">SSE</string>
+    <string name="mcp_type_streamable_http">Streamable HTTP</string>
+    <string name="mcp_auth_label">인증</string>
+    <string name="mcp_auth_none">없음</string>
+    <string name="mcp_auth_api_key">API 키</string>
+    <string name="mcp_auth_oauth">OAuth</string>
+    <string name="mcp_auth_key_type">키 유형</string>
+    <string name="mcp_auth_bearer">Bearer</string>
+    <string name="mcp_auth_basic">Basic</string>
+    <string name="mcp_auth_custom">사용자 지정</string>
+    <string name="mcp_header_name_label">헤더 이름</string>
+    <string name="mcp_header_name_placeholder">X-API-Key</string>
+    <string name="mcp_api_key_label">API 키</string>
+    <string name="mcp_oauth_client_id">Client ID</string>
+    <string name="mcp_oauth_client_secret">Client Secret</string>
+    <string name="mcp_oauth_auth_url">Authorization URL</string>
+    <string name="mcp_oauth_token_url">Token URL</string>
+    <string name="mcp_oauth_scope">Scope</string>
+    <string name="mcp_oauth_scope_placeholder">read execute</string>
+    <string name="dialog_title_delete_server">서버 삭제</string>
+    <string name="dialog_delete_server_message">\"%1$s\"을(를) 삭제하시겠습니까?</string>
+    <string name="error_failed_to_load_servers">서버를 불러오지 못했습니다</string>
+    <string name="mcp_tools_count">도구 %1$d개%2$s</string>
+    <string name="mcp_tools_available">도구 %1$d개%2$s 사용 가능</string>
+    <string name="mcp_all_tools">모든 MCP 도구</string>
+    <string name="mcp_tools_for_server">도구: %1$s</string>
+    <string name="no_tools_available">사용 가능한 도구가 없습니다</string>
+    <string name="mcp_tool_server">서버: %1$s</string>
+
+    <!-- MCP tools sheet -->
+    <string name="mcp_server_unknown">알 수 없음</string>
+
+    <!-- Fork settings -->
+    <string name="fork_mode_direct_path">표시된 메시지</string>
+    <string name="fork_mode_direct_path_desc">선택한 메시지까지의 직접 경로 메시지만</string>
+    <string name="fork_mode_include_branches">분기 포함</string>
+    <string name="fork_mode_include_branches_desc">직접 경로와 각 단계의 형제 메시지</string>
+    <string name="fork_mode_target_level">대상 단계까지 전체</string>
+    <string name="fork_mode_target_level_desc">대상 메시지 단계까지의 모든 메시지와 분기 (기본값)</string>
+
+    <!-- Language selector -->
+    <string name="hint_search_languages">언어 검색</string>
+
+    <!-- Personalization dialog -->
+    <string name="enable_personalization">개인화 사용</string>
+    <string name="about_you_label">사용자 정보</string>
+    <string name="about_you_hint">맥락을 위해 AI가 사용자에 대해 알아야 할 내용은 무엇인가요?</string>
+    <string name="response_style_label">AI가 어떻게 응답해야 하나요?</string>
+    <string name="response_style_hint">응답에 선호하는 어조, 형식 또는 스타일</string>
+
+    <!-- Commands screen -->
+    <string name="no_commands_available">사용 가능한 명령어가 없습니다</string>
+
+    <!-- Avatar upload dialog -->
+    <string name="dialog_title_update_avatar">아바타 업데이트</string>
+    <string name="avatar_choose_hint">카메라 아이콘을 탭하여 이미지를 선택하세요</string>
+
+    <!-- API Keys screen -->
+    <string name="api_keys_not_available">API 키를 사용할 수 없습니다</string>
+    <string name="api_keys_not_supported">이 기능은 사용 중인 서버 버전에서 지원되지 않습니다.</string>
+    <string name="no_api_keys">API 키 없음</string>
+    <string name="no_api_keys_desc">프로그래밍 방식으로 API에 접근하려면 API 키를 생성하세요.</string>
+    <string name="dialog_title_delete_api_key">API 키 삭제</string>
+    <string name="dialog_delete_api_key_message">API 키 \"%1$s\"을(를) 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.</string>
+    <string name="created_prefix">생성: %1$s</string>
+
+    <!-- API Key create dialog -->
+    <string name="dialog_title_create_api_key">API 키 생성</string>
+    <string name="api_key_name_hint">용도를 식별할 수 있도록 API 키에 설명적인 이름을 지정하세요.</string>
+    <string name="hint_key_name">키 이름</string>
+    <string name="hint_key_name_placeholder">예: My App</string>
+    <string name="dialog_title_api_key_created">API 키 생성됨</string>
+    <string name="api_key_created_warning">API 키가 생성되었습니다. 지금 복사하세요 — 다시 볼 수 없습니다.</string>
+    <string name="copied_to_clipboard">클립보드에 복사됨</string>
+
+    <!-- Preset manager -->
+    <string name="no_presets">프리셋 없음</string>
+    <string name="no_presets_desc">채팅 화면에서 프리셋을 저장하면 여기에서 관리할 수 있습니다</string>
+    <string name="dialog_title_delete_preset">프리셋 삭제</string>
+    <string name="dialog_delete_preset_message">\"%1$s\"을(를) 삭제하시겠습니까?</string>
+
+    <!-- Shared links -->
+    <string name="no_shared_links">공유 링크 없음</string>
+    <string name="no_shared_links_desc">대화를 공유하면 여기에 표시됩니다</string>
+    <string name="dialog_title_delete_shared_link">공유 링크 삭제</string>
+    <string name="dialog_delete_shared_link_message">\"%1$s\"의 공유 링크를 제거합니다. 링크를 가진 사람은 더 이상 접근할 수 없습니다.</string>
+    <string name="visibility_public">공개</string>
+    <string name="visibility_private">비공개</string>
+    <string name="error_failed_to_load_memories">메모리를 불러오지 못했습니다</string>
+
+    <!-- Provider API Keys -->
+    <string name="provider_keys_title">제공자 API 키</string>
+    <string name="provider_keys_subtitle">키가 필요한 엔드포인트에 자신의 키를 설정하세요</string>
+    <string name="provider_keys_dialog_title">%1$s의 API 키 설정</string>
+    <string name="provider_keys_status_set_expires">%1$s 후 만료</string>
+    <string name="provider_keys_status_set_never">키가 만료되지 않습니다</string>
+    <string name="provider_keys_status_unset">설정되지 않음</string>
+    <string name="provider_keys_status_expired">만료됨</string>
+    <string name="provider_keys_status_loading">키 상태 확인 중…</string>
+    <string name="provider_keys_field_api_key_label">키</string>
+    <string name="provider_keys_field_base_url_label">Base URL</string>
+    <string name="provider_keys_field_base_url_optional_suffix">(선택 사항)</string>
+    <string name="provider_keys_field_api_key_for_endpoint">%1$s API 키</string>
+    <string name="provider_keys_field_api_url_for_endpoint">%1$s API URL</string>
+
+    <string name="provider_keys_field_azure_api_key">Azure OpenAI API Key</string>
+    <string name="provider_keys_field_azure_instance">Azure Instance Name</string>
+    <string name="provider_keys_field_azure_deployment">Azure Deployment Name</string>
+    <string name="provider_keys_field_azure_api_version">Azure API Version</string>
+
+    <string name="provider_keys_field_google_api_key">Google API Key</string>
+    <string name="provider_keys_field_google_gemini_api">(Gemini API)</string>
+    <string name="provider_keys_field_google_service_key">Google Service Account Key</string>
+    <string name="provider_keys_field_google_import">서비스 계정 JSON 키를 가져옵니다.</string>
+    <string name="provider_keys_field_google_invalid">유효하지 않은 서비스 계정 JSON 키입니다. 올바른 파일을 가져왔나요?</string>
+    <string name="provider_keys_field_google_imported">서비스 계정 JSON 키를 가져왔습니다</string>
+    <string name="provider_keys_field_google_paste_label">또는 서비스 계정 JSON 붙여넣기</string>
+    <string name="provider_keys_field_google_paste_only_hint">아래에 서비스 계정 JSON을 붙여넣으세요.</string>
+    <string name="provider_keys_field_google_service_key_or_gemini">Google Service Key 또는 Gemini API Key</string>
+
+    <string name="provider_keys_field_bedrock_access_key_id">Access Key ID</string>
+    <string name="provider_keys_field_bedrock_secret_access_key">Secret Access Key</string>
+    <string name="provider_keys_field_bedrock_session_token">Session Token</string>
+    <string name="provider_keys_field_bedrock_session_token_optional_suffix">(선택 사항)</string>
+
+    <string name="provider_keys_required_fields">다음 필드는 필수입니다: %1$s</string>
+    <string name="provider_keys_revoke">해제</string>
+    <string name="provider_keys_revoke_failed">API 키 해제에 실패했습니다. 다시 시도하세요.</string>
+    <string name="provider_keys_revoke_success">API 키를 해제했습니다</string>
+    <string name="provider_keys_revoke_all">키 해제</string>
+    <string name="provider_keys_revoke_all_confirm">모든 키를 해제하시겠습니까?</string>
+    <string name="provider_keys_revoke_all_failed">모든 키 해제에 실패했습니다</string>
+    <string name="provider_keys_save_failed">API 키 저장에 실패했습니다. 다시 시도하세요.</string>
+    <string name="provider_keys_save_success">API 키를 저장했습니다</string>
+
+    <string name="provider_keys_expiry_label">만료</string>
+    <string name="provider_keys_expiry_30m">30분 후</string>
+    <string name="provider_keys_expiry_2h">2시간 후</string>
+    <string name="provider_keys_expiry_12h">12시간 후</string>
+    <string name="provider_keys_expiry_1d">1일 후</string>
+    <string name="provider_keys_expiry_7d">7일 후</string>
+    <string name="provider_keys_expiry_30d">30일 후</string>
+    <string name="provider_keys_expiry_never">만료 안 함</string>
+
+    <string name="provider_keys_empty_title">사용자 제공 키가 필요한 엔드포인트가 없습니다</string>
+    <string name="provider_keys_empty_desc">자신의 API 키가 필요한 엔드포인트가 여기에 표시됩니다.</string>
+    <string name="provider_keys_revoke_all_action">모두 해제</string>
+
+    <!-- Admin: role skill access -->
+    <string name="role_skills_settings_row">스킬 접근 권한 (관리자)</string>
+    <string name="role_skills_title">스킬 접근 권한</string>
+    <string name="role_skills_back">뒤로</string>
+    <string name="role_skills_description">각 역할이 가지는 스킬 기능을 제어합니다. 변경 사항은 선택한 역할을 가진 모든 사용자에게 적용됩니다.</string>
+    <string name="role_skills_role_label">역할</string>
+    <string name="role_skills_use">스킬 사용</string>
+    <string name="role_skills_create">스킬 생성 &amp; 편집</string>
+    <string name="role_skills_share">스킬 공유</string>
+    <string name="role_skills_share_public">스킬 공개 공유</string>
+    <string name="role_skills_save">저장</string>
+</resources>

--- a/feature/settings/src/commonMain/composeResources/values-pt/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-pt/strings.xml
@@ -1,0 +1,488 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Common actions -->
+    <string name="action_add">Adicionar</string>
+    <string name="action_cancel">Cancelar</string>
+    <string name="action_clear">Limpar</string>
+    <string name="action_confirm">Confirmar</string>
+    <string name="action_creating">Criando…</string>
+    <string name="action_create">Criar</string>
+    <string name="action_delete">Excluir</string>
+    <string name="action_done">Concluído</string>
+    <string name="action_retry">Tentar novamente</string>
+    <string name="action_revoke_all">Revogar tudo</string>
+    <string name="action_save">Salvar</string>
+    <string name="action_sign_out">Sair</string>
+    <string name="action_upload">Enviar</string>
+    <string name="action_uploading">Enviando…</string>
+    <string name="action_verify">Verificar</string>
+    <string name="action_verifying">Verificando…</string>
+
+    <!-- Content descriptions -->
+    <string name="cd_add_memory">Adicionar memória</string>
+    <string name="cd_add_server">Adicionar servidor</string>
+    <string name="cd_back">Voltar</string>
+    <string name="cd_change_avatar">Alterar avatar</string>
+    <string name="cd_choose_image">Escolher imagem</string>
+    <string name="cd_collapse_tools">Recolher ferramentas</string>
+    <string name="cd_copy_api_key">Copiar chave de API</string>
+    <string name="cd_copy_link">Copiar link</string>
+    <string name="cd_create_api_key">Criar chave de API</string>
+    <string name="cd_current_avatar">Avatar atual</string>
+    <string name="cd_delete">Excluir</string>
+    <string name="cd_delete_api_key">Excluir chave de API</string>
+    <string name="cd_delete_memory">Excluir memória</string>
+    <string name="cd_delete_preset">Excluir predefinição</string>
+    <string name="cd_delete_server">Excluir servidor</string>
+    <string name="cd_delete_shared_link">Excluir link compartilhado</string>
+    <string name="cd_edit">Editar</string>
+    <string name="cd_edit_memory">Editar memória</string>
+    <string name="cd_edit_server">Editar servidor</string>
+    <string name="cd_expand_tools">Expandir ferramentas</string>
+    <string name="cd_loading_profile">Carregando perfil</string>
+    <string name="cd_make_private">Tornar privado</string>
+    <string name="cd_make_public">Tornar público</string>
+    <string name="cd_preview_voice">Pré-ouvir voz</string>
+    <string name="cd_qr_code">Código QR para app autenticador</string>
+    <string name="cd_reinitialize">Reinicializar</string>
+    <string name="cd_avatar_preview">Visualização do avatar</string>
+    <string name="cd_selected">Selecionado</string>
+    <string name="cd_selected_avatar">Avatar selecionado</string>
+    <string name="cd_stop_voice_preview">Parar pré-audição de voz</string>
+    <string name="cd_test_tts_voice">Testar voz de TTS selecionada</string>
+    <string name="cd_toggle_auto_read">Alternar leitura automática das respostas</string>
+    <string name="cd_toggle_auto_send_stt">Alternar envio automático após a fala</string>
+    <string name="cd_toggle_memories">Alternar memórias</string>
+    <string name="cd_tts_voice_selector">Selecionar voz de TTS. Atualmente %1$s</string>
+    <string name="cd_user_avatar">Avatar do usuário</string>
+    <string name="cd_view_all_tools">Ver todas as ferramentas</string>
+    <string name="cd_view_tools">Ver ferramentas</string>
+
+    <!-- Section headers -->
+    <string name="section_about">Sobre</string>
+    <string name="section_account">Conta</string>
+    <string name="section_advanced">Avançado</string>
+    <string name="section_appearance">Aparência</string>
+    <string name="section_balance">Saldo</string>
+    <string name="section_chat_preferences">Preferências de conversa</string>
+    <string name="section_conversations">Conversas</string>
+    <string name="section_danger_zone">Zona de perigo</string>
+    <string name="section_data_management">Gerenciamento de dados</string>
+    <string name="section_general">Geral</string>
+    <string name="section_language">Idioma</string>
+    <string name="section_layout">Layout</string>
+    <string name="section_mcp_servers">Servidores MCP</string>
+    <string name="section_memories">Memórias</string>
+    <string name="section_personalization">Personalização</string>
+    <string name="section_presets">Predefinições</string>
+    <string name="section_profile">Perfil</string>
+    <string name="section_security">Segurança</string>
+    <string name="section_speech">Fala</string>
+    <string name="section_tablet">Tablet</string>
+
+    <!-- Screen titles -->
+    <string name="title_account">Conta</string>
+    <string name="title_api_keys">Chaves de API</string>
+    <string name="title_chat">Conversa</string>
+    <string name="title_commands">Comandos</string>
+    <string name="title_data">Dados</string>
+    <string name="title_general">Geral</string>
+    <string name="title_memories">Memórias</string>
+    <string name="title_mcp_servers">Servidores MCP</string>
+    <string name="title_presets">Predefinições</string>
+    <string name="title_settings">Configurações</string>
+    <string name="title_shared_links">Links compartilhados</string>
+
+    <!-- Tabbed settings tabs -->
+    <string name="tab_general">Geral</string>
+    <string name="tab_chat">Conversa</string>
+    <string name="tab_account">Conta</string>
+    <string name="tab_data">Dados</string>
+
+    <!-- Theme -->
+    <string name="theme_system">Padrão do sistema</string>
+    <string name="theme_light">Claro</string>
+    <string name="theme_dark">Escuro</string>
+
+    <!-- Accent color -->
+    <string name="accent_color">Cor de destaque</string>
+    <string name="accent_color_custom">Personalizada</string>
+    <string name="accent_color_hex">Hex</string>
+    <string name="use_wallpaper_colors">Usar cores do papel de parede</string>
+    <string name="use_wallpaper_colors_desc">Combinar a cor de destaque do app com o papel de parede do sistema (Material You)</string>
+
+    <!-- Settings rows -->
+    <string name="language">Idioma</string>
+    <string name="language_system_default">Padrão do sistema</string>
+    <string name="personalization">Personalização</string>
+    <string name="status_enabled">Ativado</string>
+    <string name="status_disabled">Desativado</string>
+    <string name="fork_behavior">Comportamento de bifurcação</string>
+    <string name="commands">Comandos</string>
+    <string name="commands_enabled_count">%1$d ativado(s)</string>
+    <string name="api_keys">Chaves de API</string>
+    <string name="api_keys_subtitle">Gerencie chaves de API para acesso programático</string>
+    <string name="presets">Predefinições</string>
+    <string name="presets_subtitle">Gerencie predefinições de conversa</string>
+    <string name="favorites">Favoritos</string>
+    <string name="favorites_subtitle">Gerencie agentes e modelos fixados</string>
+    <string name="favorites_title">Favoritos</string>
+    <string name="favorites_empty_title">Nenhum favorito ainda</string>
+    <string name="favorites_empty_message">Fixe agentes ou modelos no seletor de modelos para vê-los aqui.</string>
+    <string name="favorites_count_of">%1$d de %2$d</string>
+    <string name="favorites_unpin_cd">Desafixar favorito</string>
+
+    <!-- About info -->
+    <string name="app_version_label">Versão do app</string>
+    <string name="app_build_label">Build</string>
+    <string name="server_label">Servidor</string>
+    <string name="server_not_configured">Não configurado</string>
+    <string name="server_build_commit_label">Commit do servidor</string>
+    <string name="server_build_branch_label">Branch do servidor</string>
+    <string name="server_build_date_label">Data de build do servidor</string>
+
+    <!-- Tablet settings -->
+    <string name="sidebar_swipe_gesture">Gesto de deslizar da barra lateral</string>
+    <string name="sidebar_swipe_gesture_desc">Deslize a partir da borda esquerda para abrir a barra lateral em layouts de tablet</string>
+
+    <!-- Balance -->
+    <string name="token_credits">Créditos de token</string>
+    <string name="available_balance">Saldo disponível</string>
+    <string name="cd_token_balance">Saldo de tokens: %1$s créditos</string>
+
+    <!-- Chat settings -->
+    <string name="chat_layout">Layout da conversa</string>
+    <string name="chat_layout_thread">Encadeado</string>
+    <string name="chat_layout_two_sided">Conversa em dois lados</string>
+    <string name="chat_layout_thread_desc">Todas as mensagens alinhadas à esquerda com avatar e nome</string>
+    <string name="chat_layout_two_sided_desc">Mensagens do usuário à direita, do agente à esquerda</string>
+    <string name="show_bubbles">Mostrar balões</string>
+    <string name="show_bubbles_desc">Adicionar fundos de balão arredondados às mensagens</string>
+    <string name="show_avatars">Mostrar avatares</string>
+    <string name="show_avatars_desc">Exibir avatares do usuário e do agente ao lado das mensagens</string>
+    <string name="starred_models_title">Modelos favoritos</string>
+    <string name="starred_models_desc">Mostrar seus modelos e agentes fixados no topo do seletor de modelos</string>
+    <string name="starred_models_off">Desativado</string>
+    <string name="starred_models_grouped">Grupo recolhível no topo</string>
+    <string name="starred_models_top">No topo, sem agrupamento</string>
+    <string name="font_size">Tamanho da fonte</string>
+    <string name="font_size_small">Pequeno</string>
+    <string name="font_size_medium">Médio</string>
+    <string name="font_size_large">Grande</string>
+    <string name="latex_renderer">Renderizador LaTeX</string>
+    <string name="latex_katex">KaTeX (renderizado)</string>
+    <string name="latex_katex_desc">Renderização completa de LaTeX via WebView</string>
+    <string name="latex_native">Texto simples (rápido)</string>
+    <string name="latex_native_desc">Mostra o código LaTeX bruto para melhor desempenho de rolagem</string>
+    <string name="auto_scroll">Rolagem automática durante o streaming</string>
+    <string name="auto_scroll_desc">Rolar automaticamente para o novo conteúdo enquanto uma resposta está sendo gerada</string>
+    <string name="show_thinking_blocks">Mostrar blocos de raciocínio</string>
+    <string name="show_thinking_blocks_desc">Exibir as etapas de raciocínio do modelo quando disponíveis</string>
+    <string name="show_image_descriptions">Mostrar descrições das imagens</string>
+    <string name="show_image_descriptions_desc">Exibir os prompts de imagem gerados por IA abaixo das imagens</string>
+    <string name="dismiss_keyboard_on_send">Ocultar teclado após enviar</string>
+    <string name="dismiss_keyboard_on_send_desc">Ocultar automaticamente o teclado após enviar uma mensagem</string>
+
+    <!-- Artifacts -->
+    <string name="section_artifacts">Artefatos</string>
+    <string name="artifacts_section_desc">Renderizar artefatos diretamente na conversa, em vez de atrás de um cartão de toque para abrir. Toque em um artefato embutido para abrir a visualização em tela cheia.</string>
+    <string name="inline_artifact_mermaid">Diagramas Mermaid</string>
+    <string name="inline_artifact_mermaid_desc">Renderizar fluxogramas e diagramas Mermaid embutidos</string>
+    <string name="inline_artifact_svg">Imagens SVG</string>
+    <string name="inline_artifact_svg_desc">Renderizar gráficos vetoriais SVG embutidos</string>
+    <string name="inline_artifact_html">HTML</string>
+    <string name="inline_artifact_html_desc">Renderizar páginas HTML embutidas (carrega o Tailwind via CDN)</string>
+    <string name="inline_artifact_react">Componentes React</string>
+    <string name="inline_artifact_react_desc">Renderizar componentes React embutidos (carrega React + Babel via CDN)</string>
+    <string name="inline_artifact_markdown">Documentos Markdown</string>
+    <string name="inline_artifact_markdown_desc">Renderizar artefatos Markdown embutidos com blocos de código com destaque de sintaxe</string>
+
+    <!-- Security -->
+    <string name="two_factor_auth">Autenticação de dois fatores</string>
+    <string name="enable_two_factor">Ativar autenticação de dois fatores</string>
+    <string name="disable_two_factor">Desativar autenticação de dois fatores</string>
+    <string name="view_backup_codes">Ver códigos de backup</string>
+
+    <!-- 2FA setup dialog -->
+    <string name="dialog_title_enable_2fa">Ativar autenticação de dois fatores</string>
+    <string name="dialog_title_disable_2fa">Desativar autenticação de dois fatores</string>
+    <string name="twofa_scan_instructions">Copie a URI abaixo e cole-a no seu app autenticador (por exemplo, Google Authenticator, Authy) e depois digite o código de verificação.</string>
+    <string name="twofa_disable_instructions">Digite o código do seu autenticador para desativar o 2FA.</string>
+    <string name="hint_verification_code">Código de verificação</string>
+
+    <!-- OTP verification dialogs -->
+    <string name="otp_title_verify_identity">Verificar identidade</string>
+    <string name="otp_desc_delete_account">Digite seu código 2FA para excluir sua conta.</string>
+    <string name="otp_desc_reenroll_2fa">Digite seu código 2FA atual para reinscrever-se.</string>
+    <string name="otp_desc_regenerate_backup_codes">Digite seu código 2FA para regenerar os códigos de backup.</string>
+    <string name="otp_verify">Verificar</string>
+    <string name="otp_cancel">Cancelar</string>
+    <string name="otp_backup_code_label">Código de backup</string>
+    <string name="otp_use_backup_code">Usar um código de backup em vez disso</string>
+    <string name="otp_use_otp_code">Usar código OTP em vez disso</string>
+
+    <!-- Backup codes dialog -->
+    <string name="dialog_title_backup_codes">Códigos de backup</string>
+    <string name="backup_codes_instructions">Guarde estes códigos de backup em um lugar seguro. Cada código só pode ser usado uma vez.</string>
+
+    <!-- Danger zone -->
+    <string name="delete_account">Excluir conta</string>
+    <string name="dialog_title_sign_out">Sair</string>
+    <string name="dialog_sign_out_message">Tem certeza de que deseja sair?</string>
+    <string name="dialog_title_delete_account">Excluir conta</string>
+    <string name="dialog_delete_account_message">Esta ação não pode ser desfeita. Todos os seus dados serão excluídos permanentemente.</string>
+
+    <!-- Clear cache dialog -->
+    <string name="dialog_title_clear_cache">Limpar cache</string>
+    <string name="dialog_clear_cache_message">Isso limpará as imagens em cache e os dados temporários. Os dados da sua conta não serão afetados.</string>
+
+    <!-- Revoke keys dialog -->
+    <string name="dialog_title_revoke_keys">Revogar todas as chaves de API</string>
+    <string name="dialog_revoke_keys_message">Isso revogará todas as chaves de API armazenadas. Você precisará inseri-las novamente para continuar usando serviços externos.</string>
+
+    <!-- Data settings -->
+    <string name="clear_all_conversations">Limpar todas as conversas</string>
+    <string name="clearing">Limpando…</string>
+    <string name="archived_conversations">Conversas arquivadas</string>
+    <string name="export_all_data">Exportar todos os dados</string>
+    <string name="shared_links">Links compartilhados</string>
+    <string name="clear_cache">Limpar cache</string>
+    <string name="revoke_all_api_keys">Revogar todas as chaves de API</string>
+    <string name="revoking">Revogando…</string>
+    <string name="dialog_title_clear_conversations">Limpar todas as conversas</string>
+    <string name="dialog_clear_conversations_message">Isso excluirá permanentemente todas as suas conversas. Esta ação não pode ser desfeita.</string>
+    <string name="clear_all">Limpar tudo</string>
+    <string name="export_coming_soon">A exportação chegará em breve</string>
+    <string name="error_could_not_load_settings">Não foi possível carregar as configurações</string>
+
+    <!-- Diagnostic logs (issue #96) -->
+    <string name="section_diagnostic_logs">Logs de diagnóstico</string>
+    <string name="export_diagnostic_logs">Exportar logs de diagnóstico</string>
+    <string name="export_diagnostic_logs_with_size">Exportar logs de diagnóstico (%1$s)</string>
+    <string name="exporting_logs">Exportando…</string>
+    <string name="clear_diagnostic_logs">Limpar logs de diagnóstico</string>
+    <string name="clearing_logs">Limpando…</string>
+    <string name="logs_exported">Logs de diagnóstico exportados</string>
+    <string name="dialog_title_clear_logs">Limpar logs de diagnóstico</string>
+    <string name="dialog_clear_logs_message">Isso excluirá permanentemente todos os logs de diagnóstico armazenados neste dispositivo. Esta ação não pode ser desfeita.</string>
+
+    <!-- Speech settings -->
+    <string name="auto_send_after_speech">Enviar automaticamente após a fala</string>
+    <string name="auto_send_after_speech_desc">Enviar automaticamente a mensagem após o término da transcrição de fala</string>
+    <string name="auto_read_responses">Ler respostas automaticamente</string>
+    <string name="auto_read_responses_desc">Ler automaticamente as respostas da IA em voz alta usando texto para fala</string>
+    <string name="tts_voice">Voz de TTS</string>
+    <string name="test_voice">Testar voz</string>
+    <string name="no_server_tts_voices">Nenhuma voz de TTS do servidor disponível. Os recursos de fala podem não estar configurados no servidor.</string>
+    <string name="using_device_tts">Usando o mecanismo de texto para fala do dispositivo. Configure a voz e a velocidade nas Configurações de texto para fala abaixo.</string>
+    <string name="speech_to_text_settings">Configurações de fala para texto</string>
+    <string name="text_to_speech_settings">Configurações de texto para fala</string>
+
+    <!-- STT detail dialog -->
+    <string name="stt_engine_label">Mecanismo</string>
+    <string name="stt_language_label">Idioma</string>
+    <string name="stt_on_device">No dispositivo</string>
+    <string name="stt_default">Padrão</string>
+    <string name="stt_hint_whisper">O Whisper usa transcrição no lado do servidor. Seu servidor precisa ter o STT ativado.</string>
+    <string name="stt_hint_device">Usa o reconhecedor de fala integrado do seu dispositivo. Funciona offline em dispositivos compatíveis.</string>
+    <string name="stt_hint_google">Usa o reconhecedor de fala do Google. Requer que o app do Google esteja instalado.</string>
+    <string name="stt_hint_default">Usa a transcrição do servidor (Whisper) quando disponível; caso contrário, recorre ao reconhecimento no dispositivo.</string>
+    <string name="stt_auto_detect">Detecção automática</string>
+
+    <!-- TTS detail dialog -->
+    <string name="tts_source_label">Origem</string>
+    <string name="tts_source_device">Dispositivo (integrado)</string>
+    <string name="tts_source_server">Servidor</string>
+    <string name="tts_voice_label">Voz</string>
+    <string name="tts_engine_label">Mecanismo</string>
+    <string name="tts_system_default">Padrão do sistema</string>
+    <string name="tts_speech_rate">Velocidade da fala: %1$.1fx</string>
+    <string name="tts_pitch">Tom: %1$.1f</string>
+    <string name="tts_cache_audio">Armazenar áudio em cache</string>
+    <string name="tts_preview_text">Esta é uma pré-audição da voz selecionada.</string>
+    <string name="tts_stop_preview">Parar pré-audição</string>
+    <string name="tts_preview_voice">Pré-ouvir voz</string>
+
+    <!-- Memories -->
+    <string name="enable_memories">Ativar memórias</string>
+    <string name="enable_memories_desc">Permitir que a IA lembre de informações entre conversas</string>
+    <string name="no_memories_saved">Nenhuma memória salva ainda</string>
+    <string name="memories_add_hint">Toque no botão + para adicionar uma memória</string>
+    <string name="add_memory">Adicionar memória</string>
+    <string name="edit_memory">Editar memória</string>
+    <string name="dialog_title_delete_memory">Excluir memória</string>
+    <string name="dialog_delete_memory_message">Tem certeza de que deseja excluir a memória \"%1$s\"?</string>
+    <string name="memory_key_label">Chave</string>
+    <string name="memory_value_label">Valor</string>
+
+    <!-- MCP -->
+    <string name="add_mcp_server">Adicionar servidor MCP</string>
+    <string name="edit_mcp_server">Editar servidor MCP</string>
+    <string name="mcp_not_available">O MCP não está disponível neste servidor</string>
+    <string name="no_mcp_servers">Nenhum servidor MCP configurado</string>
+    <string name="mcp_add_hint">Toque no botão + para adicionar um servidor</string>
+    <string name="mcp_name_label">Nome</string>
+    <string name="mcp_description_label">Descrição</string>
+    <string name="mcp_description_optional">Opcional</string>
+    <string name="mcp_url_label">URL</string>
+    <string name="mcp_type_label">Tipo</string>
+    <string name="mcp_type_sse">SSE</string>
+    <string name="mcp_type_streamable_http">Streamable HTTP</string>
+    <string name="mcp_auth_label">Autenticação</string>
+    <string name="mcp_auth_none">Nenhuma</string>
+    <string name="mcp_auth_api_key">Chave de API</string>
+    <string name="mcp_auth_oauth">OAuth</string>
+    <string name="mcp_auth_key_type">Tipo de chave</string>
+    <string name="mcp_auth_bearer">Bearer</string>
+    <string name="mcp_auth_basic">Basic</string>
+    <string name="mcp_auth_custom">Personalizado</string>
+    <string name="mcp_header_name_label">Nome do cabeçalho</string>
+    <string name="mcp_header_name_placeholder">X-API-Key</string>
+    <string name="mcp_api_key_label">Chave de API</string>
+    <string name="mcp_oauth_client_id">Client ID</string>
+    <string name="mcp_oauth_client_secret">Client Secret</string>
+    <string name="mcp_oauth_auth_url">URL de autorização</string>
+    <string name="mcp_oauth_token_url">URL do token</string>
+    <string name="mcp_oauth_scope">Escopo</string>
+    <string name="mcp_oauth_scope_placeholder">read execute</string>
+    <string name="dialog_title_delete_server">Excluir servidor</string>
+    <string name="dialog_delete_server_message">Tem certeza de que deseja excluir \"%1$s\"?</string>
+    <string name="error_failed_to_load_servers">Falha ao carregar os servidores</string>
+    <string name="mcp_tools_count">%1$d ferramenta%2$s</string>
+    <string name="mcp_tools_available">%1$d ferramenta%2$s disponível(eis)</string>
+    <string name="mcp_all_tools">Todas as ferramentas MCP</string>
+    <string name="mcp_tools_for_server">Ferramentas: %1$s</string>
+    <string name="no_tools_available">Nenhuma ferramenta disponível</string>
+    <string name="mcp_tool_server">Servidor: %1$s</string>
+
+    <!-- MCP tools sheet -->
+    <string name="mcp_server_unknown">Desconhecido</string>
+
+    <!-- Fork settings -->
+    <string name="fork_mode_direct_path">Mensagens visíveis</string>
+    <string name="fork_mode_direct_path_desc">Apenas o caminho direto de mensagens até a mensagem selecionada</string>
+    <string name="fork_mode_include_branches">Incluir ramificações</string>
+    <string name="fork_mode_include_branches_desc">Caminho direto mais mensagens irmãs em cada nível</string>
+    <string name="fork_mode_target_level">Tudo até o nível alvo</string>
+    <string name="fork_mode_target_level_desc">Todas as mensagens e ramificações até o nível da mensagem alvo (padrão)</string>
+
+    <!-- Language selector -->
+    <string name="hint_search_languages">Buscar idiomas</string>
+
+    <!-- Personalization dialog -->
+    <string name="enable_personalization">Ativar personalização</string>
+    <string name="about_you_label">Sobre você</string>
+    <string name="about_you_hint">O que a IA deve saber sobre você para ter contexto?</string>
+    <string name="response_style_label">Como a IA deve responder?</string>
+    <string name="response_style_hint">Tom, formato ou estilo preferido para as respostas</string>
+
+    <!-- Commands screen -->
+    <string name="no_commands_available">Nenhum comando disponível</string>
+
+    <!-- Avatar upload dialog -->
+    <string name="dialog_title_update_avatar">Atualizar avatar</string>
+    <string name="avatar_choose_hint">Toque no ícone da câmera para escolher uma imagem</string>
+
+    <!-- API Keys screen -->
+    <string name="api_keys_not_available">Chaves de API indisponíveis</string>
+    <string name="api_keys_not_supported">Este recurso não é suportado na versão do seu servidor.</string>
+    <string name="no_api_keys">Nenhuma chave de API</string>
+    <string name="no_api_keys_desc">Crie uma chave de API para acessar a API de forma programática.</string>
+    <string name="dialog_title_delete_api_key">Excluir chave de API</string>
+    <string name="dialog_delete_api_key_message">Tem certeza de que deseja excluir a chave de API \"%1$s\"? Esta ação não pode ser desfeita.</string>
+    <string name="created_prefix">Criada: %1$s</string>
+
+    <!-- API Key create dialog -->
+    <string name="dialog_title_create_api_key">Criar chave de API</string>
+    <string name="api_key_name_hint">Dê à sua chave de API um nome descritivo para ajudar a identificar sua finalidade.</string>
+    <string name="hint_key_name">Nome da chave</string>
+    <string name="hint_key_name_placeholder">ex.: Meu App</string>
+    <string name="dialog_title_api_key_created">Chave de API criada</string>
+    <string name="api_key_created_warning">Sua chave de API foi criada. Copie-a agora — você não poderá vê-la novamente.</string>
+    <string name="copied_to_clipboard">Copiado para a área de transferência</string>
+
+    <!-- Preset manager -->
+    <string name="no_presets">Nenhuma predefinição</string>
+    <string name="no_presets_desc">Salve predefinições na tela de conversa para gerenciá-las aqui</string>
+    <string name="dialog_title_delete_preset">Excluir predefinição</string>
+    <string name="dialog_delete_preset_message">Tem certeza de que deseja excluir \"%1$s\"?</string>
+
+    <!-- Shared links -->
+    <string name="no_shared_links">Nenhum link compartilhado</string>
+    <string name="no_shared_links_desc">Compartilhe uma conversa para vê-la aqui</string>
+    <string name="dialog_title_delete_shared_link">Excluir link compartilhado</string>
+    <string name="dialog_delete_shared_link_message">Isso removerá o link compartilhado de \"%1$s\". Quem tiver o link não conseguirá mais acessá-lo.</string>
+    <string name="visibility_public">Público</string>
+    <string name="visibility_private">Privado</string>
+    <string name="error_failed_to_load_memories">Falha ao carregar as memórias</string>
+
+    <!-- Provider API Keys -->
+    <string name="provider_keys_title">Chaves de API de provedores</string>
+    <string name="provider_keys_subtitle">Defina suas próprias chaves para endpoints que as exigem</string>
+    <string name="provider_keys_dialog_title">Definir chave de API para %1$s</string>
+    <string name="provider_keys_status_set_expires">Expira em %1$s</string>
+    <string name="provider_keys_status_set_never">Sua chave nunca expirará</string>
+    <string name="provider_keys_status_unset">Não definida</string>
+    <string name="provider_keys_status_expired">Expirada</string>
+    <string name="provider_keys_status_loading">Verificando status da chave…</string>
+    <string name="provider_keys_field_api_key_label">Chave</string>
+    <string name="provider_keys_field_base_url_label">URL base</string>
+    <string name="provider_keys_field_base_url_optional_suffix">(Opcional)</string>
+    <string name="provider_keys_field_api_key_for_endpoint">Chave de API de %1$s</string>
+    <string name="provider_keys_field_api_url_for_endpoint">URL de API de %1$s</string>
+
+    <string name="provider_keys_field_azure_api_key">Chave de API do Azure OpenAI</string>
+    <string name="provider_keys_field_azure_instance">Nome da instância Azure</string>
+    <string name="provider_keys_field_azure_deployment">Nome da implantação Azure</string>
+    <string name="provider_keys_field_azure_api_version">Versão da API Azure</string>
+
+    <string name="provider_keys_field_google_api_key">Chave de API do Google</string>
+    <string name="provider_keys_field_google_gemini_api">(Gemini API)</string>
+    <string name="provider_keys_field_google_service_key">Chave de conta de serviço do Google</string>
+    <string name="provider_keys_field_google_import">Importar chave JSON de conta de serviço.</string>
+    <string name="provider_keys_field_google_invalid">Chave JSON de conta de serviço inválida. Você importou o arquivo correto?</string>
+    <string name="provider_keys_field_google_imported">Chave JSON de conta de serviço importada com sucesso</string>
+    <string name="provider_keys_field_google_paste_label">Ou cole o JSON da conta de serviço</string>
+    <string name="provider_keys_field_google_paste_only_hint">Cole o JSON da conta de serviço abaixo.</string>
+    <string name="provider_keys_field_google_service_key_or_gemini">Chave de serviço do Google ou chave de API do Gemini</string>
+
+    <string name="provider_keys_field_bedrock_access_key_id">Access Key ID</string>
+    <string name="provider_keys_field_bedrock_secret_access_key">Secret Access Key</string>
+    <string name="provider_keys_field_bedrock_session_token">Session Token</string>
+    <string name="provider_keys_field_bedrock_session_token_optional_suffix">(Opcional)</string>
+
+    <string name="provider_keys_required_fields">Os seguintes campos são obrigatórios: %1$s</string>
+    <string name="provider_keys_revoke">Revogar</string>
+    <string name="provider_keys_revoke_failed">Falha ao revogar a chave de API. Tente novamente.</string>
+    <string name="provider_keys_revoke_success">Chave de API revogada com sucesso</string>
+    <string name="provider_keys_revoke_all">Revogar chaves</string>
+    <string name="provider_keys_revoke_all_confirm">Tem certeza de que deseja revogar todas as chaves?</string>
+    <string name="provider_keys_revoke_all_failed">Falha ao revogar todas as chaves</string>
+    <string name="provider_keys_save_failed">Falha ao salvar a chave de API. Tente novamente.</string>
+    <string name="provider_keys_save_success">Chave de API salva com sucesso</string>
+
+    <string name="provider_keys_expiry_label">Expira</string>
+    <string name="provider_keys_expiry_30m">em 30 minutos</string>
+    <string name="provider_keys_expiry_2h">em 2 horas</string>
+    <string name="provider_keys_expiry_12h">em 12 horas</string>
+    <string name="provider_keys_expiry_1d">em 1 dia</string>
+    <string name="provider_keys_expiry_7d">em 7 dias</string>
+    <string name="provider_keys_expiry_30d">em 30 dias</string>
+    <string name="provider_keys_expiry_never">nunca</string>
+
+    <string name="provider_keys_empty_title">Nenhum endpoint exige chaves fornecidas pelo usuário</string>
+    <string name="provider_keys_empty_desc">Os endpoints que precisam da sua própria chave de API aparecerão aqui.</string>
+    <string name="provider_keys_revoke_all_action">Revogar tudo</string>
+
+    <!-- Admin: role skill access -->
+    <string name="role_skills_settings_row">Acesso a habilidades (admin)</string>
+    <string name="role_skills_title">Acesso a habilidades</string>
+    <string name="role_skills_back">Voltar</string>
+    <string name="role_skills_description">Controle quais recursos de habilidades cada função tem. As alterações se aplicam a todos os usuários com a função selecionada.</string>
+    <string name="role_skills_role_label">Função</string>
+    <string name="role_skills_use">Usar habilidades</string>
+    <string name="role_skills_create">Criar &amp; editar habilidades</string>
+    <string name="role_skills_share">Compartilhar habilidades</string>
+    <string name="role_skills_share_public">Compartilhar habilidades publicamente</string>
+    <string name="role_skills_save">Salvar</string>
+</resources>

--- a/feature/settings/src/commonMain/composeResources/values-ru/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-ru/strings.xml
@@ -1,0 +1,488 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Common actions -->
+    <string name="action_add">Добавить</string>
+    <string name="action_cancel">Отмена</string>
+    <string name="action_clear">Очистить</string>
+    <string name="action_confirm">Подтвердить</string>
+    <string name="action_creating">Создание…</string>
+    <string name="action_create">Создать</string>
+    <string name="action_delete">Удалить</string>
+    <string name="action_done">Готово</string>
+    <string name="action_retry">Повторить</string>
+    <string name="action_revoke_all">Отозвать все</string>
+    <string name="action_save">Сохранить</string>
+    <string name="action_sign_out">Выйти</string>
+    <string name="action_upload">Загрузить</string>
+    <string name="action_uploading">Загрузка…</string>
+    <string name="action_verify">Проверить</string>
+    <string name="action_verifying">Проверка…</string>
+
+    <!-- Content descriptions -->
+    <string name="cd_add_memory">Добавить запись памяти</string>
+    <string name="cd_add_server">Добавить сервер</string>
+    <string name="cd_back">Назад</string>
+    <string name="cd_change_avatar">Изменить аватар</string>
+    <string name="cd_choose_image">Выбрать изображение</string>
+    <string name="cd_collapse_tools">Свернуть инструменты</string>
+    <string name="cd_copy_api_key">Скопировать API-ключ</string>
+    <string name="cd_copy_link">Скопировать ссылку</string>
+    <string name="cd_create_api_key">Создать API-ключ</string>
+    <string name="cd_current_avatar">Текущий аватар</string>
+    <string name="cd_delete">Удалить</string>
+    <string name="cd_delete_api_key">Удалить API-ключ</string>
+    <string name="cd_delete_memory">Удалить запись памяти</string>
+    <string name="cd_delete_preset">Удалить пресет</string>
+    <string name="cd_delete_server">Удалить сервер</string>
+    <string name="cd_delete_shared_link">Удалить общую ссылку</string>
+    <string name="cd_edit">Изменить</string>
+    <string name="cd_edit_memory">Изменить запись памяти</string>
+    <string name="cd_edit_server">Изменить сервер</string>
+    <string name="cd_expand_tools">Развернуть инструменты</string>
+    <string name="cd_loading_profile">Загрузка профиля</string>
+    <string name="cd_make_private">Сделать приватным</string>
+    <string name="cd_make_public">Сделать публичным</string>
+    <string name="cd_preview_voice">Прослушать голос</string>
+    <string name="cd_qr_code">QR-код для приложения-аутентификатора</string>
+    <string name="cd_reinitialize">Переинициализировать</string>
+    <string name="cd_avatar_preview">Предпросмотр аватара</string>
+    <string name="cd_selected">Выбрано</string>
+    <string name="cd_selected_avatar">Выбранный аватар</string>
+    <string name="cd_stop_voice_preview">Остановить прослушивание голоса</string>
+    <string name="cd_test_tts_voice">Проверить выбранный голос TTS</string>
+    <string name="cd_toggle_auto_read">Переключить автоозвучивание ответов</string>
+    <string name="cd_toggle_auto_send_stt">Переключить автоотправку после речи</string>
+    <string name="cd_toggle_memories">Переключить память</string>
+    <string name="cd_tts_voice_selector">Выберите голос TTS. Сейчас выбран %1$s</string>
+    <string name="cd_user_avatar">Аватар пользователя</string>
+    <string name="cd_view_all_tools">Показать все инструменты</string>
+    <string name="cd_view_tools">Показать инструменты</string>
+
+    <!-- Section headers -->
+    <string name="section_about">О приложении</string>
+    <string name="section_account">Аккаунт</string>
+    <string name="section_advanced">Дополнительно</string>
+    <string name="section_appearance">Внешний вид</string>
+    <string name="section_balance">Баланс</string>
+    <string name="section_chat_preferences">Настройки чата</string>
+    <string name="section_conversations">Беседы</string>
+    <string name="section_danger_zone">Опасная зона</string>
+    <string name="section_data_management">Управление данными</string>
+    <string name="section_general">Общие</string>
+    <string name="section_language">Язык</string>
+    <string name="section_layout">Макет</string>
+    <string name="section_mcp_servers">Серверы MCP</string>
+    <string name="section_memories">Память</string>
+    <string name="section_personalization">Персонализация</string>
+    <string name="section_presets">Пресеты</string>
+    <string name="section_profile">Профиль</string>
+    <string name="section_security">Безопасность</string>
+    <string name="section_speech">Речь</string>
+    <string name="section_tablet">Планшет</string>
+
+    <!-- Screen titles -->
+    <string name="title_account">Аккаунт</string>
+    <string name="title_api_keys">API-ключи</string>
+    <string name="title_chat">Чат</string>
+    <string name="title_commands">Команды</string>
+    <string name="title_data">Данные</string>
+    <string name="title_general">Общие</string>
+    <string name="title_memories">Память</string>
+    <string name="title_mcp_servers">Серверы MCP</string>
+    <string name="title_presets">Пресеты</string>
+    <string name="title_settings">Настройки</string>
+    <string name="title_shared_links">Общие ссылки</string>
+
+    <!-- Tabbed settings tabs -->
+    <string name="tab_general">Общие</string>
+    <string name="tab_chat">Чат</string>
+    <string name="tab_account">Аккаунт</string>
+    <string name="tab_data">Данные</string>
+
+    <!-- Theme -->
+    <string name="theme_system">Системная</string>
+    <string name="theme_light">Светлая</string>
+    <string name="theme_dark">Тёмная</string>
+
+    <!-- Accent color -->
+    <string name="accent_color">Акцентный цвет</string>
+    <string name="accent_color_custom">Свой</string>
+    <string name="accent_color_hex">Hex</string>
+    <string name="use_wallpaper_colors">Использовать цвета обоев</string>
+    <string name="use_wallpaper_colors_desc">Подстраивать акцент приложения под системные обои (Material You)</string>
+
+    <!-- Settings rows -->
+    <string name="language">Язык</string>
+    <string name="language_system_default">Системный</string>
+    <string name="personalization">Персонализация</string>
+    <string name="status_enabled">Включено</string>
+    <string name="status_disabled">Выключено</string>
+    <string name="fork_behavior">Поведение при ответвлении</string>
+    <string name="commands">Команды</string>
+    <string name="commands_enabled_count">Включено: %1$d</string>
+    <string name="api_keys">API-ключи</string>
+    <string name="api_keys_subtitle">Управление API-ключами для программного доступа</string>
+    <string name="presets">Пресеты</string>
+    <string name="presets_subtitle">Управление пресетами бесед</string>
+    <string name="favorites">Избранное</string>
+    <string name="favorites_subtitle">Управление закреплёнными агентами и моделями</string>
+    <string name="favorites_title">Избранное</string>
+    <string name="favorites_empty_title">Пока нет избранного</string>
+    <string name="favorites_empty_message">Закрепляйте агентов или модели в выборе модели, чтобы они появлялись здесь.</string>
+    <string name="favorites_count_of">%1$d из %2$d</string>
+    <string name="favorites_unpin_cd">Открепить из избранного</string>
+
+    <!-- About info -->
+    <string name="app_version_label">Версия приложения</string>
+    <string name="app_build_label">Сборка</string>
+    <string name="server_label">Сервер</string>
+    <string name="server_not_configured">Не настроено</string>
+    <string name="server_build_commit_label">Коммит сервера</string>
+    <string name="server_build_branch_label">Ветка сервера</string>
+    <string name="server_build_date_label">Дата сборки сервера</string>
+
+    <!-- Tablet settings -->
+    <string name="sidebar_swipe_gesture">Жест открытия боковой панели</string>
+    <string name="sidebar_swipe_gesture_desc">Проведите от левого края, чтобы открыть боковую панель в режиме планшета</string>
+
+    <!-- Balance -->
+    <string name="token_credits">Токен-кредиты</string>
+    <string name="available_balance">Доступный баланс</string>
+    <string name="cd_token_balance">Баланс токенов: %1$s кредитов</string>
+
+    <!-- Chat settings -->
+    <string name="chat_layout">Макет чата</string>
+    <string name="chat_layout_thread">Лента</string>
+    <string name="chat_layout_two_sided">Двусторонний чат</string>
+    <string name="chat_layout_thread_desc">Все сообщения выровнены по левому краю с аватаром и именем</string>
+    <string name="chat_layout_two_sided_desc">Сообщения пользователя справа, агента — слева</string>
+    <string name="show_bubbles">Показывать пузырьки</string>
+    <string name="show_bubbles_desc">Добавлять скруглённый фон-пузырёк к сообщениям</string>
+    <string name="show_avatars">Показывать аватары</string>
+    <string name="show_avatars_desc">Отображать аватары пользователя и агента рядом с сообщениями</string>
+    <string name="starred_models_title">Избранные модели</string>
+    <string name="starred_models_desc">Показывать закреплённые модели и агентов в начале списка выбора модели</string>
+    <string name="starred_models_off">Выключено</string>
+    <string name="starred_models_grouped">Сворачиваемая группа вверху</string>
+    <string name="starred_models_top">Вверху, без группировки</string>
+    <string name="font_size">Размер шрифта</string>
+    <string name="font_size_small">Мелкий</string>
+    <string name="font_size_medium">Средний</string>
+    <string name="font_size_large">Крупный</string>
+    <string name="latex_renderer">Отрисовщик LaTeX</string>
+    <string name="latex_katex">KaTeX (с отрисовкой)</string>
+    <string name="latex_katex_desc">Полная отрисовка LaTeX через WebView</string>
+    <string name="latex_native">Обычный текст (быстро)</string>
+    <string name="latex_native_desc">Показывает исходный код LaTeX для более плавной прокрутки</string>
+    <string name="auto_scroll">Автопрокрутка во время потоковой передачи</string>
+    <string name="auto_scroll_desc">Автоматически прокручивать к новому содержимому во время генерации ответа</string>
+    <string name="show_thinking_blocks">Показывать блоки размышлений</string>
+    <string name="show_thinking_blocks_desc">Отображать ход рассуждений модели, когда он доступен</string>
+    <string name="show_image_descriptions">Показывать описания изображений</string>
+    <string name="show_image_descriptions_desc">Отображать сгенерированные ИИ описания под изображениями</string>
+    <string name="dismiss_keyboard_on_send">Скрывать клавиатуру после отправки</string>
+    <string name="dismiss_keyboard_on_send_desc">Автоматически скрывать клавиатуру после отправки сообщения</string>
+
+    <!-- Artifacts -->
+    <string name="section_artifacts">Артефакты</string>
+    <string name="artifacts_section_desc">Отображать артефакты прямо в чате вместо карточки «нажмите, чтобы открыть». Нажмите встроенный артефакт, чтобы открыть его в полноэкранном режиме.</string>
+    <string name="inline_artifact_mermaid">Диаграммы Mermaid</string>
+    <string name="inline_artifact_mermaid_desc">Отображать блок-схемы и диаграммы Mermaid встроенно</string>
+    <string name="inline_artifact_svg">Изображения SVG</string>
+    <string name="inline_artifact_svg_desc">Отображать векторную графику SVG встроенно</string>
+    <string name="inline_artifact_html">HTML</string>
+    <string name="inline_artifact_html_desc">Отображать страницы HTML встроенно (загружает Tailwind из CDN)</string>
+    <string name="inline_artifact_react">Компоненты React</string>
+    <string name="inline_artifact_react_desc">Отображать компоненты React встроенно (загружает React + Babel из CDN)</string>
+    <string name="inline_artifact_markdown">Документы Markdown</string>
+    <string name="inline_artifact_markdown_desc">Отображать артефакты Markdown встроенно с подсветкой синтаксиса в блоках кода</string>
+
+    <!-- Security -->
+    <string name="two_factor_auth">Двухфакторная аутентификация</string>
+    <string name="enable_two_factor">Включить двухфакторную аутентификацию</string>
+    <string name="disable_two_factor">Отключить двухфакторную аутентификацию</string>
+    <string name="view_backup_codes">Показать резервные коды</string>
+
+    <!-- 2FA setup dialog -->
+    <string name="dialog_title_enable_2fa">Включить двухфакторную аутентификацию</string>
+    <string name="dialog_title_disable_2fa">Отключить двухфакторную аутентификацию</string>
+    <string name="twofa_scan_instructions">Скопируйте URI ниже и вставьте его в приложение-аутентификатор (например, Google Authenticator, Authy), затем введите код подтверждения.</string>
+    <string name="twofa_disable_instructions">Введите код из аутентификатора, чтобы отключить 2FA.</string>
+    <string name="hint_verification_code">Код подтверждения</string>
+
+    <!-- OTP verification dialogs -->
+    <string name="otp_title_verify_identity">Подтверждение личности</string>
+    <string name="otp_desc_delete_account">Введите код 2FA, чтобы удалить аккаунт.</string>
+    <string name="otp_desc_reenroll_2fa">Введите текущий код 2FA для повторной настройки.</string>
+    <string name="otp_desc_regenerate_backup_codes">Введите код 2FA, чтобы создать новые резервные коды.</string>
+    <string name="otp_verify">Проверить</string>
+    <string name="otp_cancel">Отмена</string>
+    <string name="otp_backup_code_label">Резервный код</string>
+    <string name="otp_use_backup_code">Использовать резервный код</string>
+    <string name="otp_use_otp_code">Использовать код OTP</string>
+
+    <!-- Backup codes dialog -->
+    <string name="dialog_title_backup_codes">Резервные коды</string>
+    <string name="backup_codes_instructions">Сохраните эти резервные коды в надёжном месте. Каждый код можно использовать только один раз.</string>
+
+    <!-- Danger zone -->
+    <string name="delete_account">Удалить аккаунт</string>
+    <string name="dialog_title_sign_out">Выйти</string>
+    <string name="dialog_sign_out_message">Вы уверены, что хотите выйти?</string>
+    <string name="dialog_title_delete_account">Удалить аккаунт</string>
+    <string name="dialog_delete_account_message">Это действие нельзя отменить. Все ваши данные будут безвозвратно удалены.</string>
+
+    <!-- Clear cache dialog -->
+    <string name="dialog_title_clear_cache">Очистить кэш</string>
+    <string name="dialog_clear_cache_message">Это очистит кэшированные изображения и временные данные. Данные вашего аккаунта не пострадают.</string>
+
+    <!-- Revoke keys dialog -->
+    <string name="dialog_title_revoke_keys">Отозвать все API-ключи</string>
+    <string name="dialog_revoke_keys_message">Это отзовёт все сохранённые API-ключи. Чтобы продолжить пользоваться внешними сервисами, вам придётся ввести их заново.</string>
+
+    <!-- Data settings -->
+    <string name="clear_all_conversations">Очистить все беседы</string>
+    <string name="clearing">Очистка…</string>
+    <string name="archived_conversations">Архивированные беседы</string>
+    <string name="export_all_data">Экспортировать все данные</string>
+    <string name="shared_links">Общие ссылки</string>
+    <string name="clear_cache">Очистить кэш</string>
+    <string name="revoke_all_api_keys">Отозвать все API-ключи</string>
+    <string name="revoking">Отзыв…</string>
+    <string name="dialog_title_clear_conversations">Очистить все беседы</string>
+    <string name="dialog_clear_conversations_message">Это безвозвратно удалит все ваши беседы. Это действие нельзя отменить.</string>
+    <string name="clear_all">Очистить все</string>
+    <string name="export_coming_soon">Экспорт скоро появится</string>
+    <string name="error_could_not_load_settings">Не удалось загрузить настройки</string>
+
+    <!-- Diagnostic logs (issue #96) -->
+    <string name="section_diagnostic_logs">Диагностические журналы</string>
+    <string name="export_diagnostic_logs">Экспортировать диагностические журналы</string>
+    <string name="export_diagnostic_logs_with_size">Экспортировать диагностические журналы (%1$s)</string>
+    <string name="exporting_logs">Экспорт…</string>
+    <string name="clear_diagnostic_logs">Очистить диагностические журналы</string>
+    <string name="clearing_logs">Очистка…</string>
+    <string name="logs_exported">Диагностические журналы экспортированы</string>
+    <string name="dialog_title_clear_logs">Очистить диагностические журналы</string>
+    <string name="dialog_clear_logs_message">Это безвозвратно удалит все сохранённые диагностические журналы с этого устройства. Это действие нельзя отменить.</string>
+
+    <!-- Speech settings -->
+    <string name="auto_send_after_speech">Автоотправка после речи</string>
+    <string name="auto_send_after_speech_desc">Автоматически отправлять сообщение после завершения распознавания речи</string>
+    <string name="auto_read_responses">Автоозвучивание ответов</string>
+    <string name="auto_read_responses_desc">Автоматически озвучивать ответы ИИ с помощью синтеза речи</string>
+    <string name="tts_voice">Голос TTS</string>
+    <string name="test_voice">Проверить голос</string>
+    <string name="no_server_tts_voices">Голоса TTS на сервере недоступны. Возможно, функции речи не настроены на сервере.</string>
+    <string name="using_device_tts">Используется встроенный синтез речи устройства. Настройте голос и скорость в разделе «Настройки синтеза речи» ниже.</string>
+    <string name="speech_to_text_settings">Настройки распознавания речи</string>
+    <string name="text_to_speech_settings">Настройки синтеза речи</string>
+
+    <!-- STT detail dialog -->
+    <string name="stt_engine_label">Движок</string>
+    <string name="stt_language_label">Язык</string>
+    <string name="stt_on_device">На устройстве</string>
+    <string name="stt_default">По умолчанию</string>
+    <string name="stt_hint_whisper">Whisper использует транскрипцию на стороне сервера. На вашем сервере должно быть включено распознавание речи (STT).</string>
+    <string name="stt_hint_device">Использует встроенный распознаватель речи вашего устройства. Работает офлайн на поддерживаемых устройствах.</string>
+    <string name="stt_hint_google">Использует распознаватель речи Google. Требуется установленное приложение Google.</string>
+    <string name="stt_hint_default">Использует серверную транскрипцию (Whisper), когда она доступна, иначе переключается на распознавание на устройстве.</string>
+    <string name="stt_auto_detect">Автоопределение</string>
+
+    <!-- TTS detail dialog -->
+    <string name="tts_source_label">Источник</string>
+    <string name="tts_source_device">Устройство (встроенный)</string>
+    <string name="tts_source_server">Сервер</string>
+    <string name="tts_voice_label">Голос</string>
+    <string name="tts_engine_label">Движок</string>
+    <string name="tts_system_default">Системный</string>
+    <string name="tts_speech_rate">Скорость речи: %1$.1fx</string>
+    <string name="tts_pitch">Высота тона: %1$.1f</string>
+    <string name="tts_cache_audio">Кэшировать аудио</string>
+    <string name="tts_preview_text">Это образец выбранного голоса.</string>
+    <string name="tts_stop_preview">Остановить прослушивание</string>
+    <string name="tts_preview_voice">Прослушать голос</string>
+
+    <!-- Memories -->
+    <string name="enable_memories">Включить память</string>
+    <string name="enable_memories_desc">Разрешить ИИ запоминать информацию между беседами</string>
+    <string name="no_memories_saved">Пока нет сохранённых записей памяти</string>
+    <string name="memories_add_hint">Нажмите кнопку +, чтобы добавить запись памяти</string>
+    <string name="add_memory">Добавить запись памяти</string>
+    <string name="edit_memory">Изменить запись памяти</string>
+    <string name="dialog_title_delete_memory">Удалить запись памяти</string>
+    <string name="dialog_delete_memory_message">Вы уверены, что хотите удалить запись памяти \"%1$s\"?</string>
+    <string name="memory_key_label">Ключ</string>
+    <string name="memory_value_label">Значение</string>
+
+    <!-- MCP -->
+    <string name="add_mcp_server">Добавить сервер MCP</string>
+    <string name="edit_mcp_server">Изменить сервер MCP</string>
+    <string name="mcp_not_available">MCP недоступен на этом сервере</string>
+    <string name="no_mcp_servers">Серверы MCP не настроены</string>
+    <string name="mcp_add_hint">Нажмите кнопку +, чтобы добавить сервер</string>
+    <string name="mcp_name_label">Имя</string>
+    <string name="mcp_description_label">Описание</string>
+    <string name="mcp_description_optional">Необязательно</string>
+    <string name="mcp_url_label">URL</string>
+    <string name="mcp_type_label">Тип</string>
+    <string name="mcp_type_sse">SSE</string>
+    <string name="mcp_type_streamable_http">Streamable HTTP</string>
+    <string name="mcp_auth_label">Аутентификация</string>
+    <string name="mcp_auth_none">Нет</string>
+    <string name="mcp_auth_api_key">API-ключ</string>
+    <string name="mcp_auth_oauth">OAuth</string>
+    <string name="mcp_auth_key_type">Тип ключа</string>
+    <string name="mcp_auth_bearer">Bearer</string>
+    <string name="mcp_auth_basic">Basic</string>
+    <string name="mcp_auth_custom">Свой</string>
+    <string name="mcp_header_name_label">Имя заголовка</string>
+    <string name="mcp_header_name_placeholder">X-API-Key</string>
+    <string name="mcp_api_key_label">API-ключ</string>
+    <string name="mcp_oauth_client_id">Client ID</string>
+    <string name="mcp_oauth_client_secret">Client Secret</string>
+    <string name="mcp_oauth_auth_url">URL авторизации</string>
+    <string name="mcp_oauth_token_url">URL токена</string>
+    <string name="mcp_oauth_scope">Область</string>
+    <string name="mcp_oauth_scope_placeholder">read execute</string>
+    <string name="dialog_title_delete_server">Удалить сервер</string>
+    <string name="dialog_delete_server_message">Вы уверены, что хотите удалить \"%1$s\"?</string>
+    <string name="error_failed_to_load_servers">Не удалось загрузить серверы</string>
+    <string name="mcp_tools_count">%1$d инструмент%2$s</string>
+    <string name="mcp_tools_available">Доступно инструментов: %1$d%2$s</string>
+    <string name="mcp_all_tools">Все инструменты MCP</string>
+    <string name="mcp_tools_for_server">Инструменты: %1$s</string>
+    <string name="no_tools_available">Нет доступных инструментов</string>
+    <string name="mcp_tool_server">Сервер: %1$s</string>
+
+    <!-- MCP tools sheet -->
+    <string name="mcp_server_unknown">Неизвестно</string>
+
+    <!-- Fork settings -->
+    <string name="fork_mode_direct_path">Видимые сообщения</string>
+    <string name="fork_mode_direct_path_desc">Только прямой путь сообщений до выбранного сообщения</string>
+    <string name="fork_mode_include_branches">Включить ветви</string>
+    <string name="fork_mode_include_branches_desc">Прямой путь плюс соседние сообщения на каждом уровне</string>
+    <string name="fork_mode_target_level">Все до уровня цели</string>
+    <string name="fork_mode_target_level_desc">Все сообщения и ветви до уровня целевого сообщения (по умолчанию)</string>
+
+    <!-- Language selector -->
+    <string name="hint_search_languages">Поиск языков</string>
+
+    <!-- Personalization dialog -->
+    <string name="enable_personalization">Включить персонализацию</string>
+    <string name="about_you_label">О вас</string>
+    <string name="about_you_hint">Что ИИ следует знать о вас для контекста?</string>
+    <string name="response_style_label">Как ИИ должен отвечать?</string>
+    <string name="response_style_hint">Предпочитаемый тон, формат или стиль ответов</string>
+
+    <!-- Commands screen -->
+    <string name="no_commands_available">Нет доступных команд</string>
+
+    <!-- Avatar upload dialog -->
+    <string name="dialog_title_update_avatar">Обновить аватар</string>
+    <string name="avatar_choose_hint">Нажмите значок камеры, чтобы выбрать изображение</string>
+
+    <!-- API Keys screen -->
+    <string name="api_keys_not_available">API-ключи недоступны</string>
+    <string name="api_keys_not_supported">Эта функция не поддерживается вашей версией сервера.</string>
+    <string name="no_api_keys">Нет API-ключей</string>
+    <string name="no_api_keys_desc">Создайте API-ключ для программного доступа к API.</string>
+    <string name="dialog_title_delete_api_key">Удалить API-ключ</string>
+    <string name="dialog_delete_api_key_message">Вы уверены, что хотите удалить API-ключ \"%1$s\"? Это действие нельзя отменить.</string>
+    <string name="created_prefix">Создан: %1$s</string>
+
+    <!-- API Key create dialog -->
+    <string name="dialog_title_create_api_key">Создать API-ключ</string>
+    <string name="api_key_name_hint">Дайте API-ключу понятное имя, чтобы было проще определить его назначение.</string>
+    <string name="hint_key_name">Имя ключа</string>
+    <string name="hint_key_name_placeholder">например, Моё приложение</string>
+    <string name="dialog_title_api_key_created">API-ключ создан</string>
+    <string name="api_key_created_warning">Ваш API-ключ создан. Скопируйте его сейчас — больше вы его не увидите.</string>
+    <string name="copied_to_clipboard">Скопировано в буфер обмена</string>
+
+    <!-- Preset manager -->
+    <string name="no_presets">Нет пресетов</string>
+    <string name="no_presets_desc">Сохраняйте пресеты на экране чата, чтобы управлять ими здесь</string>
+    <string name="dialog_title_delete_preset">Удалить пресет</string>
+    <string name="dialog_delete_preset_message">Вы уверены, что хотите удалить \"%1$s\"?</string>
+
+    <!-- Shared links -->
+    <string name="no_shared_links">Нет общих ссылок</string>
+    <string name="no_shared_links_desc">Поделитесь беседой, чтобы увидеть её здесь</string>
+    <string name="dialog_title_delete_shared_link">Удалить общую ссылку</string>
+    <string name="dialog_delete_shared_link_message">Это удалит общую ссылку для \"%1$s\". Никто из тех, у кого есть ссылка, больше не сможет получить к ней доступ.</string>
+    <string name="visibility_public">Публичная</string>
+    <string name="visibility_private">Приватная</string>
+    <string name="error_failed_to_load_memories">Не удалось загрузить записи памяти</string>
+
+    <!-- Provider API Keys -->
+    <string name="provider_keys_title">API-ключи провайдеров</string>
+    <string name="provider_keys_subtitle">Задайте собственные ключи для конечных точек, которым они требуются</string>
+    <string name="provider_keys_dialog_title">Задать API-ключ для %1$s</string>
+    <string name="provider_keys_status_set_expires">Истекает через %1$s</string>
+    <string name="provider_keys_status_set_never">Ваш ключ никогда не истечёт</string>
+    <string name="provider_keys_status_unset">Не задан</string>
+    <string name="provider_keys_status_expired">Истёк</string>
+    <string name="provider_keys_status_loading">Проверка состояния ключа…</string>
+    <string name="provider_keys_field_api_key_label">Ключ</string>
+    <string name="provider_keys_field_base_url_label">Базовый URL</string>
+    <string name="provider_keys_field_base_url_optional_suffix">(Необязательно)</string>
+    <string name="provider_keys_field_api_key_for_endpoint">API-ключ %1$s</string>
+    <string name="provider_keys_field_api_url_for_endpoint">URL API %1$s</string>
+
+    <string name="provider_keys_field_azure_api_key">API-ключ Azure OpenAI</string>
+    <string name="provider_keys_field_azure_instance">Имя экземпляра Azure</string>
+    <string name="provider_keys_field_azure_deployment">Имя развёртывания Azure</string>
+    <string name="provider_keys_field_azure_api_version">Версия API Azure</string>
+
+    <string name="provider_keys_field_google_api_key">API-ключ Google</string>
+    <string name="provider_keys_field_google_gemini_api">(Gemini API)</string>
+    <string name="provider_keys_field_google_service_key">Ключ сервисного аккаунта Google</string>
+    <string name="provider_keys_field_google_import">Импортировать JSON-ключ сервисного аккаунта.</string>
+    <string name="provider_keys_field_google_invalid">Недействительный JSON-ключ сервисного аккаунта. Вы импортировали правильный файл?</string>
+    <string name="provider_keys_field_google_imported">JSON-ключ сервисного аккаунта успешно импортирован</string>
+    <string name="provider_keys_field_google_paste_label">Или вставьте JSON сервисного аккаунта</string>
+    <string name="provider_keys_field_google_paste_only_hint">Вставьте JSON сервисного аккаунта ниже.</string>
+    <string name="provider_keys_field_google_service_key_or_gemini">Ключ сервисного аккаунта Google или API-ключ Gemini</string>
+
+    <string name="provider_keys_field_bedrock_access_key_id">Access Key ID</string>
+    <string name="provider_keys_field_bedrock_secret_access_key">Secret Access Key</string>
+    <string name="provider_keys_field_bedrock_session_token">Session Token</string>
+    <string name="provider_keys_field_bedrock_session_token_optional_suffix">(Необязательно)</string>
+
+    <string name="provider_keys_required_fields">Необходимо заполнить следующие поля: %1$s</string>
+    <string name="provider_keys_revoke">Отозвать</string>
+    <string name="provider_keys_revoke_failed">Не удалось отозвать API-ключ. Попробуйте ещё раз.</string>
+    <string name="provider_keys_revoke_success">API-ключ успешно отозван</string>
+    <string name="provider_keys_revoke_all">Отозвать ключи</string>
+    <string name="provider_keys_revoke_all_confirm">Вы уверены, что хотите отозвать все ключи?</string>
+    <string name="provider_keys_revoke_all_failed">Не удалось отозвать все ключи</string>
+    <string name="provider_keys_save_failed">Не удалось сохранить API-ключ. Попробуйте ещё раз.</string>
+    <string name="provider_keys_save_success">API-ключ успешно сохранён</string>
+
+    <string name="provider_keys_expiry_label">Истекает</string>
+    <string name="provider_keys_expiry_30m">через 30 минут</string>
+    <string name="provider_keys_expiry_2h">через 2 часа</string>
+    <string name="provider_keys_expiry_12h">через 12 часов</string>
+    <string name="provider_keys_expiry_1d">через 1 день</string>
+    <string name="provider_keys_expiry_7d">через 7 дней</string>
+    <string name="provider_keys_expiry_30d">через 30 дней</string>
+    <string name="provider_keys_expiry_never">никогда</string>
+
+    <string name="provider_keys_empty_title">Ни одна конечная точка не требует ключей от пользователя</string>
+    <string name="provider_keys_empty_desc">Конечные точки, которым нужен ваш собственный API-ключ, появятся здесь.</string>
+    <string name="provider_keys_revoke_all_action">Отозвать все</string>
+
+    <!-- Admin: role skill access -->
+    <string name="role_skills_settings_row">Доступ к навыкам (админ)</string>
+    <string name="role_skills_title">Доступ к навыкам</string>
+    <string name="role_skills_back">Назад</string>
+    <string name="role_skills_description">Управляйте тем, какие возможности навыков есть у каждой роли. Изменения применяются ко всем пользователям с выбранной ролью.</string>
+    <string name="role_skills_role_label">Роль</string>
+    <string name="role_skills_use">Использовать навыки</string>
+    <string name="role_skills_create">Создавать и редактировать навыки</string>
+    <string name="role_skills_share">Делиться навыками</string>
+    <string name="role_skills_share_public">Делиться навыками публично</string>
+    <string name="role_skills_save">Сохранить</string>
+</resources>

--- a/feature/settings/src/commonMain/composeResources/values-zh/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-zh/strings.xml
@@ -1,0 +1,488 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Common actions -->
+    <string name="action_add">添加</string>
+    <string name="action_cancel">取消</string>
+    <string name="action_clear">清除</string>
+    <string name="action_confirm">确认</string>
+    <string name="action_creating">创建中…</string>
+    <string name="action_create">创建</string>
+    <string name="action_delete">删除</string>
+    <string name="action_done">完成</string>
+    <string name="action_retry">重试</string>
+    <string name="action_revoke_all">全部吊销</string>
+    <string name="action_save">保存</string>
+    <string name="action_sign_out">退出登录</string>
+    <string name="action_upload">上传</string>
+    <string name="action_uploading">上传中…</string>
+    <string name="action_verify">验证</string>
+    <string name="action_verifying">验证中…</string>
+
+    <!-- Content descriptions -->
+    <string name="cd_add_memory">添加记忆</string>
+    <string name="cd_add_server">添加服务器</string>
+    <string name="cd_back">返回</string>
+    <string name="cd_change_avatar">更换头像</string>
+    <string name="cd_choose_image">选择图片</string>
+    <string name="cd_collapse_tools">收起工具</string>
+    <string name="cd_copy_api_key">复制 API 密钥</string>
+    <string name="cd_copy_link">复制链接</string>
+    <string name="cd_create_api_key">创建 API 密钥</string>
+    <string name="cd_current_avatar">当前头像</string>
+    <string name="cd_delete">删除</string>
+    <string name="cd_delete_api_key">删除 API 密钥</string>
+    <string name="cd_delete_memory">删除记忆</string>
+    <string name="cd_delete_preset">删除预设</string>
+    <string name="cd_delete_server">删除服务器</string>
+    <string name="cd_delete_shared_link">删除分享链接</string>
+    <string name="cd_edit">编辑</string>
+    <string name="cd_edit_memory">编辑记忆</string>
+    <string name="cd_edit_server">编辑服务器</string>
+    <string name="cd_expand_tools">展开工具</string>
+    <string name="cd_loading_profile">正在加载个人资料</string>
+    <string name="cd_make_private">设为私有</string>
+    <string name="cd_make_public">设为公开</string>
+    <string name="cd_preview_voice">试听语音</string>
+    <string name="cd_qr_code">身份验证器应用的二维码</string>
+    <string name="cd_reinitialize">重新初始化</string>
+    <string name="cd_avatar_preview">头像预览</string>
+    <string name="cd_selected">已选择</string>
+    <string name="cd_selected_avatar">已选头像</string>
+    <string name="cd_stop_voice_preview">停止语音试听</string>
+    <string name="cd_test_tts_voice">测试所选 TTS 语音</string>
+    <string name="cd_toggle_auto_read">切换自动朗读回复</string>
+    <string name="cd_toggle_auto_send_stt">切换语音后自动发送</string>
+    <string name="cd_toggle_memories">切换记忆</string>
+    <string name="cd_tts_voice_selector">选择 TTS 语音。当前为 %1$s</string>
+    <string name="cd_user_avatar">用户头像</string>
+    <string name="cd_view_all_tools">查看全部工具</string>
+    <string name="cd_view_tools">查看工具</string>
+
+    <!-- Section headers -->
+    <string name="section_about">关于</string>
+    <string name="section_account">账户</string>
+    <string name="section_advanced">高级</string>
+    <string name="section_appearance">外观</string>
+    <string name="section_balance">余额</string>
+    <string name="section_chat_preferences">聊天偏好</string>
+    <string name="section_conversations">对话</string>
+    <string name="section_danger_zone">危险操作区</string>
+    <string name="section_data_management">数据管理</string>
+    <string name="section_general">通用</string>
+    <string name="section_language">语言</string>
+    <string name="section_layout">布局</string>
+    <string name="section_mcp_servers">MCP 服务器</string>
+    <string name="section_memories">记忆</string>
+    <string name="section_personalization">个性化</string>
+    <string name="section_presets">预设</string>
+    <string name="section_profile">个人资料</string>
+    <string name="section_security">安全</string>
+    <string name="section_speech">语音</string>
+    <string name="section_tablet">平板</string>
+
+    <!-- Screen titles -->
+    <string name="title_account">账户</string>
+    <string name="title_api_keys">API 密钥</string>
+    <string name="title_chat">聊天</string>
+    <string name="title_commands">命令</string>
+    <string name="title_data">数据</string>
+    <string name="title_general">通用</string>
+    <string name="title_memories">记忆</string>
+    <string name="title_mcp_servers">MCP 服务器</string>
+    <string name="title_presets">预设</string>
+    <string name="title_settings">设置</string>
+    <string name="title_shared_links">分享链接</string>
+
+    <!-- Tabbed settings tabs -->
+    <string name="tab_general">通用</string>
+    <string name="tab_chat">聊天</string>
+    <string name="tab_account">账户</string>
+    <string name="tab_data">数据</string>
+
+    <!-- Theme -->
+    <string name="theme_system">跟随系统</string>
+    <string name="theme_light">浅色</string>
+    <string name="theme_dark">深色</string>
+
+    <!-- Accent color -->
+    <string name="accent_color">强调色</string>
+    <string name="accent_color_custom">自定义</string>
+    <string name="accent_color_hex">十六进制</string>
+    <string name="use_wallpaper_colors">使用壁纸取色</string>
+    <string name="use_wallpaper_colors_desc">让应用强调色与系统壁纸保持一致（Material You）</string>
+
+    <!-- Settings rows -->
+    <string name="language">语言</string>
+    <string name="language_system_default">跟随系统</string>
+    <string name="personalization">个性化</string>
+    <string name="status_enabled">已启用</string>
+    <string name="status_disabled">已禁用</string>
+    <string name="fork_behavior">分叉行为</string>
+    <string name="commands">命令</string>
+    <string name="commands_enabled_count">已启用 %1$d 个</string>
+    <string name="api_keys">API 密钥</string>
+    <string name="api_keys_subtitle">管理用于程序化访问的 API 密钥</string>
+    <string name="presets">预设</string>
+    <string name="presets_subtitle">管理对话预设</string>
+    <string name="favorites">收藏</string>
+    <string name="favorites_subtitle">管理已固定的智能体和模型</string>
+    <string name="favorites_title">收藏</string>
+    <string name="favorites_empty_title">暂无收藏</string>
+    <string name="favorites_empty_message">在模型选择器中固定智能体或模型，即可在此查看。</string>
+    <string name="favorites_count_of">%1$d / %2$d</string>
+    <string name="favorites_unpin_cd">取消固定收藏</string>
+
+    <!-- About info -->
+    <string name="app_version_label">应用版本</string>
+    <string name="app_build_label">构建</string>
+    <string name="server_label">服务器</string>
+    <string name="server_not_configured">未配置</string>
+    <string name="server_build_commit_label">服务器提交</string>
+    <string name="server_build_branch_label">服务器分支</string>
+    <string name="server_build_date_label">服务器构建日期</string>
+
+    <!-- Tablet settings -->
+    <string name="sidebar_swipe_gesture">侧边栏滑动手势</string>
+    <string name="sidebar_swipe_gesture_desc">在平板布局中从左侧边缘滑动以打开侧边栏</string>
+
+    <!-- Balance -->
+    <string name="token_credits">Token 额度</string>
+    <string name="available_balance">可用余额</string>
+    <string name="cd_token_balance">Token 余额：%1$s 额度</string>
+
+    <!-- Chat settings -->
+    <string name="chat_layout">聊天布局</string>
+    <string name="chat_layout_thread">线程式</string>
+    <string name="chat_layout_two_sided">双侧聊天</string>
+    <string name="chat_layout_thread_desc">所有消息左对齐，带头像和名称</string>
+    <string name="chat_layout_two_sided_desc">用户消息靠右，智能体靠左</string>
+    <string name="show_bubbles">显示气泡</string>
+    <string name="show_bubbles_desc">为消息添加圆角气泡背景</string>
+    <string name="show_avatars">显示头像</string>
+    <string name="show_avatars_desc">在消息旁显示用户和智能体头像</string>
+    <string name="starred_models_title">星标模型</string>
+    <string name="starred_models_desc">在模型选择器顶部显示已固定的模型和智能体</string>
+    <string name="starred_models_off">关闭</string>
+    <string name="starred_models_grouped">顶部可折叠分组</string>
+    <string name="starred_models_top">置于顶部，不分组</string>
+    <string name="font_size">字体大小</string>
+    <string name="font_size_small">小</string>
+    <string name="font_size_medium">中</string>
+    <string name="font_size_large">大</string>
+    <string name="latex_renderer">LaTeX 渲染器</string>
+    <string name="latex_katex">KaTeX（渲染）</string>
+    <string name="latex_katex_desc">通过 WebView 完整渲染 LaTeX</string>
+    <string name="latex_native">纯文本（快速）</string>
+    <string name="latex_native_desc">显示原始 LaTeX 源码以获得更流畅的滚动性能</string>
+    <string name="auto_scroll">流式输出时自动滚动</string>
+    <string name="auto_scroll_desc">在生成回复时自动滚动到新内容</string>
+    <string name="show_thinking_blocks">显示思考块</string>
+    <string name="show_thinking_blocks_desc">在可用时显示模型的推理步骤</string>
+    <string name="show_image_descriptions">显示图片描述</string>
+    <string name="show_image_descriptions_desc">在图片下方显示 AI 生成的图片提示词</string>
+    <string name="dismiss_keyboard_on_send">发送后收起键盘</string>
+    <string name="dismiss_keyboard_on_send_desc">发送消息后自动隐藏键盘</string>
+
+    <!-- Artifacts -->
+    <string name="section_artifacts">Artifacts</string>
+    <string name="artifacts_section_desc">直接在聊天中渲染 artifact，而不是隐藏在需点击打开的卡片后面。点击内嵌 artifact 可打开全屏视图。</string>
+    <string name="inline_artifact_mermaid">Mermaid 图表</string>
+    <string name="inline_artifact_mermaid_desc">内嵌渲染 Mermaid 流程图和图表</string>
+    <string name="inline_artifact_svg">SVG 图片</string>
+    <string name="inline_artifact_svg_desc">内嵌渲染 SVG 矢量图形</string>
+    <string name="inline_artifact_html">HTML</string>
+    <string name="inline_artifact_html_desc">内嵌渲染 HTML 页面（从 CDN 加载 Tailwind）</string>
+    <string name="inline_artifact_react">React 组件</string>
+    <string name="inline_artifact_react_desc">内嵌渲染 React 组件（从 CDN 加载 React + Babel）</string>
+    <string name="inline_artifact_markdown">Markdown 文档</string>
+    <string name="inline_artifact_markdown_desc">内嵌渲染 Markdown artifact，并对代码块进行语法高亮</string>
+
+    <!-- Security -->
+    <string name="two_factor_auth">两步验证</string>
+    <string name="enable_two_factor">启用两步验证</string>
+    <string name="disable_two_factor">禁用两步验证</string>
+    <string name="view_backup_codes">查看备用码</string>
+
+    <!-- 2FA setup dialog -->
+    <string name="dialog_title_enable_2fa">启用两步验证</string>
+    <string name="dialog_title_disable_2fa">禁用两步验证</string>
+    <string name="twofa_scan_instructions">复制下方的 URI 并粘贴到你的身份验证器应用中（例如 Google Authenticator、Authy），然后输入验证码。</string>
+    <string name="twofa_disable_instructions">输入身份验证器验证码以禁用两步验证。</string>
+    <string name="hint_verification_code">验证码</string>
+
+    <!-- OTP verification dialogs -->
+    <string name="otp_title_verify_identity">验证身份</string>
+    <string name="otp_desc_delete_account">输入你的两步验证码以删除账户。</string>
+    <string name="otp_desc_reenroll_2fa">输入当前的两步验证码以重新注册。</string>
+    <string name="otp_desc_regenerate_backup_codes">输入你的两步验证码以重新生成备用码。</string>
+    <string name="otp_verify">验证</string>
+    <string name="otp_cancel">取消</string>
+    <string name="otp_backup_code_label">备用码</string>
+    <string name="otp_use_backup_code">改用备用码</string>
+    <string name="otp_use_otp_code">改用 OTP 验证码</string>
+
+    <!-- Backup codes dialog -->
+    <string name="dialog_title_backup_codes">备用码</string>
+    <string name="backup_codes_instructions">请将这些备用码保存在安全的地方。每个备用码只能使用一次。</string>
+
+    <!-- Danger zone -->
+    <string name="delete_account">删除账户</string>
+    <string name="dialog_title_sign_out">退出登录</string>
+    <string name="dialog_sign_out_message">确定要退出登录吗？</string>
+    <string name="dialog_title_delete_account">删除账户</string>
+    <string name="dialog_delete_account_message">此操作无法撤销。你的所有数据将被永久删除。</string>
+
+    <!-- Clear cache dialog -->
+    <string name="dialog_title_clear_cache">清除缓存</string>
+    <string name="dialog_clear_cache_message">这将清除已缓存的图片和临时数据。你的账户数据不会受到影响。</string>
+
+    <!-- Revoke keys dialog -->
+    <string name="dialog_title_revoke_keys">吊销所有 API 密钥</string>
+    <string name="dialog_revoke_keys_message">这将吊销你所有已存储的 API 密钥。如需继续使用外部服务，你需要重新输入它们。</string>
+
+    <!-- Data settings -->
+    <string name="clear_all_conversations">清除所有对话</string>
+    <string name="clearing">清除中…</string>
+    <string name="archived_conversations">已归档对话</string>
+    <string name="export_all_data">导出全部数据</string>
+    <string name="shared_links">分享链接</string>
+    <string name="clear_cache">清除缓存</string>
+    <string name="revoke_all_api_keys">吊销所有 API 密钥</string>
+    <string name="revoking">吊销中…</string>
+    <string name="dialog_title_clear_conversations">清除所有对话</string>
+    <string name="dialog_clear_conversations_message">这将永久删除你的所有对话。此操作无法撤销。</string>
+    <string name="clear_all">全部清除</string>
+    <string name="export_coming_soon">导出功能即将推出</string>
+    <string name="error_could_not_load_settings">无法加载设置</string>
+
+    <!-- Diagnostic logs (issue #96) -->
+    <string name="section_diagnostic_logs">诊断日志</string>
+    <string name="export_diagnostic_logs">导出诊断日志</string>
+    <string name="export_diagnostic_logs_with_size">导出诊断日志（%1$s）</string>
+    <string name="exporting_logs">导出中…</string>
+    <string name="clear_diagnostic_logs">清除诊断日志</string>
+    <string name="clearing_logs">清除中…</string>
+    <string name="logs_exported">诊断日志已导出</string>
+    <string name="dialog_title_clear_logs">清除诊断日志</string>
+    <string name="dialog_clear_logs_message">这将从本设备永久删除所有已存储的诊断日志。此操作无法撤销。</string>
+
+    <!-- Speech settings -->
+    <string name="auto_send_after_speech">语音后自动发送</string>
+    <string name="auto_send_after_speech_desc">语音转文字完成后自动发送消息</string>
+    <string name="auto_read_responses">自动朗读回复</string>
+    <string name="auto_read_responses_desc">使用文字转语音自动朗读 AI 回复</string>
+    <string name="tts_voice">TTS 语音</string>
+    <string name="test_voice">测试语音</string>
+    <string name="no_server_tts_voices">没有可用的服务器 TTS 语音。服务器上可能未配置语音功能。</string>
+    <string name="using_device_tts">正在使用设备的文字转语音引擎。请在下方的文字转语音设置中配置语音和语速。</string>
+    <string name="speech_to_text_settings">语音转文字设置</string>
+    <string name="text_to_speech_settings">文字转语音设置</string>
+
+    <!-- STT detail dialog -->
+    <string name="stt_engine_label">引擎</string>
+    <string name="stt_language_label">语言</string>
+    <string name="stt_on_device">设备端</string>
+    <string name="stt_default">默认</string>
+    <string name="stt_hint_whisper">Whisper 使用服务器端转录。你的服务器必须已启用 STT。</string>
+    <string name="stt_hint_device">使用设备内置的语音识别器。在受支持的设备上可离线使用。</string>
+    <string name="stt_hint_google">使用 Google 的语音识别器。需要安装 Google 应用。</string>
+    <string name="stt_hint_default">在可用时使用服务器转录（Whisper），否则回退到设备端识别。</string>
+    <string name="stt_auto_detect">自动检测</string>
+
+    <!-- TTS detail dialog -->
+    <string name="tts_source_label">来源</string>
+    <string name="tts_source_device">设备（内置）</string>
+    <string name="tts_source_server">服务器</string>
+    <string name="tts_voice_label">语音</string>
+    <string name="tts_engine_label">引擎</string>
+    <string name="tts_system_default">跟随系统</string>
+    <string name="tts_speech_rate">语速：%1$.1fx</string>
+    <string name="tts_pitch">音调：%1$.1f</string>
+    <string name="tts_cache_audio">缓存音频</string>
+    <string name="tts_preview_text">这是所选语音的试听。</string>
+    <string name="tts_stop_preview">停止试听</string>
+    <string name="tts_preview_voice">试听语音</string>
+
+    <!-- Memories -->
+    <string name="enable_memories">启用记忆</string>
+    <string name="enable_memories_desc">允许 AI 在不同对话间记住信息</string>
+    <string name="no_memories_saved">尚未保存任何记忆</string>
+    <string name="memories_add_hint">点击 + 按钮添加记忆</string>
+    <string name="add_memory">添加记忆</string>
+    <string name="edit_memory">编辑记忆</string>
+    <string name="dialog_title_delete_memory">删除记忆</string>
+    <string name="dialog_delete_memory_message">确定要删除记忆 \"%1$s\" 吗？</string>
+    <string name="memory_key_label">键</string>
+    <string name="memory_value_label">值</string>
+
+    <!-- MCP -->
+    <string name="add_mcp_server">添加 MCP 服务器</string>
+    <string name="edit_mcp_server">编辑 MCP 服务器</string>
+    <string name="mcp_not_available">此服务器不支持 MCP</string>
+    <string name="no_mcp_servers">未配置 MCP 服务器</string>
+    <string name="mcp_add_hint">点击 + 按钮添加服务器</string>
+    <string name="mcp_name_label">名称</string>
+    <string name="mcp_description_label">描述</string>
+    <string name="mcp_description_optional">可选</string>
+    <string name="mcp_url_label">URL</string>
+    <string name="mcp_type_label">类型</string>
+    <string name="mcp_type_sse">SSE</string>
+    <string name="mcp_type_streamable_http">Streamable HTTP</string>
+    <string name="mcp_auth_label">身份验证</string>
+    <string name="mcp_auth_none">无</string>
+    <string name="mcp_auth_api_key">API 密钥</string>
+    <string name="mcp_auth_oauth">OAuth</string>
+    <string name="mcp_auth_key_type">密钥类型</string>
+    <string name="mcp_auth_bearer">Bearer</string>
+    <string name="mcp_auth_basic">Basic</string>
+    <string name="mcp_auth_custom">自定义</string>
+    <string name="mcp_header_name_label">请求头名称</string>
+    <string name="mcp_header_name_placeholder">X-API-Key</string>
+    <string name="mcp_api_key_label">API 密钥</string>
+    <string name="mcp_oauth_client_id">Client ID</string>
+    <string name="mcp_oauth_client_secret">Client Secret</string>
+    <string name="mcp_oauth_auth_url">授权 URL</string>
+    <string name="mcp_oauth_token_url">Token URL</string>
+    <string name="mcp_oauth_scope">作用域</string>
+    <string name="mcp_oauth_scope_placeholder">read execute</string>
+    <string name="dialog_title_delete_server">删除服务器</string>
+    <string name="dialog_delete_server_message">确定要删除 \"%1$s\" 吗？</string>
+    <string name="error_failed_to_load_servers">加载服务器失败</string>
+    <string name="mcp_tools_count">%1$d 个工具%2$s</string>
+    <string name="mcp_tools_available">有 %1$d 个工具%2$s可用</string>
+    <string name="mcp_all_tools">所有 MCP 工具</string>
+    <string name="mcp_tools_for_server">工具：%1$s</string>
+    <string name="no_tools_available">没有可用的工具</string>
+    <string name="mcp_tool_server">服务器：%1$s</string>
+
+    <!-- MCP tools sheet -->
+    <string name="mcp_server_unknown">未知</string>
+
+    <!-- Fork settings -->
+    <string name="fork_mode_direct_path">可见消息</string>
+    <string name="fork_mode_direct_path_desc">仅包含到所选消息的直接消息路径</string>
+    <string name="fork_mode_include_branches">包含分支</string>
+    <string name="fork_mode_include_branches_desc">直接路径以及各层级的同级消息</string>
+    <string name="fork_mode_target_level">直到目标层级的全部</string>
+    <string name="fork_mode_target_level_desc">直到目标消息层级的所有消息和分支（默认）</string>
+
+    <!-- Language selector -->
+    <string name="hint_search_languages">搜索语言</string>
+
+    <!-- Personalization dialog -->
+    <string name="enable_personalization">启用个性化</string>
+    <string name="about_you_label">关于你</string>
+    <string name="about_you_hint">为了提供上下文，AI 应该了解你的哪些信息？</string>
+    <string name="response_style_label">AI 应如何回复？</string>
+    <string name="response_style_hint">回复时偏好的语气、格式或风格</string>
+
+    <!-- Commands screen -->
+    <string name="no_commands_available">没有可用的命令</string>
+
+    <!-- Avatar upload dialog -->
+    <string name="dialog_title_update_avatar">更新头像</string>
+    <string name="avatar_choose_hint">点击相机图标选择图片</string>
+
+    <!-- API Keys screen -->
+    <string name="api_keys_not_available">API 密钥不可用</string>
+    <string name="api_keys_not_supported">你的服务器版本不支持此功能。</string>
+    <string name="no_api_keys">没有 API 密钥</string>
+    <string name="no_api_keys_desc">创建一个 API 密钥以程序化访问 API。</string>
+    <string name="dialog_title_delete_api_key">删除 API 密钥</string>
+    <string name="dialog_delete_api_key_message">确定要删除 API 密钥 \"%1$s\" 吗？此操作无法撤销。</string>
+    <string name="created_prefix">创建于：%1$s</string>
+
+    <!-- API Key create dialog -->
+    <string name="dialog_title_create_api_key">创建 API 密钥</string>
+    <string name="api_key_name_hint">为你的 API 密钥取一个描述性名称，以便识别其用途。</string>
+    <string name="hint_key_name">密钥名称</string>
+    <string name="hint_key_name_placeholder">例如：我的应用</string>
+    <string name="dialog_title_api_key_created">API 密钥已创建</string>
+    <string name="api_key_created_warning">你的 API 密钥已创建。请立即复制——你将无法再次查看它。</string>
+    <string name="copied_to_clipboard">已复制到剪贴板</string>
+
+    <!-- Preset manager -->
+    <string name="no_presets">没有预设</string>
+    <string name="no_presets_desc">从聊天界面保存预设，即可在此管理</string>
+    <string name="dialog_title_delete_preset">删除预设</string>
+    <string name="dialog_delete_preset_message">确定要删除 \"%1$s\" 吗？</string>
+
+    <!-- Shared links -->
+    <string name="no_shared_links">没有分享链接</string>
+    <string name="no_shared_links_desc">分享一个对话即可在此查看</string>
+    <string name="dialog_title_delete_shared_link">删除分享链接</string>
+    <string name="dialog_delete_shared_link_message">这将移除 \"%1$s\" 的分享链接。拥有该链接的人将无法再访问它。</string>
+    <string name="visibility_public">公开</string>
+    <string name="visibility_private">私有</string>
+    <string name="error_failed_to_load_memories">加载记忆失败</string>
+
+    <!-- Provider API Keys -->
+    <string name="provider_keys_title">提供商 API 密钥</string>
+    <string name="provider_keys_subtitle">为需要密钥的端点设置你自己的密钥</string>
+    <string name="provider_keys_dialog_title">为 %1$s 设置 API 密钥</string>
+    <string name="provider_keys_status_set_expires">%1$s 后过期</string>
+    <string name="provider_keys_status_set_never">你的密钥永不过期</string>
+    <string name="provider_keys_status_unset">未设置</string>
+    <string name="provider_keys_status_expired">已过期</string>
+    <string name="provider_keys_status_loading">正在检查密钥状态…</string>
+    <string name="provider_keys_field_api_key_label">密钥</string>
+    <string name="provider_keys_field_base_url_label">Base URL</string>
+    <string name="provider_keys_field_base_url_optional_suffix">（可选）</string>
+    <string name="provider_keys_field_api_key_for_endpoint">%1$s API 密钥</string>
+    <string name="provider_keys_field_api_url_for_endpoint">%1$s API URL</string>
+
+    <string name="provider_keys_field_azure_api_key">Azure OpenAI API 密钥</string>
+    <string name="provider_keys_field_azure_instance">Azure 实例名称</string>
+    <string name="provider_keys_field_azure_deployment">Azure 部署名称</string>
+    <string name="provider_keys_field_azure_api_version">Azure API 版本</string>
+
+    <string name="provider_keys_field_google_api_key">Google API 密钥</string>
+    <string name="provider_keys_field_google_gemini_api">（Gemini API）</string>
+    <string name="provider_keys_field_google_service_key">Google 服务账号密钥</string>
+    <string name="provider_keys_field_google_import">导入服务账号 JSON 密钥。</string>
+    <string name="provider_keys_field_google_invalid">服务账号 JSON 密钥无效，你导入的文件正确吗？</string>
+    <string name="provider_keys_field_google_imported">已成功导入服务账号 JSON 密钥</string>
+    <string name="provider_keys_field_google_paste_label">或粘贴服务账号 JSON</string>
+    <string name="provider_keys_field_google_paste_only_hint">请在下方粘贴服务账号 JSON。</string>
+    <string name="provider_keys_field_google_service_key_or_gemini">Google 服务密钥或 Gemini API 密钥</string>
+
+    <string name="provider_keys_field_bedrock_access_key_id">Access Key ID</string>
+    <string name="provider_keys_field_bedrock_secret_access_key">Secret Access Key</string>
+    <string name="provider_keys_field_bedrock_session_token">Session Token</string>
+    <string name="provider_keys_field_bedrock_session_token_optional_suffix">（可选）</string>
+
+    <string name="provider_keys_required_fields">以下字段为必填项：%1$s</string>
+    <string name="provider_keys_revoke">吊销</string>
+    <string name="provider_keys_revoke_failed">吊销 API 密钥失败。请重试。</string>
+    <string name="provider_keys_revoke_success">API 密钥已成功吊销</string>
+    <string name="provider_keys_revoke_all">吊销密钥</string>
+    <string name="provider_keys_revoke_all_confirm">确定要吊销所有密钥吗？</string>
+    <string name="provider_keys_revoke_all_failed">吊销所有密钥失败</string>
+    <string name="provider_keys_save_failed">保存 API 密钥失败。请重试。</string>
+    <string name="provider_keys_save_success">API 密钥已成功保存</string>
+
+    <string name="provider_keys_expiry_label">过期时间</string>
+    <string name="provider_keys_expiry_30m">30 分钟后</string>
+    <string name="provider_keys_expiry_2h">2 小时后</string>
+    <string name="provider_keys_expiry_12h">12 小时后</string>
+    <string name="provider_keys_expiry_1d">1 天后</string>
+    <string name="provider_keys_expiry_7d">7 天后</string>
+    <string name="provider_keys_expiry_30d">30 天后</string>
+    <string name="provider_keys_expiry_never">永不</string>
+
+    <string name="provider_keys_empty_title">没有端点需要用户提供密钥</string>
+    <string name="provider_keys_empty_desc">需要你自己 API 密钥的端点将显示在此处。</string>
+    <string name="provider_keys_revoke_all_action">全部吊销</string>
+
+    <!-- Admin: role skill access -->
+    <string name="role_skills_settings_row">技能访问权限（管理员）</string>
+    <string name="role_skills_title">技能访问权限</string>
+    <string name="role_skills_back">返回</string>
+    <string name="role_skills_description">控制每个角色拥有哪些技能能力。更改将应用于所有具有所选角色的用户。</string>
+    <string name="role_skills_role_label">角色</string>
+    <string name="role_skills_use">使用技能</string>
+    <string name="role_skills_create">创建和编辑技能</string>
+    <string name="role_skills_share">分享技能</string>
+    <string name="role_skills_share_public">公开分享技能</string>
+    <string name="role_skills_save">保存</string>
+</resources>

--- a/feature/settings/src/commonMain/composeResources/values/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values/strings.xml
@@ -113,6 +113,7 @@
 
     <!-- Settings rows -->
     <string name="language">Language</string>
+    <string name="language_system_default">System default</string>
     <string name="personalization">Personalization</string>
     <string name="status_enabled">Enabled</string>
     <string name="status_disabled">Disabled</string>

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/GeneralSettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/GeneralSettingsScreen.kt
@@ -141,7 +141,10 @@ fun GeneralSettingsContent(
                 GeneralSettingsRow(
                     icon = Icons.Default.Language,
                     title = stringResource(Res.string.language),
-                    subtitle = uiState.selectedLanguage.uppercase(),
+                    subtitle = languageDisplayName(
+                        uiState.selectedLanguage,
+                        stringResource(Res.string.language_system_default),
+                    ),
                     onClick = viewModel::showLanguageDialog,
                 )
             }

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/LanguageSelectorDialog.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/LanguageSelectorDialog.kt
@@ -35,48 +35,36 @@ data class LanguageOption(
     val displayName: String,
 )
 
+/**
+ * The languages the app actually ships translations for. Shown as endonyms (native names), which
+ * by convention are not themselves translated. The "System default" sentinel ([SYSTEM_LANGUAGE])
+ * is prepended at render time since its label is localized.
+ */
 private val SUPPORTED_LANGUAGES = listOf(
     LanguageOption("en", "English"),
-    LanguageOption("es", "Spanish"),
-    LanguageOption("fr", "French"),
-    LanguageOption("de", "German"),
-    LanguageOption("it", "Italian"),
-    LanguageOption("pt", "Portuguese"),
-    LanguageOption("ru", "Russian"),
-    LanguageOption("zh", "Chinese (Simplified)"),
-    LanguageOption("ja", "Japanese"),
-    LanguageOption("ko", "Korean"),
-    LanguageOption("ar", "Arabic"),
-    LanguageOption("hi", "Hindi"),
-    LanguageOption("tr", "Turkish"),
-    LanguageOption("pl", "Polish"),
-    LanguageOption("nl", "Dutch"),
-    LanguageOption("sv", "Swedish"),
-    LanguageOption("da", "Danish"),
-    LanguageOption("fi", "Finnish"),
-    LanguageOption("no", "Norwegian"),
-    LanguageOption("uk", "Ukrainian"),
-    LanguageOption("th", "Thai"),
-    LanguageOption("vi", "Vietnamese"),
-    LanguageOption("id", "Indonesian"),
-    LanguageOption("ms", "Malay"),
-    LanguageOption("cs", "Czech"),
-    LanguageOption("ro", "Romanian"),
-    LanguageOption("hu", "Hungarian"),
-    LanguageOption("el", "Greek"),
-    LanguageOption("he", "Hebrew"),
-    LanguageOption("bg", "Bulgarian"),
-    LanguageOption("ca", "Catalan"),
-    LanguageOption("hr", "Croatian"),
-    LanguageOption("sk", "Slovak"),
-    LanguageOption("sl", "Slovenian"),
-    LanguageOption("sr", "Serbian"),
-    LanguageOption("lt", "Lithuanian"),
-    LanguageOption("lv", "Latvian"),
-    LanguageOption("et", "Estonian"),
+    LanguageOption("es", "Español"),
+    LanguageOption("fr", "Français"),
+    LanguageOption("de", "Deutsch"),
+    LanguageOption("pt", "Português"),
+    LanguageOption("ru", "Русский"),
+    LanguageOption("zh", "中文（简体）"),
+    LanguageOption("ja", "日本語"),
+    LanguageOption("ko", "한국어"),
+    LanguageOption("ar", "العربية"),
 )
 
-/** Searchable single-select language picker with 37+ locales. */
+/** Sentinel code meaning "follow the device locale"; mirrors SettingsDataStore.DEFAULT_LANGUAGE. */
+private const val SYSTEM_LANGUAGE = "system"
+
+/** Display name (endonym) for a stored language [code], or [systemLabel] for the system sentinel. */
+internal fun languageDisplayName(code: String, systemLabel: String): String =
+    if (code == SYSTEM_LANGUAGE) {
+        systemLabel
+    } else {
+        SUPPORTED_LANGUAGES.firstOrNull { it.code == code }?.displayName ?: code
+    }
+
+/** Searchable single-select language picker over the shipped locales. */
 @Composable
 internal fun LanguageSelectorDialog(
     selectedLanguage: String,
@@ -86,11 +74,14 @@ internal fun LanguageSelectorDialog(
 ) {
     var searchQuery by remember { mutableStateOf("") }
 
-    val filtered = remember(searchQuery) {
+    val systemOption = LanguageOption(SYSTEM_LANGUAGE, stringResource(Res.string.language_system_default))
+    val languages = remember(systemOption) { listOf(systemOption) + SUPPORTED_LANGUAGES }
+
+    val filtered = remember(searchQuery, languages) {
         if (searchQuery.isBlank()) {
-            SUPPORTED_LANGUAGES
+            languages
         } else {
-            SUPPORTED_LANGUAGES.filter {
+            languages.filter {
                 it.displayName.contains(searchQuery, ignoreCase = true) ||
                     it.code.contains(searchQuery, ignoreCase = true)
             }

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/LanguageSelectorDialog.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/LanguageSelectorDialog.kt
@@ -26,6 +26,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.garfiec.librechat.core.data.datastore.SettingsDataStore
 import com.garfiec.librechat.feature.settings.resources.*
 import com.garfiec.librechat.feature.settings.resources.Res
 import org.jetbrains.compose.resources.stringResource
@@ -37,8 +38,8 @@ data class LanguageOption(
 
 /**
  * The languages the app actually ships translations for. Shown as endonyms (native names), which
- * by convention are not themselves translated. The "System default" sentinel ([SYSTEM_LANGUAGE])
- * is prepended at render time since its label is localized.
+ * by convention are not themselves translated. The "System default" sentinel
+ * ([SettingsDataStore.DEFAULT_LANGUAGE]) is prepended at render time since its label is localized.
  */
 private val SUPPORTED_LANGUAGES = listOf(
     LanguageOption("en", "English"),
@@ -53,12 +54,9 @@ private val SUPPORTED_LANGUAGES = listOf(
     LanguageOption("ar", "العربية"),
 )
 
-/** Sentinel code meaning "follow the device locale"; mirrors SettingsDataStore.DEFAULT_LANGUAGE. */
-private const val SYSTEM_LANGUAGE = "system"
-
 /** Display name (endonym) for a stored language [code], or [systemLabel] for the system sentinel. */
 internal fun languageDisplayName(code: String, systemLabel: String): String =
-    if (code == SYSTEM_LANGUAGE) {
+    if (code == SettingsDataStore.DEFAULT_LANGUAGE) {
         systemLabel
     } else {
         SUPPORTED_LANGUAGES.firstOrNull { it.code == code }?.displayName ?: code
@@ -74,7 +72,10 @@ internal fun LanguageSelectorDialog(
 ) {
     var searchQuery by remember { mutableStateOf("") }
 
-    val systemOption = LanguageOption(SYSTEM_LANGUAGE, stringResource(Res.string.language_system_default))
+    val systemOption = LanguageOption(
+        SettingsDataStore.DEFAULT_LANGUAGE,
+        stringResource(Res.string.language_system_default),
+    )
     val languages = remember(systemOption) { listOf(systemOption) + SUPPORTED_LANGUAGES }
 
     val filtered = remember(searchQuery, languages) {

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/TabbedSettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/TabbedSettingsScreen.kt
@@ -27,7 +27,7 @@ import com.garfiec.librechat.feature.settings.resources.Res
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
 
-private val SettingsTabs = listOf("General", "Chat", "Account", "Data")
+private const val SETTINGS_TAB_COUNT = 4
 
 /**
  * Single tabbed settings screen with Material 3 secondary tabs.
@@ -48,7 +48,13 @@ fun TabbedSettingsScreen(
     onNavigateToRoleSkillsAdmin: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val pagerState = rememberPagerState(pageCount = { SettingsTabs.size })
+    val pagerState = rememberPagerState(pageCount = { SETTINGS_TAB_COUNT })
+    val tabTitles = listOf(
+        stringResource(Res.string.tab_general),
+        stringResource(Res.string.tab_chat),
+        stringResource(Res.string.tab_account),
+        stringResource(Res.string.tab_data),
+    )
     val scope = rememberCoroutineScope()
     val snackbarHostState = remember { SnackbarHostState() }
 
@@ -72,7 +78,7 @@ fun TabbedSettingsScreen(
                     selectedTabIndex = pagerState.currentPage,
                     modifier = Modifier.fillMaxWidth(),
                 ) {
-                    SettingsTabs.forEachIndexed { index, title ->
+                    tabTitles.forEachIndexed { index, title ->
                         Tab(
                             selected = pagerState.currentPage == index,
                             onClick = {

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/SettingsViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/SettingsViewModel.kt
@@ -211,7 +211,7 @@ data class SettingsUiState(
     val isCacheClearing: Boolean = false,
     val isKeyRevoking: Boolean = false,
     // Language
-    val selectedLanguage: String = "en",
+    val selectedLanguage: String = SettingsDataStore.DEFAULT_LANGUAGE,
     val showLanguageDialog: Boolean = false,
     // Fork settings
     val forkMode: String = "targetLevel",

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/SettingsViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/SettingsViewModel.kt
@@ -411,6 +411,9 @@ class SettingsViewModel(
     private val starredModelsDisplayPref: StateFlow<StarredModelsDisplay> = settingsDataStore.starredModelsDisplay
         .stateIn(viewModelScope, SharingStarted.Eagerly, StarredModelsDisplay.OFF)
 
+    private val selectedLanguagePref: StateFlow<String> = settingsDataStore.selectedLanguage
+        .stateIn(viewModelScope, SharingStarted.Eagerly, SettingsDataStore.DEFAULT_LANGUAGE)
+
     /** Additional preferences combined separately to stay within the 5-arg combine limit. */
     private data class AdditionalPreferences(
         val tabletSidebarGestureEnabled: Boolean,
@@ -424,6 +427,7 @@ class SettingsViewModel(
         val latexRenderer: LatexRenderer = LatexRenderer.KATEX,
         val inlineArtifactPrefs: InlineArtifactPrefs = InlineArtifactPrefs(),
         val starredModelsDisplay: StarredModelsDisplay = StarredModelsDisplay.OFF,
+        val selectedLanguage: String = SettingsDataStore.DEFAULT_LANGUAGE,
     )
 
     private val baseAdditionalPreferences = combine(
@@ -448,6 +452,8 @@ class SettingsViewModel(
         additional.copy(inlineArtifactPrefs = inlineArtifact)
     }.combine(starredModelsDisplayPref) { additional, starredDisplay ->
         additional.copy(starredModelsDisplay = starredDisplay)
+    }.combine(selectedLanguagePref) { additional, selectedLanguage ->
+        additional.copy(selectedLanguage = selectedLanguage)
     }.stateIn(viewModelScope, SharingStarted.Eagerly, AdditionalPreferences(true, false, "", "", true))
 
     /** The single public UI state that merges DataStore preferences with imperative state. */
@@ -489,6 +495,7 @@ class SettingsViewModel(
             latexRenderer = additional.latexRenderer,
             inlineArtifactPrefs = additional.inlineArtifactPrefs,
             starredModelsDisplay = additional.starredModelsDisplay,
+            selectedLanguage = additional.selectedLanguage,
         )
     }.stateIn(viewModelScope, SharingStarted.Eagerly, SettingsUiState())
 
@@ -765,7 +772,8 @@ class SettingsViewModel(
     }
 
     fun setLanguage(languageCode: String) {
-        _uiState.update { it.copy(selectedLanguage = languageCode, showLanguageDialog = false) }
+        viewModelScope.launch { settingsDataStore.setSelectedLanguage(languageCode) }
+        _uiState.update { it.copy(showLanguageDialog = false) }
     }
 
     // ── Fork settings ──────────────────────────────────────────────

--- a/feature/skills/src/commonMain/composeResources/values-ar/strings.xml
+++ b/feature/skills/src/commonMain/composeResources/values-ar/strings.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- List -->
+    <string name="skills_title">المهارات</string>
+    <string name="skills_back">رجوع</string>
+    <string name="skills_create">إنشاء مهارة</string>
+    <string name="skills_import">استيراد مهارة</string>
+    <string name="skills_search_hint">البحث في المهارات…</string>
+    <string name="skills_empty">لا توجد مهارات بعد.</string>
+
+    <!-- Files -->
+    <string name="skill_files_title">الملفات</string>
+    <string name="skill_files_empty">لا توجد ملفات مرفقة.</string>
+    <string name="skill_files_add">إضافة ملف</string>
+    <string name="skill_files_remove">إزالة %1$s</string>
+
+    <!-- Detail -->
+    <string name="skill_edit">تعديل</string>
+    <string name="skill_delete">حذف</string>
+    <string name="skill_show_source">إظهار المصدر</string>
+    <string name="skill_show_rendered">إظهار المعروض</string>
+    <string name="skill_category_label">الفئة: %1$s</string>
+    <string name="skill_version_label">الإصدار %1$d</string>
+    <string name="skill_delete_confirm_title">حذف المهارة؟</string>
+    <string name="skill_delete_confirm_message">سيؤدي هذا إلى حذف \"%1$s\" نهائيًا. لا يمكن التراجع عن ذلك.</string>
+    <string name="skill_empty_body">لا تحتوي هذه المهارة على محتوى.</string>
+    <string name="skill_active_label">نشط</string>
+    <string name="skill_active_description">اجعل هذه المهارة متاحة للاستخدام في المحادثات.</string>
+
+    <!-- Editor -->
+    <string name="skill_editor_create_title">مهارة جديدة</string>
+    <string name="skill_editor_edit_title">تعديل المهارة</string>
+    <string name="skill_field_name">الاسم</string>
+    <string name="skill_field_name_hint">lowercase-kebab-case</string>
+    <string name="skill_field_name_error">استخدم أحرفًا صغيرة وأرقامًا وشرطات (بحد أقصى 64).</string>
+    <string name="skill_field_display_title">عنوان العرض</string>
+    <string name="skill_field_description">الوصف</string>
+    <string name="skill_field_description_error">الوصف مطلوب (بحد أقصى 1024 حرفًا).</string>
+    <string name="skill_field_body">المحتوى (markdown)</string>
+    <string name="skill_field_category">الفئة</string>
+    <string name="skill_category_none">بدون</string>
+    <string name="skill_field_always_apply">تطبيق هذه المهارة دائمًا</string>
+    <string name="skill_save">حفظ</string>
+    <string name="skill_cancel">إلغاء</string>
+    <string name="skill_conflict_dismiss">حسنًا</string>
+
+    <!-- Sharing (ACL) -->
+    <string name="skill_acl_title">المشاركة والأذونات</string>
+    <string name="skill_acl_no_grants">غير مشتركة مع أحد بعد.</string>
+    <string name="skill_acl_add_principal">إضافة أشخاص أو مجموعات</string>
+    <string name="skill_acl_grant_dialog_title">مشاركة المهارة</string>
+    <string name="skill_acl_search_hint">البحث عن المستخدمين أو المجموعات أو الأدوار</string>
+    <string name="skill_acl_search_empty">لا توجد تطابقات</string>
+    <string name="skill_acl_role">الدور</string>
+    <string name="skill_acl_revoke">إزالة الوصول</string>
+    <string name="skill_acl_public_label">عام</string>
+    <string name="skill_acl_public_description">يمكن لأي شخص على هذا الخادم استخدام هذه المهارة.</string>
+    <string name="skill_acl_principal_user">مستخدم</string>
+    <string name="skill_acl_principal_group">مجموعة</string>
+    <string name="skill_acl_principal_role">دور</string>
+    <string name="skill_acl_collapse">طي</string>
+    <string name="skill_acl_expand">توسيع</string>
+    <string name="skill_acl_close">إغلاق</string>
+</resources>

--- a/feature/skills/src/commonMain/composeResources/values-de/strings.xml
+++ b/feature/skills/src/commonMain/composeResources/values-de/strings.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- List -->
+    <string name="skills_title">Skills</string>
+    <string name="skills_back">Zurück</string>
+    <string name="skills_create">Skill erstellen</string>
+    <string name="skills_import">Skill importieren</string>
+    <string name="skills_search_hint">Skills suchen…</string>
+    <string name="skills_empty">Noch keine Skills.</string>
+
+    <!-- Files -->
+    <string name="skill_files_title">Dateien</string>
+    <string name="skill_files_empty">Keine Dateien angehängt.</string>
+    <string name="skill_files_add">Datei hinzufügen</string>
+    <string name="skill_files_remove">%1$s entfernen</string>
+
+    <!-- Detail -->
+    <string name="skill_edit">Bearbeiten</string>
+    <string name="skill_delete">Löschen</string>
+    <string name="skill_show_source">Quelle anzeigen</string>
+    <string name="skill_show_rendered">Gerendert anzeigen</string>
+    <string name="skill_category_label">Kategorie: %1$s</string>
+    <string name="skill_version_label">Version %1$d</string>
+    <string name="skill_delete_confirm_title">Skill löschen?</string>
+    <string name="skill_delete_confirm_message">Dies löscht \"%1$s\" dauerhaft. Dies kann nicht rückgängig gemacht werden.</string>
+    <string name="skill_empty_body">Dieser Skill hat keinen Inhalt.</string>
+    <string name="skill_active_label">Aktiv</string>
+    <string name="skill_active_description">Diesen Skill zur Verwendung in Chats verfügbar machen.</string>
+
+    <!-- Editor -->
+    <string name="skill_editor_create_title">Neuer Skill</string>
+    <string name="skill_editor_edit_title">Skill bearbeiten</string>
+    <string name="skill_field_name">Name</string>
+    <string name="skill_field_name_hint">lowercase-kebab-case</string>
+    <string name="skill_field_name_error">Verwende Kleinbuchstaben, Ziffern und Bindestriche (max. 64).</string>
+    <string name="skill_field_display_title">Anzeigetitel</string>
+    <string name="skill_field_description">Beschreibung</string>
+    <string name="skill_field_description_error">Beschreibung ist erforderlich (max. 1024 Zeichen).</string>
+    <string name="skill_field_body">Inhalt (Markdown)</string>
+    <string name="skill_field_category">Kategorie</string>
+    <string name="skill_category_none">Keine</string>
+    <string name="skill_field_always_apply">Diesen Skill immer anwenden</string>
+    <string name="skill_save">Speichern</string>
+    <string name="skill_cancel">Abbrechen</string>
+    <string name="skill_conflict_dismiss">OK</string>
+
+    <!-- Sharing (ACL) -->
+    <string name="skill_acl_title">Teilen &amp; Berechtigungen</string>
+    <string name="skill_acl_no_grants">Noch mit niemandem geteilt.</string>
+    <string name="skill_acl_add_principal">Personen oder Gruppen hinzufügen</string>
+    <string name="skill_acl_grant_dialog_title">Skill teilen</string>
+    <string name="skill_acl_search_hint">Benutzer, Gruppen oder Rollen suchen</string>
+    <string name="skill_acl_search_empty">Keine Treffer</string>
+    <string name="skill_acl_role">Rolle</string>
+    <string name="skill_acl_revoke">Zugriff entfernen</string>
+    <string name="skill_acl_public_label">Öffentlich</string>
+    <string name="skill_acl_public_description">Jeder auf diesem Server kann diesen Skill verwenden.</string>
+    <string name="skill_acl_principal_user">Benutzer</string>
+    <string name="skill_acl_principal_group">Gruppe</string>
+    <string name="skill_acl_principal_role">Rolle</string>
+    <string name="skill_acl_collapse">Einklappen</string>
+    <string name="skill_acl_expand">Ausklappen</string>
+    <string name="skill_acl_close">Schließen</string>
+</resources>

--- a/feature/skills/src/commonMain/composeResources/values-es/strings.xml
+++ b/feature/skills/src/commonMain/composeResources/values-es/strings.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- List -->
+    <string name="skills_title">Habilidades</string>
+    <string name="skills_back">Atrás</string>
+    <string name="skills_create">Crear habilidad</string>
+    <string name="skills_import">Importar habilidad</string>
+    <string name="skills_search_hint">Buscar habilidades…</string>
+    <string name="skills_empty">Aún no hay habilidades.</string>
+
+    <!-- Files -->
+    <string name="skill_files_title">Archivos</string>
+    <string name="skill_files_empty">No hay archivos adjuntos.</string>
+    <string name="skill_files_add">Añadir archivo</string>
+    <string name="skill_files_remove">Eliminar %1$s</string>
+
+    <!-- Detail -->
+    <string name="skill_edit">Editar</string>
+    <string name="skill_delete">Eliminar</string>
+    <string name="skill_show_source">Mostrar fuente</string>
+    <string name="skill_show_rendered">Mostrar renderizado</string>
+    <string name="skill_category_label">Categoría: %1$s</string>
+    <string name="skill_version_label">Versión %1$d</string>
+    <string name="skill_delete_confirm_title">¿Eliminar habilidad?</string>
+    <string name="skill_delete_confirm_message">Esto elimina permanentemente \"%1$s\". Esta acción no se puede deshacer.</string>
+    <string name="skill_empty_body">Esta habilidad no tiene contenido.</string>
+    <string name="skill_active_label">Activa</string>
+    <string name="skill_active_description">Hacer que esta habilidad esté disponible para usar en los chats.</string>
+
+    <!-- Editor -->
+    <string name="skill_editor_create_title">Nueva habilidad</string>
+    <string name="skill_editor_edit_title">Editar habilidad</string>
+    <string name="skill_field_name">Nombre</string>
+    <string name="skill_field_name_hint">minúsculas-kebab-case</string>
+    <string name="skill_field_name_error">Usa letras minúsculas, dígitos y guiones (máx. 64).</string>
+    <string name="skill_field_display_title">Título visible</string>
+    <string name="skill_field_description">Descripción</string>
+    <string name="skill_field_description_error">La descripción es obligatoria (máx. 1024 caracteres).</string>
+    <string name="skill_field_body">Contenido (markdown)</string>
+    <string name="skill_field_category">Categoría</string>
+    <string name="skill_category_none">Ninguna</string>
+    <string name="skill_field_always_apply">Aplicar siempre esta habilidad</string>
+    <string name="skill_save">Guardar</string>
+    <string name="skill_cancel">Cancelar</string>
+    <string name="skill_conflict_dismiss">Aceptar</string>
+
+    <!-- Sharing (ACL) -->
+    <string name="skill_acl_title">Compartir y permisos</string>
+    <string name="skill_acl_no_grants">Aún no se ha compartido con nadie.</string>
+    <string name="skill_acl_add_principal">Añadir personas o grupos</string>
+    <string name="skill_acl_grant_dialog_title">Compartir habilidad</string>
+    <string name="skill_acl_search_hint">Buscar usuarios, grupos o roles</string>
+    <string name="skill_acl_search_empty">Sin coincidencias</string>
+    <string name="skill_acl_role">Rol</string>
+    <string name="skill_acl_revoke">Quitar acceso</string>
+    <string name="skill_acl_public_label">Público</string>
+    <string name="skill_acl_public_description">Cualquier persona en este servidor puede usar esta habilidad.</string>
+    <string name="skill_acl_principal_user">Usuario</string>
+    <string name="skill_acl_principal_group">Grupo</string>
+    <string name="skill_acl_principal_role">Rol</string>
+    <string name="skill_acl_collapse">Contraer</string>
+    <string name="skill_acl_expand">Expandir</string>
+    <string name="skill_acl_close">Cerrar</string>
+</resources>

--- a/feature/skills/src/commonMain/composeResources/values-fr/strings.xml
+++ b/feature/skills/src/commonMain/composeResources/values-fr/strings.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- List -->
+    <string name="skills_title">Compétences</string>
+    <string name="skills_back">Retour</string>
+    <string name="skills_create">Créer une compétence</string>
+    <string name="skills_import">Importer une compétence</string>
+    <string name="skills_search_hint">Rechercher des compétences…</string>
+    <string name="skills_empty">Aucune compétence pour l\'instant.</string>
+
+    <!-- Files -->
+    <string name="skill_files_title">Fichiers</string>
+    <string name="skill_files_empty">Aucun fichier joint.</string>
+    <string name="skill_files_add">Ajouter un fichier</string>
+    <string name="skill_files_remove">Supprimer %1$s</string>
+
+    <!-- Detail -->
+    <string name="skill_edit">Modifier</string>
+    <string name="skill_delete">Supprimer</string>
+    <string name="skill_show_source">Afficher la source</string>
+    <string name="skill_show_rendered">Afficher le rendu</string>
+    <string name="skill_category_label">Catégorie : %1$s</string>
+    <string name="skill_version_label">Version %1$d</string>
+    <string name="skill_delete_confirm_title">Supprimer la compétence ?</string>
+    <string name="skill_delete_confirm_message">Ceci supprime définitivement \"%1$s\". Cette action est irréversible.</string>
+    <string name="skill_empty_body">Cette compétence n\'a aucun contenu.</string>
+    <string name="skill_active_label">Active</string>
+    <string name="skill_active_description">Rendre cette compétence disponible dans les discussions.</string>
+
+    <!-- Editor -->
+    <string name="skill_editor_create_title">Nouvelle compétence</string>
+    <string name="skill_editor_edit_title">Modifier la compétence</string>
+    <string name="skill_field_name">Nom</string>
+    <string name="skill_field_name_hint">minuscules-en-kebab-case</string>
+    <string name="skill_field_name_error">Utilisez des lettres minuscules, des chiffres et des tirets (max 64).</string>
+    <string name="skill_field_display_title">Titre d\'affichage</string>
+    <string name="skill_field_description">Description</string>
+    <string name="skill_field_description_error">La description est requise (max 1024 caractères).</string>
+    <string name="skill_field_body">Contenu (markdown)</string>
+    <string name="skill_field_category">Catégorie</string>
+    <string name="skill_category_none">Aucune</string>
+    <string name="skill_field_always_apply">Toujours appliquer cette compétence</string>
+    <string name="skill_save">Enregistrer</string>
+    <string name="skill_cancel">Annuler</string>
+    <string name="skill_conflict_dismiss">OK</string>
+
+    <!-- Sharing (ACL) -->
+    <string name="skill_acl_title">Partage &amp; autorisations</string>
+    <string name="skill_acl_no_grants">Pas encore partagée avec quiconque.</string>
+    <string name="skill_acl_add_principal">Ajouter des personnes ou des groupes</string>
+    <string name="skill_acl_grant_dialog_title">Partager la compétence</string>
+    <string name="skill_acl_search_hint">Rechercher des utilisateurs, des groupes ou des rôles</string>
+    <string name="skill_acl_search_empty">Aucune correspondance</string>
+    <string name="skill_acl_role">Rôle</string>
+    <string name="skill_acl_revoke">Retirer l\'accès</string>
+    <string name="skill_acl_public_label">Public</string>
+    <string name="skill_acl_public_description">Toute personne sur ce serveur peut utiliser cette compétence.</string>
+    <string name="skill_acl_principal_user">Utilisateur</string>
+    <string name="skill_acl_principal_group">Groupe</string>
+    <string name="skill_acl_principal_role">Rôle</string>
+    <string name="skill_acl_collapse">Réduire</string>
+    <string name="skill_acl_expand">Développer</string>
+    <string name="skill_acl_close">Fermer</string>
+</resources>

--- a/feature/skills/src/commonMain/composeResources/values-ja/strings.xml
+++ b/feature/skills/src/commonMain/composeResources/values-ja/strings.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- List -->
+    <string name="skills_title">スキル</string>
+    <string name="skills_back">戻る</string>
+    <string name="skills_create">スキルを作成</string>
+    <string name="skills_import">スキルをインポート</string>
+    <string name="skills_search_hint">スキルを検索…</string>
+    <string name="skills_empty">スキルはまだありません。</string>
+
+    <!-- Files -->
+    <string name="skill_files_title">ファイル</string>
+    <string name="skill_files_empty">添付されたファイルはありません。</string>
+    <string name="skill_files_add">ファイルを追加</string>
+    <string name="skill_files_remove">%1$s を削除</string>
+
+    <!-- Detail -->
+    <string name="skill_edit">編集</string>
+    <string name="skill_delete">削除</string>
+    <string name="skill_show_source">ソースを表示</string>
+    <string name="skill_show_rendered">レンダリング表示</string>
+    <string name="skill_category_label">カテゴリ: %1$s</string>
+    <string name="skill_version_label">バージョン %1$d</string>
+    <string name="skill_delete_confirm_title">スキルを削除しますか？</string>
+    <string name="skill_delete_confirm_message">「%1$s」を完全に削除します。この操作は取り消せません。</string>
+    <string name="skill_empty_body">このスキルには内容がありません。</string>
+    <string name="skill_active_label">有効</string>
+    <string name="skill_active_description">このスキルをチャットで使用できるようにします。</string>
+
+    <!-- Editor -->
+    <string name="skill_editor_create_title">新しいスキル</string>
+    <string name="skill_editor_edit_title">スキルを編集</string>
+    <string name="skill_field_name">名前</string>
+    <string name="skill_field_name_hint">lowercase-kebab-case</string>
+    <string name="skill_field_name_error">小文字、数字、ハイフンを使用してください（最大64文字）。</string>
+    <string name="skill_field_display_title">表示タイトル</string>
+    <string name="skill_field_description">説明</string>
+    <string name="skill_field_description_error">説明は必須です（最大1024文字）。</string>
+    <string name="skill_field_body">内容（Markdown）</string>
+    <string name="skill_field_category">カテゴリ</string>
+    <string name="skill_category_none">なし</string>
+    <string name="skill_field_always_apply">このスキルを常に適用する</string>
+    <string name="skill_save">保存</string>
+    <string name="skill_cancel">キャンセル</string>
+    <string name="skill_conflict_dismiss">OK</string>
+
+    <!-- Sharing (ACL) -->
+    <string name="skill_acl_title">共有と権限</string>
+    <string name="skill_acl_no_grants">まだ誰とも共有されていません。</string>
+    <string name="skill_acl_add_principal">ユーザーまたはグループを追加</string>
+    <string name="skill_acl_grant_dialog_title">スキルを共有</string>
+    <string name="skill_acl_search_hint">ユーザー、グループ、またはロールを検索</string>
+    <string name="skill_acl_search_empty">一致するものがありません</string>
+    <string name="skill_acl_role">ロール</string>
+    <string name="skill_acl_revoke">アクセスを削除</string>
+    <string name="skill_acl_public_label">公開</string>
+    <string name="skill_acl_public_description">このサーバーの誰でもこのスキルを使用できます。</string>
+    <string name="skill_acl_principal_user">ユーザー</string>
+    <string name="skill_acl_principal_group">グループ</string>
+    <string name="skill_acl_principal_role">ロール</string>
+    <string name="skill_acl_collapse">折りたたむ</string>
+    <string name="skill_acl_expand">展開</string>
+    <string name="skill_acl_close">閉じる</string>
+</resources>

--- a/feature/skills/src/commonMain/composeResources/values-ko/strings.xml
+++ b/feature/skills/src/commonMain/composeResources/values-ko/strings.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- List -->
+    <string name="skills_title">스킬</string>
+    <string name="skills_back">뒤로</string>
+    <string name="skills_create">스킬 생성</string>
+    <string name="skills_import">스킬 가져오기</string>
+    <string name="skills_search_hint">스킬 검색…</string>
+    <string name="skills_empty">아직 스킬이 없습니다.</string>
+
+    <!-- Files -->
+    <string name="skill_files_title">파일</string>
+    <string name="skill_files_empty">첨부된 파일이 없습니다.</string>
+    <string name="skill_files_add">파일 추가</string>
+    <string name="skill_files_remove">%1$s 제거</string>
+
+    <!-- Detail -->
+    <string name="skill_edit">편집</string>
+    <string name="skill_delete">삭제</string>
+    <string name="skill_show_source">소스 보기</string>
+    <string name="skill_show_rendered">렌더링 보기</string>
+    <string name="skill_category_label">카테고리: %1$s</string>
+    <string name="skill_version_label">버전 %1$d</string>
+    <string name="skill_delete_confirm_title">스킬을 삭제하시겠습니까?</string>
+    <string name="skill_delete_confirm_message">\"%1$s\"이(가) 영구적으로 삭제됩니다. 되돌릴 수 없습니다.</string>
+    <string name="skill_empty_body">이 스킬에는 내용이 없습니다.</string>
+    <string name="skill_active_label">활성</string>
+    <string name="skill_active_description">이 스킬을 채팅에서 사용할 수 있도록 합니다.</string>
+
+    <!-- Editor -->
+    <string name="skill_editor_create_title">새 스킬</string>
+    <string name="skill_editor_edit_title">스킬 편집</string>
+    <string name="skill_field_name">이름</string>
+    <string name="skill_field_name_hint">lowercase-kebab-case</string>
+    <string name="skill_field_name_error">소문자, 숫자, 대시를 사용하세요 (최대 64자).</string>
+    <string name="skill_field_display_title">표시 제목</string>
+    <string name="skill_field_description">설명</string>
+    <string name="skill_field_description_error">설명은 필수입니다 (최대 1024자).</string>
+    <string name="skill_field_body">내용 (markdown)</string>
+    <string name="skill_field_category">카테고리</string>
+    <string name="skill_category_none">없음</string>
+    <string name="skill_field_always_apply">이 스킬을 항상 적용</string>
+    <string name="skill_save">저장</string>
+    <string name="skill_cancel">취소</string>
+    <string name="skill_conflict_dismiss">확인</string>
+
+    <!-- Sharing (ACL) -->
+    <string name="skill_acl_title">공유 &amp; 권한</string>
+    <string name="skill_acl_no_grants">아직 아무와도 공유되지 않았습니다.</string>
+    <string name="skill_acl_add_principal">사용자 또는 그룹 추가</string>
+    <string name="skill_acl_grant_dialog_title">스킬 공유</string>
+    <string name="skill_acl_search_hint">사용자, 그룹 또는 역할 검색</string>
+    <string name="skill_acl_search_empty">일치하는 항목 없음</string>
+    <string name="skill_acl_role">역할</string>
+    <string name="skill_acl_revoke">접근 제거</string>
+    <string name="skill_acl_public_label">공개</string>
+    <string name="skill_acl_public_description">이 서버의 모든 사람이 이 스킬을 사용할 수 있습니다.</string>
+    <string name="skill_acl_principal_user">사용자</string>
+    <string name="skill_acl_principal_group">그룹</string>
+    <string name="skill_acl_principal_role">역할</string>
+    <string name="skill_acl_collapse">접기</string>
+    <string name="skill_acl_expand">펼치기</string>
+    <string name="skill_acl_close">닫기</string>
+</resources>

--- a/feature/skills/src/commonMain/composeResources/values-pt/strings.xml
+++ b/feature/skills/src/commonMain/composeResources/values-pt/strings.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- List -->
+    <string name="skills_title">Habilidades</string>
+    <string name="skills_back">Voltar</string>
+    <string name="skills_create">Criar habilidade</string>
+    <string name="skills_import">Importar habilidade</string>
+    <string name="skills_search_hint">Buscar habilidades…</string>
+    <string name="skills_empty">Nenhuma habilidade ainda.</string>
+
+    <!-- Files -->
+    <string name="skill_files_title">Arquivos</string>
+    <string name="skill_files_empty">Nenhum arquivo anexado.</string>
+    <string name="skill_files_add">Adicionar arquivo</string>
+    <string name="skill_files_remove">Remover %1$s</string>
+
+    <!-- Detail -->
+    <string name="skill_edit">Editar</string>
+    <string name="skill_delete">Excluir</string>
+    <string name="skill_show_source">Mostrar fonte</string>
+    <string name="skill_show_rendered">Mostrar renderizado</string>
+    <string name="skill_category_label">Categoria: %1$s</string>
+    <string name="skill_version_label">Versão %1$d</string>
+    <string name="skill_delete_confirm_title">Excluir habilidade?</string>
+    <string name="skill_delete_confirm_message">Isso exclui permanentemente \"%1$s\". Esta ação não pode ser desfeita.</string>
+    <string name="skill_empty_body">Esta habilidade não tem conteúdo.</string>
+    <string name="skill_active_label">Ativa</string>
+    <string name="skill_active_description">Tornar esta habilidade disponível para uso nas conversas.</string>
+
+    <!-- Editor -->
+    <string name="skill_editor_create_title">Nova habilidade</string>
+    <string name="skill_editor_edit_title">Editar habilidade</string>
+    <string name="skill_field_name">Nome</string>
+    <string name="skill_field_name_hint">lowercase-kebab-case</string>
+    <string name="skill_field_name_error">Use letras minúsculas, dígitos e traços (máx. 64).</string>
+    <string name="skill_field_display_title">Título de exibição</string>
+    <string name="skill_field_description">Descrição</string>
+    <string name="skill_field_description_error">A descrição é obrigatória (máx. 1024 caracteres).</string>
+    <string name="skill_field_body">Conteúdo (markdown)</string>
+    <string name="skill_field_category">Categoria</string>
+    <string name="skill_category_none">Nenhuma</string>
+    <string name="skill_field_always_apply">Sempre aplicar esta habilidade</string>
+    <string name="skill_save">Salvar</string>
+    <string name="skill_cancel">Cancelar</string>
+    <string name="skill_conflict_dismiss">OK</string>
+
+    <!-- Sharing (ACL) -->
+    <string name="skill_acl_title">Compartilhamento &amp; permissões</string>
+    <string name="skill_acl_no_grants">Ainda não compartilhada com ninguém.</string>
+    <string name="skill_acl_add_principal">Adicionar pessoas ou grupos</string>
+    <string name="skill_acl_grant_dialog_title">Compartilhar habilidade</string>
+    <string name="skill_acl_search_hint">Buscar usuários, grupos ou funções</string>
+    <string name="skill_acl_search_empty">Nenhuma correspondência</string>
+    <string name="skill_acl_role">Função</string>
+    <string name="skill_acl_revoke">Remover acesso</string>
+    <string name="skill_acl_public_label">Público</string>
+    <string name="skill_acl_public_description">Qualquer pessoa neste servidor pode usar esta habilidade.</string>
+    <string name="skill_acl_principal_user">Usuário</string>
+    <string name="skill_acl_principal_group">Grupo</string>
+    <string name="skill_acl_principal_role">Função</string>
+    <string name="skill_acl_collapse">Recolher</string>
+    <string name="skill_acl_expand">Expandir</string>
+    <string name="skill_acl_close">Fechar</string>
+</resources>

--- a/feature/skills/src/commonMain/composeResources/values-ru/strings.xml
+++ b/feature/skills/src/commonMain/composeResources/values-ru/strings.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- List -->
+    <string name="skills_title">Навыки</string>
+    <string name="skills_back">Назад</string>
+    <string name="skills_create">Создать навык</string>
+    <string name="skills_import">Импортировать навык</string>
+    <string name="skills_search_hint">Поиск навыков…</string>
+    <string name="skills_empty">Пока нет навыков.</string>
+
+    <!-- Files -->
+    <string name="skill_files_title">Файлы</string>
+    <string name="skill_files_empty">Нет прикреплённых файлов.</string>
+    <string name="skill_files_add">Добавить файл</string>
+    <string name="skill_files_remove">Удалить %1$s</string>
+
+    <!-- Detail -->
+    <string name="skill_edit">Изменить</string>
+    <string name="skill_delete">Удалить</string>
+    <string name="skill_show_source">Показать исходник</string>
+    <string name="skill_show_rendered">Показать отрисованное</string>
+    <string name="skill_category_label">Категория: %1$s</string>
+    <string name="skill_version_label">Версия %1$d</string>
+    <string name="skill_delete_confirm_title">Удалить навык?</string>
+    <string name="skill_delete_confirm_message">Это безвозвратно удалит \"%1$s\". Это нельзя отменить.</string>
+    <string name="skill_empty_body">У этого навыка нет содержимого.</string>
+    <string name="skill_active_label">Активен</string>
+    <string name="skill_active_description">Сделать этот навык доступным для использования в чатах.</string>
+
+    <!-- Editor -->
+    <string name="skill_editor_create_title">Новый навык</string>
+    <string name="skill_editor_edit_title">Изменить навык</string>
+    <string name="skill_field_name">Имя</string>
+    <string name="skill_field_name_hint">lowercase-kebab-case</string>
+    <string name="skill_field_name_error">Используйте строчные буквы, цифры и дефисы (макс. 64).</string>
+    <string name="skill_field_display_title">Отображаемое название</string>
+    <string name="skill_field_description">Описание</string>
+    <string name="skill_field_description_error">Описание обязательно (макс. 1024 символа).</string>
+    <string name="skill_field_body">Содержимое (markdown)</string>
+    <string name="skill_field_category">Категория</string>
+    <string name="skill_category_none">Нет</string>
+    <string name="skill_field_always_apply">Всегда применять этот навык</string>
+    <string name="skill_save">Сохранить</string>
+    <string name="skill_cancel">Отмена</string>
+    <string name="skill_conflict_dismiss">ОК</string>
+
+    <!-- Sharing (ACL) -->
+    <string name="skill_acl_title">Доступ и разрешения</string>
+    <string name="skill_acl_no_grants">Пока ни с кем не поделено.</string>
+    <string name="skill_acl_add_principal">Добавить людей или группы</string>
+    <string name="skill_acl_grant_dialog_title">Поделиться навыком</string>
+    <string name="skill_acl_search_hint">Поиск пользователей, групп или ролей</string>
+    <string name="skill_acl_search_empty">Совпадений нет</string>
+    <string name="skill_acl_role">Роль</string>
+    <string name="skill_acl_revoke">Закрыть доступ</string>
+    <string name="skill_acl_public_label">Публичный</string>
+    <string name="skill_acl_public_description">Этот навык может использовать любой на этом сервере.</string>
+    <string name="skill_acl_principal_user">Пользователь</string>
+    <string name="skill_acl_principal_group">Группа</string>
+    <string name="skill_acl_principal_role">Роль</string>
+    <string name="skill_acl_collapse">Свернуть</string>
+    <string name="skill_acl_expand">Развернуть</string>
+    <string name="skill_acl_close">Закрыть</string>
+</resources>

--- a/feature/skills/src/commonMain/composeResources/values-zh/strings.xml
+++ b/feature/skills/src/commonMain/composeResources/values-zh/strings.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- List -->
+    <string name="skills_title">技能</string>
+    <string name="skills_back">返回</string>
+    <string name="skills_create">创建技能</string>
+    <string name="skills_import">导入技能</string>
+    <string name="skills_search_hint">搜索技能…</string>
+    <string name="skills_empty">暂无技能。</string>
+
+    <!-- Files -->
+    <string name="skill_files_title">文件</string>
+    <string name="skill_files_empty">未附加文件。</string>
+    <string name="skill_files_add">添加文件</string>
+    <string name="skill_files_remove">移除 %1$s</string>
+
+    <!-- Detail -->
+    <string name="skill_edit">编辑</string>
+    <string name="skill_delete">删除</string>
+    <string name="skill_show_source">显示源码</string>
+    <string name="skill_show_rendered">显示渲染结果</string>
+    <string name="skill_category_label">类别：%1$s</string>
+    <string name="skill_version_label">版本 %1$d</string>
+    <string name="skill_delete_confirm_title">删除技能？</string>
+    <string name="skill_delete_confirm_message">这将永久删除 \"%1$s\"。此操作无法撤销。</string>
+    <string name="skill_empty_body">此技能没有内容。</string>
+    <string name="skill_active_label">已启用</string>
+    <string name="skill_active_description">让此技能可在聊天中使用。</string>
+
+    <!-- Editor -->
+    <string name="skill_editor_create_title">新建技能</string>
+    <string name="skill_editor_edit_title">编辑技能</string>
+    <string name="skill_field_name">名称</string>
+    <string name="skill_field_name_hint">lowercase-kebab-case</string>
+    <string name="skill_field_name_error">请使用小写字母、数字和连字符（最多 64 个字符）。</string>
+    <string name="skill_field_display_title">显示标题</string>
+    <string name="skill_field_description">描述</string>
+    <string name="skill_field_description_error">描述为必填项（最多 1024 个字符）。</string>
+    <string name="skill_field_body">内容（markdown）</string>
+    <string name="skill_field_category">类别</string>
+    <string name="skill_category_none">无</string>
+    <string name="skill_field_always_apply">始终应用此技能</string>
+    <string name="skill_save">保存</string>
+    <string name="skill_cancel">取消</string>
+    <string name="skill_conflict_dismiss">确定</string>
+
+    <!-- Sharing (ACL) -->
+    <string name="skill_acl_title">分享与权限</string>
+    <string name="skill_acl_no_grants">尚未与任何人分享。</string>
+    <string name="skill_acl_add_principal">添加用户或群组</string>
+    <string name="skill_acl_grant_dialog_title">分享技能</string>
+    <string name="skill_acl_search_hint">搜索用户、群组或角色</string>
+    <string name="skill_acl_search_empty">无匹配项</string>
+    <string name="skill_acl_role">角色</string>
+    <string name="skill_acl_revoke">移除访问权限</string>
+    <string name="skill_acl_public_label">公开</string>
+    <string name="skill_acl_public_description">此服务器上的任何人都可以使用此技能。</string>
+    <string name="skill_acl_principal_user">用户</string>
+    <string name="skill_acl_principal_group">群组</string>
+    <string name="skill_acl_principal_role">角色</string>
+    <string name="skill_acl_collapse">收起</string>
+    <string name="skill_acl_expand">展开</string>
+    <string name="skill_acl_close">关闭</string>
+</resources>

--- a/shared/src/commonMain/composeResources/values-ar/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ar/strings.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Connectivity -->
+    <string name="no_connection">لا يوجد اتصال بالإنترنت</string>
+
+    <!-- Drawer -->
+    <string name="new_chat">محادثة جديدة</string>
+    <string name="favorites">المفضلة</string>
+    <string name="no_conversations_found">لم يتم العثور على محادثات</string>
+    <string name="remove_bookmark">إزالة الإشارة المرجعية</string>
+    <string name="bookmark">إشارة مرجعية</string>
+    <string name="agents">الوكلاء</string>
+    <string name="skills">المهارات</string>
+    <string name="files">الملفات</string>
+    <string name="settings">الإعدادات</string>
+
+    <!-- Content descriptions -->
+    <string name="cd_search">بحث</string>
+    <string name="cd_clear_search">مسح البحث</string>
+    <string name="cd_back_to_conversations">العودة إلى المحادثات</string>
+
+    <!-- Search -->
+    <string name="search_conversations_placeholder">البحث في المحادثات…</string>
+
+    <!-- Version mismatch dialog -->
+    <string name="version_mismatch_title">عدم تطابق إصدار الخادم</string>
+    <string name="version_mismatch_message">تم إنشاء هذا التطبيق لـ LibreChat v%1$s، لكن خادمك يعمل بالإصدار v%2$s. قد لا تعمل بعض الميزات بشكل صحيح.</string>
+    <string name="dismiss">تجاهل</string>
+    <string name="dont_warn_again">عدم التحذير مرة أخرى</string>
+</resources>

--- a/shared/src/commonMain/composeResources/values-de/strings.xml
+++ b/shared/src/commonMain/composeResources/values-de/strings.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Connectivity -->
+    <string name="no_connection">Keine Internetverbindung</string>
+
+    <!-- Drawer -->
+    <string name="new_chat">Neuer Chat</string>
+    <string name="favorites">Favoriten</string>
+    <string name="no_conversations_found">Keine Unterhaltungen gefunden</string>
+    <string name="remove_bookmark">Lesezeichen entfernen</string>
+    <string name="bookmark">Lesezeichen</string>
+    <string name="agents">Agenten</string>
+    <string name="skills">Skills</string>
+    <string name="files">Dateien</string>
+    <string name="settings">Einstellungen</string>
+
+    <!-- Content descriptions -->
+    <string name="cd_search">Suchen</string>
+    <string name="cd_clear_search">Suche löschen</string>
+    <string name="cd_back_to_conversations">Zurück zu den Unterhaltungen</string>
+
+    <!-- Search -->
+    <string name="search_conversations_placeholder">Unterhaltungen suchen…</string>
+
+    <!-- Version mismatch dialog -->
+    <string name="version_mismatch_title">Backend-Versionskonflikt</string>
+    <string name="version_mismatch_message">Diese App wurde für LibreChat v%1$s entwickelt, aber dein Server läuft mit v%2$s. Einige Funktionen funktionieren möglicherweise nicht korrekt.</string>
+    <string name="dismiss">Schließen</string>
+    <string name="dont_warn_again">Nicht erneut warnen</string>
+</resources>

--- a/shared/src/commonMain/composeResources/values-es/strings.xml
+++ b/shared/src/commonMain/composeResources/values-es/strings.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Connectivity -->
+    <string name="no_connection">Sin conexión a internet</string>
+
+    <!-- Drawer -->
+    <string name="new_chat">Nuevo chat</string>
+    <string name="favorites">Favoritos</string>
+    <string name="no_conversations_found">No se encontraron conversaciones</string>
+    <string name="remove_bookmark">Quitar marcador</string>
+    <string name="bookmark">Marcador</string>
+    <string name="agents">Agentes</string>
+    <string name="skills">Habilidades</string>
+    <string name="files">Archivos</string>
+    <string name="settings">Ajustes</string>
+
+    <!-- Content descriptions -->
+    <string name="cd_search">Buscar</string>
+    <string name="cd_clear_search">Borrar búsqueda</string>
+    <string name="cd_back_to_conversations">Volver a conversaciones</string>
+
+    <!-- Search -->
+    <string name="search_conversations_placeholder">Buscar conversaciones…</string>
+
+    <!-- Version mismatch dialog -->
+    <string name="version_mismatch_title">Versión del servidor incompatible</string>
+    <string name="version_mismatch_message">Esta app se creó para LibreChat v%1$s, pero tu servidor ejecuta la v%2$s. Es posible que algunas funciones no funcionen correctamente.</string>
+    <string name="dismiss">Descartar</string>
+    <string name="dont_warn_again">No volver a avisar</string>
+</resources>

--- a/shared/src/commonMain/composeResources/values-fr/strings.xml
+++ b/shared/src/commonMain/composeResources/values-fr/strings.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Connectivity -->
+    <string name="no_connection">Aucune connexion Internet</string>
+
+    <!-- Drawer -->
+    <string name="new_chat">Nouvelle discussion</string>
+    <string name="favorites">Favoris</string>
+    <string name="no_conversations_found">Aucune conversation trouvée</string>
+    <string name="remove_bookmark">Supprimer le signet</string>
+    <string name="bookmark">Signet</string>
+    <string name="agents">Agents</string>
+    <string name="skills">Compétences</string>
+    <string name="files">Fichiers</string>
+    <string name="settings">Paramètres</string>
+
+    <!-- Content descriptions -->
+    <string name="cd_search">Rechercher</string>
+    <string name="cd_clear_search">Effacer la recherche</string>
+    <string name="cd_back_to_conversations">Retour aux conversations</string>
+
+    <!-- Search -->
+    <string name="search_conversations_placeholder">Rechercher des conversations…</string>
+
+    <!-- Version mismatch dialog -->
+    <string name="version_mismatch_title">Incompatibilité de version du backend</string>
+    <string name="version_mismatch_message">Cette application a été conçue pour LibreChat v%1$s, mais votre serveur exécute la v%2$s. Certaines fonctionnalités pourraient ne pas fonctionner correctement.</string>
+    <string name="dismiss">Ignorer</string>
+    <string name="dont_warn_again">Ne plus avertir</string>
+</resources>

--- a/shared/src/commonMain/composeResources/values-ja/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ja/strings.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Connectivity -->
+    <string name="no_connection">インターネット接続がありません</string>
+
+    <!-- Drawer -->
+    <string name="new_chat">新しいチャット</string>
+    <string name="favorites">お気に入り</string>
+    <string name="no_conversations_found">会話が見つかりません</string>
+    <string name="remove_bookmark">ブックマークを解除</string>
+    <string name="bookmark">ブックマーク</string>
+    <string name="agents">エージェント</string>
+    <string name="skills">スキル</string>
+    <string name="files">ファイル</string>
+    <string name="settings">設定</string>
+
+    <!-- Content descriptions -->
+    <string name="cd_search">検索</string>
+    <string name="cd_clear_search">検索をクリア</string>
+    <string name="cd_back_to_conversations">会話に戻る</string>
+
+    <!-- Search -->
+    <string name="search_conversations_placeholder">会話を検索…</string>
+
+    <!-- Version mismatch dialog -->
+    <string name="version_mismatch_title">バックエンドのバージョン不一致</string>
+    <string name="version_mismatch_message">このアプリはLibreChat v%1$s 向けに作られていますが、お使いのサーバーは v%2$s で動作しています。一部の機能が正しく動作しない可能性があります。</string>
+    <string name="dismiss">閉じる</string>
+    <string name="dont_warn_again">今後警告しない</string>
+</resources>

--- a/shared/src/commonMain/composeResources/values-ko/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ko/strings.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Connectivity -->
+    <string name="no_connection">인터넷 연결 없음</string>
+
+    <!-- Drawer -->
+    <string name="new_chat">새 채팅</string>
+    <string name="favorites">즐겨찾기</string>
+    <string name="no_conversations_found">대화를 찾을 수 없습니다</string>
+    <string name="remove_bookmark">북마크 제거</string>
+    <string name="bookmark">북마크</string>
+    <string name="agents">에이전트</string>
+    <string name="skills">스킬</string>
+    <string name="files">파일</string>
+    <string name="settings">설정</string>
+
+    <!-- Content descriptions -->
+    <string name="cd_search">검색</string>
+    <string name="cd_clear_search">검색 지우기</string>
+    <string name="cd_back_to_conversations">대화로 돌아가기</string>
+
+    <!-- Search -->
+    <string name="search_conversations_placeholder">대화 검색…</string>
+
+    <!-- Version mismatch dialog -->
+    <string name="version_mismatch_title">백엔드 버전 불일치</string>
+    <string name="version_mismatch_message">이 앱은 LibreChat v%1$s용으로 빌드되었지만 서버는 v%2$s을(를) 실행 중입니다. 일부 기능이 올바르게 작동하지 않을 수 있습니다.</string>
+    <string name="dismiss">닫기</string>
+    <string name="dont_warn_again">다시 알리지 않기</string>
+</resources>

--- a/shared/src/commonMain/composeResources/values-pt/strings.xml
+++ b/shared/src/commonMain/composeResources/values-pt/strings.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Connectivity -->
+    <string name="no_connection">Sem conexão com a internet</string>
+
+    <!-- Drawer -->
+    <string name="new_chat">Nova conversa</string>
+    <string name="favorites">Favoritos</string>
+    <string name="no_conversations_found">Nenhuma conversa encontrada</string>
+    <string name="remove_bookmark">Remover marcador</string>
+    <string name="bookmark">Marcar</string>
+    <string name="agents">Agentes</string>
+    <string name="skills">Habilidades</string>
+    <string name="files">Arquivos</string>
+    <string name="settings">Configurações</string>
+
+    <!-- Content descriptions -->
+    <string name="cd_search">Buscar</string>
+    <string name="cd_clear_search">Limpar busca</string>
+    <string name="cd_back_to_conversations">Voltar às conversas</string>
+
+    <!-- Search -->
+    <string name="search_conversations_placeholder">Buscar conversas…</string>
+
+    <!-- Version mismatch dialog -->
+    <string name="version_mismatch_title">Incompatibilidade de versão do backend</string>
+    <string name="version_mismatch_message">Este app foi desenvolvido para o LibreChat v%1$s, mas seu servidor está executando a v%2$s. Alguns recursos podem não funcionar corretamente.</string>
+    <string name="dismiss">Dispensar</string>
+    <string name="dont_warn_again">Não avisar novamente</string>
+</resources>

--- a/shared/src/commonMain/composeResources/values-ru/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ru/strings.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Connectivity -->
+    <string name="no_connection">Нет подключения к интернету</string>
+
+    <!-- Drawer -->
+    <string name="new_chat">Новый чат</string>
+    <string name="favorites">Избранное</string>
+    <string name="no_conversations_found">Беседы не найдены</string>
+    <string name="remove_bookmark">Убрать закладку</string>
+    <string name="bookmark">В закладки</string>
+    <string name="agents">Агенты</string>
+    <string name="skills">Навыки</string>
+    <string name="files">Файлы</string>
+    <string name="settings">Настройки</string>
+
+    <!-- Content descriptions -->
+    <string name="cd_search">Поиск</string>
+    <string name="cd_clear_search">Очистить поиск</string>
+    <string name="cd_back_to_conversations">Назад к беседам</string>
+
+    <!-- Search -->
+    <string name="search_conversations_placeholder">Поиск бесед…</string>
+
+    <!-- Version mismatch dialog -->
+    <string name="version_mismatch_title">Несоответствие версии бэкенда</string>
+    <string name="version_mismatch_message">Это приложение собрано для LibreChat v%1$s, но ваш сервер работает на v%2$s. Некоторые функции могут работать некорректно.</string>
+    <string name="dismiss">Закрыть</string>
+    <string name="dont_warn_again">Больше не предупреждать</string>
+</resources>

--- a/shared/src/commonMain/composeResources/values-zh/strings.xml
+++ b/shared/src/commonMain/composeResources/values-zh/strings.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Connectivity -->
+    <string name="no_connection">无网络连接</string>
+
+    <!-- Drawer -->
+    <string name="new_chat">新建聊天</string>
+    <string name="favorites">收藏</string>
+    <string name="no_conversations_found">未找到对话</string>
+    <string name="remove_bookmark">取消收藏</string>
+    <string name="bookmark">收藏</string>
+    <string name="agents">智能体</string>
+    <string name="skills">技能</string>
+    <string name="files">文件</string>
+    <string name="settings">设置</string>
+
+    <!-- Content descriptions -->
+    <string name="cd_search">搜索</string>
+    <string name="cd_clear_search">清除搜索</string>
+    <string name="cd_back_to_conversations">返回对话</string>
+
+    <!-- Search -->
+    <string name="search_conversations_placeholder">搜索对话…</string>
+
+    <!-- Version mismatch dialog -->
+    <string name="version_mismatch_title">后端版本不匹配</string>
+    <string name="version_mismatch_message">此应用是为 LibreChat v%1$s 构建的，但你的服务器运行的是 v%2$s。某些功能可能无法正常使用。</string>
+    <string name="dismiss">关闭</string>
+    <string name="dont_warn_again">不再提醒</string>
+</resources>

--- a/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/app/LibreChatApp.kt
+++ b/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/app/LibreChatApp.kt
@@ -12,6 +12,7 @@ import coil3.memory.MemoryCache
 import coil3.network.ktor3.KtorNetworkFetcherFactory
 import coil3.request.crossfade
 import coil3.svg.SvgDecoder
+import com.garfiec.librechat.core.data.datastore.SettingsDataStore
 import com.garfiec.librechat.core.data.datastore.ThemeDataStore
 import com.garfiec.librechat.core.data.datastore.ThemeMode
 import com.garfiec.librechat.core.ui.theme.LibreChatTheme
@@ -57,19 +58,30 @@ fun LibreChatApp() {
     val themeMode by themeDataStore.themeMode.collectAsState(initial = themeDataStore.initialThemeMode)
     val accentColorArgb by themeDataStore.accentColor.collectAsState(initial = themeDataStore.initialAccentColor)
     val useDynamicColor by themeDataStore.useDynamicColor.collectAsState(initial = themeDataStore.initialUseDynamicColor)
+
+    val settingsDataStore = koinInject<SettingsDataStore>()
+    // Gate on the language warm-up too so a persisted non-system language is applied before the
+    // first frame (no flash of the system locale before switching).
+    val localeReady by settingsDataStore.isReady.collectAsState()
+    val selectedLanguage by settingsDataStore.selectedLanguage.collectAsState(
+        initial = settingsDataStore.initialSelectedLanguage,
+    )
+    // The DEFAULT_LANGUAGE sentinel ("system") maps to no override → keep the device locale.
+    val appLocale = selectedLanguage.takeIf { it != SettingsDataStore.DEFAULT_LANGUAGE }
+
     val systemDark = isSystemInDarkTheme()
     val darkTheme = when (themeMode) {
         ThemeMode.LIGHT -> false
         ThemeMode.DARK -> true
         ThemeMode.SYSTEM -> systemDark
     }
-    if (themeReady) {
+    if (themeReady && localeReady) {
         LibreChatTheme(
             darkTheme = darkTheme,
             accentColor = Color(accentColorArgb),
             useDynamicColor = useDynamicColor,
         ) {
-            LibreChatNavHost()
+            LibreChatNavHost(appLocaleTag = appLocale)
         }
     }
 }

--- a/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/LibreChatNavHost.kt
+++ b/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/LibreChatNavHost.kt
@@ -36,6 +36,7 @@ import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
 import androidx.navigation3.ui.NavDisplay
 import com.garfiec.librechat.core.logging.Diag
 import com.garfiec.librechat.core.ui.components.BannerDisplay
+import com.garfiec.librechat.core.ui.theme.AppLocale
 import com.garfiec.librechat.feature.agents.navigation.AgentMarketplace
 import com.garfiec.librechat.feature.agents.navigation.agentsEntries
 import com.garfiec.librechat.feature.auth.navigation.authEntries
@@ -72,6 +73,7 @@ import org.koin.compose.viewmodel.koinViewModel
 @Composable
 fun LibreChatNavHost(
     modifier: Modifier = Modifier,
+    appLocaleTag: String? = null,
     navHostViewModel: NavHostViewModel = koinViewModel(),
     content: (@Composable (Navigator, NavHostViewModel, Modifier) -> Unit)? = null,
 ) {
@@ -105,24 +107,29 @@ fun LibreChatNavHost(
         }
     }
 
-    if (content != null) {
-        content(navigator, navHostViewModel, modifier)
-    } else {
-        PhoneLayout(
-            navigator = navigator,
-            modifier = modifier,
-        )
-    }
+    // The locale wrapper must sit BELOW the back stack: changing language recreates the rendered
+    // UI so every stringResource re-resolves, while the back stack created above survives the swap
+    // and the user stays on their current screen.
+    AppLocale(tag = appLocaleTag) {
+        if (content != null) {
+            content(navigator, navHostViewModel, modifier)
+        } else {
+            PhoneLayout(
+                navigator = navigator,
+                modifier = modifier,
+            )
+        }
 
-    // Version mismatch warning dialog
-    val versionMismatch by navHostViewModel.versionMismatch.collectAsStateWithLifecycle()
-    versionMismatch?.let { mismatch ->
-        VersionMismatchDialog(
-            supportedVersion = mismatch.supportedVersion,
-            backendVersion = mismatch.backendVersion,
-            onDismiss = navHostViewModel::dismissVersionWarning,
-            onDismissPermanently = navHostViewModel::dismissVersionWarningPermanently,
-        )
+        // Version mismatch warning dialog
+        val versionMismatch by navHostViewModel.versionMismatch.collectAsStateWithLifecycle()
+        versionMismatch?.let { mismatch ->
+            VersionMismatchDialog(
+                supportedVersion = mismatch.supportedVersion,
+                backendVersion = mismatch.backendVersion,
+                onDismiss = navHostViewModel::dismissVersionWarning,
+                onDismissPermanently = navHostViewModel::dismissVersionWarningPermanently,
+            )
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Settings → General → Language now actually works: the selected language is persisted and applied to the UI at runtime (no app restart), with translations added for nine languages on top of the English source. Previously the picker only updated in-memory state and had no translations, so a selection neither stuck nor changed anything.

## Changes

**Mechanism**
- Persist the selected language in `SettingsDataStore` (with an off-main warm-up so the choice is applied before the first frame), surfaced through `SettingsViewModel`; `setLanguage()` now writes to DataStore.
- Add `LocalAppLocale` (expect/actual for Android + iOS) and an `AppLocale` wrapper in `core/ui` that applies the chosen locale to Compose resources at runtime — the official CMP runtime-locale approach.
- Apply it in `LibreChatNavHost` below the nav back stack, so switching language re-resolves all strings while keeping the user on their current screen.
- Provide `LocalLayoutDirection` for RTL locales so right-to-left languages mirror the layout (back arrow, row icons, chevrons), not just text alignment.

**UI**
- Default to following the device locale (a "System default" entry); explicit picks override it.
- Trim the language picker to the languages actually shipped, shown as native names.
- Localize the settings tab labels (previously hardcoded English).

**Translations**
- Add `values-<lang>/strings.xml` across the modules that carry UI strings (the seven feature modules and `shared`) for: Spanish, French, German, Portuguese, Russian, Simplified Chinese, Japanese, Korean, and Arabic. English remains the default source. Translations were seeded from the upstream LibreChat locale files and machine-filled for the rest.

## Testing
- `:app:assembleDebug` and unit tests (`:core:data` DataStore round-trip, `:feature:settings` ViewModel) pass.
- Translation files validated for key-set + placeholder parity against the English source and well-formed XML.
- Device-tested on Android: live switch with no restart, persistence across reinstall, full re-localization (title/headers/tabs), and correct RTL mirroring for Arabic; switching stays on the current screen.
- iOS: `core:ui` compiles and the shared framework links for the simulator. iOS runtime switching is not yet verified on a simulator/device.

## Notes
- Translations for the nine non-English languages are machine-grade (upstream-seeded) and welcome community review.
- Some date-bucket labels in the conversation drawer ("Yesterday", "Previous 7 Days") remain English — they live in a pure-Kotlin module without Compose-resource access and need a separate localization pass.
