### PR TITLE
chore(release): switch versioning from semver to calver (YYYY.MM.PATCH)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,25 +1,22 @@
 name: Release
 
-# Manual, one-button release. Pick a semver bump; the job bumps version.properties,
-# builds a signed universal APK, and ONLY THEN commits + tags it and publishes a draft
-# GitHub Release with auto-generated notes — so a failed build never leaves an orphaned
-# tag or a burned version on the branch. Review the draft, then publish it;
-# Obtainium/IzzyOnDroid pick up published releases.
+# Manual, one-button release. Versions are calver (YYYY.MM.PATCH); year/month come
+# from the current UTC date automatically, so the only choice is stable vs candidate.
+# The job bumps version.properties, builds a signed universal APK, and ONLY THEN
+# commits + tags it and publishes a draft GitHub Release with auto-generated notes —
+# so a failed build never leaves an orphaned tag or a burned version on the branch.
+# Review the draft, then publish it; Obtainium/IzzyOnDroid pick up published releases.
 on:
   workflow_dispatch:
     inputs:
       bump:
-        description: "Version bump (pre* starts an -rc, rc advances it, finalize promotes to stable)"
+        description: "Release type (patch ships YYYY.MM.PATCH from today's UTC date; prepatch starts an -rc, rc advances it, finalize promotes to stable)"
         required: true
         type: choice
         default: patch
         options:
           - patch
-          - minor
-          - major
           - prepatch
-          - preminor
-          - premajor
           - rc
           - finalize
 
@@ -158,7 +155,7 @@ jobs:
           tag_name: ${{ steps.bump.outputs.tag }}
           name: ${{ steps.bump.outputs.tag }}
           draft: true
-          # A hyphenated version (e.g. 0.2.0-rc1) is a pre-release; Obtainium then
+          # A hyphenated version (e.g. 2026.07.1-rc1) is a pre-release; Obtainium then
           # ignores it unless the user opts into "Include prereleases".
           prerelease: ${{ contains(steps.bump.outputs.tag, '-') }}
           generate_release_notes: true

--- a/README.md
+++ b/README.md
@@ -55,20 +55,20 @@ Pre-built, signed APKs are published on the [Releases](https://github.com/garfie
 2. Tap the **Add to Obtainium** badge above (or, in Obtainium, *Add App* → paste `https://github.com/garfiec/Librechat-Mobile`).
 3. Obtainium tracks new releases and prompts you to update when one ships.
 
-Release-candidate builds (versions like `0.2.0-rc1`) are published as GitHub *pre-releases* and are ignored unless you enable **Include prereleases** for the app in Obtainium.
+Release-candidate builds (versions like `2026.07.1-rc1`) are published as GitHub *pre-releases* and are ignored unless you enable **Include prereleases** for the app in Obtainium.
 
 ### Manual install
 
-Download the latest `librechat-vX.Y.Z.apk` from [Releases](https://github.com/garfiec/Librechat-Mobile/releases) and open it on your device (you may need to allow installs from your browser/file manager).
+Download the latest `librechat-vYYYY.MM.P.apk` from [Releases](https://github.com/garfiec/Librechat-Mobile/releases) and open it on your device (you may need to allow installs from your browser/file manager).
 
 ### Verifying the signing key
 
 All releases are signed with the same key, so updates install in place. Verify a downloaded APK matches the published certificate:
 
 ```bash
-apksigner verify --print-certs librechat-vX.Y.Z.apk
+apksigner verify --print-certs librechat-vYYYY.MM.P.apk
 # or check the .sha256 checksum attached to each release:
-sha256sum -c librechat-vX.Y.Z.apk.sha256
+sha256sum -c librechat-vYYYY.MM.P.apk.sha256
 ```
 
 > Signing certificate SHA-256: `66:8A:71:96:6A:07:06:14:D1:44:95:5D:83:E7:23:6A:3C:ED:77:F8:64:08:57:C3:FA:84:B0:3C:CD:E4:0E:59`
@@ -80,7 +80,7 @@ If the signing key ever changed, Android would refuse the update — so this key
 Every release APK carries a [SLSA build-provenance attestation](https://github.com/garfiec/Librechat-Mobile/attestations), signed by GitHub Actions via Sigstore. Unlike the `.sha256` — which whoever attaches a release could regenerate — the attestation proves the binary was produced by this repo's release workflow at a specific commit, and **cannot be forged outside GitHub's CI**. With the [GitHub CLI](https://cli.github.com):
 
 ```bash
-gh attestation verify librechat-vX.Y.Z.apk \
+gh attestation verify librechat-vYYYY.MM.P.apk \
   --repo garfiec/Librechat-Mobile \
   --signer-workflow garfiec/Librechat-Mobile/.github/workflows/release.yml
 ```

--- a/build-logic/convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt
@@ -81,15 +81,17 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
 private data class AppVersion(val name: String, val code: Int)
 
 /**
- * Reads `versionName` from version.properties and derives a monotonic `versionCode`
- * from it as `MAJOR * 10_000 + MINOR * 100 + PATCH` (i.e. the digits XXYYZZ), so the
+ * Reads `versionName` (calver `YYYY.MM.PATCH`) from version.properties and derives a
+ * monotonic `versionCode` from it as `YEAR * 10_000 + MONTH * 100 + PATCH`, so the
  * code is a deterministic function of the name with nothing to track separately:
- * `0.1.0` -> 100, `1.2.3` -> 10203. MINOR and PATCH must each be <= 99 to stay
- * monotonic; the build fails fast if either overflows.
+ * `2026.06.0` -> 20260600, `2026.06.1` -> 20260601. MONTH and PATCH must each be
+ * <= 99 to stay monotonic; the build fails fast if either overflows. Pre-calver
+ * semver releases used the same packing (`0.1.3` -> 103), so codes stayed monotonic
+ * across the cutover.
  *
- * Pre-release suffixes (`-rc1`) are stripped, so `0.8.6-rc1` and `0.8.6` map to the
- * same code — fine for tagged stable releases; bump the patch if you ship an RC users
- * actually update from.
+ * Pre-release suffixes (`-rc1`) are stripped, so `2026.06.1-rc1` and `2026.06.1` map
+ * to the same code — fine for tagged stable releases; bump the patch if you ship an
+ * RC users actually update from.
  */
 private fun readAppVersion(target: Project): AppVersion {
     val props = Properties().apply {
@@ -97,19 +99,20 @@ private fun readAppVersion(target: Project): AppVersion {
         if (file.exists()) file.inputStream().use { load(it) }
     }
     val name = props.getProperty("versionName") ?: "0.0.0"
-    val (major, minor, patch) = name.substringBefore('-')
+    val (year, month, patch) = name.substringBefore('-')
         .split('.')
         .map { it.toIntOrNull() ?: 0 }
         .plus(listOf(0, 0, 0))
         .take(3)
-    // The XXYYZZ packing only stays monotonic while MINOR and PATCH each fit in two
-    // digits; e.g. 0.1.100 would collide with 0.2.0 (both -> 200). Fail the build
-    // (and therefore CI) rather than silently ship a non-monotonic versionCode.
-    check(minor in 0..99 && patch in 0..99) {
-        "versionName '$name' exceeds the XXYYZZ versionCode scheme: MINOR and PATCH " +
-            "must each be <= 99 (got minor=$minor, patch=$patch). Bump MAJOR/MINOR instead."
+    // The packing only stays monotonic while MONTH and PATCH each fit in two digits;
+    // e.g. 2026.06.100 would collide with 2026.07.0 (both -> 20260700). MONTH never
+    // exceeds 12, so in practice only PATCH can overflow. Fail the build (and
+    // therefore CI) rather than silently ship a non-monotonic versionCode.
+    check(month in 0..99 && patch in 0..99) {
+        "versionName '$name' exceeds the YYYYMMPP versionCode scheme: MONTH and PATCH " +
+            "must each be <= 99 (got month=$month, patch=$patch)."
     }
-    return AppVersion(name = name, code = major * 10_000 + minor * 100 + patch)
+    return AppVersion(name = name, code = year * 10_000 + month * 100 + patch)
 }
 
 private data class ReleaseSigning(

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -4,16 +4,20 @@ How releases are versioned, signed, and published for LibreChat Mobile (Android)
 
 ## Versioning
 
-The app version lives in **one place**: `version.properties` at the repo root.
+The app version is calendar-based — **`YYYY.MM.PATCH`** (zero-padded month, e.g.
+`2026.06.0`) — and lives in **one place**: `version.properties` at the repo root.
 
 ```properties
-versionName=0.1.0          # human-facing semver — the only thing you bump
-backendTargetVersion=0.8.5 # LibreChat backend this build targets (best-tested)
+versionName=2026.06.0      # calver YYYY.MM.PATCH — bumped by the release workflow
+backendTargetVersion=0.8.6 # LibreChat backend this build targets (best-tested)
 ```
 
+- Year and month come from the current **UTC** date automatically when bumping; the only
+  thing a release decides is patch-level vs release-candidate. PATCH resets to 0 when the
+  month rolls over and increments for further releases within the same month.
 - `AndroidApplicationConventionPlugin` reads `versionName` and **derives** `versionCode` as
-  `MAJOR*10000 + MINOR*100 + PATCH` (digits XXYYZZ): `0.1.0` → `100`, `1.2.3` → `10203`.
-  Monotonic as long as semver increases; limits are MINOR ≤ 99, PATCH ≤ 99.
+  `YEAR*10000 + MONTH*100 + PATCH`: `2026.06.0` → `20260600`, `2026.06.1` → `20260601`.
+  Monotonic as the date advances; limits are MONTH ≤ 99 (trivially true), PATCH ≤ 99.
 - The About screen reads the *installed* version via `AppInfo` (package metadata), so it can never drift.
 - This is the **app's** version and is intentionally independent of `backendTargetVersion`.
 - `backendTargetVersion` is the **single source of truth** for the LibreChat backend the app
@@ -26,8 +30,8 @@ Both platforms derive from the same `versionName`, so they stay in lockstep:
 
 | Platform | versionName | versionCode | Where |
 |---|---|---|---|
-| Android | `versionName` verbatim | derived XXYYZZ | `AndroidApplicationConventionPlugin` reads `version.properties` at build |
-| iOS | `CFBundleShortVersionString` | `CFBundleVersion` (same XXYYZZ) | *Stamp Version* Xcode build phase reads `version.properties` at build |
+| Android | `versionName` verbatim | derived YYYYMMPP | `AndroidApplicationConventionPlugin` reads `version.properties` at build |
+| iOS | `CFBundleShortVersionString` | `CFBundleVersion` (same YYYYMMPP) | *Stamp Version* Xcode build phase reads `version.properties` at build |
 
 > iOS isn't published on GitHub Releases — the stamp exists only to keep the two platforms'
 > reported versions identical. The "Stamp Version from version.properties" run-script phase
@@ -35,12 +39,12 @@ Both platforms derive from the same `versionName`, so they stay in lockstep:
 > literals (and the unused `MARKETING_VERSION`/`CURRENT_PROJECT_VERSION` build settings) are
 > just a fallback snapshot — the build always reflects `version.properties`.
 
-Bump it with the script (also run by the release workflow):
+Bump it with the script (also run by the release workflow). For example, running in
+June 2026 with stored version `2026.05.2`:
 
 ```bash
-scripts/bump-version.sh patch   # 0.1.0 -> 0.1.1  (versionCode 100 -> 101)
-scripts/bump-version.sh minor   # 0.1.0 -> 0.2.0  (versionCode 100 -> 200)
-scripts/bump-version.sh major   # 0.1.0 -> 1.0.0  (versionCode 100 -> 10000)
+scripts/bump-version.sh patch   # 2026.05.2 -> 2026.06.0  (new month: PATCH resets)
+scripts/bump-version.sh patch   # 2026.06.0 -> 2026.06.1  (same month: PATCH+1)
 ```
 
 ### Release candidates
@@ -48,20 +52,29 @@ scripts/bump-version.sh major   # 0.1.0 -> 1.0.0  (versionCode 100 -> 10000)
 To ship a candidate before a stable release, use the pre-release bumps:
 
 ```bash
-scripts/bump-version.sh preminor  # 0.1.0    -> 0.2.0-rc1   (next minor, candidate 1)
-scripts/bump-version.sh rc        # 0.2.0-rc1 -> 0.2.0-rc2  (next candidate)
-scripts/bump-version.sh finalize  # 0.2.0-rc2 -> 0.2.0      (promote to stable)
+scripts/bump-version.sh prepatch  # 2026.06.1     -> 2026.06.2-rc1  (start a candidate)
+scripts/bump-version.sh rc        # 2026.06.2-rc1 -> 2026.06.2-rc2  (next candidate)
+scripts/bump-version.sh finalize  # 2026.06.2-rc2 -> 2026.06.2      (promote to stable)
 ```
 
-`prepatch`/`preminor`/`premajor` start a candidate for the bumped version; `rc` advances
-the candidate number; `finalize` drops the suffix to promote the current candidate. A
-hyphenated version is published as a GitHub **pre-release**, which Obtainium skips unless
-the user enables *Include prereleases*.
+`prepatch` starts a candidate for the next patch version; `rc` advances the candidate
+number; `finalize` drops the suffix to promote the current candidate. `rc` and `finalize`
+never touch the version core: a candidate started in June and finalized in July still
+ships as `2026.06.x` — the date reflects when the release train started. A hyphenated
+version is published as a GitHub **pre-release**, which Obtainium skips unless the user
+enables *Include prereleases*.
 
-> The `-rcN` suffix is stripped when deriving the versionCode, so `0.2.0-rc1`, `0.2.0-rc2`,
-> and the final `0.2.0` all share one versionCode. Candidates install over each other fine,
-> but if users update *from* a candidate *to* the final build, bump the patch instead of
-> finalizing so the version visibly advances.
+> The `-rcN` suffix is stripped when deriving the versionCode, so `2026.06.2-rc1`,
+> `2026.06.2-rc2`, and the final `2026.06.2` all share one versionCode. Candidates install
+> over each other fine, but if users update *from* a candidate *to* the final build, bump
+> the patch instead of finalizing so the version visibly advances.
+
+### Calver cutover
+
+Versions before the calver switch were semver (`0.1.0` – `0.1.3`) under the same
+versionCode packing (`0.1.3` → `103`), so codes stayed monotonic across the cutover
+(`103` → first calver release's `YYYYMM00`). The jump is intentionally one-way: calver
+codes are ~20M, so there is no path back to small semver codes without an epoch scheme.
 
 ## One-time signing key setup
 
@@ -115,10 +128,11 @@ release builds fall back to the debug key so local builds and CI checks still wo
 
 ## Cutting a release
 
-1. Actions → **Release** → *Run workflow* → choose the bump (`patch`/`minor`/`major`, or a
-   `prepatch`/`preminor`/`premajor`/`rc`/`finalize` candidate).
+1. Actions → **Release** → *Run workflow* → choose the bump (`patch` for a stable
+   release, or `prepatch`/`rc`/`finalize` for the candidate flow). Year/month are
+   derived from the current UTC date automatically.
 2. The job bumps `version.properties`, builds a signed universal APK, signs a SLSA
-   build-provenance attestation for it, and **only then** commits + tags `vX.Y.Z` and creates
+   build-provenance attestation for it, and **only then** commits + tags `vYYYY.MM.P` and creates
    a **draft** GitHub Release with auto-generated notes and a `.sha256` checksum. Candidate
    versions are flagged as pre-releases automatically. If the build fails, nothing is committed
    or tagged — just re-run after fixing it.

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -59,7 +59,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# Stamp the iOS bundle version from version.properties, the single source of\n# truth shared with Android. versionName -> CFBundleShortVersionString; a derived\n# XXYYZZ versionCode (MAJOR*10000 + MINOR*100 + PATCH) -> CFBundleVersion, using the\n# same formula as Android so both platforms report the same version. This runs as the\n# last build phase (after Info.plist is in the bundle, before codesign), so the value\n# always reflects version.properties regardless of the committed Info.plist literals.\nset -eu\nPROPS=\"$SRCROOT/../version.properties\"\nif [ ! -f \"$PROPS\" ]; then\n    echo \"error: version.properties not found at $PROPS\"\n    exit 1\nfi\nVERSION_NAME=$(grep -E '^versionName=' \"$PROPS\" | cut -d'=' -f2 | tr -d '[:space:]')\nif [ -z \"$VERSION_NAME\" ]; then\n    echo \"error: versionName missing or malformed in $PROPS\"\n    exit 1\nfi\nCORE=${VERSION_NAME%%-*}\n# Split into MAJOR/MINOR/PATCH on '.'; any missing component defaults to 0.\nIFS=.\nset -f\nset -- $CORE\nset +f\nunset IFS\nMAJOR=${1:-0}\nMINOR=${2:-0}\nPATCH=${3:-0}\n# Treat any empty or non-numeric component as 0, the same way Android parses it.\ncase \"$MAJOR\" in \"\"|*[!0-9]*) MAJOR=0 ;; esac\ncase \"$MINOR\" in \"\"|*[!0-9]*) MINOR=0 ;; esac\ncase \"$PATCH\" in \"\"|*[!0-9]*) PATCH=0 ;; esac\nif [ \"$MINOR\" -gt 99 ] || [ \"$PATCH\" -gt 99 ]; then\n    echo \"error: versionName '$VERSION_NAME' exceeds the XXYYZZ scheme (MINOR/PATCH must be <= 99)\"\n    exit 1\nfi\n# Force base 10 so a zero-padded component (e.g. 08) is not interpreted as octal.\nVERSION_CODE=$((10#$MAJOR * 10000 + 10#$MINOR * 100 + 10#$PATCH))\nPLIST=\"$TARGET_BUILD_DIR/$INFOPLIST_PATH\"\n/usr/libexec/PlistBuddy -c \"Set :CFBundleShortVersionString $VERSION_NAME\" \"$PLIST\"\n/usr/libexec/PlistBuddy -c \"Set :CFBundleVersion $VERSION_CODE\" \"$PLIST\"\necho \"Stamped iOS version $VERSION_NAME ($VERSION_CODE) into $PLIST\"\n";
+			shellScript = "# Stamp the iOS bundle version from version.properties, the single source of\n# truth shared with Android. versionName (calver YYYY.MM.PATCH) ->\n# CFBundleShortVersionString; a derived versionCode (YEAR*10000 + MONTH*100 + PATCH)\n# -> CFBundleVersion, using the same formula as Android so both platforms report the\n# same version. This runs as the last build phase (after Info.plist is in the bundle,\n# before codesign), so the value always reflects version.properties regardless of the\n# committed Info.plist literals.\nset -eu\nPROPS=\"$SRCROOT/../version.properties\"\nif [ ! -f \"$PROPS\" ]; then\n    echo \"error: version.properties not found at $PROPS\"\n    exit 1\nfi\nVERSION_NAME=$(grep -E '^versionName=' \"$PROPS\" | cut -d'=' -f2 | tr -d '[:space:]')\nif [ -z \"$VERSION_NAME\" ]; then\n    echo \"error: versionName missing or malformed in $PROPS\"\n    exit 1\nfi\nCORE=${VERSION_NAME%%-*}\n# Split into YEAR/MONTH/PATCH on '.'; any missing component defaults to 0.\nIFS=.\nset -f\nset -- $CORE\nset +f\nunset IFS\nYEAR=${1:-0}\nMONTH=${2:-0}\nPATCH=${3:-0}\n# Treat any empty or non-numeric component as 0, the same way Android parses it.\ncase \"$YEAR\" in \"\"|*[!0-9]*) YEAR=0 ;; esac\ncase \"$MONTH\" in \"\"|*[!0-9]*) MONTH=0 ;; esac\ncase \"$PATCH\" in \"\"|*[!0-9]*) PATCH=0 ;; esac\nif [ \"$MONTH\" -gt 99 ] || [ \"$PATCH\" -gt 99 ]; then\n    echo \"error: versionName '$VERSION_NAME' exceeds the YYYYMMPP scheme (MONTH/PATCH must be <= 99)\"\n    exit 1\nfi\n# Force base 10 so a zero-padded component (e.g. 06) is not interpreted as octal.\nVERSION_CODE=$((10#$YEAR * 10000 + 10#$MONTH * 100 + 10#$PATCH))\nPLIST=\"$TARGET_BUILD_DIR/$INFOPLIST_PATH\"\n/usr/libexec/PlistBuddy -c \"Set :CFBundleShortVersionString $VERSION_NAME\" \"$PLIST\"\n/usr/libexec/PlistBuddy -c \"Set :CFBundleVersion $VERSION_CODE\" \"$PLIST\"\necho \"Stamped iOS version $VERSION_NAME ($VERSION_CODE) into $PLIST\"\n";
 		};
 		SSS00003 /* Stamp Git SHA */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -272,7 +272,7 @@
 				CODE_SIGN_IDENTITY = "-";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 100;
+				CURRENT_PROJECT_VERSION = 103;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -292,7 +292,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.1.0;
+				MARKETING_VERSION = 0.1.3;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-lsqlite3",
@@ -311,7 +311,7 @@
 				CODE_SIGN_IDENTITY = "-";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 100;
+				CURRENT_PROJECT_VERSION = 103;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -331,7 +331,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.1.0;
+				MARKETING_VERSION = 0.1.3;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-lsqlite3",

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -20,9 +20,9 @@
 	     build phase; version.properties is the single source of truth. These
 	     literals are just a sane fallback snapshot. -->
 	<key>CFBundleShortVersionString</key>
-	<string>0.1.0</string>
+	<string>0.1.3</string>
 	<key>CFBundleVersion</key>
-	<string>100</string>
+	<string>103</string>
 	<!-- Overwritten at build time by the "Stamp Git SHA" build phase. AppInfo.gitSha reads this
 	     key; the "unknown" literal is the fallback when there's no git checkout. -->
 	<key>GitSHA</key>

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -2,26 +2,33 @@
 #
 # Bump the app version in version.properties (the single source of truth).
 #
+# Versions are calendar-based: YYYY.MM.PATCH (month zero-padded, PATCH 0-99).
+# Year and month come from the current UTC date — CI runners are UTC — so the
+# only choice a release makes is patch-level vs release-candidate.
+#
 # Usage:
 #   scripts/bump-version.sh <bump>
 #
 # Stable bumps (clear any pre-release suffix):
-#   major     X.y.z       -> (X+1).0.0
-#   minor     x.Y.z       -> x.(Y+1).0
-#   patch     x.y.Z       -> x.y.(Z+1)
+#   patch     new month        -> YYYY.MM.0
+#             same month       -> YYYY.MM.(PATCH+1)
 #
 # Pre-release bumps (append/advance an -rcN suffix):
-#   premajor  X.y.z       -> (X+1).0.0-rc1
-#   preminor  x.Y.z       -> x.(Y+1).0-rc1
-#   prepatch  x.y.Z       -> x.y.(Z+1)-rc1
-#   rc        x.y.z-rcN   -> x.y.z-rc(N+1)   (requires an existing -rcN)
-#   finalize  x.y.z-rcN   -> x.y.z           (promote a candidate to stable)
+#   prepatch  like patch, but emits YYYY.MM.P-rc1
+#   rc        x.y.z-rcN        -> x.y.z-rc(N+1)   (requires an existing -rcN)
+#   finalize  x.y.z-rcN        -> x.y.z           (promote a candidate to stable)
+#
+# rc/finalize never touch the version core: a candidate started in June and
+# finalized in July still ships as 2026.06.x — the date reflects when the
+# release train started.
 #
 # A version with an -rcN suffix is treated as a pre-release: the release workflow
 # marks the GitHub Release as a pre-release so Obtainium ignores it unless the user
 # opts in. versionCode is NOT stored here — it is derived from versionName at build
-# time by the Android convention plugin (MAJOR*10000 + MINOR*100 + PATCH), which
+# time by the Android convention plugin (YEAR*10000 + MONTH*100 + PATCH), which
 # strips the suffix, so an -rcN and its final release share a versionCode.
+#
+# Set BUMP_DATE=YYYY-MM to override the current date (for testing).
 #
 # Output:
 #   - prints the new version name to stdout
@@ -31,9 +38,9 @@ set -euo pipefail
 
 BUMP="${1:-}"
 case "$BUMP" in
-  major|minor|patch|premajor|preminor|prepatch|rc|finalize) ;;
+  patch|prepatch|rc|finalize) ;;
   *)
-    echo "Usage: $0 <major|minor|patch|premajor|preminor|prepatch|rc|finalize>" >&2
+    echo "Usage: $0 <patch|prepatch|rc|finalize>" >&2
     exit 1
     ;;
 esac
@@ -46,17 +53,30 @@ if [[ ! -f "$PROPS" ]]; then
   exit 1
 fi
 
-current_name="$(grep -E '^versionName=' "$PROPS" | cut -d'=' -f2 | tr -d '[:space:]')"
+current_name="$( (grep -m1 -E '^versionName=' "$PROPS" || true) | cut -d'=' -f2 | tr -d '[:space:]')"
 
 if [[ -z "$current_name" ]]; then
   echo "versionName missing or malformed in $PROPS" >&2
   exit 1
 fi
 
-# Parse the semver core (everything before the first '-') and the current rc number.
+# Current UTC year/month, overridable for tests via BUMP_DATE=YYYY-MM.
+if [[ -n "${BUMP_DATE:-}" ]]; then
+  if [[ ! "$BUMP_DATE" =~ ^[0-9]{4}-[0-9]{2}$ ]]; then
+    echo "BUMP_DATE must be YYYY-MM (got '$BUMP_DATE')" >&2
+    exit 1
+  fi
+  now_year="${BUMP_DATE%-*}"
+  now_month="${BUMP_DATE#*-}"
+else
+  now_year="$(date -u +%Y)"
+  now_month="$(date -u +%m)"
+fi
+
+# Parse the version core (everything before the first '-').
 core_name="${current_name%%-*}"
-IFS='.' read -r major minor patch <<< "$core_name"
-major="${major:-0}"; minor="${minor:-0}"; patch="${patch:-0}"
+IFS='.' read -r cur_year cur_month cur_patch <<< "$core_name"
+cur_year="${cur_year:-0}"; cur_month="${cur_month:-0}"; cur_patch="${cur_patch:-0}"
 
 # Extract N from a current -rcN suffix, if any (else empty -> not a pre-release).
 rc=""
@@ -64,43 +84,73 @@ if [[ "$current_name" == *-rc* ]]; then
   rc="${current_name##*-rc}"
 fi
 
-pre=""   # set to "-rcN" to emit a pre-release version
+# Compare numerically (10# guards against zero-padded months being read as octal).
+same_month=false
+if [[ "$cur_year" =~ ^[0-9]+$ && "$cur_month" =~ ^[0-9]+$ ]]; then
+  if (( 10#$cur_year == 10#$now_year && 10#$cur_month == 10#$now_month )); then
+    same_month=true
+  elif (( 10#$cur_year * 100 + 10#$cur_month > 10#$now_year * 100 + 10#$now_month )); then
+    # A stored version ahead of today (clock skew, BUMP_DATE typo, bad hand edit)
+    # would regress the derived versionCode and break updates — refuse.
+    echo "stored version '$current_name' is ahead of the current date ${now_year}-${now_month}; fix the clock (or BUMP_DATE) or version.properties" >&2
+    exit 1
+  fi
+fi
+
+new_core=""  # set by patch/prepatch; rc/finalize keep the current core
+pre=""       # set to "-rcN" to emit a pre-release version
 case "$BUMP" in
-  major)    major=$((major + 1)); minor=0; patch=0 ;;
-  minor)    minor=$((minor + 1)); patch=0 ;;
-  patch)    patch=$((patch + 1)) ;;
-  premajor) major=$((major + 1)); minor=0; patch=0; pre="-rc1" ;;
-  preminor) minor=$((minor + 1)); patch=0; pre="-rc1" ;;
-  prepatch) patch=$((patch + 1)); pre="-rc1" ;;
+  patch|prepatch)
+    if $same_month; then
+      if [[ ! "$cur_patch" =~ ^[0-9]+$ ]]; then
+        echo "current patch component '$cur_patch' is not numeric in '$current_name'" >&2
+        exit 1
+      fi
+      new_patch=$((10#$cur_patch + 1))
+      if (( new_patch > 99 )); then
+        echo "patch component would exceed 99 ('$current_name'); the YYYYMMPP versionCode scheme caps PATCH at 99" >&2
+        exit 1
+      fi
+      new_core="${now_year}.${now_month}.${new_patch}"
+    else
+      new_core="${now_year}.${now_month}.0"
+    fi
+    if [[ "$BUMP" == "prepatch" ]]; then
+      pre="-rc1"
+    fi
+    ;;
   rc)
     if [[ -z "$rc" || ! "$rc" =~ ^[0-9]+$ ]]; then
-      echo "'rc' requires a current -rcN pre-release (got '$current_name'); start one with prepatch/preminor/premajor" >&2
+      echo "'rc' requires a current -rcN pre-release (got '$current_name'); start one with prepatch" >&2
       exit 1
     fi
-    pre="-rc$((rc + 1))"   # core stays put; only the candidate number advances
+    new_core="$core_name"
+    pre="-rc$((10#$rc + 1))"   # core stays put; only the candidate number advances
     ;;
   finalize)
     if [[ -z "$rc" || ! "$rc" =~ ^[0-9]+$ ]]; then
       echo "'finalize' requires a current -rcN pre-release to promote (got '$current_name')" >&2
       exit 1
     fi
-    # core stays put; pre cleared -> stable release
+    new_core="$core_name"   # core stays put; pre cleared -> stable release
     ;;
 esac
 
-new_name="${major}.${minor}.${patch}${pre}"
+new_name="${new_core}${pre}"
 tag="v${new_name}"
 
-# Rewrite version.properties, preserving the header comments.
+# Rewrite version.properties, preserving the header comments (and, by writing
+# through the original file rather than mv-ing a mktemp over it, its file mode).
 tmp="$(mktemp)"
 while IFS= read -r line || [[ -n "$line" ]]; do
   if [[ "$line" == versionName=* ]]; then
-    echo "versionName=${new_name}"
+    printf '%s\n' "versionName=${new_name}"
   else
-    echo "$line"
+    printf '%s\n' "$line"
   fi
 done < "$PROPS" > "$tmp"
-mv "$tmp" "$PROPS"
+cat "$tmp" > "$PROPS"
+rm -f "$tmp"
 
 echo "$new_name"
 

--- a/version.properties
+++ b/version.properties
@@ -1,7 +1,10 @@
-# Single source of truth for the app version.
-# Bumped by scripts/bump-version.sh (major | minor | patch).
+# Single source of truth for the app version (calver: YYYY.MM.PATCH).
+# Bumped by scripts/bump-version.sh (patch | prepatch | rc | finalize);
+# year/month come from the current UTC date automatically.
 # versionCode is DERIVED from versionName by AndroidApplicationConventionPlugin as
-# MAJOR*10000 + MINOR*100 + PATCH (digits XXYYZZ): 0.1.0 -> 100, 1.2.3 -> 10203.
+# YEAR*10000 + MONTH*100 + PATCH: 2026.06.0 -> 20260600. Releases before the
+# calver cutover were semver under the same packing (0.1.3 -> 103), so codes
+# stayed monotonic.
 # This is the app's own version, independent of SUPPORTED_BACKEND_VERSION.
 versionName=0.1.3
 


### PR DESCRIPTION
## Summary
Switches app release versioning from semver to calendar versioning, `YYYY.MM.PATCH` (zero-padded month, patch 0–99). Year and month derive automatically from the UTC date at bump time, so a release only chooses stable vs candidate. The versionCode packing formula is unchanged (`YEAR*10000 + MONTH*100 + PATCH`), so codes stay monotonic across the cutover (`0.1.3` → `103`, first calver release → `2026MM00`) and no migration is needed.

## Changes
- **`scripts/bump-version.sh`** — rewritten for calver. Verbs reduced to `patch | prepatch | rc | finalize`; `rc`/`finalize` freeze the version core (a candidate started in June and finalized in July still ships `2026.06.x`). Refuses a stored version ahead of the current date (would regress versionCode). `BUMP_DATE=YYYY-MM` env override for deterministic testing. Parsing hardened (first matching `versionName` key wins; a missing key reports a clean error) and the rewrite preserves file comments and mode.
- **`.github/workflows/release.yml`** — bump input choices reduced to the four verbs; prerelease detection, artifact naming, and build-then-commit ordering unchanged.
- **Android convention plugin + iOS stamp phase** — versionCode derivation untouched; components renamed to YEAR/MONTH/PATCH, guards and error messages updated.
- **Cosmetic** — committed `Info.plist`/pbxproj fallback version literals refreshed to `0.1.3`/`103` (stamp phase always overrides).
- **Docs** — `docs/RELEASING.md` (new verb examples, calver-cutover note) and `README.md` (rc example, APK filename placeholders).

`version.properties` deliberately stays at `0.1.3`; the first post-merge release run emits `2026.MM.0` automatically (stored month ≠ current month → reset).

## Testing
- Bump script matrix executed on macOS bash 3.2/BSD date and bash 5/GNU date: cutover (`0.1.3` → `2026.06.0`), same-month increment, month and year rollover (`2026.12.5` → `2027.01.0`), full rc flow, core freeze across months, patch-99 cap, and error guards — all error paths exit before modifying the file.
- Debug APK built with a calver version: `aapt` reports `versionCode=20260600`, `versionName=2026.06.0`; `2026.06.100` fails the build via the guard.
- iOS stamp script extracted from the pbxproj and executed standalone against a scratch plist: identical outputs to Android (incl. rc-suffix and zero-padded-month cases); `xcodebuild -list` parses the modified pbxproj.
- `./gradlew test` green (BackendVersion semver tests untouched — backend version is a separate axis).

## Notes
- The cutover is one-way: calver versionCodes are ~20M, so there is no path back to semver codes without an epoch scheme.
- First real validation of the workflow happens on the first post-merge release run (drafts `v2026.MM.0`; Obtainium treats it as a normal update over `0.1.3`).
