### PR TITLE
feat(chat): conversation media gallery with predictive-back viewer

### DIFF
--- a/app/src/main/res/xml/file_provider_paths.xml
+++ b/app/src/main/res/xml/file_provider_paths.xml
@@ -2,5 +2,6 @@
 <paths>
     <cache-path name="artifacts" path="artifacts/" />
     <cache-path name="shared_images" path="shared_images/" />
+    <cache-path name="shared_files" path="shared_files/" />
     <cache-path name="camera_photos" path="camera_photos/" />
 </paths>

--- a/build-logic/convention/src/main/kotlin/KmpComposeConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/KmpComposeConventionPlugin.kt
@@ -4,6 +4,7 @@ import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.getByType
 import org.jetbrains.compose.ComposeExtension
 import org.jetbrains.compose.resources.ResourcesExtension
+import org.jetbrains.kotlin.compose.compiler.gradle.ComposeCompilerGradlePluginExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 
 class KmpComposeConventionPlugin : Plugin<Project> {
@@ -11,6 +12,22 @@ class KmpComposeConventionPlugin : Plugin<Project> {
         with(target) {
             pluginManager.apply("org.jetbrains.compose")
             pluginManager.apply("org.jetbrains.kotlin.plugin.compose")
+
+            // Apply the shared stability config to every target (JVM, Android, iOS). The Android
+            // convention plugin wires this via KotlinCompile freeCompilerArgs, which only reaches
+            // JVM/Android compilations — KMP modules need the compose-compiler extension to also
+            // cover native, so commonMain composables get the configured stable types.
+            extensions.configure<ComposeCompilerGradlePluginExtension> {
+                val stabilityConfig = rootProject.layout.projectDirectory.file("compose-stability.conf")
+                if (stabilityConfig.asFile.exists()) {
+                    stabilityConfigurationFiles.add(stabilityConfig)
+                }
+                if (providers.gradleProperty("enableComposeCompilerReports").orNull == "true") {
+                    val reportsDir = layout.buildDirectory.dir("compose_metrics")
+                    reportsDestination.set(reportsDir)
+                    metricsDestination.set(reportsDir)
+                }
+            }
 
             val composeExtension = extensions.getByType<ComposeExtension>()
             val compose = composeExtension.dependencies

--- a/core/ui/build.gradle.kts
+++ b/core/ui/build.gradle.kts
@@ -16,6 +16,7 @@ kotlin {
             implementation(libs.coil3.network.ktor)
             implementation(libs.zoomimage.compose.coil3.core)
             implementation(libs.material.kolor)
+            implementation(libs.compose.ui.backhandler)
         }
         androidMain.dependencies {
             // Runtime-permission launcher for saving images to the gallery (API < 29).

--- a/core/ui/src/androidMain/kotlin/com/garfiec/librechat/core/ui/media/MediaActions.android.kt
+++ b/core/ui/src/androidMain/kotlin/com/garfiec/librechat/core/ui/media/MediaActions.android.kt
@@ -121,6 +121,46 @@ actual fun rememberShareImage(): (url: String) -> Unit {
     }
 }
 
+@Composable
+actual fun rememberShareFile(): (bytes: ByteArray, filename: String, mime: String?) -> Unit {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    return remember(context, scope) {
+        { bytes, filename, mime ->
+            scope.launch {
+                try {
+                    val file = withContext(Dispatchers.IO) {
+                        val dir = File(context.cacheDir, "shared_files")
+                        dir.mkdirs()
+                        // Sweep prior shares safely past any in-flight read (mirrors the image path).
+                        sweepStaleFiles(dir, STALE_THRESHOLD_MS)
+                        val f = File(dir, sanitizeFilename(filename))
+                        f.writeBytes(bytes)
+                        f
+                    }
+                    val contentUri = FileProvider.getUriForFile(
+                        context,
+                        "${context.packageName}.fileprovider",
+                        file,
+                    )
+                    val shareIntent = Intent(Intent.ACTION_SEND).apply {
+                        putExtra(Intent.EXTRA_STREAM, contentUri)
+                        type = mime?.takeIf { it.isNotBlank() } ?: "application/octet-stream"
+                        addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                    }
+                    context.startActivity(Intent.createChooser(shareIntent, null))
+                } catch (e: Exception) {
+                    toast(context, "Failed to share file: ${e.localizedMessage ?: ""}")
+                }
+            }
+        }
+    }
+}
+
+/** Strips path separators so a server-supplied filename can't escape the cache dir. */
+private fun sanitizeFilename(filename: String): String =
+    filename.substringAfterLast('/').substringAfterLast('\\').ifBlank { "file" }
+
 private suspend fun saveUrlToGallery(context: Context, url: String) {
     try {
         val image = loadEncodedImage(context, url)

--- a/core/ui/src/commonMain/kotlin/com/garfiec/librechat/core/ui/media/MediaActions.kt
+++ b/core/ui/src/commonMain/kotlin/com/garfiec/librechat/core/ui/media/MediaActions.kt
@@ -21,3 +21,15 @@ expect fun rememberSaveImageToGallery(): ((url: String) -> Unit)?
  */
 @Composable
 expect fun rememberShareImage(): (url: String) -> Unit
+
+/**
+ * Returns a handler that shares an arbitrary file (the already-downloaded [bytes]) via the platform
+ * share sheet, letting the user open it in another app, save to Files, AirDrop, etc. Unlike
+ * [rememberShareImage] this takes raw bytes because non-image files aren't in Coil's cache — the
+ * caller downloads them (authenticated) first. [filename] names the temp file (so the chooser shows
+ * the real name + extension) and [mime] hints the content type when known.
+ *
+ * Composable so the Android implementation can resolve a `Context` from composition.
+ */
+@Composable
+expect fun rememberShareFile(): (bytes: ByteArray, filename: String, mime: String?) -> Unit

--- a/core/ui/src/commonMain/kotlin/com/garfiec/librechat/core/ui/media/ZoomableMediaPager.kt
+++ b/core/ui/src/commonMain/kotlin/com/garfiec/librechat/core/ui/media/ZoomableMediaPager.kt
@@ -1,5 +1,7 @@
 package com.garfiec.librechat.core.ui.media
 
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -13,6 +15,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.BrokenImage
 import androidx.compose.material.icons.filled.Close
@@ -21,6 +24,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -28,17 +32,19 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.backhandler.PredictiveBackHandler
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.window.Dialog
-import androidx.compose.ui.window.DialogProperties
 import coil3.SingletonImageLoader
 import coil3.compose.LocalPlatformContext
 import com.github.panpf.zoomimage.CoilZoomAsyncImage
 import com.github.panpf.zoomimage.rememberCoilZoomState
+import kotlinx.coroutines.CancellationException
 
 /**
  * A single zoomable/pannable media item displayed by [ZoomableMediaPager].
@@ -46,6 +52,7 @@ import com.github.panpf.zoomimage.rememberCoilZoomState
  * [url] is the resolved, ready-to-load image URL and doubles as the stable pager key,
  * so callers must dedupe by URL before passing the list in.
  */
+@Immutable
 data class MediaItem(
     val url: String,
     val contentDescription: String,
@@ -56,6 +63,7 @@ data class MediaItem(
  * Open-state for the media viewer, held in a ViewModel's UI state so it survives rotation.
  * `null` (the absence of this object) means the viewer is closed.
  */
+@Immutable
 data class MediaPreviewState(
     val items: List<MediaItem>,
     val initialIndex: Int,
@@ -75,7 +83,16 @@ data class MediaPreviewState(
  *
  * Each surface supplies its own toolbar buttons (save / share / download) via [actions];
  * core/ui owns only the close button + page counter.
+ *
+ * Rendered as an in-composition full-screen overlay (not a `Dialog`) so it can drive a
+ * predictive-back dismiss: a back-gesture shrinks the viewer and fades the scrim to reveal the
+ * screen behind, committing on release and springing back if cancelled. Callers therefore host
+ * it as the last child of a stacking layout (it overlays whatever it's emitted alongside).
  */
+// PredictiveBackHandler is deprecated in favour of NavigationEventHandler, which only lands in a
+// later Compose; this stays on the working API until the Compose version is bumped.
+@Suppress("DEPRECATION")
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun ZoomableMediaPager(
     items: List<MediaItem>,
@@ -92,17 +109,42 @@ fun ZoomableMediaPager(
         return
     }
     val startIndex = initialIndex.coerceIn(0, items.size - 1)
-    Dialog(
-        onDismissRequest = onDismiss,
-        properties = DialogProperties(usePlatformDefaultWidth = false),
+
+    // Drives the predictive-back animation: 0 = at rest, 1 = gesture fully committed. Snapped to
+    // the live gesture progress while dragging; commit dismisses, cancel springs back to 0.
+    val backProgress = remember { Animatable(0f) }
+    PredictiveBackHandler { progress ->
+        try {
+            progress.collect { event -> backProgress.snapTo(event.progress) }
+            currentOnDismiss()
+        } catch (cancellation: CancellationException) {
+            backProgress.animateTo(0f, animationSpec = spring())
+            throw cancellation
+        }
+    }
+
+    val pagerState = rememberPagerState(initialPage = startIndex) { items.size }
+    val platformContext = LocalPlatformContext.current
+    val imageLoader = remember(platformContext) { SingletonImageLoader.get(platformContext) }
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            // Scrim dims with the gesture so the underlying screen shows through as the viewer
+            // shrinks, but only down to MIN_SCRIM_ALPHA — it never goes fully transparent, so the
+            // viewer stays visually distinct from the screen behind until it commits.
+            .background(Color.Black.copy(alpha = 1f - (1f - MIN_SCRIM_ALPHA) * backProgress.value)),
     ) {
-        val pagerState = rememberPagerState(initialPage = startIndex) { items.size }
-        val platformContext = LocalPlatformContext.current
-        val imageLoader = remember(platformContext) { SingletonImageLoader.get(platformContext) }
         Box(
-            modifier = modifier
+            modifier = Modifier
                 .fillMaxSize()
-                .background(Color.Black),
+                .graphicsLayer {
+                    val progress = backProgress.value
+                    val scale = 1f - 0.15f * progress
+                    scaleX = scale
+                    scaleY = scale
+                    clip = progress > 0f
+                    shape = RoundedCornerShape((28f * progress).dp)
+                },
         ) {
             HorizontalPager(
                 state = pagerState,
@@ -153,6 +195,11 @@ fun ZoomableMediaPager(
                 modifier = Modifier
                     .fillMaxWidth()
                     .statusBarsPadding()
+                    // Fade the toolbar out faster than the image so it's already gone by the time
+                    // the back gesture is partway through (TOOLBAR_FADE_END), leaving a clean image.
+                    .graphicsLayer {
+                        alpha = (1f - backProgress.value / TOOLBAR_FADE_END).coerceIn(0f, 1f)
+                    }
                     .padding(horizontal = 4.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
@@ -183,6 +230,12 @@ fun ZoomableMediaPager(
         }
     }
 }
+
+/** Scrim opacity at full back-gesture progress — the viewer dims but never goes fully transparent. */
+private const val MIN_SCRIM_ALPHA = 0.6f
+
+/** Back-gesture progress at which the top toolbar has fully faded out (halfway through the swipe). */
+private const val TOOLBAR_FADE_END = 0.5f
 
 private enum class MediaLoadState { LOADING, SUCCESS, ERROR }
 

--- a/core/ui/src/iosMain/kotlin/com/garfiec/librechat/core/ui/media/MediaActions.ios.kt
+++ b/core/ui/src/iosMain/kotlin/com/garfiec/librechat/core/ui/media/MediaActions.ios.kt
@@ -1,8 +1,22 @@
 package com.garfiec.librechat.core.ui.media
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import com.garfiec.librechat.core.ui.platform.currentTopmostViewController
 import com.garfiec.librechat.core.ui.platform.presentSheet
+import kotlinx.cinterop.BetaInteropApi
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.usePinned
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import platform.Foundation.NSData
+import platform.Foundation.NSTemporaryDirectory
+import platform.Foundation.NSURL
+import platform.Foundation.create
+import platform.Foundation.writeToFile
 import platform.UIKit.UIActivityViewController
 
 // iOS has no in-app gallery-save today (parity with the previous FullscreenImageViewer, which
@@ -14,6 +28,14 @@ actual fun rememberSaveImageToGallery(): ((url: String) -> Unit)? = null
 @Composable
 actual fun rememberShareImage(): (url: String) -> Unit = { url -> shareUrl(url) }
 
+@Composable
+actual fun rememberShareFile(): (bytes: ByteArray, filename: String, mime: String?) -> Unit {
+    val scope = rememberCoroutineScope()
+    return remember(scope) {
+        { bytes, filename, _ -> scope.launch { shareFile(bytes, filename) } }
+    }
+}
+
 private fun shareUrl(url: String) {
     val viewController = currentTopmostViewController() ?: return
     val activityVC = UIActivityViewController(
@@ -21,4 +43,38 @@ private fun shareUrl(url: String) {
         applicationActivities = null,
     )
     presentSheet(activityVC, from = viewController)
+}
+
+// Writes the downloaded bytes to a temp file and shares the file URL, so the user can open it in
+// another app / save to Files / AirDrop. Mirrors the diagnostic-log saver's NSData + temp-file
+// pattern (see feature/settings LogFileSaver.ios.kt and the project iOS cinterop gotchas).
+// The NSData copy and disk write are sized by the file, so they run off the main thread; only the
+// UIKit presentation hops back to main.
+@OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
+private suspend fun shareFile(bytes: ByteArray, filename: String) {
+    val tempPath = NSTemporaryDirectory() + sanitizeFilename(filename)
+    val wrote = withContext(Dispatchers.Default) {
+        bytes.toNSData().writeToFile(tempPath, atomically = true)
+    }
+    if (!wrote) return
+    withContext(Dispatchers.Main) {
+        val viewController = currentTopmostViewController() ?: return@withContext
+        val activityVC = UIActivityViewController(
+            activityItems = listOf(NSURL.fileURLWithPath(tempPath)),
+            applicationActivities = null,
+        )
+        presentSheet(activityVC, from = viewController)
+    }
+}
+
+/** Strips path separators so a server-supplied filename can't escape the temp dir. */
+private fun sanitizeFilename(filename: String): String =
+    filename.substringAfterLast('/').substringAfterLast('\\').ifBlank { "file" }
+
+@OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
+private fun ByteArray.toNSData(): NSData {
+    if (isEmpty()) return NSData()
+    return usePinned { pinned ->
+        NSData.create(bytes = pinned.addressOf(0), length = size.toULong())
+    }
 }

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatScreen.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.material.icons.outlined.ContentCopy
 import androidx.compose.material.icons.outlined.DeleteOutline
 import androidx.compose.material.icons.outlined.Edit
 import androidx.compose.material.icons.outlined.FileOpen
+import androidx.compose.material.icons.outlined.PhotoLibrary
 import androidx.compose.material.icons.outlined.SaveAs
 import androidx.compose.material.icons.outlined.Share
 import androidx.compose.material3.AlertDialog
@@ -113,6 +114,7 @@ actual fun ChatScreen(
     onOpenDrawer: (() -> Unit)?,
     onNavigateToPromptsLibrary: (() -> Unit)?,
     onNavigateBack: (() -> Unit)?,
+    onShowAllMedia: (() -> Unit)?,
     onNavigateToProviderKeys: (endpointName: String?) -> Unit,
 ) {
     val viewModel: ChatViewModel = koinViewModel { parametersOf(conversationId, initialAgentId) }
@@ -340,6 +342,7 @@ actual fun ChatScreen(
                     onOpenDrawer = onOpenDrawer,
                     onOpenSearch = viewModel::openSearch,
                     onOpenPromptsLibrary = onNavigateToPromptsLibrary,
+                    onShowAllMedia = onShowAllMedia,
                     promptsEnabled = uiState.promptsEnabled,
                     presetsEnabled = uiState.presetsEnabled,
                     multiConvoEnabled = uiState.multiConvoEnabled,
@@ -850,6 +853,7 @@ private fun ChatTopBar(
     modifier: Modifier = Modifier,
     onOpenSearch: () -> Unit = {},
     onOpenPromptsLibrary: (() -> Unit)? = null,
+    onShowAllMedia: (() -> Unit)? = null,
     promptsEnabled: Boolean = true,
     presetsEnabled: Boolean = true,
     multiConvoEnabled: Boolean = true,
@@ -932,6 +936,18 @@ private fun ChatTopBar(
                         },
                         leadingIcon = {
                             Icon(Icons.Default.Search, contentDescription = null)
+                        },
+                    )
+                }
+                if (onShowAllMedia != null) {
+                    DropdownMenuItem(
+                        text = { Text(stringResource(Res.string.action_show_all_media)) },
+                        onClick = {
+                            showOverflowMenu = false
+                            onShowAllMedia()
+                        },
+                        leadingIcon = {
+                            Icon(Icons.Outlined.PhotoLibrary, contentDescription = null)
                         },
                     )
                 }

--- a/feature/chat/src/commonMain/composeResources/values/strings.xml
+++ b/feature/chat/src/commonMain/composeResources/values/strings.xml
@@ -366,4 +366,18 @@
     <string name="send_block_agent_not_available">The selected agent isn\'t available on this server. Please pick a different agent.</string>
     <string name="send_block_model_not_available">The selected model isn\'t available on this server. Please pick a different model.</string>
     <string name="send_block_model_load_failed">Couldn\'t load the selected model yet. Please try again or pick a different model.</string>
+
+    <!-- Conversation media gallery ("Show all media") -->
+    <string name="action_show_all_media">Show all media</string>
+    <string name="media_gallery_title">Media</string>
+    <string name="media_tab_media">Media</string>
+    <string name="media_tab_files">Files</string>
+    <string name="media_tab_links">Links</string>
+    <string name="media_tab_artifacts">Artifacts</string>
+    <string name="media_scope_whole_chat">Whole chat</string>
+    <string name="media_scope_this_branch">This branch</string>
+    <string name="media_empty_media">No media in this conversation</string>
+    <string name="media_empty_files">No files in this conversation</string>
+    <string name="media_empty_links">No links in this conversation</string>
+    <string name="media_empty_artifacts">No artifacts in this conversation</string>
 </resources>

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/di/ChatModule.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/di/ChatModule.kt
@@ -1,7 +1,9 @@
 package com.garfiec.librechat.feature.chat.di
 
+import com.garfiec.librechat.core.common.di.KoinQualifiers
 import com.garfiec.librechat.feature.chat.prompts.PromptEditorViewModel
 import com.garfiec.librechat.feature.chat.prompts.PromptsViewModel
+import com.garfiec.librechat.feature.chat.viewmodel.ConversationMediaViewModel
 import org.koin.core.module.Module
 import org.koin.core.module.dsl.viewModel
 import org.koin.core.module.dsl.viewModelOf
@@ -20,6 +22,18 @@ val chatModule = module {
         PromptEditorViewModel(
             promptRepository = get(),
             initialGroupId = params.getOrNull(),
+        )
+    }
+    // conversationId arrives from the navigation layer via parametersOf — same reason as above.
+    @Suppress("DeprecatedKoinApi")
+    viewModel { params ->
+        ConversationMediaViewModel(
+            conversationId = params.get(),
+            messageRepository = get(),
+            fileRepository = get(),
+            userRepository = get(),
+            serverDataStore = get(),
+            defaultDispatcher = get(KoinQualifiers.Default),
         )
     }
 }

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/navigation/ChatNavigation.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/navigation/ChatNavigation.kt
@@ -5,6 +5,7 @@ import androidx.navigation3.runtime.NavKey
 import com.garfiec.librechat.feature.chat.prompts.PromptEditorScreen
 import com.garfiec.librechat.feature.chat.prompts.PromptsLibraryScreen
 import com.garfiec.librechat.feature.chat.screen.ChatScreen
+import com.garfiec.librechat.feature.chat.screen.ConversationMediaScreen
 import com.garfiec.librechat.feature.chat.screen.NewChatScreen
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.modules.SerializersModule
@@ -23,6 +24,9 @@ import kotlinx.serialization.modules.subclass
 @Serializable data object PromptsLibrary : ChatRoute
 
 @Serializable data class PromptEditor(val groupId: String? = null) : ChatRoute
+
+/** Telegram-style "Show all media" gallery for a single conversation. */
+@Serializable data class ConversationMedia(val conversationId: String) : ChatRoute
 
 fun EntryProviderScope<NavKey>.chatEntries(
     onNavigate: (NavKey) -> Unit,
@@ -55,7 +59,15 @@ fun EntryProviderScope<NavKey>.chatEntries(
             onNavigateToPromptsLibrary = { onNavigate(PromptsLibrary) },
             onNavigateBack = onBack,
             onNavigateToConversation = { conversationId -> onNavigateToChat(conversationId) },
+            // Null on a new chat with no id yet, which hides the overflow menu item.
+            onShowAllMedia = key.conversationId?.let { id -> { onNavigate(ConversationMedia(id)) } },
             onNavigateToProviderKeys = onNavigateToProviderKeys,
+        )
+    }
+    entry<ConversationMedia> { key ->
+        ConversationMediaScreen(
+            conversationId = key.conversationId,
+            onNavigateBack = onBack,
         )
     }
     entry<PromptsLibrary> {
@@ -81,5 +93,6 @@ val chatSerializersModule = SerializersModule {
         subclass(Chat::class, Chat.serializer())
         subclass(PromptsLibrary::class, PromptsLibrary.serializer())
         subclass(PromptEditor::class, PromptEditor.serializer())
+        subclass(ConversationMedia::class, ConversationMedia.serializer())
     }
 }

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/screen/ConversationMediaScreen.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/screen/ConversationMediaScreen.kt
@@ -1,0 +1,396 @@
+package com.garfiec.librechat.feature.chat.screen
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.InsertDriveFile
+import androidx.compose.material.icons.outlined.Dashboard
+import androidx.compose.material.icons.outlined.Link
+import androidx.compose.material.icons.outlined.PermMedia
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.PrimaryTabRow
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
+import androidx.compose.material3.Tab
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import coil3.compose.AsyncImage
+import com.garfiec.librechat.core.ui.components.EmptyState
+import com.garfiec.librechat.core.ui.components.LibreChatTopBar
+import com.garfiec.librechat.core.ui.components.LoadingIndicator
+import com.garfiec.librechat.core.ui.media.MediaActionBar
+import com.garfiec.librechat.core.ui.media.MediaItem
+import com.garfiec.librechat.core.ui.media.ZoomableMediaPager
+import com.garfiec.librechat.core.ui.media.rememberSaveImageToGallery
+import com.garfiec.librechat.core.ui.media.rememberShareFile
+import com.garfiec.librechat.core.ui.media.rememberShareImage
+import com.garfiec.librechat.feature.chat.components.artifact.Artifact
+import com.garfiec.librechat.feature.chat.components.artifact.ArtifactButton
+import com.garfiec.librechat.feature.chat.components.artifact.ArtifactPanel
+import com.garfiec.librechat.feature.chat.resources.Res
+import com.garfiec.librechat.feature.chat.resources.cd_close
+import com.garfiec.librechat.feature.chat.resources.cd_image
+import com.garfiec.librechat.feature.chat.resources.cd_save_to_device
+import com.garfiec.librechat.feature.chat.resources.cd_share_image
+import com.garfiec.librechat.feature.chat.resources.media_empty_artifacts
+import com.garfiec.librechat.feature.chat.resources.media_empty_files
+import com.garfiec.librechat.feature.chat.resources.media_empty_links
+import com.garfiec.librechat.feature.chat.resources.media_empty_media
+import com.garfiec.librechat.feature.chat.resources.media_gallery_title
+import com.garfiec.librechat.feature.chat.resources.media_scope_this_branch
+import com.garfiec.librechat.feature.chat.resources.media_scope_whole_chat
+import com.garfiec.librechat.feature.chat.resources.media_tab_artifacts
+import com.garfiec.librechat.feature.chat.resources.media_tab_files
+import com.garfiec.librechat.feature.chat.resources.media_tab_links
+import com.garfiec.librechat.feature.chat.resources.media_tab_media
+import com.garfiec.librechat.feature.chat.util.ConversationFile
+import com.garfiec.librechat.feature.chat.util.ConversationLink
+import com.garfiec.librechat.feature.chat.viewmodel.ConversationMediaViewModel
+import com.garfiec.librechat.feature.chat.viewmodel.MediaScope
+import kotlinx.coroutines.launch
+import org.jetbrains.compose.resources.stringResource
+import org.koin.compose.viewmodel.koinViewModel
+import org.koin.core.parameter.parametersOf
+
+private enum class MediaTab { MEDIA, FILES, LINKS, ARTIFACTS }
+
+private val MediaThumbShape = RoundedCornerShape(4.dp)
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ConversationMediaScreen(
+    conversationId: String,
+    onNavigateBack: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: ConversationMediaViewModel = koinViewModel { parametersOf(conversationId) },
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    var selectedTab by rememberSaveable { mutableIntStateOf(MediaTab.MEDIA.ordinal) }
+
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            LibreChatTopBar(
+                title = stringResource(Res.string.media_gallery_title),
+                onNavigateBack = onNavigateBack,
+            )
+        },
+    ) { padding ->
+        Column(modifier = Modifier.fillMaxSize().padding(padding)) {
+            PrimaryTabRow(selectedTabIndex = selectedTab) {
+                Tab(
+                    selected = selectedTab == MediaTab.MEDIA.ordinal,
+                    onClick = { selectedTab = MediaTab.MEDIA.ordinal },
+                    text = { Text(stringResource(Res.string.media_tab_media)) },
+                )
+                Tab(
+                    selected = selectedTab == MediaTab.FILES.ordinal,
+                    onClick = { selectedTab = MediaTab.FILES.ordinal },
+                    text = { Text(stringResource(Res.string.media_tab_files)) },
+                )
+                Tab(
+                    selected = selectedTab == MediaTab.LINKS.ordinal,
+                    onClick = { selectedTab = MediaTab.LINKS.ordinal },
+                    text = { Text(stringResource(Res.string.media_tab_links)) },
+                )
+                Tab(
+                    selected = selectedTab == MediaTab.ARTIFACTS.ordinal,
+                    onClick = { selectedTab = MediaTab.ARTIFACTS.ordinal },
+                    text = { Text(stringResource(Res.string.media_tab_artifacts)) },
+                )
+            }
+
+            ScopeToggle(
+                scope = uiState.scope,
+                onScopeChange = viewModel::setScope,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 8.dp),
+            )
+
+            Box(modifier = Modifier.fillMaxSize()) {
+                when {
+                    uiState.isLoading -> LoadingIndicator(modifier = Modifier.fillMaxSize())
+                    selectedTab == MediaTab.MEDIA.ordinal ->
+                        MediaGrid(uiState.media, onOpen = viewModel::openMedia)
+                    selectedTab == MediaTab.FILES.ordinal ->
+                        FilesList(uiState.files, downloadBytes = viewModel::downloadFileBytes)
+                    selectedTab == MediaTab.LINKS.ordinal -> LinksList(uiState.links)
+                    else -> ArtifactsList(uiState.artifacts)
+                }
+            }
+        }
+    }
+
+    val mediaPreview = uiState.mediaPreview
+    if (mediaPreview != null) {
+        val saveImage = rememberSaveImageToGallery()
+        val shareImage = rememberShareImage()
+        val saveDescription = stringResource(Res.string.cd_save_to_device)
+        val shareDescription = stringResource(Res.string.cd_share_image)
+        val imageDescription = stringResource(Res.string.cd_image)
+        ZoomableMediaPager(
+            items = mediaPreview.items,
+            initialIndex = mediaPreview.initialIndex,
+            onDismiss = viewModel::closeMedia,
+            closeContentDescription = stringResource(Res.string.cd_close),
+            defaultContentDescription = imageDescription,
+            actions = { item ->
+                MediaActionBar(
+                    item = item,
+                    onSave = saveImage,
+                    onShare = shareImage,
+                    saveContentDescription = saveDescription,
+                    shareContentDescription = shareDescription,
+                )
+            },
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ScopeToggle(
+    scope: MediaScope,
+    onScopeChange: (MediaScope) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    SingleChoiceSegmentedButtonRow(modifier = modifier) {
+        SegmentedButton(
+            selected = scope == MediaScope.ACTIVE_BRANCH,
+            onClick = { onScopeChange(MediaScope.ACTIVE_BRANCH) },
+            shape = SegmentedButtonDefaults.itemShape(index = 0, count = 2),
+        ) {
+            Text(stringResource(Res.string.media_scope_this_branch))
+        }
+        SegmentedButton(
+            selected = scope == MediaScope.ENTIRE,
+            onClick = { onScopeChange(MediaScope.ENTIRE) },
+            shape = SegmentedButtonDefaults.itemShape(index = 1, count = 2),
+        ) {
+            Text(stringResource(Res.string.media_scope_whole_chat))
+        }
+    }
+}
+
+@Composable
+private fun MediaGrid(
+    media: List<MediaItem>,
+    onOpen: (url: String) -> Unit,
+) {
+    if (media.isEmpty()) {
+        EmptyState(
+            title = stringResource(Res.string.media_empty_media),
+            icon = Icons.Outlined.PermMedia,
+        )
+        return
+    }
+    LazyVerticalGrid(
+        columns = GridCells.Adaptive(minSize = 120.dp),
+        contentPadding = PaddingValues(4.dp),
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        items(media, key = { it.url }) { item ->
+            AsyncImage(
+                model = item.url,
+                contentDescription = item.contentDescription.ifBlank { null },
+                contentScale = ContentScale.Crop,
+                modifier = Modifier
+                    .aspectRatio(1f)
+                    .clip(MediaThumbShape)
+                    .clickable { onOpen(item.url) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun FilesList(
+    files: List<ConversationFile>,
+    downloadBytes: suspend (fileId: String) -> ByteArray?,
+) {
+    if (files.isEmpty()) {
+        EmptyState(
+            title = stringResource(Res.string.media_empty_files),
+            icon = Icons.AutoMirrored.Outlined.InsertDriveFile,
+        )
+        return
+    }
+    val scope = rememberCoroutineScope()
+    val shareFile = rememberShareFile()
+    LazyColumn(modifier = Modifier.fillMaxSize()) {
+        items(files, key = { it.fileId }) { file ->
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable {
+                        scope.launch {
+                            val bytes = downloadBytes(file.fileId)
+                            if (bytes != null) shareFile(bytes, file.filename, file.type)
+                        }
+                    }
+                    .padding(horizontal = 16.dp, vertical = 12.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Outlined.InsertDriveFile,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(40.dp),
+                )
+                Column(modifier = Modifier.padding(start = 16.dp)) {
+                    Text(
+                        text = file.filename,
+                        style = MaterialTheme.typography.bodyLarge,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                    val subtitle = listOfNotNull(
+                        file.bytes?.let { formatBytes(it) },
+                        file.type,
+                    ).joinToString(" · ")
+                    if (subtitle.isNotBlank()) {
+                        Text(
+                            text = subtitle,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun LinksList(links: List<ConversationLink>) {
+    if (links.isEmpty()) {
+        EmptyState(
+            title = stringResource(Res.string.media_empty_links),
+            icon = Icons.Outlined.Link,
+        )
+        return
+    }
+    val uriHandler = LocalUriHandler.current
+    LazyColumn(modifier = Modifier.fillMaxSize()) {
+        items(links, key = { it.url }) { link ->
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { runCatching { uriHandler.openUri(link.url) } }
+                    .padding(horizontal = 16.dp, vertical = 12.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Icon(
+                    imageVector = Icons.Outlined.Link,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(40.dp),
+                )
+                Column(modifier = Modifier.padding(start = 16.dp)) {
+                    Text(
+                        text = link.host,
+                        style = MaterialTheme.typography.bodyLarge,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                    Text(
+                        text = link.url,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ArtifactsList(artifacts: List<List<Artifact>>) {
+    if (artifacts.isEmpty()) {
+        EmptyState(
+            title = stringResource(Res.string.media_empty_artifacts),
+            icon = Icons.Outlined.Dashboard,
+        )
+        return
+    }
+    // Tapping a card opens the shared ArtifactPanel with that artifact's full version history.
+    // Only the identifier is held (a Saveable String) so the open panel survives rotation; the
+    // version list is re-derived from [artifacts] each composition.
+    var activeIdentifier by rememberSaveable { mutableStateOf<String?>(null) }
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = PaddingValues(16.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        items(artifacts, key = { it.first().identifier }) { versions ->
+            ArtifactButton(
+                artifact = versions.last(),
+                onClick = { activeIdentifier = versions.first().identifier },
+                versionCount = versions.size,
+            )
+        }
+    }
+    val activeVersions = activeIdentifier?.let { id ->
+        artifacts.firstOrNull { it.first().identifier == id }
+    }
+    activeVersions?.let { versions ->
+        ArtifactPanel(
+            artifact = versions.last(),
+            onDismiss = { activeIdentifier = null },
+            versions = versions,
+        )
+    }
+}
+
+private fun formatBytes(bytes: Long): String {
+    if (bytes < 1024) return "$bytes B"
+    val kb = bytes / 1024.0
+    if (kb < 1024) return "${kb.format1()} KB"
+    val mb = kb / 1024.0
+    if (mb < 1024) return "${mb.format1()} MB"
+    return "${(mb / 1024.0).format1()} GB"
+}
+
+private fun Double.format1(): String {
+    val rounded = (this * 10).toLong()
+    return "${rounded / 10}.${rounded % 10}"
+}

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/screen/PlatformScreens.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/screen/PlatformScreens.kt
@@ -14,6 +14,9 @@ expect fun ChatScreen(
     onOpenDrawer: (() -> Unit)? = null,
     onNavigateToPromptsLibrary: (() -> Unit)? = null,
     onNavigateBack: (() -> Unit)? = null,
+    /** Opens the "Show all media" gallery for the current conversation. Null (and the menu item
+     *  hidden) on a brand-new chat that has no conversation id yet. */
+    onShowAllMedia: (() -> Unit)? = null,
     /**
      * Deep-link CTA from the user-provided-key error snackbar and the
      * model-selector "Set API Key" CTA on greyed endpoint groups. Tap navigates to

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/util/BranchMedia.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/util/BranchMedia.kt
@@ -2,6 +2,7 @@ package com.garfiec.librechat.feature.chat.util
 
 import com.garfiec.librechat.core.model.Attachment
 import com.garfiec.librechat.core.model.ContentType
+import com.garfiec.librechat.core.model.Message
 import com.garfiec.librechat.core.ui.media.MediaItem
 import com.garfiec.librechat.feature.chat.components.isImageGenToolCall
 import com.garfiec.librechat.feature.chat.components.parseImageGenResult
@@ -34,46 +35,7 @@ internal fun extractBranchMedia(
     val items = mutableListOf<MediaItem>()
 
     for (node in displayMessages) {
-        val message = node.message
-
-        message.files?.forEach { file ->
-            if (file.type?.startsWith("image/") == true) {
-                val url = resolveFileReferenceUrl(file, baseUrl)
-                if (!url.isNullOrBlank()) {
-                    items += MediaItem(
-                        url = url,
-                        contentDescription = file.filename.orEmpty(),
-                        filename = file.filename,
-                    )
-                }
-            }
-        }
-
-        val attachments = message.attachments.orEmpty()
-        message.content?.forEach { part ->
-            when (part.type) {
-                ContentType.IMAGE_FILE -> {
-                    val url = resolveImageFilePartUrl(part, baseUrl)
-                    if (!url.isNullOrBlank()) items += MediaItem(url, contentDescription = "")
-                }
-                ContentType.IMAGE_URL -> {
-                    val url = part.imageUrl?.url
-                    if (!url.isNullOrBlank()) items += MediaItem(url, contentDescription = "")
-                }
-                ContentType.TOOL_CALL -> {
-                    val toolCall = part.toolCall
-                    val name = (toolCall?.name ?: toolCall?.function?.name).orEmpty().lowercase()
-                    if (isImageGenToolCall(name)) {
-                        val result = parseImageGenResult(toolCall, baseUrl, attachments)
-                        val url = result.imageUrl
-                        if (!url.isNullOrBlank()) {
-                            items += MediaItem(url, contentDescription = result.prompt.orEmpty())
-                        }
-                    }
-                }
-                else -> Unit
-            }
-        }
+        items += collectMessageMedia(node.message, baseUrl)
     }
 
     // In-flight generated image (streamed, not yet persisted to a message).
@@ -88,4 +50,57 @@ internal fun extractBranchMedia(
     }
 
     return items.distinctBy { it.url }
+}
+
+/**
+ * Collects the viewable images carried by a single [message], in render order: attached image
+ * files first (rendered above the text), then inline `image_file` / `image_url` content parts and
+ * persisted image-gen tool-call results in content order. Shared by [extractBranchMedia] (active
+ * branch + streaming) and the conversation-wide gallery
+ * (`com.garfiec.librechat.feature.chat.util.extractConversationMedia`) so both resolve the exact
+ * same URLs as the message renderers. Not deduped — callers dedupe across messages.
+ */
+internal fun collectMessageMedia(message: Message, baseUrl: String): List<MediaItem> {
+    val items = mutableListOf<MediaItem>()
+
+    message.files?.forEach { file ->
+        if (file.type?.startsWith("image/") == true) {
+            val url = resolveFileReferenceUrl(file, baseUrl)
+            if (!url.isNullOrBlank()) {
+                items += MediaItem(
+                    url = url,
+                    contentDescription = file.filename.orEmpty(),
+                    filename = file.filename,
+                )
+            }
+        }
+    }
+
+    val attachments = message.attachments.orEmpty()
+    message.content?.forEach { part ->
+        when (part.type) {
+            ContentType.IMAGE_FILE -> {
+                val url = resolveImageFilePartUrl(part, baseUrl)
+                if (!url.isNullOrBlank()) items += MediaItem(url, contentDescription = "")
+            }
+            ContentType.IMAGE_URL -> {
+                val url = part.imageUrl?.url
+                if (!url.isNullOrBlank()) items += MediaItem(url, contentDescription = "")
+            }
+            ContentType.TOOL_CALL -> {
+                val toolCall = part.toolCall
+                val name = (toolCall?.name ?: toolCall?.function?.name).orEmpty().lowercase()
+                if (isImageGenToolCall(name)) {
+                    val result = parseImageGenResult(toolCall, baseUrl, attachments)
+                    val url = result.imageUrl
+                    if (!url.isNullOrBlank()) {
+                        items += MediaItem(url, contentDescription = result.prompt.orEmpty())
+                    }
+                }
+            }
+            else -> Unit
+        }
+    }
+
+    return items
 }

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/util/ConversationMediaExtractor.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/util/ConversationMediaExtractor.kt
@@ -1,0 +1,118 @@
+package com.garfiec.librechat.feature.chat.util
+
+import com.garfiec.librechat.core.model.Attachment
+import com.garfiec.librechat.core.model.FileReference
+import com.garfiec.librechat.core.model.Message
+import com.garfiec.librechat.core.ui.media.MediaItem
+import com.garfiec.librechat.feature.chat.components.artifact.Artifact
+import com.garfiec.librechat.feature.chat.components.artifact.ArtifactSegment
+import com.garfiec.librechat.feature.chat.components.artifact.detectArtifacts
+
+/**
+ * A non-image attachment surfaced in the conversation-media gallery's **Files** tab.
+ * [fileId] is required for the on-tap download; [bytes] drives the size label when known.
+ */
+data class ConversationFile(
+    val fileId: String,
+    val filename: String,
+    val type: String?,
+    val bytes: Long?,
+)
+
+/**
+ * A URL extracted from a message's text for the gallery's **Links** tab.
+ * [host] is the display label (the bare domain); [url] is the full link to open.
+ */
+data class ConversationLink(
+    val url: String,
+    val host: String,
+)
+
+/**
+ * Pulls every viewable image across [messages] for the **Media** tab. Reuses
+ * [collectMessageMedia] (the same per-message collector the in-chat viewer uses), so the gallery
+ * resolves the exact URLs the messages rendered. Deduped by URL, first occurrence wins — the same
+ * contract [MediaItem] requires for use as a pager key.
+ */
+fun extractConversationMedia(messages: List<Message>, baseUrl: String): List<MediaItem> =
+    messages.flatMap { collectMessageMedia(it, baseUrl) }.distinctBy { it.url }
+
+/**
+ * Pulls non-image attachments across [messages] for the **Files** tab: user-attached [Message.files]
+ * and generated [Message.attachments] whose MIME type is not in the image family. Deduped by file id.
+ */
+fun extractConversationFiles(messages: List<Message>): List<ConversationFile> {
+    val files = mutableListOf<ConversationFile>()
+    for (message in messages) {
+        message.files?.forEach { file -> file.toConversationFile()?.let(files::add) }
+        message.attachments?.forEach { attachment -> attachment.toConversationFile()?.let(files::add) }
+    }
+    return files.distinctBy { it.fileId }
+}
+
+private fun FileReference.toConversationFile(): ConversationFile? {
+    if (type?.startsWith("image/") == true) return null
+    val id = fileId ?: return null
+    return ConversationFile(fileId = id, filename = filename ?: id, type = type, bytes = bytes)
+}
+
+private fun Attachment.toConversationFile(): ConversationFile? {
+    if (type?.startsWith("image/") == true) return null
+    val id = fileId ?: return null
+    return ConversationFile(fileId = id, filename = filename ?: id, type = type, bytes = null)
+}
+
+// Matches http(s) URLs, stopping before trailing punctuation that's usually prose, not part of the
+// link (e.g. a sentence-ending period or a closing paren/bracket/quote/angle).
+private val URL_REGEX = Regex("""https?://[^\s<>()\[\]"']+""")
+
+/**
+ * Extracts http(s) links from the text of [messages] for the **Links** tab. Reads each message's
+ * content-part text (falling back to [Message.text]), the same way `InConversationSearchDelegate`
+ * derives searchable text. Deduped by URL.
+ */
+fun extractConversationLinks(messages: List<Message>): List<ConversationLink> {
+    val links = mutableListOf<ConversationLink>()
+    for (message in messages) {
+        val text = message.searchableText()
+        if (text.isBlank()) continue
+        URL_REGEX.findAll(text).forEach { match ->
+            val url = match.value.trimEnd('.', ',', ';', ':', '!', '?')
+            if (url.isNotBlank()) links += ConversationLink(url = url, host = url.host())
+        }
+    }
+    return links.distinctBy { it.url }
+}
+
+/**
+ * Extracts artifacts (`:::artifact{...}` directives) embedded in the text of [messages] for the
+ * **Artifacts** tab, via the same [detectArtifacts] parser the in-chat renderer uses. Grouped by
+ * identifier in first-seen order; each group is the version history sorted ascending (so the tile
+ * shows the latest version + count, and tapping opens the panel with all versions). Mirrors
+ * `groupArtifactVersions` but spans the whole conversation rather than one message.
+ */
+fun extractConversationArtifacts(messages: List<Message>): List<List<Artifact>> {
+    val all = mutableListOf<Artifact>()
+    for (message in messages) {
+        val text = message.searchableText()
+        if (text.isBlank()) continue
+        detectArtifacts(text).forEach { segment ->
+            if (segment is ArtifactSegment.ArtifactReference) all += segment.artifact
+        }
+    }
+    // groupBy yields a LinkedHashMap, preserving first-seen identifier order.
+    return all.groupBy { it.identifier }.map { (_, versions) -> versions.sortedBy { it.version } }
+}
+
+private fun Message.searchableText(): String {
+    val parts = content
+    return if (!parts.isNullOrEmpty()) {
+        parts.mapNotNull { it.text ?: it.think }.joinToString("\n")
+    } else {
+        text
+    }
+}
+
+/** Bare host for a link's display label, e.g. `https://a.example.com/x?y` → `a.example.com`. */
+private fun String.host(): String =
+    substringAfter("://").substringBefore('/').substringBefore('?').ifBlank { this }

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ConversationMediaViewModel.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ConversationMediaViewModel.kt
@@ -1,0 +1,163 @@
+package com.garfiec.librechat.feature.chat.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import co.touchlab.kermit.Logger
+import com.garfiec.librechat.core.common.result.Result
+import com.garfiec.librechat.core.data.datastore.ServerDataStore
+import com.garfiec.librechat.core.data.repository.FileRepository
+import com.garfiec.librechat.core.data.repository.MessageRepository
+import com.garfiec.librechat.core.data.repository.UserRepository
+import com.garfiec.librechat.core.model.Message
+import com.garfiec.librechat.core.ui.media.MediaItem
+import com.garfiec.librechat.core.ui.media.MediaPreviewState
+import com.garfiec.librechat.feature.chat.components.artifact.Artifact
+import com.garfiec.librechat.feature.chat.util.ConversationFile
+import com.garfiec.librechat.feature.chat.util.ConversationLink
+import com.garfiec.librechat.feature.chat.util.buildActiveMessagePath
+import com.garfiec.librechat.feature.chat.util.extractConversationArtifacts
+import com.garfiec.librechat.feature.chat.util.extractConversationFiles
+import com.garfiec.librechat.feature.chat.util.extractConversationLinks
+import com.garfiec.librechat.feature.chat.util.extractConversationMedia
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+/** Whether the gallery shows media from the whole conversation tree or only the active branch. */
+enum class MediaScope { ENTIRE, ACTIVE_BRANCH }
+
+data class ConversationMediaUiState(
+    val isLoading: Boolean = true,
+    val scope: MediaScope = MediaScope.ACTIVE_BRANCH,
+    val media: List<MediaItem> = emptyList(),
+    val files: List<ConversationFile> = emptyList(),
+    val links: List<ConversationLink> = emptyList(),
+    /** Each entry is one artifact's version history (sorted ascending); tile shows the latest. */
+    val artifacts: List<List<Artifact>> = emptyList(),
+    val mediaPreview: MediaPreviewState? = null,
+    val error: String? = null,
+)
+
+/**
+ * Backs the "Show all media" gallery for a single conversation. Loads the full (unpaginated)
+ * message list once, then derives the Media / Files / Links / Artifacts tabs for the current
+ * [MediaScope]. Pure read — never writes Room or mutates branch state.
+ */
+class ConversationMediaViewModel(
+    private val conversationId: String,
+    private val messageRepository: MessageRepository,
+    private val fileRepository: FileRepository,
+    private val userRepository: UserRepository,
+    private val serverDataStore: ServerDataStore,
+    private val defaultDispatcher: CoroutineDispatcher,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(ConversationMediaUiState())
+    val uiState: StateFlow<ConversationMediaUiState> = _uiState.asStateFlow()
+
+    private var allMessages: List<Message> = emptyList()
+    private var baseUrl: String = ""
+
+    // Cached so tapping several files doesn't re-fetch the user on each download.
+    private var cachedUserId: String? = null
+
+    init {
+        load()
+    }
+
+    private fun load() {
+        viewModelScope.launch {
+            baseUrl = serverDataStore.awaitBaseUrl()
+            when (val result = messageRepository.getMessages(conversationId)) {
+                is Result.Success -> {
+                    allMessages = result.data
+                    recompute()
+                }
+                is Result.Error -> {
+                    Logger.e(result.exception) { "Failed to load conversation media: ${result.message}" }
+                    _uiState.update { it.copy(isLoading = false, error = result.message) }
+                }
+                is Result.Loading -> Unit
+            }
+        }
+    }
+
+    fun setScope(scope: MediaScope) {
+        if (scope == _uiState.value.scope) return
+        _uiState.update { it.copy(scope = scope) }
+        viewModelScope.launch { recompute() }
+    }
+
+    // Extraction runs the active-branch tree-build plus four regex/scan passes over the full message
+    // text, so it stays off the main thread to keep load and scope toggles from hitching the UI.
+    private suspend fun recompute() {
+        val scope = _uiState.value.scope
+        val derived = withContext(defaultDispatcher) {
+            val messages = when (scope) {
+                MediaScope.ENTIRE -> allMessages
+                MediaScope.ACTIVE_BRANCH -> buildActiveMessagePath(allMessages).map { it.message }
+            }
+            DerivedTabs(
+                media = extractConversationMedia(messages, baseUrl),
+                files = extractConversationFiles(messages),
+                links = extractConversationLinks(messages),
+                artifacts = extractConversationArtifacts(messages),
+            )
+        }
+        _uiState.update {
+            it.copy(
+                isLoading = false,
+                media = derived.media,
+                files = derived.files,
+                links = derived.links,
+                artifacts = derived.artifacts,
+            )
+        }
+    }
+
+    private data class DerivedTabs(
+        val media: List<MediaItem>,
+        val files: List<ConversationFile>,
+        val links: List<ConversationLink>,
+        val artifacts: List<List<Artifact>>,
+    )
+
+    /**
+     * Opens the full-screen pager at [url], swiping over the whole Media tab (the current scope's
+     * image set) — same viewer as the in-chat one. Falls back to index 0 if [url] isn't found.
+     */
+    fun openMedia(url: String) {
+        if (url.isBlank()) return
+        val items = _uiState.value.media
+        if (items.isEmpty()) return
+        val index = items.indexOfFirst { it.url == url }.takeIf { it >= 0 } ?: 0
+        _uiState.update { it.copy(mediaPreview = MediaPreviewState(items = items, initialIndex = index)) }
+    }
+
+    fun closeMedia() {
+        _uiState.update { it.copy(mediaPreview = null) }
+    }
+
+    /** Downloads a file's bytes (authenticated) for the Files-tab share action; null on failure. */
+    suspend fun downloadFileBytes(fileId: String): ByteArray? {
+        val userId = cachedUserId ?: resolveUserId() ?: return null
+        return when (val result = fileRepository.downloadFile(userId, fileId)) {
+            is Result.Success -> result.data
+            is Result.Error -> {
+                Logger.e(result.exception) { "Failed to download file $fileId: ${result.message}" }
+                null
+            }
+            is Result.Loading -> null
+        }
+    }
+
+    private suspend fun resolveUserId(): String? {
+        val id = (userRepository.getUser() as? Result.Success)?.data?.id
+        cachedUserId = id
+        return id
+    }
+}

--- a/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/screen/PlatformScreens.ios.kt
+++ b/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/screen/PlatformScreens.ios.kt
@@ -27,6 +27,7 @@ import androidx.compose.material.icons.outlined.ContentCopy
 import androidx.compose.material.icons.outlined.DeleteOutline
 import androidx.compose.material.icons.outlined.Edit
 import androidx.compose.material.icons.outlined.FileOpen
+import androidx.compose.material.icons.outlined.PhotoLibrary
 import androidx.compose.material.icons.outlined.SaveAs
 import androidx.compose.material.icons.outlined.Share
 import androidx.compose.material3.AlertDialog
@@ -96,6 +97,7 @@ actual fun ChatScreen(
     onOpenDrawer: (() -> Unit)?,
     onNavigateToPromptsLibrary: (() -> Unit)?,
     onNavigateBack: (() -> Unit)?,
+    onShowAllMedia: (() -> Unit)?,
     onNavigateToProviderKeys: (endpointName: String?) -> Unit,
 ) {
     val viewModel: ChatViewModel = koinViewModel { parametersOf(conversationId, initialAgentId) }
@@ -241,6 +243,18 @@ actual fun ChatScreen(
                                         },
                                         leadingIcon = {
                                             Icon(Icons.Default.Search, contentDescription = null)
+                                        },
+                                    )
+                                }
+                                if (onShowAllMedia != null) {
+                                    DropdownMenuItem(
+                                        text = { Text(stringResource(Res.string.action_show_all_media)) },
+                                        onClick = {
+                                            showOptionsMenu = false
+                                            onShowAllMedia()
+                                        },
+                                        leadingIcon = {
+                                            Icon(Icons.Outlined.PhotoLibrary, contentDescription = null)
                                         },
                                     )
                                 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -177,6 +177,8 @@ kotlin-gradlePlugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-pl
 kotlin-multiplatform-gradlePlugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }
 compose-gradlePlugin = { group = "org.jetbrains.kotlin", name = "compose-compiler-gradle-plugin", version.ref = "kotlin" }
 compose-multiplatform-gradlePlugin = { group = "org.jetbrains.compose", name = "compose-gradle-plugin", version.ref = "compose-multiplatform" }
+# Multiplatform PredictiveBackHandler (not bundled with compose.ui); version tracks compose-multiplatform.
+compose-ui-backhandler = { group = "org.jetbrains.compose.ui", name = "ui-backhandler", version.ref = "compose-multiplatform" }
 ksp-gradlePlugin = { group = "com.google.devtools.ksp", name = "symbol-processing-gradle-plugin", version.ref = "ksp" }
 room-gradlePlugin = { group = "androidx.room", name = "room-gradle-plugin", version.ref = "room" }
 


### PR DESCRIPTION
## Summary

Adds a **"Show all media"** gallery for a conversation, reached from the chat overflow menu. It's the familiar tabbed media browser seen in most messaging apps — **Media / Files / Links / Artifacts** tabs with a **this-branch vs. whole-chat** scope toggle — so you can browse everything shared in a conversation without scrolling the thread.

It also reworks the shared full-screen viewer to dismiss with a **predictive-back** gesture instead of a hard Dialog cut.

## Changes

- **Gallery screen (`feature/chat`)** — new `ConversationMediaScreen` + `ConversationMediaViewModel`, reached from the chat overflow menu (both Android and iOS menus wired). Tabs:
  - **Media** — image/video grid; tap opens the shared `ZoomableMediaPager`, swipeable across the whole set.
  - **Files** — non-image attachments; tap downloads the bytes and hands off to the platform share sheet.
  - **Links** — URLs parsed from message text; tap opens externally.
  - **Artifacts** — grouped by artifact (version history); tap opens the shared `ArtifactPanel`.
- **Scope toggle** — switch between the active branch only and the entire conversation tree (edits/regenerations included).
- **Predictive-back viewer (`core/ui`)** — `ZoomableMediaPager` converted from a `Dialog` to an in-composition overlay driven by `PredictiveBackHandler`: the back gesture shrinks the viewer and dims the scrim (60% floor, never fully transparent) to reveal the screen behind, toolbar fading out by the halfway point; commit dismisses, cancel springs back.
- **Shared file share (`core/ui`)** — new `rememberShareFile` expect/actual (Android `FileProvider` + `ACTION_SEND`, iOS `UIActivityViewController`), so the Files tab can share arbitrary attachments.
- **Extraction utilities (`feature/chat`)** — `ConversationMediaExtractor` derives the four tabs from the message list; reuses the existing branch/media/URL helpers. Tab derivation runs off the main thread.

## Testing

- Android device test: gallery opens from the overflow menu; Media/Files/Links/Artifacts tabs populate; full-screen viewer swipes across images and dismisses with the predictive-back gesture; file share sheet works; scope toggle changes the set on a branched conversation; empty states show on a text-only conversation.
- Both platforms build: Android `:app:assembleDebug` + install, iOS `core:ui` / shared framework compile.
- detekt passes; Koin DI verification test passes.

## Screenshots

| Description | Screenshot |
| --- | --- |
| Overflow menu with the **Show all media** entry | <img width="485" height="1101" alt="image" src="https://github.com/user-attachments/assets/2f571f3a-9b11-4894-a4f7-55e59fdde2f7" /> |
| Media tab (image grid) | <img width="485" height="1100" alt="image" src="https://github.com/user-attachments/assets/b5bb03e5-e0cf-41b9-932c-91d69ac45f21" /> |
| Swiping between images in the full-screen viewer | <img width="486" height="1097" alt="image" src="https://github.com/user-attachments/assets/9f506ea5-5cb6-4f20-9606-aa7e1aeceba8" /> |
| Predictive-back dismiss animation | <img width="483" height="1101" alt="image" src="https://github.com/user-attachments/assets/9efce495-d264-4c48-952c-9fcd4b584b99" /> |
| Artifacts tab | <img width="483" height="1092" alt="image" src="https://github.com/user-attachments/assets/7c5650ec-ea72-42bf-b4b0-f71f8faf1ad6" /> |
