### PR TITLE
perf(compose): stabilize composable params across the app

### DIFF
--- a/compose-stability.conf
+++ b/compose-stability.conf
@@ -4,10 +4,14 @@
 // See: https://developer.android.com/develop/ui/compose/performance/stability/fix#configuration-file
 
 // Core model classes — all are data classes with val-only fields, never mutated after creation.
-// Wildcard patterns auto-cover new models without manual maintenance.
-com.garfiec.librechat.core.model.*
-com.garfiec.librechat.core.model.mcp.*
-com.garfiec.librechat.core.model.speech.*
+// Recursive wildcard (**) covers core.model and every subpackage (config, content, endpoint,
+// error, permissions, request, response, mcp, speech, …); a single * matches only direct symbols.
+com.garfiec.librechat.core.model.**
+
+// DataStore-backed preference value classes consumed by composables. These live in :core:data
+// (no Compose dependency), so they cannot carry @Immutable at the source — list them here.
+// All-val data classes, only ever swapped wholesale, never mutated in place.
+com.garfiec.librechat.core.data.datastore.InlineArtifactPrefs
 
 // Kotlin stdlib collections (we only use immutable instances in practice)
 kotlin.collections.List

--- a/core/ui/src/commonMain/kotlin/com/garfiec/librechat/core/ui/components/ColorPicker.kt
+++ b/core/ui/src/commonMain/kotlin/com/garfiec/librechat/core/ui/components/ColorPicker.kt
@@ -25,6 +25,10 @@ private val HueSpectrumBrush = Brush.horizontalGradient(
 )
 private val ValueOverlayBrush = Brush.verticalGradient(listOf(Color.Transparent, Color.Black))
 
+// Static clip shapes hoisted out of the Canvas modifier chains (core/ui rule 13).
+private val PanelShape = RoundedCornerShape(12.dp)
+private val SliderShape = RoundedCornerShape(14.dp)
+
 /**
  * Stateless saturation/value selection panel. Renders a white -> hue horizontal
  * gradient overlaid with a transparent -> black vertical gradient, plus a thumb at
@@ -57,7 +61,7 @@ fun SaturationValuePanel(
         modifier = modifier
             .fillMaxWidth()
             .height(200.dp)
-            .clip(RoundedCornerShape(12.dp))
+            .clip(PanelShape)
             .pointerInput(Unit) {
                 detectTapGestures { offset -> report(offset, size.width, size.height) }
             }
@@ -98,7 +102,7 @@ fun HueSlider(
         modifier = modifier
             .fillMaxWidth()
             .height(28.dp)
-            .clip(RoundedCornerShape(14.dp))
+            .clip(SliderShape)
             .pointerInput(Unit) {
                 detectTapGestures { offset -> report(offset, size.width) }
             }

--- a/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/components/ConversationSearchBar.kt
+++ b/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/components/ConversationSearchBar.kt
@@ -21,6 +21,9 @@ import com.garfiec.librechat.feature.conversations.resources.*
 import com.garfiec.librechat.feature.conversations.resources.Res
 import org.jetbrains.compose.resources.stringResource
 
+// Hoisted so the shape isn't reallocated on every keystroke recomposition.
+private val SearchBarShape = RoundedCornerShape(28.dp)
+
 @Composable
 fun ConversationSearchBar(
     query: String,
@@ -57,7 +60,7 @@ fun ConversationSearchBar(
         },
         textStyle = MaterialTheme.typography.bodyMedium,
         singleLine = true,
-        shape = RoundedCornerShape(28.dp),
+        shape = SearchBarShape,
         colors = TextFieldDefaults.colors(
             focusedContainerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
             unfocusedContainerColor = MaterialTheme.colorScheme.surfaceContainerHigh,

--- a/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/screen/ConversationListScreen.kt
+++ b/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/screen/ConversationListScreen.kt
@@ -61,6 +61,9 @@ import com.garfiec.librechat.feature.conversations.viewmodel.ConversationListVie
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
 
+// Hoisted: compiled once instead of per export event.
+private val ExportFileNameSanitizer = Regex("[^a-zA-Z0-9._-]")
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ConversationListScreen(
@@ -128,7 +131,7 @@ fun ConversationListScreen(
                         ExportFormat.JSON -> "json"
                         ExportFormat.MARKDOWN -> "md"
                     }
-                    val safeTitle = event.title.replace(Regex("[^a-zA-Z0-9._-]"), "_")
+                    val safeTitle = event.title.replace(ExportFileNameSanitizer, "_")
                     pendingExportFileName = "$safeTitle.$ext"
                 }
                 is ConversationListEvent.ImportSuccess -> {


### PR DESCRIPTION
## Summary

Retroactive Compose stability pass, now that `compose-stability.conf` reaches KMP modules (#145 wired it into the KMP convention plugin). Scoped to the highest-value, lowest-risk subset only: architecture-backed stability-config entries and zero-risk allocation hoists — no source `@Immutable` contracts and no rendering changes.

## Changes

- **Recursive `core.model` wildcard:** replace `core.model.*` plus the explicit `core.model.mcp.*` / `core.model.speech.*` entries with a single `core.model.**`. A single `*` matches only a package's direct symbols, so the other subpackages (config, content, endpoint, error, permissions, request, response) weren't treated as stable across module boundaries; `**` covers the whole tree.
- **`InlineArtifactPrefs` declared stable via config:** it lives in `:core:data` (no Compose dependency), so it can't carry `@Immutable` at the source. It's an all-`val` data class consumed by `SettingsUiState` and `ChatRoot`.
- **Allocation hoists to top-level constants:** `ColorPicker` Canvas shapes, the conversation search-bar shape, and the export-filename `Regex` (recompiled per export before).

## Why

Strong skipping only skips when the *same instance* is passed (`===`). ViewModels emit a fresh state via `copy()` on every change and pass lists down, so structural stability (compiler compares with `.equals()`) is what lets those composables skip on equal content.

## Verification

- Compose compiler reports confirm the targeted param (`InlineArtifactPrefs`) now reports `stable`.
- Builds on Android (`:app:assembleDebug`) and iOS (`:shared:linkDebugFrameworkIosSimulatorArm64`).
- Device-tested: inline-artifact toggles propagate to chat rendering; conversation search + export behave correctly.

## Notes

Two further changes were evaluated and deliberately left out to keep this low-risk: an `@Immutable` on `AgentAdvancedSettings` (marginal — a form screen, not a hot scroll path) and switching `AvatarImage` fallbacks from `clip(shape).background()` to `background(color, shape)` (a real render-layer saving on scrolling lists, but the only change that alters rendering). The `AvatarImage` optimization is worth doing later as its own separately-verifiable perf change.

Closes #146
