### PR TITLE
fix(chat): show the correct model on a newly created chat

### DIFF
--- a/feature/chat/build.gradle.kts
+++ b/feature/chat/build.gradle.kts
@@ -10,6 +10,7 @@ kotlin {
     sourceSets {
         commonMain.dependencies {
             implementation(project(":core:network"))
+            implementation(project(":core:logging"))
             implementation(libs.atomicfu)
             implementation(libs.kermit)
             implementation(libs.kotlinx.serialization.json)

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/di/ChatPlatformModule.android.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/di/ChatPlatformModule.android.kt
@@ -48,6 +48,7 @@ actual val chatPlatformModule: Module = module {
             platformDelegateFactory = get(),
             json = get(),
             defaultDispatcher = get(KoinQualifiers.Default),
+            selectionHandoff = get(),
         )
     }
 }

--- a/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/NewChatSelectionHandoffTest.kt
+++ b/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/NewChatSelectionHandoffTest.kt
@@ -1,0 +1,60 @@
+package com.garfiec.librechat.feature.chat.viewmodel
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class NewChatSelectionHandoffTest {
+
+    @Test
+    fun takeWithMatchingIdReturnsAndClears() {
+        val handoff = NewChatSelectionHandoff()
+        handoff.put("conv_1", "openAI", "gpt-4o")
+
+        val taken = handoff.take("conv_1")
+        assertThat(taken).isEqualTo(
+            NewChatSelectionHandoff.Selection("conv_1", "openAI", "gpt-4o"),
+        )
+        // Single-slot: a second take of the same id is empty (already consumed).
+        assertThat(handoff.take("conv_1")).isNull()
+    }
+
+    @Test
+    fun takeWithMismatchedIdReturnsNullAndKeepsEntry() {
+        val handoff = NewChatSelectionHandoff()
+        handoff.put("conv_1", "agents", "agent_X")
+
+        assertThat(handoff.take("other")).isNull()
+        // The staged entry survives a mismatched take and is still retrievable.
+        assertThat(handoff.take("conv_1")).isEqualTo(
+            NewChatSelectionHandoff.Selection("conv_1", "agents", "agent_X"),
+        )
+    }
+
+    @Test
+    fun takeOnEmptyReturnsNull() {
+        assertThat(NewChatSelectionHandoff().take("conv_1")).isNull()
+    }
+
+    @Test
+    fun putOverwritesPreviousSingleSlot() {
+        val handoff = NewChatSelectionHandoff()
+        handoff.put("conv_1", "openAI", "gpt-4o")
+        handoff.put("conv_2", "anthropic", "claude-3")
+
+        // Only the latest staged transition is retained.
+        assertThat(handoff.take("conv_1")).isNull()
+        assertThat(handoff.take("conv_2")).isEqualTo(
+            NewChatSelectionHandoff.Selection("conv_2", "anthropic", "claude-3"),
+        )
+    }
+
+    @Test
+    fun nullModelIsCarriedThrough() {
+        val handoff = NewChatSelectionHandoff()
+        handoff.put("conv_1", "agents", null)
+
+        assertThat(handoff.take("conv_1")).isEqualTo(
+            NewChatSelectionHandoff.Selection("conv_1", "agents", null),
+        )
+    }
+}

--- a/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/ModelSelectionDelegateTest.kt
+++ b/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/ModelSelectionDelegateTest.kt
@@ -291,7 +291,7 @@ class ModelSelectionDelegateTest {
         coEvery { agentRepository.getAgents() } returns
             Result.Success(listOf(Agent(id = "agent_1"), Agent(id = "agent_2")))
 
-        delegate.loadAgents()
+        delegate.loadAgents(isNewConversation = false)
         advanceUntilIdle()
 
         assertThat(handle.state.agents).hasSize(2)
@@ -308,7 +308,7 @@ class ModelSelectionDelegateTest {
         val delegate = newDelegate(handle)
         denyAgents()
 
-        delegate.loadAgents()
+        delegate.loadAgents(isNewConversation = false)
         advanceUntilIdle()
 
         coVerify(exactly = 0) { agentRepository.getAgents() }
@@ -327,7 +327,7 @@ class ModelSelectionDelegateTest {
         allowAgents()
         coEvery { agentRepository.getAgents() } returns Result.Error(RuntimeException("boom"))
 
-        delegate.loadAgents()
+        delegate.loadAgents(isNewConversation = false)
         advanceUntilIdle()
 
         assertThat(handle.state.error).isEqualTo("Could not load available agents")
@@ -540,7 +540,7 @@ class ModelSelectionDelegateTest {
         availableModels.value = mapOf("openAI" to listOf("gpt-4o"))
 
         delegate.seedInitialSelection(isNewConversation = true)
-        delegate.loadAgents()
+        delegate.loadAgents(isNewConversation = true)
         advanceUntilIdle()
 
         assertThat(handle.state.selectedEndpoint).isEqualTo("openAI")
@@ -561,7 +561,7 @@ class ModelSelectionDelegateTest {
         availableModels.value = mapOf("openAI" to listOf("gpt-4o"))
 
         delegate.seedInitialSelection(isNewConversation = true)
-        delegate.loadAgents()
+        delegate.loadAgents(isNewConversation = true)
         advanceUntilIdle()
 
         assertThat(handle.state.selectedEndpoint).isEqualTo("openAI")
@@ -761,5 +761,118 @@ class ModelSelectionDelegateTest {
         // Must NOT be stranded on the (nonexistent) agent — resolve to a config model.
         assertThat(handle.state.selectedEndpoint).isEqualTo("openAI")
         assertThat(handle.state.selectedModel).isEqualTo("gpt-4o")
+    }
+
+    // ── Group E: conversation-model resolution + agents corrective fallback ───
+    // Covers the new-chat-display-race fix (the handoff applies via
+    // applyResolvedConversationModel) and the agents hole in the existing-
+    // conversation corrective fallback.
+
+    @Test
+    fun applyResolvedConversationModelSetsSelectionAndFlagsAndRefilterDoesNotClobber() = runTest {
+        val scope = TestScope(StandardTestDispatcher(testScheduler))
+        val handle = newHandle(scope, ChatUiState(conversationId = "c1"))
+        val delegate = newDelegate(handle)
+
+        delegate.applyResolvedConversationModel("anthropic", "claude-3")
+
+        assertThat(handle.state.selectedEndpoint).isEqualTo("anthropic")
+        assertThat(handle.state.selectedModel).isEqualTo("claude-3")
+        assertThat(delegate.conversationModelLoaded).isTrue()
+        assertThat(delegate.conversationModelResolved).isTrue()
+
+        // A subsequent existing-conversation refilter must leave the resolved selection alone.
+        availableModels.value = mapOf("anthropic" to listOf("claude-3"), "openAI" to listOf("gpt-4o"))
+        delegate.refilterModels(isNewConversation = false)
+        advanceUntilIdle()
+
+        assertThat(handle.state.selectedEndpoint).isEqualTo("anthropic")
+        assertThat(handle.state.selectedModel).isEqualTo("claude-3")
+        coVerify(exactly = 0) { settingsDataStore.setLastUsedModel(any(), any()) }
+    }
+
+    @Test
+    fun refilterCorrectiveFallbackRestoresAgentsLastUsedWhenPresent() = runTest {
+        // Regression for the dead agents branch: an agents last-used was validated against
+        // filtered["agents"] (always null) and silently skipped to a config model. It must
+        // now validate against the loaded agents list and be restored.
+        val scope = TestScope(StandardTestDispatcher(testScheduler))
+        val handle = newHandle(
+            scope,
+            ChatUiState(
+                conversationId = "c1",
+                selectedEndpoint = "openAI",
+                selectedModel = "ghost",
+                agents = listOf(Agent(id = "agent_1")),
+            ),
+        )
+        val delegate = newDelegate(handle)
+        delegate.conversationModelLoaded = true
+        delegate.agentsLoaded.value = true
+        delegate.cachedLastUsedEndpoint = EndpointConstants.AGENTS
+        delegate.cachedLastUsedModel = "agent_1"
+        availableModels.value = mapOf("openAI" to listOf("gpt-4o"))
+
+        delegate.refilterModels(isNewConversation = false)
+        advanceUntilIdle()
+
+        assertThat(handle.state.selectedEndpoint).isEqualTo(EndpointConstants.AGENTS)
+        assertThat(handle.state.selectedModel).isEqualTo("agent_1")
+    }
+
+    @Test
+    fun refilterCorrectiveFallbackAgentsLastUsedAbsentPicksFirstConfigModel() = runTest {
+        val scope = TestScope(StandardTestDispatcher(testScheduler))
+        val handle = newHandle(
+            scope,
+            ChatUiState(
+                conversationId = "c1",
+                selectedEndpoint = "openAI",
+                selectedModel = "ghost",
+                agents = listOf(Agent(id = "agent_1")),
+            ),
+        )
+        val delegate = newDelegate(handle)
+        delegate.conversationModelLoaded = true
+        delegate.agentsLoaded.value = true
+        delegate.cachedLastUsedEndpoint = EndpointConstants.AGENTS
+        delegate.cachedLastUsedModel = "agent_missing" // not in the loaded list
+        availableModels.value = mapOf("openAI" to listOf("gpt-4o"))
+
+        delegate.refilterModels(isNewConversation = false)
+        advanceUntilIdle()
+
+        assertThat(handle.state.selectedEndpoint).isEqualTo("openAI")
+        assertThat(handle.state.selectedModel).isEqualTo("gpt-4o")
+    }
+
+    @Test
+    fun refilterCorrectiveFallbackHoldsUntilAgentsLoadedThenRestores() = runTest {
+        // Agents not loaded → the corrective fallback must HOLD (not pick a config model),
+        // then loadAgents' re-run of refilter restores the agents last-used.
+        val scope = TestScope(StandardTestDispatcher(testScheduler))
+        val handle = newHandle(
+            scope,
+            ChatUiState(conversationId = "c1", selectedEndpoint = "openAI", selectedModel = "ghost"),
+        )
+        val delegate = newDelegate(handle)
+        delegate.conversationModelLoaded = true
+        delegate.cachedLastUsedEndpoint = EndpointConstants.AGENTS
+        delegate.cachedLastUsedModel = "agent_1"
+        availableModels.value = mapOf("openAI" to listOf("gpt-4o"))
+        allowAgents()
+        coEvery { agentRepository.getAgents() } returns Result.Success(listOf(Agent(id = "agent_1")))
+
+        delegate.refilterModels(isNewConversation = false)
+        advanceUntilIdle()
+        // Held: agents unloaded, so neither last-used nor first-model was applied.
+        assertThat(handle.state.selectedEndpoint).isEqualTo("openAI")
+        assertThat(handle.state.selectedModel).isEqualTo("ghost")
+
+        delegate.loadAgents(isNewConversation = false)
+        advanceUntilIdle()
+
+        assertThat(handle.state.selectedEndpoint).isEqualTo(EndpointConstants.AGENTS)
+        assertThat(handle.state.selectedModel).isEqualTo("agent_1")
     }
 }

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/di/ChatModule.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/di/ChatModule.kt
@@ -4,6 +4,7 @@ import com.garfiec.librechat.core.common.di.KoinQualifiers
 import com.garfiec.librechat.feature.chat.prompts.PromptEditorViewModel
 import com.garfiec.librechat.feature.chat.prompts.PromptsViewModel
 import com.garfiec.librechat.feature.chat.viewmodel.ConversationMediaViewModel
+import com.garfiec.librechat.feature.chat.viewmodel.NewChatSelectionHandoff
 import org.koin.core.module.Module
 import org.koin.core.module.dsl.viewModel
 import org.koin.core.module.dsl.viewModelOf
@@ -11,6 +12,7 @@ import org.koin.dsl.module
 
 val chatModule = module {
     includes(chatPlatformModule)
+    single { NewChatSelectionHandoff() }
     viewModelOf(::PromptsViewModel)
     // Koin's constructor-DSL (`viewModelOf`) wires every argument via `get()` and cannot read
     // values passed through `parametersOf`. This VM receives its `initialGroupId` from the

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModel.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModel.kt
@@ -29,7 +29,10 @@ import com.garfiec.librechat.core.data.repository.RoleRepository
 import com.garfiec.librechat.core.data.repository.ShareRepository
 import com.garfiec.librechat.core.data.repository.UserRepository
 import com.garfiec.librechat.core.data.util.PermissionGate
+import com.garfiec.librechat.core.logging.Diag
+import com.garfiec.librechat.core.logging.LogOrigin
 import com.garfiec.librechat.core.model.Attachment
+import com.garfiec.librechat.core.model.Conversation
 import com.garfiec.librechat.core.model.Message
 import com.garfiec.librechat.core.model.Preset
 import com.garfiec.librechat.core.model.StreamEvent
@@ -112,6 +115,7 @@ class ChatViewModel(
     platformDelegateFactory: PlatformDelegateFactory,
     private val json: Json,
     private val defaultDispatcher: CoroutineDispatcher,
+    private val selectionHandoff: NewChatSelectionHandoff,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(ChatUiState())
@@ -279,6 +283,19 @@ class ChatViewModel(
                     screenState = ChatScreenState.LOADING,
                 )
             }
+            // If we arrived here straight from the NewChat landing (the common case for a
+            // just-created chat), the landing VM staged the exact (endpoint, model) it sent.
+            // Apply it up front so the header/selection is correct immediately and the
+            // racy loadConversationModel GET below can't clobber it with a fallback guess
+            // when the server hasn't persisted the conversation yet (the created-before-save
+            // race). See NewChatSelectionHandoff.
+            selectionHandoff.take(conversationId)?.let { handoff ->
+                Diag.d(
+                    tag = "ModelSel",
+                    attrs = mapOf("endpoint" to handoff.endpoint, "model" to (handoff.model ?: "null")),
+                ) { "handoff applied for $conversationId" }
+                modelDelegate.applyResolvedConversationModel(handoff.endpoint, handoff.model)
+            }
             loadConversation(conversationId)
             loadConversationModel(conversationId)
             restoreDraft(conversationId)
@@ -403,7 +420,7 @@ class ChatViewModel(
             // flips its agentsLoaded flag on every path (including denial). Skipping it
             // here would leave the flag false and park the seeder on the agents tier
             // forever (no model on the landing) for agents-denied users.
-            modelDelegate.loadAgents()
+            modelDelegate.loadAgents(isNewConversation)
         }
     }
 
@@ -475,33 +492,53 @@ class ChatViewModel(
             val result = conversationRepository.getConversation(conversationId)
             val conversation = result.getOrNull()
             if (conversation != null) {
-                val endpoint = conversation.endpoint
-                val model = conversation.model
-                val isAgentConversation = endpoint == EndpointConstants.AGENTS
-                val resolvedModel = if (isAgentConversation) {
-                    conversation.agentId ?: model
-                } else {
-                    model
-                }
-                _uiState.update {
-                    it.copy(
-                        selectedEndpoint = if (endpoint != null && (resolvedModel != null || isAgentConversation)) {
-                            endpoint
-                        } else {
-                            it.selectedEndpoint
-                        },
-                        selectedModel = if (endpoint != null && resolvedModel != null) {
-                            resolvedModel
-                        } else {
-                            it.selectedModel
-                        },
-                        conversationTitle = conversation.title,
-                    )
-                }
+                _uiState.update { it.copy(conversationTitle = conversation.title) }
+                val applied = applyConversationModel(conversation)
+                Diag.d(
+                    tag = "ModelSel",
+                    attrs = mapOf(
+                        "found" to "true",
+                        "applied" to applied.toString(),
+                        "endpoint" to (conversation.endpoint ?: "null"),
+                    ),
+                ) { "loadConversationModel resolved for $conversationId" }
+            } else {
+                // The just-created conversation isn't readable yet: the server emits the
+                // `created` SSE event before the unawaited save persists it, so this GET can
+                // race that save and 404. The in-process handoff already seeded the correct
+                // selection in init, so we deliberately leave it untouched here. Only mark
+                // "load attempted" — never "resolved" — so handleFinal can re-derive later.
+                Diag.w(
+                    tag = "ModelSel",
+                    origin = LogOrigin.SERVER,
+                    attrs = mapOf("found" to "false"),
+                ) { "loadConversationModel: conversation not readable for $conversationId" }
             }
             modelDelegate.conversationModelLoaded = true
             modelDelegate.refilterModels(isNewConversation)
         }
+    }
+
+    /**
+     * Resolves a loaded [conversation]'s authoritative (endpoint, model) and applies it as
+     * the active selection via [ModelSelectionDelegate.applyResolvedConversationModel].
+     * Agents conversations carry the agent in `agentId`, so prefer that over `model` for the
+     * AGENTS endpoint. Returns true when a concrete selection was applied (i.e. the
+     * conversation model is now resolved), false when the conversation lacked enough info.
+     */
+    private fun applyConversationModel(conversation: Conversation): Boolean {
+        val endpoint = conversation.endpoint
+        val isAgentConversation = endpoint == EndpointConstants.AGENTS
+        val resolvedModel = if (isAgentConversation) {
+            conversation.agentId ?: conversation.model
+        } else {
+            conversation.model
+        }
+        if (endpoint != null && resolvedModel != null) {
+            modelDelegate.applyResolvedConversationModel(endpoint, resolvedModel)
+            return true
+        }
+        return false
     }
 
     private fun refreshConversationTitle(conversationId: String) {
@@ -1309,6 +1346,12 @@ class ChatViewModel(
             }
         }
         if (isNewConversation) {
+            // Stage the selection we actually sent so the about-to-be-created Chat(id) VM can
+            // apply it directly instead of re-deriving it from a GET that races the server's
+            // unawaited conversation save. Keyed by id, so a deferred nav (comparison-mode
+            // branch) still picks it up. See NewChatSelectionHandoff.
+            val sent = _uiState.value
+            selectionHandoff.put(event.conversationId, sent.selectedEndpoint, sent.selectedModel)
             _uiState.update {
                 if (it.pendingNavigationConversationId == null && !it.comparisonState.isEnabled) {
                     it.copy(pendingNavigationConversationId = event.conversationId)
@@ -1375,6 +1418,17 @@ class ChatViewModel(
             }
         }
         val finalConversation = event.conversation
+        // Belt-and-braces: if no handoff seeded the selection and the initial GET 404'd
+        // against the created-before-save race, the conversation model is still unresolved.
+        // The Final event carries the authoritative conversation, so re-derive from it here
+        // rather than leaving a fallback guess on screen.
+        if (!modelDelegate.conversationModelResolved && finalConversation != null) {
+            val applied = applyConversationModel(finalConversation)
+            Diag.i(
+                tag = "ModelSel",
+                attrs = mapOf("applied" to applied.toString()),
+            ) { "handleFinal re-derived conversation model" }
+        }
         // SECURITY: do not remove — temp-chat data-at-rest guard.
         // Temporary chats (v0.8.6) are kept out of normal history — the server excludes
         // them from the conversation list, so don't cache them to Room either (it would

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/NewChatSelectionHandoff.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/NewChatSelectionHandoff.kt
@@ -1,0 +1,45 @@
+package com.garfiec.librechat.feature.chat.viewmodel
+
+/**
+ * In-process, single-slot handoff of the model selection from the NewChat landing
+ * ViewModel to the freshly-created Chat(id) ViewModel.
+ *
+ * Why this exists: navigation to `Chat(id)` fires at the `created` SSE event, but the
+ * server emits `created` BEFORE it has persisted the conversation (the save is
+ * unawaited). The new VM's `loadConversationModel` GET therefore races that save and
+ * can 404, leaving the selection to be re-derived from a fallback guess — which is how
+ * the wrong model ends up displayed (and, worse, used on a follow-up send). The landing
+ * VM already knows exactly what it sent, so it hands that off here instead of forcing
+ * the new VM to re-read it from a racy server endpoint.
+ *
+ * Single-slot by design: only one new-chat → Chat(id) transition can be in flight at a
+ * time. [take] returns the entry only when the conversationId matches, so a stale entry
+ * (e.g. the transition never completed) can never be mis-applied to a different chat.
+ *
+ * Threading: both the [put] (in `handleCreated`) and [take] (in `ChatViewModel.init`)
+ * call sites run on the ViewModel's main-dispatcher scope, so no locking is needed.
+ * It also self-expires across process death — the slot is empty on restart, and by then
+ * the conversation GET succeeds anyway (the race window is milliseconds).
+ */
+class NewChatSelectionHandoff {
+
+    data class Selection(
+        val conversationId: String,
+        val endpoint: String,
+        val model: String?,
+    )
+
+    private var pending: Selection? = null
+
+    fun put(conversationId: String, endpoint: String, model: String?) {
+        pending = Selection(conversationId, endpoint, model)
+    }
+
+    /** Returns and clears the pending selection only when it was staged for [conversationId]. */
+    fun take(conversationId: String): Selection? {
+        val current = pending ?: return null
+        if (current.conversationId != conversationId) return null
+        pending = null
+        return current
+    }
+}

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/ModelSelectionDelegate.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/ModelSelectionDelegate.kt
@@ -9,6 +9,7 @@ import com.garfiec.librechat.core.data.repository.AgentRepository
 import com.garfiec.librechat.core.data.repository.ConfigRepository
 import com.garfiec.librechat.core.data.repository.McpRepository
 import com.garfiec.librechat.core.data.util.PermissionGate
+import com.garfiec.librechat.core.logging.Diag
 import com.garfiec.librechat.core.model.Agent
 import com.garfiec.librechat.core.model.EndpointConfig
 import com.garfiec.librechat.core.model.mcp.McpServer
@@ -61,12 +62,37 @@ class ModelSelectionDelegate(
     var cachedLastUsedModel: String? = null
 
     /**
-     * True once the conversation's model has been loaded from the server.
-     * Used to prevent [refilterModels] from overwriting the conversation
-     * model with a fallback before loadConversationModel has had a chance
-     * to set it.
+     * True once a conversation-model LOAD has been attempted (success, 404, or new-chat
+     * short-circuit). Used to prevent [refilterModels] from overwriting the conversation
+     * model with a fallback before loadConversationModel has had a chance to set it.
+     *
+     * NOTE: "attempted", not "succeeded" — a 404 (the created-before-save race) still flips
+     * this. To tell "we actually have the conversation's real model" use
+     * [conversationModelResolved].
      */
     var conversationModelLoaded = false
+
+    /**
+     * True once the conversation's authoritative (endpoint, model) has actually been applied
+     * — either from the in-process new-chat handoff or from a successful conversation read.
+     * Distinct from [conversationModelLoaded], which only records that a load was attempted
+     * (and is set even on a 404). [ChatViewModel.handleFinal] re-derives the selection from
+     * the Final event only while this is still false, so a racy 404 can't strand a fallback
+     * guess on screen.
+     */
+    var conversationModelResolved = false
+
+    /**
+     * Applies an authoritative conversation (endpoint, model) as the active selection and
+     * marks the conversation model both loaded and resolved. The single write point for a
+     * resolved existing/just-created conversation's selection — used by the new-chat handoff
+     * and by [ChatViewModel]'s conversation reads — so the flags can't drift from the value.
+     */
+    fun applyResolvedConversationModel(endpoint: String, model: String?) {
+        applySelection(endpoint, model, reason = "conversationResolved")
+        conversationModelLoaded = true
+        conversationModelResolved = true
+    }
 
     /**
      * True once [loadAgents] has finished on ANY path (success, error, or
@@ -153,8 +179,31 @@ class ModelSelectionDelegate(
         val lastEndpoint = cachedLastUsedEndpoint
         val lastModel = cachedLastUsedModel
         if (lastEndpoint != null && lastModel != null) {
-            val lastModelsForEndpoint = filtered[lastEndpoint]
-            if (lastModelsForEndpoint != null && lastModel in lastModelsForEndpoint) {
+            val lastUsedRestorable = if (lastEndpoint == EndpointConstants.AGENTS) {
+                // Agents never appear in `filtered` (/api/models has no "agents" key), so the
+                // old `filtered[lastEndpoint]` check always failed and a valid agents last-used
+                // was silently skipped to a config model. Validate the agent id against the
+                // authoritative agents list instead (mirroring selectability()). Hold — don't
+                // fall through to a config-model guess — until that list has loaded; loadAgents
+                // re-runs refilterModels on success to un-stick this.
+                when {
+                    !agentsLoaded.value -> return
+                    stateHandle.state.agents.any { it.id == lastModel } -> true
+                    else -> false
+                }
+            } else {
+                val lastModelsForEndpoint = filtered[lastEndpoint]
+                lastModelsForEndpoint != null && lastModel in lastModelsForEndpoint
+            }
+            if (lastUsedRestorable) {
+                Diag.w(
+                    tag = "ModelSel",
+                    attrs = mapOf(
+                        "branch" to "lastUsed",
+                        "from" to (currentModel ?: "null"),
+                        "endpoint" to lastEndpoint,
+                    ),
+                ) { "refilterModels corrective fallback → last-used" }
                 stateHandle.update {
                     copy(
                         selectedEndpoint = lastEndpoint,
@@ -167,6 +216,14 @@ class ModelSelectionDelegate(
 
         val firstEndpoint = filtered.entries.firstOrNull()
         if (firstEndpoint != null) {
+            Diag.w(
+                tag = "ModelSel",
+                attrs = mapOf(
+                    "branch" to "firstModel",
+                    "from" to (currentModel ?: "null"),
+                    "endpoint" to firstEndpoint.key,
+                ),
+            ) { "refilterModels corrective fallback → first model" }
             stateHandle.update {
                 copy(
                     selectedEndpoint = firstEndpoint.key,
@@ -275,7 +332,7 @@ class ModelSelectionDelegate(
             // (agentsLoaded=true, agents=[]) emission would score the agent INVALID/PENDING
             // and clobber it to a config model.
             holdAgentForPopulate = true
-            applySelection(EndpointConstants.AGENTS, agentId)
+            applySelection(EndpointConstants.AGENTS, agentId, reason = "tier0-agentOverride")
             return
         }
         val lastUsedSelectability = lastUsed?.let {
@@ -283,7 +340,7 @@ class ModelSelectionDelegate(
         }
         fun applyLastUsed(): Boolean {
             if (lastUsed != null && lastUsedSelectability == Selectability.VALID) {
-                applySelection(lastUsed.first, lastUsed.second)
+                applySelection(lastUsed.first, lastUsed.second, reason = "tier1-lastUsed")
                 lastAppliedLastUsed = lastUsed
                 return true
             }
@@ -372,7 +429,7 @@ class ModelSelectionDelegate(
             if (!input.agentsLoaded) return // WAIT for the agent list
             val firstAgent = input.agents.firstOrNull()
             if (firstAgent != null) {
-                applySelection(EndpointConstants.AGENTS, firstAgent.id)
+                applySelection(EndpointConstants.AGENTS, firstAgent.id, reason = "tier2-firstAgent")
                 return
             }
             // Agents loaded and genuinely empty — fall through.
@@ -381,12 +438,24 @@ class ModelSelectionDelegate(
         // Tier 3: first available config model.
         if (filtered.isEmpty()) return // WAIT for models
         val firstEntry = filtered.entries.firstOrNull() ?: return
-        applySelection(firstEntry.key, firstEntry.value.firstOrNull())
+        applySelection(firstEntry.key, firstEntry.value.firstOrNull(), reason = "tier3-firstModel")
     }
 
-    private fun applySelection(endpoint: String, model: String?) {
+    private fun applySelection(endpoint: String, model: String?, reason: String) {
+        val previous = stateHandle.state
+        val changed = previous.selectedEndpoint != endpoint || previous.selectedModel != model
         stateHandle.update {
             copy(selectedEndpoint = endpoint, selectedModel = model)
+        }
+        if (changed) {
+            Diag.d(
+                tag = "ModelSel",
+                attrs = mapOf(
+                    "reason" to reason,
+                    "endpoint" to endpoint,
+                    "model" to (model ?: "null"),
+                ),
+            ) { "applySelection" }
         }
     }
 
@@ -584,13 +653,15 @@ class ModelSelectionDelegate(
      * [agentsLoaded] on every exit path so the seeder can distinguish "agents
      * still loading" (wait) from "agents loaded and empty" (fall through).
      */
-    fun loadAgents() {
+    fun loadAgents(isNewConversation: Boolean) {
         stateHandle.scope.launch {
             // Skip the fetch entirely when the role denies AGENTS.USE; otherwise
             // the server would return 403 and we'd have to decide whether it's a
             // genuine 403 (rate limit, tenancy) vs. permission denial.
             if (permissionGate.awaitRole()?.hasAccess(PermissionType.AGENTS, Permission.USE) == false) {
                 agentsLoaded.value = true
+                // Un-stick the corrective-fallback hold (see below) even on this path.
+                refilterModels(isNewConversation)
                 return@launch
             }
             when (val result = agentRepository.getAgents()) {
@@ -607,8 +678,14 @@ class ModelSelectionDelegate(
                     stateHandle.update { copy(error = "Could not load available agents") }
                     agentsLoaded.value = true
                 }
-                is Result.Loading -> { /* no-op */ }
+                is Result.Loading -> return@launch
             }
+            // The existing-conversation corrective fallback in [refilterModels] HOLDS
+            // (returns early) for an agents last-used while the agents list is unloaded.
+            // Re-run on EVERY terminal path that flips [agentsLoaded] — success, error,
+            // AND denial — so the hold is always released; an error/denied load (empty
+            // list) correctly falls through to a config model instead of staying stuck.
+            refilterModels(isNewConversation)
         }
     }
 

--- a/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/di/ChatPlatformModule.ios.kt
+++ b/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/di/ChatPlatformModule.ios.kt
@@ -46,6 +46,7 @@ actual val chatPlatformModule: Module = module {
             platformDelegateFactory = get(),
             json = get(),
             defaultDispatcher = get(KoinQualifiers.Default),
+            selectionHandoff = get(),
         )
     }
 }


### PR DESCRIPTION
## Summary
After sending the first message from the new-chat landing, the chat header/selector could show the wrong model (e.g. the first agent/config model) even though the message was sent with the model the user actually picked. This hands the selected `(endpoint, model)` off in-process from the landing ViewModel to the freshly-created `Chat(id)` ViewModel, so the new screen trusts what was sent instead of re-deriving it from a server read. This mirrors the web client, which preserves the client-side selection and does not re-fetch the conversation for a just-created chat.

## Root cause
Navigation to `Chat(id)` fires on the `created` SSE event, but the backend emits `created` before its unawaited save persists the conversation. The new ViewModel's `loadConversationModel` read therefore races that save and can come back empty (a 404 in the captured logs); on an unreadable conversation the selection fell back to a guess. The agents branch of that fallback was also dead (it validated a last-used agent against the models map, which never contains agents), so an agents last-used was skipped to the first config model — and nothing corrected it afterward, so a follow-up send could use the wrong model.

## Changes
- **`NewChatSelectionHandoff`** — in-memory, single-slot, id-keyed handoff registered as a Koin singleton (wired into both the Android and iOS ViewModel factories); written when the conversation is created, read when the `Chat(id)` ViewModel initializes.
- **`ModelSelectionDelegate.applyResolvedConversationModel`** — one authoritative entry point for applying a resolved conversation's selection, with a new `conversationModelResolved` flag distinct from `conversationModelLoaded` ("attempted, even on a failed read").
- **`handleFinal` re-derive** — if the selection was never resolved (no handoff and a failed read), re-derive it from the authoritative conversation on the final event.
- **Agents corrective-fallback fix** in `refilterModels` — validate an agents last-used against the loaded agents list, hold until that list is available, and re-run on every `loadAgents` terminal path (success/error/denied) so the hold can't get stuck. `loadAgents` now takes `isNewConversation` to drive that re-run.
- **`[ModelSel]` diagnostic logging** at the previously-silent selection points so the race is observable in an exported log.

## Testing
- New unit tests: `NewChatSelectionHandoffTest` + added `ModelSelectionDelegate` cases (resolved-selection no-clobber, agents fallback present/absent/hold-then-restore). Existing delegate tests were updated for the new `loadAgents` signature and pass; the Koin module-verification test passes.
- `./gradlew :feature:chat:testDebugUnitTest detekt` — pass.
- `./gradlew :app:assembleDebug :shared:compileKotlinIosSimulatorArm64` — both platforms compile.
- Not yet device-tested.

## Notes
- Adds a `:core:logging` dependency to `:feature:chat` for the `Diag` logging.
- The agents corrective-fallback fix also hardens model selection for existing conversations, not just newly created ones.
