### PR TITLE
ci(release): publish unsigned iOS IPA for sideloading

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,11 @@ jobs:
     # Gate signing secrets behind a protected environment (add required reviewers in repo
     # settings). Secrets are unavailable to fork PRs, so this stays off the PR path.
     environment: release
+    # Surface the bumped version + tag so the secondary `ios` job can check out the tagged
+    # commit and name/upload its IPA against the same draft release.
+    outputs:
+      version_name: ${{ steps.bump.outputs.version_name }}
+      tag: ${{ steps.bump.outputs.tag }}
 
     steps:
       - name: Checkout
@@ -156,19 +161,32 @@ jobs:
           TAG: ${{ steps.bump.outputs.tag }}
           BACKEND: ${{ steps.backend.outputs.target }}
           APK: ${{ steps.artifacts.outputs.apk }}
+          VERSION: ${{ steps.bump.outputs.version_name }}
         run: |
           # Generate the same changelog GitHub would auto-produce. Omitting previous_tag_name
           # lets the API auto-detect the prior tag, matching the old generate_release_notes.
           gh api --method POST "repos/${{ github.repository }}/releases/generate-notes" \
             -f tag_name="$TAG" --jq .body > "$RUNNER_TEMP/changelog.md"
 
+          # The iOS job uploads this deterministic asset name to the same draft; reference it
+          # statically here even though this step runs before that job finishes.
+          IPA="librechat-v${VERSION}.ipa"
+
           # Badge row (rendered side-by-side). The Target Backend badge replaces the old
-          # plain-text "Target backend: LibreChat v…" line. The APK Downloads badge tracks
-          # download counts for this release's APK asset.
+          # plain-text "Target backend: LibreChat v…" line. The Downloads badges track
+          # download counts for this release's APK / IPA assets.
           {
             printf '![Target Backend](https://img.shields.io/badge/Target_Backend-LibreChat_v%s-orange)' "$BACKEND"
             printf ' '
-            printf '![APK Downloads](https://img.shields.io/github/downloads/garfiec/Librechat-Mobile/%s/%s?displayAssetName=false&logo=android&label=APK%%20Downloads&color=blue)\n' "$TAG" "$APK"
+            printf '![APK Downloads](https://img.shields.io/github/downloads/garfiec/Librechat-Mobile/%s/%s?displayAssetName=false&logo=android&label=APK%%20Downloads&color=blue)' "$TAG" "$APK"
+            printf ' '
+            printf '![IPA Downloads](https://img.shields.io/github/downloads/garfiec/Librechat-Mobile/%s/%s?displayAssetName=false&logo=apple&label=IPA%%20Downloads&color=blue)\n' "$TAG" "$IPA"
+            printf '\n'
+            # iOS is distributed as an UNSIGNED IPA for sideloading — install via
+            # AltStore / SideStore / Sideloadly (re-signs with a free Apple ID) or TrollStore.
+            # See docs/RELEASING.md for details. The asset is attached by the secondary iOS
+            # job and may appear a few minutes after the Android assets.
+            printf '**iOS (sideload):** download `%s` and install via AltStore / SideStore / Sideloadly (free Apple ID) or TrollStore — see [install notes](https://github.com/%s/blob/%s/docs/RELEASING.md#installing-the-ios-ipa).\n' "$IPA" "${{ github.repository }}" "$TAG"
             printf '\n'
             cat "$RUNNER_TEMP/changelog.md"
             # Slim provenance footer: discoverability links, not proof. Canonical "how to
@@ -205,3 +223,97 @@ jobs:
       - name: Remind to publish the draft
         run: |
           echo "::warning title=Release is a DRAFT::${{ steps.bump.outputs.tag }} was created as a DRAFT. Obtainium and direct downloads will NOT see it until you open it in the GitHub Releases UI and click Publish."
+
+  # Secondary, NON-BLOCKING iOS job: builds an UNSIGNED, device-arch IPA from the just-tagged
+  # commit and attaches it to the same draft release. It needs no secrets and no Apple account
+  # — sideload installers (AltStore/SideStore/Sideloadly) re-sign with the user's free Apple ID,
+  # and TrollStore/jailbreak installers accept unsigned IPAs directly. If this macOS job fails,
+  # the Android release (tag + APK + draft) already stands; just re-run it or upload manually.
+  ios:
+    name: Build & attach unsigned IPA
+    needs: release
+    runs-on: macos-latest
+    # No `environment: release` — this job uses no signing secrets. It inherits the
+    # workflow-level permissions (contents: write to upload the asset; id-token/attestations
+    # for provenance parity with the APK).
+    steps:
+      - name: Checkout (tagged commit)
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.release.outputs.tag }}   # the bump commit the release job just pushed
+
+      - name: Select Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - name: Setup Gradle
+        # SHA-pinned to match the release job's supply-chain policy (Dependabot bumps it).
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+
+      - name: Cache Kotlin/Native toolchain
+        uses: actions/cache@v5
+        with:
+          path: ~/.konan
+          key: ${{ runner.os }}-konan-${{ hashFiles('gradle/libs.versions.toml') }}
+          restore-keys: ${{ runner.os }}-konan-
+
+      # The device framework must exist before xcodebuild — the Xcode project's framework
+      # search path points at shared/build/bin/iosArm64/releaseFramework.
+      - name: Build shared KMP framework (device, release)
+        run: ./gradlew :shared:linkReleaseFrameworkIosArm64
+
+      - name: Archive & package unsigned IPA
+        id: ipa
+        env:
+          TAG: ${{ needs.release.outputs.tag }}
+          VERSION: ${{ needs.release.outputs.version_name }}
+        run: |
+          set -euo pipefail
+          # Unsigned device archive. Signing is fully disabled: the project's Release config
+          # carries an sdk-scoped `CODE_SIGN_IDENTITY[sdk=iphoneos*] = "Apple Development"` +
+          # `CODE_SIGN_STYLE = Automatic`, which on a device archive would otherwise demand a
+          # provisioning profile on this account-less runner — so we override the sdk-scoped
+          # key, force Manual style, and blank the profile, not just the unscoped identity.
+          # The "Copy Compose Resources" build phase shells out to ./gradlew itself, which is
+          # why JDK + Gradle are set up above.
+          xcodebuild archive \
+            -project iosApp/iosApp.xcodeproj \
+            -scheme iosApp \
+            -configuration Release \
+            -destination 'generic/platform=iOS' \
+            -archivePath "$RUNNER_TEMP/iosApp.xcarchive" \
+            CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGN_IDENTITY="" "CODE_SIGN_IDENTITY[sdk=iphoneos*]=" \
+            CODE_SIGN_STYLE=Manual PROVISIONING_PROFILE_SPECIFIER="" \
+            DEVELOPMENT_TEAM="" ONLY_ACTIVE_ARCH=NO
+
+          # Repackage the archived .app into an unsigned IPA (Payload/ + zip).
+          cd "$RUNNER_TEMP/iosApp.xcarchive/Products/Applications"
+          mkdir -p Payload && mv iosApp.app Payload/
+          OUT="$RUNNER_TEMP/librechat-v${VERSION}.ipa"
+          zip -qry "$OUT" Payload
+          ( cd "$RUNNER_TEMP" && shasum -a 256 "librechat-v${VERSION}.ipa" > "librechat-v${VERSION}.ipa.sha256" )
+          echo "ipa=$OUT" >> "$GITHUB_OUTPUT"
+          echo "sha=$OUT.sha256" >> "$GITHUB_OUTPUT"
+
+      # Provenance parity with the APK: a keyless SLSA attestation for the IPA bytes.
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-path: ${{ steps.ipa.outputs.ipa }}
+
+      - name: Upload IPA to the draft release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.release.outputs.tag }}
+        run: |
+          gh release upload "$TAG" \
+            "${{ steps.ipa.outputs.ipa }}" \
+            "${{ steps.ipa.outputs.sha }}" --clobber

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,6 +1,6 @@
 # Releasing
 
-How releases are versioned, signed, and published for LibreChat Mobile (Android).
+How releases are versioned, signed, and published for LibreChat Mobile (Android & iOS).
 
 ## Versioning
 
@@ -33,11 +33,11 @@ Both platforms derive from the same `versionName`, so they stay in lockstep:
 | Android | `versionName` verbatim | derived YYYYMMPP | `AndroidApplicationConventionPlugin` reads `version.properties` at build |
 | iOS | `CFBundleShortVersionString` | `CFBundleVersion` (same YYYYMMPP) | *Stamp Version* Xcode build phase reads `version.properties` at build |
 
-> iOS isn't published on GitHub Releases — the stamp exists only to keep the two platforms'
-> reported versions identical. The "Stamp Version from version.properties" run-script phase
-> runs after Info.plist is in the bundle and before codesign, so the committed `Info.plist`
-> literals (and the unused `MARKETING_VERSION`/`CURRENT_PROJECT_VERSION` build settings) are
-> just a fallback snapshot — the build always reflects `version.properties`.
+> The "Stamp Version from version.properties" run-script phase runs after Info.plist is in
+> the bundle and before codesign, so the committed `Info.plist` literals (and the unused
+> `MARKETING_VERSION`/`CURRENT_PROJECT_VERSION` build settings) are just a fallback snapshot —
+> the build always reflects `version.properties`. The same stamp drives the published iOS IPA
+> (see *Cutting a release* below), so both platforms' assets carry the identical calver.
 
 Bump it with the script (also run by the release workflow). For example, running in
 June 2026 with stored version `2026.05.2`:
@@ -136,8 +136,15 @@ release builds fall back to the debug key so local builds and CI checks still wo
    a **draft** GitHub Release with auto-generated notes and a `.sha256` checksum. Candidate
    versions are flagged as pre-releases automatically. If the build fails, nothing is committed
    or tagged — just re-run after fixing it.
-3. Review the draft, edit the notes for users, then **publish**.
-4. Obtainium / IzzyOnDroid pick up the published release automatically.
+3. A **secondary `ios` job** (macOS runner) then checks out the freshly tagged commit, builds
+   an **unsigned device IPA**, attests it, and attaches `librechat-vX.ipa` + `.sha256` to the
+   same draft. It uses **no secrets and no Apple account** (sideload installers re-sign on the
+   user's device), so it needs nothing beyond the standard CI setup. It is **non-blocking**: if
+   the macOS build fails the Android tag + APK + draft already stand — re-run just the `ios` job
+   or attach the IPA by hand. The IPA may land a few minutes after the APK.
+4. Review the draft, edit the notes for users, then **publish**.
+5. Obtainium / IzzyOnDroid pick up the published release automatically (Android); iOS users
+   sideload the IPA manually (see *Installing the iOS IPA* below).
 
 > **Drafts are invisible to Obtainium.** A release stays hidden from every user until you
 > click **Publish** — Obtainium's GitHub source skips drafts. The workflow ends with a
@@ -151,17 +158,42 @@ release builds fall back to the debug key so local builds and CI checks still wo
 > as the repo owner (already a bypass actor); without it the run fails fast at the
 > *Verify signing secrets* step.
 
+## Installing the iOS IPA
+
+The iOS asset (`librechat-vX.ipa`) is **unsigned** — there is no Apple Developer account or
+App Store path. iOS refuses to run unsigned code, so every install route below re-signs the
+app on (or for) your device. Pick whichever your device supports:
+
+- **AltStore / SideStore / Sideloadly** (any non-jailbroken iPhone). These re-sign the IPA
+  with your **free Apple ID** on install. The free tier means a **7-day** signature that the
+  app auto-refreshes while it can reach a desktop/Wi-Fi pairing (SideStore/AltStore do this in
+  the background), and a limit of **3 sideloaded apps** at a time. No paid account needed.
+- **TrollStore** (devices vulnerable to the CoreTrust bug — broadly iOS 14.0–16.6.1 and some
+  17.0). Installs the unsigned IPA **permanently** (no 7-day refresh, no app limit) by
+  fakesigning it on-device. The most convenient route if your device/iOS is in range.
+- **Jailbroken devices** can install the IPA directly (e.g. `appinst`).
+
+Because the IPA ships unsigned, the bundled signature is irrelevant — these tools all apply
+their own. The build is provenance-attested all the same; verify the **download** the same way
+as the APK (next section, swapping `.apk` for the `.ipa`).
+
+> The app is a plain network client (no push, app groups, or associated domains), so it stays
+> within free-Apple-ID entitlement limits — nothing extra to configure when sideloading.
+
 ## Verifying a release
 
-Three checks are available to anyone who downloads an APK, in descending order of strength:
+Three checks are available to anyone who downloads an APK (or IPA), in descending order of strength:
 
 1. **Build provenance (strongest)** — `gh attestation verify <apk> --repo garfiec/Librechat-Mobile
    --signer-workflow garfiec/Librechat-Mobile/.github/workflows/release.yml`. This is the only
    check that resists a *tampered upload*: it's signed by GitHub's CI via Sigstore and can't be
    forged outside the runner. Each release's notes link the run + attestation, but a link is not
-   proof — only this command verifies the downloaded bytes. See the README install section.
+   proof — only this command verifies the downloaded bytes. See the README install section. The
+   **IPA is attested too** — run the same command with the `.ipa` in place of `<apk>`.
 2. **Signing certificate** — `apksigner verify --print-certs <apk>`, compared against the
-   published cert SHA-256. Catches a build signed with a different key.
+   published cert SHA-256. Catches a build signed with a different key. **APK only** — the IPA
+   ships unsigned (the sideload installer applies its own signature), so there is no fixed iOS
+   cert to pin; rely on provenance + checksum for the IPA.
 3. **Checksum** — `sha256sum -c <apk>.sha256`. Catches accidental corruption or a download MITM
    only; it does *not* defend against a malicious release (the attacker would control both files).
 
@@ -171,3 +203,7 @@ Three checks are available to anyone who downloads an APK, in descending order o
   releases are full releases; `-rcN` candidate tags are marked pre-release.
 - **IzzyOnDroid** (future) — ingests the developer-signed APK and pins the signing key via
   `AllowedAPKSigningKeys`. Use the *same* key. Reproducible builds earn a verification badge.
+- **iOS sideloading** — the unsigned `.ipa` is attached to every GitHub Release for
+  AltStore / SideStore / Sideloadly / TrollStore installs (see *Installing the iOS IPA*). There
+  is no App Store or Obtainium-equivalent auto-update channel; users re-download on each release
+  (a SideStore/AltStore source manifest is a possible future follow-up).

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -13,24 +13,24 @@
 		AAA0000B /* ComposeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBB0000B; };
 		AAA0000C /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BBB0000C; };
 		AAA00010 /* Shared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BBB00010; };
-		AAA00011 /* Shared.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = BBB00010; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
-/* Begin PBXCopyFilesBuildPhase section */
-		CCC00001 /* Embed Frameworks */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = "";
-			dstSubfolderSpec = 10;
-			files = (
-				AAA00011 /* Shared.framework in Embed Frameworks */,
-			);
-			name = "Embed Frameworks";
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXCopyFilesBuildPhase section */
-
 /* Begin PBXShellScriptBuildPhase section */
+		SSS00004 /* Embed Shared Framework */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Embed Shared Framework";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Embed the Kotlin/Native Shared.framework matching the active SDK + configuration.\n# FRAMEWORK_SEARCH_PATHS already resolve the framework for *linking*; this phase copies\n# that same framework into the app bundle's Frameworks/ dir. Keyed on PLATFORM_NAME +\n# CONFIGURATION to mirror the search paths, so simulator-debug and device-release both\n# embed the correct slice.\nset -eu\nif [ \"$PLATFORM_NAME\" = \"iphonesimulator\" ]; then\n    ARCH_DIR=\"iosSimulatorArm64\"\nelse\n    ARCH_DIR=\"iosArm64\"\nfi\nif [ \"$CONFIGURATION\" = \"Release\" ]; then\n    FW_DIR=\"releaseFramework\"\nelse\n    FW_DIR=\"debugFramework\"\nfi\nSRC=\"$SRCROOT/../shared/build/bin/$ARCH_DIR/$FW_DIR/Shared.framework\"\nif [ ! -d \"$SRC\" ]; then\n    echo \"error: Shared.framework not found at $SRC -- build the matching :shared:link${CONFIGURATION}Framework task first\"\n    exit 1\nfi\nDST=\"$BUILT_PRODUCTS_DIR/$PRODUCT_NAME.app/Frameworks\"\nrm -rf \"$DST/Shared.framework\"\nmkdir -p \"$DST\"\ncp -R \"$SRC\" \"$DST/\"\n# Mirror the old RemoveHeadersOnCopy attribute.\nrm -rf \"$DST/Shared.framework/Headers\" \"$DST/Shared.framework/PrivateHeaders\"\n# Code-sign on copy only when signing is enabled (skipped for unsigned sideload/CI builds).\nif [ \"${CODE_SIGNING_ALLOWED:-YES}\" != \"NO\" ] && [ -n \"${EXPANDED_CODE_SIGN_IDENTITY:-}\" ] && [ \"${EXPANDED_CODE_SIGN_IDENTITY}\" != \"-\" ]; then\n    codesign --force --sign \"$EXPANDED_CODE_SIGN_IDENTITY\" \"$DST/Shared.framework\"\nfi\necho \"Embedded Shared.framework from $SRC\"\n";
+		};
 		SSS00001 /* Copy Compose Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -160,7 +160,7 @@
 				III00001 /* Sources */,
 				RRR00001 /* Resources */,
 				EEE00001 /* Frameworks */,
-				CCC00001 /* Embed Frameworks */,
+				SSS00004 /* Embed Shared Framework */,
 				SSS00001 /* Copy Compose Resources */,
 				SSS00002 /* Stamp Version from version.properties */,
 				SSS00003 /* Stamp Git SHA */,

--- a/iosApp/iosApp.xcodeproj/xcshareddata/xcschemes/iosApp.xcscheme
+++ b/iosApp/iosApp.xcodeproj/xcshareddata/xcschemes/iosApp.xcscheme
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1500"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "GGG00001"
+               BuildableName = "iosApp.app"
+               BlueprintName = "iosApp"
+               ReferencedContainer = "container:iosApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "GGG00001"
+            BuildableName = "iosApp.app"
+            BlueprintName = "iosApp"
+            ReferencedContainer = "container:iosApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "GGG00001"
+            BuildableName = "iosApp.app"
+            BlueprintName = "iosApp"
+            ReferencedContainer = "container:iosApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
## Summary
The release pipeline now produces an iOS IPA alongside the Android APK, so iOS users can sideload the app. Addresses #144.

## Changes
- **release.yml** — new **non-blocking** `ios` job (macOS) that builds an unsigned device IPA, attests its provenance, and uploads it to the same draft GitHub Release. Needs no secrets and no Apple account. Promoted the release job's version/tag to job-level outputs so the iOS job can consume them.
- **Release notes** — added an IPA downloads badge and an "iOS (sideload)" install line.
- **iOS project (`project.pbxproj`)** — replaced the static-path *Embed Frameworks* phase with an SDK/config-aware run-script embed so device-release archives embed the correct framework slice (simulator-debug builds unchanged). Added a shared `iosApp` scheme so `xcodebuild archive` resolves deterministically on a clean checkout.
- **docs/RELEASING.md** — documented the iOS job and added an "Installing the iOS IPA" guide (AltStore/SideStore/Sideloadly vs TrollStore).

## Why unsigned
All sideload paths re-sign on the user's device (AltStore/SideStore/Sideloadly use a free Apple ID; TrollStore/jailbreak install unsigned directly), so a baked-in signature would be discarded. No new secrets or entitlements.

## Testing
- Locally on macOS (Xcode 26.5): `:shared:linkReleaseFrameworkIosArm64` + the unsigned `xcodebuild archive` produced an unsigned arm64 IPA — verified app + framework report "not signed at all", version stamp `2026.06.1` / `20260601`, and `Frameworks/Shared.framework` + `compose-resources/` present in the bundle.
- Regression: the existing `ci.yml` simulator-debug build still succeeds with the new embed phase.
- Not yet exercised end-to-end in a CI release run, and not yet sideload-installed on a physical device.

## Follow-ups (out of scope)
- Per-PR unsigned IPA in `ci.yml`; a SideStore/AltStore source manifest for iOS auto-updates; making the embed phase incremental (it currently re-copies the framework each build).

Closes #144
