### PR TITLE
fix(chat): refresh new-chat title in the conversation list

### DIFF
--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/ConversationRepository.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/ConversationRepository.kt
@@ -15,6 +15,13 @@ interface ConversationRepository {
         isArchived: Boolean = false,
     ): Result<String?>
     suspend fun getConversation(id: String): Result<Conversation>
+
+    /**
+     * Fetches [id] from the server and upserts it into the cache, bypassing
+     * [getConversation]'s cache-first read. Use when the local row is known to be
+     * stale (e.g. picking up a server-generated title).
+     */
+    suspend fun refreshConversation(id: String): Result<Conversation>
     suspend fun updateTitle(id: String, title: String): Result<Conversation>
     suspend fun generateTitle(conversationId: String): Result<String>
     suspend fun archive(id: String, isArchived: Boolean): Result<Conversation>

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/ConversationRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/ConversationRepositoryImpl.kt
@@ -57,10 +57,13 @@ class ConversationRepositoryImpl(
     override suspend fun getConversation(id: String): Result<Conversation> {
         val cached = conversationDao.getById(id)
         if (cached != null) return Result.Success(cached.toModel())
+        return refreshConversation(id)
+    }
 
+    override suspend fun refreshConversation(id: String): Result<Conversation> {
         return safeApiCall {
             val conversation = conversationsApi.getConversation(id)
-            conversationDao.upsert(conversation.toEntity())
+            conversationDao.upsertPreservingTags(conversation.toEntity())
             conversation
         }
     }

--- a/feature/chat/CLAUDE.md
+++ b/feature/chat/CLAUDE.md
@@ -10,7 +10,7 @@
 - Sealed interface: `ChatRoute : NavKey` with typed route classes
 - Routes: `NewChat` (landing), `Chat(conversationId: String? = null)`, `PromptsLibrary`, `PromptEditor(groupId: String? = null)` (all `@Serializable`)
 - Feature entries registered via `EntryProviderScope<NavKey>.chatEntries()`
-- When a new conversation starts from the landing page, `pendingNavigationConversationId` triggers navigation to `Chat(id)` after the first stream completes (data persisted to Room), keeping `NewChat` in the back stack
+- When a new conversation starts from the landing page, `pendingNavigationConversationId` triggers navigation to `Chat(id)` at `StreamEvent.Created`, keeping `NewChat` in the back stack. The landing VM is reset (`onPendingNavigationHandled`) and the new Chat(id) VM resumes the active stream — so the Chat(id) VM (with `isNewConversation = false`) is the one that handles the first stream's Final. New-chat-only work there (title generation) is gated on `isHandedOffNewChat`, derived from consuming `NewChatSelectionHandoff`
 - `navigateToChat()` replaces the current chat entry on the `NavBackStack` when switching between chats so back returns to `NewChat`
 
 ## Message Tree

--- a/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/TitleGenerationGateTest.kt
+++ b/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/TitleGenerationGateTest.kt
@@ -1,0 +1,91 @@
+package com.garfiec.librechat.feature.chat.viewmodel
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Pins the title-generation gate contract for `handleFinal`.
+ *
+ * The load-bearing case is the handed-off chat: navigation to Chat(id) fires at the
+ * `created` event, so the VM that sees a brand-new chat's first Final has
+ * `isNewConversation = false` and only `isHandedOffNewChat` keeps gen_title alive.
+ * Removing either flag from [shouldRequestTitleGeneration] must fail here.
+ */
+class TitleGenerationGateTest {
+
+    @Test
+    fun handedOffNewChatWithPlaceholderTitleRequestsGeneration() {
+        assertThat(
+            shouldRequestTitleGeneration(
+                isNewConversation = false,
+                isHandedOffNewChat = true,
+                currentTitle = PLACEHOLDER_CONVERSATION_TITLE,
+                alreadyRequested = false,
+            ),
+        ).isTrue()
+    }
+
+    @Test
+    fun landingVmNewConversationRequestsGeneration() {
+        // Comparison mode defers navigation, so the landing VM (no conversationId)
+        // can still be the one handling the first Final.
+        assertThat(
+            shouldRequestTitleGeneration(
+                isNewConversation = true,
+                isHandedOffNewChat = false,
+                currentTitle = null,
+                alreadyRequested = false,
+            ),
+        ).isTrue()
+    }
+
+    @Test
+    fun existingConversationWithPlaceholderTitleDoesNotRequestGeneration() {
+        // Deliberate: gen_title long-polls ~15s before 404-ing when no title will
+        // generate, so placeholder title alone must not trigger it on every send.
+        assertThat(
+            shouldRequestTitleGeneration(
+                isNewConversation = false,
+                isHandedOffNewChat = false,
+                currentTitle = PLACEHOLDER_CONVERSATION_TITLE,
+                alreadyRequested = false,
+            ),
+        ).isFalse()
+    }
+
+    @Test
+    fun alreadyRequestedNeverRequestsAgain() {
+        assertThat(
+            shouldRequestTitleGeneration(
+                isNewConversation = false,
+                isHandedOffNewChat = true,
+                currentTitle = PLACEHOLDER_CONVERSATION_TITLE,
+                alreadyRequested = true,
+            ),
+        ).isFalse()
+    }
+
+    @Test
+    fun realTitleDoesNotRequestGeneration() {
+        assertThat(
+            shouldRequestTitleGeneration(
+                isNewConversation = false,
+                isHandedOffNewChat = true,
+                currentTitle = "Kotlin coroutine cancellation",
+                alreadyRequested = false,
+            ),
+        ).isFalse()
+    }
+
+    @Test
+    fun blankTitleCountsAsNeedingGeneration() {
+        assertThat(
+            shouldRequestTitleGeneration(
+                isNewConversation = true,
+                isHandedOffNewChat = false,
+                currentTitle = "  ",
+                alreadyRequested = false,
+            ),
+        ).isTrue()
+    }
+}

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModel.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModel.kt
@@ -270,6 +270,15 @@ class ChatViewModel(
     /** True when this ViewModel was opened for a brand-new chat (no conversationId from navigation). */
     private val isNewConversation: Boolean
 
+    /**
+     * True when this ViewModel took the [NewChatSelectionHandoff] for a conversation just
+     * created from the NewChat landing. Navigation to Chat(id) fires at the `created` SSE
+     * event and resets the landing VM, so THIS VM is the one whose resumed stream sees the
+     * first Final — with [isNewConversation] false. This flag keeps new-chat-only work
+     * (title generation) running for the handed-off chat.
+     */
+    private val isHandedOffNewChat: Boolean
+
     /** Guard to ensure we only attempt title generation once per conversation. */
     private var titleGenerationRequested = false
 
@@ -289,7 +298,9 @@ class ChatViewModel(
             // racy loadConversationModel GET below can't clobber it with a fallback guess
             // when the server hasn't persisted the conversation yet (the created-before-save
             // race). See NewChatSelectionHandoff.
-            selectionHandoff.take(conversationId)?.let { handoff ->
+            val handoff = selectionHandoff.take(conversationId)
+            isHandedOffNewChat = handoff != null
+            if (handoff != null) {
                 Diag.d(
                     tag = "ModelSel",
                     attrs = mapOf("endpoint" to handoff.endpoint, "model" to (handoff.model ?: "null")),
@@ -304,6 +315,7 @@ class ChatViewModel(
             // resume it so the user sees streaming content on this screen.
             resumeActiveStreamIfNeeded(conversationId)
         } else {
+            isHandedOffNewChat = false
             // For new chats, mark conversationModelLoaded so refilterModels
             // doesn't wait for a conversation model that will never arrive.
             modelDelegate.conversationModelLoaded = true
@@ -557,7 +569,15 @@ class ChatViewModel(
                 }
                 is Result.Error -> {
                     Logger.d { "Title generation failed for $conversationId: ${result.message}" }
-                    refreshConversationTitle(conversationId)
+                    // The gen_title long-poll can miss even though the server generated and
+                    // persisted a title (404 after its backoff window, or another client
+                    // consumed the one-shot cache). Fetch network-first: the cached row
+                    // still holds the "New Chat" placeholder, so cache-first getConversation
+                    // could never observe the title, and refreshConversation's upsert also
+                    // propagates it to the Room-observing conversation list.
+                    conversationRepository.refreshConversation(conversationId).getOrNull()?.let { conversation ->
+                        _uiState.update { it.copy(conversationTitle = conversation.title) }
+                    }
                 }
                 is Result.Loading -> { /* no-op */ }
             }
@@ -1449,9 +1469,13 @@ class ChatViewModel(
                 finalizeTemporaryChatDisplay(event)
             } else {
                 loadConversation(conversationId)
-                val currentTitle = _uiState.value.conversationTitle
-                val needsTitle = currentTitle.isNullOrBlank() || currentTitle == "New Chat"
-                if (isNewConversation && needsTitle && !titleGenerationRequested) {
+                val shouldGenerate = shouldRequestTitleGeneration(
+                    isNewConversation = isNewConversation,
+                    isHandedOffNewChat = isHandedOffNewChat,
+                    currentTitle = _uiState.value.conversationTitle,
+                    alreadyRequested = titleGenerationRequested,
+                )
+                if (shouldGenerate) {
                     titleGenerationRequested = true
                     generateAndSetTitle(conversationId)
                 } else {

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/NewChatSelectionHandoff.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/NewChatSelectionHandoff.kt
@@ -16,10 +16,18 @@ package com.garfiec.librechat.feature.chat.viewmodel
  * time. [take] returns the entry only when the conversationId matches, so a stale entry
  * (e.g. the transition never completed) can never be mis-applied to a different chat.
  *
+ * A successful [take] also tells the new VM its conversation was just created in this
+ * session (`isHandedOffNewChat`): the landing VM is reset at navigation, so the Chat(id)
+ * VM is the one that sees the first stream's Final and must run new-chat-only work like
+ * title generation, even though its `isNewConversation` is false.
+ *
  * Threading: both the [put] (in `handleCreated`) and [take] (in `ChatViewModel.init`)
  * call sites run on the ViewModel's main-dispatcher scope, so no locking is needed.
  * It also self-expires across process death — the slot is empty on restart, and by then
- * the conversation GET succeeds anyway (the race window is milliseconds).
+ * the conversation GET succeeds anyway (the race window is milliseconds). Losing the
+ * just-created signal that way is accepted: the server generates and persists the title
+ * on its own regardless of the client's gen_title long-poll, so the next conversation
+ * list sync (loadNextPage) picks it up — the title is briefly stale, not lost.
  */
 class NewChatSelectionHandoff {
 

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/TitleGenerationGate.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/TitleGenerationGate.kt
@@ -1,0 +1,29 @@
+package com.garfiec.librechat.feature.chat.viewmodel
+
+/** The server's placeholder title for a conversation whose title hasn't been generated yet. */
+internal const val PLACEHOLDER_CONVERSATION_TITLE = "New Chat"
+
+/**
+ * Decides whether `handleFinal` should long-poll `gen_title` for the just-finished stream.
+ *
+ * Lives outside `ChatViewModel` (like `resolveEndpointDispatch`) so the contract is
+ * pinned by tests: the VM that handles a brand-new chat's first Final is usually NOT the
+ * landing VM — navigation to Chat(id) fires at the `created` event, so [isNewConversation]
+ * is false there and [isHandedOffNewChat] (from consuming `NewChatSelectionHandoff`) is
+ * what keeps title generation alive. Dropping either flag from this gate silently kills
+ * title generation for one of the two paths.
+ *
+ * Gating on the flags rather than on the placeholder title alone is deliberate: the
+ * server's gen_title endpoint long-polls ~15s before 404-ing for conversations whose
+ * title will never generate, so firing it for every placeholder-titled conversation
+ * would hold a connection open on every send in such chats.
+ */
+internal fun shouldRequestTitleGeneration(
+    isNewConversation: Boolean,
+    isHandedOffNewChat: Boolean,
+    currentTitle: String?,
+    alreadyRequested: Boolean,
+): Boolean {
+    val needsTitle = currentTitle.isNullOrBlank() || currentTitle == PLACEHOLDER_CONVERSATION_TITLE
+    return (isNewConversation || isHandedOffNewChat) && needsTitle && !alreadyRequested
+}


### PR DESCRIPTION
## Summary
New conversations stayed titled "New Chat" in the drawer/conversation list, never picking up the server-generated title. The title generation request was silently dropped for chats started from the landing page.

## Root cause
Navigation to `Chat(id)` fires at the `created` SSE event, which resets the landing ViewModel. The new `Chat(id)` ViewModel — which has `isNewConversation = false` — is the one that resumes the stream and handles the first `Final`. The title-generation gate only fired when `isNewConversation` was true, so `gen_title` was never requested for these chats.

## Changes
- Carry a "just created in this session" signal to the `Chat(id)` ViewModel via the existing `NewChatSelectionHandoff` (`isHandedOffNewChat`), and gate title generation on it in addition to `isNewConversation`.
- Extract the gate into a pure `shouldRequestTitleGeneration` function (`TitleGenerationGate.kt`) so the contract is covered by unit tests.
- Add `ConversationRepository.refreshConversation(id)` — a network-first fetch that upserts into the cache (preserving local tags). Used in `generateAndSetTitle`'s error branch so that when the `gen_title` long-poll misses (404 after its backoff window, or the one-shot cache was consumed by another client) the server-generated title still lands in Room and the conversation list.
- `getConversation`'s cache-miss path now delegates to `refreshConversation`, so it upserts via `upsertPreservingTags` (keeping local tags such as Saved) instead of a plain `upsert`.

## Testing
- New `TitleGenerationGateTest` (6 cases) pins the gate, including the load-bearing handed-off case.
- Android + iOS simulator compile clean; unit tests and detekt pass.
- Device-verified: new-chat title now refreshes in the conversation list.
