### PR TITLE
feat(conversations): long-press conversation action menu in nav drawer

### DIFF
--- a/app/src/test/kotlin/com/garfiec/librechat/KoinGraphVerificationTest.kt
+++ b/app/src/test/kotlin/com/garfiec/librechat/KoinGraphVerificationTest.kt
@@ -76,6 +76,7 @@ import com.garfiec.librechat.feature.auth.di.authModule
 import com.garfiec.librechat.feature.auth.oauth.OAuthLauncher
 import com.garfiec.librechat.feature.chat.di.chatModule
 import com.garfiec.librechat.feature.conversations.di.conversationsModule
+import com.garfiec.librechat.feature.conversations.export.ConversationExporter
 import com.garfiec.librechat.feature.files.di.filesModule
 import com.garfiec.librechat.feature.files.platform.FileReader
 import com.garfiec.librechat.feature.settings.di.settingsModule
@@ -197,6 +198,8 @@ class KoinGraphVerificationTest {
             OAuthLauncher::class,
             // feature:files platform provides
             FileReader::class,
+            // feature:conversations provides (consumed cross-module by shared NavHostViewModel)
+            ConversationExporter::class,
             // Wrappers/DSL types that verify can't resolve via constructor
             Lazy::class,
             File::class,

--- a/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/components/ConversationActionEffects.kt
+++ b/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/components/ConversationActionEffects.kt
@@ -1,0 +1,85 @@
+package com.garfiec.librechat.feature.conversations.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import com.garfiec.librechat.feature.conversations.export.ExportFormat
+import com.garfiec.librechat.feature.conversations.platform.FileSaver
+import com.garfiec.librechat.feature.conversations.platform.copyToClipboard
+import com.garfiec.librechat.feature.conversations.platform.showToast
+import com.garfiec.librechat.feature.conversations.resources.*
+import com.garfiec.librechat.feature.conversations.resources.Res
+import com.garfiec.librechat.feature.conversations.viewmodel.ConversationListEvent
+import kotlinx.coroutines.flow.Flow
+import org.jetbrains.compose.resources.stringResource
+
+// Hoisted: compiled once instead of per export event.
+private val ExportFileNameSanitizer = Regex("[^a-zA-Z0-9._-]")
+
+/**
+ * Hosts the platform side-effects for conversation actions driven by [ConversationListEvent]:
+ * copies share links to the clipboard, saves exports via the platform file picker, surfaces
+ * errors as toasts, and forwards duplicate/navigation events. Keeps the clipboard/toast/file-save
+ * helpers and their localized strings in this module so callers in other modules (e.g. the
+ * navigation drawer) can reuse the full action set without duplicating resources.
+ */
+@Composable
+fun ConversationActionEffects(
+    events: Flow<ConversationListEvent>,
+    onNavigateToConversation: (String) -> Unit,
+) {
+    var pendingExportFileName by remember { mutableStateOf<String?>(null) }
+    var pendingExportContent by remember { mutableStateOf<String?>(null) }
+
+    val currentOnNavigate by rememberUpdatedState(onNavigateToConversation)
+
+    val linkCopiedMsg = stringResource(Res.string.link_copied)
+    val conversationExportedMsg = stringResource(Res.string.conversation_exported)
+
+    FileSaver(
+        triggerFileName = pendingExportFileName,
+        content = pendingExportContent,
+        onComplete = { success, errorMessage ->
+            if (success) {
+                showToast(conversationExportedMsg)
+            } else if (errorMessage != null) {
+                showToast(errorMessage)
+            }
+        },
+        onReset = {
+            pendingExportFileName = null
+            pendingExportContent = null
+        },
+    )
+
+    LaunchedEffect(Unit) {
+        events.collect { event ->
+            when (event) {
+                is ConversationListEvent.ShareLinkCopied -> {
+                    copyToClipboard(event.url, "Share Link")
+                    showToast(linkCopiedMsg)
+                }
+                is ConversationListEvent.NavigateToConversation -> {
+                    currentOnNavigate(event.conversationId)
+                }
+                is ConversationListEvent.ShowError -> {
+                    showToast(event.message)
+                }
+                is ConversationListEvent.ExportReady -> {
+                    pendingExportContent = event.content
+                    val ext = when (event.format) {
+                        ExportFormat.JSON -> "json"
+                        ExportFormat.MARKDOWN -> "md"
+                    }
+                    val safeTitle = event.title.replace(ExportFileNameSanitizer, "_")
+                    pendingExportFileName = "$safeTitle.$ext"
+                }
+                is ConversationListEvent.ImportSuccess -> { /* not used by the drawer */ }
+            }
+        }
+    }
+}

--- a/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/components/ConversationActions.kt
+++ b/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/components/ConversationActions.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Label
 import androidx.compose.material.icons.filled.Archive
 import androidx.compose.material.icons.filled.Bookmark
 import androidx.compose.material.icons.filled.BookmarkBorder
@@ -102,7 +103,7 @@ fun ConversationActions(
             }
 
             ActionRow(
-                icon = Icons.Default.BookmarkBorder,
+                icon = Icons.AutoMirrored.Filled.Label,
                 label = stringResource(Res.string.tags),
                 onClick = {
                     onDismiss()
@@ -214,7 +215,7 @@ private fun ActionRow(
 }
 
 @Composable
-private fun RenameDialog(
+internal fun RenameDialog(
     currentTitle: String,
     onDismiss: () -> Unit,
     onConfirm: (String) -> Unit,
@@ -258,7 +259,7 @@ private fun RenameDialog(
 }
 
 @Composable
-private fun DeleteConfirmationDialog(
+internal fun DeleteConfirmationDialog(
     conversationTitle: String,
     onDismiss: () -> Unit,
     onConfirm: () -> Unit,

--- a/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/components/ConversationActionsMenu.kt
+++ b/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/components/ConversationActionsMenu.kt
@@ -1,0 +1,212 @@
+package com.garfiec.librechat.feature.conversations.components
+
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Label
+import androidx.compose.material.icons.filled.Archive
+import androidx.compose.material.icons.filled.Bookmark
+import androidx.compose.material.icons.filled.BookmarkBorder
+import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.FileDownload
+import androidx.compose.material.icons.filled.Share
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MenuDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.dp
+import com.garfiec.librechat.feature.conversations.resources.*
+import com.garfiec.librechat.feature.conversations.resources.Res
+import org.jetbrains.compose.resources.stringResource
+
+// Rounded to match the app's other surfaces (dialogs/sheets) rather than the menu default's
+// near-square corners.
+private val MenuShape = RoundedCornerShape(16.dp)
+
+/**
+ * Anchored dropdown variant of [ConversationActions]. Same action set, but presented as a
+ * [DropdownMenu] (web-style) instead of a bottom sheet — used by the navigation drawer's
+ * long-press menu. Must be placed inside the anchor's layout (e.g. the conversation row's Box)
+ * so the menu positions itself at the row. Tags/Export are delegated to the caller (which hosts
+ * the pickers), mirroring [ConversationActions].
+ *
+ * Rename/Delete only *request* their confirmation dialogs via [onRenameRequest]/[onDeleteRequest];
+ * the caller hosts a single [ConversationActionDialogs] so the dialog survives this menu leaving
+ * composition (the drawer composes the menu only for the row whose menu is open).
+ */
+@Composable
+fun ConversationActionsMenu(
+    expanded: Boolean,
+    onDismiss: () -> Unit,
+    title: String,
+    onRenameRequest: () -> Unit,
+    onArchive: () -> Unit,
+    onDeleteRequest: () -> Unit,
+    modifier: Modifier = Modifier,
+    onTags: () -> Unit = {},
+    onShare: () -> Unit = {},
+    onDuplicate: (String) -> Unit = {},
+    onExport: () -> Unit = {},
+    onBookmarkToggle: () -> Unit = {},
+    isBookmarked: Boolean = false,
+    showShareAction: Boolean = false,
+    bookmarksEnabled: Boolean = true,
+    // Position offset relative to the anchor; callers feed the long-press point so the menu
+    // opens with its left edge under the finger.
+    offset: DpOffset = DpOffset.Zero,
+) {
+    DropdownMenu(
+        expanded = expanded,
+        onDismissRequest = onDismiss,
+        offset = offset,
+        shape = MenuShape,
+        // A step above the drawer's surfaceContainerLow so the menu reads as a distinct surface
+        // floating over it instead of blending into the panel.
+        containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+        modifier = modifier,
+    ) {
+        MenuActionItem(
+            icon = Icons.Default.Edit,
+            label = stringResource(Res.string.rename),
+            onClick = {
+                onDismiss()
+                onRenameRequest()
+            },
+        )
+
+        if (bookmarksEnabled) {
+            MenuActionItem(
+                icon = if (isBookmarked) Icons.Default.Bookmark else Icons.Default.BookmarkBorder,
+                label = if (isBookmarked) stringResource(Res.string.remove_bookmark) else stringResource(Res.string.bookmark),
+                iconTint = if (isBookmarked) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface,
+                onClick = {
+                    onDismiss()
+                    onBookmarkToggle()
+                },
+            )
+        }
+
+        MenuActionItem(
+            icon = Icons.AutoMirrored.Filled.Label,
+            label = stringResource(Res.string.tags),
+            onClick = {
+                onDismiss()
+                onTags()
+            },
+        )
+
+        if (showShareAction) {
+            MenuActionItem(
+                icon = Icons.Default.Share,
+                label = stringResource(Res.string.share),
+                onClick = {
+                    onDismiss()
+                    onShare()
+                },
+            )
+        }
+
+        val duplicateTitle = stringResource(Res.string.copy_of).replace("%1\$s", title)
+        MenuActionItem(
+            icon = Icons.Default.ContentCopy,
+            label = stringResource(Res.string.duplicate),
+            onClick = {
+                onDismiss()
+                onDuplicate(duplicateTitle)
+            },
+        )
+
+        MenuActionItem(
+            icon = Icons.Default.FileDownload,
+            label = stringResource(Res.string.export),
+            onClick = {
+                onDismiss()
+                onExport()
+            },
+        )
+
+        MenuActionItem(
+            icon = Icons.Default.Archive,
+            label = stringResource(Res.string.archive),
+            onClick = {
+                onDismiss()
+                onArchive()
+            },
+        )
+
+        MenuActionItem(
+            icon = Icons.Default.Delete,
+            label = stringResource(Res.string.delete),
+            tint = MaterialTheme.colorScheme.error,
+            onClick = {
+                onDismiss()
+                onDeleteRequest()
+            },
+        )
+    }
+}
+
+/**
+ * Single host for the rename/delete confirmation dialogs driven by [ConversationActionsMenu].
+ * Hoisted out of the menu so it survives the menu (and its row) leaving composition; a non-null
+ * title shows the corresponding dialog. Lives in this module so it can reach the internal
+ * [RenameDialog]/[DeleteConfirmationDialog] and their localized strings.
+ */
+@Composable
+fun ConversationActionDialogs(
+    renameTitle: String?,
+    deleteTitle: String?,
+    onDismissRename: () -> Unit,
+    onConfirmRename: (String) -> Unit,
+    onDismissDelete: () -> Unit,
+    onConfirmDelete: () -> Unit,
+) {
+    if (renameTitle != null) {
+        RenameDialog(
+            currentTitle = renameTitle,
+            onDismiss = onDismissRename,
+            onConfirm = onConfirmRename,
+        )
+    }
+
+    if (deleteTitle != null) {
+        DeleteConfirmationDialog(
+            conversationTitle = deleteTitle,
+            onDismiss = onDismissDelete,
+            onConfirm = onConfirmDelete,
+        )
+    }
+}
+
+@Composable
+private fun MenuActionItem(
+    icon: ImageVector,
+    label: String,
+    onClick: () -> Unit,
+    tint: Color = MaterialTheme.colorScheme.onSurface,
+    iconTint: Color = tint,
+) {
+    DropdownMenuItem(
+        text = { Text(label) },
+        onClick = onClick,
+        leadingIcon = {
+            Icon(
+                imageVector = icon,
+                contentDescription = label,
+                tint = iconTint,
+            )
+        },
+        colors = MenuDefaults.itemColors(
+            textColor = tint,
+            leadingIconColor = iconTint,
+        ),
+    )
+}

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -18,6 +18,7 @@
     <string name="cd_search">Search</string>
     <string name="cd_clear_search">Clear search</string>
     <string name="cd_back_to_conversations">Back to conversations</string>
+    <string name="cd_conversation_actions">Show conversation actions</string>
 
     <!-- Search -->
     <string name="search_conversations_placeholder">Search conversations\u2026</string>

--- a/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/DrawerContent.kt
+++ b/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/DrawerContent.kt
@@ -1,8 +1,12 @@
 package com.garfiec.librechat.shared.navigation
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.focusable
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -43,24 +47,39 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.garfiec.librechat.core.model.SAVED_TAG
 import com.garfiec.librechat.core.ui.components.EndpointIcon
+import com.garfiec.librechat.feature.conversations.components.ConversationActionDialogs
+import com.garfiec.librechat.feature.conversations.components.ConversationActionEffects
+import com.garfiec.librechat.feature.conversations.components.ConversationActionsMenu
+import com.garfiec.librechat.feature.conversations.components.TagPicker
+import com.garfiec.librechat.feature.conversations.export.ExportFormat
+import com.garfiec.librechat.feature.conversations.export.ExportFormatPicker
 import com.garfiec.librechat.shared.resources.Res
 import com.garfiec.librechat.shared.resources.agents
 import com.garfiec.librechat.shared.resources.bookmark
 import com.garfiec.librechat.shared.resources.cd_clear_search
+import com.garfiec.librechat.shared.resources.cd_conversation_actions
 import com.garfiec.librechat.shared.resources.cd_search
 import com.garfiec.librechat.shared.resources.favorites
 import com.garfiec.librechat.shared.resources.files
@@ -77,6 +96,9 @@ import org.koin.compose.viewmodel.koinViewModel
 private val ItemShape = RoundedCornerShape(8.dp)
 private val ActiveIndicatorShape = RoundedCornerShape(2.dp)
 
+// Gap between the conversation row's bottom edge and the long-press menu's top edge.
+private val MenuVerticalGap = 4.dp
+
 /**
  * Stateful DrawerContent that collects its own state from the ViewModel.
  */
@@ -92,6 +114,15 @@ fun DrawerContent(
     viewModel: NavHostViewModel = koinViewModel(),
 ) {
     val uiState by viewModel.drawerUiState.collectAsStateWithLifecycle()
+
+    // Side-effects for the long-press action menu (share-link copy, export file-save, navigate to
+    // a duplicated conversation, error toasts). Lives in feature/conversations so it owns the
+    // clipboard/toast/file-save plumbing and its localized strings.
+    ConversationActionEffects(
+        events = viewModel.events,
+        onNavigateToConversation = onConversationClick,
+    )
+
     DrawerContent(
         uiState = uiState,
         onSearchQueryChange = viewModel::onSearchQueryChanged,
@@ -104,6 +135,13 @@ fun DrawerContent(
         onToggleFavorite = { data -> viewModel.toggleFavorite(data.conversationId, data.tags) },
         onRefresh = viewModel::refreshConversations,
         onLoadMore = viewModel::loadMoreConversations,
+        onRename = { id, newTitle -> viewModel.renameConversation(id, newTitle) },
+        onArchive = viewModel::archiveConversation,
+        onDelete = viewModel::deleteConversation,
+        onShare = viewModel::shareConversation,
+        onDuplicate = { id, title -> viewModel.duplicateConversation(id, title) },
+        onUpdateTags = { data, tags -> viewModel.updateConversationTags(data.conversationId, data.tags, tags) },
+        onExportFormat = { data, format -> viewModel.exportConversation(data.conversationId, data.title, format) },
         modifier = modifier,
     )
 }
@@ -123,7 +161,25 @@ fun DrawerContent(
     onToggleFavorite: (DrawerConversationDisplayData) -> Unit = {},
     onRefresh: () -> Unit = {},
     onLoadMore: () -> Unit = {},
+    onRename: (String, String) -> Unit = { _, _ -> },
+    onArchive: (String) -> Unit = {},
+    onDelete: (String) -> Unit = {},
+    onShare: (String) -> Unit = {},
+    onDuplicate: (String, String) -> Unit = { _, _ -> },
+    onUpdateTags: (DrawerConversationDisplayData, List<String>) -> Unit = { _, _ -> },
+    onExportFormat: (DrawerConversationDisplayData, ExportFormat) -> Unit = { _, _ -> },
 ) {
+    // Which row's long-press action menu is currently open (null = none). Keyed by the row's
+    // LazyColumn key, not the conversation id: a favorited conversation appears in BOTH the
+    // favorites section and its date group, so an id-keyed menu would open in both rows at once.
+    var menuRowKey by remember { mutableStateOf<String?>(null) }
+    // Targets for the dialogs/pickers opened from the action menu. Hoisted here (single instance)
+    // so they survive the per-row menu — which is composed only for the open row — leaving the tree.
+    var renameTarget by remember { mutableStateOf<DrawerConversationDisplayData?>(null) }
+    var deleteTarget by remember { mutableStateOf<DrawerConversationDisplayData?>(null) }
+    var tagPickerTarget by remember { mutableStateOf<DrawerConversationDisplayData?>(null) }
+    var exportPickerTarget by remember { mutableStateOf<DrawerConversationDisplayData?>(null) }
+
     // Invisible anchor that claims initial focus so the search field below
     // doesn't auto-focus and pop the keyboard when the drawer opens. Tapping
     // the search field still focuses it normally. See Android focus docs
@@ -219,6 +275,44 @@ fun DrawerContent(
         val listState = rememberLazyListState()
         val currentOnLoadMore by rememberUpdatedState(onLoadMore)
 
+        // Single item renderer shared by the favorites section and the date groups so the
+        // long-press action menu wiring isn't duplicated across both call sites. rowKey is the
+        // row's LazyColumn key (unique per rendered row, unlike the conversation id).
+        val renderConversationItem: @Composable (String, DrawerConversationDisplayData) -> Unit = { rowKey, data ->
+            DrawerConversationItem(
+                data = data,
+                onClick = { onConversationClick(data.conversationId) },
+                onToggleFavorite = { onToggleFavorite(data) },
+                showBookmarkToggle = uiState.bookmarksEnabled,
+                onLongPress = { menuRowKey = rowKey },
+                menuContent = { menuOffset ->
+                    // Only the open row materializes the menu, so there's one menu in the tree at
+                    // a time (and the dialogs it triggers are hoisted below, outside this row).
+                    if (menuRowKey == rowKey) {
+                        ConversationActionsMenu(
+                            expanded = true,
+                            onDismiss = { menuRowKey = null },
+                            title = data.title,
+                            offset = menuOffset,
+                            isBookmarked = data.isFavorite,
+                            bookmarksEnabled = uiState.bookmarksEnabled,
+                            // Share is shown here when the server enables shared links; the
+                            // full-screen list intentionally omits it (passes showShareAction=false).
+                            showShareAction = uiState.sharedLinksEnabled,
+                            onBookmarkToggle = { onToggleFavorite(data) },
+                            onRenameRequest = { renameTarget = data },
+                            onArchive = { onArchive(data.conversationId) },
+                            onDeleteRequest = { deleteTarget = data },
+                            onShare = { onShare(data.conversationId) },
+                            onDuplicate = { newTitle -> onDuplicate(data.conversationId, newTitle) },
+                            onTags = { tagPickerTarget = data },
+                            onExport = { exportPickerTarget = data },
+                        )
+                    }
+                },
+            )
+        }
+
         val shouldLoadMore = remember {
             derivedStateOf {
                 val lastVisibleItem = listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
@@ -278,12 +372,7 @@ fun DrawerContent(
                         key = { "fav_${it.conversationId}" },
                         contentType = { "conversation" },
                     ) { data ->
-                        DrawerConversationItem(
-                            data = data,
-                            onClick = { onConversationClick(data.conversationId) },
-                            onToggleFavorite = { onToggleFavorite(data) },
-                            showBookmarkToggle = uiState.bookmarksEnabled,
-                        )
+                        renderConversationItem("fav_${data.conversationId}", data)
                     }
 
                     item(key = "favorites_divider") {
@@ -325,12 +414,7 @@ fun DrawerContent(
                         key = { it.conversationId },
                         contentType = { "conversation" },
                     ) { data ->
-                        DrawerConversationItem(
-                            data = data,
-                            onClick = { onConversationClick(data.conversationId) },
-                            onToggleFavorite = { onToggleFavorite(data) },
-                            showBookmarkToggle = uiState.bookmarksEnabled,
-                        )
+                        renderConversationItem(data.conversationId, data)
                     }
                 }
 
@@ -385,15 +469,56 @@ fun DrawerContent(
 
         Spacer(modifier = Modifier.height(8.dp))
     }
+
+    // Rename/Delete confirmation dialogs for the long-press action menu. Single hoisted instance
+    // (a non-null target shows the dialog) so it outlives the per-row menu that requested it.
+    ConversationActionDialogs(
+        renameTitle = renameTarget?.title,
+        deleteTitle = deleteTarget?.title,
+        onDismissRename = { renameTarget = null },
+        onConfirmRename = { newTitle ->
+            renameTarget?.let { onRename(it.conversationId, newTitle) }
+            renameTarget = null
+        },
+        onDismissDelete = { deleteTarget = null },
+        onConfirmDelete = {
+            deleteTarget?.let { onDelete(it.conversationId) }
+            deleteTarget = null
+        },
+    )
+
+    // Secondary pickers opened from the long-press action menu. Rendered as overlay bottom
+    // sheets, so their position in the tree doesn't matter.
+    tagPickerTarget?.let { target ->
+        TagPicker(
+            availableTags = uiState.availableTags,
+            currentTags = target.tags.filterNot { it == SAVED_TAG },
+            onTagsChange = { newTags -> onUpdateTags(target, newTags) },
+            onDismiss = { tagPickerTarget = null },
+        )
+    }
+
+    exportPickerTarget?.let { target ->
+        ExportFormatPicker(
+            onFormatSelect = { format ->
+                onExportFormat(target, format)
+                exportPickerTarget = null
+            },
+            onDismiss = { exportPickerTarget = null },
+        )
+    }
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun DrawerConversationItem(
     data: DrawerConversationDisplayData,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     onToggleFavorite: () -> Unit = {},
+    onLongPress: () -> Unit = {},
     showBookmarkToggle: Boolean = true,
+    menuContent: @Composable (DpOffset) -> Unit = {},
 ) {
     val backgroundColor = if (data.isActive) {
         MaterialTheme.colorScheme.secondaryContainer
@@ -401,101 +526,133 @@ private fun DrawerConversationItem(
         Color.Transparent
     }
 
-    Row(
-        modifier = modifier
-            .padding(horizontal = 4.dp, vertical = 1.dp)
-            .fillMaxWidth()
-            .background(backgroundColor, ItemShape)
-            .clickable(onClick = onClick)
-            .padding(horizontal = 12.dp, vertical = 10.dp),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        if (data.isActive) {
-            Box(
-                modifier = Modifier
-                    .width(3.dp)
-                    .height(24.dp)
-                    .background(MaterialTheme.colorScheme.primary, ActiveIndicatorShape),
-            )
-            Spacer(modifier = Modifier.width(8.dp))
-        }
+    // Horizontal pixel position of the last press, so the long-press menu can open with its
+    // left edge under the finger. Kept in pixels (no density captured in the gesture) and
+    // converted to dp at use-site to stay correct across density changes.
+    var pressXpx by remember { mutableFloatStateOf(0f) }
+    val density = LocalDensity.current
 
-        if (data.isFavorite) {
-            Icon(
-                imageVector = Icons.Default.Star,
-                contentDescription = null,
-                modifier = Modifier.size(18.dp),
-                tint = MaterialTheme.colorScheme.primary,
-            )
-        } else {
-            EndpointIcon(
-                endpointName = data.endpoint,
-                iconUrl = data.endpointIconUrl,
-                size = 18.dp,
-                glyphTint = if (data.isActive) {
-                    MaterialTheme.colorScheme.primary
-                } else {
-                    MaterialTheme.colorScheme.onSurfaceVariant
-                },
-            )
-        }
+    // onLongClickLabel announces the long-press action to TalkBack — without it the action menu
+    // (the only way to reach rename/delete/share/etc. from the drawer) is undiscoverable.
+    val longPressLabel = stringResource(Res.string.cd_conversation_actions)
 
-        Spacer(modifier = Modifier.width(10.dp))
-
-        Column(modifier = Modifier.weight(1f)) {
-            Text(
-                text = data.title,
-                style = MaterialTheme.typography.bodyMedium,
-                color = if (data.isActive) {
-                    MaterialTheme.colorScheme.onSecondaryContainer
-                } else {
-                    MaterialTheme.colorScheme.onSurface
-                },
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-            )
-
-            val subtitle = remember(data.model, data.relativeTime) {
-                buildString {
-                    data.model?.let { model ->
-                        append(model.take(20))
-                    }
-                    if (data.relativeTime.isNotEmpty()) {
-                        if (isNotEmpty()) append(" \u00B7 ")
-                        append(data.relativeTime)
+    // Box wraps the row so the long-press action menu (a DropdownMenu) anchors to this row.
+    Box(modifier = modifier) {
+        Row(
+            // pointerInput is outermost so the captured x shares the Box's coordinate space
+            // (the menu anchor), and recorded without consuming the down so combinedClickable
+            // still handles tap + long-press normally.
+            modifier = Modifier
+                .pointerInput(Unit) {
+                    awaitEachGesture {
+                        val down = awaitFirstDown(requireUnconsumed = false)
+                        pressXpx = down.position.x
                     }
                 }
+                .padding(horizontal = 4.dp, vertical = 1.dp)
+                .fillMaxWidth()
+                .background(backgroundColor, ItemShape)
+                .combinedClickable(
+                    role = Role.Button,
+                    onClick = onClick,
+                    onLongClickLabel = longPressLabel,
+                    onLongClick = onLongPress,
+                )
+                .padding(horizontal = 12.dp, vertical = 10.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            if (data.isActive) {
+                Box(
+                    modifier = Modifier
+                        .width(3.dp)
+                        .height(24.dp)
+                        .background(MaterialTheme.colorScheme.primary, ActiveIndicatorShape),
+                )
+                Spacer(modifier = Modifier.width(8.dp))
             }
-            if (subtitle.isNotEmpty()) {
+
+            if (data.isFavorite) {
+                Icon(
+                    imageVector = Icons.Default.Star,
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp),
+                    tint = MaterialTheme.colorScheme.primary,
+                )
+            } else {
+                EndpointIcon(
+                    endpointName = data.endpoint,
+                    iconUrl = data.endpointIconUrl,
+                    size = 18.dp,
+                    glyphTint = if (data.isActive) {
+                        MaterialTheme.colorScheme.primary
+                    } else {
+                        MaterialTheme.colorScheme.onSurfaceVariant
+                    },
+                )
+            }
+
+            Spacer(modifier = Modifier.width(10.dp))
+
+            Column(modifier = Modifier.weight(1f)) {
                 Text(
-                    text = subtitle,
-                    style = MaterialTheme.typography.labelSmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    text = data.title,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = if (data.isActive) {
+                        MaterialTheme.colorScheme.onSecondaryContainer
+                    } else {
+                        MaterialTheme.colorScheme.onSurface
+                    },
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
+                )
+
+                val subtitle = remember(data.model, data.relativeTime) {
+                    buildString {
+                        data.model?.let { model ->
+                            append(model.take(20))
+                        }
+                        if (data.relativeTime.isNotEmpty()) {
+                            if (isNotEmpty()) append(" \u00B7 ")
+                            append(data.relativeTime)
+                        }
+                    }
+                }
+                if (subtitle.isNotEmpty()) {
+                    Text(
+                        text = subtitle,
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+            }
+
+            if (showBookmarkToggle) {
+                Icon(
+                    imageVector = if (data.isFavorite) Icons.Default.Star else Icons.Default.StarBorder,
+                    contentDescription = if (data.isFavorite) {
+                        stringResource(Res.string.remove_bookmark)
+                    } else {
+                        stringResource(Res.string.bookmark)
+                    },
+                    modifier = Modifier
+                        .size(32.dp)
+                        .clickable(onClick = onToggleFavorite)
+                        .padding(8.dp),
+                    tint = if (data.isFavorite) {
+                        MaterialTheme.colorScheme.primary
+                    } else {
+                        MaterialTheme.colorScheme.onSurfaceVariant
+                    },
                 )
             }
         }
 
-        if (showBookmarkToggle) {
-            Icon(
-                imageVector = if (data.isFavorite) Icons.Default.Star else Icons.Default.StarBorder,
-                contentDescription = if (data.isFavorite) {
-                    stringResource(Res.string.remove_bookmark)
-                } else {
-                    stringResource(Res.string.bookmark)
-                },
-                modifier = Modifier
-                    .size(32.dp)
-                    .clickable(onClick = onToggleFavorite)
-                    .padding(8.dp),
-                tint = if (data.isFavorite) {
-                    MaterialTheme.colorScheme.primary
-                } else {
-                    MaterialTheme.colorScheme.onSurfaceVariant
-                },
-            )
-        }
+        // Open the menu just below the row, with its left edge under the press point. The
+        // DropdownMenu position provider flips it above the row near the screen bottom and
+        // clamps it within a margin, so it never clips off-screen.
+        menuContent(with(density) { DpOffset(x = pressXpx.toDp(), y = MenuVerticalGap) })
     }
 }
 

--- a/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/DrawerUiModels.kt
+++ b/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/DrawerUiModels.kt
@@ -1,6 +1,7 @@
 package com.garfiec.librechat.shared.navigation
 
 import androidx.compose.runtime.Immutable
+import com.garfiec.librechat.core.model.ConversationTag
 
 /**
  * Lightweight snapshot of fields DrawerConversationItem actually renders.
@@ -34,4 +35,8 @@ data class DrawerUiState(
     val agentsEnabled: Boolean = true,
     val bookmarksEnabled: Boolean = true,
     val skillsEnabled: Boolean = true,
+    // User-defined tags (excluding the favorites tag) for the action menu's tag picker.
+    val availableTags: List<ConversationTag> = emptyList(),
+    // Config-driven: whether server-side shared links are enabled (gates the menu's Share action).
+    val sharedLinksEnabled: Boolean = false,
 )

--- a/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/NavHostViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/NavHostViewModel.kt
@@ -10,20 +10,27 @@ import com.garfiec.librechat.core.data.repository.BannerRepository
 import com.garfiec.librechat.core.data.repository.ConfigRepository
 import com.garfiec.librechat.core.data.repository.ConversationRepository
 import com.garfiec.librechat.core.data.repository.RoleRepository
+import com.garfiec.librechat.core.data.repository.ShareRepository
 import com.garfiec.librechat.core.data.repository.TagRepository
 import com.garfiec.librechat.core.data.util.SessionTaskRunner
 import com.garfiec.librechat.core.model.Banner
 import com.garfiec.librechat.core.model.Conversation
+import com.garfiec.librechat.core.model.ConversationTag
 import com.garfiec.librechat.core.model.SAVED_TAG
 import com.garfiec.librechat.core.model.permissions.Permission
 import com.garfiec.librechat.core.model.permissions.PermissionType
 import com.garfiec.librechat.core.model.permissions.hasAccessOrPermissive
 import com.garfiec.librechat.core.network.client.ServerUrlProvider
 import com.garfiec.librechat.core.network.client.TokenManager
+import com.garfiec.librechat.feature.conversations.export.ConversationExporter
+import com.garfiec.librechat.feature.conversations.export.ExportFormat
+import com.garfiec.librechat.feature.conversations.viewmodel.ConversationListEvent
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
@@ -41,6 +48,8 @@ class NavHostViewModel(
     private val tokenManager: TokenManager,
     private val settingsDataStore: SettingsDataStore,
     private val serverUrlProvider: ServerUrlProvider,
+    private val shareRepository: ShareRepository,
+    private val conversationExporter: ConversationExporter,
 ) : ViewModel() {
 
     private val bannerStateHolder = BannerStateHolder(bannerRepository, viewModelScope)
@@ -51,6 +60,25 @@ class NavHostViewModel(
         conversationListStateHolder.recentConversations
             .map { list -> list.filter { SAVED_TAG in it.tags } }
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
+    // Inputs for the drawer long-press action menu: the user-defined tags (excluding favorites,
+    // same filter as ConversationListViewModel.observeTags) for the tag picker, plus the
+    // config-driven shared-links flag that gates the Share action.
+    private val drawerActionMenuState: StateFlow<DrawerActionMenuState> =
+        combine(
+            tagRepository.observeTags()
+                .map { tags -> tags.filter { it.count > 0 && it.tag != SAVED_TAG } },
+            configRepository.startupConfig,
+        ) { tags, config ->
+            DrawerActionMenuState(tags, config?.sharedLinksEnabled ?: false)
+        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), DrawerActionMenuState())
+
+    // One-shot events for the drawer action menu (share-link copied, export-ready,
+    // navigate-to-duplicate, errors). Reuses the conversation-list event type. extraBufferCapacity
+    // lets emit() return immediately instead of suspending if the collector (ConversationActionEffects)
+    // is momentarily absent — e.g. an action's result arriving as the drawer leaves composition.
+    private val _events = MutableSharedFlow<ConversationListEvent>(extraBufferCapacity = 1)
+    val events: SharedFlow<ConversationListEvent> = _events.asSharedFlow()
 
     // Seeded synchronously so first-frame routing (LibreChatNavHost reads isLoggedIn.value
     // once in a LaunchedEffect to redirect to auth) gets the correct value with no flash.
@@ -136,7 +164,8 @@ class NavHostViewModel(
         },
         drawerPermissionFlags,
         configRepository.endpointConfigs,
-    ) { data, refreshState, perms, endpointConfigs ->
+        drawerActionMenuState,
+    ) { data, refreshState, perms, endpointConfigs, actionMenu ->
         val (refreshing, loadingMore, hasMore) = refreshState
         DrawerUiState(
             groupedConversations = data.grouped.map { (group, convos) ->
@@ -152,6 +181,8 @@ class NavHostViewModel(
             agentsEnabled = perms.agentsEnabled,
             bookmarksEnabled = perms.bookmarksEnabled,
             skillsEnabled = perms.skillsEnabled,
+            availableTags = actionMenu.availableTags,
+            sharedLinksEnabled = actionMenu.sharedLinksEnabled,
         )
     }.stateIn(viewModelScope, SharingStarted.Eagerly, DrawerUiState())
 
@@ -159,6 +190,11 @@ class NavHostViewModel(
         val agentsEnabled: Boolean = true,
         val bookmarksEnabled: Boolean = true,
         val skillsEnabled: Boolean = true,
+    )
+
+    private data class DrawerActionMenuState(
+        val availableTags: List<ConversationTag> = emptyList(),
+        val sharedLinksEnabled: Boolean = false,
     )
 
     init {
@@ -216,6 +252,122 @@ class NavHostViewModel(
             val result = tagRepository.toggleFavorite(conversationId, currentTags)
             if (result is Result.Error) {
                 Logger.w(result.exception) { "Failed to toggle favorite for $conversationId" }
+            }
+        }
+    }
+
+    // --- Drawer conversation action menu (long-press). Bodies mirror ConversationListViewModel. ---
+
+    fun renameConversation(id: String, newTitle: String) {
+        viewModelScope.launch {
+            try {
+                conversationRepository.updateTitle(id, newTitle)
+            } catch (e: Exception) {
+                Logger.e(e) { "Failed to rename conversation" }
+                _events.emit(ConversationListEvent.ShowError("Failed to rename conversation"))
+            }
+        }
+    }
+
+    fun archiveConversation(id: String) {
+        viewModelScope.launch {
+            try {
+                conversationRepository.archive(id, true)
+            } catch (e: Exception) {
+                Logger.e(e) { "Failed to archive conversation" }
+                _events.emit(ConversationListEvent.ShowError("Failed to archive conversation"))
+            }
+        }
+    }
+
+    fun deleteConversation(id: String) {
+        viewModelScope.launch {
+            try {
+                conversationRepository.delete(id)
+            } catch (e: Exception) {
+                Logger.e(e) { "Failed to delete conversation" }
+                _events.emit(ConversationListEvent.ShowError("Failed to delete conversation"))
+            }
+        }
+    }
+
+    fun shareConversation(conversationId: String) {
+        viewModelScope.launch {
+            when (val result = shareRepository.createShareLink(conversationId)) {
+                is Result.Success -> {
+                    _events.emit(ConversationListEvent.ShareLinkCopied(result.data))
+                }
+                is Result.Error -> {
+                    _events.emit(
+                        ConversationListEvent.ShowError(result.message ?: "Failed to create share link"),
+                    )
+                }
+                is Result.Loading -> { /* no-op */ }
+            }
+        }
+    }
+
+    fun duplicateConversation(conversationId: String, title: String?) {
+        viewModelScope.launch {
+            when (val result = conversationRepository.duplicateConversation(conversationId, title)) {
+                is Result.Success -> {
+                    result.data.conversationId?.let { newId ->
+                        _events.emit(ConversationListEvent.NavigateToConversation(newId))
+                    }
+                }
+                is Result.Error -> {
+                    _events.emit(
+                        ConversationListEvent.ShowError(result.message ?: "Failed to duplicate conversation"),
+                    )
+                }
+                is Result.Loading -> { /* no-op */ }
+            }
+        }
+    }
+
+    fun exportConversation(conversationId: String, title: String?, format: ExportFormat) {
+        viewModelScope.launch {
+            val result = when (format) {
+                ExportFormat.JSON -> conversationExporter.exportAsJson(conversationId)
+                ExportFormat.MARKDOWN -> conversationExporter.exportAsMarkdown(conversationId)
+            }
+            when (result) {
+                is Result.Success -> {
+                    _events.emit(
+                        ConversationListEvent.ExportReady(
+                            content = result.data,
+                            format = format,
+                            title = title ?: "conversation",
+                        ),
+                    )
+                }
+                is Result.Error -> {
+                    _events.emit(
+                        ConversationListEvent.ShowError(result.message ?: "Failed to export conversation"),
+                    )
+                }
+                is Result.Loading -> { /* no-op */ }
+            }
+        }
+    }
+
+    /**
+     * Persists the user-chosen tags for [conversationId], preserving favorite status.
+     * [currentTags] is the conversation's existing tag list (to detect the SAVED_TAG).
+     */
+    fun updateConversationTags(conversationId: String, currentTags: List<String>, userTags: List<String>) {
+        val wasFavorited = SAVED_TAG in currentTags
+        val cleaned = userTags.filterNot { it == SAVED_TAG }
+        val finalTags = if (wasFavorited) cleaned + SAVED_TAG else cleaned
+        viewModelScope.launch {
+            when (tagRepository.setConversationTags(conversationId, finalTags)) {
+                is Result.Success -> {
+                    tagRepository.refreshTags()
+                }
+                is Result.Error -> {
+                    _events.emit(ConversationListEvent.ShowError("Failed to update tags"))
+                }
+                is Result.Loading -> { /* no-op */ }
             }
         }
     }


### PR DESCRIPTION
## Summary
Adds a long-press action menu to conversation rows in the navigation drawer, bringing the drawer history list to parity with the full-screen conversation list. Actions appear as an anchored dropdown (web-style) opening at the horizontal press point, just below the row.

## Changes
- **Long-press any drawer conversation row** → anchored `DropdownMenu` with full action parity: Rename, Bookmark, Tags, Share, Duplicate, Export, Archive, Delete. Single tap still opens the chat; the inline favorite star is unchanged.
- New `ConversationActionsMenu` (dropdown) and `ConversationActionEffects` (clipboard / toast / file-save + export-filename handling) composables in `feature/conversations`, hosted by the drawer; the existing `RenameDialog` / `DeleteConfirmationDialog` are reused. These live in that module because Compose Resources are generated per-module.
- `NavHostViewModel` gains the conversation action methods (rename / archive / delete / share / duplicate / export / tags) and a one-shot event stream; available tags and shared-links availability are surfaced to drive the menu.
- **Share** is shown only when the server enables shared links (config-gated).
- **Accessibility:** long-press exposes an action label and `Button` role so TalkBack can discover and invoke it.
- Corrects the Tags icon in the existing conversation-list action sheet (bookmark-border → label) to match its action.

## Screenshots

| Web | Mobile |
| --- | --- |
| <img width="1225" height="1217" alt="image" src="https://github.com/user-attachments/assets/b81ce556-f624-439f-b2b5-c6f26758cc1f" /> | <img width="1236" height="2495" alt="image" src="https://github.com/user-attachments/assets/410093aa-d90e-4b04-b697-6857690c02bf" /> |

## Testing
- Both platforms compile (Android `:app:compileDebugKotlin`, iOS `:shared:compileKotlinIosSimulatorArm64`); detekt clean on the changed modules.

## Notes
- The drawer intentionally shows **Share** where the full-screen list does not.
- Action-method logic mirrors `ConversationListViewModel`; deduplicating it into a shared handler and localizing error strings are tracked as follow-ups.
