### PR TITLE
refactor(chat): decompose ChatViewModel into focused delegates

### DIFF
--- a/MODULARIZATION.md
+++ b/MODULARIZATION.md
@@ -20,7 +20,7 @@ and bring the code closer to idiomatic Compose / unidirectional-data-flow conven
 
 | # | File | Lines | Type | Status |
 |---|------|-------|------|--------|
-| 1 | `feature/chat/.../viewmodel/ChatViewModel.kt` | 2151 | VM god-class | **in progress** |
+| 1 | `feature/chat/.../viewmodel/ChatViewModel.kt` | 2151→1068 | VM god-class | **done (awaiting device test)** |
 | 2 | `feature/agents/.../viewmodel/AgentEditorViewModel.kt` | 1938 | VM god-class (no delegates yet) | planned |
 | 3 | `feature/chat/androidMain/.../screen/ChatScreen.kt` | 1232 | Composable + leaked logic | planned |
 | 4 | `feature/agents/.../components/AgentActionsPanel.kt` | 882 | Two 240+ line dialogs | planned |
@@ -40,6 +40,8 @@ and bring the code closer to idiomatic Compose / unidirectional-data-flow conven
 
 **Shape:** one PR, one commit per delegate, single device-test pass at the end.
 **Decision:** extract the deeply-coupled completion logic too (5 delegates, not 4).
+**Result:** ChatViewModel 2151 → 1068 lines (−50%). Android + iOS compile, detekt, and the
+chat unit-test suite all green. Awaiting device test before push.
 
 The send/stream code is a layered pipeline, so extraction order is dependency-driven
 (leaves first, the high-coupling streaming/completion core last):

--- a/MODULARIZATION.md
+++ b/MODULARIZATION.md
@@ -1,0 +1,101 @@
+# Modularization Backlog
+
+Tracking the file-size / decomposition initiative. Each row is a planned back-to-back PR.
+Goal is not just line count: each pass should also tighten architecture, remove code smells,
+and bring the code closer to idiomatic Compose / unidirectional-data-flow conventions.
+
+## Established conventions to follow
+
+- **Delegate pattern** (`feature/chat/.../viewmodel/delegate/`): a delegate is a plain class
+  constructed with a `ChatStateHandle` (or feature equivalent) + repositories. It mutates shared
+  UI state via `stateHandle.update { copy(...) }`, owns transient one-shot signals via its own
+  `MutableStateFlow`, and uses `stateHandle.scope` for coroutines. The ViewModel holds it as a
+  private val and re-exposes delegate flows through `get()`.
+- **No cross-feature deps**: feature modules depend on `:core:*` only.
+- **UDF**: UI → ViewModel → Repository. Composables stay dumb; logic moves down, not into the view.
+- **Pure helpers** (codecs, mappers, builders) go in plain top-level objects/files, unit-testable
+  without Android or coroutines.
+
+## Backlog (priority order)
+
+| # | File | Lines | Type | Status |
+|---|------|-------|------|--------|
+| 1 | `feature/chat/.../viewmodel/ChatViewModel.kt` | 2151 | VM god-class | **in progress** |
+| 2 | `feature/agents/.../viewmodel/AgentEditorViewModel.kt` | 1938 | VM god-class (no delegates yet) | planned |
+| 3 | `feature/chat/androidMain/.../screen/ChatScreen.kt` | 1232 | Composable + leaked logic | planned |
+| 4 | `feature/agents/.../components/AgentActionsPanel.kt` | 882 | Two 240+ line dialogs | planned |
+| 5 | `feature/agents/.../screen/AgentEditorScreen.kt` | 926 | One 467-line Column | planned |
+| 6 | `feature/settings/.../viewmodel/SettingsViewModel.kt` | 966 | Partial delegation | planned |
+| 7 | `feature/chat/.../components/SharedContentParts.kt` | 711 | Duplicate collapsible cards | planned |
+
+## Explicitly NOT decomposing
+
+- `core/ui/.../EndpointParameterRegistry.kt` (913) — intentional 1:1 mirror of upstream
+  `parameterSettings.ts`; extracting a base template adds indirection without cutting lines.
+- `core/network/.../SseEventMapper.kt` (560) — dense but one-task-per-function; cohesive.
+
+---
+
+## PR #1 — ChatViewModel
+
+**Shape:** one PR, one commit per delegate, single device-test pass at the end.
+**Decision:** extract the deeply-coupled completion logic too (5 delegates, not 4).
+
+The send/stream code is a layered pipeline, so extraction order is dependency-driven
+(leaves first, the high-coupling streaming/completion core last):
+
+### Commit 1 — `MessageTreeDelegate` (~80L, LOW risk)
+- Moves: `switchBranch`, `anchorStreamTo`, `finalizeTemporaryChatDisplay`, temp-chat toggle + guards.
+- Deps: `stateHandle` only (uses pure utils `buildActiveMessagePath`, `mergeFinalMessagesInMemory`).
+- Leaf utility the other delegates call. Upholds the streaming-anchor invariant (chat CLAUDE.md).
+
+### Commit 2 — `ComparisonModeDelegate` (~150L, MED risk)
+- Moves: dual-stream buffers + `isSecondaryEvent` (relocated **out of** `ModelSelectionDelegate`),
+  comparison init in `doSendMessage`, the 3-way branches in `handleStreamEvent`, comparison cleanup
+  in error/final/stop, `branchFromComparison`.
+- Exposes `routeEvent(event): Boolean` so `handleStreamEvent` collapses to
+  `if (comparison.isEnabled && comparison.routeEvent(event)) return`. **This shrinks the dispatch.**
+- Deps: `stateHandle`, `modelDelegate` (buildAddedConvo).
+
+### Commit 3 — `SendCompletionDelegate` (~250L, HIGH risk)
+- Moves: `handleCreated`, `handleFinal`, title generation (`TitleGenerationGate` exists),
+  `applyConversationModel` re-derive, optimistic-id reconciliation, temp-chat-merge dispatch,
+  `titleGenerationRequested`, NewChat nav handoff (`selectionHandoff`).
+- Deps: `stateHandle`, conversation/draft/message repos, `ttsDelegate`, `modelDelegate`,
+  `officePreviewDelegate`, `treeDelegate`, `selectionHandoff`, flags (`isNewConversation`,
+  `isHandedOffNewChat`), `loadConversation` callback, final-text supplier.
+
+### Commit 4 — `StreamingManagerDelegate` (~200L, HIGH risk, mechanical after #3)
+- Moves: `streamingBuffer`/dirty, `streamJob`/`streamingUpdateJob`/`connectivityJob`,
+  `lastErrorWasNetwork`/`wasStreaming`, updater start/stop + flush, `collectStreamSafely`,
+  the slim `handleStreamEvent`, connectivity observer (`start`/`cancel`/`attemptNetworkRecovery`),
+  `resumeStream`, `resumeActiveStreamIfNeeded`, `onPause`/`onResume` stream parts.
+- Deps: `stateHandle`, `chatRepository`, `connectivityObserver`, `comparisonDelegate`,
+  `subagentTraceDelegate`, `officePreviewDelegate`, `sendCompletionDelegate` (onCreated/onFinal),
+  `userKeyErrors` emitter, `loadConversation` callback.
+
+### Commit 5 — `MessageEditingDelegate` (~200L, MED risk)
+- Moves: `editMessage`/`editUserMessage`/`editAiMessage`, `regenerate*`, `continueGeneration*`,
+  edit UI state (`startEditing`/`onEditTextChanged`/`cancelEditing`/`submitEdit`/`saveEditOnly`),
+  `isEditOrRegenerate`.
+- Deps: `stateHandle`, chat/message repos, `streamingDelegate`, `treeDelegate`, `ChatRequestBuilder`.
+
+### Supporting extraction
+- `ChatRequestBuilder` (pure helper): `buildEphemeralAgent()` + `currentDispatch()`, shared by the
+  VM send path and `MessageEditingDelegate` — avoids cross-delegate calls for request assembly.
+  Unit-testable without coroutines/Android.
+- `doSendMessage` / `sendMessage` stay in the VM as the thin orchestrator wiring the delegates.
+
+### Cross-cutting cleanups to fold in
+- Unify state writes on `stateHandle.update {}` (VM currently mixes raw `_uiState.update {}` with
+  delegate `stateHandle.update {}`).
+- Replace inline fully-qualified types (`com.garfiec...MermaidRenderCache`, `...InlineArtifactPrefs`)
+  with imports.
+- `@Suppress("TooManyFunctions", "LongParameterList")` should shrink/drop as logic moves out.
+
+### Load-bearing invariants — DO NOT break (verify each commit)
+- Streaming anchor: no Room write / `activeBranches` mutation mid-stream.
+- Temp-chat data-at-rest guard (handleFinal / loadConversation / refreshMessages).
+- Optimistic-id reconciliation: `userMessageId` echoed in Final `requestMessage`.
+- Network recovery: `lastErrorWasNetwork` must propagate through Sync/Created/Final.
+- Comparison isolation: dual-stream branches gated on `comparisonState.isEnabled`.

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatRequestBuilder.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatRequestBuilder.kt
@@ -1,0 +1,59 @@
+package com.garfiec.librechat.feature.chat.viewmodel
+
+import com.garfiec.librechat.core.common.ToolConstants
+import com.garfiec.librechat.core.data.endpoint.EndpointDispatch
+import com.garfiec.librechat.core.model.request.EphemeralAgent
+
+/**
+ * Builds the per-send request pieces shared by every chat-send path (new message, edit,
+ * regenerate, continue): the endpoint dispatch for the active selection and the optional
+ * [EphemeralAgent] derived from the current ephemeral tool/MCP selections.
+ *
+ * Pure reads over [ChatStateHandle.state] — no coroutines, no repositories — so it can be
+ * unit-tested directly. Extracted so both `ChatViewModel`'s send path and
+ * [com.garfiec.librechat.feature.chat.viewmodel.delegate.MessageEditingDelegate] share one
+ * implementation instead of duplicating it.
+ */
+class ChatRequestBuilder(
+    private val stateHandle: ChatStateHandle,
+) {
+
+    /**
+     * Resolves the chat-send dispatch for the currently-selected endpoint by snapshotting
+     * state once. Callers that target a different endpoint (e.g. the comparison-mode
+     * secondary) must call [resolveEndpointDispatch] directly with that endpoint name.
+     */
+    fun currentDispatch(): EndpointDispatch {
+        val state = stateHandle.state
+        return resolveEndpointDispatch(
+            endpointName = state.selectedEndpoint,
+            endpointConfigs = state.endpointConfigs,
+            endpointKeyStates = state.endpointKeyStates,
+        )
+    }
+
+    /**
+     * Builds an [EphemeralAgent] from the current UI state (selected MCP servers and
+     * enabled tools). Returns null when there is nothing to send.
+     */
+    fun buildEphemeralAgent(): EphemeralAgent? {
+        val state = stateHandle.state
+        // A saved agent uses its own configured tools; the backend ignores client-supplied
+        // ephemeral tools for agent runs. Mirror web's `showEphemeralBadges` (ChatForm.tsx)
+        // and never serialize leftover UI selections on the agents endpoint.
+        if (!state.showEphemeralTools) return null
+        val mcpServers = state.selectedMcpServerNames.toList().ifEmpty { null }
+        val enabledTools = state.enabledTools
+        val webSearchEnabled = state.modelParameters.webSearch
+
+        val hasAnything = mcpServers != null || enabledTools.isNotEmpty() || webSearchEnabled
+        if (!hasAnything) return null
+
+        return EphemeralAgent(
+            mcp = mcpServers,
+            webSearch = if (webSearchEnabled) true else null,
+            fileSearch = if (ToolConstants.FILE_SEARCH in enabledTools) true else null,
+            executeCode = if (ToolConstants.CODE_INTERPRETER in enabledTools || ToolConstants.EXECUTE_CODE in enabledTools) true else null,
+        )
+    }
+}

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModel.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModel.kt
@@ -31,13 +31,10 @@ import com.garfiec.librechat.core.data.repository.UserRepository
 import com.garfiec.librechat.core.data.util.PermissionGate
 import com.garfiec.librechat.core.logging.Diag
 import com.garfiec.librechat.core.logging.LogOrigin
-import com.garfiec.librechat.core.model.Attachment
 import com.garfiec.librechat.core.model.Message
 import com.garfiec.librechat.core.model.Preset
-import com.garfiec.librechat.core.model.StreamEvent
 import com.garfiec.librechat.core.model.config.InterfaceConfig
 import com.garfiec.librechat.core.model.error.UserKeyError
-import com.garfiec.librechat.core.model.error.parseUserKeyError
 import com.garfiec.librechat.core.model.permissions.Permission
 import com.garfiec.librechat.core.model.permissions.PermissionType
 import com.garfiec.librechat.core.model.permissions.hasAccessOrPermissive
@@ -47,7 +44,6 @@ import com.garfiec.librechat.core.ui.media.MediaItem
 import com.garfiec.librechat.core.ui.media.MediaPreviewState
 import com.garfiec.librechat.feature.chat.components.AttachedFile
 import com.garfiec.librechat.feature.chat.components.ParsedMarkdownCache
-import com.garfiec.librechat.feature.chat.components.artifact.ArtifactType
 import com.garfiec.librechat.feature.chat.model.PresetDisplayData
 import com.garfiec.librechat.feature.chat.model.PromptMentionDisplayData
 import com.garfiec.librechat.feature.chat.util.NEW_CHAT_DRAFT_KEY
@@ -64,12 +60,11 @@ import com.garfiec.librechat.feature.chat.viewmodel.delegate.OfficePreviewDelega
 import com.garfiec.librechat.feature.chat.viewmodel.delegate.PlatformDelegateFactory
 import com.garfiec.librechat.feature.chat.viewmodel.delegate.PresetPromptDelegate
 import com.garfiec.librechat.feature.chat.viewmodel.delegate.SendCompletionDelegate
+import com.garfiec.librechat.feature.chat.viewmodel.delegate.StreamingManagerDelegate
 import com.garfiec.librechat.feature.chat.viewmodel.delegate.SubagentTraceDelegate
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -82,7 +77,6 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.serialization.json.Json
@@ -258,31 +252,28 @@ class ChatViewModel(
     private val _userKeyErrors = Channel<UserKeyError>(Channel.BUFFERED)
     val userKeyErrors: Flow<UserKeyError> = _userKeyErrors.receiveAsFlow()
 
-    private var streamJob: Job? = null
     private var roomObserverJob: Job? = null
-    private var streamingUpdateJob: Job? = null
-    private val streamingBuffer = StringBuilder()
-    private var streamingBufferDirty = false
-    private var wasStreaming = false
 
-    /** Tracks whether the last stream failure was a network error, to enable auto-reconnect. */
-    private var lastErrorWasNetwork = false
-
-    /** Job for the connectivity observer; started lazily only when a network error occurs. */
-    private var connectivityJob: Job? = null
+    private val streamingManager = StreamingManagerDelegate(
+        stateHandle = stateHandle,
+        chatRepository = chatRepository,
+        connectivityObserver = connectivityObserver,
+        comparisonDelegate = comparisonDelegate,
+        subagentTraceDelegate = subagentTraceDelegate,
+        officePreviewDelegate = officePreviewDelegate,
+        completionDelegate = completionDelegate,
+        emitUserKeyError = { _userKeyErrors.trySend(it) },
+        reloadConversation = ::loadConversation,
+        isNewConversation = { isNewConversation },
+        isHandedOffNewChat = { isHandedOffNewChat },
+    )
 
     companion object {
-        /** Minimum interval between streaming UI state updates to avoid recomposition spam. */
-        private const val STREAMING_UI_UPDATE_INTERVAL_MS = 50L
-
         /** Timeout for the pre-send "is the endpoint/config ready" await. Snappier than the
          *  5 s role-load timeout because this only needs one of role OR availableModels to
          *  satisfy the check. */
         private const val SEND_READY_TIMEOUT_MS = 3_000L
     }
-
-    /** True when the current stream is from an edit, regenerate, or continue operation. */
-    private var isEditOrRegenerate = false
 
     /** True when this ViewModel was opened for a brand-new chat (no conversationId from navigation). */
     private val isNewConversation: Boolean
@@ -327,7 +318,7 @@ class ChatViewModel(
             // Check if there's an active stream for this conversation (e.g. when
             // navigating here from NewChat immediately after sending). If so,
             // resume it so the user sees streaming content on this screen.
-            resumeActiveStreamIfNeeded(conversationId)
+            streamingManager.resumeActiveStreamIfNeeded(conversationId)
         } else {
             isHandedOffNewChat = false
             // For new chats, mark conversationModelLoaded so refilterModels
@@ -653,8 +644,6 @@ class ChatViewModel(
             createdAt = Clock.System.now().toString(),
             files = fileRefs.takeIf { it.isNotEmpty() },
         )
-        isEditOrRegenerate = false
-
         val isNewChat = conversationId == null
         _uiState.update {
             val updatedMessages = it.messages + optimisticMessage
@@ -676,11 +665,7 @@ class ChatViewModel(
         viewModelScope.launch { draftRepository.deleteDraft(draftKey) }
         // Clear attached files
         fileDelegate.clearAttachedFiles()
-        streamingBuffer.clear()
-        streamingBufferDirty = false
-        subagentTraceDelegate.reset()
-        officePreviewDelegate.reset()
-        startStreamingUpdater()
+        streamingManager.beginStreaming(isEdit = false)
 
         val isAgent = _uiState.value.selectedEndpoint == EndpointConstants.AGENTS
         val webSearchEnabled = _uiState.value.modelParameters.webSearch
@@ -701,29 +686,26 @@ class ChatViewModel(
         val effectiveAgentId = if (isAgent) _uiState.value.selectedModel else null
         comparisonDelegate.onSendStart()
 
-        streamJob?.cancel()
-        streamJob = viewModelScope.launch {
-            val effectiveAddedConvo = comparisonDelegate.buildAddedConvo(parentMessageId = lastMessageId)
-            val dispatch = currentDispatch()
-            collectStreamSafely(
-                chatRepository.startChat(
-                    text = messageText,
-                    conversationId = conversationId,
-                    endpoint = effectiveEndpoint,
-                    endpointType = dispatch.endpointType,
-                    key = dispatch.key,
-                    modelDisplayLabel = dispatch.modelDisplayLabel,
-                    model = _uiState.value.selectedModel,
-                    userMessageId = optimisticMessage.messageId,
-                    parentMessageId = lastMessageId,
-                    agentId = effectiveAgentId,
-                    webSearch = webSearchEnabled,
-                    files = fileRefs.takeIf { it.isNotEmpty() },
-                    addedConvo = effectiveAddedConvo,
-                    ephemeralAgent = ephemeralAgent,
-                    isTemporary = _uiState.value.isTemporaryChat,
-                ),
-            )
+        val effectiveAddedConvo = comparisonDelegate.buildAddedConvo(parentMessageId = lastMessageId)
+        val dispatch = currentDispatch()
+        val stream = chatRepository.startChat(
+            text = messageText,
+            conversationId = conversationId,
+            endpoint = effectiveEndpoint,
+            endpointType = dispatch.endpointType,
+            key = dispatch.key,
+            modelDisplayLabel = dispatch.modelDisplayLabel,
+            model = _uiState.value.selectedModel,
+            userMessageId = optimisticMessage.messageId,
+            parentMessageId = lastMessageId,
+            agentId = effectiveAgentId,
+            webSearch = webSearchEnabled,
+            files = fileRefs.takeIf { it.isNotEmpty() },
+            addedConvo = effectiveAddedConvo,
+            ephemeralAgent = ephemeralAgent,
+            isTemporary = _uiState.value.isTemporaryChat,
+        )
+        streamingManager.launchStream(stream) {
             // Safety net: if the flow ends without Final or Error, clear streaming
             if (_uiState.value.isStreaming) {
                 val cid = _uiState.value.conversationId
@@ -734,62 +716,6 @@ class ChatViewModel(
                 }
             }
         }
-    }
-
-    /**
-     * Resets streaming-related UI state and clears the buffer in preparation
-     * for a new stream (edit, regenerate, or continue).
-     */
-    private fun prepareForStreaming() {
-        _uiState.update {
-            it.copy(
-                isStreaming = true,
-                streamingContent = "",
-                activeToolCalls = emptyList(),
-                streamingAttachments = emptyList(),
-                error = null,
-            )
-        }
-        streamingBuffer.clear()
-        streamingBufferDirty = false
-        subagentTraceDelegate.reset()
-        officePreviewDelegate.reset()
-        startStreamingUpdater()
-    }
-
-    /**
-     * Launches a periodic coroutine that flushes the [streamingBuffer] to UI state
-     * at most every [STREAMING_UI_UPDATE_INTERVAL_MS] ms. This avoids recomposition spam
-     * from high-frequency SSE chunks (each chunk would otherwise trigger a full state copy).
-     */
-    private fun startStreamingUpdater() {
-        streamingUpdateJob?.cancel()
-        streamingUpdateJob = viewModelScope.launch {
-            while (isActive) {
-                delay(STREAMING_UI_UPDATE_INTERVAL_MS)
-                flushStreamingBuffer()
-            }
-        }
-    }
-
-    /**
-     * Flushes the streaming buffer to UI state if it has been modified since the last flush.
-     * Called both periodically (by the updater) and immediately on stream completion/error.
-     */
-    private fun flushStreamingBuffer() {
-        if (!streamingBufferDirty) return
-        streamingBufferDirty = false
-        _uiState.update { it.copy(streamingContent = streamingBuffer.toString()) }
-    }
-
-    /**
-     * Stops the periodic streaming updater and performs a final flush so the last
-     * chunk is never lost.
-     */
-    private fun stopStreamingUpdater() {
-        streamingUpdateJob?.cancel()
-        streamingUpdateJob = null
-        flushStreamingBuffer()
     }
 
     fun editMessage(messageId: String, newText: String) {
@@ -809,8 +735,6 @@ class ChatViewModel(
     @OptIn(ExperimentalUuidApi::class)
     private fun editUserMessage(originalMessage: Message, newText: String) {
         val parentMessageId = originalMessage.parentMessageId
-
-        isEditOrRegenerate = true
 
         // Optimistically insert the edited text as a new sibling of the original user
         // message and anchor the stream to it, so the new message — with the response
@@ -838,34 +762,31 @@ class ChatViewModel(
             )
         }
 
-        prepareForStreaming()
+        streamingManager.prepareForStreaming(isEdit = true)
 
         val isAgent = _uiState.value.selectedEndpoint == EndpointConstants.AGENTS
         val webSearchEnabled = _uiState.value.modelParameters.webSearch
         val ephemeralAgent = buildEphemeralAgent()
         Logger.d { "editUserMessage: webSearch=$webSearchEnabled, ephemeralAgent=$ephemeralAgent" }
-        streamJob?.cancel()
-        streamJob = viewModelScope.launch {
-            val dispatch = currentDispatch()
-            collectStreamSafely(
-                chatRepository.startChat(
-                    text = newText,
-                    conversationId = _uiState.value.conversationId,
-                    endpoint = _uiState.value.selectedEndpoint,
-                    endpointType = dispatch.endpointType,
-                    key = dispatch.key,
-                    modelDisplayLabel = dispatch.modelDisplayLabel,
-                    model = _uiState.value.selectedModel,
-                    userMessageId = optimisticMessage.messageId,
-                    parentMessageId = parentMessageId,
-                    agentId = if (isAgent) _uiState.value.selectedModel else null,
-                    isEdited = true,
-                    webSearch = webSearchEnabled,
-                    ephemeralAgent = ephemeralAgent,
-                    isTemporary = _uiState.value.isTemporaryChat,
-                ),
-            )
-        }
+        val dispatch = currentDispatch()
+        streamingManager.launchStream(
+            chatRepository.startChat(
+                text = newText,
+                conversationId = _uiState.value.conversationId,
+                endpoint = _uiState.value.selectedEndpoint,
+                endpointType = dispatch.endpointType,
+                key = dispatch.key,
+                modelDisplayLabel = dispatch.modelDisplayLabel,
+                model = _uiState.value.selectedModel,
+                userMessageId = optimisticMessage.messageId,
+                parentMessageId = parentMessageId,
+                agentId = if (isAgent) _uiState.value.selectedModel else null,
+                isEdited = true,
+                webSearch = webSearchEnabled,
+                ephemeralAgent = ephemeralAgent,
+                isTemporary = _uiState.value.isTemporaryChat,
+            ),
+        )
     }
 
     private fun editAiMessage(aiMessage: Message) {
@@ -875,7 +796,6 @@ class ChatViewModel(
 
         val conversationId = _uiState.value.conversationId ?: return
 
-        isEditOrRegenerate = true
         // Editing an assistant message resubmits its parent user turn (isEdited +
         // isRegenerate) — the same shape as regenerate, so anchor the stream to the
         // parent user message and let the new response stream in below it, replacing
@@ -883,35 +803,32 @@ class ChatViewModel(
         // for a transient preview; we don't (the regenerated server response is
         // authoritative on Final either way).
         treeDelegate.anchorStreamTo(parentUserMessage.messageId)
-        prepareForStreaming()
+        streamingManager.prepareForStreaming(isEdit = true)
 
         val isAgent = _uiState.value.selectedEndpoint == EndpointConstants.AGENTS
         val webSearchEnabled = _uiState.value.modelParameters.webSearch
         val ephemeralAgent = buildEphemeralAgent()
         Logger.d { "editAiMessage: webSearch=$webSearchEnabled, ephemeralAgent=$ephemeralAgent" }
-        streamJob?.cancel()
-        streamJob = viewModelScope.launch {
-            val dispatch = currentDispatch()
-            collectStreamSafely(
-                chatRepository.startChat(
-                    text = parentUserMessage.text,
-                    conversationId = conversationId,
-                    endpoint = _uiState.value.selectedEndpoint,
-                    endpointType = dispatch.endpointType,
-                    key = dispatch.key,
-                    modelDisplayLabel = dispatch.modelDisplayLabel,
-                    model = _uiState.value.selectedModel,
-                    parentMessageId = parentUserMessage.parentMessageId,
-                    agentId = if (isAgent) _uiState.value.selectedModel else null,
-                    overrideParentMessageId = parentUserMessage.messageId,
-                    isEdited = true,
-                    isRegenerate = true,
-                    webSearch = webSearchEnabled,
-                    ephemeralAgent = ephemeralAgent,
-                    isTemporary = _uiState.value.isTemporaryChat,
-                ),
-            )
-        }
+        val dispatch = currentDispatch()
+        streamingManager.launchStream(
+            chatRepository.startChat(
+                text = parentUserMessage.text,
+                conversationId = conversationId,
+                endpoint = _uiState.value.selectedEndpoint,
+                endpointType = dispatch.endpointType,
+                key = dispatch.key,
+                modelDisplayLabel = dispatch.modelDisplayLabel,
+                model = _uiState.value.selectedModel,
+                parentMessageId = parentUserMessage.parentMessageId,
+                agentId = if (isAgent) _uiState.value.selectedModel else null,
+                overrideParentMessageId = parentUserMessage.messageId,
+                isEdited = true,
+                isRegenerate = true,
+                webSearch = webSearchEnabled,
+                ephemeralAgent = ephemeralAgent,
+                isTemporary = _uiState.value.isTemporaryChat,
+            ),
+        )
     }
 
     fun regenerateMessage(messageId: String) {
@@ -928,36 +845,32 @@ class ChatViewModel(
     }
 
     private fun regenerateMessageNow(parentUserMessage: Message) {
-        isEditOrRegenerate = true
         treeDelegate.anchorStreamTo(parentUserMessage.messageId)
-        prepareForStreaming()
+        streamingManager.prepareForStreaming(isEdit = true)
 
         val isAgentRegen = _uiState.value.selectedEndpoint == EndpointConstants.AGENTS
         val webSearchEnabled = _uiState.value.modelParameters.webSearch
         val ephemeralAgent = buildEphemeralAgent()
         Logger.d { "regenerateMessage: webSearch=$webSearchEnabled, ephemeralAgent=$ephemeralAgent" }
-        streamJob?.cancel()
-        streamJob = viewModelScope.launch {
-            val dispatch = currentDispatch()
-            collectStreamSafely(
-                chatRepository.startChat(
-                    text = parentUserMessage.text,
-                    conversationId = _uiState.value.conversationId,
-                    endpoint = _uiState.value.selectedEndpoint,
-                    endpointType = dispatch.endpointType,
-                    key = dispatch.key,
-                    modelDisplayLabel = dispatch.modelDisplayLabel,
-                    model = _uiState.value.selectedModel,
-                    parentMessageId = parentUserMessage.parentMessageId,
-                    agentId = if (isAgentRegen) _uiState.value.selectedModel else null,
-                    overrideParentMessageId = parentUserMessage.messageId,
-                    isRegenerate = true,
-                    webSearch = webSearchEnabled,
-                    ephemeralAgent = ephemeralAgent,
-                    isTemporary = _uiState.value.isTemporaryChat,
-                ),
-            )
-        }
+        val dispatch = currentDispatch()
+        streamingManager.launchStream(
+            chatRepository.startChat(
+                text = parentUserMessage.text,
+                conversationId = _uiState.value.conversationId,
+                endpoint = _uiState.value.selectedEndpoint,
+                endpointType = dispatch.endpointType,
+                key = dispatch.key,
+                modelDisplayLabel = dispatch.modelDisplayLabel,
+                model = _uiState.value.selectedModel,
+                parentMessageId = parentUserMessage.parentMessageId,
+                agentId = if (isAgentRegen) _uiState.value.selectedModel else null,
+                overrideParentMessageId = parentUserMessage.messageId,
+                isRegenerate = true,
+                webSearch = webSearchEnabled,
+                ephemeralAgent = ephemeralAgent,
+                isTemporary = _uiState.value.isTemporaryChat,
+            ),
+        )
     }
 
     fun getMessageText(messageId: String): String {
@@ -971,270 +884,7 @@ class ChatViewModel(
         return message.text
     }
 
-    private suspend fun collectStreamSafely(stream: Flow<StreamEvent>) {
-        try {
-            stream.collect { event -> handleStreamEvent(event) }
-        } catch (e: CancellationException) {
-            throw e // Never swallow cancellation
-        } catch (e: Exception) {
-            Logger.e(e) { "Stream collection failed" }
-            stopStreamingUpdater()
-            // Preserve partial content so users can read/copy what was received
-            val partialContent = streamingBuffer.toString()
-            _uiState.update {
-                it.copy(
-                    isStreaming = false,
-                    streamingContent = partialContent,
-                    activeToolCalls = emptyList(),
-                    streamingAttachments = emptyList(),
-                    error = e.message ?: "Chat request failed",
-                )
-            }
-            comparisonDelegate.endStreaming()
-            // If the server already created a conversation, fetch whatever it persisted
-            val conversationId = _uiState.value.conversationId
-            if (conversationId != null) {
-                loadConversation(conversationId)
-            }
-        }
-    }
-
-    private fun handleStreamEvent(event: StreamEvent) {
-        // In comparison mode the delegate fans streaming deltas/tool-calls into the dual
-        // panes; if it consumed the event, skip the single-stream handling below.
-        if (comparisonDelegate.routeEvent(event)) return
-        when (event) {
-            is StreamEvent.Created -> handleCreated(event)
-            is StreamEvent.ContentDelta -> {
-                streamingBuffer.append(event.chunk)
-                streamingBufferDirty = true
-            }
-            is StreamEvent.ThinkingDelta -> {
-                streamingBuffer.append(event.chunk)
-                streamingBufferDirty = true
-            }
-            is StreamEvent.Final -> handleFinal(event)
-            is StreamEvent.Error -> {
-                stopStreamingUpdater()
-                // Track network errors so auto-reconnect can kick in when connectivity returns
-                lastErrorWasNetwork = event.isNetworkError
-                if (event.isNetworkError) {
-                    startConnectivityObserver()
-                }
-                // Try to parse the message as a typed user-provided-key error envelope.
-                // If recognized, emit a one-shot effect so the UI can surface a snackbar
-                // with a deep-link CTA to Settings → Provider Keys, and skip the generic
-                // `error = event.message` fallback to avoid double-surfacing.
-                val keyError = parseUserKeyError(event.message)
-                // Preserve partial content so users can read/copy what was received
-                val partialContent = streamingBuffer.toString()
-                _uiState.update {
-                    it.copy(
-                        isStreaming = false,
-                        streamingContent = partialContent,
-                        error = if (keyError != null) null else event.message,
-                        retryInfo = null,
-                        activeToolCalls = emptyList(),
-                        streamingAttachments = emptyList(),
-                    )
-                }
-                comparisonDelegate.endStreaming()
-                if (keyError != null) {
-                    _userKeyErrors.trySend(keyError)
-                }
-                // If the server already created a conversation, fetch whatever it persisted
-                val conversationId = _uiState.value.conversationId
-                if (conversationId != null) {
-                    loadConversation(conversationId)
-                }
-            }
-            is StreamEvent.Retrying -> {
-                _uiState.update {
-                    it.copy(
-                        retryInfo = RetryInfo(
-                            attempt = event.attempt,
-                            maxAttempts = event.maxAttempts,
-                        ),
-                    )
-                }
-            }
-            is StreamEvent.ToolCallStart -> {
-                val newToolCall = ActiveToolCall(
-                    id = event.toolCallId,
-                    name = event.toolName,
-                    input = event.input,
-                )
-                _uiState.update {
-                    it.copy(activeToolCalls = it.activeToolCalls + newToolCall)
-                }
-            }
-            is StreamEvent.ToolCallComplete -> {
-                _uiState.update { state ->
-                    val updated = state.activeToolCalls.map { tc ->
-                        if (tc.id == event.toolCallId) {
-                            tc.copy(isComplete = true, output = event.output)
-                        } else {
-                            tc
-                        }
-                    }
-                    state.copy(activeToolCalls = updated)
-                }
-                // If this was a `subagent` tool_call, freeze its live trace —
-                // the child run is done; stop accumulating for that key.
-                subagentTraceDelegate.onParentToolCallResolved(event.toolCallId)
-            }
-            is StreamEvent.AttachmentCreated -> {
-                val attachment = Attachment(
-                    fileId = event.fileId,
-                    filename = event.filename,
-                    filepath = event.filepath,
-                    type = event.type,
-                    toolCallId = event.toolCallId,
-                    width = event.width,
-                    height = event.height,
-                    status = event.status,
-                    text = event.text,
-                    textFormat = event.textFormat,
-                    previewError = event.previewError,
-                )
-                // Office-doc previews (v0.8.6) arrive twice per file_id (pending →
-                // ready/failed) — route through the delegate for upsert-by-file_id +
-                // poll-while-pending. Ordinary attachments keep the simple append path.
-                if (ArtifactType.isOfficePreviewMime(event.type)) {
-                    officePreviewDelegate.onAttachment(attachment)
-                } else {
-                    _uiState.update {
-                        it.copy(streamingAttachments = it.streamingAttachments + attachment)
-                    }
-                }
-            }
-            is StreamEvent.Sync -> {
-                // Resume snapshot: `aggregatedContent` is the authoritative state of
-                // the response so far, so we REPLACE (not append) the streaming
-                // pipeline's fields from it — both the text buffer and the tool-call
-                // list. Any pendingEvents in the same frame arrive as their own
-                // StreamEvents after this and fold on top via the normal handlers.
-                if (lastErrorWasNetwork) {
-                    lastErrorWasNetwork = false
-                    cancelConnectivityObserver()
-                }
-                _uiState.update {
-                    if (it.retryInfo != null) it.copy(retryInfo = null) else it
-                }
-                val textContent = event.aggregatedContent
-                    .mapNotNull { it.text }
-                    .joinToString("")
-                streamingBuffer.clear()
-                streamingBuffer.append(textContent)
-                streamingBufferDirty = true
-
-                // Rebuild active tool calls from the snapshot's tool_call parts so an
-                // in-progress image gen (or any tool call) started before we resumed
-                // still renders its live card. The same ActiveToolCall the live path
-                // produces, so the existing StreamingToolCallCard / ImageGenCard render
-                // it identically. A part with a non-blank output is already complete.
-                val syncedToolCalls = event.aggregatedContent
-                    .mapNotNull { part -> part.toolCall?.takeIf { !it.id.isNullOrBlank() } }
-                    .map { tc ->
-                        ActiveToolCall(
-                            id = tc.id.orEmpty(),
-                            name = tc.name.orEmpty(),
-                            input = tc.args?.toString(),
-                            isComplete = !tc.output.isNullOrBlank(),
-                            output = tc.output,
-                        )
-                    }
-                _uiState.update { it.copy(activeToolCalls = syncedToolCalls) }
-                flushStreamingBuffer()
-            }
-            is StreamEvent.Step -> { /* no-op */ }
-            is StreamEvent.ContextSummary -> {
-                // Server compacted earlier turns into a summary. The compacted text is
-                // persisted to the final message as a SUMMARY content part and rendered
-                // there; nothing extra to do during streaming.
-            }
-            is StreamEvent.SubagentUpdate -> subagentTraceDelegate.onUpdate(event)
-        }
-    }
-
-    private fun handleCreated(event: StreamEvent.Created) {
-        if (lastErrorWasNetwork) {
-            lastErrorWasNetwork = false
-            cancelConnectivityObserver()
-        }
-        _uiState.update {
-            if (it.retryInfo != null) {
-                it.copy(conversationId = event.conversationId, retryInfo = null)
-            } else {
-                it.copy(conversationId = event.conversationId)
-            }
-        }
-        completionDelegate.onConversationCreated(event.conversationId, isNewConversation)
-    }
-
-    private fun handleFinal(event: StreamEvent.Final) {
-        stopStreamingUpdater()
-        // The stream has ended: any office-doc attachment still `pending` (its
-        // `ready` SSE update may never arrive once the run closes) now falls back
-        // to polling GET /api/files/:id/preview. De-duped + bounded in the delegate.
-        officePreviewDelegate.onStreamEnded()
-        val isComparison = _uiState.value.comparisonState.isEnabled
-        val conversationId = _uiState.value.conversationId
-            ?: event.conversation?.conversationId
-        val completedResponseText = if (isComparison) {
-            comparisonDelegate.primaryContent()
-        } else {
-            streamingBuffer.toString()
-        }
-        val shouldAutoRead = !isEditOrRegenerate
-        // Clear the single-stream UI fields; comparison panes are finalized via the delegate.
-        _uiState.update {
-            it.copy(
-                isStreaming = false,
-                streamingContent = "",
-                activeToolCalls = emptyList(),
-                streamingAttachments = emptyList(),
-                conversationId = conversationId ?: it.conversationId,
-            )
-        }
-        if (isComparison) {
-            comparisonDelegate.onFinal((event.responseMessage ?: event.message)?.messageId)
-        }
-        completionDelegate.onFinal(
-            event = event,
-            conversationId = conversationId,
-            completedResponseText = completedResponseText,
-            shouldAutoRead = shouldAutoRead,
-            isNewConversation = isNewConversation,
-            isHandedOffNewChat = isHandedOffNewChat,
-        )
-    }
-
-    fun stopGeneration() {
-        val conversationId = _uiState.value.conversationId ?: return
-        streamJob?.cancel()
-        stopStreamingUpdater()
-        streamingBuffer.clear()
-        streamingBufferDirty = false
-        viewModelScope.launch {
-            val abortResult = chatRepository.abortChat(conversationId)
-            if (abortResult is Result.Error) {
-                Logger.w(abortResult.exception) { "Failed to abort chat: ${abortResult.message}" }
-            }
-            _uiState.update {
-                it.copy(
-                    isStreaming = false,
-                    streamingContent = "",
-                    activeToolCalls = emptyList(),
-                    streamingAttachments = emptyList(),
-                )
-            }
-            comparisonDelegate.endStreaming(clearContent = true)
-            // Refresh messages from server so the message tree reflects
-            // the partially-streamed response that was aborted.
-            loadConversation(conversationId)
-        }
-    }
+    fun stopGeneration() = streamingManager.stopGeneration()
 
     fun continueGeneration() {
         if (_uiState.value.isStreaming) return
@@ -1250,174 +900,39 @@ class ChatViewModel(
     }
 
     private fun continueGenerationNow(lastAiMessage: Message, parentUserMessage: Message) {
-        isEditOrRegenerate = true
-        prepareForStreaming()
+        streamingManager.prepareForStreaming(isEdit = true)
 
         val isAgentContinue = _uiState.value.selectedEndpoint == EndpointConstants.AGENTS
         val webSearchEnabled = _uiState.value.modelParameters.webSearch
         val ephemeralAgent = buildEphemeralAgent()
         Logger.d { "continueGeneration: webSearch=$webSearchEnabled, ephemeralAgent=$ephemeralAgent" }
-        streamJob?.cancel()
-        streamJob = viewModelScope.launch {
-            val dispatch = currentDispatch()
-            collectStreamSafely(
-                chatRepository.startChat(
-                    text = parentUserMessage.text,
-                    conversationId = _uiState.value.conversationId,
-                    endpoint = _uiState.value.selectedEndpoint,
-                    endpointType = dispatch.endpointType,
-                    key = dispatch.key,
-                    modelDisplayLabel = dispatch.modelDisplayLabel,
-                    model = _uiState.value.selectedModel,
-                    parentMessageId = parentUserMessage.parentMessageId,
-                    agentId = if (isAgentContinue) _uiState.value.selectedModel else null,
-                    overrideParentMessageId = parentUserMessage.messageId,
-                    responseMessageId = lastAiMessage.messageId,
-                    isEdited = true,
-                    isRegenerate = true,
-                    isContinued = true,
-                    webSearch = webSearchEnabled,
-                    ephemeralAgent = ephemeralAgent,
-                    isTemporary = _uiState.value.isTemporaryChat,
-                ),
-            )
-        }
+        val dispatch = currentDispatch()
+        streamingManager.launchStream(
+            chatRepository.startChat(
+                text = parentUserMessage.text,
+                conversationId = _uiState.value.conversationId,
+                endpoint = _uiState.value.selectedEndpoint,
+                endpointType = dispatch.endpointType,
+                key = dispatch.key,
+                modelDisplayLabel = dispatch.modelDisplayLabel,
+                model = _uiState.value.selectedModel,
+                parentMessageId = parentUserMessage.parentMessageId,
+                agentId = if (isAgentContinue) _uiState.value.selectedModel else null,
+                overrideParentMessageId = parentUserMessage.messageId,
+                responseMessageId = lastAiMessage.messageId,
+                isEdited = true,
+                isRegenerate = true,
+                isContinued = true,
+                webSearch = webSearchEnabled,
+                ephemeralAgent = ephemeralAgent,
+                isTemporary = _uiState.value.isTemporaryChat,
+            ),
+        )
     }
 
-    fun onPause() {
-        wasStreaming = _uiState.value.isStreaming
-        if (wasStreaming) {
-            streamJob?.cancel()
-            stopStreamingUpdater()
-        }
-    }
+    fun onPause() = streamingManager.onPause()
 
-    fun onResume() {
-        if (!wasStreaming) return
-        wasStreaming = false
-
-        val conversationId = _uiState.value.conversationId ?: return
-
-        viewModelScope.launch {
-            try {
-                val status = chatRepository.checkStreamStatus(conversationId)
-                if (status.active) {
-                    _uiState.update { it.copy(isStreaming = true) }
-                    resumeStream(conversationId)
-                } else {
-                    _uiState.update {
-                        it.copy(isStreaming = false, streamingContent = "")
-                    }
-                    loadConversation(conversationId)
-                }
-            } catch (e: Exception) {
-                Logger.e(e) { "Could not resume stream" }
-                _uiState.update {
-                    it.copy(
-                        isStreaming = false,
-                        streamingContent = "",
-                        error = "Could not resume stream",
-                    )
-                }
-            }
-        }
-    }
-
-    /**
-     * Shared resume logic: clears the buffer, starts the updater, and launches
-     * stream collection. Caller is responsible for setting any UI state fields
-     * (e.g. isStreaming, error) before calling this.
-     */
-    private fun resumeStream(conversationId: String) {
-        streamingBuffer.clear()
-        streamingBufferDirty = false
-        startStreamingUpdater()
-        streamJob?.cancel()
-        streamJob = viewModelScope.launch {
-            collectStreamSafely(chatRepository.resumeStream(conversationId))
-        }
-    }
-
-    private fun resumeActiveStreamIfNeeded(conversationId: String) {
-        viewModelScope.launch {
-            try {
-                val status = chatRepository.checkStreamStatus(conversationId)
-                if (status.active) {
-                    _uiState.update {
-                        it.copy(
-                            isStreaming = true,
-                            screenState = ChatScreenState.ACTIVE,
-                        )
-                    }
-                    resumeStream(conversationId)
-                }
-            } catch (e: Exception) {
-                Logger.d(e) { "No active stream to resume for $conversationId" }
-            }
-        }
-    }
-
-    /**
-     * Starts observing connectivity for auto-reconnect after a network error.
-     * Cancels any existing observer first. The observer self-cancels after recovery fires.
-     */
-    private fun startConnectivityObserver() {
-        connectivityJob?.cancel()
-        connectivityJob = viewModelScope.launch {
-            var wasConnected = true
-            connectivityObserver.isConnected.collect { connected ->
-                val recovered = !wasConnected && connected
-                wasConnected = connected
-                if (recovered) {
-                    attemptNetworkRecovery()
-                }
-            }
-        }
-    }
-
-    /** Cancels the connectivity observer and clears the network-error flag. */
-    private fun cancelConnectivityObserver() {
-        connectivityJob?.cancel()
-        connectivityJob = null
-    }
-
-    /**
-     * Called when network connectivity transitions from offline to online.
-     * If the last stream ended due to a network error, attempts to resume it
-     * or falls back to reloading the conversation from the server.
-     */
-    private fun attemptNetworkRecovery() {
-        if (!lastErrorWasNetwork) return
-        val state = _uiState.value
-        val conversationId = state.conversationId ?: return
-        if (state.isStreaming) return
-
-        lastErrorWasNetwork = false
-        cancelConnectivityObserver()
-        Logger.d { "Network recovered, attempting to resume conversation $conversationId" }
-
-        viewModelScope.launch {
-            try {
-                val status = chatRepository.checkStreamStatus(conversationId)
-                if (status.active) {
-                    _uiState.update {
-                        it.copy(
-                            isStreaming = true,
-                            error = null,
-                            retryInfo = null,
-                        )
-                    }
-                    resumeStream(conversationId)
-                } else {
-                    // Stream expired while offline — reload conversation from server
-                    _uiState.update { it.copy(error = null, retryInfo = null) }
-                    loadConversation(conversationId)
-                }
-            } catch (e: Exception) {
-                Logger.w(e) { "Network recovery: could not check stream status" }
-            }
-        }
-    }
+    fun onResume() = streamingManager.onResume()
 
     fun submitFeedback(messageId: String, rating: String?) {
         val conversationId = _uiState.value.conversationId ?: return
@@ -1463,9 +978,7 @@ class ChatViewModel(
     }
 
     fun onPendingNavigationHandled() {
-        streamJob?.cancel()
-        streamJob = null
-        stopStreamingUpdater()
+        streamingManager.reset()
         roomObserverJob?.cancel()
         roomObserverJob = null
         _uiState.update { current ->
@@ -1486,7 +999,6 @@ class ChatViewModel(
                 sharedLinksEnabled = current.sharedLinksEnabled,
             )
         }
-        streamingBuffer.clear()
     }
 
     fun toggleTemporaryChat() = treeDelegate.toggleTemporaryChat()

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModel.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModel.kt
@@ -12,7 +12,6 @@ import com.garfiec.librechat.core.common.result.getOrNull
 import com.garfiec.librechat.core.data.datastore.LatexRenderer
 import com.garfiec.librechat.core.data.datastore.ServerDataStore
 import com.garfiec.librechat.core.data.datastore.SettingsDataStore
-import com.garfiec.librechat.core.data.endpoint.EndpointDispatch
 import com.garfiec.librechat.core.data.repository.AgentRepository
 import com.garfiec.librechat.core.data.repository.ChatRepository
 import com.garfiec.librechat.core.data.repository.ConfigRepository
@@ -38,7 +37,6 @@ import com.garfiec.librechat.core.model.error.UserKeyError
 import com.garfiec.librechat.core.model.permissions.Permission
 import com.garfiec.librechat.core.model.permissions.PermissionType
 import com.garfiec.librechat.core.model.permissions.hasAccessOrPermissive
-import com.garfiec.librechat.core.model.request.EphemeralAgent
 import com.garfiec.librechat.core.ui.components.ModelParameters
 import com.garfiec.librechat.core.ui.media.MediaItem
 import com.garfiec.librechat.core.ui.media.MediaPreviewState
@@ -54,6 +52,7 @@ import com.garfiec.librechat.feature.chat.viewmodel.delegate.ConversationActions
 import com.garfiec.librechat.feature.chat.viewmodel.delegate.EndpointKeyStatusDelegate
 import com.garfiec.librechat.feature.chat.viewmodel.delegate.FavoritesDelegate
 import com.garfiec.librechat.feature.chat.viewmodel.delegate.InConversationSearchDelegate
+import com.garfiec.librechat.feature.chat.viewmodel.delegate.MessageEditingDelegate
 import com.garfiec.librechat.feature.chat.viewmodel.delegate.MessageTreeDelegate
 import com.garfiec.librechat.feature.chat.viewmodel.delegate.ModelSelectionDelegate
 import com.garfiec.librechat.feature.chat.viewmodel.delegate.OfficePreviewDelegate
@@ -137,6 +136,7 @@ class ChatViewModel(
     private val shareConsumer = platformDelegateFactory.createShareConsumer()
 
     // --- Delegates ---
+    private val requestBuilder = ChatRequestBuilder(stateHandle)
     private val treeDelegate = MessageTreeDelegate(stateHandle)
     private val comparisonDelegate = ComparisonModeDelegate(
         stateHandle = stateHandle,
@@ -266,6 +266,17 @@ class ChatViewModel(
         reloadConversation = ::loadConversation,
         isNewConversation = { isNewConversation },
         isHandedOffNewChat = { isHandedOffNewChat },
+    )
+
+    private val editingDelegate = MessageEditingDelegate(
+        stateHandle = stateHandle,
+        chatRepository = chatRepository,
+        messageRepository = messageRepository,
+        treeDelegate = treeDelegate,
+        streamingManager = streamingManager,
+        requestBuilder = requestBuilder,
+        getMessageText = ::getMessageText,
+        runWhenSendReady = ::runWhenSendReady,
     )
 
     companion object {
@@ -581,46 +592,6 @@ class ChatViewModel(
         runWhenSendReady { doSendMessage(text) }
     }
 
-    /**
-     * Builds an [EphemeralAgent] from the current UI state (selected MCP servers
-     * and enabled tools). Returns null when there is nothing to send.
-     */
-    private fun buildEphemeralAgent(): EphemeralAgent? {
-        val state = _uiState.value
-        // A saved agent uses its own configured tools; the backend ignores client-supplied
-        // ephemeral tools for agent runs. Mirror web's `showEphemeralBadges` (ChatForm.tsx)
-        // and never serialize leftover UI selections on the agents endpoint.
-        if (!state.showEphemeralTools) return null
-        val mcpServers = state.selectedMcpServerNames.toList().ifEmpty { null }
-        val enabledTools = state.enabledTools
-        val webSearchEnabled = state.modelParameters.webSearch
-
-        val hasAnything = mcpServers != null || enabledTools.isNotEmpty() || webSearchEnabled
-        if (!hasAnything) return null
-
-        return EphemeralAgent(
-            mcp = mcpServers,
-            webSearch = if (webSearchEnabled) true else null,
-            fileSearch = if (ToolConstants.FILE_SEARCH in enabledTools) true else null,
-            executeCode = if (ToolConstants.CODE_INTERPRETER in enabledTools || ToolConstants.EXECUTE_CODE in enabledTools) true else null,
-        )
-    }
-
-    /**
-     * Resolves the chat-send dispatch for the currently-selected endpoint by snapshotting
-     * `_uiState.value` once. Used by every chat-send code path (new message, edit, regenerate,
-     * continue) — callers that target a different endpoint (e.g. the comparison-mode
-     * secondary) must call [resolveEndpointDispatch] directly with that endpoint name.
-     */
-    private fun currentDispatch(): EndpointDispatch {
-        val state = _uiState.value
-        return resolveEndpointDispatch(
-            endpointName = state.selectedEndpoint,
-            endpointConfigs = state.endpointConfigs,
-            endpointKeyStates = state.endpointKeyStates,
-        )
-    }
-
     @OptIn(ExperimentalUuidApi::class)
     private fun doSendMessage(text: String) {
         val fileRefs = fileDelegate.buildFileReferences()
@@ -669,7 +640,7 @@ class ChatViewModel(
 
         val isAgent = _uiState.value.selectedEndpoint == EndpointConstants.AGENTS
         val webSearchEnabled = _uiState.value.modelParameters.webSearch
-        val ephemeralAgent = buildEphemeralAgent()
+        val ephemeralAgent = requestBuilder.buildEphemeralAgent()
         Logger.d {
             "sendMessage: webSearch=$webSearchEnabled, " +
                 "endpoint=${_uiState.value.selectedEndpoint}, " +
@@ -687,7 +658,7 @@ class ChatViewModel(
         comparisonDelegate.onSendStart()
 
         val effectiveAddedConvo = comparisonDelegate.buildAddedConvo(parentMessageId = lastMessageId)
-        val dispatch = currentDispatch()
+        val dispatch = requestBuilder.currentDispatch()
         val stream = chatRepository.startChat(
             text = messageText,
             conversationId = conversationId,
@@ -718,160 +689,9 @@ class ChatViewModel(
         }
     }
 
-    fun editMessage(messageId: String, newText: String) {
-        if (newText.isBlank() || _uiState.value.isStreaming) return
+    fun editMessage(messageId: String, newText: String) = editingDelegate.editMessage(messageId, newText)
 
-        val originalMessage = _uiState.value.messages.find { it.messageId == messageId } ?: return
-
-        runWhenSendReady {
-            if (originalMessage.isCreatedByUser) {
-                editUserMessage(originalMessage, newText)
-            } else {
-                editAiMessage(originalMessage)
-            }
-        }
-    }
-
-    @OptIn(ExperimentalUuidApi::class)
-    private fun editUserMessage(originalMessage: Message, newText: String) {
-        val parentMessageId = originalMessage.parentMessageId
-
-        // Optimistically insert the edited text as a new sibling of the original user
-        // message and anchor the stream to it, so the new message — with the response
-        // streaming below it — replaces the old branch in place. The anchor truncates
-        // the active path here (see buildActiveMessagePath), mirroring the web client's
-        // `currentMsg + initialResponse` placeholder insert. The optimistic id is sent
-        // as `userMessageId` so the server adopts it; that lets the message reconcile by
-        // id on Final — via loadConversation() for normal chats, or in-memory via
-        // mergeFinalMessagesInMemory for temp chats (which never touch Room).
-        val optimisticMessage = Message(
-            messageId = Uuid.random().toString(),
-            conversationId = _uiState.value.conversationId ?: "",
-            parentMessageId = parentMessageId,
-            text = newText,
-            isCreatedByUser = true,
-            sender = "User",
-            createdAt = Clock.System.now().toString(),
-            files = originalMessage.files,
-        )
-        _uiState.update {
-            val updatedMessages = it.messages + optimisticMessage
-            it.copy(
-                messages = updatedMessages,
-                displayMessages = buildActiveMessagePath(updatedMessages, it.activeBranches, optimisticMessage.messageId),
-            )
-        }
-
-        streamingManager.prepareForStreaming(isEdit = true)
-
-        val isAgent = _uiState.value.selectedEndpoint == EndpointConstants.AGENTS
-        val webSearchEnabled = _uiState.value.modelParameters.webSearch
-        val ephemeralAgent = buildEphemeralAgent()
-        Logger.d { "editUserMessage: webSearch=$webSearchEnabled, ephemeralAgent=$ephemeralAgent" }
-        val dispatch = currentDispatch()
-        streamingManager.launchStream(
-            chatRepository.startChat(
-                text = newText,
-                conversationId = _uiState.value.conversationId,
-                endpoint = _uiState.value.selectedEndpoint,
-                endpointType = dispatch.endpointType,
-                key = dispatch.key,
-                modelDisplayLabel = dispatch.modelDisplayLabel,
-                model = _uiState.value.selectedModel,
-                userMessageId = optimisticMessage.messageId,
-                parentMessageId = parentMessageId,
-                agentId = if (isAgent) _uiState.value.selectedModel else null,
-                isEdited = true,
-                webSearch = webSearchEnabled,
-                ephemeralAgent = ephemeralAgent,
-                isTemporary = _uiState.value.isTemporaryChat,
-            ),
-        )
-    }
-
-    private fun editAiMessage(aiMessage: Message) {
-        val parentUserMessage = _uiState.value.messages.find {
-            it.messageId == aiMessage.parentMessageId
-        } ?: return
-
-        val conversationId = _uiState.value.conversationId ?: return
-
-        // Editing an assistant message resubmits its parent user turn (isEdited +
-        // isRegenerate) — the same shape as regenerate, so anchor the stream to the
-        // parent user message and let the new response stream in below it, replacing
-        // the old one. The web client seeds the placeholder with the edited content
-        // for a transient preview; we don't (the regenerated server response is
-        // authoritative on Final either way).
-        treeDelegate.anchorStreamTo(parentUserMessage.messageId)
-        streamingManager.prepareForStreaming(isEdit = true)
-
-        val isAgent = _uiState.value.selectedEndpoint == EndpointConstants.AGENTS
-        val webSearchEnabled = _uiState.value.modelParameters.webSearch
-        val ephemeralAgent = buildEphemeralAgent()
-        Logger.d { "editAiMessage: webSearch=$webSearchEnabled, ephemeralAgent=$ephemeralAgent" }
-        val dispatch = currentDispatch()
-        streamingManager.launchStream(
-            chatRepository.startChat(
-                text = parentUserMessage.text,
-                conversationId = conversationId,
-                endpoint = _uiState.value.selectedEndpoint,
-                endpointType = dispatch.endpointType,
-                key = dispatch.key,
-                modelDisplayLabel = dispatch.modelDisplayLabel,
-                model = _uiState.value.selectedModel,
-                parentMessageId = parentUserMessage.parentMessageId,
-                agentId = if (isAgent) _uiState.value.selectedModel else null,
-                overrideParentMessageId = parentUserMessage.messageId,
-                isEdited = true,
-                isRegenerate = true,
-                webSearch = webSearchEnabled,
-                ephemeralAgent = ephemeralAgent,
-                isTemporary = _uiState.value.isTemporaryChat,
-            ),
-        )
-    }
-
-    fun regenerateMessage(messageId: String) {
-        if (_uiState.value.isStreaming) return
-
-        val aiMessage = _uiState.value.messages.find { it.messageId == messageId } ?: return
-        if (aiMessage.isCreatedByUser) return
-
-        val parentUserMessage = _uiState.value.messages.find {
-            it.messageId == aiMessage.parentMessageId
-        } ?: return
-
-        runWhenSendReady { regenerateMessageNow(parentUserMessage) }
-    }
-
-    private fun regenerateMessageNow(parentUserMessage: Message) {
-        treeDelegate.anchorStreamTo(parentUserMessage.messageId)
-        streamingManager.prepareForStreaming(isEdit = true)
-
-        val isAgentRegen = _uiState.value.selectedEndpoint == EndpointConstants.AGENTS
-        val webSearchEnabled = _uiState.value.modelParameters.webSearch
-        val ephemeralAgent = buildEphemeralAgent()
-        Logger.d { "regenerateMessage: webSearch=$webSearchEnabled, ephemeralAgent=$ephemeralAgent" }
-        val dispatch = currentDispatch()
-        streamingManager.launchStream(
-            chatRepository.startChat(
-                text = parentUserMessage.text,
-                conversationId = _uiState.value.conversationId,
-                endpoint = _uiState.value.selectedEndpoint,
-                endpointType = dispatch.endpointType,
-                key = dispatch.key,
-                modelDisplayLabel = dispatch.modelDisplayLabel,
-                model = _uiState.value.selectedModel,
-                parentMessageId = parentUserMessage.parentMessageId,
-                agentId = if (isAgentRegen) _uiState.value.selectedModel else null,
-                overrideParentMessageId = parentUserMessage.messageId,
-                isRegenerate = true,
-                webSearch = webSearchEnabled,
-                ephemeralAgent = ephemeralAgent,
-                isTemporary = _uiState.value.isTemporaryChat,
-            ),
-        )
-    }
+    fun regenerateMessage(messageId: String) = editingDelegate.regenerateMessage(messageId)
 
     fun getMessageText(messageId: String): String {
         val message = _uiState.value.messages.find { it.messageId == messageId } ?: return ""
@@ -886,49 +706,7 @@ class ChatViewModel(
 
     fun stopGeneration() = streamingManager.stopGeneration()
 
-    fun continueGeneration() {
-        if (_uiState.value.isStreaming) return
-        val lastAiMessage = _uiState.value.displayMessages.lastOrNull {
-            !it.message.isCreatedByUser
-        } ?: return
-
-        val parentUserMessage = _uiState.value.messages.find {
-            it.messageId == lastAiMessage.message.parentMessageId
-        } ?: return
-
-        runWhenSendReady { continueGenerationNow(lastAiMessage.message, parentUserMessage) }
-    }
-
-    private fun continueGenerationNow(lastAiMessage: Message, parentUserMessage: Message) {
-        streamingManager.prepareForStreaming(isEdit = true)
-
-        val isAgentContinue = _uiState.value.selectedEndpoint == EndpointConstants.AGENTS
-        val webSearchEnabled = _uiState.value.modelParameters.webSearch
-        val ephemeralAgent = buildEphemeralAgent()
-        Logger.d { "continueGeneration: webSearch=$webSearchEnabled, ephemeralAgent=$ephemeralAgent" }
-        val dispatch = currentDispatch()
-        streamingManager.launchStream(
-            chatRepository.startChat(
-                text = parentUserMessage.text,
-                conversationId = _uiState.value.conversationId,
-                endpoint = _uiState.value.selectedEndpoint,
-                endpointType = dispatch.endpointType,
-                key = dispatch.key,
-                modelDisplayLabel = dispatch.modelDisplayLabel,
-                model = _uiState.value.selectedModel,
-                parentMessageId = parentUserMessage.parentMessageId,
-                agentId = if (isAgentContinue) _uiState.value.selectedModel else null,
-                overrideParentMessageId = parentUserMessage.messageId,
-                responseMessageId = lastAiMessage.messageId,
-                isEdited = true,
-                isRegenerate = true,
-                isContinued = true,
-                webSearch = webSearchEnabled,
-                ephemeralAgent = ephemeralAgent,
-                isTemporary = _uiState.value.isTemporaryChat,
-            ),
-        )
-    }
+    fun continueGeneration() = editingDelegate.continueGeneration()
 
     fun onPause() = streamingManager.onPause()
 
@@ -941,41 +719,15 @@ class ChatViewModel(
         }
     }
 
-    fun startEditing(messageId: String) {
-        val text = getMessageText(messageId)
-        _uiState.update {
-            it.copy(editingMessageId = messageId, editingText = text)
-        }
-    }
+    fun startEditing(messageId: String) = editingDelegate.startEditing(messageId)
 
-    fun onEditTextChanged(text: String) {
-        _uiState.update { it.copy(editingText = text) }
-    }
+    fun onEditTextChanged(text: String) = editingDelegate.onEditTextChanged(text)
 
-    fun cancelEditing() {
-        _uiState.update { it.copy(editingMessageId = null, editingText = "") }
-    }
+    fun cancelEditing() = editingDelegate.cancelEditing()
 
-    fun submitEdit() {
-        val messageId = _uiState.value.editingMessageId ?: return
-        val newText = _uiState.value.editingText.trim()
-        if (newText.isBlank()) return
+    fun submitEdit() = editingDelegate.submitEdit()
 
-        _uiState.update { it.copy(editingMessageId = null, editingText = "") }
-        editMessage(messageId, newText)
-    }
-
-    fun saveEditOnly() {
-        val messageId = _uiState.value.editingMessageId ?: return
-        val conversationId = _uiState.value.conversationId ?: return
-        val newText = _uiState.value.editingText.trim()
-        if (newText.isBlank()) return
-
-        _uiState.update { it.copy(editingMessageId = null, editingText = "") }
-        viewModelScope.launch {
-            messageRepository.updateMessageText(conversationId, messageId, newText)
-        }
-    }
+    fun saveEditOnly() = editingDelegate.saveEditOnly()
 
     fun onPendingNavigationHandled() {
         streamingManager.reset()

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModel.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModel.kt
@@ -54,11 +54,11 @@ import com.garfiec.librechat.feature.chat.model.PromptMentionDisplayData
 import com.garfiec.librechat.feature.chat.util.NEW_CHAT_DRAFT_KEY
 import com.garfiec.librechat.feature.chat.util.buildActiveMessagePath
 import com.garfiec.librechat.feature.chat.util.extractBranchMedia
-import com.garfiec.librechat.feature.chat.util.mergeFinalMessagesInMemory
 import com.garfiec.librechat.feature.chat.viewmodel.delegate.ConversationActionsDelegate
 import com.garfiec.librechat.feature.chat.viewmodel.delegate.EndpointKeyStatusDelegate
 import com.garfiec.librechat.feature.chat.viewmodel.delegate.FavoritesDelegate
 import com.garfiec.librechat.feature.chat.viewmodel.delegate.InConversationSearchDelegate
+import com.garfiec.librechat.feature.chat.viewmodel.delegate.MessageTreeDelegate
 import com.garfiec.librechat.feature.chat.viewmodel.delegate.ModelSelectionDelegate
 import com.garfiec.librechat.feature.chat.viewmodel.delegate.OfficePreviewDelegate
 import com.garfiec.librechat.feature.chat.viewmodel.delegate.PlatformDelegateFactory
@@ -142,6 +142,7 @@ class ChatViewModel(
     private val shareConsumer = platformDelegateFactory.createShareConsumer()
 
     // --- Delegates ---
+    private val treeDelegate = MessageTreeDelegate(stateHandle)
     private val searchDelegate = InConversationSearchDelegate(stateHandle)
     private val conversationActionsDelegate =
         ConversationActionsDelegate(stateHandle, conversationRepository, shareRepository)
@@ -584,23 +585,8 @@ class ChatViewModel(
         }
     }
 
-    fun switchBranch(parentMessageId: String, siblingIndex: Int) {
-        // Ignore branch switches mid-stream: the in-flight reply's path is truncated at
-        // its parent (see anchorStreamTo / buildActiveMessagePath's streamingLeafId), and
-        // mutating activeBranches re-triggers loadConversation's combine, which rebuilds
-        // displayMessages WITHOUT the leaf — un-truncating the path and dropping the
-        // streaming reply back to the end. editMessage/regenerateMessage are likewise
-        // gated on isStreaming; this closes the same gap for sibling navigation.
-        if (_uiState.value.isStreaming) return
-        // Only mutate the branch selection; the observeMessages/activeBranches combine in
-        // loadConversation recomputes displayMessages off the Main thread in response, so the
-        // tree walk no longer runs synchronously on this UI click path.
-        _uiState.update {
-            val newBranches = it.activeBranches.toMutableMap()
-            newBranches[parentMessageId] = siblingIndex
-            it.copy(activeBranches = newBranches)
-        }
-    }
+    fun switchBranch(parentMessageId: String, siblingIndex: Int) =
+        treeDelegate.switchBranch(parentMessageId, siblingIndex)
 
     fun onInputChanged(text: String) {
         _uiState.update { it.copy(inputText = text) }
@@ -835,29 +821,6 @@ class ChatViewModel(
     }
 
     /**
-     * Rebuilds the active path truncated at [parentMessageId] — the message the
-     * in-flight reply attaches to — so the streaming bubble renders in place
-     * (replacing the stale branch for edit/regenerate) rather than being appended
-     * after it. Used by the paths that reuse an existing message as the parent
-     * (regenerate, edit-AI); the optimistic-message paths (send, edit-user) pass the
-     * same leaf to [buildActiveMessagePath] inline alongside their message insert.
-     *
-     * The full tree stays in `messages` and the DB, so the old branch remains
-     * reachable via sibling navigation, and loadConversation() rebuilds the real
-     * path on Final. This truncated displayMessages then simply persists in state
-     * for the duration of the stream: safe because no streaming entry point writes
-     * to Room mid-stream and none mutate activeBranches, so the Room observer never
-     * re-emits to rebuild (and un-truncate) the path before the stream completes.
-     */
-    private fun anchorStreamTo(parentMessageId: String) {
-        _uiState.update {
-            it.copy(
-                displayMessages = buildActiveMessagePath(it.messages, it.activeBranches, parentMessageId),
-            )
-        }
-    }
-
-    /**
      * Launches a periodic coroutine that flushes the [streamingBuffer] to UI state
      * at most every [STREAMING_UI_UPDATE_INTERVAL_MS] ms. This avoids recomposition spam
      * from high-frequency SSE chunks (each chunk would otherwise trigger a full state copy).
@@ -982,7 +945,7 @@ class ChatViewModel(
         // the old one. The web client seeds the placeholder with the edited content
         // for a transient preview; we don't (the regenerated server response is
         // authoritative on Final either way).
-        anchorStreamTo(parentUserMessage.messageId)
+        treeDelegate.anchorStreamTo(parentUserMessage.messageId)
         prepareForStreaming()
 
         val isAgent = _uiState.value.selectedEndpoint == EndpointConstants.AGENTS
@@ -1029,7 +992,7 @@ class ChatViewModel(
 
     private fun regenerateMessageNow(parentUserMessage: Message) {
         isEditOrRegenerate = true
-        anchorStreamTo(parentUserMessage.messageId)
+        treeDelegate.anchorStreamTo(parentUserMessage.messageId)
         prepareForStreaming()
 
         val isAgentRegen = _uiState.value.selectedEndpoint == EndpointConstants.AGENTS
@@ -1466,7 +1429,7 @@ class ChatViewModel(
                 // read-through (which would upsert the message rows to disk). Drive the
                 // display from the final event in memory instead. Title generation is
                 // also skipped server-side for temp chats, so there's nothing to refresh.
-                finalizeTemporaryChatDisplay(event)
+                treeDelegate.finalizeTemporaryChatDisplay(event)
             } else {
                 loadConversation(conversationId)
                 val shouldGenerate = shouldRequestTitleGeneration(
@@ -1485,29 +1448,6 @@ class ChatViewModel(
         }
         if (shouldAutoRead && completedResponseText.isNotBlank()) {
             ttsDelegate.maybeAutoReadResponse(completedResponseText)
-        }
-    }
-
-    /**
-     * Finalizes a temporary chat's display purely in memory, WITHOUT persisting to
-     * Room. For a normal chat, [handleFinal] calls [loadConversation], which routes
-     * through [MessageRepository.getMessages]'s read-through cache and upserts the
-     * message rows to disk — for a temp chat that would leave the message content on
-     * disk forever even though the conversation never appears in history. Instead we
-     * merge the final request/response messages from the SSE event into the existing
-     * in-memory list (replacing the optimistic user message by id) and recompute the
-     * display path. Nothing touches the DB.
-     */
-    private fun finalizeTemporaryChatDisplay(event: StreamEvent.Final) {
-        val finalMessages = listOfNotNull(event.requestMessage, event.responseMessage ?: event.message)
-        if (finalMessages.isEmpty()) return
-        _uiState.update { state ->
-            val mergedMessages = mergeFinalMessagesInMemory(state.messages, finalMessages)
-            state.copy(
-                messages = mergedMessages,
-                displayMessages = buildActiveMessagePath(mergedMessages, state.activeBranches),
-                screenState = ChatScreenState.ACTIVE,
-            )
         }
     }
 
@@ -1802,13 +1742,7 @@ class ChatViewModel(
         streamingBuffer.clear()
     }
 
-    fun toggleTemporaryChat() {
-        // Only togglable before the conversation exists. Once a temporary chat is
-        // active the toggle is a read-only indicator — the server already created
-        // it temporary, so flipping it off here would be misleading.
-        if (_uiState.value.conversationId != null) return
-        _uiState.update { it.copy(isTemporaryChat = !it.isTemporaryChat) }
-    }
+    fun toggleTemporaryChat() = treeDelegate.toggleTemporaryChat()
 
     fun refreshMessages() {
         val conversationId = _uiState.value.conversationId ?: return

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModel.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModel.kt
@@ -54,6 +54,7 @@ import com.garfiec.librechat.feature.chat.model.PromptMentionDisplayData
 import com.garfiec.librechat.feature.chat.util.NEW_CHAT_DRAFT_KEY
 import com.garfiec.librechat.feature.chat.util.buildActiveMessagePath
 import com.garfiec.librechat.feature.chat.util.extractBranchMedia
+import com.garfiec.librechat.feature.chat.viewmodel.delegate.ComparisonModeDelegate
 import com.garfiec.librechat.feature.chat.viewmodel.delegate.ConversationActionsDelegate
 import com.garfiec.librechat.feature.chat.viewmodel.delegate.EndpointKeyStatusDelegate
 import com.garfiec.librechat.feature.chat.viewmodel.delegate.FavoritesDelegate
@@ -143,6 +144,11 @@ class ChatViewModel(
 
     // --- Delegates ---
     private val treeDelegate = MessageTreeDelegate(stateHandle)
+    private val comparisonDelegate = ComparisonModeDelegate(
+        stateHandle = stateHandle,
+        messageRepository = messageRepository,
+        reloadConversation = ::loadConversation,
+    )
     private val searchDelegate = InConversationSearchDelegate(stateHandle)
     private val conversationActionsDelegate =
         ConversationActionsDelegate(stateHandle, conversationRepository, shareRepository)
@@ -739,34 +745,11 @@ class ChatViewModel(
         // swapping is needed. Just keep the primary's original endpoint.
         val effectiveEndpoint = _uiState.value.selectedEndpoint
         val effectiveAgentId = if (isAgent) _uiState.value.selectedModel else null
-        val isComparisonEnabled = _uiState.value.comparisonState.isEnabled
-        if (isComparisonEnabled) {
-            modelDelegate.primaryComparisonBuffer.clear()
-            modelDelegate.secondaryComparisonBuffer.clear()
-            _uiState.update {
-                it.copy(comparisonState = it.comparisonState.copy(
-                    primaryIsStreaming = true,
-                    secondaryIsStreaming = true,
-                    primaryStreamingContent = "",
-                    secondaryStreamingContent = "",
-                    primaryActiveToolCalls = emptyList(),
-                    secondaryActiveToolCalls = emptyList(),
-                    primaryAgentId = null,
-                    secondaryAgentId = null,
-                    parallelMessageId = null,
-                    primaryFinalContent = null,
-                    secondaryFinalContent = null,
-                ))
-            }
-        }
+        comparisonDelegate.onSendStart()
 
         streamJob?.cancel()
         streamJob = viewModelScope.launch {
-            val effectiveAddedConvo = if (isComparisonEnabled) {
-                modelDelegate.buildAddedConvo(parentMessageId = lastMessageId)
-            } else {
-                null
-            }
+            val effectiveAddedConvo = comparisonDelegate.buildAddedConvo(parentMessageId = lastMessageId)
             val dispatch = currentDispatch()
             collectStreamSafely(
                 chatRepository.startChat(
@@ -1051,14 +1034,9 @@ class ChatViewModel(
                     activeToolCalls = emptyList(),
                     streamingAttachments = emptyList(),
                     error = e.message ?: "Chat request failed",
-                    comparisonState = it.comparisonState.copy(
-                        primaryIsStreaming = false,
-                        secondaryIsStreaming = false,
-                        primaryActiveToolCalls = emptyList(),
-                        secondaryActiveToolCalls = emptyList(),
-                    ),
                 )
             }
+            comparisonDelegate.endStreaming()
             // If the server already created a conversation, fetch whatever it persisted
             val conversationId = _uiState.value.conversationId
             if (conversationId != null) {
@@ -1068,63 +1046,18 @@ class ChatViewModel(
     }
 
     private fun handleStreamEvent(event: StreamEvent) {
+        // In comparison mode the delegate fans streaming deltas/tool-calls into the dual
+        // panes; if it consumed the event, skip the single-stream handling below.
+        if (comparisonDelegate.routeEvent(event)) return
         when (event) {
             is StreamEvent.Created -> handleCreated(event)
             is StreamEvent.ContentDelta -> {
-                val isComparison = _uiState.value.comparisonState.isEnabled
-                if (isComparison && modelDelegate.isSecondaryEvent(event.agentId)) {
-                    modelDelegate.secondaryComparisonBuffer.append(event.chunk)
-                    _uiState.update {
-                        it.copy(comparisonState = it.comparisonState.copy(
-                            secondaryStreamingContent = modelDelegate.secondaryComparisonBuffer.toString(),
-                            secondaryIsStreaming = true,
-                            secondaryAgentId = it.comparisonState.secondaryAgentId ?: event.agentId,
-                        ))
-                    }
-                } else if (isComparison) {
-                    modelDelegate.primaryComparisonBuffer.append(event.chunk)
-                    _uiState.update {
-                        it.copy(
-                            comparisonState = it.comparisonState.copy(
-                                primaryStreamingContent = modelDelegate.primaryComparisonBuffer.toString(),
-                                primaryIsStreaming = true,
-                                primaryAgentId = it.comparisonState.primaryAgentId ?: event.agentId,
-                            ),
-                            streamingContent = modelDelegate.primaryComparisonBuffer.toString(),
-                        )
-                    }
-                } else {
-                    streamingBuffer.append(event.chunk)
-                    streamingBufferDirty = true
-                }
+                streamingBuffer.append(event.chunk)
+                streamingBufferDirty = true
             }
             is StreamEvent.ThinkingDelta -> {
-                val isComparison = _uiState.value.comparisonState.isEnabled
-                if (isComparison && modelDelegate.isSecondaryEvent(event.agentId)) {
-                    modelDelegate.secondaryComparisonBuffer.append(event.chunk)
-                    _uiState.update {
-                        it.copy(comparisonState = it.comparisonState.copy(
-                            secondaryStreamingContent = modelDelegate.secondaryComparisonBuffer.toString(),
-                            secondaryIsStreaming = true,
-                            secondaryAgentId = it.comparisonState.secondaryAgentId ?: event.agentId,
-                        ))
-                    }
-                } else if (isComparison) {
-                    modelDelegate.primaryComparisonBuffer.append(event.chunk)
-                    _uiState.update {
-                        it.copy(
-                            comparisonState = it.comparisonState.copy(
-                                primaryStreamingContent = modelDelegate.primaryComparisonBuffer.toString(),
-                                primaryIsStreaming = true,
-                                primaryAgentId = it.comparisonState.primaryAgentId ?: event.agentId,
-                            ),
-                            streamingContent = modelDelegate.primaryComparisonBuffer.toString(),
-                        )
-                    }
-                } else {
-                    streamingBuffer.append(event.chunk)
-                    streamingBufferDirty = true
-                }
+                streamingBuffer.append(event.chunk)
+                streamingBufferDirty = true
             }
             is StreamEvent.Final -> handleFinal(event)
             is StreamEvent.Error -> {
@@ -1149,14 +1082,9 @@ class ChatViewModel(
                         retryInfo = null,
                         activeToolCalls = emptyList(),
                         streamingAttachments = emptyList(),
-                        comparisonState = it.comparisonState.copy(
-                            primaryIsStreaming = false,
-                            secondaryIsStreaming = false,
-                            primaryActiveToolCalls = emptyList(),
-                            secondaryActiveToolCalls = emptyList(),
-                        ),
                     )
                 }
+                comparisonDelegate.endStreaming()
                 if (keyError != null) {
                     _userKeyErrors.trySend(keyError)
                 }
@@ -1182,56 +1110,24 @@ class ChatViewModel(
                     name = event.toolName,
                     input = event.input,
                 )
-                val isComparison = _uiState.value.comparisonState.isEnabled
-                if (isComparison && modelDelegate.isSecondaryEvent(event.agentId)) {
-                    _uiState.update {
-                        it.copy(comparisonState = it.comparisonState.copy(
-                            secondaryActiveToolCalls = it.comparisonState.secondaryActiveToolCalls + newToolCall,
-                        ))
-                    }
-                } else if (isComparison) {
-                    _uiState.update {
-                        it.copy(comparisonState = it.comparisonState.copy(
-                            primaryActiveToolCalls = it.comparisonState.primaryActiveToolCalls + newToolCall,
-                        ))
-                    }
-                } else {
-                    _uiState.update {
-                        it.copy(activeToolCalls = it.activeToolCalls + newToolCall)
-                    }
+                _uiState.update {
+                    it.copy(activeToolCalls = it.activeToolCalls + newToolCall)
                 }
             }
             is StreamEvent.ToolCallComplete -> {
-                val isComparison = _uiState.value.comparisonState.isEnabled
-                if (isComparison && modelDelegate.isSecondaryEvent(event.agentId)) {
-                    _uiState.update { state ->
-                        val updated = state.comparisonState.secondaryActiveToolCalls.map { tc ->
-                            if (tc.id == event.toolCallId) tc.copy(isComplete = true, output = event.output) else tc
+                _uiState.update { state ->
+                    val updated = state.activeToolCalls.map { tc ->
+                        if (tc.id == event.toolCallId) {
+                            tc.copy(isComplete = true, output = event.output)
+                        } else {
+                            tc
                         }
-                        state.copy(comparisonState = state.comparisonState.copy(secondaryActiveToolCalls = updated))
                     }
-                } else if (isComparison) {
-                    _uiState.update { state ->
-                        val updated = state.comparisonState.primaryActiveToolCalls.map { tc ->
-                            if (tc.id == event.toolCallId) tc.copy(isComplete = true, output = event.output) else tc
-                        }
-                        state.copy(comparisonState = state.comparisonState.copy(primaryActiveToolCalls = updated))
-                    }
-                } else {
-                    _uiState.update { state ->
-                        val updated = state.activeToolCalls.map { tc ->
-                            if (tc.id == event.toolCallId) {
-                                tc.copy(isComplete = true, output = event.output)
-                            } else {
-                                tc
-                            }
-                        }
-                        state.copy(activeToolCalls = updated)
-                    }
-                    // If this was a `subagent` tool_call, freeze its live trace —
-                    // the child run is done; stop accumulating for that key.
-                    subagentTraceDelegate.onParentToolCallResolved(event.toolCallId)
+                    state.copy(activeToolCalls = updated)
                 }
+                // If this was a `subagent` tool_call, freeze its live trace —
+                // the child run is done; stop accumulating for that key.
+                subagentTraceDelegate.onParentToolCallResolved(event.toolCallId)
             }
             is StreamEvent.AttachmentCreated -> {
                 val attachment = Attachment(
@@ -1360,45 +1256,23 @@ class ChatViewModel(
         val conversationId = _uiState.value.conversationId
             ?: event.conversation?.conversationId
         val completedResponseText = if (isComparison) {
-            modelDelegate.primaryComparisonBuffer.toString()
+            comparisonDelegate.primaryContent()
         } else {
             streamingBuffer.toString()
         }
         val shouldAutoRead = !isEditOrRegenerate
+        // Clear the single-stream UI fields; comparison panes are finalized via the delegate.
+        _uiState.update {
+            it.copy(
+                isStreaming = false,
+                streamingContent = "",
+                activeToolCalls = emptyList(),
+                streamingAttachments = emptyList(),
+                conversationId = conversationId ?: it.conversationId,
+            )
+        }
         if (isComparison) {
-            val responseMessage = event.responseMessage ?: event.message
-            val primaryContent = modelDelegate.primaryComparisonBuffer.toString()
-            val secondaryContent = modelDelegate.secondaryComparisonBuffer.toString()
-            _uiState.update {
-                it.copy(
-                    isStreaming = false,
-                    streamingContent = "",
-                    activeToolCalls = emptyList(),
-                    streamingAttachments = emptyList(),
-                    conversationId = conversationId ?: it.conversationId,
-                    comparisonState = it.comparisonState.copy(
-                        primaryIsStreaming = false,
-                        secondaryIsStreaming = false,
-                        primaryStreamingContent = "",
-                        secondaryStreamingContent = "",
-                        primaryActiveToolCalls = emptyList(),
-                        secondaryActiveToolCalls = emptyList(),
-                        parallelMessageId = responseMessage?.messageId,
-                        primaryFinalContent = primaryContent,
-                        secondaryFinalContent = secondaryContent,
-                    ),
-                )
-            }
-        } else {
-            _uiState.update {
-                it.copy(
-                    isStreaming = false,
-                    streamingContent = "",
-                    activeToolCalls = emptyList(),
-                    streamingAttachments = emptyList(),
-                    conversationId = conversationId ?: it.conversationId,
-                )
-            }
+            comparisonDelegate.onFinal((event.responseMessage ?: event.message)?.messageId)
         }
         val finalConversation = event.conversation
         // Belt-and-braces: if no handoff seeded the selection and the initial GET 404'd
@@ -1462,27 +1336,15 @@ class ChatViewModel(
             if (abortResult is Result.Error) {
                 Logger.w(abortResult.exception) { "Failed to abort chat: ${abortResult.message}" }
             }
-            // Clean up comparison state if active
             _uiState.update {
                 it.copy(
                     isStreaming = false,
                     streamingContent = "",
                     activeToolCalls = emptyList(),
                     streamingAttachments = emptyList(),
-                    comparisonState = if (it.comparisonState.isEnabled) {
-                        it.comparisonState.copy(
-                            primaryIsStreaming = false,
-                            secondaryIsStreaming = false,
-                            primaryStreamingContent = "",
-                            secondaryStreamingContent = "",
-                            primaryActiveToolCalls = emptyList(),
-                            secondaryActiveToolCalls = emptyList(),
-                        )
-                    } else {
-                        it.comparisonState
-                    },
                 )
             }
+            comparisonDelegate.endStreaming(clearContent = true)
             // Refresh messages from server so the message tree reflects
             // the partially-streamed response that was aborted.
             loadConversation(conversationId)
@@ -2044,42 +1906,14 @@ class ChatViewModel(
 
     // Model selection and comparison
     fun onModelSelected(endpoint: String, model: String) = modelDelegate.onModelSelected(endpoint, model)
-    fun toggleComparison() = modelDelegate.toggleComparison()
-    fun setSecondaryModel(endpoint: String, model: String) = modelDelegate.setSecondaryModel(endpoint, model)
-    fun getSecondaryModelDisplayName(): String? = modelDelegate.getSecondaryModelDisplayName()
+    fun toggleComparison() = comparisonDelegate.toggleComparison()
+    fun setSecondaryModel(endpoint: String, model: String) = comparisonDelegate.setSecondaryModel(endpoint, model)
+    fun getSecondaryModelDisplayName(): String? = comparisonDelegate.getSecondaryModelDisplayName()
     fun toggleMcpServer(serverName: String) = modelDelegate.toggleMcpServer(serverName)
     fun toggleTool(toolName: String) = modelDelegate.toggleTool(toolName)
     fun showModelParameters() = modelDelegate.showModelParameters()
     fun hideModelParameters() = modelDelegate.hideModelParameters()
     fun updateModelParameters(parameters: ModelParameters) = modelDelegate.updateModelParameters(parameters)
 
-    fun branchFromComparison(agentId: String) {
-        val messageId = _uiState.value.comparisonState.parallelMessageId ?: return
-        val conversationId = _uiState.value.conversationId ?: return
-        viewModelScope.launch {
-            try {
-                messageRepository.branchMessage(
-                    conversationId = conversationId,
-                    messageId = messageId,
-                    agentId = agentId,
-                )
-                // Disable comparison and continue with the branched response
-                _uiState.update {
-                    it.copy(comparisonState = ComparisonState())
-                }
-                // Trigger deferred navigation for new chats that skipped navigation during comparison
-                val cid = _uiState.value.conversationId
-                if (cid != null && _uiState.value.pendingNavigationConversationId == null) {
-                    _uiState.update { it.copy(pendingNavigationConversationId = cid) }
-                }
-                // Refresh messages to show the branched message
-                loadConversation(conversationId)
-            } catch (e: Exception) {
-                Logger.e(e) { "Failed to branch comparison message" }
-                _uiState.update {
-                    it.copy(error = "Failed to continue with selected response")
-                }
-            }
-        }
-    }
+    fun branchFromComparison(agentId: String) = comparisonDelegate.branchFromComparison(agentId)
 }

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModel.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModel.kt
@@ -32,7 +32,6 @@ import com.garfiec.librechat.core.data.util.PermissionGate
 import com.garfiec.librechat.core.logging.Diag
 import com.garfiec.librechat.core.logging.LogOrigin
 import com.garfiec.librechat.core.model.Attachment
-import com.garfiec.librechat.core.model.Conversation
 import com.garfiec.librechat.core.model.Message
 import com.garfiec.librechat.core.model.Preset
 import com.garfiec.librechat.core.model.StreamEvent
@@ -64,6 +63,7 @@ import com.garfiec.librechat.feature.chat.viewmodel.delegate.ModelSelectionDeleg
 import com.garfiec.librechat.feature.chat.viewmodel.delegate.OfficePreviewDelegate
 import com.garfiec.librechat.feature.chat.viewmodel.delegate.PlatformDelegateFactory
 import com.garfiec.librechat.feature.chat.viewmodel.delegate.PresetPromptDelegate
+import com.garfiec.librechat.feature.chat.viewmodel.delegate.SendCompletionDelegate
 import com.garfiec.librechat.feature.chat.viewmodel.delegate.SubagentTraceDelegate
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
@@ -169,6 +169,16 @@ class ChatViewModel(
     )
     private val subagentTraceDelegate = SubagentTraceDelegate(stateHandle, json)
     private val officePreviewDelegate = OfficePreviewDelegate(stateHandle, fileRepository)
+    private val completionDelegate = SendCompletionDelegate(
+        stateHandle = stateHandle,
+        conversationRepository = conversationRepository,
+        draftRepository = draftRepository,
+        modelDelegate = modelDelegate,
+        treeDelegate = treeDelegate,
+        tts = ttsDelegate,
+        selectionHandoff = selectionHandoff,
+        reloadConversation = ::loadConversation,
+    )
 
     // --- Delegate-owned flows exposed to the UI ---
     val attachedFiles: StateFlow<List<AttachedFile>> get() = fileDelegate.attachedFiles
@@ -285,9 +295,6 @@ class ChatViewModel(
      * (title generation) running for the handed-off chat.
      */
     private val isHandedOffNewChat: Boolean
-
-    /** Guard to ensure we only attempt title generation once per conversation. */
-    private var titleGenerationRequested = false
 
     init {
         val conversationId = initialConversationId
@@ -512,7 +519,7 @@ class ChatViewModel(
             val conversation = result.getOrNull()
             if (conversation != null) {
                 _uiState.update { it.copy(conversationTitle = conversation.title) }
-                val applied = applyConversationModel(conversation)
+                val applied = modelDelegate.applyConversationModel(conversation)
                 Diag.d(
                     tag = "ModelSel",
                     attrs = mapOf(
@@ -535,59 +542,6 @@ class ChatViewModel(
             }
             modelDelegate.conversationModelLoaded = true
             modelDelegate.refilterModels(isNewConversation)
-        }
-    }
-
-    /**
-     * Resolves a loaded [conversation]'s authoritative (endpoint, model) and applies it as
-     * the active selection via [ModelSelectionDelegate.applyResolvedConversationModel].
-     * Agents conversations carry the agent in `agentId`, so prefer that over `model` for the
-     * AGENTS endpoint. Returns true when a concrete selection was applied (i.e. the
-     * conversation model is now resolved), false when the conversation lacked enough info.
-     */
-    private fun applyConversationModel(conversation: Conversation): Boolean {
-        val endpoint = conversation.endpoint
-        val isAgentConversation = endpoint == EndpointConstants.AGENTS
-        val resolvedModel = if (isAgentConversation) {
-            conversation.agentId ?: conversation.model
-        } else {
-            conversation.model
-        }
-        if (endpoint != null && resolvedModel != null) {
-            modelDelegate.applyResolvedConversationModel(endpoint, resolvedModel)
-            return true
-        }
-        return false
-    }
-
-    private fun refreshConversationTitle(conversationId: String) {
-        viewModelScope.launch {
-            val result = conversationRepository.getConversation(conversationId)
-            val conversation = result.getOrNull() ?: return@launch
-            _uiState.update { it.copy(conversationTitle = conversation.title) }
-        }
-    }
-
-    private fun generateAndSetTitle(conversationId: String) {
-        viewModelScope.launch {
-            when (val result = conversationRepository.generateTitle(conversationId)) {
-                is Result.Success -> {
-                    _uiState.update { it.copy(conversationTitle = result.data) }
-                }
-                is Result.Error -> {
-                    Logger.d { "Title generation failed for $conversationId: ${result.message}" }
-                    // The gen_title long-poll can miss even though the server generated and
-                    // persisted a title (404 after its backoff window, or another client
-                    // consumed the one-shot cache). Fetch network-first: the cached row
-                    // still holds the "New Chat" placeholder, so cache-first getConversation
-                    // could never observe the title, and refreshConversation's upsert also
-                    // propagates it to the Room-observing conversation list.
-                    conversationRepository.refreshConversation(conversationId).getOrNull()?.let { conversation ->
-                        _uiState.update { it.copy(conversationTitle = conversation.title) }
-                    }
-                }
-                is Result.Loading -> { /* no-op */ }
-            }
         }
     }
 
@@ -1204,15 +1158,6 @@ class ChatViewModel(
     }
 
     private fun handleCreated(event: StreamEvent.Created) {
-        if (isNewConversation) {
-            viewModelScope.launch {
-                val existingDraft = draftRepository.getDraft(NEW_CHAT_DRAFT_KEY)
-                if (existingDraft != null) {
-                    draftRepository.saveDraft(event.conversationId, existingDraft)
-                    draftRepository.deleteDraft(NEW_CHAT_DRAFT_KEY)
-                }
-            }
-        }
         if (lastErrorWasNetwork) {
             lastErrorWasNetwork = false
             cancelConnectivityObserver()
@@ -1224,26 +1169,7 @@ class ChatViewModel(
                 it.copy(conversationId = event.conversationId)
             }
         }
-        if (isNewConversation) {
-            // Stage the selection we actually sent so the about-to-be-created Chat(id) VM can
-            // apply it directly instead of re-deriving it from a GET that races the server's
-            // unawaited conversation save. Keyed by id, so a deferred nav (comparison-mode
-            // branch) still picks it up. See NewChatSelectionHandoff.
-            val sent = _uiState.value
-            selectionHandoff.put(event.conversationId, sent.selectedEndpoint, sent.selectedModel)
-            _uiState.update {
-                if (it.pendingNavigationConversationId == null && !it.comparisonState.isEnabled) {
-                    it.copy(pendingNavigationConversationId = event.conversationId)
-                } else {
-                    it
-                }
-            }
-        }
-        // Eagerly fetch and cache the conversation the server just created,
-        // so it appears in the conversation list even if the stream fails later
-        viewModelScope.launch {
-            conversationRepository.getConversation(event.conversationId)
-        }
+        completionDelegate.onConversationCreated(event.conversationId, isNewConversation)
     }
 
     private fun handleFinal(event: StreamEvent.Final) {
@@ -1274,55 +1200,14 @@ class ChatViewModel(
         if (isComparison) {
             comparisonDelegate.onFinal((event.responseMessage ?: event.message)?.messageId)
         }
-        val finalConversation = event.conversation
-        // Belt-and-braces: if no handoff seeded the selection and the initial GET 404'd
-        // against the created-before-save race, the conversation model is still unresolved.
-        // The Final event carries the authoritative conversation, so re-derive from it here
-        // rather than leaving a fallback guess on screen.
-        if (!modelDelegate.conversationModelResolved && finalConversation != null) {
-            val applied = applyConversationModel(finalConversation)
-            Diag.i(
-                tag = "ModelSel",
-                attrs = mapOf("applied" to applied.toString()),
-            ) { "handleFinal re-derived conversation model" }
-        }
-        // SECURITY: do not remove — temp-chat data-at-rest guard.
-        // Temporary chats (v0.8.6) are kept out of normal history — the server excludes
-        // them from the conversation list, so don't cache them to Room either (it would
-        // leak a temp chat into the local list the server hides).
-        val isTemporary = _uiState.value.isTemporaryChat || finalConversation?.isTemporary == true
-        if (finalConversation?.conversationId != null && !isTemporary) {
-            viewModelScope.launch {
-                conversationRepository.saveConversation(finalConversation)
-            }
-        }
-        if (conversationId != null) {
-            if (isTemporary) {
-                // SECURITY: do not remove — temp-chat data-at-rest guard.
-                // Temp chats are never persisted: don't round-trip through the Room
-                // read-through (which would upsert the message rows to disk). Drive the
-                // display from the final event in memory instead. Title generation is
-                // also skipped server-side for temp chats, so there's nothing to refresh.
-                treeDelegate.finalizeTemporaryChatDisplay(event)
-            } else {
-                loadConversation(conversationId)
-                val shouldGenerate = shouldRequestTitleGeneration(
-                    isNewConversation = isNewConversation,
-                    isHandedOffNewChat = isHandedOffNewChat,
-                    currentTitle = _uiState.value.conversationTitle,
-                    alreadyRequested = titleGenerationRequested,
-                )
-                if (shouldGenerate) {
-                    titleGenerationRequested = true
-                    generateAndSetTitle(conversationId)
-                } else {
-                    refreshConversationTitle(conversationId)
-                }
-            }
-        }
-        if (shouldAutoRead && completedResponseText.isNotBlank()) {
-            ttsDelegate.maybeAutoReadResponse(completedResponseText)
-        }
+        completionDelegate.onFinal(
+            event = event,
+            conversationId = conversationId,
+            completedResponseText = completedResponseText,
+            shouldAutoRead = shouldAutoRead,
+            isNewConversation = isNewConversation,
+            isHandedOffNewChat = isHandedOffNewChat,
+        )
     }
 
     fun stopGeneration() {

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/ComparisonModeDelegate.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/ComparisonModeDelegate.kt
@@ -1,0 +1,317 @@
+package com.garfiec.librechat.feature.chat.viewmodel.delegate
+
+import co.touchlab.kermit.Logger
+import com.garfiec.librechat.core.common.EndpointConstants
+import com.garfiec.librechat.core.data.repository.MessageRepository
+import com.garfiec.librechat.core.model.StreamEvent
+import com.garfiec.librechat.core.model.request.AddedConversation
+import com.garfiec.librechat.feature.chat.viewmodel.ActiveToolCall
+import com.garfiec.librechat.feature.chat.viewmodel.ChatScreenState
+import com.garfiec.librechat.feature.chat.viewmodel.ChatStateHandle
+import com.garfiec.librechat.feature.chat.viewmodel.ComparisonState
+import com.garfiec.librechat.feature.chat.viewmodel.resolveEndpointDispatch
+import kotlinx.coroutines.launch
+
+/**
+ * Owns model-comparison mode end to end: selecting the secondary model, building its
+ * [AddedConversation] request, and routing the dual SSE streams into the primary/secondary
+ * panes of [ComparisonState]. Keeps the comparison's 3-way streaming fan-out out of
+ * `ChatViewModel.handleStreamEvent` — callers funnel streaming events through [routeEvent],
+ * which returns `true` once it has consumed an event for comparison mode.
+ *
+ * The two [StringBuilder] buffers accumulate each pane's text independently because the
+ * server interleaves both agents' deltas on one stream (distinguished via [isSecondaryEvent]).
+ */
+class ComparisonModeDelegate(
+    private val stateHandle: ChatStateHandle,
+    private val messageRepository: MessageRepository,
+    /** Reloads the conversation from the server after branching (VM-owned Room observer). */
+    private val reloadConversation: (String) -> Unit,
+) {
+
+    private val primaryBuffer = StringBuilder()
+    private val secondaryBuffer = StringBuilder()
+
+    /** Accumulated primary-pane text — used as the auto-read source on Final. */
+    fun primaryContent(): String = primaryBuffer.toString()
+
+    // ── Selection ────────────────────────────────────────────────────
+
+    /** Toggles comparison mode on/off, inheriting the primary endpoint/model when enabling. */
+    fun toggleComparison() {
+        val current = stateHandle.state.comparisonState
+        if (current.isEnabled) {
+            primaryBuffer.clear()
+            secondaryBuffer.clear()
+            stateHandle.update { copy(comparisonState = ComparisonState()) }
+        } else {
+            stateHandle.update {
+                copy(
+                    comparisonState = ComparisonState(
+                        isEnabled = true,
+                        secondaryEndpoint = selectedEndpoint,
+                        secondaryModel = selectedModel,
+                    ),
+                    // When enabling on LANDING, switch to ACTIVE so comparison tabs render
+                    screenState = if (screenState == ChatScreenState.LANDING) ChatScreenState.ACTIVE else screenState,
+                )
+            }
+        }
+    }
+
+    /** Updates the secondary model selection for comparison mode. */
+    fun setSecondaryModel(endpoint: String, model: String) {
+        val comparison = stateHandle.state.comparisonState
+        if (!comparison.isEnabled) return
+        stateHandle.update {
+            copy(comparisonState = comparison.copy(secondaryEndpoint = endpoint, secondaryModel = model))
+        }
+    }
+
+    /** Resolves a display-friendly name for the secondary model. */
+    fun getSecondaryModelDisplayName(): String? {
+        val comparison = stateHandle.state.comparisonState
+        val endpoint = comparison.secondaryEndpoint ?: return null
+        val model = comparison.secondaryModel ?: return null
+        return if (endpoint == EndpointConstants.AGENTS) {
+            stateHandle.state.agents.find { it.id == model }?.name ?: model
+        } else {
+            model
+        }
+    }
+
+    /**
+     * Builds an [AddedConversation] for the secondary agent/model in comparison mode.
+     * Returns null if comparison is not enabled or secondary selection is incomplete.
+     *
+     * Reads the per-endpoint user-provided-key state out of `ChatUiState.endpointKeyStates`
+     * (populated by `EndpointKeyStatusDelegate`) instead of issuing a per-call
+     * `getKeyExpiry` GET — keeps the chat-send hot path off the network.
+     */
+    fun buildAddedConvo(parentMessageId: String? = null): AddedConversation? {
+        val state = stateHandle.state
+        val comparison = state.comparisonState
+        if (!comparison.isEnabled) return null
+        val endpoint = comparison.secondaryEndpoint ?: return null
+        val model = comparison.secondaryModel ?: return null
+        val isAgent = endpoint == EndpointConstants.AGENTS
+        val dispatch = resolveEndpointDispatch(
+            endpointName = endpoint,
+            endpointConfigs = state.endpointConfigs,
+            endpointKeyStates = state.endpointKeyStates,
+        )
+        return AddedConversation(
+            conversationId = state.conversationId,
+            parentMessageId = parentMessageId,
+            endpoint = endpoint,
+            endpointType = dispatch.endpointType,
+            modelDisplayLabel = dispatch.modelDisplayLabel,
+            key = dispatch.key,
+            agentId = if (isAgent) model else null,
+            model = if (isAgent) null else model,
+        )
+    }
+
+    // ── Streaming lifecycle ──────────────────────────────────────────
+
+    /**
+     * Resets both panes' buffers and streaming state at the start of a comparison send.
+     * No-ops when comparison is disabled, so callers can invoke it unconditionally.
+     */
+    fun onSendStart() {
+        if (!stateHandle.state.comparisonState.isEnabled) return
+        primaryBuffer.clear()
+        secondaryBuffer.clear()
+        stateHandle.update {
+            copy(
+                comparisonState = comparisonState.copy(
+                    primaryIsStreaming = true,
+                    secondaryIsStreaming = true,
+                    primaryStreamingContent = "",
+                    secondaryStreamingContent = "",
+                    primaryActiveToolCalls = emptyList(),
+                    secondaryActiveToolCalls = emptyList(),
+                    primaryAgentId = null,
+                    secondaryAgentId = null,
+                    parallelMessageId = null,
+                    primaryFinalContent = null,
+                    secondaryFinalContent = null,
+                ),
+            )
+        }
+    }
+
+    /**
+     * Routes a streaming event into the comparison panes. Returns `true` if the event
+     * was consumed for comparison mode (so the caller skips its normal handling), `false`
+     * otherwise — including when comparison is disabled, leaving the standard path intact.
+     */
+    fun routeEvent(event: StreamEvent): Boolean {
+        if (!stateHandle.state.comparisonState.isEnabled) return false
+        return when (event) {
+            // Thinking and content deltas both feed the same pane buffer in comparison mode.
+            is StreamEvent.ContentDelta -> { routeTextDelta(event.agentId, event.chunk); true }
+            is StreamEvent.ThinkingDelta -> { routeTextDelta(event.agentId, event.chunk); true }
+            is StreamEvent.ToolCallStart -> { routeToolCallStart(event); true }
+            is StreamEvent.ToolCallComplete -> { routeToolCallComplete(event); true }
+            else -> false
+        }
+    }
+
+    private fun routeTextDelta(agentId: String?, chunk: String) {
+        if (isSecondaryEvent(agentId)) {
+            secondaryBuffer.append(chunk)
+            stateHandle.update {
+                copy(
+                    comparisonState = comparisonState.copy(
+                        secondaryStreamingContent = secondaryBuffer.toString(),
+                        secondaryIsStreaming = true,
+                        secondaryAgentId = comparisonState.secondaryAgentId ?: agentId,
+                    ),
+                )
+            }
+        } else {
+            primaryBuffer.append(chunk)
+            stateHandle.update {
+                copy(
+                    comparisonState = comparisonState.copy(
+                        primaryStreamingContent = primaryBuffer.toString(),
+                        primaryIsStreaming = true,
+                        primaryAgentId = comparisonState.primaryAgentId ?: agentId,
+                    ),
+                    streamingContent = primaryBuffer.toString(),
+                )
+            }
+        }
+    }
+
+    private fun routeToolCallStart(event: StreamEvent.ToolCallStart) {
+        val newToolCall = ActiveToolCall(id = event.toolCallId, name = event.toolName, input = event.input)
+        if (isSecondaryEvent(event.agentId)) {
+            stateHandle.update {
+                copy(
+                    comparisonState = comparisonState.copy(
+                        secondaryActiveToolCalls = comparisonState.secondaryActiveToolCalls + newToolCall,
+                    ),
+                )
+            }
+        } else {
+            stateHandle.update {
+                copy(
+                    comparisonState = comparisonState.copy(
+                        primaryActiveToolCalls = comparisonState.primaryActiveToolCalls + newToolCall,
+                    ),
+                )
+            }
+        }
+    }
+
+    private fun routeToolCallComplete(event: StreamEvent.ToolCallComplete) {
+        if (isSecondaryEvent(event.agentId)) {
+            stateHandle.update {
+                val updated = comparisonState.secondaryActiveToolCalls.map { tc ->
+                    if (tc.id == event.toolCallId) tc.copy(isComplete = true, output = event.output) else tc
+                }
+                copy(comparisonState = comparisonState.copy(secondaryActiveToolCalls = updated))
+            }
+        } else {
+            stateHandle.update {
+                val updated = comparisonState.primaryActiveToolCalls.map { tc ->
+                    if (tc.id == event.toolCallId) tc.copy(isComplete = true, output = event.output) else tc
+                }
+                copy(comparisonState = comparisonState.copy(primaryActiveToolCalls = updated))
+            }
+        }
+    }
+
+    /**
+     * Clears both panes' streaming flags and active tool calls. No-ops when comparison
+     * is disabled. Pass [clearContent] = true to also wipe the in-progress pane text
+     * (stream stop / abort); the default preserves it so an errored stream's partial
+     * panes stay readable.
+     */
+    fun endStreaming(clearContent: Boolean = false) {
+        if (!stateHandle.state.comparisonState.isEnabled) return
+        stateHandle.update {
+            copy(
+                comparisonState = comparisonState.copy(
+                    primaryIsStreaming = false,
+                    secondaryIsStreaming = false,
+                    primaryActiveToolCalls = emptyList(),
+                    secondaryActiveToolCalls = emptyList(),
+                    primaryStreamingContent = if (clearContent) "" else comparisonState.primaryStreamingContent,
+                    secondaryStreamingContent = if (clearContent) "" else comparisonState.secondaryStreamingContent,
+                ),
+            )
+        }
+    }
+
+    /**
+     * Finalizes both panes on a successful Final: freezes each buffer as the pane's final
+     * content and records the parallel response message id for branch-from-comparison.
+     */
+    fun onFinal(parallelMessageId: String?) {
+        stateHandle.update {
+            copy(
+                comparisonState = comparisonState.copy(
+                    primaryIsStreaming = false,
+                    secondaryIsStreaming = false,
+                    primaryStreamingContent = "",
+                    secondaryStreamingContent = "",
+                    primaryActiveToolCalls = emptyList(),
+                    secondaryActiveToolCalls = emptyList(),
+                    parallelMessageId = parallelMessageId,
+                    primaryFinalContent = primaryBuffer.toString(),
+                    secondaryFinalContent = secondaryBuffer.toString(),
+                ),
+            )
+        }
+    }
+
+    /**
+     * Branches the conversation onto the chosen agent's response, disables comparison,
+     * and reloads so the branched message surfaces. Triggers deferred navigation for new
+     * chats that skipped it during comparison.
+     */
+    fun branchFromComparison(agentId: String) {
+        val messageId = stateHandle.state.comparisonState.parallelMessageId ?: return
+        val conversationId = stateHandle.state.conversationId ?: return
+        stateHandle.scope.launch {
+            try {
+                messageRepository.branchMessage(
+                    conversationId = conversationId,
+                    messageId = messageId,
+                    agentId = agentId,
+                )
+                stateHandle.update { copy(comparisonState = ComparisonState()) }
+                val cid = stateHandle.state.conversationId
+                if (cid != null && stateHandle.state.pendingNavigationConversationId == null) {
+                    stateHandle.update { copy(pendingNavigationConversationId = cid) }
+                }
+                reloadConversation(conversationId)
+            } catch (e: Exception) {
+                Logger.e(e) { "Failed to branch comparison message" }
+                stateHandle.update { copy(error = "Failed to continue with selected response") }
+            }
+        }
+    }
+
+    /**
+     * Determines whether a stream event belongs to the secondary (added) agent.
+     *
+     * The server gives both agents the same `groupId` (they share a parallel
+     * execution group), so groupId alone cannot distinguish them. Instead, the
+     * server suffixes added-agent IDs with `"____N"` (e.g. `openAI__gpt-5.2____1`).
+     * The primary never has this suffix.
+     */
+    fun isSecondaryEvent(agentId: String?): Boolean {
+        if (agentId == null) return false
+        val comparison = stateHandle.state.comparisonState
+        // If we've already resolved the secondary agentId from earlier SSE events, use that
+        if (comparison.secondaryAgentId != null) {
+            return agentId == comparison.secondaryAgentId
+        }
+        // The "____N" suffix identifies the addedConvo (added/secondary) agent.
+        return agentId.contains("____")
+    }
+}

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/MessageEditingDelegate.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/MessageEditingDelegate.kt
@@ -1,0 +1,274 @@
+package com.garfiec.librechat.feature.chat.viewmodel.delegate
+
+import co.touchlab.kermit.Logger
+import com.garfiec.librechat.core.common.EndpointConstants
+import com.garfiec.librechat.core.data.repository.ChatRepository
+import com.garfiec.librechat.core.data.repository.MessageRepository
+import com.garfiec.librechat.core.model.Message
+import com.garfiec.librechat.feature.chat.util.buildActiveMessagePath
+import com.garfiec.librechat.feature.chat.viewmodel.ChatRequestBuilder
+import com.garfiec.librechat.feature.chat.viewmodel.ChatStateHandle
+import kotlinx.coroutines.launch
+import kotlin.time.Clock
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+/**
+ * Owns the message-mutation send paths — edit (user / assistant), regenerate, and continue —
+ * plus the inline edit-field UI state. Each path optimistically reshapes the tree (a new
+ * sibling or a stream anchor via [MessageTreeDelegate]) and resubmits through
+ * [StreamingManagerDelegate], reusing [ChatRequestBuilder] for the shared request pieces.
+ *
+ * The send-readiness gate and message-text extraction live in `ChatViewModel` (shared with
+ * the new-message send path and TTS); they're injected as [runWhenSendReady] / [getMessageText].
+ */
+class MessageEditingDelegate(
+    private val stateHandle: ChatStateHandle,
+    private val chatRepository: ChatRepository,
+    private val messageRepository: MessageRepository,
+    private val treeDelegate: MessageTreeDelegate,
+    private val streamingManager: StreamingManagerDelegate,
+    private val requestBuilder: ChatRequestBuilder,
+    private val getMessageText: (String) -> String,
+    private val runWhenSendReady: (action: () -> Unit) -> Unit,
+) {
+
+    fun editMessage(messageId: String, newText: String) {
+        if (newText.isBlank() || stateHandle.state.isStreaming) return
+
+        val originalMessage = stateHandle.state.messages.find { it.messageId == messageId } ?: return
+
+        runWhenSendReady {
+            if (originalMessage.isCreatedByUser) {
+                editUserMessage(originalMessage, newText)
+            } else {
+                editAiMessage(originalMessage)
+            }
+        }
+    }
+
+    @OptIn(ExperimentalUuidApi::class)
+    private fun editUserMessage(originalMessage: Message, newText: String) {
+        val parentMessageId = originalMessage.parentMessageId
+
+        // Optimistically insert the edited text as a new sibling of the original user
+        // message and anchor the stream to it, so the new message — with the response
+        // streaming below it — replaces the old branch in place. The anchor truncates
+        // the active path here (see buildActiveMessagePath), mirroring the web client's
+        // `currentMsg + initialResponse` placeholder insert. The optimistic id is sent
+        // as `userMessageId` so the server adopts it; that lets the message reconcile by
+        // id on Final — via loadConversation() for normal chats, or in-memory via
+        // mergeFinalMessagesInMemory for temp chats (which never touch Room).
+        val optimisticMessage = Message(
+            messageId = Uuid.random().toString(),
+            conversationId = stateHandle.state.conversationId ?: "",
+            parentMessageId = parentMessageId,
+            text = newText,
+            isCreatedByUser = true,
+            sender = "User",
+            createdAt = Clock.System.now().toString(),
+            files = originalMessage.files,
+        )
+        stateHandle.update {
+            val updatedMessages = messages + optimisticMessage
+            copy(
+                messages = updatedMessages,
+                displayMessages = buildActiveMessagePath(updatedMessages, activeBranches, optimisticMessage.messageId),
+            )
+        }
+
+        streamingManager.prepareForStreaming(isEdit = true)
+
+        val state = stateHandle.state
+        val isAgent = state.selectedEndpoint == EndpointConstants.AGENTS
+        val webSearchEnabled = state.modelParameters.webSearch
+        val ephemeralAgent = requestBuilder.buildEphemeralAgent()
+        Logger.d { "editUserMessage: webSearch=$webSearchEnabled, ephemeralAgent=$ephemeralAgent" }
+        val dispatch = requestBuilder.currentDispatch()
+        streamingManager.launchStream(
+            chatRepository.startChat(
+                text = newText,
+                conversationId = state.conversationId,
+                endpoint = state.selectedEndpoint,
+                endpointType = dispatch.endpointType,
+                key = dispatch.key,
+                modelDisplayLabel = dispatch.modelDisplayLabel,
+                model = state.selectedModel,
+                userMessageId = optimisticMessage.messageId,
+                parentMessageId = parentMessageId,
+                agentId = if (isAgent) state.selectedModel else null,
+                isEdited = true,
+                webSearch = webSearchEnabled,
+                ephemeralAgent = ephemeralAgent,
+                isTemporary = state.isTemporaryChat,
+            ),
+        )
+    }
+
+    private fun editAiMessage(aiMessage: Message) {
+        val parentUserMessage = stateHandle.state.messages.find {
+            it.messageId == aiMessage.parentMessageId
+        } ?: return
+
+        val conversationId = stateHandle.state.conversationId ?: return
+
+        // Editing an assistant message resubmits its parent user turn (isEdited +
+        // isRegenerate) — the same shape as regenerate, so anchor the stream to the
+        // parent user message and let the new response stream in below it, replacing
+        // the old one. The web client seeds the placeholder with the edited content
+        // for a transient preview; we don't (the regenerated server response is
+        // authoritative on Final either way).
+        treeDelegate.anchorStreamTo(parentUserMessage.messageId)
+        streamingManager.prepareForStreaming(isEdit = true)
+
+        val state = stateHandle.state
+        val isAgent = state.selectedEndpoint == EndpointConstants.AGENTS
+        val webSearchEnabled = state.modelParameters.webSearch
+        val ephemeralAgent = requestBuilder.buildEphemeralAgent()
+        Logger.d { "editAiMessage: webSearch=$webSearchEnabled, ephemeralAgent=$ephemeralAgent" }
+        val dispatch = requestBuilder.currentDispatch()
+        streamingManager.launchStream(
+            chatRepository.startChat(
+                text = parentUserMessage.text,
+                conversationId = conversationId,
+                endpoint = state.selectedEndpoint,
+                endpointType = dispatch.endpointType,
+                key = dispatch.key,
+                modelDisplayLabel = dispatch.modelDisplayLabel,
+                model = state.selectedModel,
+                parentMessageId = parentUserMessage.parentMessageId,
+                agentId = if (isAgent) state.selectedModel else null,
+                overrideParentMessageId = parentUserMessage.messageId,
+                isEdited = true,
+                isRegenerate = true,
+                webSearch = webSearchEnabled,
+                ephemeralAgent = ephemeralAgent,
+                isTemporary = state.isTemporaryChat,
+            ),
+        )
+    }
+
+    fun regenerateMessage(messageId: String) {
+        if (stateHandle.state.isStreaming) return
+
+        val aiMessage = stateHandle.state.messages.find { it.messageId == messageId } ?: return
+        if (aiMessage.isCreatedByUser) return
+
+        val parentUserMessage = stateHandle.state.messages.find {
+            it.messageId == aiMessage.parentMessageId
+        } ?: return
+
+        runWhenSendReady { regenerateMessageNow(parentUserMessage) }
+    }
+
+    private fun regenerateMessageNow(parentUserMessage: Message) {
+        treeDelegate.anchorStreamTo(parentUserMessage.messageId)
+        streamingManager.prepareForStreaming(isEdit = true)
+
+        val state = stateHandle.state
+        val isAgentRegen = state.selectedEndpoint == EndpointConstants.AGENTS
+        val webSearchEnabled = state.modelParameters.webSearch
+        val ephemeralAgent = requestBuilder.buildEphemeralAgent()
+        Logger.d { "regenerateMessage: webSearch=$webSearchEnabled, ephemeralAgent=$ephemeralAgent" }
+        val dispatch = requestBuilder.currentDispatch()
+        streamingManager.launchStream(
+            chatRepository.startChat(
+                text = parentUserMessage.text,
+                conversationId = state.conversationId,
+                endpoint = state.selectedEndpoint,
+                endpointType = dispatch.endpointType,
+                key = dispatch.key,
+                modelDisplayLabel = dispatch.modelDisplayLabel,
+                model = state.selectedModel,
+                parentMessageId = parentUserMessage.parentMessageId,
+                agentId = if (isAgentRegen) state.selectedModel else null,
+                overrideParentMessageId = parentUserMessage.messageId,
+                isRegenerate = true,
+                webSearch = webSearchEnabled,
+                ephemeralAgent = ephemeralAgent,
+                isTemporary = state.isTemporaryChat,
+            ),
+        )
+    }
+
+    fun continueGeneration() {
+        if (stateHandle.state.isStreaming) return
+        val lastAiMessage = stateHandle.state.displayMessages.lastOrNull {
+            !it.message.isCreatedByUser
+        } ?: return
+
+        val parentUserMessage = stateHandle.state.messages.find {
+            it.messageId == lastAiMessage.message.parentMessageId
+        } ?: return
+
+        runWhenSendReady { continueGenerationNow(lastAiMessage.message, parentUserMessage) }
+    }
+
+    private fun continueGenerationNow(lastAiMessage: Message, parentUserMessage: Message) {
+        streamingManager.prepareForStreaming(isEdit = true)
+
+        val state = stateHandle.state
+        val isAgentContinue = state.selectedEndpoint == EndpointConstants.AGENTS
+        val webSearchEnabled = state.modelParameters.webSearch
+        val ephemeralAgent = requestBuilder.buildEphemeralAgent()
+        Logger.d { "continueGeneration: webSearch=$webSearchEnabled, ephemeralAgent=$ephemeralAgent" }
+        val dispatch = requestBuilder.currentDispatch()
+        streamingManager.launchStream(
+            chatRepository.startChat(
+                text = parentUserMessage.text,
+                conversationId = state.conversationId,
+                endpoint = state.selectedEndpoint,
+                endpointType = dispatch.endpointType,
+                key = dispatch.key,
+                modelDisplayLabel = dispatch.modelDisplayLabel,
+                model = state.selectedModel,
+                parentMessageId = parentUserMessage.parentMessageId,
+                agentId = if (isAgentContinue) state.selectedModel else null,
+                overrideParentMessageId = parentUserMessage.messageId,
+                responseMessageId = lastAiMessage.messageId,
+                isEdited = true,
+                isRegenerate = true,
+                isContinued = true,
+                webSearch = webSearchEnabled,
+                ephemeralAgent = ephemeralAgent,
+                isTemporary = state.isTemporaryChat,
+            ),
+        )
+    }
+
+    // ── Inline edit-field UI state ───────────────────────────────────
+
+    fun startEditing(messageId: String) {
+        val text = getMessageText(messageId)
+        stateHandle.update { copy(editingMessageId = messageId, editingText = text) }
+    }
+
+    fun onEditTextChanged(text: String) {
+        stateHandle.update { copy(editingText = text) }
+    }
+
+    fun cancelEditing() {
+        stateHandle.update { copy(editingMessageId = null, editingText = "") }
+    }
+
+    fun submitEdit() {
+        val messageId = stateHandle.state.editingMessageId ?: return
+        val newText = stateHandle.state.editingText.trim()
+        if (newText.isBlank()) return
+
+        stateHandle.update { copy(editingMessageId = null, editingText = "") }
+        editMessage(messageId, newText)
+    }
+
+    fun saveEditOnly() {
+        val messageId = stateHandle.state.editingMessageId ?: return
+        val conversationId = stateHandle.state.conversationId ?: return
+        val newText = stateHandle.state.editingText.trim()
+        if (newText.isBlank()) return
+
+        stateHandle.update { copy(editingMessageId = null, editingText = "") }
+        stateHandle.scope.launch {
+            messageRepository.updateMessageText(conversationId, messageId, newText)
+        }
+    }
+}

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/MessageEditingDelegate.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/MessageEditingDelegate.kt
@@ -77,31 +77,12 @@ class MessageEditingDelegate(
             )
         }
 
-        streamingManager.prepareForStreaming(isEdit = true)
-
-        val state = stateHandle.state
-        val isAgent = state.selectedEndpoint == EndpointConstants.AGENTS
-        val webSearchEnabled = state.modelParameters.webSearch
-        val ephemeralAgent = requestBuilder.buildEphemeralAgent()
-        Logger.d { "editUserMessage: webSearch=$webSearchEnabled, ephemeralAgent=$ephemeralAgent" }
-        val dispatch = requestBuilder.currentDispatch()
-        streamingManager.launchStream(
-            chatRepository.startChat(
-                text = newText,
-                conversationId = state.conversationId,
-                endpoint = state.selectedEndpoint,
-                endpointType = dispatch.endpointType,
-                key = dispatch.key,
-                modelDisplayLabel = dispatch.modelDisplayLabel,
-                model = state.selectedModel,
-                userMessageId = optimisticMessage.messageId,
-                parentMessageId = parentMessageId,
-                agentId = if (isAgent) state.selectedModel else null,
-                isEdited = true,
-                webSearch = webSearchEnabled,
-                ephemeralAgent = ephemeralAgent,
-                isTemporary = state.isTemporaryChat,
-            ),
+        launchSend(
+            text = newText,
+            parentMessageId = parentMessageId,
+            userMessageId = optimisticMessage.messageId,
+            isEdited = true,
+            logLabel = "editUserMessage",
         )
     }
 
@@ -110,41 +91,21 @@ class MessageEditingDelegate(
             it.messageId == aiMessage.parentMessageId
         } ?: return
 
-        val conversationId = stateHandle.state.conversationId ?: return
-
         // Editing an assistant message resubmits its parent user turn (isEdited +
         // isRegenerate) — the same shape as regenerate, so anchor the stream to the
         // parent user message and let the new response stream in below it, replacing
         // the old one. The web client seeds the placeholder with the edited content
         // for a transient preview; we don't (the regenerated server response is
         // authoritative on Final either way).
+        if (stateHandle.state.conversationId == null) return
         treeDelegate.anchorStreamTo(parentUserMessage.messageId)
-        streamingManager.prepareForStreaming(isEdit = true)
-
-        val state = stateHandle.state
-        val isAgent = state.selectedEndpoint == EndpointConstants.AGENTS
-        val webSearchEnabled = state.modelParameters.webSearch
-        val ephemeralAgent = requestBuilder.buildEphemeralAgent()
-        Logger.d { "editAiMessage: webSearch=$webSearchEnabled, ephemeralAgent=$ephemeralAgent" }
-        val dispatch = requestBuilder.currentDispatch()
-        streamingManager.launchStream(
-            chatRepository.startChat(
-                text = parentUserMessage.text,
-                conversationId = conversationId,
-                endpoint = state.selectedEndpoint,
-                endpointType = dispatch.endpointType,
-                key = dispatch.key,
-                modelDisplayLabel = dispatch.modelDisplayLabel,
-                model = state.selectedModel,
-                parentMessageId = parentUserMessage.parentMessageId,
-                agentId = if (isAgent) state.selectedModel else null,
-                overrideParentMessageId = parentUserMessage.messageId,
-                isEdited = true,
-                isRegenerate = true,
-                webSearch = webSearchEnabled,
-                ephemeralAgent = ephemeralAgent,
-                isTemporary = state.isTemporaryChat,
-            ),
+        launchSend(
+            text = parentUserMessage.text,
+            parentMessageId = parentUserMessage.parentMessageId,
+            overrideParentMessageId = parentUserMessage.messageId,
+            isEdited = true,
+            isRegenerate = true,
+            logLabel = "editAiMessage",
         )
     }
 
@@ -163,31 +124,12 @@ class MessageEditingDelegate(
 
     private fun regenerateMessageNow(parentUserMessage: Message) {
         treeDelegate.anchorStreamTo(parentUserMessage.messageId)
-        streamingManager.prepareForStreaming(isEdit = true)
-
-        val state = stateHandle.state
-        val isAgentRegen = state.selectedEndpoint == EndpointConstants.AGENTS
-        val webSearchEnabled = state.modelParameters.webSearch
-        val ephemeralAgent = requestBuilder.buildEphemeralAgent()
-        Logger.d { "regenerateMessage: webSearch=$webSearchEnabled, ephemeralAgent=$ephemeralAgent" }
-        val dispatch = requestBuilder.currentDispatch()
-        streamingManager.launchStream(
-            chatRepository.startChat(
-                text = parentUserMessage.text,
-                conversationId = state.conversationId,
-                endpoint = state.selectedEndpoint,
-                endpointType = dispatch.endpointType,
-                key = dispatch.key,
-                modelDisplayLabel = dispatch.modelDisplayLabel,
-                model = state.selectedModel,
-                parentMessageId = parentUserMessage.parentMessageId,
-                agentId = if (isAgentRegen) state.selectedModel else null,
-                overrideParentMessageId = parentUserMessage.messageId,
-                isRegenerate = true,
-                webSearch = webSearchEnabled,
-                ephemeralAgent = ephemeralAgent,
-                isTemporary = state.isTemporaryChat,
-            ),
+        launchSend(
+            text = parentUserMessage.text,
+            parentMessageId = parentUserMessage.parentMessageId,
+            overrideParentMessageId = parentUserMessage.messageId,
+            isRegenerate = true,
+            logLabel = "regenerateMessage",
         )
     }
 
@@ -205,30 +147,65 @@ class MessageEditingDelegate(
     }
 
     private fun continueGenerationNow(lastAiMessage: Message, parentUserMessage: Message) {
+        launchSend(
+            text = parentUserMessage.text,
+            parentMessageId = parentUserMessage.parentMessageId,
+            overrideParentMessageId = parentUserMessage.messageId,
+            responseMessageId = lastAiMessage.messageId,
+            isEdited = true,
+            isRegenerate = true,
+            isContinued = true,
+            logLabel = "continueGeneration",
+        )
+    }
+
+    /**
+     * Shared tail for the edit / regenerate / continue paths: snapshots the current
+     * selection, builds the per-send request pieces via [ChatRequestBuilder], and launches
+     * the resubmit stream. Each caller first reshapes the tree (optimistic insert or
+     * [MessageTreeDelegate.anchorStreamTo]) and then supplies only the args that differ.
+     *
+     * The new-message send path (`doSendMessage`) stays in `ChatViewModel`: it additionally
+     * carries attached files, an added-conversation for comparison mode, and a bespoke
+     * stream-terminated callback this helper deliberately omits.
+     */
+    @Suppress("LongParameterList")
+    private fun launchSend(
+        text: String,
+        parentMessageId: String?,
+        logLabel: String,
+        userMessageId: String? = null,
+        overrideParentMessageId: String? = null,
+        responseMessageId: String? = null,
+        isEdited: Boolean = false,
+        isRegenerate: Boolean = false,
+        isContinued: Boolean = false,
+    ) {
         streamingManager.prepareForStreaming(isEdit = true)
 
         val state = stateHandle.state
-        val isAgentContinue = state.selectedEndpoint == EndpointConstants.AGENTS
+        val isAgent = state.selectedEndpoint == EndpointConstants.AGENTS
         val webSearchEnabled = state.modelParameters.webSearch
         val ephemeralAgent = requestBuilder.buildEphemeralAgent()
-        Logger.d { "continueGeneration: webSearch=$webSearchEnabled, ephemeralAgent=$ephemeralAgent" }
+        Logger.d { "$logLabel: webSearch=$webSearchEnabled, ephemeralAgent=$ephemeralAgent" }
         val dispatch = requestBuilder.currentDispatch()
         streamingManager.launchStream(
             chatRepository.startChat(
-                text = parentUserMessage.text,
+                text = text,
                 conversationId = state.conversationId,
                 endpoint = state.selectedEndpoint,
                 endpointType = dispatch.endpointType,
                 key = dispatch.key,
                 modelDisplayLabel = dispatch.modelDisplayLabel,
                 model = state.selectedModel,
-                parentMessageId = parentUserMessage.parentMessageId,
-                agentId = if (isAgentContinue) state.selectedModel else null,
-                overrideParentMessageId = parentUserMessage.messageId,
-                responseMessageId = lastAiMessage.messageId,
-                isEdited = true,
-                isRegenerate = true,
-                isContinued = true,
+                userMessageId = userMessageId,
+                parentMessageId = parentMessageId,
+                agentId = if (isAgent) state.selectedModel else null,
+                overrideParentMessageId = overrideParentMessageId,
+                responseMessageId = responseMessageId,
+                isEdited = isEdited,
+                isRegenerate = isRegenerate,
+                isContinued = isContinued,
                 webSearch = webSearchEnabled,
                 ephemeralAgent = ephemeralAgent,
                 isTemporary = state.isTemporaryChat,

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/MessageTreeDelegate.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/MessageTreeDelegate.kt
@@ -1,0 +1,96 @@
+package com.garfiec.librechat.feature.chat.viewmodel.delegate
+
+import com.garfiec.librechat.core.model.StreamEvent
+import com.garfiec.librechat.feature.chat.util.buildActiveMessagePath
+import com.garfiec.librechat.feature.chat.util.mergeFinalMessagesInMemory
+import com.garfiec.librechat.feature.chat.viewmodel.ChatScreenState
+import com.garfiec.librechat.feature.chat.viewmodel.ChatStateHandle
+
+/**
+ * Owns the message-tree branch state and the in-place streaming anchor — the parts
+ * of [com.garfiec.librechat.feature.chat.viewmodel.ChatViewModel] that decide which
+ * sibling is displayed per parent and where the in-flight reply attaches in the
+ * display path. Also owns the temporary-chat toggle and the temp-chat in-memory
+ * finalization (the one finalize path that must never touch Room).
+ *
+ * Pure state transforms over [ChatStateHandle] — no repositories, no coroutines.
+ * The streaming-anchor invariant lives here (see [anchorStreamTo]); the send/edit
+ * paths call into this delegate to truncate the path so the trailing streaming
+ * bubble renders as the pending child of the right branch.
+ */
+class MessageTreeDelegate(
+    private val stateHandle: ChatStateHandle,
+) {
+
+    fun switchBranch(parentMessageId: String, siblingIndex: Int) {
+        // Ignore branch switches mid-stream: the in-flight reply's path is truncated at
+        // its parent (see anchorStreamTo / buildActiveMessagePath's streamingLeafId), and
+        // mutating activeBranches re-triggers loadConversation's combine, which rebuilds
+        // displayMessages WITHOUT the leaf — un-truncating the path and dropping the
+        // streaming reply back to the end. editMessage/regenerateMessage are likewise
+        // gated on isStreaming; this closes the same gap for sibling navigation.
+        if (stateHandle.state.isStreaming) return
+        // Only mutate the branch selection; the observeMessages/activeBranches combine in
+        // loadConversation recomputes displayMessages off the Main thread in response, so the
+        // tree walk no longer runs synchronously on this UI click path.
+        stateHandle.update {
+            val newBranches = activeBranches.toMutableMap()
+            newBranches[parentMessageId] = siblingIndex
+            copy(activeBranches = newBranches)
+        }
+    }
+
+    /**
+     * Rebuilds the active path truncated at [parentMessageId] — the message the
+     * in-flight reply attaches to — so the streaming bubble renders in place
+     * (replacing the stale branch for edit/regenerate) rather than being appended
+     * after it. Used by the paths that reuse an existing message as the parent
+     * (regenerate, edit-AI); the optimistic-message paths (send, edit-user) pass the
+     * same leaf to [buildActiveMessagePath] inline alongside their message insert.
+     *
+     * The full tree stays in `messages` and the DB, so the old branch remains
+     * reachable via sibling navigation, and loadConversation() rebuilds the real
+     * path on Final. This truncated displayMessages then simply persists in state
+     * for the duration of the stream: safe because no streaming entry point writes
+     * to Room mid-stream and none mutate activeBranches, so the Room observer never
+     * re-emits to rebuild (and un-truncate) the path before the stream completes.
+     */
+    fun anchorStreamTo(parentMessageId: String) {
+        stateHandle.update {
+            copy(
+                displayMessages = buildActiveMessagePath(messages, activeBranches, parentMessageId),
+            )
+        }
+    }
+
+    fun toggleTemporaryChat() {
+        // Only togglable before the conversation exists. Once a temporary chat is
+        // active the toggle is a read-only indicator — the server already created
+        // it temporary, so flipping it off here would be misleading.
+        if (stateHandle.state.conversationId != null) return
+        stateHandle.update { copy(isTemporaryChat = !isTemporaryChat) }
+    }
+
+    /**
+     * Finalizes a temporary chat's display purely in memory, WITHOUT persisting to
+     * Room. For a normal chat, handleFinal calls loadConversation, which routes
+     * through [com.garfiec.librechat.core.data.repository.MessageRepository.getMessages]'s
+     * read-through cache and upserts the message rows to disk — for a temp chat that
+     * would leave the message content on disk forever even though the conversation
+     * never appears in history. Instead we merge the final request/response messages
+     * from the SSE event into the existing in-memory list (replacing the optimistic
+     * user message by id) and recompute the display path. Nothing touches the DB.
+     */
+    fun finalizeTemporaryChatDisplay(event: StreamEvent.Final) {
+        val finalMessages = listOfNotNull(event.requestMessage, event.responseMessage ?: event.message)
+        if (finalMessages.isEmpty()) return
+        stateHandle.update {
+            val mergedMessages = mergeFinalMessagesInMemory(messages, finalMessages)
+            copy(
+                messages = mergedMessages,
+                displayMessages = buildActiveMessagePath(mergedMessages, activeBranches),
+                screenState = ChatScreenState.ACTIVE,
+            )
+        }
+    }
+}

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/ModelSelectionDelegate.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/ModelSelectionDelegate.kt
@@ -15,13 +15,9 @@ import com.garfiec.librechat.core.model.EndpointConfig
 import com.garfiec.librechat.core.model.mcp.McpServer
 import com.garfiec.librechat.core.model.permissions.Permission
 import com.garfiec.librechat.core.model.permissions.PermissionType
-import com.garfiec.librechat.core.model.request.AddedConversation
 import com.garfiec.librechat.core.ui.components.ModelParameters
 import com.garfiec.librechat.feature.chat.model.McpServerDisplayData
-import com.garfiec.librechat.feature.chat.viewmodel.ChatScreenState
 import com.garfiec.librechat.feature.chat.viewmodel.ChatStateHandle
-import com.garfiec.librechat.feature.chat.viewmodel.ComparisonState
-import com.garfiec.librechat.feature.chat.viewmodel.resolveEndpointDispatch
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
@@ -48,10 +44,6 @@ class ModelSelectionDelegate(
      * clobber-guard in [refilterModels] never sees it).
      */
     private var pendingAgentOverride: String? = initialAgentId?.takeIf { it.isNotBlank() }
-
-    // --- Model Comparison ---
-    val primaryComparisonBuffer = StringBuilder()
-    val secondaryComparisonBuffer = StringBuilder()
 
     /**
      * Cached last-used endpoint/model from DataStore, kept in sync by
@@ -535,116 +527,6 @@ class ModelSelectionDelegate(
         stateHandle.scope.launch {
             settingsDataStore.setLastUsedModel(endpoint, model)
         }
-    }
-
-    // ── Model Comparison ─────────────────────────────────────────────
-
-    /**
-     * Toggles comparison mode on/off.
-     */
-    fun toggleComparison() {
-        val currentComparison = stateHandle.state.comparisonState
-        if (currentComparison.isEnabled) {
-            // Disable: clear all comparison state
-            primaryComparisonBuffer.clear()
-            secondaryComparisonBuffer.clear()
-            stateHandle.update { copy(comparisonState = ComparisonState()) }
-        } else {
-            // Enable: inherit primary endpoint/model
-            stateHandle.update {
-                copy(
-                    comparisonState = ComparisonState(
-                        isEnabled = true,
-                        secondaryEndpoint = selectedEndpoint,
-                        secondaryModel = selectedModel,
-                    ),
-                    // When enabling on LANDING, switch to ACTIVE so comparison tabs render
-                    screenState = if (screenState == ChatScreenState.LANDING) ChatScreenState.ACTIVE else screenState,
-                )
-            }
-        }
-    }
-
-    /**
-     * Updates the secondary model selection for comparison mode.
-     */
-    fun setSecondaryModel(endpoint: String, model: String) {
-        val comparison = stateHandle.state.comparisonState
-        if (!comparison.isEnabled) return
-        stateHandle.update {
-            copy(
-                comparisonState = comparison.copy(
-                    secondaryEndpoint = endpoint,
-                    secondaryModel = model,
-                ),
-            )
-        }
-    }
-
-    /**
-     * Resolves a display-friendly name for the secondary model.
-     */
-    fun getSecondaryModelDisplayName(): String? {
-        val comparison = stateHandle.state.comparisonState
-        val endpoint = comparison.secondaryEndpoint ?: return null
-        val model = comparison.secondaryModel ?: return null
-        return if (endpoint == EndpointConstants.AGENTS) {
-            stateHandle.state.agents.find { it.id == model }?.name ?: model
-        } else {
-            model
-        }
-    }
-
-    /**
-     * Builds an [AddedConversation] for the secondary agent/model in comparison mode.
-     * Returns null if comparison is not enabled or secondary selection is incomplete.
-     *
-     * Reads the per-endpoint user-provided-key state out of `ChatUiState.endpointKeyStates`
-     * (populated by `EndpointKeyStatusDelegate`) instead of issuing a per-call
-     * `getKeyExpiry` GET — keeps the chat-send hot path off the network.
-     */
-    fun buildAddedConvo(parentMessageId: String? = null): AddedConversation? {
-        val state = stateHandle.state
-        val comparison = state.comparisonState
-        if (!comparison.isEnabled) return null
-        val endpoint = comparison.secondaryEndpoint ?: return null
-        val model = comparison.secondaryModel ?: return null
-        val isAgent = endpoint == EndpointConstants.AGENTS
-        val dispatch = resolveEndpointDispatch(
-            endpointName = endpoint,
-            endpointConfigs = state.endpointConfigs,
-            endpointKeyStates = state.endpointKeyStates,
-        )
-        val added = AddedConversation(
-            conversationId = stateHandle.state.conversationId,
-            parentMessageId = parentMessageId,
-            endpoint = endpoint,
-            endpointType = dispatch.endpointType,
-            modelDisplayLabel = dispatch.modelDisplayLabel,
-            key = dispatch.key,
-            agentId = if (isAgent) model else null,
-            model = if (isAgent) null else model,
-        )
-        return added
-    }
-
-    /**
-     * Determines whether a stream event belongs to the secondary (added) agent.
-     *
-     * The server gives both agents the same `groupId` (they share a parallel
-     * execution group), so groupId alone cannot distinguish them. Instead, the
-     * server suffixes added-agent IDs with `"____N"` (e.g. `openAI__gpt-5.2____1`).
-     * The primary never has this suffix.
-     */
-    fun isSecondaryEvent(agentId: String?): Boolean {
-        if (agentId == null) return false
-        val comparison = stateHandle.state.comparisonState
-        // If we've already resolved the secondary agentId from earlier SSE events, use that
-        if (comparison.secondaryAgentId != null) {
-            return agentId == comparison.secondaryAgentId
-        }
-        // The "____N" suffix identifies the addedConvo (added/secondary) agent.
-        return agentId.contains("____")
     }
 
     /**

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/ModelSelectionDelegate.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/ModelSelectionDelegate.kt
@@ -11,6 +11,7 @@ import com.garfiec.librechat.core.data.repository.McpRepository
 import com.garfiec.librechat.core.data.util.PermissionGate
 import com.garfiec.librechat.core.logging.Diag
 import com.garfiec.librechat.core.model.Agent
+import com.garfiec.librechat.core.model.Conversation
 import com.garfiec.librechat.core.model.EndpointConfig
 import com.garfiec.librechat.core.model.mcp.McpServer
 import com.garfiec.librechat.core.model.permissions.Permission
@@ -84,6 +85,28 @@ class ModelSelectionDelegate(
         applySelection(endpoint, model, reason = "conversationResolved")
         conversationModelLoaded = true
         conversationModelResolved = true
+    }
+
+    /**
+     * Resolves a loaded [conversation]'s authoritative (endpoint, model) and applies it as
+     * the active selection via [applyResolvedConversationModel]. Agents conversations carry
+     * the agent in `agentId`, so prefer that over `model` for the AGENTS endpoint. Returns
+     * true when a concrete selection was applied (i.e. the conversation model is now
+     * resolved), false when the conversation lacked enough info.
+     */
+    fun applyConversationModel(conversation: Conversation): Boolean {
+        val endpoint = conversation.endpoint
+        val isAgentConversation = endpoint == EndpointConstants.AGENTS
+        val resolvedModel = if (isAgentConversation) {
+            conversation.agentId ?: conversation.model
+        } else {
+            conversation.model
+        }
+        if (endpoint != null && resolvedModel != null) {
+            applyResolvedConversationModel(endpoint, resolvedModel)
+            return true
+        }
+        return false
     }
 
     /**

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/SendCompletionDelegate.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/SendCompletionDelegate.kt
@@ -1,0 +1,174 @@
+package com.garfiec.librechat.feature.chat.viewmodel.delegate
+
+import co.touchlab.kermit.Logger
+import com.garfiec.librechat.core.common.result.Result
+import com.garfiec.librechat.core.common.result.getOrNull
+import com.garfiec.librechat.core.data.repository.ConversationRepository
+import com.garfiec.librechat.core.data.repository.DraftRepository
+import com.garfiec.librechat.core.logging.Diag
+import com.garfiec.librechat.core.model.StreamEvent
+import com.garfiec.librechat.feature.chat.util.NEW_CHAT_DRAFT_KEY
+import com.garfiec.librechat.feature.chat.viewmodel.ChatStateHandle
+import com.garfiec.librechat.feature.chat.viewmodel.NewChatSelectionHandoff
+import com.garfiec.librechat.feature.chat.viewmodel.shouldRequestTitleGeneration
+import kotlinx.coroutines.launch
+
+/**
+ * Owns what happens when a chat send reaches the server: the `created` and `final`
+ * SSE milestones and everything they trigger that is NOT raw stream plumbing —
+ * draft migration onto the new conversation id, the new-chat selection handoff +
+ * deferred navigation, persisting the final conversation (with the temp-chat
+ * data-at-rest guard), title generation, and conversation-model re-derivation.
+ *
+ * `ChatViewModel`'s stream handler invokes [onConversationCreated] / [onFinal] with the
+ * streaming-derived inputs (the new id, the completed text); the streaming-internal
+ * cleanup (buffer flush, connectivity reset) stays on the caller's side.
+ */
+class SendCompletionDelegate(
+    private val stateHandle: ChatStateHandle,
+    private val conversationRepository: ConversationRepository,
+    private val draftRepository: DraftRepository,
+    private val modelDelegate: ModelSelectionDelegate,
+    private val treeDelegate: MessageTreeDelegate,
+    private val tts: PlatformTts,
+    private val selectionHandoff: NewChatSelectionHandoff,
+    /** Reloads the conversation from the server (VM-owned Room observer). */
+    private val reloadConversation: (String) -> Unit,
+) {
+
+    private var titleGenerationRequested = false
+
+    /**
+     * Handles the `created` milestone: migrates the new-chat draft onto the real
+     * conversation id, stages the sent selection for the about-to-be-created Chat(id) VM,
+     * arms deferred navigation, and eagerly caches the conversation so it lands in the
+     * list even if the stream later fails.
+     */
+    fun onConversationCreated(conversationId: String, isNewConversation: Boolean) {
+        if (isNewConversation) {
+            stateHandle.scope.launch {
+                val existingDraft = draftRepository.getDraft(NEW_CHAT_DRAFT_KEY)
+                if (existingDraft != null) {
+                    draftRepository.saveDraft(conversationId, existingDraft)
+                    draftRepository.deleteDraft(NEW_CHAT_DRAFT_KEY)
+                }
+            }
+            // Stage the selection we actually sent so the about-to-be-created Chat(id) VM can
+            // apply it directly instead of re-deriving it from a GET that races the server's
+            // unawaited conversation save. Keyed by id, so a deferred nav (comparison-mode
+            // branch) still picks it up. See NewChatSelectionHandoff.
+            val sent = stateHandle.state
+            selectionHandoff.put(conversationId, sent.selectedEndpoint, sent.selectedModel)
+            stateHandle.update {
+                if (pendingNavigationConversationId == null && !comparisonState.isEnabled) {
+                    copy(pendingNavigationConversationId = conversationId)
+                } else {
+                    this
+                }
+            }
+        }
+        // Eagerly fetch and cache the conversation the server just created,
+        // so it appears in the conversation list even if the stream fails later
+        stateHandle.scope.launch {
+            conversationRepository.getConversation(conversationId)
+        }
+    }
+
+    /**
+     * Handles the `final` milestone (single-stream and comparison alike): re-derives the
+     * conversation model if it never resolved, persists the final conversation (unless
+     * temporary), drives the display (Room reload for normal chats, in-memory finalize for
+     * temp chats), kicks off title generation, and auto-reads the response.
+     *
+     * @param completedResponseText the streamed response text, for auto-read.
+     * @param shouldAutoRead false for edit/regenerate/continue (no auto-TTS).
+     */
+    fun onFinal(
+        event: StreamEvent.Final,
+        conversationId: String?,
+        completedResponseText: String,
+        shouldAutoRead: Boolean,
+        isNewConversation: Boolean,
+        isHandedOffNewChat: Boolean,
+    ) {
+        val finalConversation = event.conversation
+        // Belt-and-braces: if no handoff seeded the selection and the initial GET 404'd
+        // against the created-before-save race, the conversation model is still unresolved.
+        // The Final event carries the authoritative conversation, so re-derive from it here
+        // rather than leaving a fallback guess on screen.
+        if (!modelDelegate.conversationModelResolved && finalConversation != null) {
+            val applied = modelDelegate.applyConversationModel(finalConversation)
+            Diag.i(
+                tag = "ModelSel",
+                attrs = mapOf("applied" to applied.toString()),
+            ) { "handleFinal re-derived conversation model" }
+        }
+        // SECURITY: do not remove — temp-chat data-at-rest guard.
+        // Temporary chats (v0.8.6) are kept out of normal history — the server excludes
+        // them from the conversation list, so don't cache them to Room either (it would
+        // leak a temp chat into the local list the server hides).
+        val isTemporary = stateHandle.state.isTemporaryChat || finalConversation?.isTemporary == true
+        if (finalConversation?.conversationId != null && !isTemporary) {
+            stateHandle.scope.launch {
+                conversationRepository.saveConversation(finalConversation)
+            }
+        }
+        if (conversationId != null) {
+            if (isTemporary) {
+                // SECURITY: do not remove — temp-chat data-at-rest guard.
+                // Temp chats are never persisted: don't round-trip through the Room
+                // read-through (which would upsert the message rows to disk). Drive the
+                // display from the final event in memory instead. Title generation is
+                // also skipped server-side for temp chats, so there's nothing to refresh.
+                treeDelegate.finalizeTemporaryChatDisplay(event)
+            } else {
+                reloadConversation(conversationId)
+                val shouldGenerate = shouldRequestTitleGeneration(
+                    isNewConversation = isNewConversation,
+                    isHandedOffNewChat = isHandedOffNewChat,
+                    currentTitle = stateHandle.state.conversationTitle,
+                    alreadyRequested = titleGenerationRequested,
+                )
+                if (shouldGenerate) {
+                    titleGenerationRequested = true
+                    generateAndSetTitle(conversationId)
+                } else {
+                    refreshConversationTitle(conversationId)
+                }
+            }
+        }
+        if (shouldAutoRead && completedResponseText.isNotBlank()) {
+            tts.maybeAutoReadResponse(completedResponseText)
+        }
+    }
+
+    private fun refreshConversationTitle(conversationId: String) {
+        stateHandle.scope.launch {
+            val conversation = conversationRepository.getConversation(conversationId).getOrNull() ?: return@launch
+            stateHandle.update { copy(conversationTitle = conversation.title) }
+        }
+    }
+
+    private fun generateAndSetTitle(conversationId: String) {
+        stateHandle.scope.launch {
+            when (val result = conversationRepository.generateTitle(conversationId)) {
+                is Result.Success -> {
+                    stateHandle.update { copy(conversationTitle = result.data) }
+                }
+                is Result.Error -> {
+                    Logger.d { "Title generation failed for $conversationId: ${result.message}" }
+                    // The gen_title long-poll can miss even though the server generated and
+                    // persisted a title (404 after its backoff window, or another client
+                    // consumed the one-shot cache). Fetch network-first: the cached row
+                    // still holds the "New Chat" placeholder, so cache-first getConversation
+                    // could never observe the title, and refreshConversation's upsert also
+                    // propagates it to the Room-observing conversation list.
+                    conversationRepository.refreshConversation(conversationId).getOrNull()?.let { conversation ->
+                        stateHandle.update { copy(conversationTitle = conversation.title) }
+                    }
+                }
+                is Result.Loading -> { /* no-op */ }
+            }
+        }
+    }
+}

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/StreamingManagerDelegate.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/StreamingManagerDelegate.kt
@@ -1,0 +1,558 @@
+package com.garfiec.librechat.feature.chat.viewmodel.delegate
+
+import co.touchlab.kermit.Logger
+import com.garfiec.librechat.core.common.network.ConnectivityObserver
+import com.garfiec.librechat.core.common.result.Result
+import com.garfiec.librechat.core.data.repository.ChatRepository
+import com.garfiec.librechat.core.model.Attachment
+import com.garfiec.librechat.core.model.StreamEvent
+import com.garfiec.librechat.core.model.error.UserKeyError
+import com.garfiec.librechat.core.model.error.parseUserKeyError
+import com.garfiec.librechat.feature.chat.components.artifact.ArtifactType
+import com.garfiec.librechat.feature.chat.viewmodel.ActiveToolCall
+import com.garfiec.librechat.feature.chat.viewmodel.ChatScreenState
+import com.garfiec.librechat.feature.chat.viewmodel.ChatStateHandle
+import com.garfiec.librechat.feature.chat.viewmodel.RetryInfo
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+
+/**
+ * Owns the streaming session lifecycle: the SSE collection job, the text buffer and its
+ * throttled flush to UI state, the per-event dispatch ([handleStreamEvent]), stream
+ * resume on app foreground, and network-error auto-reconnect.
+ *
+ * Collaborators are injected: comparison routing, subagent traces, office-doc previews,
+ * and send completion (the `created`/`final` milestones) are owned by their own delegates;
+ * this one is the hub that drives them as events arrive. The send paths in `ChatViewModel`
+ * build a request flow and hand it to [launchStream]; everything downstream lives here.
+ */
+class StreamingManagerDelegate(
+    private val stateHandle: ChatStateHandle,
+    private val chatRepository: ChatRepository,
+    private val connectivityObserver: ConnectivityObserver,
+    private val comparisonDelegate: ComparisonModeDelegate,
+    private val subagentTraceDelegate: SubagentTraceDelegate,
+    private val officePreviewDelegate: OfficePreviewDelegate,
+    private val completionDelegate: SendCompletionDelegate,
+    /** Emits a typed user-provided-key error for one-shot UI surfacing (snackbar + CTA). */
+    private val emitUserKeyError: (UserKeyError) -> Unit,
+    /** Reloads the conversation from the server (VM-owned Room observer). */
+    private val reloadConversation: (String) -> Unit,
+    private val isNewConversation: () -> Boolean,
+    private val isHandedOffNewChat: () -> Boolean,
+) {
+
+    private val scope get() = stateHandle.scope
+
+    private var streamJob: Job? = null
+    private var streamingUpdateJob: Job? = null
+    private val streamingBuffer = StringBuilder()
+    private var streamingBufferDirty = false
+    private var wasStreaming = false
+
+    /** Tracks whether the last stream failure was a network error, to enable auto-reconnect. */
+    private var lastErrorWasNetwork = false
+
+    /** Job for the connectivity observer; started lazily only when a network error occurs. */
+    private var connectivityJob: Job? = null
+
+    /** True when the current stream is from an edit, regenerate, or continue operation. */
+    var isEditOrRegenerate = false
+        private set
+
+    /**
+     * Resets the streaming-internal session state (buffer, edit flag, traces) and starts the
+     * throttled updater. Does NOT touch [stateHandle] — callers that already mutate UI state
+     * for their send (e.g. the optimistic-insert path) use this; [prepareForStreaming] wraps
+     * it with the standard streaming-field reset.
+     */
+    fun beginStreaming(isEdit: Boolean) {
+        isEditOrRegenerate = isEdit
+        streamingBuffer.clear()
+        streamingBufferDirty = false
+        subagentTraceDelegate.reset()
+        officePreviewDelegate.reset()
+        startStreamingUpdater()
+    }
+
+    /**
+     * Resets streaming-related UI state and the buffer in preparation for a new stream
+     * (edit, regenerate, or continue).
+     */
+    fun prepareForStreaming(isEdit: Boolean) {
+        stateHandle.update {
+            copy(
+                isStreaming = true,
+                streamingContent = "",
+                activeToolCalls = emptyList(),
+                streamingAttachments = emptyList(),
+                error = null,
+            )
+        }
+        beginStreaming(isEdit)
+    }
+
+    /**
+     * Cancels any in-flight stream and launches collection of [flow]. [onTerminated] runs
+     * after collection completes (success, error, or normal end) — the send paths use it as
+     * a safety net for flows that end without a Final/Error event.
+     */
+    fun launchStream(flow: Flow<StreamEvent>, onTerminated: suspend () -> Unit = {}) {
+        streamJob?.cancel()
+        streamJob = scope.launch {
+            collectStreamSafely(flow)
+            onTerminated()
+        }
+    }
+
+    /** Cancels the active stream, stops the updater, and clears the buffer (nav reset / handoff). */
+    fun reset() {
+        streamJob?.cancel()
+        streamJob = null
+        stopStreamingUpdater()
+        streamingBuffer.clear()
+        streamingBufferDirty = false
+    }
+
+    private suspend fun collectStreamSafely(stream: Flow<StreamEvent>) {
+        try {
+            stream.collect { event -> handleStreamEvent(event) }
+        } catch (e: CancellationException) {
+            throw e // Never swallow cancellation
+        } catch (e: Exception) {
+            Logger.e(e) { "Stream collection failed" }
+            stopStreamingUpdater()
+            // Preserve partial content so users can read/copy what was received
+            val partialContent = streamingBuffer.toString()
+            stateHandle.update {
+                copy(
+                    isStreaming = false,
+                    streamingContent = partialContent,
+                    activeToolCalls = emptyList(),
+                    streamingAttachments = emptyList(),
+                    error = e.message ?: "Chat request failed",
+                )
+            }
+            comparisonDelegate.endStreaming()
+            // If the server already created a conversation, fetch whatever it persisted
+            val conversationId = stateHandle.state.conversationId
+            if (conversationId != null) {
+                reloadConversation(conversationId)
+            }
+        }
+    }
+
+    private fun handleStreamEvent(event: StreamEvent) {
+        // In comparison mode the delegate fans streaming deltas/tool-calls into the dual
+        // panes; if it consumed the event, skip the single-stream handling below.
+        if (comparisonDelegate.routeEvent(event)) return
+        when (event) {
+            is StreamEvent.Created -> handleCreated(event)
+            is StreamEvent.ContentDelta -> {
+                streamingBuffer.append(event.chunk)
+                streamingBufferDirty = true
+            }
+            is StreamEvent.ThinkingDelta -> {
+                streamingBuffer.append(event.chunk)
+                streamingBufferDirty = true
+            }
+            is StreamEvent.Final -> handleFinal(event)
+            is StreamEvent.Error -> {
+                stopStreamingUpdater()
+                // Track network errors so auto-reconnect can kick in when connectivity returns
+                lastErrorWasNetwork = event.isNetworkError
+                if (event.isNetworkError) {
+                    startConnectivityObserver()
+                }
+                // Try to parse the message as a typed user-provided-key error envelope.
+                // If recognized, emit a one-shot effect so the UI can surface a snackbar
+                // with a deep-link CTA to Settings → Provider Keys, and skip the generic
+                // `error = event.message` fallback to avoid double-surfacing.
+                val keyError = parseUserKeyError(event.message)
+                // Preserve partial content so users can read/copy what was received
+                val partialContent = streamingBuffer.toString()
+                stateHandle.update {
+                    copy(
+                        isStreaming = false,
+                        streamingContent = partialContent,
+                        error = if (keyError != null) null else event.message,
+                        retryInfo = null,
+                        activeToolCalls = emptyList(),
+                        streamingAttachments = emptyList(),
+                    )
+                }
+                comparisonDelegate.endStreaming()
+                if (keyError != null) {
+                    emitUserKeyError(keyError)
+                }
+                // If the server already created a conversation, fetch whatever it persisted
+                val conversationId = stateHandle.state.conversationId
+                if (conversationId != null) {
+                    reloadConversation(conversationId)
+                }
+            }
+            is StreamEvent.Retrying -> {
+                stateHandle.update {
+                    copy(
+                        retryInfo = RetryInfo(
+                            attempt = event.attempt,
+                            maxAttempts = event.maxAttempts,
+                        ),
+                    )
+                }
+            }
+            is StreamEvent.ToolCallStart -> {
+                val newToolCall = ActiveToolCall(
+                    id = event.toolCallId,
+                    name = event.toolName,
+                    input = event.input,
+                )
+                stateHandle.update {
+                    copy(activeToolCalls = activeToolCalls + newToolCall)
+                }
+            }
+            is StreamEvent.ToolCallComplete -> {
+                stateHandle.update {
+                    val updated = activeToolCalls.map { tc ->
+                        if (tc.id == event.toolCallId) {
+                            tc.copy(isComplete = true, output = event.output)
+                        } else {
+                            tc
+                        }
+                    }
+                    copy(activeToolCalls = updated)
+                }
+                // If this was a `subagent` tool_call, freeze its live trace —
+                // the child run is done; stop accumulating for that key.
+                subagentTraceDelegate.onParentToolCallResolved(event.toolCallId)
+            }
+            is StreamEvent.AttachmentCreated -> {
+                val attachment = Attachment(
+                    fileId = event.fileId,
+                    filename = event.filename,
+                    filepath = event.filepath,
+                    type = event.type,
+                    toolCallId = event.toolCallId,
+                    width = event.width,
+                    height = event.height,
+                    status = event.status,
+                    text = event.text,
+                    textFormat = event.textFormat,
+                    previewError = event.previewError,
+                )
+                // Office-doc previews (v0.8.6) arrive twice per file_id (pending →
+                // ready/failed) — route through the delegate for upsert-by-file_id +
+                // poll-while-pending. Ordinary attachments keep the simple append path.
+                if (ArtifactType.isOfficePreviewMime(event.type)) {
+                    officePreviewDelegate.onAttachment(attachment)
+                } else {
+                    stateHandle.update {
+                        copy(streamingAttachments = streamingAttachments + attachment)
+                    }
+                }
+            }
+            is StreamEvent.Sync -> {
+                // Resume snapshot: `aggregatedContent` is the authoritative state of
+                // the response so far, so we REPLACE (not append) the streaming
+                // pipeline's fields from it — both the text buffer and the tool-call
+                // list. Any pendingEvents in the same frame arrive as their own
+                // StreamEvents after this and fold on top via the normal handlers.
+                if (lastErrorWasNetwork) {
+                    lastErrorWasNetwork = false
+                    cancelConnectivityObserver()
+                }
+                stateHandle.update {
+                    if (retryInfo != null) copy(retryInfo = null) else this
+                }
+                val textContent = event.aggregatedContent
+                    .mapNotNull { it.text }
+                    .joinToString("")
+                streamingBuffer.clear()
+                streamingBuffer.append(textContent)
+                streamingBufferDirty = true
+
+                // Rebuild active tool calls from the snapshot's tool_call parts so an
+                // in-progress image gen (or any tool call) started before we resumed
+                // still renders its live card. The same ActiveToolCall the live path
+                // produces, so the existing StreamingToolCallCard / ImageGenCard render
+                // it identically. A part with a non-blank output is already complete.
+                val syncedToolCalls = event.aggregatedContent
+                    .mapNotNull { part -> part.toolCall?.takeIf { !it.id.isNullOrBlank() } }
+                    .map { tc ->
+                        ActiveToolCall(
+                            id = tc.id.orEmpty(),
+                            name = tc.name.orEmpty(),
+                            input = tc.args?.toString(),
+                            isComplete = !tc.output.isNullOrBlank(),
+                            output = tc.output,
+                        )
+                    }
+                stateHandle.update { copy(activeToolCalls = syncedToolCalls) }
+                flushStreamingBuffer()
+            }
+            is StreamEvent.Step -> { /* no-op */ }
+            is StreamEvent.ContextSummary -> {
+                // Server compacted earlier turns into a summary. The compacted text is
+                // persisted to the final message as a SUMMARY content part and rendered
+                // there; nothing extra to do during streaming.
+            }
+            is StreamEvent.SubagentUpdate -> subagentTraceDelegate.onUpdate(event)
+        }
+    }
+
+    private fun handleCreated(event: StreamEvent.Created) {
+        if (lastErrorWasNetwork) {
+            lastErrorWasNetwork = false
+            cancelConnectivityObserver()
+        }
+        stateHandle.update {
+            if (retryInfo != null) {
+                copy(conversationId = event.conversationId, retryInfo = null)
+            } else {
+                copy(conversationId = event.conversationId)
+            }
+        }
+        completionDelegate.onConversationCreated(event.conversationId, isNewConversation())
+    }
+
+    private fun handleFinal(event: StreamEvent.Final) {
+        stopStreamingUpdater()
+        // The stream has ended: any office-doc attachment still `pending` (its
+        // `ready` SSE update may never arrive once the run closes) now falls back
+        // to polling GET /api/files/:id/preview. De-duped + bounded in the delegate.
+        officePreviewDelegate.onStreamEnded()
+        val isComparison = stateHandle.state.comparisonState.isEnabled
+        val conversationId = stateHandle.state.conversationId
+            ?: event.conversation?.conversationId
+        val completedResponseText = if (isComparison) {
+            comparisonDelegate.primaryContent()
+        } else {
+            streamingBuffer.toString()
+        }
+        val shouldAutoRead = !isEditOrRegenerate
+        // Clear the single-stream UI fields; comparison panes are finalized via the delegate.
+        stateHandle.update {
+            copy(
+                isStreaming = false,
+                streamingContent = "",
+                activeToolCalls = emptyList(),
+                streamingAttachments = emptyList(),
+                conversationId = conversationId ?: this.conversationId,
+            )
+        }
+        if (isComparison) {
+            comparisonDelegate.onFinal((event.responseMessage ?: event.message)?.messageId)
+        }
+        completionDelegate.onFinal(
+            event = event,
+            conversationId = conversationId,
+            completedResponseText = completedResponseText,
+            shouldAutoRead = shouldAutoRead,
+            isNewConversation = isNewConversation(),
+            isHandedOffNewChat = isHandedOffNewChat(),
+        )
+    }
+
+    /**
+     * Launches a periodic coroutine that flushes the [streamingBuffer] to UI state
+     * at most every [STREAMING_UI_UPDATE_INTERVAL_MS] ms. This avoids recomposition spam
+     * from high-frequency SSE chunks (each chunk would otherwise trigger a full state copy).
+     */
+    private fun startStreamingUpdater() {
+        streamingUpdateJob?.cancel()
+        streamingUpdateJob = scope.launch {
+            while (isActive) {
+                delay(STREAMING_UI_UPDATE_INTERVAL_MS)
+                flushStreamingBuffer()
+            }
+        }
+    }
+
+    /**
+     * Flushes the streaming buffer to UI state if it has been modified since the last flush.
+     * Called both periodically (by the updater) and immediately on stream completion/error.
+     */
+    private fun flushStreamingBuffer() {
+        if (!streamingBufferDirty) return
+        streamingBufferDirty = false
+        stateHandle.update { copy(streamingContent = streamingBuffer.toString()) }
+    }
+
+    /**
+     * Stops the periodic streaming updater and performs a final flush so the last
+     * chunk is never lost.
+     */
+    private fun stopStreamingUpdater() {
+        streamingUpdateJob?.cancel()
+        streamingUpdateJob = null
+        flushStreamingBuffer()
+    }
+
+    fun stopGeneration() {
+        val conversationId = stateHandle.state.conversationId ?: return
+        streamJob?.cancel()
+        stopStreamingUpdater()
+        streamingBuffer.clear()
+        streamingBufferDirty = false
+        scope.launch {
+            val abortResult = chatRepository.abortChat(conversationId)
+            if (abortResult is Result.Error) {
+                Logger.w(abortResult.exception) { "Failed to abort chat: ${abortResult.message}" }
+            }
+            stateHandle.update {
+                copy(
+                    isStreaming = false,
+                    streamingContent = "",
+                    activeToolCalls = emptyList(),
+                    streamingAttachments = emptyList(),
+                )
+            }
+            comparisonDelegate.endStreaming(clearContent = true)
+            // Refresh messages from server so the message tree reflects
+            // the partially-streamed response that was aborted.
+            reloadConversation(conversationId)
+        }
+    }
+
+    fun onPause() {
+        wasStreaming = stateHandle.state.isStreaming
+        if (wasStreaming) {
+            streamJob?.cancel()
+            stopStreamingUpdater()
+        }
+    }
+
+    fun onResume() {
+        if (!wasStreaming) return
+        wasStreaming = false
+
+        val conversationId = stateHandle.state.conversationId ?: return
+
+        scope.launch {
+            try {
+                val status = chatRepository.checkStreamStatus(conversationId)
+                if (status.active) {
+                    stateHandle.update { copy(isStreaming = true) }
+                    resumeStream(conversationId)
+                } else {
+                    stateHandle.update { copy(isStreaming = false, streamingContent = "") }
+                    reloadConversation(conversationId)
+                }
+            } catch (e: Exception) {
+                Logger.e(e) { "Could not resume stream" }
+                stateHandle.update {
+                    copy(
+                        isStreaming = false,
+                        streamingContent = "",
+                        error = "Could not resume stream",
+                    )
+                }
+            }
+        }
+    }
+
+    /**
+     * Shared resume logic: clears the buffer, starts the updater, and launches
+     * stream collection. Caller is responsible for setting any UI state fields
+     * (e.g. isStreaming, error) before calling this.
+     */
+    private fun resumeStream(conversationId: String) {
+        streamingBuffer.clear()
+        streamingBufferDirty = false
+        startStreamingUpdater()
+        streamJob?.cancel()
+        streamJob = scope.launch {
+            collectStreamSafely(chatRepository.resumeStream(conversationId))
+        }
+    }
+
+    fun resumeActiveStreamIfNeeded(conversationId: String) {
+        scope.launch {
+            try {
+                val status = chatRepository.checkStreamStatus(conversationId)
+                if (status.active) {
+                    stateHandle.update {
+                        copy(
+                            isStreaming = true,
+                            screenState = ChatScreenState.ACTIVE,
+                        )
+                    }
+                    resumeStream(conversationId)
+                }
+            } catch (e: Exception) {
+                Logger.d(e) { "No active stream to resume for $conversationId" }
+            }
+        }
+    }
+
+    /**
+     * Starts observing connectivity for auto-reconnect after a network error.
+     * Cancels any existing observer first. The observer self-cancels after recovery fires.
+     */
+    private fun startConnectivityObserver() {
+        connectivityJob?.cancel()
+        connectivityJob = scope.launch {
+            var wasConnected = true
+            connectivityObserver.isConnected.collect { connected ->
+                val recovered = !wasConnected && connected
+                wasConnected = connected
+                if (recovered) {
+                    attemptNetworkRecovery()
+                }
+            }
+        }
+    }
+
+    /** Cancels the connectivity observer and clears the network-error flag. */
+    private fun cancelConnectivityObserver() {
+        connectivityJob?.cancel()
+        connectivityJob = null
+    }
+
+    /**
+     * Called when network connectivity transitions from offline to online.
+     * If the last stream ended due to a network error, attempts to resume it
+     * or falls back to reloading the conversation from the server.
+     */
+    private fun attemptNetworkRecovery() {
+        if (!lastErrorWasNetwork) return
+        val state = stateHandle.state
+        val conversationId = state.conversationId ?: return
+        if (state.isStreaming) return
+
+        lastErrorWasNetwork = false
+        cancelConnectivityObserver()
+        Logger.d { "Network recovered, attempting to resume conversation $conversationId" }
+
+        scope.launch {
+            try {
+                val status = chatRepository.checkStreamStatus(conversationId)
+                if (status.active) {
+                    stateHandle.update {
+                        copy(
+                            isStreaming = true,
+                            error = null,
+                            retryInfo = null,
+                        )
+                    }
+                    resumeStream(conversationId)
+                } else {
+                    // Stream expired while offline — reload conversation from server
+                    stateHandle.update { copy(error = null, retryInfo = null) }
+                    reloadConversation(conversationId)
+                }
+            } catch (e: Exception) {
+                Logger.w(e) { "Network recovery: could not check stream status" }
+            }
+        }
+    }
+
+    private companion object {
+        /** Minimum interval between streaming UI state updates to avoid recomposition spam. */
+        const val STREAMING_UI_UPDATE_INTERVAL_MS = 50L
+    }
+}


### PR DESCRIPTION
## Summary
Decomposes the `ChatViewModel` god-class (2151 lines) into five focused delegates plus a pure request-builder helper, cutting the ViewModel to ~1068 lines (−50%). This is a behavior-preserving refactor — no user-facing change — and the first PR in the file-size/decomposition initiative tracked in `MODULARIZATION.md`.

## Changes
- **`MessageTreeDelegate`** — branch switching, stream anchoring, temp-chat display finalization.
- **`ComparisonModeDelegate`** — dual-stream buffers, comparison event routing, branch-from-comparison.
- **`SendCompletionDelegate`** — Created/Final handling, title generation, optimistic-id reconciliation, new-chat nav handoff.
- **`StreamingManagerDelegate`** — streaming buffer/jobs, stream collection, connectivity-recovery, pause/resume.
- **`MessageEditingDelegate`** — edit (user/assistant), regenerate, continue, and inline edit-field state; the four resubmit paths now share one `launchSend` helper.
- **`ChatRequestBuilder`** — pure helper for `buildEphemeralAgent()` + `currentDispatch()`, shared by the VM send path and the editing delegate.
- `applyConversationModel` relocated into `ModelSelectionDelegate`; `doSendMessage` stays in the VM as a thin orchestrator.
- Adds `MODULARIZATION.md` documenting the backlog and delegate conventions.

Each delegate is a plain class built with `ChatStateHandle` (`state` / `update {}` / `scope`) + repositories, following the existing delegate convention; the ViewModel holds them as private vals and re-exposes their flows.

## Testing
- Android + iOS compile, detekt, and the chat unit-test suite all green.
- Device-tested on the Pixel 10 Pro Fold emulator: edit-user-message, edit-AI-message, regenerate, inline save-only, stop-mid-stream, and new-chat title generation all verified — correct branch placement, sibling-nav counters, and in-place replacement.

## Notes
- Load-bearing invariants preserved: streaming anchor (no mid-stream Room write), temp-chat data-at-rest guard, optimistic-id reconciliation, network-recovery flag propagation, comparison isolation.
- Continue-generation was not exercised live — its affordance only surfaces in Comparison mode in the current UI (pre-existing, unchanged here); its send path is identical in shape to the verified resubmit paths.
