### PR TITLE
refactor(chat): decompose ChatScreen into focused sibling files

### DIFF
--- a/MODULARIZATION.md
+++ b/MODULARIZATION.md
@@ -22,7 +22,7 @@ and bring the code closer to idiomatic Compose / unidirectional-data-flow conven
 |---|------|-------|------|--------|
 | 1 | `feature/chat/.../viewmodel/ChatViewModel.kt` | 2151→1068 | VM god-class | **done — PR #157 (merged)** |
 | 2 | `feature/agents/.../viewmodel/AgentEditorViewModel.kt` | 1938→518 | VM god-class (no delegates yet) | **done — device-verified** |
-| 3 | `feature/chat/androidMain/.../screen/ChatScreen.kt` | 1232 | Composable + leaked logic | planned |
+| 3 | `feature/chat/androidMain/.../screen/ChatScreen.kt` | 1232→260 | Composable + leaked logic | **done — device-verified** |
 | 4 | `feature/agents/.../components/AgentActionsPanel.kt` | 882 | Two 240+ line dialogs | planned |
 | 5 | `feature/agents/.../screen/AgentEditorScreen.kt` | 926 | One 467-line Column | planned |
 | 6 | `feature/settings/.../viewmodel/SettingsViewModel.kt` | 966 | Partial delegation | planned |
@@ -33,6 +33,41 @@ and bring the code closer to idiomatic Compose / unidirectional-data-flow conven
 - `core/ui/.../EndpointParameterRegistry.kt` (913) — intentional 1:1 mirror of upstream
   `parameterSettings.ts`; extracting a base template adds indirection without cutting lines.
 - `core/network/.../SseEventMapper.kt` (560) — dense but one-task-per-function; cohesive.
+
+---
+
+## PR #3 — ChatScreen
+
+**Shape:** one PR, one commit per extraction, single device-test pass at the end.
+**Result:** ChatScreen.kt 1232 → 260 lines (−79%). Android + iOS compile, detekt +
+detektMetadataCommonMain + `:app:lint`, and the chat unit-test suite all green.
+Device-verified on the Pixel 10 Pro Fold emulator (landing, send + streamed reply,
+top-bar overflow menu, model selector — all render with no regression; the
+pre-existing cold-start ANR from issue #93 is unrelated to this UI-only split).
+
+This is an Android-only Compose decomposition (the iOS `ChatScreen` actual lives
+separately in `PlatformScreens.ios.kt` and is untouched). The public `ChatScreen`
+signature is unchanged, so `NewChatScreen` / `ChatNavigation` callers are unaffected.
+Five sibling files in the same `screen/` package, `private` → `internal` where a
+symbol crosses a file:
+
+1. **`ChatSpeechToText.kt`** — `rememberChatStartRecording()`: the device/server STT
+   launchers, the RECORD_AUDIO permission flow, and the engine/language mapping
+   helpers. Moves the leaked Android intent plumbing out of the view.
+2. **`ChatScreenEffects.kt`** — the screen's one-shot side effects (new-conversation
+   nav handoff, error/share-link snackbars, fork/duplicate nav, stream resume on
+   foreground, provider-key error snackbar, back-nav after delete/archive).
+3. **`ChatContent.kt`** — `ColumnScope.ChatContent`: the per-state content area
+   (landing / loading / active), including the comparison dual-pane (tablet) and
+   tab-pager (phone) layouts and `buildComparisonDisplayMessages`.
+4. **`ChatScreenDialogs.kt`** — the dialogs/sheets (preset load/save, fork options,
+   model parameters, rename/delete confirmations, primary + secondary model
+   selectors) plus the relocated `ChatRenameDialog` / `ChatDeleteConfirmationDialog`.
+5. **`ChatTopBar.kt`** — the existing `ChatTopBar` composable relocated unchanged.
+
+`ChatScreen.kt` is now a thin scaffold wiring the top bar, content, effects, dialogs,
+and composer. Local-only sheet visibility (preset picker, save-preset, secondary
+model sheet) is hoisted to the caller via boolean flags + setter lambdas.
 
 ---
 

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatContent.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatContent.kt
@@ -1,0 +1,337 @@
+package com.garfiec.librechat.feature.chat.screen
+
+import android.content.ClipData
+import android.content.ClipboardManager
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
+import com.garfiec.librechat.core.common.EndpointConstants
+import com.garfiec.librechat.core.model.ContentType
+import com.garfiec.librechat.core.model.content.MessageContentPart
+import com.garfiec.librechat.core.ui.components.LoadingIndicator
+import com.garfiec.librechat.feature.chat.components.ComparisonDualPane
+import com.garfiec.librechat.feature.chat.components.ComparisonTabBar
+import com.garfiec.librechat.feature.chat.components.LandingContent
+import com.garfiec.librechat.feature.chat.components.MessageList
+import com.garfiec.librechat.feature.chat.components.ModelSelectorButton
+import com.garfiec.librechat.feature.chat.components.SecondaryMessageList
+import com.garfiec.librechat.feature.chat.resources.Res
+import com.garfiec.librechat.feature.chat.resources.select_model
+import com.garfiec.librechat.feature.chat.util.MessageNode
+import com.garfiec.librechat.feature.chat.viewmodel.ChatScreenState
+import com.garfiec.librechat.feature.chat.viewmodel.ChatUiState
+import com.garfiec.librechat.feature.chat.viewmodel.ChatViewModel
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * Renders the chat screen's main content area for each [ChatScreenState]: the
+ * landing greeting, the loading spinner, or the active message list. In active
+ * comparison mode it lays out the dual primary/secondary panes (side-by-side on
+ * wide screens, a tab pager on phones); otherwise it shows the single message
+ * list. Lives in a [ColumnScope] so the panes can claim the remaining height via
+ * `weight`, leaving the bottom of the box for the composer overlay.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun ColumnScope.ChatContent(
+    uiState: ChatUiState,
+    viewModel: ChatViewModel,
+    clipboardManager: ClipboardManager,
+    agentName: String?,
+    displayModel: String?,
+    fontSizeMultiplier: Float,
+    showImageDescriptions: Boolean,
+    chatLayoutStyle: String,
+    showAvatars: Boolean,
+    showBubbles: Boolean,
+    useKatex: Boolean,
+    onShowSecondaryModelSheet: () -> Unit,
+    onComparisonTabChange: (Int) -> Unit,
+) {
+    when (uiState.screenState) {
+        ChatScreenState.LANDING -> {
+            LandingContent(
+                selectedModel = uiState.selectedModel,
+                selectedAgentName = agentName,
+                modifier = Modifier.weight(1f),
+            )
+        }
+        ChatScreenState.LOADING -> {
+            LoadingIndicator(
+                modifier = Modifier.weight(1f),
+            )
+        }
+        ChatScreenState.ACTIVE -> {
+            val comparisonState = uiState.comparisonState
+            if (comparisonState.isEnabled) {
+                val screenWidthDp = LocalConfiguration.current.screenWidthDp
+                val isWideScreen = screenWidthDp >= 600
+
+                val canBranch = comparisonState.parallelMessageId != null &&
+                    !comparisonState.primaryIsStreaming &&
+                    !comparisonState.secondaryIsStreaming
+
+                // Replace the parallel response message's content with
+                // the captured streaming buffer for each agent's pane.
+                // The server-loaded message may only contain the primary
+                // agent's content, so we substitute from the buffers.
+                val primarySenderName = run {
+                    val model = uiState.selectedModel
+                    if (uiState.selectedEndpoint == EndpointConstants.AGENTS && model != null) {
+                        uiState.agents.find { it.id == model }?.name ?: model
+                    } else {
+                        model ?: "Assistant"
+                    }
+                }
+                val primaryDisplayMessages = remember(
+                    uiState.displayMessages,
+                    comparisonState.parallelMessageId,
+                    comparisonState.primaryFinalContent,
+                ) {
+                    buildComparisonDisplayMessages(
+                        uiState.displayMessages,
+                        comparisonState.parallelMessageId,
+                        comparisonState.primaryFinalContent,
+                        primarySenderName,
+                    )
+                }
+                val secondarySenderName = viewModel.getSecondaryModelDisplayName()
+                    ?: comparisonState.secondaryModel ?: "Assistant"
+                val secondaryDisplayMessages = remember(
+                    uiState.displayMessages,
+                    comparisonState.parallelMessageId,
+                    comparisonState.secondaryFinalContent,
+                    secondarySenderName,
+                ) {
+                    buildComparisonDisplayMessages(
+                        uiState.displayMessages,
+                        comparisonState.parallelMessageId,
+                        comparisonState.secondaryFinalContent,
+                        secondarySenderName,
+                    )
+                }
+
+                val primaryMessageList: @Composable () -> Unit = {
+                    MessageList(
+                        displayMessages = primaryDisplayMessages,
+                        isStreaming = comparisonState.primaryIsStreaming || uiState.isStreaming,
+                        streamingContent = if (comparisonState.primaryIsStreaming) {
+                            comparisonState.primaryStreamingContent
+                        } else {
+                            uiState.streamingContent
+                        },
+                        activeToolCalls = if (comparisonState.primaryIsStreaming) {
+                            comparisonState.primaryActiveToolCalls
+                        } else {
+                            uiState.activeToolCalls
+                        },
+                        streamingAttachments = uiState.streamingAttachments,
+                        onSiblingNavigation = viewModel::switchBranch,
+                        onEditMessage = viewModel::startEditing,
+                        onRegenerateMessage = viewModel::regenerateMessage,
+                        onCopyMessage = { messageId ->
+                            val text = viewModel.getMessageText(messageId)
+                            if (text.isNotBlank()) {
+                                clipboardManager.setPrimaryClip(
+                                    ClipData.newPlainText("Message", text),
+                                )
+                            }
+                        },
+                        onFeedback = viewModel::submitFeedback,
+                        onContinue = { viewModel.continueGeneration() },
+                        onReadAloud = viewModel::readAloud,
+                        onFork = viewModel::showForkOptions,
+                        currentlyReadingMessageId = uiState.currentlyReadingMessageId,
+                        editingMessageId = uiState.editingMessageId,
+                        editingText = uiState.editingText,
+                        onEditTextChange = viewModel::onEditTextChanged,
+                        onEditSaveAndSubmit = viewModel::submitEdit,
+                        onEditSaveOnly = viewModel::saveEditOnly,
+                        onEditCancel = viewModel::cancelEditing,
+                        baseUrl = uiState.serverUrl,
+                        fontSizeMultiplier = fontSizeMultiplier,
+                        isRefreshing = uiState.isRefreshingMessages,
+                        onRefresh = viewModel::refreshMessages,
+                        userAvatarUrl = uiState.userAvatarUrl,
+                        userName = uiState.userName,
+                        selectedEndpoint = uiState.selectedEndpoint,
+                        streamingSenderName = primarySenderName,
+                        showImageDescriptions = showImageDescriptions,
+                        chatLayoutStyle = chatLayoutStyle,
+                        showAvatars = showAvatars,
+                        showBubbles = showBubbles,
+                        useKatex = useKatex,
+                        searchQuery = if (uiState.isSearchOpen) uiState.searchQuery else null,
+                        searchMatchIndices = uiState.searchMatchIndices,
+                        currentSearchMatchIndex = uiState.currentSearchMatchIndex,
+                        searchScrollToIndex = uiState.searchScrollToIndex,
+                        onSearchScrollHandle = viewModel::onSearchScrollHandled,
+                        modifier = Modifier.fillMaxSize(),
+                    )
+                }
+
+                val secondaryEndpoint = comparisonState.secondaryEndpoint ?: "agents"
+                val secondaryModelName = viewModel.getSecondaryModelDisplayName()
+                    ?: comparisonState.secondaryModel
+                    ?: stringResource(Res.string.select_model)
+
+                val secondaryMessageList: @Composable () -> Unit = {
+                    SecondaryMessageList(
+                        displayMessages = secondaryDisplayMessages,
+                        isStreaming = comparisonState.secondaryIsStreaming,
+                        streamingContent = comparisonState.secondaryStreamingContent,
+                        activeToolCalls = comparisonState.secondaryActiveToolCalls,
+                        streamingAttachments = uiState.streamingAttachments,
+                        error = null,
+                        baseUrl = uiState.serverUrl,
+                        fontSizeMultiplier = fontSizeMultiplier,
+                        selectedEndpoint = secondaryEndpoint,
+                        streamingSenderName = secondaryModelName,
+                        showImageDescriptions = showImageDescriptions,
+                        chatLayoutStyle = chatLayoutStyle,
+                        showAvatars = showAvatars,
+                        showBubbles = showBubbles,
+                        useKatex = useKatex,
+                        modifier = Modifier.fillMaxSize(),
+                    )
+                }
+
+                val onContinuePrimary = if (canBranch && comparisonState.primaryAgentId != null) {
+                    { viewModel.branchFromComparison(comparisonState.primaryAgentId) }
+                } else {
+                    null
+                }
+                val onContinueSecondary = if (canBranch && comparisonState.secondaryAgentId != null) {
+                    { viewModel.branchFromComparison(comparisonState.secondaryAgentId) }
+                } else {
+                    null
+                }
+
+                if (isWideScreen) {
+                    // Tablet: dual pane side-by-side
+                    ComparisonDualPane(
+                        primaryModelSelector = {
+                            ModelSelectorButton(
+                                modelName = displayModel,
+                                onClick = viewModel::openModelSheet,
+                            )
+                        },
+                        secondaryModelSelector = {
+                            ModelSelectorButton(
+                                modelName = secondaryModelName,
+                                onClick = onShowSecondaryModelSheet,
+                            )
+                        },
+                        primaryContent = primaryMessageList,
+                        secondaryContent = secondaryMessageList,
+                        onContinueWithPrimary = onContinuePrimary,
+                        onContinueWithSecondary = onContinueSecondary,
+                        modifier = Modifier.weight(1f),
+                    )
+                } else {
+                    // Phone: tab bar with pager
+                    ComparisonTabBar(
+                        primaryModelName = displayModel ?: "Primary",
+                        secondaryModelName = secondaryModelName,
+                        primaryContent = primaryMessageList,
+                        secondaryContent = secondaryMessageList,
+                        onContinueWithPrimary = onContinuePrimary,
+                        onContinueWithSecondary = onContinueSecondary,
+                        onTabChange = onComparisonTabChange,
+                        modifier = Modifier.weight(1f),
+                    )
+                }
+            } else {
+                MessageList(
+                    displayMessages = uiState.displayMessages,
+                    isStreaming = uiState.isStreaming,
+                    streamingContent = uiState.streamingContent,
+                    activeToolCalls = uiState.activeToolCalls,
+                    streamingAttachments = uiState.streamingAttachments,
+                    onSiblingNavigation = viewModel::switchBranch,
+                    onEditMessage = viewModel::startEditing,
+                    onRegenerateMessage = viewModel::regenerateMessage,
+                    onCopyMessage = { messageId ->
+                        val text = viewModel.getMessageText(messageId)
+                        if (text.isNotBlank()) {
+                            clipboardManager.setPrimaryClip(
+                                ClipData.newPlainText("Message", text),
+                            )
+                        }
+                    },
+                    onFeedback = viewModel::submitFeedback,
+                    onContinue = { viewModel.continueGeneration() },
+                    onReadAloud = viewModel::readAloud,
+                    onFork = viewModel::showForkOptions,
+                    currentlyReadingMessageId = uiState.currentlyReadingMessageId,
+                    editingMessageId = uiState.editingMessageId,
+                    editingText = uiState.editingText,
+                    onEditTextChange = viewModel::onEditTextChanged,
+                    onEditSaveAndSubmit = viewModel::submitEdit,
+                    onEditSaveOnly = viewModel::saveEditOnly,
+                    onEditCancel = viewModel::cancelEditing,
+                    baseUrl = uiState.serverUrl,
+                    fontSizeMultiplier = fontSizeMultiplier,
+                    isRefreshing = uiState.isRefreshingMessages,
+                    onRefresh = viewModel::refreshMessages,
+                    userAvatarUrl = uiState.userAvatarUrl,
+                    userName = uiState.userName,
+                    selectedEndpoint = uiState.selectedEndpoint,
+                    streamingSenderName = run {
+                        val model = uiState.selectedModel
+                        if (uiState.selectedEndpoint == EndpointConstants.AGENTS && model != null) {
+                            uiState.agents.find { it.id == model }?.name ?: model
+                        } else {
+                            model ?: "Assistant"
+                        }
+                    },
+                    showImageDescriptions = showImageDescriptions,
+                    chatLayoutStyle = chatLayoutStyle,
+                    showAvatars = showAvatars,
+                    showBubbles = showBubbles,
+                    useKatex = useKatex,
+                    searchQuery = if (uiState.isSearchOpen) uiState.searchQuery else null,
+                    searchMatchIndices = uiState.searchMatchIndices,
+                    currentSearchMatchIndex = uiState.currentSearchMatchIndex,
+                    searchScrollToIndex = uiState.searchScrollToIndex,
+                    onSearchScrollHandle = viewModel::onSearchScrollHandled,
+                    modifier = Modifier.weight(1f),
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Replaces the parallel response message's content with [finalContent] captured from
+ * the streaming buffer. The server-loaded message may only contain the primary agent's
+ * content, so for the secondary pane we substitute the captured text.
+ * Also updates the sender name so the bubble shows the correct model.
+ */
+private fun buildComparisonDisplayMessages(
+    displayMessages: List<MessageNode>,
+    parallelMessageId: String?,
+    finalContent: String?,
+    senderName: String?,
+): List<MessageNode> {
+    if (parallelMessageId == null || finalContent.isNullOrBlank()) return displayMessages
+    return displayMessages.map { node ->
+        if (node.message.messageId == parallelMessageId) {
+            // Substitute the parallel message content with the captured final content for this pane
+            node.copy(
+                message = node.message.copy(
+                    content = listOf(
+                        MessageContentPart(type = ContentType.TEXT, text = finalContent),
+                    ),
+                    sender = senderName ?: node.message.sender,
+                ),
+            )
+        } else {
+            node
+        }
+    }
+}

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatContent.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatContent.kt
@@ -22,6 +22,7 @@ import com.garfiec.librechat.feature.chat.components.SecondaryMessageList
 import com.garfiec.librechat.feature.chat.resources.Res
 import com.garfiec.librechat.feature.chat.resources.select_model
 import com.garfiec.librechat.feature.chat.util.MessageNode
+import com.garfiec.librechat.feature.chat.viewmodel.ActiveToolCall
 import com.garfiec.librechat.feature.chat.viewmodel.ChatScreenState
 import com.garfiec.librechat.feature.chat.viewmodel.ChatUiState
 import com.garfiec.librechat.feature.chat.viewmodel.ChatViewModel
@@ -67,6 +68,16 @@ internal fun ColumnScope.ChatContent(
         }
         ChatScreenState.ACTIVE -> {
             val comparisonState = uiState.comparisonState
+            // Streaming-bubble sender label for the active model: the agent's
+            // display name under the agents endpoint, else the raw model id.
+            val senderName = run {
+                val model = uiState.selectedModel
+                if (uiState.selectedEndpoint == EndpointConstants.AGENTS && model != null) {
+                    uiState.agents.find { it.id == model }?.name ?: model
+                } else {
+                    model ?: "Assistant"
+                }
+            }
             if (comparisonState.isEnabled) {
                 val screenWidthDp = LocalConfiguration.current.screenWidthDp
                 val isWideScreen = screenWidthDp >= 600
@@ -79,14 +90,6 @@ internal fun ColumnScope.ChatContent(
                 // the captured streaming buffer for each agent's pane.
                 // The server-loaded message may only contain the primary
                 // agent's content, so we substitute from the buffers.
-                val primarySenderName = run {
-                    val model = uiState.selectedModel
-                    if (uiState.selectedEndpoint == EndpointConstants.AGENTS && model != null) {
-                        uiState.agents.find { it.id == model }?.name ?: model
-                    } else {
-                        model ?: "Assistant"
-                    }
-                }
                 val primaryDisplayMessages = remember(
                     uiState.displayMessages,
                     comparisonState.parallelMessageId,
@@ -96,7 +99,7 @@ internal fun ColumnScope.ChatContent(
                         uiState.displayMessages,
                         comparisonState.parallelMessageId,
                         comparisonState.primaryFinalContent,
-                        primarySenderName,
+                        senderName,
                     )
                 }
                 val secondarySenderName = viewModel.getSecondaryModelDisplayName()
@@ -116,7 +119,16 @@ internal fun ColumnScope.ChatContent(
                 }
 
                 val primaryMessageList: @Composable () -> Unit = {
-                    MessageList(
+                    ChatMessageListPane(
+                        uiState = uiState,
+                        viewModel = viewModel,
+                        clipboardManager = clipboardManager,
+                        fontSizeMultiplier = fontSizeMultiplier,
+                        showImageDescriptions = showImageDescriptions,
+                        chatLayoutStyle = chatLayoutStyle,
+                        showAvatars = showAvatars,
+                        showBubbles = showBubbles,
+                        useKatex = useKatex,
                         displayMessages = primaryDisplayMessages,
                         isStreaming = comparisonState.primaryIsStreaming || uiState.isStreaming,
                         streamingContent = if (comparisonState.primaryIsStreaming) {
@@ -129,47 +141,7 @@ internal fun ColumnScope.ChatContent(
                         } else {
                             uiState.activeToolCalls
                         },
-                        streamingAttachments = uiState.streamingAttachments,
-                        onSiblingNavigation = viewModel::switchBranch,
-                        onEditMessage = viewModel::startEditing,
-                        onRegenerateMessage = viewModel::regenerateMessage,
-                        onCopyMessage = { messageId ->
-                            val text = viewModel.getMessageText(messageId)
-                            if (text.isNotBlank()) {
-                                clipboardManager.setPrimaryClip(
-                                    ClipData.newPlainText("Message", text),
-                                )
-                            }
-                        },
-                        onFeedback = viewModel::submitFeedback,
-                        onContinue = { viewModel.continueGeneration() },
-                        onReadAloud = viewModel::readAloud,
-                        onFork = viewModel::showForkOptions,
-                        currentlyReadingMessageId = uiState.currentlyReadingMessageId,
-                        editingMessageId = uiState.editingMessageId,
-                        editingText = uiState.editingText,
-                        onEditTextChange = viewModel::onEditTextChanged,
-                        onEditSaveAndSubmit = viewModel::submitEdit,
-                        onEditSaveOnly = viewModel::saveEditOnly,
-                        onEditCancel = viewModel::cancelEditing,
-                        baseUrl = uiState.serverUrl,
-                        fontSizeMultiplier = fontSizeMultiplier,
-                        isRefreshing = uiState.isRefreshingMessages,
-                        onRefresh = viewModel::refreshMessages,
-                        userAvatarUrl = uiState.userAvatarUrl,
-                        userName = uiState.userName,
-                        selectedEndpoint = uiState.selectedEndpoint,
-                        streamingSenderName = primarySenderName,
-                        showImageDescriptions = showImageDescriptions,
-                        chatLayoutStyle = chatLayoutStyle,
-                        showAvatars = showAvatars,
-                        showBubbles = showBubbles,
-                        useKatex = useKatex,
-                        searchQuery = if (uiState.isSearchOpen) uiState.searchQuery else null,
-                        searchMatchIndices = uiState.searchMatchIndices,
-                        currentSearchMatchIndex = uiState.currentSearchMatchIndex,
-                        searchScrollToIndex = uiState.searchScrollToIndex,
-                        onSearchScrollHandle = viewModel::onSearchScrollHandled,
+                        streamingSenderName = senderName,
                         modifier = Modifier.fillMaxSize(),
                     )
                 }
@@ -246,64 +218,100 @@ internal fun ColumnScope.ChatContent(
                     )
                 }
             } else {
-                MessageList(
-                    displayMessages = uiState.displayMessages,
-                    isStreaming = uiState.isStreaming,
-                    streamingContent = uiState.streamingContent,
-                    activeToolCalls = uiState.activeToolCalls,
-                    streamingAttachments = uiState.streamingAttachments,
-                    onSiblingNavigation = viewModel::switchBranch,
-                    onEditMessage = viewModel::startEditing,
-                    onRegenerateMessage = viewModel::regenerateMessage,
-                    onCopyMessage = { messageId ->
-                        val text = viewModel.getMessageText(messageId)
-                        if (text.isNotBlank()) {
-                            clipboardManager.setPrimaryClip(
-                                ClipData.newPlainText("Message", text),
-                            )
-                        }
-                    },
-                    onFeedback = viewModel::submitFeedback,
-                    onContinue = { viewModel.continueGeneration() },
-                    onReadAloud = viewModel::readAloud,
-                    onFork = viewModel::showForkOptions,
-                    currentlyReadingMessageId = uiState.currentlyReadingMessageId,
-                    editingMessageId = uiState.editingMessageId,
-                    editingText = uiState.editingText,
-                    onEditTextChange = viewModel::onEditTextChanged,
-                    onEditSaveAndSubmit = viewModel::submitEdit,
-                    onEditSaveOnly = viewModel::saveEditOnly,
-                    onEditCancel = viewModel::cancelEditing,
-                    baseUrl = uiState.serverUrl,
+                ChatMessageListPane(
+                    uiState = uiState,
+                    viewModel = viewModel,
+                    clipboardManager = clipboardManager,
                     fontSizeMultiplier = fontSizeMultiplier,
-                    isRefreshing = uiState.isRefreshingMessages,
-                    onRefresh = viewModel::refreshMessages,
-                    userAvatarUrl = uiState.userAvatarUrl,
-                    userName = uiState.userName,
-                    selectedEndpoint = uiState.selectedEndpoint,
-                    streamingSenderName = run {
-                        val model = uiState.selectedModel
-                        if (uiState.selectedEndpoint == EndpointConstants.AGENTS && model != null) {
-                            uiState.agents.find { it.id == model }?.name ?: model
-                        } else {
-                            model ?: "Assistant"
-                        }
-                    },
                     showImageDescriptions = showImageDescriptions,
                     chatLayoutStyle = chatLayoutStyle,
                     showAvatars = showAvatars,
                     showBubbles = showBubbles,
                     useKatex = useKatex,
-                    searchQuery = if (uiState.isSearchOpen) uiState.searchQuery else null,
-                    searchMatchIndices = uiState.searchMatchIndices,
-                    currentSearchMatchIndex = uiState.currentSearchMatchIndex,
-                    searchScrollToIndex = uiState.searchScrollToIndex,
-                    onSearchScrollHandle = viewModel::onSearchScrollHandled,
+                    displayMessages = uiState.displayMessages,
+                    isStreaming = uiState.isStreaming,
+                    streamingContent = uiState.streamingContent,
+                    activeToolCalls = uiState.activeToolCalls,
+                    streamingSenderName = senderName,
                     modifier = Modifier.weight(1f),
                 )
             }
         }
     }
+}
+
+/**
+ * The single (non-comparison) and comparison-primary message lists differ only in
+ * their streaming source, sender label, and modifier; everything else — the action
+ * callbacks, editing state, search wiring, and display prefs — is identical. This
+ * wrapper holds that shared configuration so both call sites stay in sync.
+ */
+@Composable
+private fun ChatMessageListPane(
+    uiState: ChatUiState,
+    viewModel: ChatViewModel,
+    clipboardManager: ClipboardManager,
+    fontSizeMultiplier: Float,
+    showImageDescriptions: Boolean,
+    chatLayoutStyle: String,
+    showAvatars: Boolean,
+    showBubbles: Boolean,
+    useKatex: Boolean,
+    displayMessages: List<MessageNode>,
+    isStreaming: Boolean,
+    streamingContent: String,
+    activeToolCalls: List<ActiveToolCall>,
+    streamingSenderName: String,
+    modifier: Modifier,
+) {
+    MessageList(
+        displayMessages = displayMessages,
+        isStreaming = isStreaming,
+        streamingContent = streamingContent,
+        activeToolCalls = activeToolCalls,
+        streamingAttachments = uiState.streamingAttachments,
+        onSiblingNavigation = viewModel::switchBranch,
+        onEditMessage = viewModel::startEditing,
+        onRegenerateMessage = viewModel::regenerateMessage,
+        onCopyMessage = { messageId ->
+            val text = viewModel.getMessageText(messageId)
+            if (text.isNotBlank()) {
+                clipboardManager.setPrimaryClip(
+                    ClipData.newPlainText("Message", text),
+                )
+            }
+        },
+        onFeedback = viewModel::submitFeedback,
+        onContinue = { viewModel.continueGeneration() },
+        onReadAloud = viewModel::readAloud,
+        onFork = viewModel::showForkOptions,
+        currentlyReadingMessageId = uiState.currentlyReadingMessageId,
+        editingMessageId = uiState.editingMessageId,
+        editingText = uiState.editingText,
+        onEditTextChange = viewModel::onEditTextChanged,
+        onEditSaveAndSubmit = viewModel::submitEdit,
+        onEditSaveOnly = viewModel::saveEditOnly,
+        onEditCancel = viewModel::cancelEditing,
+        baseUrl = uiState.serverUrl,
+        fontSizeMultiplier = fontSizeMultiplier,
+        isRefreshing = uiState.isRefreshingMessages,
+        onRefresh = viewModel::refreshMessages,
+        userAvatarUrl = uiState.userAvatarUrl,
+        userName = uiState.userName,
+        selectedEndpoint = uiState.selectedEndpoint,
+        streamingSenderName = streamingSenderName,
+        showImageDescriptions = showImageDescriptions,
+        chatLayoutStyle = chatLayoutStyle,
+        showAvatars = showAvatars,
+        showBubbles = showBubbles,
+        useKatex = useKatex,
+        searchQuery = if (uiState.isSearchOpen) uiState.searchQuery else null,
+        searchMatchIndices = uiState.searchMatchIndices,
+        currentSearchMatchIndex = uiState.currentSearchMatchIndex,
+        searchScrollToIndex = uiState.searchScrollToIndex,
+        onSearchScrollHandle = viewModel::onSearchScrollHandled,
+        modifier = modifier,
+    )
 }
 
 /**

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatContent.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatContent.kt
@@ -86,10 +86,6 @@ internal fun ColumnScope.ChatContent(
                     !comparisonState.primaryIsStreaming &&
                     !comparisonState.secondaryIsStreaming
 
-                // Replace the parallel response message's content with
-                // the captured streaming buffer for each agent's pane.
-                // The server-loaded message may only contain the primary
-                // agent's content, so we substitute from the buffers.
                 val primaryDisplayMessages = remember(
                     uiState.displayMessages,
                     comparisonState.parallelMessageId,
@@ -184,7 +180,6 @@ internal fun ColumnScope.ChatContent(
                 }
 
                 if (isWideScreen) {
-                    // Tablet: dual pane side-by-side
                     ComparisonDualPane(
                         primaryModelSelector = {
                             ModelSelectorButton(
@@ -205,7 +200,6 @@ internal fun ColumnScope.ChatContent(
                         modifier = Modifier.weight(1f),
                     )
                 } else {
-                    // Phone: tab bar with pager
                     ComparisonTabBar(
                         primaryModelName = displayModel ?: "Primary",
                         secondaryModelName = secondaryModelName,
@@ -329,7 +323,6 @@ private fun buildComparisonDisplayMessages(
     if (parallelMessageId == null || finalContent.isNullOrBlank()) return displayMessages
     return displayMessages.map { node ->
         if (node.message.messageId == parallelMessageId) {
-            // Substitute the parallel message content with the captured final content for this pane
             node.copy(
                 message = node.message.copy(
                     content = listOf(

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatScreen.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatScreen.kt
@@ -47,7 +47,6 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -55,42 +54,27 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.compose.LifecycleEventEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.garfiec.librechat.core.common.EndpointConstants
 import com.garfiec.librechat.core.data.datastore.ChatFontSize
 import com.garfiec.librechat.core.data.datastore.LatexRenderer
-import com.garfiec.librechat.core.model.ContentType
-import com.garfiec.librechat.core.model.content.MessageContentPart
-import com.garfiec.librechat.core.ui.components.LoadingIndicator
 import com.garfiec.librechat.core.ui.components.ModelParameterSheet
 import com.garfiec.librechat.feature.chat.components.ChatInput
 import com.garfiec.librechat.feature.chat.components.ChatRoot
-import com.garfiec.librechat.feature.chat.components.ComparisonDualPane
-import com.garfiec.librechat.feature.chat.components.ComparisonTabBar
 import com.garfiec.librechat.feature.chat.components.ForkOptionsBottomSheet
 import com.garfiec.librechat.feature.chat.components.InConvoSearchBar
-import com.garfiec.librechat.feature.chat.components.LandingContent
-import com.garfiec.librechat.feature.chat.components.MessageList
-import com.garfiec.librechat.feature.chat.components.ModelSelectorButton
 import com.garfiec.librechat.feature.chat.components.ModelSelectorSheet
 import com.garfiec.librechat.feature.chat.components.PresetPicker
 import com.garfiec.librechat.feature.chat.components.SavePresetDialog
-import com.garfiec.librechat.feature.chat.components.SecondaryMessageList
 import com.garfiec.librechat.feature.chat.components.TempChatToggle
 import com.garfiec.librechat.feature.chat.resources.*
 import com.garfiec.librechat.feature.chat.resources.Res
-import com.garfiec.librechat.feature.chat.util.MessageNode
-import com.garfiec.librechat.feature.chat.viewmodel.ChatScreenState
 import com.garfiec.librechat.feature.chat.viewmodel.ChatViewModel
 import com.garfiec.librechat.feature.chat.viewmodel.asString
-import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.parameter.parametersOf
@@ -154,86 +138,19 @@ actual fun ChatScreen(
         coroutineScope = coroutineScope,
     )
 
-    // When a new conversation starts, navigate to Chat(conversationId) immediately
-    // (at StreamEvent.Created) so the NewChat landing page stays clean in the back
-    // stack. The new ChatViewModel at Chat(id) will resume the active stream.
-    // onPendingNavigationHandled() resets this ViewModel to a fresh landing state.
-    LaunchedEffect(uiState.pendingNavigationConversationId) {
-        val pendingId = uiState.pendingNavigationConversationId
-        if (pendingId != null && onConversationStart != null) {
-            onConversationStart(pendingId)
-            viewModel.onPendingNavigationHandled()
-        }
-    }
-
-    // Show errors in snackbar
-    LaunchedEffect(uiState.error) {
-        val error = uiState.error
-        if (error != null) {
-            snackbarHostState.showSnackbar(
-                message = error,
-                actionLabel = "Dismiss",
-            )
-            viewModel.dismissError()
-        }
-    }
-
-    UserKeyErrorSnackbarEffect(
+    ChatScreenEffects(
+        uiState = uiState,
+        shareLinkUrl = shareLinkUrl,
         viewModel = viewModel,
         snackbarHostState = snackbarHostState,
+        clipboardManager = clipboardManager,
+        onConversationStart = onConversationStart,
+        onNavigateToConversation = onNavigateToConversation,
+        onNavigateBack = onNavigateBack,
         onNavigateToProviderKeys = onNavigateToProviderKeys,
     )
 
     val sendBlockMessage = uiState.sendBlockReason?.asString()
-
-    // Stream resume on foreground
-    LifecycleEventEffect(Lifecycle.Event.ON_PAUSE) { viewModel.onPause() }
-    LifecycleEventEffect(Lifecycle.Event.ON_RESUME) { viewModel.onResume() }
-
-    // Navigate to forked conversation
-    LaunchedEffect(uiState.forkedConversationId) {
-        val forkId = uiState.forkedConversationId
-        if (forkId != null) {
-            viewModel.onForkedConversationHandled()
-            if (onNavigateToConversation != null) {
-                onNavigateToConversation(forkId)
-            } else if (onConversationStart != null) {
-                onConversationStart(forkId)
-            }
-        }
-    }
-
-    // Navigate to duplicated conversation
-    LaunchedEffect(uiState.duplicatedConversationId) {
-        val dupId = uiState.duplicatedConversationId
-        if (dupId != null) {
-            viewModel.onDuplicatedConversationHandled()
-            if (onNavigateToConversation != null) {
-                onNavigateToConversation(dupId)
-            } else if (onConversationStart != null) {
-                onConversationStart(dupId)
-            }
-        }
-    }
-
-    // Copy share link to clipboard
-    LaunchedEffect(shareLinkUrl) {
-        val url = shareLinkUrl
-        if (url != null) {
-            clipboardManager.setPrimaryClip(ClipData.newPlainText("Share Link", url))
-            viewModel.onShareLinkHandled()
-            snackbarHostState.showSnackbar("Share link copied to clipboard")
-        }
-    }
-
-    // Navigate back after delete/archive (conversationId becomes null)
-    var hadConversation by remember { mutableStateOf(uiState.conversationId != null) }
-    LaunchedEffect(uiState.conversationId) {
-        if (hadConversation && uiState.conversationId == null) {
-            onNavigateBack?.invoke()
-        }
-        hadConversation = uiState.conversationId != null
-    }
 
     ChatRoot(
         inlineArtifactPrefs = prefs.inlineArtifactPrefs,
@@ -301,258 +218,21 @@ actual fun ChatScreen(
             Column(
                 modifier = Modifier.fillMaxSize(),
             ) {
-                when (uiState.screenState) {
-                    ChatScreenState.LANDING -> {
-                        LandingContent(
-                            selectedModel = uiState.selectedModel,
-                            selectedAgentName = agentName,
-                            modifier = Modifier.weight(1f),
-                        )
-                    }
-                    ChatScreenState.LOADING -> {
-                        LoadingIndicator(
-                            modifier = Modifier.weight(1f),
-                        )
-                    }
-                    ChatScreenState.ACTIVE -> {
-                        val comparisonState = uiState.comparisonState
-                        if (comparisonState.isEnabled) {
-                            val screenWidthDp = LocalConfiguration.current.screenWidthDp
-                            val isWideScreen = screenWidthDp >= 600
-
-                            val canBranch = comparisonState.parallelMessageId != null &&
-                                !comparisonState.primaryIsStreaming &&
-                                !comparisonState.secondaryIsStreaming
-
-                            // Replace the parallel response message's content with
-                            // the captured streaming buffer for each agent's pane.
-                            // The server-loaded message may only contain the primary
-                            // agent's content, so we substitute from the buffers.
-                            val primarySenderName = run {
-                                val model = uiState.selectedModel
-                                if (uiState.selectedEndpoint == EndpointConstants.AGENTS && model != null) {
-                                    uiState.agents.find { it.id == model }?.name ?: model
-                                } else {
-                                    model ?: "Assistant"
-                                }
-                            }
-                            val primaryDisplayMessages = remember(
-                                uiState.displayMessages,
-                                comparisonState.parallelMessageId,
-                                comparisonState.primaryFinalContent,
-                            ) {
-                                buildComparisonDisplayMessages(
-                                    uiState.displayMessages,
-                                    comparisonState.parallelMessageId,
-                                    comparisonState.primaryFinalContent,
-                                    primarySenderName,
-                                )
-                            }
-                            val secondarySenderName = viewModel.getSecondaryModelDisplayName()
-                                ?: comparisonState.secondaryModel ?: "Assistant"
-                            val secondaryDisplayMessages = remember(
-                                uiState.displayMessages,
-                                comparisonState.parallelMessageId,
-                                comparisonState.secondaryFinalContent,
-                                secondarySenderName,
-                            ) {
-                                buildComparisonDisplayMessages(
-                                    uiState.displayMessages,
-                                    comparisonState.parallelMessageId,
-                                    comparisonState.secondaryFinalContent,
-                                    secondarySenderName,
-                                )
-                            }
-
-                            val primaryMessageList: @Composable () -> Unit = {
-                                MessageList(
-                                    displayMessages = primaryDisplayMessages,
-                                    isStreaming = comparisonState.primaryIsStreaming || uiState.isStreaming,
-                                    streamingContent = if (comparisonState.primaryIsStreaming) {
-                                        comparisonState.primaryStreamingContent
-                                    } else {
-                                        uiState.streamingContent
-                                    },
-                                    activeToolCalls = if (comparisonState.primaryIsStreaming) {
-                                        comparisonState.primaryActiveToolCalls
-                                    } else {
-                                        uiState.activeToolCalls
-                                    },
-                                    streamingAttachments = uiState.streamingAttachments,
-                                    onSiblingNavigation = viewModel::switchBranch,
-                                    onEditMessage = viewModel::startEditing,
-                                    onRegenerateMessage = viewModel::regenerateMessage,
-                                    onCopyMessage = { messageId ->
-                                        val text = viewModel.getMessageText(messageId)
-                                        if (text.isNotBlank()) {
-                                            clipboardManager.setPrimaryClip(
-                                                ClipData.newPlainText("Message", text),
-                                            )
-                                        }
-                                    },
-                                    onFeedback = viewModel::submitFeedback,
-                                    onContinue = { viewModel.continueGeneration() },
-                                    onReadAloud = viewModel::readAloud,
-                                    onFork = viewModel::showForkOptions,
-                                    currentlyReadingMessageId = uiState.currentlyReadingMessageId,
-                                    editingMessageId = uiState.editingMessageId,
-                                    editingText = uiState.editingText,
-                                    onEditTextChange = viewModel::onEditTextChanged,
-                                    onEditSaveAndSubmit = viewModel::submitEdit,
-                                    onEditSaveOnly = viewModel::saveEditOnly,
-                                    onEditCancel = viewModel::cancelEditing,
-                                    baseUrl = uiState.serverUrl,
-                                    fontSizeMultiplier = fontSizeMultiplier,
-                                    isRefreshing = uiState.isRefreshingMessages,
-                                    onRefresh = viewModel::refreshMessages,
-                                    userAvatarUrl = uiState.userAvatarUrl,
-                                    userName = uiState.userName,
-                                    selectedEndpoint = uiState.selectedEndpoint,
-                                    streamingSenderName = primarySenderName,
-                                    showImageDescriptions = showImageDescriptions,
-                                    chatLayoutStyle = chatLayoutStyle,
-                                    showAvatars = showAvatars,
-                                    showBubbles = showBubbles,
-                                    useKatex = useKatex,
-                                    searchQuery = if (uiState.isSearchOpen) uiState.searchQuery else null,
-                                    searchMatchIndices = uiState.searchMatchIndices,
-                                    currentSearchMatchIndex = uiState.currentSearchMatchIndex,
-                                    searchScrollToIndex = uiState.searchScrollToIndex,
-                                    onSearchScrollHandle = viewModel::onSearchScrollHandled,
-                                    modifier = Modifier.fillMaxSize(),
-                                )
-                            }
-
-                            val secondaryEndpoint = comparisonState.secondaryEndpoint ?: "agents"
-                            val secondaryModelName = viewModel.getSecondaryModelDisplayName()
-                                ?: comparisonState.secondaryModel
-                                ?: stringResource(Res.string.select_model)
-
-                            val secondaryMessageList: @Composable () -> Unit = {
-                                SecondaryMessageList(
-                                    displayMessages = secondaryDisplayMessages,
-                                    isStreaming = comparisonState.secondaryIsStreaming,
-                                    streamingContent = comparisonState.secondaryStreamingContent,
-                                    activeToolCalls = comparisonState.secondaryActiveToolCalls,
-                                    streamingAttachments = uiState.streamingAttachments,
-                                    error = null,
-                                    baseUrl = uiState.serverUrl,
-                                    fontSizeMultiplier = fontSizeMultiplier,
-                                    selectedEndpoint = secondaryEndpoint,
-                                    streamingSenderName = secondaryModelName,
-                                    showImageDescriptions = showImageDescriptions,
-                                    chatLayoutStyle = chatLayoutStyle,
-                                    showAvatars = showAvatars,
-                                    showBubbles = showBubbles,
-                                    useKatex = useKatex,
-                                    modifier = Modifier.fillMaxSize(),
-                                )
-                            }
-
-                            val onContinuePrimary = if (canBranch && comparisonState.primaryAgentId != null) {
-                                { viewModel.branchFromComparison(comparisonState.primaryAgentId) }
-                            } else {
-                                null
-                            }
-                            val onContinueSecondary = if (canBranch && comparisonState.secondaryAgentId != null) {
-                                { viewModel.branchFromComparison(comparisonState.secondaryAgentId) }
-                            } else {
-                                null
-                            }
-
-                            if (isWideScreen) {
-                                // Tablet: dual pane side-by-side
-                                ComparisonDualPane(
-                                    primaryModelSelector = {
-                                        ModelSelectorButton(
-                                            modelName = displayModel,
-                                            onClick = viewModel::openModelSheet,
-                                        )
-                                    },
-                                    secondaryModelSelector = {
-                                        ModelSelectorButton(
-                                            modelName = secondaryModelName,
-                                            onClick = { showSecondaryModelSheet = true },
-                                        )
-                                    },
-                                    primaryContent = primaryMessageList,
-                                    secondaryContent = secondaryMessageList,
-                                    onContinueWithPrimary = onContinuePrimary,
-                                    onContinueWithSecondary = onContinueSecondary,
-                                    modifier = Modifier.weight(1f),
-                                )
-                            } else {
-                                // Phone: tab bar with pager
-                                ComparisonTabBar(
-                                    primaryModelName = displayModel ?: "Primary",
-                                    secondaryModelName = secondaryModelName,
-                                    primaryContent = primaryMessageList,
-                                    secondaryContent = secondaryMessageList,
-                                    onContinueWithPrimary = onContinuePrimary,
-                                    onContinueWithSecondary = onContinueSecondary,
-                                    onTabChange = { activeComparisonTab = it },
-                                    modifier = Modifier.weight(1f),
-                                )
-                            }
-                        } else {
-                            MessageList(
-                                displayMessages = uiState.displayMessages,
-                                isStreaming = uiState.isStreaming,
-                                streamingContent = uiState.streamingContent,
-                                activeToolCalls = uiState.activeToolCalls,
-                                streamingAttachments = uiState.streamingAttachments,
-                                onSiblingNavigation = viewModel::switchBranch,
-                                onEditMessage = viewModel::startEditing,
-                                onRegenerateMessage = viewModel::regenerateMessage,
-                                onCopyMessage = { messageId ->
-                                    val text = viewModel.getMessageText(messageId)
-                                    if (text.isNotBlank()) {
-                                        clipboardManager.setPrimaryClip(
-                                            ClipData.newPlainText("Message", text),
-                                        )
-                                    }
-                                },
-                                onFeedback = viewModel::submitFeedback,
-                                onContinue = { viewModel.continueGeneration() },
-                                onReadAloud = viewModel::readAloud,
-                                onFork = viewModel::showForkOptions,
-                                currentlyReadingMessageId = uiState.currentlyReadingMessageId,
-                                editingMessageId = uiState.editingMessageId,
-                                editingText = uiState.editingText,
-                                onEditTextChange = viewModel::onEditTextChanged,
-                                onEditSaveAndSubmit = viewModel::submitEdit,
-                                onEditSaveOnly = viewModel::saveEditOnly,
-                                onEditCancel = viewModel::cancelEditing,
-                                baseUrl = uiState.serverUrl,
-                                fontSizeMultiplier = fontSizeMultiplier,
-                                isRefreshing = uiState.isRefreshingMessages,
-                                onRefresh = viewModel::refreshMessages,
-                                userAvatarUrl = uiState.userAvatarUrl,
-                                userName = uiState.userName,
-                                selectedEndpoint = uiState.selectedEndpoint,
-                                streamingSenderName = run {
-                                    val model = uiState.selectedModel
-                                    if (uiState.selectedEndpoint == EndpointConstants.AGENTS && model != null) {
-                                        uiState.agents.find { it.id == model }?.name ?: model
-                                    } else {
-                                        model ?: "Assistant"
-                                    }
-                                },
-                                showImageDescriptions = showImageDescriptions,
-                                chatLayoutStyle = chatLayoutStyle,
-                                showAvatars = showAvatars,
-                                showBubbles = showBubbles,
-                                useKatex = useKatex,
-                                searchQuery = if (uiState.isSearchOpen) uiState.searchQuery else null,
-                                searchMatchIndices = uiState.searchMatchIndices,
-                                currentSearchMatchIndex = uiState.currentSearchMatchIndex,
-                                searchScrollToIndex = uiState.searchScrollToIndex,
-                                onSearchScrollHandle = viewModel::onSearchScrollHandled,
-                                modifier = Modifier.weight(1f),
-                            )
-                        }
-                    }
-                }
+                ChatContent(
+                    uiState = uiState,
+                    viewModel = viewModel,
+                    clipboardManager = clipboardManager,
+                    agentName = agentName,
+                    displayModel = displayModel,
+                    fontSizeMultiplier = fontSizeMultiplier,
+                    showImageDescriptions = showImageDescriptions,
+                    chatLayoutStyle = chatLayoutStyle,
+                    showAvatars = showAvatars,
+                    showBubbles = showBubbles,
+                    useKatex = useKatex,
+                    onShowSecondaryModelSheet = { showSecondaryModelSheet = true },
+                    onComparisonTabChange = { activeComparisonTab = it },
+                )
             }
 
             // ChatInput overlays at the bottom so gradient shows content behind
@@ -1080,34 +760,4 @@ private fun ChatDeleteConfirmationDialog(
             }
         },
     )
-}
-
-/**
- * Replaces the parallel response message's content with [finalContent] captured from
- * the streaming buffer. The server-loaded message may only contain the primary agent's
- * content, so for the secondary pane we substitute the captured text.
- * Also updates the sender name so the bubble shows the correct model.
- */
-private fun buildComparisonDisplayMessages(
-    displayMessages: List<MessageNode>,
-    parallelMessageId: String?,
-    finalContent: String?,
-    senderName: String?,
-): List<MessageNode> {
-    if (parallelMessageId == null || finalContent.isNullOrBlank()) return displayMessages
-    return displayMessages.map { node ->
-        if (node.message.messageId == parallelMessageId) {
-            // Substitute the parallel message content with the captured final content for this pane
-            node.copy(
-                message = node.message.copy(
-                    content = listOf(
-                        MessageContentPart(type = ContentType.TEXT, text = finalContent),
-                    ),
-                    sender = senderName ?: node.message.sender,
-                ),
-            )
-        } else {
-            node
-        }
-    }
 }

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatScreen.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatScreen.kt
@@ -1,47 +1,16 @@
 package com.garfiec.librechat.feature.chat.screen
 
-import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.statusBarsPadding
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Check
-import androidx.compose.material.icons.filled.Menu
-import androidx.compose.material.icons.filled.MoreVert
-import androidx.compose.material.icons.filled.Search
-import androidx.compose.material.icons.outlined.Archive
-import androidx.compose.material.icons.outlined.AutoAwesome
-import androidx.compose.material.icons.outlined.Compare
-import androidx.compose.material.icons.outlined.ContentCopy
-import androidx.compose.material.icons.outlined.DeleteOutline
-import androidx.compose.material.icons.outlined.Edit
-import androidx.compose.material.icons.outlined.FileOpen
-import androidx.compose.material.icons.outlined.PhotoLibrary
-import androidx.compose.material.icons.outlined.SaveAs
-import androidx.compose.material.icons.outlined.Share
-import androidx.compose.material3.DropdownMenu
-import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -52,20 +21,14 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
-import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.garfiec.librechat.core.data.datastore.ChatFontSize
 import com.garfiec.librechat.core.data.datastore.LatexRenderer
 import com.garfiec.librechat.feature.chat.components.ChatInput
 import com.garfiec.librechat.feature.chat.components.ChatRoot
 import com.garfiec.librechat.feature.chat.components.InConvoSearchBar
-import com.garfiec.librechat.feature.chat.components.TempChatToggle
-import com.garfiec.librechat.feature.chat.resources.*
-import com.garfiec.librechat.feature.chat.resources.Res
 import com.garfiec.librechat.feature.chat.viewmodel.ChatViewModel
 import com.garfiec.librechat.feature.chat.viewmodel.asString
-import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.parameter.parametersOf
 
@@ -293,254 +256,5 @@ actual fun ChatScreen(
         onSetShowSecondaryModelSheet = { showSecondaryModelSheet = it },
         onNavigateToProviderKeys = onNavigateToProviderKeys,
     )
-    }
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun ChatTopBar(
-    onLoadPreset: () -> Unit,
-    onSavePreset: () -> Unit,
-    onOpenDrawer: (() -> Unit)?,
-    modifier: Modifier = Modifier,
-    onOpenSearch: () -> Unit = {},
-    onOpenPromptsLibrary: (() -> Unit)? = null,
-    onShowAllMedia: (() -> Unit)? = null,
-    promptsEnabled: Boolean = true,
-    presetsEnabled: Boolean = true,
-    multiConvoEnabled: Boolean = true,
-    isTemporaryChat: Boolean = false,
-    onToggleTemporaryChat: () -> Unit = {},
-    showTempChatToggle: Boolean = false,
-    isComparisonEnabled: Boolean = false,
-    onToggleComparison: () -> Unit = {},
-    conversationId: String? = null,
-    conversationTitle: String? = null,
-    sharedLinksEnabled: Boolean = false,
-    onShare: () -> Unit = {},
-    onRename: () -> Unit = {},
-    onDuplicate: () -> Unit = {},
-    onArchive: () -> Unit = {},
-    onDelete: () -> Unit = {},
-) {
-    var showOverflowMenu by remember { mutableStateOf(false) }
-
-    Row(
-        modifier = modifier
-            .fillMaxWidth()
-            .statusBarsPadding()
-            .padding(horizontal = 4.dp, vertical = 4.dp),
-        horizontalArrangement = Arrangement.Start,
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        // Hamburger menu button to open drawer
-        if (onOpenDrawer != null) {
-            IconButton(onClick = onOpenDrawer) {
-                Icon(
-                    imageVector = Icons.Default.Menu,
-                    contentDescription = "Open navigation drawer",
-                )
-            }
-        }
-
-        // Show the conversation title when viewing an existing conversation. The header
-        // intentionally has no model selector — model/params stay reachable from the
-        // composer "+" menu (tools sheet), a deliberate mobile decluttering choice that
-        // diverges from web's header model selector.
-        if (conversationId != null && !conversationTitle.isNullOrBlank()) {
-            Text(
-                text = conversationTitle,
-                style = MaterialTheme.typography.titleSmall,
-                color = MaterialTheme.colorScheme.onSurface,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-                modifier = Modifier.weight(1f),
-            )
-            Spacer(modifier = Modifier.width(4.dp))
-        } else {
-            Spacer(modifier = Modifier.weight(1f))
-        }
-
-        if (showTempChatToggle) {
-            TempChatToggle(
-                isTemporary = isTemporaryChat,
-                onToggle = onToggleTemporaryChat,
-            )
-        }
-        Box {
-            IconButton(onClick = { showOverflowMenu = true }) {
-                Icon(
-                    imageVector = Icons.Default.MoreVert,
-                    contentDescription = stringResource(Res.string.cd_more_options),
-                )
-            }
-            DropdownMenu(
-                expanded = showOverflowMenu,
-                onDismissRequest = { showOverflowMenu = false },
-                shape = RoundedCornerShape(16.dp),
-            ) {
-                if (conversationId != null) {
-                    DropdownMenuItem(
-                        text = { Text(stringResource(Res.string.action_search)) },
-                        onClick = {
-                            showOverflowMenu = false
-                            onOpenSearch()
-                        },
-                        leadingIcon = {
-                            Icon(Icons.Default.Search, contentDescription = null)
-                        },
-                    )
-                }
-                if (onShowAllMedia != null) {
-                    DropdownMenuItem(
-                        text = { Text(stringResource(Res.string.action_show_all_media)) },
-                        onClick = {
-                            showOverflowMenu = false
-                            onShowAllMedia()
-                        },
-                        leadingIcon = {
-                            Icon(Icons.Outlined.PhotoLibrary, contentDescription = null)
-                        },
-                    )
-                }
-                // Preset load/save — hidden when the server disables `interface.presets`
-                // (or `interface.modelSelect`), matching web's Header.tsx presets menu.
-                if (presetsEnabled) {
-                    DropdownMenuItem(
-                        text = { Text(stringResource(Res.string.load_preset)) },
-                        onClick = {
-                            showOverflowMenu = false
-                            onLoadPreset()
-                        },
-                        leadingIcon = {
-                            Icon(Icons.Outlined.FileOpen, contentDescription = null)
-                        },
-                    )
-                    DropdownMenuItem(
-                        text = { Text(stringResource(Res.string.save_as_preset)) },
-                        onClick = {
-                            showOverflowMenu = false
-                            onSavePreset()
-                        },
-                        leadingIcon = {
-                            Icon(Icons.Outlined.SaveAs, contentDescription = null)
-                        },
-                    )
-                }
-                if (onOpenPromptsLibrary != null && promptsEnabled) {
-                    DropdownMenuItem(
-                        text = { Text(stringResource(Res.string.prompts_library)) },
-                        onClick = {
-                            showOverflowMenu = false
-                            onOpenPromptsLibrary()
-                        },
-                        leadingIcon = {
-                            Icon(Icons.Outlined.AutoAwesome, contentDescription = null)
-                        },
-                    )
-                }
-                if (multiConvoEnabled) {
-                    DropdownMenuItem(
-                        text = {
-                            Row(verticalAlignment = Alignment.CenterVertically) {
-                                Text(
-                                    text = stringResource(Res.string.compare_models),
-                                    modifier = Modifier.weight(1f),
-                                )
-                                if (isComparisonEnabled) {
-                                    Spacer(modifier = Modifier.width(8.dp))
-                                    Icon(
-                                        imageVector = Icons.Filled.Check,
-                                        contentDescription = stringResource(Res.string.cd_comparison_enabled),
-                                        tint = MaterialTheme.colorScheme.primary,
-                                        modifier = Modifier.size(18.dp),
-                                    )
-                                }
-                            }
-                        },
-                        onClick = {
-                            showOverflowMenu = false
-                            onToggleComparison()
-                        },
-                        leadingIcon = {
-                            Icon(Icons.Outlined.Compare, contentDescription = null)
-                        },
-                    )
-                }
-                if (conversationId != null) {
-                    HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
-                    Text(
-                        text = conversationTitle ?: "New Chat",
-                        style = MaterialTheme.typography.titleSmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
-                    )
-                    if (sharedLinksEnabled) {
-                        DropdownMenuItem(
-                            text = { Text(stringResource(Res.string.action_share)) },
-                            onClick = {
-                                showOverflowMenu = false
-                                onShare()
-                            },
-                            leadingIcon = {
-                                Icon(Icons.Outlined.Share, contentDescription = null)
-                            },
-                        )
-                    }
-                    DropdownMenuItem(
-                        text = { Text(stringResource(Res.string.action_rename)) },
-                        onClick = {
-                            showOverflowMenu = false
-                            onRename()
-                        },
-                        leadingIcon = {
-                            Icon(Icons.Outlined.Edit, contentDescription = null)
-                        },
-                    )
-                    DropdownMenuItem(
-                        text = { Text(stringResource(Res.string.action_duplicate)) },
-                        onClick = {
-                            showOverflowMenu = false
-                            onDuplicate()
-                        },
-                        leadingIcon = {
-                            Icon(Icons.Outlined.ContentCopy, contentDescription = null)
-                        },
-                    )
-                    DropdownMenuItem(
-                        text = { Text(stringResource(Res.string.action_archive)) },
-                        onClick = {
-                            showOverflowMenu = false
-                            onArchive()
-                        },
-                        leadingIcon = {
-                            Icon(Icons.Outlined.Archive, contentDescription = null)
-                        },
-                    )
-                    HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
-                    DropdownMenuItem(
-                        text = {
-                            Text(
-                                "Delete",
-                                color = MaterialTheme.colorScheme.error,
-                            )
-                        },
-                        onClick = {
-                            showOverflowMenu = false
-                            onDelete()
-                        },
-                        leadingIcon = {
-                            Icon(
-                                Icons.Outlined.DeleteOutline,
-                                contentDescription = null,
-                                tint = MaterialTheme.colorScheme.error,
-                            )
-                        },
-                    )
-                }
-            }
-        }
     }
 }

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatScreen.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatScreen.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -32,7 +31,6 @@ import androidx.compose.material.icons.outlined.FileOpen
 import androidx.compose.material.icons.outlined.PhotoLibrary
 import androidx.compose.material.icons.outlined.SaveAs
 import androidx.compose.material.icons.outlined.Share
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -40,12 +38,10 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -59,17 +55,11 @@ import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.garfiec.librechat.core.common.EndpointConstants
 import com.garfiec.librechat.core.data.datastore.ChatFontSize
 import com.garfiec.librechat.core.data.datastore.LatexRenderer
-import com.garfiec.librechat.core.ui.components.ModelParameterSheet
 import com.garfiec.librechat.feature.chat.components.ChatInput
 import com.garfiec.librechat.feature.chat.components.ChatRoot
-import com.garfiec.librechat.feature.chat.components.ForkOptionsBottomSheet
 import com.garfiec.librechat.feature.chat.components.InConvoSearchBar
-import com.garfiec.librechat.feature.chat.components.ModelSelectorSheet
-import com.garfiec.librechat.feature.chat.components.PresetPicker
-import com.garfiec.librechat.feature.chat.components.SavePresetDialog
 import com.garfiec.librechat.feature.chat.components.TempChatToggle
 import com.garfiec.librechat.feature.chat.resources.*
 import com.garfiec.librechat.feature.chat.resources.Res
@@ -291,150 +281,18 @@ actual fun ChatScreen(
         }
     }
 
-    if (showPresetPicker) {
-        PresetPicker(
-            presets = uiState.presets,
-            onPresetSelect = { preset ->
-                viewModel.loadPreset(preset)
-                showPresetPicker = false
-            },
-            onDismiss = { showPresetPicker = false },
-            onEditPreset = { preset ->
-                viewModel.loadPreset(preset)
-                showPresetPicker = false
-            },
-            onDeletePreset = { preset ->
-                preset.presetId?.let { viewModel.deletePreset(it) }
-            },
-        )
-    }
-
-    if (showSavePresetDialog) {
-        SavePresetDialog(
-            currentEndpoint = uiState.selectedEndpoint,
-            currentModel = uiState.selectedModel,
-            onSave = { name ->
-                viewModel.savePreset(name)
-                showSavePresetDialog = false
-            },
-            onDismiss = { showSavePresetDialog = false },
-        )
-    }
-
-    if (uiState.showForkOptionsForMessageId != null) {
-        ForkOptionsBottomSheet(
-            onDismiss = viewModel::dismissForkOptions,
-            onFork = { option, splitAtTarget ->
-                viewModel.forkFromMessage(
-                    messageId = uiState.showForkOptionsForMessageId!!,
-                    option = option,
-                    splitAtTarget = splitAtTarget,
-                )
-            },
-        )
-    }
-
-    if (uiState.showModelParameters) {
-        val activeAgent = remember(uiState.agents, uiState.selectedModel, uiState.selectedEndpoint) {
-            if (uiState.selectedEndpoint == EndpointConstants.AGENTS) {
-                uiState.agents.find { it.id == uiState.selectedModel }
-            } else {
-                null
-            }
-        }
-        ModelParameterSheet(
-            parameters = uiState.modelParameters,
-            onParametersChange = viewModel::updateModelParameters,
-            onDismiss = viewModel::hideModelParameters,
-            selectedEndpoint = uiState.selectedEndpoint,
-            extendedEffortSupported = uiState.extendedEffortSupported,
-            selectedProvider = activeAgent?.provider,
-            selectedModel = activeAgent?.model ?: uiState.selectedModel,
-            onSaveAsPreset = {
-                viewModel.hideModelParameters()
-                showSavePresetDialog = true
-            },
-        )
-    }
-
-    if (uiState.showRenameDialog) {
-        ChatRenameDialog(
-            currentTitle = uiState.conversationTitle ?: "",
-            onDismiss = viewModel::dismissRenameDialog,
-            onConfirm = viewModel::renameConversation,
-        )
-    }
-
-    if (uiState.showDeleteConfirmation) {
-        ChatDeleteConfirmationDialog(
-            conversationTitle = uiState.conversationTitle ?: "this conversation",
-            onDismiss = viewModel::dismissDeleteConfirmation,
-            onConfirm = viewModel::deleteConversation,
-        )
-    }
-
-    if (uiState.showModelSheet) {
-        ModelSelectorSheet(
-            endpointConfigs = uiState.endpointConfigs,
-            availableModels = uiState.availableModels,
-            agents = uiState.agents,
-            selectedEndpoint = uiState.selectedEndpoint,
-            selectedModel = uiState.selectedModel,
-            onModelSelect = { endpoint, model ->
-                viewModel.onModelSelected(endpoint, model)
-                // Clear any pending scaffold-level snackbar for the same error so it
-                // doesn't flash behind the sheet's close animation. Harmless no-op when
-                // error is already null.
-                viewModel.dismissError()
-                viewModel.dismissSendBlockReason()
-                viewModel.dismissModelSheet()
-            },
-            onDismiss = {
-                viewModel.dismissError()
-                viewModel.dismissSendBlockReason()
-                viewModel.dismissModelSheet()
-            },
-            serverUrl = uiState.serverUrl,
-            // Send-block reasons take precedence: when set, the sheet was auto-opened
-            // to help the user resolve the block, so surface that context inline.
-            errorMessage = sendBlockMessage ?: uiState.error,
-            onErrorDismiss = {
-                viewModel.dismissSendBlockReason()
-                viewModel.dismissError()
-            },
-            favoriteAgentIds = uiState.favoriteAgentIds,
-            favoriteModelKeys = uiState.favoriteModelKeys,
-            onToggleAgentFavorite = viewModel::toggleAgentFavorite,
-            onToggleModelFavorite = viewModel::toggleModelFavorite,
-            starredDisplay = uiState.starredModelsDisplay,
-            endpointKeyStates = uiState.endpointKeyStates,
-            onSetApiKey = { name -> onNavigateToProviderKeys(name) },
-        )
-    }
-
-    // Secondary model selector sheet for comparison mode
-    if (showSecondaryModelSheet) {
-        ModelSelectorSheet(
-            endpointConfigs = uiState.endpointConfigs,
-            availableModels = uiState.availableModels,
-            agents = uiState.agents,
-            selectedEndpoint = uiState.comparisonState.secondaryEndpoint,
-            selectedModel = uiState.comparisonState.secondaryModel,
-            onModelSelect = { endpoint, model ->
-                viewModel.setSecondaryModel(endpoint, model)
-                showSecondaryModelSheet = false
-            },
-            onDismiss = { showSecondaryModelSheet = false },
-            serverUrl = uiState.serverUrl,
-            favoriteAgentIds = uiState.favoriteAgentIds,
-            favoriteModelKeys = uiState.favoriteModelKeys,
-            onToggleAgentFavorite = viewModel::toggleAgentFavorite,
-            onToggleModelFavorite = viewModel::toggleModelFavorite,
-            starredDisplay = uiState.starredModelsDisplay,
-            endpointKeyStates = uiState.endpointKeyStates,
-            onSetApiKey = { name -> onNavigateToProviderKeys(name) },
-        )
-    }
+    ChatScreenDialogs(
+        uiState = uiState,
+        viewModel = viewModel,
+        sendBlockMessage = sendBlockMessage,
+        showPresetPicker = showPresetPicker,
+        showSavePresetDialog = showSavePresetDialog,
+        showSecondaryModelSheet = showSecondaryModelSheet,
+        onSetShowPresetPicker = { showPresetPicker = it },
+        onSetShowSavePresetDialog = { showSavePresetDialog = it },
+        onSetShowSecondaryModelSheet = { showSecondaryModelSheet = it },
+        onNavigateToProviderKeys = onNavigateToProviderKeys,
+    )
     }
 }
 
@@ -685,79 +543,4 @@ private fun ChatTopBar(
             }
         }
     }
-}
-
-@Composable
-private fun ChatRenameDialog(
-    currentTitle: String,
-    onDismiss: () -> Unit,
-    onConfirm: (String) -> Unit,
-) {
-    var title by remember { mutableStateOf(currentTitle) }
-
-    AlertDialog(
-        onDismissRequest = onDismiss,
-        title = { Text(stringResource(Res.string.dialog_title_rename)) },
-        text = {
-            Column {
-                Text(
-                    text = "Enter a new title for this conversation.",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-                Spacer(modifier = Modifier.height(16.dp))
-                OutlinedTextField(
-                    value = title,
-                    onValueChange = { title = it },
-                    singleLine = true,
-                    modifier = Modifier.fillMaxWidth(),
-                    label = { Text(stringResource(Res.string.hint_title)) },
-                )
-            }
-        },
-        confirmButton = {
-            TextButton(
-                onClick = { onConfirm(title) },
-                enabled = title.isNotBlank(),
-            ) {
-                Text(stringResource(Res.string.action_rename))
-            }
-        },
-        dismissButton = {
-            TextButton(onClick = onDismiss) {
-                Text(stringResource(Res.string.cancel))
-            }
-        },
-    )
-}
-
-@Composable
-private fun ChatDeleteConfirmationDialog(
-    conversationTitle: String,
-    onDismiss: () -> Unit,
-    onConfirm: () -> Unit,
-) {
-    AlertDialog(
-        onDismissRequest = onDismiss,
-        title = { Text(stringResource(Res.string.dialog_title_delete_conversation)) },
-        text = {
-            Text(
-                text = "Are you sure you want to delete \"$conversationTitle\"? This action cannot be undone.",
-                style = MaterialTheme.typography.bodyMedium,
-            )
-        },
-        confirmButton = {
-            TextButton(onClick = onConfirm) {
-                Text(
-                    text = stringResource(Res.string.delete),
-                    color = MaterialTheme.colorScheme.error,
-                )
-            }
-        },
-        dismissButton = {
-            TextButton(onClick = onDismiss) {
-                Text(stringResource(Res.string.cancel))
-            }
-        },
-    )
 }

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatScreen.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatScreen.kt
@@ -1,15 +1,8 @@
 package com.garfiec.librechat.feature.chat.screen
 
-import android.Manifest
-import android.app.Activity
 import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
-import android.content.Intent
-import android.content.pm.PackageManager
-import android.speech.RecognizerIntent
-import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -67,7 +60,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.core.content.ContextCompat
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LifecycleEventEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -153,92 +145,14 @@ actual fun ChatScreen(
         agents = uiState.agents,
     )
 
-    // Device speech recognizer launcher (used when server STT is not available)
-    val speechRecognizerLauncher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.StartActivityForResult(),
-    ) { result ->
-        if (result.resultCode == Activity.RESULT_OK) {
-            val matches = result.data?.getStringArrayListExtra(RecognizerIntent.EXTRA_RESULTS)
-            val transcribed = matches?.firstOrNull()
-            if (!transcribed.isNullOrBlank()) {
-                viewModel.onDeviceSpeechResult(transcribed)
-            }
-        }
-    }
-
-    // Runtime permission request for RECORD_AUDIO (server STT path)
-    val audioPermissionLauncher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.RequestPermission(),
-    ) { isGranted ->
-        if (isGranted) {
-            viewModel.startRecording()
-        } else {
-            coroutineScope.launch {
-                snackbarHostState.showSnackbar("Microphone permission is required for voice input")
-            }
-        }
-    }
-
-    val onStartRecordingWithPermission: () -> Unit = {
-        val useServerStt = sttEngine.equals("whisper", ignoreCase = true) ||
-            (sttEngine.isBlank() || sttEngine.equals("default", ignoreCase = true)) &&
-            uiState.serverSttEnabled
-
-        if (useServerStt) {
-            if (!uiState.serverSttEnabled && sttEngine.equals("whisper", ignoreCase = true)) {
-                // User selected Whisper but server STT is not configured
-                coroutineScope.launch {
-                    snackbarHostState.showSnackbar(
-                        "Server speech-to-text is not enabled. " +
-                            "Ask your server admin to enable STT, or switch to Device or Google engine.",
-                    )
-                }
-            } else {
-                // Server STT path: record audio and upload for transcription
-                val hasPermission = ContextCompat.checkSelfPermission(
-                    context,
-                    Manifest.permission.RECORD_AUDIO,
-                ) == PackageManager.PERMISSION_GRANTED
-                if (hasPermission) {
-                    viewModel.startRecording()
-                } else {
-                    audioPermissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
-                }
-            }
-        } else {
-            // Device speech recognizer path (Device, Google, or Default without server)
-            val intent = Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH).apply {
-                putExtra(
-                    RecognizerIntent.EXTRA_LANGUAGE_MODEL,
-                    RecognizerIntent.LANGUAGE_MODEL_FREE_FORM,
-                )
-                putExtra(RecognizerIntent.EXTRA_PROMPT, "Speak now...")
-                // Apply user's STT language preference
-                val languageLocale = mapSttLanguageToLocale(sttLanguage)
-                if (languageLocale != null) {
-                    putExtra(RecognizerIntent.EXTRA_LANGUAGE, languageLocale)
-                    putExtra(RecognizerIntent.EXTRA_LANGUAGE_PREFERENCE, languageLocale)
-                }
-            }
-            // Apply user's STT engine preference (set the recognizer package)
-            val enginePackage = mapSttEngineToPackage(sttEngine)
-            if (enginePackage != null) {
-                intent.setPackage(enginePackage)
-            }
-            try {
-                speechRecognizerLauncher.launch(intent)
-            } catch (_: Exception) {
-                val engineLabel = if (sttEngine.equals("google", ignoreCase = true)) {
-                    "Google speech recognition is not available. Is the Google app installed?"
-                } else {
-                    "Speech recognition is not available on this device"
-                }
-                coroutineScope.launch {
-                    snackbarHostState.showSnackbar(engineLabel)
-                }
-            }
-        }
-    }
+    val onStartRecordingWithPermission = rememberChatStartRecording(
+        viewModel = viewModel,
+        sttEngine = sttEngine,
+        sttLanguage = sttLanguage,
+        serverSttEnabled = uiState.serverSttEnabled,
+        snackbarHostState = snackbarHostState,
+        coroutineScope = coroutineScope,
+    )
 
     // When a new conversation starts, navigate to Chat(conversationId) immediately
     // (at StreamEvent.Created) so the NewChat landing page stays clean in the back
@@ -1166,39 +1080,6 @@ private fun ChatDeleteConfirmationDialog(
             }
         },
     )
-}
-
-/**
- * Maps the user-facing STT engine name (from settings) to an Android package name
- * that can be set on the device speech recognition intent. Returns null for "Default",
- * empty/unknown values, or "Whisper" (which uses server-side STT, not a device package).
- *
- * Note: "Whisper" is handled separately in [onStartRecordingWithPermission] above --
- * it routes through the server STT path (record audio + upload) rather than the device
- * speech recognizer. This function is only called for the device recognizer path.
- */
-private fun mapSttEngineToPackage(engine: String): String? = when (engine.lowercase()) {
-    "google" -> "com.google.android.googlequicksearchbox"
-    "whisper" -> null // Server-side engine; never reaches device recognizer path
-    "device" -> null // Explicit on-device; uses system default speech recognizer
-    "default", "" -> null
-    else -> null
-}
-
-/**
- * Maps the user-facing STT language name (from settings) to a BCP-47 locale tag
- * for [RecognizerIntent.EXTRA_LANGUAGE]. Returns null for "Auto-detect" or
- * empty values, which lets the recognizer use the device default.
- */
-private fun mapSttLanguageToLocale(language: String): String? = when (language.lowercase()) {
-    "english" -> "en-US"
-    "spanish" -> "es-ES"
-    "french" -> "fr-FR"
-    "german" -> "de-DE"
-    "japanese" -> "ja-JP"
-    "chinese" -> "zh-CN"
-    "auto-detect", "" -> null
-    else -> null
 }
 
 /**

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatScreenDialogs.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatScreenDialogs.kt
@@ -1,0 +1,272 @@
+package com.garfiec.librechat.feature.chat.screen
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.garfiec.librechat.core.common.EndpointConstants
+import com.garfiec.librechat.core.ui.components.ModelParameterSheet
+import com.garfiec.librechat.feature.chat.components.ForkOptionsBottomSheet
+import com.garfiec.librechat.feature.chat.components.ModelSelectorSheet
+import com.garfiec.librechat.feature.chat.components.PresetPicker
+import com.garfiec.librechat.feature.chat.components.SavePresetDialog
+import com.garfiec.librechat.feature.chat.resources.*
+import com.garfiec.librechat.feature.chat.resources.Res
+import com.garfiec.librechat.feature.chat.viewmodel.ChatUiState
+import com.garfiec.librechat.feature.chat.viewmodel.ChatViewModel
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * Hosts the chat screen's transient dialogs and bottom sheets — preset load/save,
+ * fork options, model parameters, rename/delete confirmations, and the primary +
+ * secondary model selectors — so [ChatScreen] only has to declare which are open.
+ * Local-only visibility (preset picker, save-preset, secondary model sheet) is
+ * hoisted to the caller via the boolean flags and their setters.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun ChatScreenDialogs(
+    uiState: ChatUiState,
+    viewModel: ChatViewModel,
+    sendBlockMessage: String?,
+    showPresetPicker: Boolean,
+    showSavePresetDialog: Boolean,
+    showSecondaryModelSheet: Boolean,
+    onSetShowPresetPicker: (Boolean) -> Unit,
+    onSetShowSavePresetDialog: (Boolean) -> Unit,
+    onSetShowSecondaryModelSheet: (Boolean) -> Unit,
+    onNavigateToProviderKeys: (endpointName: String?) -> Unit,
+) {
+    if (showPresetPicker) {
+        PresetPicker(
+            presets = uiState.presets,
+            onPresetSelect = { preset ->
+                viewModel.loadPreset(preset)
+                onSetShowPresetPicker(false)
+            },
+            onDismiss = { onSetShowPresetPicker(false) },
+            onEditPreset = { preset ->
+                viewModel.loadPreset(preset)
+                onSetShowPresetPicker(false)
+            },
+            onDeletePreset = { preset ->
+                preset.presetId?.let { viewModel.deletePreset(it) }
+            },
+        )
+    }
+
+    if (showSavePresetDialog) {
+        SavePresetDialog(
+            currentEndpoint = uiState.selectedEndpoint,
+            currentModel = uiState.selectedModel,
+            onSave = { name ->
+                viewModel.savePreset(name)
+                onSetShowSavePresetDialog(false)
+            },
+            onDismiss = { onSetShowSavePresetDialog(false) },
+        )
+    }
+
+    if (uiState.showForkOptionsForMessageId != null) {
+        ForkOptionsBottomSheet(
+            onDismiss = viewModel::dismissForkOptions,
+            onFork = { option, splitAtTarget ->
+                viewModel.forkFromMessage(
+                    messageId = uiState.showForkOptionsForMessageId!!,
+                    option = option,
+                    splitAtTarget = splitAtTarget,
+                )
+            },
+        )
+    }
+
+    if (uiState.showModelParameters) {
+        val activeAgent = remember(uiState.agents, uiState.selectedModel, uiState.selectedEndpoint) {
+            if (uiState.selectedEndpoint == EndpointConstants.AGENTS) {
+                uiState.agents.find { it.id == uiState.selectedModel }
+            } else {
+                null
+            }
+        }
+        ModelParameterSheet(
+            parameters = uiState.modelParameters,
+            onParametersChange = viewModel::updateModelParameters,
+            onDismiss = viewModel::hideModelParameters,
+            selectedEndpoint = uiState.selectedEndpoint,
+            extendedEffortSupported = uiState.extendedEffortSupported,
+            selectedProvider = activeAgent?.provider,
+            selectedModel = activeAgent?.model ?: uiState.selectedModel,
+            onSaveAsPreset = {
+                viewModel.hideModelParameters()
+                onSetShowSavePresetDialog(true)
+            },
+        )
+    }
+
+    if (uiState.showRenameDialog) {
+        ChatRenameDialog(
+            currentTitle = uiState.conversationTitle ?: "",
+            onDismiss = viewModel::dismissRenameDialog,
+            onConfirm = viewModel::renameConversation,
+        )
+    }
+
+    if (uiState.showDeleteConfirmation) {
+        ChatDeleteConfirmationDialog(
+            conversationTitle = uiState.conversationTitle ?: "this conversation",
+            onDismiss = viewModel::dismissDeleteConfirmation,
+            onConfirm = viewModel::deleteConversation,
+        )
+    }
+
+    if (uiState.showModelSheet) {
+        ModelSelectorSheet(
+            endpointConfigs = uiState.endpointConfigs,
+            availableModels = uiState.availableModels,
+            agents = uiState.agents,
+            selectedEndpoint = uiState.selectedEndpoint,
+            selectedModel = uiState.selectedModel,
+            onModelSelect = { endpoint, model ->
+                viewModel.onModelSelected(endpoint, model)
+                // Clear any pending scaffold-level snackbar for the same error so it
+                // doesn't flash behind the sheet's close animation. Harmless no-op when
+                // error is already null.
+                viewModel.dismissError()
+                viewModel.dismissSendBlockReason()
+                viewModel.dismissModelSheet()
+            },
+            onDismiss = {
+                viewModel.dismissError()
+                viewModel.dismissSendBlockReason()
+                viewModel.dismissModelSheet()
+            },
+            serverUrl = uiState.serverUrl,
+            // Send-block reasons take precedence: when set, the sheet was auto-opened
+            // to help the user resolve the block, so surface that context inline.
+            errorMessage = sendBlockMessage ?: uiState.error,
+            onErrorDismiss = {
+                viewModel.dismissSendBlockReason()
+                viewModel.dismissError()
+            },
+            favoriteAgentIds = uiState.favoriteAgentIds,
+            favoriteModelKeys = uiState.favoriteModelKeys,
+            onToggleAgentFavorite = viewModel::toggleAgentFavorite,
+            onToggleModelFavorite = viewModel::toggleModelFavorite,
+            starredDisplay = uiState.starredModelsDisplay,
+            endpointKeyStates = uiState.endpointKeyStates,
+            onSetApiKey = { name -> onNavigateToProviderKeys(name) },
+        )
+    }
+
+    // Secondary model selector sheet for comparison mode
+    if (showSecondaryModelSheet) {
+        ModelSelectorSheet(
+            endpointConfigs = uiState.endpointConfigs,
+            availableModels = uiState.availableModels,
+            agents = uiState.agents,
+            selectedEndpoint = uiState.comparisonState.secondaryEndpoint,
+            selectedModel = uiState.comparisonState.secondaryModel,
+            onModelSelect = { endpoint, model ->
+                viewModel.setSecondaryModel(endpoint, model)
+                onSetShowSecondaryModelSheet(false)
+            },
+            onDismiss = { onSetShowSecondaryModelSheet(false) },
+            serverUrl = uiState.serverUrl,
+            favoriteAgentIds = uiState.favoriteAgentIds,
+            favoriteModelKeys = uiState.favoriteModelKeys,
+            onToggleAgentFavorite = viewModel::toggleAgentFavorite,
+            onToggleModelFavorite = viewModel::toggleModelFavorite,
+            starredDisplay = uiState.starredModelsDisplay,
+            endpointKeyStates = uiState.endpointKeyStates,
+            onSetApiKey = { name -> onNavigateToProviderKeys(name) },
+        )
+    }
+}
+
+@Composable
+private fun ChatRenameDialog(
+    currentTitle: String,
+    onDismiss: () -> Unit,
+    onConfirm: (String) -> Unit,
+) {
+    var title by remember { mutableStateOf(currentTitle) }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(Res.string.dialog_title_rename)) },
+        text = {
+            Column {
+                Text(
+                    text = "Enter a new title for this conversation.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(modifier = Modifier.height(16.dp))
+                OutlinedTextField(
+                    value = title,
+                    onValueChange = { title = it },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                    label = { Text(stringResource(Res.string.hint_title)) },
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = { onConfirm(title) },
+                enabled = title.isNotBlank(),
+            ) {
+                Text(stringResource(Res.string.action_rename))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(Res.string.cancel))
+            }
+        },
+    )
+}
+
+@Composable
+private fun ChatDeleteConfirmationDialog(
+    conversationTitle: String,
+    onDismiss: () -> Unit,
+    onConfirm: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(Res.string.dialog_title_delete_conversation)) },
+        text = {
+            Text(
+                text = "Are you sure you want to delete \"$conversationTitle\"? This action cannot be undone.",
+                style = MaterialTheme.typography.bodyMedium,
+            )
+        },
+        confirmButton = {
+            TextButton(onClick = onConfirm) {
+                Text(
+                    text = stringResource(Res.string.delete),
+                    color = MaterialTheme.colorScheme.error,
+                )
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(Res.string.cancel))
+            }
+        },
+    )
+}

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatScreenEffects.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatScreenEffects.kt
@@ -44,7 +44,6 @@ internal fun ChatScreenEffects(
         }
     }
 
-    // Show errors in snackbar
     LaunchedEffect(uiState.error) {
         val error = uiState.error
         if (error != null) {
@@ -62,11 +61,9 @@ internal fun ChatScreenEffects(
         onNavigateToProviderKeys = onNavigateToProviderKeys,
     )
 
-    // Stream resume on foreground
     LifecycleEventEffect(Lifecycle.Event.ON_PAUSE) { viewModel.onPause() }
     LifecycleEventEffect(Lifecycle.Event.ON_RESUME) { viewModel.onResume() }
 
-    // Navigate to forked conversation
     LaunchedEffect(uiState.forkedConversationId) {
         val forkId = uiState.forkedConversationId
         if (forkId != null) {
@@ -79,7 +76,6 @@ internal fun ChatScreenEffects(
         }
     }
 
-    // Navigate to duplicated conversation
     LaunchedEffect(uiState.duplicatedConversationId) {
         val dupId = uiState.duplicatedConversationId
         if (dupId != null) {
@@ -92,7 +88,6 @@ internal fun ChatScreenEffects(
         }
     }
 
-    // Copy share link to clipboard
     LaunchedEffect(shareLinkUrl) {
         val url = shareLinkUrl
         if (url != null) {

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatScreenEffects.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatScreenEffects.kt
@@ -1,0 +1,113 @@
+package com.garfiec.librechat.feature.chat.screen
+
+import android.content.ClipData
+import android.content.ClipboardManager
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LifecycleEventEffect
+import com.garfiec.librechat.feature.chat.viewmodel.ChatUiState
+import com.garfiec.librechat.feature.chat.viewmodel.ChatViewModel
+
+/**
+ * Hosts the chat screen's one-shot side effects so [ChatScreen] reads as layout.
+ * Covers: new-conversation navigation handoff, error/share-link snackbars,
+ * fork/duplicate navigation, stream resume on foreground, the provider-key error
+ * snackbar, and back-navigation after a delete/archive clears the conversation.
+ */
+@Composable
+internal fun ChatScreenEffects(
+    uiState: ChatUiState,
+    shareLinkUrl: String?,
+    viewModel: ChatViewModel,
+    snackbarHostState: SnackbarHostState,
+    clipboardManager: ClipboardManager,
+    onConversationStart: ((String) -> Unit)?,
+    onNavigateToConversation: ((String) -> Unit)?,
+    onNavigateBack: (() -> Unit)?,
+    onNavigateToProviderKeys: (endpointName: String?) -> Unit,
+) {
+    // When a new conversation starts, navigate to Chat(conversationId) immediately
+    // (at StreamEvent.Created) so the NewChat landing page stays clean in the back
+    // stack. The new ChatViewModel at Chat(id) will resume the active stream.
+    // onPendingNavigationHandled() resets this ViewModel to a fresh landing state.
+    LaunchedEffect(uiState.pendingNavigationConversationId) {
+        val pendingId = uiState.pendingNavigationConversationId
+        if (pendingId != null && onConversationStart != null) {
+            onConversationStart(pendingId)
+            viewModel.onPendingNavigationHandled()
+        }
+    }
+
+    // Show errors in snackbar
+    LaunchedEffect(uiState.error) {
+        val error = uiState.error
+        if (error != null) {
+            snackbarHostState.showSnackbar(
+                message = error,
+                actionLabel = "Dismiss",
+            )
+            viewModel.dismissError()
+        }
+    }
+
+    UserKeyErrorSnackbarEffect(
+        viewModel = viewModel,
+        snackbarHostState = snackbarHostState,
+        onNavigateToProviderKeys = onNavigateToProviderKeys,
+    )
+
+    // Stream resume on foreground
+    LifecycleEventEffect(Lifecycle.Event.ON_PAUSE) { viewModel.onPause() }
+    LifecycleEventEffect(Lifecycle.Event.ON_RESUME) { viewModel.onResume() }
+
+    // Navigate to forked conversation
+    LaunchedEffect(uiState.forkedConversationId) {
+        val forkId = uiState.forkedConversationId
+        if (forkId != null) {
+            viewModel.onForkedConversationHandled()
+            if (onNavigateToConversation != null) {
+                onNavigateToConversation(forkId)
+            } else if (onConversationStart != null) {
+                onConversationStart(forkId)
+            }
+        }
+    }
+
+    // Navigate to duplicated conversation
+    LaunchedEffect(uiState.duplicatedConversationId) {
+        val dupId = uiState.duplicatedConversationId
+        if (dupId != null) {
+            viewModel.onDuplicatedConversationHandled()
+            if (onNavigateToConversation != null) {
+                onNavigateToConversation(dupId)
+            } else if (onConversationStart != null) {
+                onConversationStart(dupId)
+            }
+        }
+    }
+
+    // Copy share link to clipboard
+    LaunchedEffect(shareLinkUrl) {
+        val url = shareLinkUrl
+        if (url != null) {
+            clipboardManager.setPrimaryClip(ClipData.newPlainText("Share Link", url))
+            viewModel.onShareLinkHandled()
+            snackbarHostState.showSnackbar("Share link copied to clipboard")
+        }
+    }
+
+    // Navigate back after delete/archive (conversationId becomes null)
+    var hadConversation by remember { mutableStateOf(uiState.conversationId != null) }
+    LaunchedEffect(uiState.conversationId) {
+        if (hadConversation && uiState.conversationId == null) {
+            onNavigateBack?.invoke()
+        }
+        hadConversation = uiState.conversationId != null
+    }
+}

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatSpeechToText.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatSpeechToText.kt
@@ -1,0 +1,157 @@
+package com.garfiec.librechat.feature.chat.screen
+
+import android.Manifest
+import android.app.Activity
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.speech.RecognizerIntent
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
+import androidx.core.content.ContextCompat
+import com.garfiec.librechat.feature.chat.viewmodel.ChatViewModel
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+/**
+ * Builds the "start recording" action for the chat composer, routing between the
+ * server speech-to-text path (record audio + upload for transcription) and the
+ * device speech recognizer based on the user's STT engine preference. This keeps
+ * the Android permission + intent plumbing out of [ChatScreen].
+ *
+ * Returns a lambda to invoke when the user taps the mic; it is rebuilt on each
+ * recomposition so it always sees the latest [serverSttEnabled].
+ */
+@Composable
+internal fun rememberChatStartRecording(
+    viewModel: ChatViewModel,
+    sttEngine: String,
+    sttLanguage: String,
+    serverSttEnabled: Boolean,
+    snackbarHostState: SnackbarHostState,
+    coroutineScope: CoroutineScope,
+): () -> Unit {
+    val context = LocalContext.current
+
+    // Device speech recognizer launcher (used when server STT is not available)
+    val speechRecognizerLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.StartActivityForResult(),
+    ) { result ->
+        if (result.resultCode == Activity.RESULT_OK) {
+            val matches = result.data?.getStringArrayListExtra(RecognizerIntent.EXTRA_RESULTS)
+            val transcribed = matches?.firstOrNull()
+            if (!transcribed.isNullOrBlank()) {
+                viewModel.onDeviceSpeechResult(transcribed)
+            }
+        }
+    }
+
+    // Runtime permission request for RECORD_AUDIO (server STT path)
+    val audioPermissionLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestPermission(),
+    ) { isGranted ->
+        if (isGranted) {
+            viewModel.startRecording()
+        } else {
+            coroutineScope.launch {
+                snackbarHostState.showSnackbar("Microphone permission is required for voice input")
+            }
+        }
+    }
+
+    return {
+        val useServerStt = sttEngine.equals("whisper", ignoreCase = true) ||
+            (sttEngine.isBlank() || sttEngine.equals("default", ignoreCase = true)) &&
+            serverSttEnabled
+
+        if (useServerStt) {
+            if (!serverSttEnabled && sttEngine.equals("whisper", ignoreCase = true)) {
+                // User selected Whisper but server STT is not configured
+                coroutineScope.launch {
+                    snackbarHostState.showSnackbar(
+                        "Server speech-to-text is not enabled. " +
+                            "Ask your server admin to enable STT, or switch to Device or Google engine.",
+                    )
+                }
+            } else {
+                // Server STT path: record audio and upload for transcription
+                val hasPermission = ContextCompat.checkSelfPermission(
+                    context,
+                    Manifest.permission.RECORD_AUDIO,
+                ) == PackageManager.PERMISSION_GRANTED
+                if (hasPermission) {
+                    viewModel.startRecording()
+                } else {
+                    audioPermissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
+                }
+            }
+        } else {
+            // Device speech recognizer path (Device, Google, or Default without server)
+            val intent = Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH).apply {
+                putExtra(
+                    RecognizerIntent.EXTRA_LANGUAGE_MODEL,
+                    RecognizerIntent.LANGUAGE_MODEL_FREE_FORM,
+                )
+                putExtra(RecognizerIntent.EXTRA_PROMPT, "Speak now...")
+                // Apply user's STT language preference
+                val languageLocale = mapSttLanguageToLocale(sttLanguage)
+                if (languageLocale != null) {
+                    putExtra(RecognizerIntent.EXTRA_LANGUAGE, languageLocale)
+                    putExtra(RecognizerIntent.EXTRA_LANGUAGE_PREFERENCE, languageLocale)
+                }
+            }
+            // Apply user's STT engine preference (set the recognizer package)
+            val enginePackage = mapSttEngineToPackage(sttEngine)
+            if (enginePackage != null) {
+                intent.setPackage(enginePackage)
+            }
+            try {
+                speechRecognizerLauncher.launch(intent)
+            } catch (_: Exception) {
+                val engineLabel = if (sttEngine.equals("google", ignoreCase = true)) {
+                    "Google speech recognition is not available. Is the Google app installed?"
+                } else {
+                    "Speech recognition is not available on this device"
+                }
+                coroutineScope.launch {
+                    snackbarHostState.showSnackbar(engineLabel)
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Maps the user-facing STT engine name (from settings) to an Android package name
+ * that can be set on the device speech recognition intent. Returns null for "Default",
+ * empty/unknown values, or "Whisper" (which uses server-side STT, not a device package).
+ *
+ * Note: "Whisper" is handled separately in [rememberChatStartRecording] above --
+ * it routes through the server STT path (record audio + upload) rather than the device
+ * speech recognizer. This function is only called for the device recognizer path.
+ */
+private fun mapSttEngineToPackage(engine: String): String? = when (engine.lowercase()) {
+    "google" -> "com.google.android.googlequicksearchbox"
+    "whisper" -> null // Server-side engine; never reaches device recognizer path
+    "device" -> null // Explicit on-device; uses system default speech recognizer
+    "default", "" -> null
+    else -> null
+}
+
+/**
+ * Maps the user-facing STT language name (from settings) to a BCP-47 locale tag
+ * for [RecognizerIntent.EXTRA_LANGUAGE]. Returns null for "Auto-detect" or
+ * empty values, which lets the recognizer use the device default.
+ */
+private fun mapSttLanguageToLocale(language: String): String? = when (language.lowercase()) {
+    "english" -> "en-US"
+    "spanish" -> "es-ES"
+    "french" -> "fr-FR"
+    "german" -> "de-DE"
+    "japanese" -> "ja-JP"
+    "chinese" -> "zh-CN"
+    "auto-detect", "" -> null
+    else -> null
+}

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatSpeechToText.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatSpeechToText.kt
@@ -95,14 +95,12 @@ internal fun rememberChatStartRecording(
                     RecognizerIntent.LANGUAGE_MODEL_FREE_FORM,
                 )
                 putExtra(RecognizerIntent.EXTRA_PROMPT, "Speak now...")
-                // Apply user's STT language preference
                 val languageLocale = mapSttLanguageToLocale(sttLanguage)
                 if (languageLocale != null) {
                     putExtra(RecognizerIntent.EXTRA_LANGUAGE, languageLocale)
                     putExtra(RecognizerIntent.EXTRA_LANGUAGE_PREFERENCE, languageLocale)
                 }
             }
-            // Apply user's STT engine preference (set the recognizer package)
             val enginePackage = mapSttEngineToPackage(sttEngine)
             if (enginePackage != null) {
                 intent.setPackage(enginePackage)

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatTopBar.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatTopBar.kt
@@ -84,7 +84,6 @@ internal fun ChatTopBar(
         horizontalArrangement = Arrangement.Start,
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        // Hamburger menu button to open drawer
         if (onOpenDrawer != null) {
             IconButton(onClick = onOpenDrawer) {
                 Icon(

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatTopBar.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatTopBar.kt
@@ -1,0 +1,297 @@
+package com.garfiec.librechat.feature.chat.screen
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Menu
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.outlined.Archive
+import androidx.compose.material.icons.outlined.AutoAwesome
+import androidx.compose.material.icons.outlined.Compare
+import androidx.compose.material.icons.outlined.ContentCopy
+import androidx.compose.material.icons.outlined.DeleteOutline
+import androidx.compose.material.icons.outlined.Edit
+import androidx.compose.material.icons.outlined.FileOpen
+import androidx.compose.material.icons.outlined.PhotoLibrary
+import androidx.compose.material.icons.outlined.SaveAs
+import androidx.compose.material.icons.outlined.Share
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.garfiec.librechat.feature.chat.components.TempChatToggle
+import com.garfiec.librechat.feature.chat.resources.*
+import com.garfiec.librechat.feature.chat.resources.Res
+import org.jetbrains.compose.resources.stringResource
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun ChatTopBar(
+    onLoadPreset: () -> Unit,
+    onSavePreset: () -> Unit,
+    onOpenDrawer: (() -> Unit)?,
+    modifier: Modifier = Modifier,
+    onOpenSearch: () -> Unit = {},
+    onOpenPromptsLibrary: (() -> Unit)? = null,
+    onShowAllMedia: (() -> Unit)? = null,
+    promptsEnabled: Boolean = true,
+    presetsEnabled: Boolean = true,
+    multiConvoEnabled: Boolean = true,
+    isTemporaryChat: Boolean = false,
+    onToggleTemporaryChat: () -> Unit = {},
+    showTempChatToggle: Boolean = false,
+    isComparisonEnabled: Boolean = false,
+    onToggleComparison: () -> Unit = {},
+    conversationId: String? = null,
+    conversationTitle: String? = null,
+    sharedLinksEnabled: Boolean = false,
+    onShare: () -> Unit = {},
+    onRename: () -> Unit = {},
+    onDuplicate: () -> Unit = {},
+    onArchive: () -> Unit = {},
+    onDelete: () -> Unit = {},
+) {
+    var showOverflowMenu by remember { mutableStateOf(false) }
+
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .statusBarsPadding()
+            .padding(horizontal = 4.dp, vertical = 4.dp),
+        horizontalArrangement = Arrangement.Start,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        // Hamburger menu button to open drawer
+        if (onOpenDrawer != null) {
+            IconButton(onClick = onOpenDrawer) {
+                Icon(
+                    imageVector = Icons.Default.Menu,
+                    contentDescription = "Open navigation drawer",
+                )
+            }
+        }
+
+        // Show the conversation title when viewing an existing conversation. The header
+        // intentionally has no model selector — model/params stay reachable from the
+        // composer "+" menu (tools sheet), a deliberate mobile decluttering choice that
+        // diverges from web's header model selector.
+        if (conversationId != null && !conversationTitle.isNullOrBlank()) {
+            Text(
+                text = conversationTitle,
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.weight(1f),
+            )
+            Spacer(modifier = Modifier.width(4.dp))
+        } else {
+            Spacer(modifier = Modifier.weight(1f))
+        }
+
+        if (showTempChatToggle) {
+            TempChatToggle(
+                isTemporary = isTemporaryChat,
+                onToggle = onToggleTemporaryChat,
+            )
+        }
+        Box {
+            IconButton(onClick = { showOverflowMenu = true }) {
+                Icon(
+                    imageVector = Icons.Default.MoreVert,
+                    contentDescription = stringResource(Res.string.cd_more_options),
+                )
+            }
+            DropdownMenu(
+                expanded = showOverflowMenu,
+                onDismissRequest = { showOverflowMenu = false },
+                shape = RoundedCornerShape(16.dp),
+            ) {
+                if (conversationId != null) {
+                    DropdownMenuItem(
+                        text = { Text(stringResource(Res.string.action_search)) },
+                        onClick = {
+                            showOverflowMenu = false
+                            onOpenSearch()
+                        },
+                        leadingIcon = {
+                            Icon(Icons.Default.Search, contentDescription = null)
+                        },
+                    )
+                }
+                if (onShowAllMedia != null) {
+                    DropdownMenuItem(
+                        text = { Text(stringResource(Res.string.action_show_all_media)) },
+                        onClick = {
+                            showOverflowMenu = false
+                            onShowAllMedia()
+                        },
+                        leadingIcon = {
+                            Icon(Icons.Outlined.PhotoLibrary, contentDescription = null)
+                        },
+                    )
+                }
+                // Preset load/save — hidden when the server disables `interface.presets`
+                // (or `interface.modelSelect`), matching web's Header.tsx presets menu.
+                if (presetsEnabled) {
+                    DropdownMenuItem(
+                        text = { Text(stringResource(Res.string.load_preset)) },
+                        onClick = {
+                            showOverflowMenu = false
+                            onLoadPreset()
+                        },
+                        leadingIcon = {
+                            Icon(Icons.Outlined.FileOpen, contentDescription = null)
+                        },
+                    )
+                    DropdownMenuItem(
+                        text = { Text(stringResource(Res.string.save_as_preset)) },
+                        onClick = {
+                            showOverflowMenu = false
+                            onSavePreset()
+                        },
+                        leadingIcon = {
+                            Icon(Icons.Outlined.SaveAs, contentDescription = null)
+                        },
+                    )
+                }
+                if (onOpenPromptsLibrary != null && promptsEnabled) {
+                    DropdownMenuItem(
+                        text = { Text(stringResource(Res.string.prompts_library)) },
+                        onClick = {
+                            showOverflowMenu = false
+                            onOpenPromptsLibrary()
+                        },
+                        leadingIcon = {
+                            Icon(Icons.Outlined.AutoAwesome, contentDescription = null)
+                        },
+                    )
+                }
+                if (multiConvoEnabled) {
+                    DropdownMenuItem(
+                        text = {
+                            Row(verticalAlignment = Alignment.CenterVertically) {
+                                Text(
+                                    text = stringResource(Res.string.compare_models),
+                                    modifier = Modifier.weight(1f),
+                                )
+                                if (isComparisonEnabled) {
+                                    Spacer(modifier = Modifier.width(8.dp))
+                                    Icon(
+                                        imageVector = Icons.Filled.Check,
+                                        contentDescription = stringResource(Res.string.cd_comparison_enabled),
+                                        tint = MaterialTheme.colorScheme.primary,
+                                        modifier = Modifier.size(18.dp),
+                                    )
+                                }
+                            }
+                        },
+                        onClick = {
+                            showOverflowMenu = false
+                            onToggleComparison()
+                        },
+                        leadingIcon = {
+                            Icon(Icons.Outlined.Compare, contentDescription = null)
+                        },
+                    )
+                }
+                if (conversationId != null) {
+                    HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
+                    Text(
+                        text = conversationTitle ?: "New Chat",
+                        style = MaterialTheme.typography.titleSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                    )
+                    if (sharedLinksEnabled) {
+                        DropdownMenuItem(
+                            text = { Text(stringResource(Res.string.action_share)) },
+                            onClick = {
+                                showOverflowMenu = false
+                                onShare()
+                            },
+                            leadingIcon = {
+                                Icon(Icons.Outlined.Share, contentDescription = null)
+                            },
+                        )
+                    }
+                    DropdownMenuItem(
+                        text = { Text(stringResource(Res.string.action_rename)) },
+                        onClick = {
+                            showOverflowMenu = false
+                            onRename()
+                        },
+                        leadingIcon = {
+                            Icon(Icons.Outlined.Edit, contentDescription = null)
+                        },
+                    )
+                    DropdownMenuItem(
+                        text = { Text(stringResource(Res.string.action_duplicate)) },
+                        onClick = {
+                            showOverflowMenu = false
+                            onDuplicate()
+                        },
+                        leadingIcon = {
+                            Icon(Icons.Outlined.ContentCopy, contentDescription = null)
+                        },
+                    )
+                    DropdownMenuItem(
+                        text = { Text(stringResource(Res.string.action_archive)) },
+                        onClick = {
+                            showOverflowMenu = false
+                            onArchive()
+                        },
+                        leadingIcon = {
+                            Icon(Icons.Outlined.Archive, contentDescription = null)
+                        },
+                    )
+                    HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
+                    DropdownMenuItem(
+                        text = {
+                            Text(
+                                "Delete",
+                                color = MaterialTheme.colorScheme.error,
+                            )
+                        },
+                        onClick = {
+                            showOverflowMenu = false
+                            onDelete()
+                        },
+                        leadingIcon = {
+                            Icon(
+                                Icons.Outlined.DeleteOutline,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.error,
+                            )
+                        },
+                    )
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Splits the Android `ChatScreen.kt` (1232 lines) into five focused sibling files in the same `screen/` package. Pure structural refactor — no behavior change. The public `ChatScreen` signature is unchanged, so callers are unaffected, and the iOS `ChatScreen` actual (in `PlatformScreens.ios.kt`) is untouched.

## Changes
- **`ChatSpeechToText.kt`** — `rememberChatStartRecording()`: the device/server STT launchers, the `RECORD_AUDIO` permission flow, and the engine/language mapping helpers, moved out of the view body.
- **`ChatScreenEffects.kt`** — the screen's one-shot side effects (new-conversation nav handoff, error/share-link snackbars, fork/duplicate nav, stream resume on foreground, provider-key error, back-nav after delete/archive).
- **`ChatContent.kt`** — `ColumnScope.ChatContent`: the per-state content area (landing / loading / active), including the comparison dual-pane and tab-pager layouts. The two message-list call sites are consolidated into one `ChatMessageListPane` helper.
- **`ChatScreenDialogs.kt`** — the dialogs/sheets (preset load/save, fork options, model parameters, rename/delete confirmations, primary + secondary model selectors).
- **`ChatTopBar.kt`** — the existing `ChatTopBar` composable relocated with no logic change.
- `ChatScreen.kt` is now a thin scaffold wiring the top bar, content, effects, dialogs, and composer. Local-only sheet visibility is hoisted via boolean flags + setter lambdas.
- `MODULARIZATION.md` updated to record this pass.

## Testing
- Android + iOS compile; detekt + `detektMetadataCommonMain` + `:app:lint`; chat unit-test suite — all green.
- Device-verified on the Pixel 10 Pro Fold emulator: landing, send + streamed reply, top-bar overflow menu, and model selector all render with no regression.
