### PR TITLE
refactor(agents): split AgentActionsPanel into per-dialog files

### DIFF
--- a/MODULARIZATION.md
+++ b/MODULARIZATION.md
@@ -22,8 +22,8 @@ and bring the code closer to idiomatic Compose / unidirectional-data-flow conven
 |---|------|-------|------|--------|
 | 1 | `feature/chat/.../viewmodel/ChatViewModel.kt` | 2151→1068 | VM god-class | **done — PR #157 (merged)** |
 | 2 | `feature/agents/.../viewmodel/AgentEditorViewModel.kt` | 1938→518 | VM god-class (no delegates yet) | **done — device-verified** |
-| 3 | `feature/chat/androidMain/.../screen/ChatScreen.kt` | 1232→260 | Composable + leaked logic | **done — device-verified** |
-| 4 | `feature/agents/.../components/AgentActionsPanel.kt` | 882 | Two 240+ line dialogs | planned |
+| 3 | `feature/chat/androidMain/.../screen/ChatScreen.kt` | 1232→260 | Composable + leaked logic | **done — PR #159 merged** |
+| 4 | `feature/agents/.../components/AgentActionsPanel.kt` | 882→185 | Two 240+ line dialogs | **done — local** |
 | 5 | `feature/agents/.../screen/AgentEditorScreen.kt` | 926 | One 467-line Column | planned |
 | 6 | `feature/settings/.../viewmodel/SettingsViewModel.kt` | 966 | Partial delegation | planned |
 | 7 | `feature/chat/.../components/SharedContentParts.kt` | 711 | Duplicate collapsible cards | planned |
@@ -33,6 +33,29 @@ and bring the code closer to idiomatic Compose / unidirectional-data-flow conven
 - `core/ui/.../EndpointParameterRegistry.kt` (913) — intentional 1:1 mirror of upstream
   `parameterSettings.ts`; extracting a base template adds indirection without cutting lines.
 - `core/network/.../SseEventMapper.kt` (560) — dense but one-task-per-function; cohesive.
+
+---
+
+## PR #4 — AgentActionsPanel
+
+**Shape:** one PR, one commit per extraction, single device-test pass at the end.
+**Result:** AgentActionsPanel.kt 882 → 185 lines (−79%). Android + iOS compile and
+detektMetadataCommonMain all green.
+
+A `commonMain` (shared Android + iOS) Compose decomposition. The public
+`AgentActionsPanel` signature is unchanged, so `AgentEditorScreen` is unaffected.
+Two sibling files in the same `components/` package, `private` → `internal` where a
+symbol crosses a file:
+
+1. **`ActionEditorDialog.kt`** — the full-screen OpenAPI action editor (`Dialog` +
+   `Scaffold`, debounced spec validation, save-metadata assembly) plus its
+   `AuthenticationSection` and `FunctionTable` helpers.
+2. **`ActionAuthConfigDialog.kt`** — the auth-configuration `AlertDialog`
+   (none / API-key / OAuth) plus its `AuthTypeRadioOption` helper and the shared
+   `HIDDEN_PLACEHOLDER` constant.
+
+`AgentActionsPanel.kt` now holds only the collapsible panel shell and its
+per-action `ActionCard`.
 
 ---
 

--- a/feature/agents/src/commonMain/kotlin/com/garfiec/librechat/feature/agents/components/ActionAuthConfigDialog.kt
+++ b/feature/agents/src/commonMain/kotlin/com/garfiec/librechat/feature/agents/components/ActionAuthConfigDialog.kt
@@ -1,0 +1,304 @@
+package com.garfiec.librechat.feature.agents.components
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.unit.dp
+import com.garfiec.librechat.feature.agents.resources.*
+import com.garfiec.librechat.feature.agents.resources.Res
+import org.jetbrains.compose.resources.stringResource
+
+internal const val HIDDEN_PLACEHOLDER = "<HIDDEN>"
+
+@Composable
+internal fun AuthConfigDialog(
+    currentAuthType: String,
+    apiKey: String,
+    authorizationType: String,
+    customAuthHeader: String,
+    oauthClientId: String,
+    oauthClientSecret: String,
+    authorizationUrl: String,
+    clientUrl: String,
+    scope: String,
+    tokenExchangeMethod: String,
+    isEditing: Boolean,
+    onDismiss: () -> Unit,
+    onSave: (
+        authType: String,
+        apiKey: String,
+        authorizationType: String,
+        customAuthHeader: String,
+        oauthClientId: String,
+        oauthClientSecret: String,
+        authorizationUrl: String,
+        clientUrl: String,
+        scope: String,
+        tokenExchangeMethod: String,
+    ) -> Unit,
+) {
+    var selectedAuthType by rememberSaveable { mutableStateOf(currentAuthType) }
+    var localApiKey by rememberSaveable { mutableStateOf(apiKey) }
+    var localAuthorizationType by rememberSaveable { mutableStateOf(authorizationType) }
+    var localCustomHeader by rememberSaveable { mutableStateOf(customAuthHeader) }
+    var localOauthClientId by rememberSaveable { mutableStateOf(oauthClientId) }
+    var localOauthClientSecret by rememberSaveable { mutableStateOf(oauthClientSecret) }
+    var localAuthUrl by rememberSaveable { mutableStateOf(authorizationUrl) }
+    var localClientUrl by rememberSaveable { mutableStateOf(clientUrl) }
+    var localScope by rememberSaveable { mutableStateOf(scope) }
+    var localTokenExchangeMethod by rememberSaveable { mutableStateOf(tokenExchangeMethod) }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(Res.string.label_authentication)) },
+        text = {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                // Auth type radio group
+                Text(
+                    text = stringResource(Res.string.label_authentication_type),
+                    style = MaterialTheme.typography.labelLarge,
+                )
+
+                AuthTypeRadioOption(
+                    label = stringResource(Res.string.auth_none),
+                    selected = selectedAuthType == "none",
+                    onClick = { selectedAuthType = "none" },
+                )
+                AuthTypeRadioOption(
+                    label = stringResource(Res.string.auth_api_key),
+                    selected = selectedAuthType == "service_http",
+                    onClick = { selectedAuthType = "service_http" },
+                )
+                AuthTypeRadioOption(
+                    label = stringResource(Res.string.auth_oauth),
+                    selected = selectedAuthType == "oauth",
+                    onClick = { selectedAuthType = "oauth" },
+                )
+
+                // API Key configuration
+                AnimatedVisibility(visible = selectedAuthType == "service_http") {
+                    Column(
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        HorizontalDivider()
+                        Text(
+                            text = stringResource(Res.string.label_api_key_settings),
+                            style = MaterialTheme.typography.labelLarge,
+                        )
+
+                        OutlinedTextField(
+                            value = localApiKey,
+                            onValueChange = { localApiKey = it },
+                            label = { Text(stringResource(Res.string.label_api_key)) },
+                            placeholder = {
+                                Text(if (isEditing) HIDDEN_PLACEHOLDER else "sk-...")
+                            },
+                            singleLine = true,
+                            visualTransformation = if (localApiKey == HIDDEN_PLACEHOLDER) {
+                                VisualTransformation.None
+                            } else {
+                                PasswordVisualTransformation()
+                            },
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+
+                        Text(
+                            text = stringResource(Res.string.label_authorization_type),
+                            style = MaterialTheme.typography.labelMedium,
+                        )
+
+                        AuthTypeRadioOption(
+                            label = stringResource(Res.string.auth_basic),
+                            selected = localAuthorizationType == "basic",
+                            onClick = { localAuthorizationType = "basic" },
+                        )
+                        AuthTypeRadioOption(
+                            label = stringResource(Res.string.auth_bearer),
+                            selected = localAuthorizationType == "bearer",
+                            onClick = { localAuthorizationType = "bearer" },
+                        )
+                        AuthTypeRadioOption(
+                            label = stringResource(Res.string.auth_custom),
+                            selected = localAuthorizationType == "custom",
+                            onClick = { localAuthorizationType = "custom" },
+                        )
+
+                        AnimatedVisibility(visible = localAuthorizationType == "custom") {
+                            OutlinedTextField(
+                                value = localCustomHeader,
+                                onValueChange = { localCustomHeader = it },
+                                label = { Text(stringResource(Res.string.label_custom_auth_header)) },
+                                placeholder = { Text("X-Api-Key") },
+                                singleLine = true,
+                                modifier = Modifier.fillMaxWidth(),
+                            )
+                        }
+                    }
+                }
+
+                // OAuth configuration
+                AnimatedVisibility(visible = selectedAuthType == "oauth") {
+                    Column(
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        HorizontalDivider()
+                        Text(
+                            text = stringResource(Res.string.label_oauth_settings),
+                            style = MaterialTheme.typography.labelLarge,
+                        )
+
+                        OutlinedTextField(
+                            value = localOauthClientId,
+                            onValueChange = { localOauthClientId = it },
+                            label = { Text(stringResource(Res.string.label_client_id)) },
+                            placeholder = {
+                                Text(if (isEditing) HIDDEN_PLACEHOLDER else "client-id")
+                            },
+                            singleLine = true,
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+
+                        OutlinedTextField(
+                            value = localOauthClientSecret,
+                            onValueChange = { localOauthClientSecret = it },
+                            label = { Text(stringResource(Res.string.label_client_secret)) },
+                            placeholder = {
+                                Text(if (isEditing) HIDDEN_PLACEHOLDER else "client-secret")
+                            },
+                            singleLine = true,
+                            visualTransformation = if (localOauthClientSecret == HIDDEN_PLACEHOLDER) {
+                                VisualTransformation.None
+                            } else {
+                                PasswordVisualTransformation()
+                            },
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+
+                        OutlinedTextField(
+                            value = localAuthUrl,
+                            onValueChange = { localAuthUrl = it },
+                            label = { Text(stringResource(Res.string.label_authorization_url)) },
+                            placeholder = { Text("https://auth.example.com/authorize") },
+                            singleLine = true,
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+
+                        OutlinedTextField(
+                            value = localClientUrl,
+                            onValueChange = { localClientUrl = it },
+                            label = { Text(stringResource(Res.string.label_token_url)) },
+                            placeholder = { Text("https://auth.example.com/token") },
+                            singleLine = true,
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+
+                        OutlinedTextField(
+                            value = localScope,
+                            onValueChange = { localScope = it },
+                            label = { Text(stringResource(Res.string.label_scope)) },
+                            placeholder = { Text("openid profile") },
+                            singleLine = true,
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+
+                        Text(
+                            text = stringResource(Res.string.label_token_exchange_method),
+                            style = MaterialTheme.typography.labelMedium,
+                        )
+
+                        AuthTypeRadioOption(
+                            label = stringResource(Res.string.token_default_post),
+                            selected = localTokenExchangeMethod == "default_post",
+                            onClick = { localTokenExchangeMethod = "default_post" },
+                        )
+                        AuthTypeRadioOption(
+                            label = stringResource(Res.string.token_basic_auth_header),
+                            selected = localTokenExchangeMethod == "basic_auth_header",
+                            onClick = { localTokenExchangeMethod = "basic_auth_header" },
+                        )
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = {
+                    onSave(
+                        selectedAuthType,
+                        localApiKey,
+                        localAuthorizationType,
+                        localCustomHeader,
+                        localOauthClientId,
+                        localOauthClientSecret,
+                        localAuthUrl,
+                        localClientUrl,
+                        localScope,
+                        localTokenExchangeMethod,
+                    )
+                },
+            ) {
+                Text(stringResource(Res.string.apply))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(Res.string.cancel))
+            }
+        },
+    )
+}
+
+@Composable
+private fun AuthTypeRadioOption(
+    label: String,
+    selected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        RadioButton(
+            selected = selected,
+            onClick = onClick,
+        )
+        Spacer(modifier = Modifier.width(8.dp))
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyMedium,
+        )
+    }
+}

--- a/feature/agents/src/commonMain/kotlin/com/garfiec/librechat/feature/agents/components/ActionEditorDialog.kt
+++ b/feature/agents/src/commonMain/kotlin/com/garfiec/librechat/feature/agents/components/ActionEditorDialog.kt
@@ -1,0 +1,438 @@
+package com.garfiec.librechat.feature.agents.components
+
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material.icons.filled.Security
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import com.garfiec.librechat.core.model.ActionAuth
+import com.garfiec.librechat.core.model.ActionMetadata
+import com.garfiec.librechat.core.model.request.FunctionTool
+import com.garfiec.librechat.feature.agents.AgentActionDisplayData
+import com.garfiec.librechat.feature.agents.resources.*
+import com.garfiec.librechat.feature.agents.resources.Res
+import com.garfiec.librechat.feature.agents.util.OpenApiSpecParser
+import com.garfiec.librechat.feature.agents.util.ParsedFunctionInfo
+import kotlinx.coroutines.delay
+import org.jetbrains.compose.resources.stringResource
+
+private const val VALIDATION_DEBOUNCE_MS = 800L
+
+@Composable
+internal fun ActionEditorDialog(
+    existingAction: AgentActionDisplayData?,
+    onDismiss: () -> Unit,
+    onSave: (actionId: String?, metadata: ActionMetadata, functions: List<FunctionTool>) -> Unit,
+) {
+    // State for the editor
+    var rawSpec by rememberSaveable { mutableStateOf(existingAction?.rawSpec ?: "") }
+    var authType by rememberSaveable { mutableStateOf(existingAction?.authType ?: "none") }
+    var apiKey by rememberSaveable { mutableStateOf("") }
+    var authorizationType by rememberSaveable { mutableStateOf("bearer") }
+    var customAuthHeader by rememberSaveable { mutableStateOf("") }
+    var oauthClientId by rememberSaveable { mutableStateOf("") }
+    var oauthClientSecret by rememberSaveable { mutableStateOf("") }
+    var authorizationUrl by rememberSaveable { mutableStateOf("") }
+    var clientUrl by rememberSaveable { mutableStateOf("") }
+    var scope by rememberSaveable { mutableStateOf("") }
+    var tokenExchangeMethod by rememberSaveable { mutableStateOf("default_post") }
+    var privacyPolicyUrl by rememberSaveable { mutableStateOf("") }
+
+    // Validation state
+    var parsedDomain by remember { mutableStateOf("") }
+    var parsedFunctions by remember { mutableStateOf<List<FunctionTool>>(emptyList()) }
+    var parsedFunctionInfos by remember { mutableStateOf<List<ParsedFunctionInfo>>(emptyList()) }
+    var validationErrors by remember { mutableStateOf<List<String>>(emptyList()) }
+    var isValidating by remember { mutableStateOf(false) }
+
+    // Auth config dialog
+    var showAuthConfig by rememberSaveable { mutableStateOf(false) }
+
+    // For editing existing actions: show hidden placeholder for sensitive fields
+    val isEditing = existingAction?.actionId != null
+
+    // Debounced validation
+    LaunchedEffect(rawSpec) {
+        if (rawSpec.isBlank()) {
+            parsedDomain = ""
+            parsedFunctions = emptyList()
+            parsedFunctionInfos = emptyList()
+            validationErrors = emptyList()
+            return@LaunchedEffect
+        }
+        isValidating = true
+        delay(VALIDATION_DEBOUNCE_MS)
+        val result = OpenApiSpecParser.parse(rawSpec)
+        parsedDomain = result.domain
+        parsedFunctions = result.functions
+        parsedFunctionInfos = OpenApiSpecParser.extractFunctionInfo(rawSpec)
+        validationErrors = result.errors
+        isValidating = false
+    }
+
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(
+            usePlatformDefaultWidth = false,
+            dismissOnBackPress = true,
+            dismissOnClickOutside = false,
+        ),
+    ) {
+        Scaffold(
+            topBar = {
+                Surface(tonalElevation = 2.dp) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp, vertical = 12.dp),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Text(
+                            text = if (isEditing) stringResource(Res.string.edit_action) else stringResource(Res.string.add_action),
+                            style = MaterialTheme.typography.titleMedium,
+                        )
+                        Row {
+                            TextButton(onClick = onDismiss) {
+                                Text(stringResource(Res.string.cancel))
+                            }
+                            Spacer(modifier = Modifier.width(8.dp))
+                            TextButton(
+                                onClick = {
+                                    val auth = ActionAuth(
+                                        type = authType,
+                                        authorizationType = if (authType == "service_http") authorizationType else null,
+                                        customAuthHeader = if (authType == "service_http" && authorizationType == "custom") {
+                                            customAuthHeader.ifBlank { null }
+                                        } else {
+                                            null
+                                        },
+                                        authorizationUrl = if (authType == "oauth") authorizationUrl.ifBlank { null } else null,
+                                        clientUrl = if (authType == "oauth") clientUrl.ifBlank { null } else null,
+                                        scope = if (authType == "oauth") scope.ifBlank { null } else null,
+                                        tokenExchangeMethod = if (authType == "oauth") tokenExchangeMethod else null,
+                                    )
+                                    val metadata = ActionMetadata(
+                                        domain = parsedDomain,
+                                        auth = auth,
+                                        rawSpec = rawSpec,
+                                        apiKey = if (
+                                            authType == "service_http" &&
+                                            apiKey.isNotBlank() &&
+                                            apiKey != HIDDEN_PLACEHOLDER
+                                        ) {
+                                            apiKey
+                                        } else {
+                                            null
+                                        },
+                                        oauthClientId = if (
+                                            authType == "oauth" &&
+                                            oauthClientId.isNotBlank() &&
+                                            oauthClientId != HIDDEN_PLACEHOLDER
+                                        ) {
+                                            oauthClientId
+                                        } else {
+                                            null
+                                        },
+                                        oauthClientSecret = if (
+                                            authType == "oauth" &&
+                                            oauthClientSecret.isNotBlank() &&
+                                            oauthClientSecret != HIDDEN_PLACEHOLDER
+                                        ) {
+                                            oauthClientSecret
+                                        } else {
+                                            null
+                                        },
+                                        privacyPolicyUrl = privacyPolicyUrl.ifBlank { null },
+                                    )
+                                    onSave(existingAction?.actionId, metadata, parsedFunctions)
+                                },
+                                enabled = parsedFunctions.isNotEmpty() && validationErrors.isEmpty() && !isValidating,
+                            ) {
+                                Text(if (isEditing) stringResource(Res.string.save) else stringResource(Res.string.create))
+                            }
+                        }
+                    }
+                }
+            },
+        ) { innerPadding ->
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding)
+                    .verticalScroll(rememberScrollState())
+                    .padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                // 1. Authentication section
+                AuthenticationSection(
+                    authType = authType,
+                    onShowAuthConfig = { showAuthConfig = true },
+                )
+
+                HorizontalDivider()
+
+                // 2. Schema input
+                Text(
+                    text = stringResource(Res.string.label_openapi_schema),
+                    style = MaterialTheme.typography.titleSmall,
+                )
+                Text(
+                    text = stringResource(Res.string.openapi_schema_hint),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                OutlinedTextField(
+                    value = rawSpec,
+                    onValueChange = { rawSpec = it },
+                    label = { Text(stringResource(Res.string.label_openapi_spec)) },
+                    placeholder = {
+                        Text(
+                            text = "{\n  \"openapi\": \"3.0.0\",\n" +
+                                "  \"info\": { ... },\n  \"paths\": { ... }\n}",
+                            fontFamily = FontFamily.Monospace,
+                        )
+                    },
+                    textStyle = MaterialTheme.typography.bodySmall.copy(
+                        fontFamily = FontFamily.Monospace,
+                    ),
+                    minLines = 8,
+                    maxLines = 20,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+
+                // Validation feedback
+                if (isValidating) {
+                    Text(
+                        text = stringResource(Res.string.validating),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.primary,
+                    )
+                }
+
+                if (validationErrors.isNotEmpty()) {
+                    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                        validationErrors.forEach { error ->
+                            Text(
+                                text = error,
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.error,
+                            )
+                        }
+                    }
+                }
+
+                // Domain display
+                if (parsedDomain.isNotBlank()) {
+                    Text(
+                        text = stringResource(Res.string.domain_prefix, parsedDomain),
+                        style = MaterialTheme.typography.bodyMedium,
+                        fontWeight = FontWeight.Medium,
+                    )
+                }
+
+                // 3. Available actions table
+                if (parsedFunctionInfos.isNotEmpty()) {
+                    HorizontalDivider()
+                    Text(
+                        text = stringResource(Res.string.available_actions_count, parsedFunctionInfos.size),
+                        style = MaterialTheme.typography.titleSmall,
+                    )
+                    FunctionTable(functions = parsedFunctionInfos)
+                }
+
+                // 4. Privacy policy URL
+                OutlinedTextField(
+                    value = privacyPolicyUrl,
+                    onValueChange = { privacyPolicyUrl = it },
+                    label = { Text(stringResource(Res.string.label_privacy_policy_url)) },
+                    placeholder = { Text("https://example.com/privacy") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+        }
+    }
+
+    // Auth configuration dialog
+    if (showAuthConfig) {
+        AuthConfigDialog(
+            currentAuthType = authType,
+            apiKey = apiKey,
+            authorizationType = authorizationType,
+            customAuthHeader = customAuthHeader,
+            oauthClientId = oauthClientId,
+            oauthClientSecret = oauthClientSecret,
+            authorizationUrl = authorizationUrl,
+            clientUrl = clientUrl,
+            scope = scope,
+            tokenExchangeMethod = tokenExchangeMethod,
+            isEditing = isEditing,
+            onDismiss = { showAuthConfig = false },
+            onSave = { newAuthType, newApiKey, newAuthorizationType, newCustomHeader,
+                       newOauthClientId, newOauthClientSecret, newAuthUrl, newClientUrl,
+                       newScope, newTokenExchangeMethod ->
+                authType = newAuthType
+                apiKey = newApiKey
+                authorizationType = newAuthorizationType
+                customAuthHeader = newCustomHeader
+                oauthClientId = newOauthClientId
+                oauthClientSecret = newOauthClientSecret
+                authorizationUrl = newAuthUrl
+                clientUrl = newClientUrl
+                scope = newScope
+                tokenExchangeMethod = newTokenExchangeMethod
+                showAuthConfig = false
+            },
+        )
+    }
+}
+
+@Composable
+private fun AuthenticationSection(
+    authType: String,
+    onShowAuthConfig: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier.fillMaxWidth()) {
+        Text(
+            text = stringResource(Res.string.label_authentication),
+            style = MaterialTheme.typography.titleSmall,
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        OutlinedButton(
+            onClick = onShowAuthConfig,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Icon(
+                imageVector = when (authType) {
+                    "service_http" -> Icons.Default.Lock
+                    "oauth" -> Icons.Default.Security
+                    else -> Icons.Default.Lock
+                },
+                contentDescription = null,
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+                text = when (authType) {
+                    "service_http" -> stringResource(Res.string.auth_api_key_full)
+                    "oauth" -> stringResource(Res.string.auth_oauth_full)
+                    else -> stringResource(Res.string.auth_no_auth)
+                },
+            )
+        }
+    }
+}
+
+@Composable
+private fun FunctionTable(
+    functions: List<ParsedFunctionInfo>,
+    modifier: Modifier = Modifier,
+) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant,
+        ),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .horizontalScroll(rememberScrollState())
+                .padding(12.dp),
+            verticalArrangement = Arrangement.spacedBy(2.dp),
+        ) {
+            // Header
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                Text(
+                    text = stringResource(Res.string.table_name),
+                    style = MaterialTheme.typography.labelMedium,
+                    fontWeight = FontWeight.Bold,
+                    modifier = Modifier.width(180.dp),
+                )
+                Text(
+                    text = stringResource(Res.string.table_method),
+                    style = MaterialTheme.typography.labelMedium,
+                    fontWeight = FontWeight.Bold,
+                    modifier = Modifier.width(60.dp),
+                )
+                Text(
+                    text = stringResource(Res.string.table_path),
+                    style = MaterialTheme.typography.labelMedium,
+                    fontWeight = FontWeight.Bold,
+                    modifier = Modifier.width(200.dp),
+                )
+            }
+            HorizontalDivider()
+
+            // Rows
+            functions.forEach { func ->
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 4.dp),
+                    horizontalArrangement = Arrangement.spacedBy(16.dp),
+                ) {
+                    Text(
+                        text = func.name,
+                        style = MaterialTheme.typography.bodySmall,
+                        fontFamily = FontFamily.Monospace,
+                        modifier = Modifier.width(180.dp),
+                        maxLines = 1,
+                    )
+                    Text(
+                        text = func.method,
+                        style = MaterialTheme.typography.bodySmall,
+                        fontWeight = FontWeight.Medium,
+                        modifier = Modifier.width(60.dp),
+                    )
+                    Text(
+                        text = func.path,
+                        style = MaterialTheme.typography.bodySmall,
+                        fontFamily = FontFamily.Monospace,
+                        modifier = Modifier.width(200.dp),
+                        maxLines = 1,
+                    )
+                }
+            }
+        }
+    }
+}

--- a/feature/agents/src/commonMain/kotlin/com/garfiec/librechat/feature/agents/components/ActionEditorDialog.kt
+++ b/feature/agents/src/commonMain/kotlin/com/garfiec/librechat/feature/agents/components/ActionEditorDialog.kt
@@ -340,11 +340,7 @@ private fun AuthenticationSection(
             modifier = Modifier.fillMaxWidth(),
         ) {
             Icon(
-                imageVector = when (authType) {
-                    "service_http" -> Icons.Default.Lock
-                    "oauth" -> Icons.Default.Security
-                    else -> Icons.Default.Lock
-                },
+                imageVector = if (authType == "oauth") Icons.Default.Security else Icons.Default.Lock,
                 contentDescription = null,
             )
             Spacer(modifier = Modifier.width(8.dp))

--- a/feature/agents/src/commonMain/kotlin/com/garfiec/librechat/feature/agents/components/AgentActionsPanel.kt
+++ b/feature/agents/src/commonMain/kotlin/com/garfiec/librechat/feature/agents/components/AgentActionsPanel.kt
@@ -22,7 +22,6 @@ import androidx.compose.material.icons.filled.ExpandLess
 import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.Security
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.HorizontalDivider
@@ -31,7 +30,6 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -47,8 +45,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.input.PasswordVisualTransformation
-import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
@@ -64,7 +60,6 @@ import kotlinx.coroutines.delay
 import org.jetbrains.compose.resources.stringResource
 
 private const val VALIDATION_DEBOUNCE_MS = 800L
-private const val HIDDEN_PLACEHOLDER = "<HIDDEN>"
 
 /** Collapsible CRUD panel for OpenAPI actions with full editor. */
 @Composable
@@ -523,279 +518,6 @@ private fun AuthenticationSection(
                 },
             )
         }
-    }
-}
-
-// ==========================================
-// Auth Configuration Dialog
-// ==========================================
-
-@Composable
-private fun AuthConfigDialog(
-    currentAuthType: String,
-    apiKey: String,
-    authorizationType: String,
-    customAuthHeader: String,
-    oauthClientId: String,
-    oauthClientSecret: String,
-    authorizationUrl: String,
-    clientUrl: String,
-    scope: String,
-    tokenExchangeMethod: String,
-    isEditing: Boolean,
-    onDismiss: () -> Unit,
-    onSave: (
-        authType: String,
-        apiKey: String,
-        authorizationType: String,
-        customAuthHeader: String,
-        oauthClientId: String,
-        oauthClientSecret: String,
-        authorizationUrl: String,
-        clientUrl: String,
-        scope: String,
-        tokenExchangeMethod: String,
-    ) -> Unit,
-) {
-    var selectedAuthType by rememberSaveable { mutableStateOf(currentAuthType) }
-    var localApiKey by rememberSaveable { mutableStateOf(apiKey) }
-    var localAuthorizationType by rememberSaveable { mutableStateOf(authorizationType) }
-    var localCustomHeader by rememberSaveable { mutableStateOf(customAuthHeader) }
-    var localOauthClientId by rememberSaveable { mutableStateOf(oauthClientId) }
-    var localOauthClientSecret by rememberSaveable { mutableStateOf(oauthClientSecret) }
-    var localAuthUrl by rememberSaveable { mutableStateOf(authorizationUrl) }
-    var localClientUrl by rememberSaveable { mutableStateOf(clientUrl) }
-    var localScope by rememberSaveable { mutableStateOf(scope) }
-    var localTokenExchangeMethod by rememberSaveable { mutableStateOf(tokenExchangeMethod) }
-
-    AlertDialog(
-        onDismissRequest = onDismiss,
-        title = { Text(stringResource(Res.string.label_authentication)) },
-        text = {
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .verticalScroll(rememberScrollState()),
-                verticalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                // Auth type radio group
-                Text(
-                    text = stringResource(Res.string.label_authentication_type),
-                    style = MaterialTheme.typography.labelLarge,
-                )
-
-                AuthTypeRadioOption(
-                    label = stringResource(Res.string.auth_none),
-                    selected = selectedAuthType == "none",
-                    onClick = { selectedAuthType = "none" },
-                )
-                AuthTypeRadioOption(
-                    label = stringResource(Res.string.auth_api_key),
-                    selected = selectedAuthType == "service_http",
-                    onClick = { selectedAuthType = "service_http" },
-                )
-                AuthTypeRadioOption(
-                    label = stringResource(Res.string.auth_oauth),
-                    selected = selectedAuthType == "oauth",
-                    onClick = { selectedAuthType = "oauth" },
-                )
-
-                // API Key configuration
-                AnimatedVisibility(visible = selectedAuthType == "service_http") {
-                    Column(
-                        verticalArrangement = Arrangement.spacedBy(8.dp),
-                    ) {
-                        HorizontalDivider()
-                        Text(
-                            text = stringResource(Res.string.label_api_key_settings),
-                            style = MaterialTheme.typography.labelLarge,
-                        )
-
-                        OutlinedTextField(
-                            value = localApiKey,
-                            onValueChange = { localApiKey = it },
-                            label = { Text(stringResource(Res.string.label_api_key)) },
-                            placeholder = {
-                                Text(if (isEditing) HIDDEN_PLACEHOLDER else "sk-...")
-                            },
-                            singleLine = true,
-                            visualTransformation = if (localApiKey == HIDDEN_PLACEHOLDER) {
-                                VisualTransformation.None
-                            } else {
-                                PasswordVisualTransformation()
-                            },
-                            modifier = Modifier.fillMaxWidth(),
-                        )
-
-                        Text(
-                            text = stringResource(Res.string.label_authorization_type),
-                            style = MaterialTheme.typography.labelMedium,
-                        )
-
-                        AuthTypeRadioOption(
-                            label = stringResource(Res.string.auth_basic),
-                            selected = localAuthorizationType == "basic",
-                            onClick = { localAuthorizationType = "basic" },
-                        )
-                        AuthTypeRadioOption(
-                            label = stringResource(Res.string.auth_bearer),
-                            selected = localAuthorizationType == "bearer",
-                            onClick = { localAuthorizationType = "bearer" },
-                        )
-                        AuthTypeRadioOption(
-                            label = stringResource(Res.string.auth_custom),
-                            selected = localAuthorizationType == "custom",
-                            onClick = { localAuthorizationType = "custom" },
-                        )
-
-                        AnimatedVisibility(visible = localAuthorizationType == "custom") {
-                            OutlinedTextField(
-                                value = localCustomHeader,
-                                onValueChange = { localCustomHeader = it },
-                                label = { Text(stringResource(Res.string.label_custom_auth_header)) },
-                                placeholder = { Text("X-Api-Key") },
-                                singleLine = true,
-                                modifier = Modifier.fillMaxWidth(),
-                            )
-                        }
-                    }
-                }
-
-                // OAuth configuration
-                AnimatedVisibility(visible = selectedAuthType == "oauth") {
-                    Column(
-                        verticalArrangement = Arrangement.spacedBy(8.dp),
-                    ) {
-                        HorizontalDivider()
-                        Text(
-                            text = stringResource(Res.string.label_oauth_settings),
-                            style = MaterialTheme.typography.labelLarge,
-                        )
-
-                        OutlinedTextField(
-                            value = localOauthClientId,
-                            onValueChange = { localOauthClientId = it },
-                            label = { Text(stringResource(Res.string.label_client_id)) },
-                            placeholder = {
-                                Text(if (isEditing) HIDDEN_PLACEHOLDER else "client-id")
-                            },
-                            singleLine = true,
-                            modifier = Modifier.fillMaxWidth(),
-                        )
-
-                        OutlinedTextField(
-                            value = localOauthClientSecret,
-                            onValueChange = { localOauthClientSecret = it },
-                            label = { Text(stringResource(Res.string.label_client_secret)) },
-                            placeholder = {
-                                Text(if (isEditing) HIDDEN_PLACEHOLDER else "client-secret")
-                            },
-                            singleLine = true,
-                            visualTransformation = if (localOauthClientSecret == HIDDEN_PLACEHOLDER) {
-                                VisualTransformation.None
-                            } else {
-                                PasswordVisualTransformation()
-                            },
-                            modifier = Modifier.fillMaxWidth(),
-                        )
-
-                        OutlinedTextField(
-                            value = localAuthUrl,
-                            onValueChange = { localAuthUrl = it },
-                            label = { Text(stringResource(Res.string.label_authorization_url)) },
-                            placeholder = { Text("https://auth.example.com/authorize") },
-                            singleLine = true,
-                            modifier = Modifier.fillMaxWidth(),
-                        )
-
-                        OutlinedTextField(
-                            value = localClientUrl,
-                            onValueChange = { localClientUrl = it },
-                            label = { Text(stringResource(Res.string.label_token_url)) },
-                            placeholder = { Text("https://auth.example.com/token") },
-                            singleLine = true,
-                            modifier = Modifier.fillMaxWidth(),
-                        )
-
-                        OutlinedTextField(
-                            value = localScope,
-                            onValueChange = { localScope = it },
-                            label = { Text(stringResource(Res.string.label_scope)) },
-                            placeholder = { Text("openid profile") },
-                            singleLine = true,
-                            modifier = Modifier.fillMaxWidth(),
-                        )
-
-                        Text(
-                            text = stringResource(Res.string.label_token_exchange_method),
-                            style = MaterialTheme.typography.labelMedium,
-                        )
-
-                        AuthTypeRadioOption(
-                            label = stringResource(Res.string.token_default_post),
-                            selected = localTokenExchangeMethod == "default_post",
-                            onClick = { localTokenExchangeMethod = "default_post" },
-                        )
-                        AuthTypeRadioOption(
-                            label = stringResource(Res.string.token_basic_auth_header),
-                            selected = localTokenExchangeMethod == "basic_auth_header",
-                            onClick = { localTokenExchangeMethod = "basic_auth_header" },
-                        )
-                    }
-                }
-            }
-        },
-        confirmButton = {
-            TextButton(
-                onClick = {
-                    onSave(
-                        selectedAuthType,
-                        localApiKey,
-                        localAuthorizationType,
-                        localCustomHeader,
-                        localOauthClientId,
-                        localOauthClientSecret,
-                        localAuthUrl,
-                        localClientUrl,
-                        localScope,
-                        localTokenExchangeMethod,
-                    )
-                },
-            ) {
-                Text(stringResource(Res.string.apply))
-            }
-        },
-        dismissButton = {
-            TextButton(onClick = onDismiss) {
-                Text(stringResource(Res.string.cancel))
-            }
-        },
-    )
-}
-
-@Composable
-private fun AuthTypeRadioOption(
-    label: String,
-    selected: Boolean,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    Row(
-        modifier = modifier
-            .fillMaxWidth()
-            .clickable(onClick = onClick)
-            .padding(vertical = 4.dp),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        RadioButton(
-            selected = selected,
-            onClick = onClick,
-        )
-        Spacer(modifier = Modifier.width(8.dp))
-        Text(
-            text = label,
-            style = MaterialTheme.typography.bodyMedium,
-        )
     }
 }
 

--- a/feature/agents/src/commonMain/kotlin/com/garfiec/librechat/feature/agents/components/AgentActionsPanel.kt
+++ b/feature/agents/src/commonMain/kotlin/com/garfiec/librechat/feature/agents/components/AgentActionsPanel.kt
@@ -2,40 +2,27 @@ package com.garfiec.librechat.feature.agents.components
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.ExpandLess
 import androidx.compose.material.icons.filled.ExpandMore
-import androidx.compose.material.icons.filled.Lock
-import androidx.compose.material.icons.filled.Security
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
-import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -43,23 +30,13 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.window.Dialog
-import androidx.compose.ui.window.DialogProperties
-import com.garfiec.librechat.core.model.ActionAuth
 import com.garfiec.librechat.core.model.ActionMetadata
 import com.garfiec.librechat.core.model.request.FunctionTool
 import com.garfiec.librechat.feature.agents.AgentActionDisplayData
 import com.garfiec.librechat.feature.agents.resources.*
 import com.garfiec.librechat.feature.agents.resources.Res
-import com.garfiec.librechat.feature.agents.util.OpenApiSpecParser
-import com.garfiec.librechat.feature.agents.util.ParsedFunctionInfo
-import kotlinx.coroutines.delay
 import org.jetbrains.compose.resources.stringResource
-
-private const val VALIDATION_DEBOUNCE_MS = 800L
 
 /** Collapsible CRUD panel for OpenAPI actions with full editor. */
 @Composable
@@ -200,402 +177,6 @@ private fun ActionCard(
                         imageVector = Icons.Default.Delete,
                         contentDescription = stringResource(Res.string.cd_delete_action),
                         tint = MaterialTheme.colorScheme.error,
-                    )
-                }
-            }
-        }
-    }
-}
-
-// ==========================================
-// Action Editor Dialog (Full-screen)
-// ==========================================
-
-@Composable
-private fun ActionEditorDialog(
-    existingAction: AgentActionDisplayData?,
-    onDismiss: () -> Unit,
-    onSave: (actionId: String?, metadata: ActionMetadata, functions: List<FunctionTool>) -> Unit,
-) {
-    // State for the editor
-    var rawSpec by rememberSaveable { mutableStateOf(existingAction?.rawSpec ?: "") }
-    var authType by rememberSaveable { mutableStateOf(existingAction?.authType ?: "none") }
-    var apiKey by rememberSaveable { mutableStateOf("") }
-    var authorizationType by rememberSaveable { mutableStateOf("bearer") }
-    var customAuthHeader by rememberSaveable { mutableStateOf("") }
-    var oauthClientId by rememberSaveable { mutableStateOf("") }
-    var oauthClientSecret by rememberSaveable { mutableStateOf("") }
-    var authorizationUrl by rememberSaveable { mutableStateOf("") }
-    var clientUrl by rememberSaveable { mutableStateOf("") }
-    var scope by rememberSaveable { mutableStateOf("") }
-    var tokenExchangeMethod by rememberSaveable { mutableStateOf("default_post") }
-    var privacyPolicyUrl by rememberSaveable { mutableStateOf("") }
-
-    // Validation state
-    var parsedDomain by remember { mutableStateOf("") }
-    var parsedFunctions by remember { mutableStateOf<List<FunctionTool>>(emptyList()) }
-    var parsedFunctionInfos by remember { mutableStateOf<List<ParsedFunctionInfo>>(emptyList()) }
-    var validationErrors by remember { mutableStateOf<List<String>>(emptyList()) }
-    var isValidating by remember { mutableStateOf(false) }
-
-    // Auth config dialog
-    var showAuthConfig by rememberSaveable { mutableStateOf(false) }
-
-    // For editing existing actions: show hidden placeholder for sensitive fields
-    val isEditing = existingAction?.actionId != null
-
-    // Debounced validation
-    LaunchedEffect(rawSpec) {
-        if (rawSpec.isBlank()) {
-            parsedDomain = ""
-            parsedFunctions = emptyList()
-            parsedFunctionInfos = emptyList()
-            validationErrors = emptyList()
-            return@LaunchedEffect
-        }
-        isValidating = true
-        delay(VALIDATION_DEBOUNCE_MS)
-        val result = OpenApiSpecParser.parse(rawSpec)
-        parsedDomain = result.domain
-        parsedFunctions = result.functions
-        parsedFunctionInfos = OpenApiSpecParser.extractFunctionInfo(rawSpec)
-        validationErrors = result.errors
-        isValidating = false
-    }
-
-    Dialog(
-        onDismissRequest = onDismiss,
-        properties = DialogProperties(
-            usePlatformDefaultWidth = false,
-            dismissOnBackPress = true,
-            dismissOnClickOutside = false,
-        ),
-    ) {
-        Scaffold(
-            topBar = {
-                Surface(tonalElevation = 2.dp) {
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 16.dp, vertical = 12.dp),
-                        horizontalArrangement = Arrangement.SpaceBetween,
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        Text(
-                            text = if (isEditing) stringResource(Res.string.edit_action) else stringResource(Res.string.add_action),
-                            style = MaterialTheme.typography.titleMedium,
-                        )
-                        Row {
-                            TextButton(onClick = onDismiss) {
-                                Text(stringResource(Res.string.cancel))
-                            }
-                            Spacer(modifier = Modifier.width(8.dp))
-                            TextButton(
-                                onClick = {
-                                    val auth = ActionAuth(
-                                        type = authType,
-                                        authorizationType = if (authType == "service_http") authorizationType else null,
-                                        customAuthHeader = if (authType == "service_http" && authorizationType == "custom") {
-                                            customAuthHeader.ifBlank { null }
-                                        } else {
-                                            null
-                                        },
-                                        authorizationUrl = if (authType == "oauth") authorizationUrl.ifBlank { null } else null,
-                                        clientUrl = if (authType == "oauth") clientUrl.ifBlank { null } else null,
-                                        scope = if (authType == "oauth") scope.ifBlank { null } else null,
-                                        tokenExchangeMethod = if (authType == "oauth") tokenExchangeMethod else null,
-                                    )
-                                    val metadata = ActionMetadata(
-                                        domain = parsedDomain,
-                                        auth = auth,
-                                        rawSpec = rawSpec,
-                                        apiKey = if (
-                                            authType == "service_http" &&
-                                            apiKey.isNotBlank() &&
-                                            apiKey != HIDDEN_PLACEHOLDER
-                                        ) {
-                                            apiKey
-                                        } else {
-                                            null
-                                        },
-                                        oauthClientId = if (
-                                            authType == "oauth" &&
-                                            oauthClientId.isNotBlank() &&
-                                            oauthClientId != HIDDEN_PLACEHOLDER
-                                        ) {
-                                            oauthClientId
-                                        } else {
-                                            null
-                                        },
-                                        oauthClientSecret = if (
-                                            authType == "oauth" &&
-                                            oauthClientSecret.isNotBlank() &&
-                                            oauthClientSecret != HIDDEN_PLACEHOLDER
-                                        ) {
-                                            oauthClientSecret
-                                        } else {
-                                            null
-                                        },
-                                        privacyPolicyUrl = privacyPolicyUrl.ifBlank { null },
-                                    )
-                                    onSave(existingAction?.actionId, metadata, parsedFunctions)
-                                },
-                                enabled = parsedFunctions.isNotEmpty() && validationErrors.isEmpty() && !isValidating,
-                            ) {
-                                Text(if (isEditing) stringResource(Res.string.save) else stringResource(Res.string.create))
-                            }
-                        }
-                    }
-                }
-            },
-        ) { innerPadding ->
-            Column(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(innerPadding)
-                    .verticalScroll(rememberScrollState())
-                    .padding(16.dp),
-                verticalArrangement = Arrangement.spacedBy(16.dp),
-            ) {
-                // 1. Authentication section
-                AuthenticationSection(
-                    authType = authType,
-                    onShowAuthConfig = { showAuthConfig = true },
-                )
-
-                HorizontalDivider()
-
-                // 2. Schema input
-                Text(
-                    text = stringResource(Res.string.label_openapi_schema),
-                    style = MaterialTheme.typography.titleSmall,
-                )
-                Text(
-                    text = stringResource(Res.string.openapi_schema_hint),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-                OutlinedTextField(
-                    value = rawSpec,
-                    onValueChange = { rawSpec = it },
-                    label = { Text(stringResource(Res.string.label_openapi_spec)) },
-                    placeholder = {
-                        Text(
-                            text = "{\n  \"openapi\": \"3.0.0\",\n" +
-                                "  \"info\": { ... },\n  \"paths\": { ... }\n}",
-                            fontFamily = FontFamily.Monospace,
-                        )
-                    },
-                    textStyle = MaterialTheme.typography.bodySmall.copy(
-                        fontFamily = FontFamily.Monospace,
-                    ),
-                    minLines = 8,
-                    maxLines = 20,
-                    modifier = Modifier.fillMaxWidth(),
-                )
-
-                // Validation feedback
-                if (isValidating) {
-                    Text(
-                        text = stringResource(Res.string.validating),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.primary,
-                    )
-                }
-
-                if (validationErrors.isNotEmpty()) {
-                    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-                        validationErrors.forEach { error ->
-                            Text(
-                                text = error,
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.error,
-                            )
-                        }
-                    }
-                }
-
-                // Domain display
-                if (parsedDomain.isNotBlank()) {
-                    Text(
-                        text = stringResource(Res.string.domain_prefix, parsedDomain),
-                        style = MaterialTheme.typography.bodyMedium,
-                        fontWeight = FontWeight.Medium,
-                    )
-                }
-
-                // 3. Available actions table
-                if (parsedFunctionInfos.isNotEmpty()) {
-                    HorizontalDivider()
-                    Text(
-                        text = stringResource(Res.string.available_actions_count, parsedFunctionInfos.size),
-                        style = MaterialTheme.typography.titleSmall,
-                    )
-                    FunctionTable(functions = parsedFunctionInfos)
-                }
-
-                // 4. Privacy policy URL
-                OutlinedTextField(
-                    value = privacyPolicyUrl,
-                    onValueChange = { privacyPolicyUrl = it },
-                    label = { Text(stringResource(Res.string.label_privacy_policy_url)) },
-                    placeholder = { Text("https://example.com/privacy") },
-                    singleLine = true,
-                    modifier = Modifier.fillMaxWidth(),
-                )
-            }
-        }
-    }
-
-    // Auth configuration dialog
-    if (showAuthConfig) {
-        AuthConfigDialog(
-            currentAuthType = authType,
-            apiKey = apiKey,
-            authorizationType = authorizationType,
-            customAuthHeader = customAuthHeader,
-            oauthClientId = oauthClientId,
-            oauthClientSecret = oauthClientSecret,
-            authorizationUrl = authorizationUrl,
-            clientUrl = clientUrl,
-            scope = scope,
-            tokenExchangeMethod = tokenExchangeMethod,
-            isEditing = isEditing,
-            onDismiss = { showAuthConfig = false },
-            onSave = { newAuthType, newApiKey, newAuthorizationType, newCustomHeader,
-                       newOauthClientId, newOauthClientSecret, newAuthUrl, newClientUrl,
-                       newScope, newTokenExchangeMethod ->
-                authType = newAuthType
-                apiKey = newApiKey
-                authorizationType = newAuthorizationType
-                customAuthHeader = newCustomHeader
-                oauthClientId = newOauthClientId
-                oauthClientSecret = newOauthClientSecret
-                authorizationUrl = newAuthUrl
-                clientUrl = newClientUrl
-                scope = newScope
-                tokenExchangeMethod = newTokenExchangeMethod
-                showAuthConfig = false
-            },
-        )
-    }
-}
-
-// ==========================================
-// Authentication Section
-// ==========================================
-
-@Composable
-private fun AuthenticationSection(
-    authType: String,
-    onShowAuthConfig: () -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    Column(modifier = modifier.fillMaxWidth()) {
-        Text(
-            text = stringResource(Res.string.label_authentication),
-            style = MaterialTheme.typography.titleSmall,
-        )
-        Spacer(modifier = Modifier.height(8.dp))
-        OutlinedButton(
-            onClick = onShowAuthConfig,
-            modifier = Modifier.fillMaxWidth(),
-        ) {
-            Icon(
-                imageVector = when (authType) {
-                    "service_http" -> Icons.Default.Lock
-                    "oauth" -> Icons.Default.Security
-                    else -> Icons.Default.Lock
-                },
-                contentDescription = null,
-            )
-            Spacer(modifier = Modifier.width(8.dp))
-            Text(
-                text = when (authType) {
-                    "service_http" -> stringResource(Res.string.auth_api_key_full)
-                    "oauth" -> stringResource(Res.string.auth_oauth_full)
-                    else -> stringResource(Res.string.auth_no_auth)
-                },
-            )
-        }
-    }
-}
-
-// ==========================================
-// Function Table
-// ==========================================
-
-@Composable
-private fun FunctionTable(
-    functions: List<ParsedFunctionInfo>,
-    modifier: Modifier = Modifier,
-) {
-    Card(
-        modifier = modifier.fillMaxWidth(),
-        colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surfaceVariant,
-        ),
-    ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .horizontalScroll(rememberScrollState())
-                .padding(12.dp),
-            verticalArrangement = Arrangement.spacedBy(2.dp),
-        ) {
-            // Header
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(16.dp),
-            ) {
-                Text(
-                    text = stringResource(Res.string.table_name),
-                    style = MaterialTheme.typography.labelMedium,
-                    fontWeight = FontWeight.Bold,
-                    modifier = Modifier.width(180.dp),
-                )
-                Text(
-                    text = stringResource(Res.string.table_method),
-                    style = MaterialTheme.typography.labelMedium,
-                    fontWeight = FontWeight.Bold,
-                    modifier = Modifier.width(60.dp),
-                )
-                Text(
-                    text = stringResource(Res.string.table_path),
-                    style = MaterialTheme.typography.labelMedium,
-                    fontWeight = FontWeight.Bold,
-                    modifier = Modifier.width(200.dp),
-                )
-            }
-            HorizontalDivider()
-
-            // Rows
-            functions.forEach { func ->
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(vertical = 4.dp),
-                    horizontalArrangement = Arrangement.spacedBy(16.dp),
-                ) {
-                    Text(
-                        text = func.name,
-                        style = MaterialTheme.typography.bodySmall,
-                        fontFamily = FontFamily.Monospace,
-                        modifier = Modifier.width(180.dp),
-                        maxLines = 1,
-                    )
-                    Text(
-                        text = func.method,
-                        style = MaterialTheme.typography.bodySmall,
-                        fontWeight = FontWeight.Medium,
-                        modifier = Modifier.width(60.dp),
-                    )
-                    Text(
-                        text = func.path,
-                        style = MaterialTheme.typography.bodySmall,
-                        fontFamily = FontFamily.Monospace,
-                        modifier = Modifier.width(200.dp),
-                        maxLines = 1,
                     )
                 }
             }


### PR DESCRIPTION
## Summary
Decomposes the 882-line `AgentActionsPanel.kt` into three cohesive files with no behavior change, continuing the large-file reduction initiative. The public `AgentActionsPanel` API is unchanged.

## Changes
- Extract the full-screen OpenAPI action editor (`Dialog` + `Scaffold`, debounced spec validation, save-metadata assembly) plus its `AuthenticationSection` and `FunctionTable` helpers into `ActionEditorDialog.kt`.
- Extract the auth-configuration `AlertDialog` (none / API key / OAuth) plus its `AuthTypeRadioOption` helper and the shared `HIDDEN_PLACEHOLDER` constant into `ActionAuthConfigDialog.kt`.
- `AgentActionsPanel.kt` now holds only the collapsible panel shell and the per-action `ActionCard`.
- Promote the three cross-file symbols (`ActionEditorDialog`, `AuthConfigDialog`, `HIDDEN_PLACEHOLDER`) to `internal`; file-local helpers stay `private`.
- Collapse a redundant `when` branch in the auth-trigger icon (the `"service_http"` and `else` arms were identical) into an `if`.

Net: `AgentActionsPanel.kt` 882 → 185 lines (−79%). The file is in `commonMain`, so this covers both Android and iOS.

## Testing
- `:feature:agents` Android compile + `detektMetadataCommonMain` + iOS `compileKotlinIosSimulatorArm64` all pass.
- Device-tested on the Pixel 10 Pro Fold emulator: opened the agent editor → OpenAPI Actions → Add Action; verified the editor dialog and the auth-config dialog (None / API key + Basic/Bearer/Custom / OAuth) render, switch field groups, scroll, round-trip state on Apply, and dismiss cleanly with no regression.
