### PR TITLE
refactor(settings): decompose SettingsViewModel into state, prefs controller, and account delegate

### DIFF
--- a/MODULARIZATION.md
+++ b/MODULARIZATION.md
@@ -24,8 +24,8 @@ and bring the code closer to idiomatic Compose / unidirectional-data-flow conven
 | 2 | `feature/agents/.../viewmodel/AgentEditorViewModel.kt` | 1938→518 | VM god-class (no delegates yet) | **done — device-verified** |
 | 3 | `feature/chat/androidMain/.../screen/ChatScreen.kt` | 1232→260 | Composable + leaked logic | **done — PR #159 merged** |
 | 4 | `feature/agents/.../components/AgentActionsPanel.kt` | 882→185 | Two 240+ line dialogs | **done — PR #160 merged** |
-| 5 | `feature/agents/.../screen/AgentEditorScreen.kt` | 926→141 | One 467-line Column | **done — local** |
-| 6 | `feature/settings/.../viewmodel/SettingsViewModel.kt` | 966 | Partial delegation | planned |
+| 5 | `feature/agents/.../screen/AgentEditorScreen.kt` | 926→141 | One 467-line Column | **done — PR #161 merged** |
+| 6 | `feature/settings/.../viewmodel/SettingsViewModel.kt` | 966→435 | Partial delegation | **done — device-verified** |
 | 7 | `feature/chat/.../components/SharedContentParts.kt` | 711 | Duplicate collapsible cards | planned |
 
 ## Explicitly NOT decomposing
@@ -33,6 +33,36 @@ and bring the code closer to idiomatic Compose / unidirectional-data-flow conven
 - `core/ui/.../EndpointParameterRegistry.kt` (913) — intentional 1:1 mirror of upstream
   `parameterSettings.ts`; extracting a base template adds indirection without cutting lines.
 - `core/network/.../SseEventMapper.kt` (560) — dense but one-task-per-function; cohesive.
+
+---
+
+## PR #6 — SettingsViewModel
+
+**Shape:** one PR, one commit per extraction, single device-test pass at the end.
+**Result:** SettingsViewModel.kt 966 → 435 lines (−55%). Android + iOS compile and
+detektMetadataCommonMain all green.
+
+A `commonMain` VM god-class with **partial** delegation: 5 delegates already existed
+on the write side, but the DataStore read flows and the account logic still lived in
+the ViewModel. This pass finishes the delegation. The public `SettingsViewModel`
+constructor and API are unchanged. Three commits:
+
+1. **`SettingsUiState.kt`** — moves the 160-line `SettingsUiState`, plus
+   `SettingsCommand`, `LogsExportPayload`, `DEFAULT_COMMANDS`, and the
+   `User.toDisplayData()` mapper (`private` → `internal`) into a sibling state file.
+2. **`SettingsPreferencesController.kt`** — extracts the entire DataStore layer: the
+   four intermediate preference holders, every `stateIn` flow, the multi-stage
+   `combine` that merges them with the imperative state into `uiState`, and the
+   matching write setters (theme / chat / tablet / inline-artifact / language). One
+   object now owns both the read flows and the writes; the ViewModel forwards.
+3. **`AccountDelegate.kt`** — extracts the account section (profile load with the
+   cancel-on-retry job, avatar upload, balance, sign-out, and account deletion with
+   the 403 → OTP step-up) into a `SettingsStateHandle`-based delegate matching the
+   existing delegate pattern.
+
+`SettingsViewModel.kt` now holds only delegate/controller construction, `init`, the
+role / permission / account-deletion observers, the small dialog-toggle state
+(language / fork / commands / personalization), and the thin delegate forwarders.
 
 ---
 

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/SettingsPreferencesController.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/SettingsPreferencesController.kt
@@ -1,0 +1,306 @@
+package com.garfiec.librechat.feature.settings.viewmodel
+
+import com.garfiec.librechat.core.common.ChatLayoutConstants
+import com.garfiec.librechat.core.data.datastore.ChatFontSize
+import com.garfiec.librechat.core.data.datastore.InlineArtifactPrefs
+import com.garfiec.librechat.core.data.datastore.LatexRenderer
+import com.garfiec.librechat.core.data.datastore.ServerDataStore
+import com.garfiec.librechat.core.data.datastore.SettingsDataStore
+import com.garfiec.librechat.core.data.datastore.StarredModelsDisplay
+import com.garfiec.librechat.core.data.datastore.ThemeDataStore
+import com.garfiec.librechat.core.data.datastore.ThemeMode
+import com.garfiec.librechat.core.ui.theme.supportsDynamicColor
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+/** Intermediate holder for the combined DataStore preferences. */
+private data class DataStorePreferences(
+    val themeMode: ThemeMode,
+    val serverUrl: String,
+    val chatFontSize: ChatFontSize,
+    val autoScrollEnabled: Boolean,
+    val showThinkingBlocks: Boolean,
+    val accentColor: Int = ThemeDataStore.DEFAULT_ACCENT_COLOR,
+    val useDynamicColor: Boolean = false,
+)
+
+/** Extra DataStore preferences (separate combine since Kotlin combine maxes at 5). */
+private data class ExtraPreferences(
+    val autoRead: Boolean,
+    val selectedVoiceId: String?,
+    val showImageDescriptions: Boolean,
+    val dismissKeyboardOnSend: Boolean,
+    val ttsSource: String,
+)
+
+/** Device TTS preferences (speech rate, pitch, voice name, engine, voice selection). */
+private data class DeviceTtsPreferences(
+    val speechRate: Float,
+    val pitch: Float,
+    val voiceName: String,
+    val ttsEngine: String,
+    val ttsVoice: String,
+)
+
+/** Additional preferences combined separately to stay within the 5-arg combine limit. */
+private data class AdditionalPreferences(
+    val tabletSidebarGestureEnabled: Boolean,
+    val autoSendAfterStt: Boolean,
+    val sttEngine: String,
+    val sttLanguage: String,
+    val ttsCaching: Boolean,
+    val chatLayoutStyle: String = ChatLayoutConstants.THREAD,
+    val showAvatars: Boolean = true,
+    val showBubbles: Boolean = false,
+    val latexRenderer: LatexRenderer = LatexRenderer.KATEX,
+    val inlineArtifactPrefs: InlineArtifactPrefs = InlineArtifactPrefs(),
+    val starredModelsDisplay: StarredModelsDisplay = StarredModelsDisplay.OFF,
+    val selectedLanguage: String = SettingsDataStore.DEFAULT_LANGUAGE,
+)
+
+/**
+ * Owns the DataStore side of settings: the read flows (the multi-stage `combine`
+ * machinery, split across holders because Kotlin's `combine` maxes at 5 sources)
+ * merged with the ViewModel's imperative [baseState] into a single [uiState], plus
+ * the matching write setters. The ViewModel keeps only imperative state and
+ * forwards preference reads/writes here.
+ */
+class SettingsPreferencesController(
+    private val themeDataStore: ThemeDataStore,
+    serverDataStore: ServerDataStore,
+    private val settingsDataStore: SettingsDataStore,
+    baseState: StateFlow<SettingsUiState>,
+    private val scope: CoroutineScope,
+) {
+    /** Combined DataStore preferences flow. */
+    private val dataStorePreferences: StateFlow<DataStorePreferences> = combine(
+        themeDataStore.themeMode,
+        serverDataStore.currentUrlFlow,
+        settingsDataStore.chatFontSize,
+        settingsDataStore.autoScrollEnabled,
+        settingsDataStore.showThinkingBlocks,
+    ) { theme, serverUrl, fontSize, autoScroll, showThinking ->
+        DataStorePreferences(
+            themeMode = theme,
+            serverUrl = serverUrl,
+            chatFontSize = fontSize,
+            autoScrollEnabled = autoScroll,
+            showThinkingBlocks = showThinking,
+        )
+    }.combine(themeDataStore.accentColor) { prefs, accent ->
+        prefs.copy(accentColor = accent)
+    }.combine(themeDataStore.useDynamicColor) { prefs, dynamic ->
+        prefs.copy(useDynamicColor = dynamic)
+    }.stateIn(scope, SharingStarted.Eagerly, DataStorePreferences(
+        themeMode = ThemeMode.SYSTEM,
+        serverUrl = "",
+        chatFontSize = ChatFontSize.MEDIUM,
+        autoScrollEnabled = true,
+        showThinkingBlocks = true,
+    ))
+
+    private val extraPreferences: StateFlow<ExtraPreferences> = combine(
+        settingsDataStore.autoReadEnabled,
+        settingsDataStore.selectedVoiceId,
+        settingsDataStore.showImageDescriptions,
+        settingsDataStore.dismissKeyboardOnSend,
+        settingsDataStore.ttsSource,
+    ) { autoRead, voiceId, showImgDesc, dismissKeyboard, ttsSource ->
+        ExtraPreferences(autoRead, voiceId, showImgDesc, dismissKeyboard, ttsSource)
+    }.stateIn(scope, SharingStarted.Eagerly, ExtraPreferences(false, null, false, false, "device"))
+
+    private val deviceTtsPreferences: StateFlow<DeviceTtsPreferences> = combine(
+        settingsDataStore.ttsSpeechRate,
+        settingsDataStore.ttsPitch,
+        settingsDataStore.ttsVoiceName,
+        settingsDataStore.ttsEngine,
+        settingsDataStore.ttsVoice,
+    ) { rate, pitch, voiceName, ttsEngine, ttsVoice ->
+        DeviceTtsPreferences(rate, pitch, voiceName, ttsEngine, ttsVoice)
+    }.stateIn(scope, SharingStarted.Eagerly, DeviceTtsPreferences(1.0f, 1.0f, "", "", ""))
+
+    /** TTS caching preference. Kept as a separate flow to stay within the 5-arg combine limit. */
+    private val ttsCachingPreference: StateFlow<Boolean> = settingsDataStore.ttsCaching
+        .stateIn(scope, SharingStarted.Eagerly, true)
+
+    /** Tablet-specific preferences. */
+    private val tabletSidebarGestureEnabled: StateFlow<Boolean> = settingsDataStore.tabletSidebarGestureEnabled
+        .stateIn(scope, SharingStarted.Eagerly, true)
+
+    /** Chat layout preferences. */
+    private val chatLayoutStylePref: StateFlow<String> = settingsDataStore.chatLayoutStyle
+        .stateIn(scope, SharingStarted.Eagerly, ChatLayoutConstants.THREAD)
+
+    private val showAvatarsPref: StateFlow<Boolean> = settingsDataStore.showAvatars
+        .stateIn(scope, SharingStarted.Eagerly, true)
+
+    private val showBubblesPref: StateFlow<Boolean> = settingsDataStore.showBubbles
+        .stateIn(scope, SharingStarted.Eagerly, false)
+
+    private val latexRendererPref: StateFlow<LatexRenderer> = settingsDataStore.latexRenderer
+        .stateIn(scope, SharingStarted.Eagerly, LatexRenderer.KATEX)
+
+    private val inlineArtifactPrefsFlow: StateFlow<InlineArtifactPrefs> = settingsDataStore.inlineArtifactPrefs
+        .stateIn(scope, SharingStarted.Eagerly, InlineArtifactPrefs())
+
+    private val starredModelsDisplayPref: StateFlow<StarredModelsDisplay> = settingsDataStore.starredModelsDisplay
+        .stateIn(scope, SharingStarted.Eagerly, StarredModelsDisplay.OFF)
+
+    private val selectedLanguagePref: StateFlow<String> = settingsDataStore.selectedLanguage
+        .stateIn(scope, SharingStarted.Eagerly, SettingsDataStore.DEFAULT_LANGUAGE)
+
+    private val baseAdditionalPreferences = combine(
+        tabletSidebarGestureEnabled,
+        settingsDataStore.autoSendAfterStt,
+        settingsDataStore.sttEngine,
+        settingsDataStore.sttLanguage,
+        ttsCachingPreference,
+    ) { tabletGesture, autoSendStt, sttEngine, sttLanguage, ttsCaching ->
+        AdditionalPreferences(tabletGesture, autoSendStt, sttEngine, sttLanguage, ttsCaching)
+    }
+
+    private val additionalPreferences: StateFlow<AdditionalPreferences> = combine(
+        baseAdditionalPreferences,
+        chatLayoutStylePref,
+        showAvatarsPref,
+        showBubblesPref,
+        latexRendererPref,
+    ) { base, layoutStyle, showAvatars, showBubbles, latexRenderer ->
+        base.copy(chatLayoutStyle = layoutStyle, showAvatars = showAvatars, showBubbles = showBubbles, latexRenderer = latexRenderer)
+    }.combine(inlineArtifactPrefsFlow) { additional, inlineArtifact ->
+        additional.copy(inlineArtifactPrefs = inlineArtifact)
+    }.combine(starredModelsDisplayPref) { additional, starredDisplay ->
+        additional.copy(starredModelsDisplay = starredDisplay)
+    }.combine(selectedLanguagePref) { additional, selectedLanguage ->
+        additional.copy(selectedLanguage = selectedLanguage)
+    }.stateIn(scope, SharingStarted.Eagerly, AdditionalPreferences(true, false, "", "", true))
+
+    /** The single public UI state that merges DataStore preferences with imperative state. */
+    val uiState: StateFlow<SettingsUiState> = combine(
+        baseState,
+        dataStorePreferences,
+        extraPreferences,
+        deviceTtsPreferences,
+        additionalPreferences,
+    ) { state, prefs, extra, deviceTts, additional ->
+        val selectedVoice = extra.selectedVoiceId?.let { id -> state.availableVoices.find { it.id == id } }
+        state.copy(
+            themeMode = prefs.themeMode,
+            accentColor = prefs.accentColor,
+            useDynamicColor = prefs.useDynamicColor,
+            dynamicColorSupported = supportsDynamicColor(),
+            serverUrl = prefs.serverUrl,
+            chatFontSize = prefs.chatFontSize,
+            autoScrollEnabled = prefs.autoScrollEnabled,
+            showThinkingBlocks = prefs.showThinkingBlocks,
+            autoReadEnabled = extra.autoRead,
+            selectedVoice = selectedVoice,
+            showImageDescriptions = extra.showImageDescriptions,
+            dismissKeyboardOnSend = extra.dismissKeyboardOnSend,
+            ttsSource = extra.ttsSource,
+            ttsSpeechRate = deviceTts.speechRate,
+            ttsPitch = deviceTts.pitch,
+            ttsDeviceVoiceName = deviceTts.voiceName,
+            ttsEngine = deviceTts.ttsEngine,
+            ttsVoice = deviceTts.ttsVoice,
+            ttsCaching = additional.ttsCaching,
+            tabletSidebarGestureEnabled = additional.tabletSidebarGestureEnabled,
+            sttAutoSend = additional.autoSendAfterStt,
+            sttEngine = additional.sttEngine,
+            sttLanguage = additional.sttLanguage,
+            chatLayoutStyle = additional.chatLayoutStyle,
+            showAvatars = additional.showAvatars,
+            showBubbles = additional.showBubbles,
+            latexRenderer = additional.latexRenderer,
+            inlineArtifactPrefs = additional.inlineArtifactPrefs,
+            starredModelsDisplay = additional.starredModelsDisplay,
+            selectedLanguage = additional.selectedLanguage,
+        )
+    }.stateIn(scope, SharingStarted.Eagerly, SettingsUiState())
+
+    // ── Write setters (fire-and-forget; return Unit, not the launched Job) ──
+
+    fun setThemeMode(mode: ThemeMode) {
+        scope.launch { themeDataStore.setThemeMode(mode) }
+    }
+
+    fun setAccentColor(argb: Int) {
+        scope.launch { themeDataStore.setAccentColor(argb) }
+    }
+
+    fun setUseDynamicColor(enabled: Boolean) {
+        scope.launch { themeDataStore.setUseDynamicColor(enabled) }
+    }
+
+    fun setChatFontSize(size: ChatFontSize) {
+        scope.launch { settingsDataStore.setChatFontSize(size) }
+    }
+
+    fun setStarredModelsDisplay(display: StarredModelsDisplay) {
+        scope.launch { settingsDataStore.setStarredModelsDisplay(display) }
+    }
+
+    fun setAutoScrollEnabled(enabled: Boolean) {
+        scope.launch { settingsDataStore.setAutoScrollEnabled(enabled) }
+    }
+
+    fun setShowThinkingBlocks(show: Boolean) {
+        scope.launch { settingsDataStore.setShowThinkingBlocks(show) }
+    }
+
+    fun setShowImageDescriptions(show: Boolean) {
+        scope.launch { settingsDataStore.setShowImageDescriptions(show) }
+    }
+
+    fun setDismissKeyboardOnSend(enabled: Boolean) {
+        scope.launch { settingsDataStore.setDismissKeyboardOnSend(enabled) }
+    }
+
+    fun setChatLayoutStyle(style: String) {
+        scope.launch { settingsDataStore.setChatLayoutStyle(style) }
+    }
+
+    fun setShowAvatars(show: Boolean) {
+        scope.launch { settingsDataStore.setShowAvatars(show) }
+    }
+
+    fun setShowBubbles(show: Boolean) {
+        scope.launch { settingsDataStore.setShowBubbles(show) }
+    }
+
+    fun setLatexRenderer(renderer: LatexRenderer) {
+        scope.launch { settingsDataStore.setLatexRenderer(renderer) }
+    }
+
+    fun setInlineArtifactMermaid(enabled: Boolean) {
+        scope.launch { settingsDataStore.setInlineArtifactMermaid(enabled) }
+    }
+
+    fun setInlineArtifactSvg(enabled: Boolean) {
+        scope.launch { settingsDataStore.setInlineArtifactSvg(enabled) }
+    }
+
+    fun setInlineArtifactHtml(enabled: Boolean) {
+        scope.launch { settingsDataStore.setInlineArtifactHtml(enabled) }
+    }
+
+    fun setInlineArtifactReact(enabled: Boolean) {
+        scope.launch { settingsDataStore.setInlineArtifactReact(enabled) }
+    }
+
+    fun setInlineArtifactMarkdown(enabled: Boolean) {
+        scope.launch { settingsDataStore.setInlineArtifactMarkdown(enabled) }
+    }
+
+    fun setTabletSidebarGestureEnabled(enabled: Boolean) {
+        scope.launch { settingsDataStore.setTabletSidebarGestureEnabled(enabled) }
+    }
+
+    fun setSelectedLanguage(languageCode: String) {
+        scope.launch { settingsDataStore.setSelectedLanguage(languageCode) }
+    }
+}

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/SettingsUiState.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/SettingsUiState.kt
@@ -1,0 +1,210 @@
+package com.garfiec.librechat.feature.settings.viewmodel
+
+import androidx.compose.runtime.Immutable
+import com.garfiec.librechat.core.common.ChatLayoutConstants
+import com.garfiec.librechat.core.data.datastore.ChatFontSize
+import com.garfiec.librechat.core.data.datastore.InlineArtifactPrefs
+import com.garfiec.librechat.core.data.datastore.LatexRenderer
+import com.garfiec.librechat.core.data.datastore.SettingsDataStore
+import com.garfiec.librechat.core.data.datastore.StarredModelsDisplay
+import com.garfiec.librechat.core.data.datastore.ThemeDataStore
+import com.garfiec.librechat.core.data.datastore.ThemeMode
+import com.garfiec.librechat.core.model.Memory
+import com.garfiec.librechat.core.model.User
+import com.garfiec.librechat.core.model.config.BuildInfo
+import com.garfiec.librechat.core.model.mcp.McpServer
+import com.garfiec.librechat.core.model.mcp.McpServerStatus
+import com.garfiec.librechat.core.model.speech.TtsVoice
+import com.garfiec.librechat.feature.settings.model.SharedLinkDisplayData
+import com.garfiec.librechat.feature.settings.model.UserDisplayData
+import com.garfiec.librechat.feature.settings.screen.DeviceVoiceInfo
+
+data class SettingsCommand(
+    val name: String,
+    val description: String,
+    val enabled: Boolean = true,
+)
+
+/** One-shot diagnostic-log export payload handed from the ViewModel to the platform file saver. */
+@Immutable
+data class LogsExportPayload(
+    val content: String,
+    val fileName: String,
+)
+
+val DEFAULT_COMMANDS = listOf(
+    SettingsCommand("help", "Show available commands", true),
+    SettingsCommand("clear", "Clear current conversation", true),
+    SettingsCommand("new", "Start a new conversation", true),
+    SettingsCommand("model", "Switch the current model", true),
+    SettingsCommand("system", "Set a system message", true),
+    SettingsCommand("fork", "Fork the current conversation", true),
+)
+
+@Immutable
+data class SettingsUiState(
+    val user: UserDisplayData? = null,
+    val themeMode: ThemeMode = ThemeMode.SYSTEM,
+    val accentColor: Int = ThemeDataStore.DEFAULT_ACCENT_COLOR,
+    val useDynamicColor: Boolean = false,
+    val dynamicColorSupported: Boolean = false,
+    val showAccentColorDialog: Boolean = false,
+    val serverUrl: String = "",
+    /** Human-facing app version (e.g. `0.1.0`), sourced from the installed package. */
+    val appVersion: String = "",
+    /** Short git commit the build was cut from (e.g. `1a2b3c4d`), or `unknown`. */
+    val gitSha: String = "",
+    val isDeletingAccount: Boolean = false,
+    /**
+     * Transient errors surfaced via snackbar; cleared by [SettingsViewModel.dismissError]
+     * after the snackbar is shown/acted on. Used for one-shot failures: avatar upload,
+     * account-deletion submit, 2FA mutations, etc. Do NOT use this for profile-fetch
+     * failures — those are sticky and must remain visible until the user retries.
+     * See [profileLoadError].
+     */
+    val error: String? = null,
+    /**
+     * Sticky inline error for profile-fetch failures. Rendered as an `ErrorBanner` inside
+     * the Account section so the rest of the screen (Sign Out, Delete Account, etc.) stays
+     * reachable while the server is unreachable. Cleared at the start of each `loadUser()`.
+     */
+    val profileLoadError: String? = null,
+    val isLoggedOut: Boolean = false,
+    val isAccountDeleted: Boolean = false,
+    /**
+     * Mirrors `StartupConfig.allowAccountDeletion`. New in v0.8.5 — older servers
+     * don't send the flag, so it defaults to `true` and the Delete Account button
+     * stays visible. When the server sends `false`, mobile hides the button to
+     * avoid a guaranteed 403 on submission.
+     */
+    val allowAccountDeletion: Boolean = true,
+    /**
+     * Server build metadata (commit/branch/buildDate) from `/api/config`
+     * (`StartupConfig.buildInfo`, gated by `interface.buildInfo`). null when the
+     * server doesn't report it; the About section omits the rows in that case.
+     */
+    val buildInfo: BuildInfo? = null,
+    /** True only when the authenticated user's system role is ADMIN. Gates the
+     *  admin role-skills row fail-CLOSED (defaults false until the profile loads). */
+    val isAdmin: Boolean = false,
+    // Chat preferences
+    val chatFontSize: ChatFontSize = ChatFontSize.MEDIUM,
+    val autoScrollEnabled: Boolean = true,
+    val showThinkingBlocks: Boolean = true,
+    val showImageDescriptions: Boolean = false,
+    val dismissKeyboardOnSend: Boolean = false,
+    // Data management
+    val archivedCount: Int = 0,
+    val isClearing: Boolean = false,
+    val showExportComingSoon: Boolean = false,
+    // Diagnostic logs (issue #96)
+    val isLogsExporting: Boolean = false,
+    val isLogsClearing: Boolean = false,
+    val logsBufferBytes: Long = 0,
+    /**
+     * One-shot export payload. Set when [SettingsViewModel.exportLogs] finishes reading the
+     * buffer; the screen observes it, hands it to the platform `LogFileSaver`, then calls
+     * [SettingsViewModel.consumeLogsExport] to clear it (so a recomposition doesn't re-trigger
+     * the save). Mirrors the conversations `ExportReady` event but state-based, since Settings
+     * has no events SharedFlow.
+     */
+    val logsExportReady: LogsExportPayload? = null,
+    // Security (2FA)
+    val isTwoFactorEnabled: Boolean = false,
+    val isTwoFactorLoading: Boolean = false,
+    val showTwoFactorSetupDialog: Boolean = false,
+    val twoFactorOtpauthUrl: String? = null,
+    val showBackupCodesDialog: Boolean = false,
+    val backupCodes: List<String> = emptyList(),
+    val showDisableTwoFactorDialog: Boolean = false,
+    val showEnableTwoFactorOtpDialog: Boolean = false,
+    val showBackupCodesOtpDialog: Boolean = false,
+    val showDeleteAccountOtpDialog: Boolean = false,
+    // MCP
+    val mcpServers: List<McpServer> = emptyList(),
+    val mcpConnectionStatus: Map<String, McpServerStatus> = emptyMap(),
+    val mcpError: String? = null,
+    val showMcpServerDialog: Boolean = false,
+    val editingMcpServer: McpServer? = null,
+    val mcpReinitializingServers: Set<String> = emptySet(),
+    val mcpReinitializeMessage: String? = null,
+    // Speech settings
+    val autoReadEnabled: Boolean = false,
+    val selectedVoice: TtsVoice? = null,
+    val availableVoices: List<TtsVoice> = emptyList(),
+    // Memories
+    val memories: List<Memory> = emptyList(),
+    val memoriesEnabled: Boolean = true,
+    val showMemoryDialog: Boolean = false,
+    val editingMemory: Memory? = null,
+    // Balance
+    val tokenCredits: Long = 0,
+    val isBalanceLoading: Boolean = false,
+    // Avatar
+    val showAvatarDialog: Boolean = false,
+    val isAvatarUploading: Boolean = false,
+    // Shared links
+    val sharedLinks: List<SharedLinkDisplayData> = emptyList(),
+    val sharedLinksNextCursor: String? = null,
+    val sharedLinksHasNextPage: Boolean = false,
+    val isSharedLinksLoading: Boolean = false,
+    // Speech detail dialogs
+    val showSttDetailDialog: Boolean = false,
+    val showTtsDetailDialog: Boolean = false,
+    val sttEngine: String = "",
+    val sttLanguage: String = "",
+    val sttAutoSend: Boolean = false,
+    val ttsEngine: String = "",
+    val ttsVoice: String = "",
+    val ttsSpeechRate: Float = 1.0f,
+    val ttsPitch: Float = 1.0f,
+    val ttsDeviceVoiceName: String = "",
+    val ttsCaching: Boolean = true,
+    val ttsSource: String = "device",
+    val availableDeviceVoices: List<DeviceVoiceInfo> = emptyList(),
+    // TTS preview
+    val isTtsPreviewPlaying: Boolean = false,
+    // Cache / Keys
+    val isCacheClearing: Boolean = false,
+    val isKeyRevoking: Boolean = false,
+    // Language
+    val selectedLanguage: String = SettingsDataStore.DEFAULT_LANGUAGE,
+    val showLanguageDialog: Boolean = false,
+    // Fork settings
+    val forkMode: String = "targetLevel",
+    val showForkSettingsDialog: Boolean = false,
+    // Commands
+    val showCommandsScreen: Boolean = false,
+    val commands: List<SettingsCommand> = DEFAULT_COMMANDS,
+    // Personalization
+    val showPersonalizationDialog: Boolean = false,
+    val personalizationEnabled: Boolean = true,
+    val aboutUser: String = "",
+    val responseStyle: String = "",
+    // Tablet
+    val tabletSidebarGestureEnabled: Boolean = true,
+    // Chat layout
+    val chatLayoutStyle: String = ChatLayoutConstants.THREAD,
+    val showAvatars: Boolean = true,
+    val showBubbles: Boolean = false,
+    val latexRenderer: LatexRenderer = LatexRenderer.KATEX,
+    // Mobile-only: how pinned models/agents surface in the model-selection sheet
+    val starredModelsDisplay: StarredModelsDisplay = StarredModelsDisplay.OFF,
+    // Inline artifact rendering (per-type toggles)
+    val inlineArtifactPrefs: InlineArtifactPrefs = InlineArtifactPrefs(),
+    // Role-permission gates. `serverMemoriesEnabled` is the SERVER-level MEMORIES.USE
+    // gate and is orthogonal to [memoriesEnabled], which is the user's own opt-out
+    // stored on their profile (`user.personalization.memories`).
+    val mcpServersEnabled: Boolean = true,
+    val mcpServersCreateEnabled: Boolean = true,
+    val serverMemoriesEnabled: Boolean = true,
+    val remoteAgentsEnabled: Boolean = true,
+    val remoteAgentsCreateEnabled: Boolean = true,
+)
+
+internal fun User.toDisplayData() = UserDisplayData(
+    name = name ?: "",
+    email = email,
+    username = username ?: "",
+    avatar = avatar,
+)

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/SettingsViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/SettingsViewModel.kt
@@ -1,14 +1,9 @@
 package com.garfiec.librechat.feature.settings.viewmodel
 
-import androidx.compose.runtime.Immutable
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import co.touchlab.kermit.Logger
 import com.garfiec.librechat.core.common.AppInfo
-import com.garfiec.librechat.core.common.ChatLayoutConstants
-import com.garfiec.librechat.core.common.result.Result
 import com.garfiec.librechat.core.data.datastore.ChatFontSize
-import com.garfiec.librechat.core.data.datastore.InlineArtifactPrefs
 import com.garfiec.librechat.core.data.datastore.LatexRenderer
 import com.garfiec.librechat.core.data.datastore.ServerDataStore
 import com.garfiec.librechat.core.data.datastore.SettingsDataStore
@@ -28,257 +23,42 @@ import com.garfiec.librechat.core.data.repository.UserRepository
 import com.garfiec.librechat.core.data.util.PermissionGate
 import com.garfiec.librechat.core.logging.DiagnosticLogRepository
 import com.garfiec.librechat.core.model.Memory
-import com.garfiec.librechat.core.model.User
-import com.garfiec.librechat.core.model.config.BuildInfo
 import com.garfiec.librechat.core.model.mcp.McpApiKeyConfig
 import com.garfiec.librechat.core.model.mcp.McpOAuthConfig
 import com.garfiec.librechat.core.model.mcp.McpServer
-import com.garfiec.librechat.core.model.mcp.McpServerStatus
 import com.garfiec.librechat.core.model.mcp.McpServerType
 import com.garfiec.librechat.core.model.permissions.Permission
 import com.garfiec.librechat.core.model.permissions.PermissionType
 import com.garfiec.librechat.core.model.permissions.hasAccessOrPermissive
 import com.garfiec.librechat.core.model.speech.TtsVoice
-import com.garfiec.librechat.core.ui.theme.supportsDynamicColor
-import com.garfiec.librechat.feature.settings.model.SharedLinkDisplayData
-import com.garfiec.librechat.feature.settings.model.UserDisplayData
-import com.garfiec.librechat.feature.settings.screen.DeviceVoiceInfo
 import com.garfiec.librechat.feature.settings.util.ContentReader
 import com.garfiec.librechat.feature.settings.util.PlatformCacheCleaner
+import com.garfiec.librechat.feature.settings.viewmodel.delegate.AccountDelegate
 import com.garfiec.librechat.feature.settings.viewmodel.delegate.DataManagementDelegate
 import com.garfiec.librechat.feature.settings.viewmodel.delegate.McpServerDelegate
 import com.garfiec.librechat.feature.settings.viewmodel.delegate.MemoryManagementDelegate
 import com.garfiec.librechat.feature.settings.viewmodel.delegate.SpeechSettingsFactory
 import com.garfiec.librechat.feature.settings.viewmodel.delegate.TwoFactorSecurityDelegate
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
-
-data class SettingsCommand(
-    val name: String,
-    val description: String,
-    val enabled: Boolean = true,
-)
-
-/** One-shot diagnostic-log export payload handed from the ViewModel to the platform file saver. */
-@Immutable
-data class LogsExportPayload(
-    val content: String,
-    val fileName: String,
-)
-
-val DEFAULT_COMMANDS = listOf(
-    SettingsCommand("help", "Show available commands", true),
-    SettingsCommand("clear", "Clear current conversation", true),
-    SettingsCommand("new", "Start a new conversation", true),
-    SettingsCommand("model", "Switch the current model", true),
-    SettingsCommand("system", "Set a system message", true),
-    SettingsCommand("fork", "Fork the current conversation", true),
-)
-
-@Immutable
-data class SettingsUiState(
-    val user: UserDisplayData? = null,
-    val themeMode: ThemeMode = ThemeMode.SYSTEM,
-    val accentColor: Int = ThemeDataStore.DEFAULT_ACCENT_COLOR,
-    val useDynamicColor: Boolean = false,
-    val dynamicColorSupported: Boolean = false,
-    val showAccentColorDialog: Boolean = false,
-    val serverUrl: String = "",
-    /** Human-facing app version (e.g. `0.1.0`), sourced from the installed package. */
-    val appVersion: String = "",
-    /** Short git commit the build was cut from (e.g. `1a2b3c4d`), or `unknown`. */
-    val gitSha: String = "",
-    val isDeletingAccount: Boolean = false,
-    /**
-     * Transient errors surfaced via snackbar; cleared by [SettingsViewModel.dismissError]
-     * after the snackbar is shown/acted on. Used for one-shot failures: avatar upload,
-     * account-deletion submit, 2FA mutations, etc. Do NOT use this for profile-fetch
-     * failures — those are sticky and must remain visible until the user retries.
-     * See [profileLoadError].
-     */
-    val error: String? = null,
-    /**
-     * Sticky inline error for profile-fetch failures. Rendered as an `ErrorBanner` inside
-     * the Account section so the rest of the screen (Sign Out, Delete Account, etc.) stays
-     * reachable while the server is unreachable. Cleared at the start of each `loadUser()`.
-     */
-    val profileLoadError: String? = null,
-    val isLoggedOut: Boolean = false,
-    val isAccountDeleted: Boolean = false,
-    /**
-     * Mirrors `StartupConfig.allowAccountDeletion`. New in v0.8.5 — older servers
-     * don't send the flag, so it defaults to `true` and the Delete Account button
-     * stays visible. When the server sends `false`, mobile hides the button to
-     * avoid a guaranteed 403 on submission.
-     */
-    val allowAccountDeletion: Boolean = true,
-    /**
-     * Server build metadata (commit/branch/buildDate) from `/api/config`
-     * (`StartupConfig.buildInfo`, gated by `interface.buildInfo`). null when the
-     * server doesn't report it; the About section omits the rows in that case.
-     */
-    val buildInfo: BuildInfo? = null,
-    /** True only when the authenticated user's system role is ADMIN. Gates the
-     *  admin role-skills row fail-CLOSED (defaults false until the profile loads). */
-    val isAdmin: Boolean = false,
-    // Chat preferences
-    val chatFontSize: ChatFontSize = ChatFontSize.MEDIUM,
-    val autoScrollEnabled: Boolean = true,
-    val showThinkingBlocks: Boolean = true,
-    val showImageDescriptions: Boolean = false,
-    val dismissKeyboardOnSend: Boolean = false,
-    // Data management
-    val archivedCount: Int = 0,
-    val isClearing: Boolean = false,
-    val showExportComingSoon: Boolean = false,
-    // Diagnostic logs (issue #96)
-    val isLogsExporting: Boolean = false,
-    val isLogsClearing: Boolean = false,
-    val logsBufferBytes: Long = 0,
-    /**
-     * One-shot export payload. Set when [SettingsViewModel.exportLogs] finishes reading the
-     * buffer; the screen observes it, hands it to the platform `LogFileSaver`, then calls
-     * [SettingsViewModel.consumeLogsExport] to clear it (so a recomposition doesn't re-trigger
-     * the save). Mirrors the conversations `ExportReady` event but state-based, since Settings
-     * has no events SharedFlow.
-     */
-    val logsExportReady: LogsExportPayload? = null,
-    // Security (2FA)
-    val isTwoFactorEnabled: Boolean = false,
-    val isTwoFactorLoading: Boolean = false,
-    val showTwoFactorSetupDialog: Boolean = false,
-    val twoFactorOtpauthUrl: String? = null,
-    val showBackupCodesDialog: Boolean = false,
-    val backupCodes: List<String> = emptyList(),
-    val showDisableTwoFactorDialog: Boolean = false,
-    val showEnableTwoFactorOtpDialog: Boolean = false,
-    val showBackupCodesOtpDialog: Boolean = false,
-    val showDeleteAccountOtpDialog: Boolean = false,
-    // MCP
-    val mcpServers: List<McpServer> = emptyList(),
-    val mcpConnectionStatus: Map<String, McpServerStatus> = emptyMap(),
-    val mcpError: String? = null,
-    val showMcpServerDialog: Boolean = false,
-    val editingMcpServer: McpServer? = null,
-    val mcpReinitializingServers: Set<String> = emptySet(),
-    val mcpReinitializeMessage: String? = null,
-    // Speech settings
-    val autoReadEnabled: Boolean = false,
-    val selectedVoice: TtsVoice? = null,
-    val availableVoices: List<TtsVoice> = emptyList(),
-    // Memories
-    val memories: List<Memory> = emptyList(),
-    val memoriesEnabled: Boolean = true,
-    val showMemoryDialog: Boolean = false,
-    val editingMemory: Memory? = null,
-    // Balance
-    val tokenCredits: Long = 0,
-    val isBalanceLoading: Boolean = false,
-    // Avatar
-    val showAvatarDialog: Boolean = false,
-    val isAvatarUploading: Boolean = false,
-    // Shared links
-    val sharedLinks: List<SharedLinkDisplayData> = emptyList(),
-    val sharedLinksNextCursor: String? = null,
-    val sharedLinksHasNextPage: Boolean = false,
-    val isSharedLinksLoading: Boolean = false,
-    // Speech detail dialogs
-    val showSttDetailDialog: Boolean = false,
-    val showTtsDetailDialog: Boolean = false,
-    val sttEngine: String = "",
-    val sttLanguage: String = "",
-    val sttAutoSend: Boolean = false,
-    val ttsEngine: String = "",
-    val ttsVoice: String = "",
-    val ttsSpeechRate: Float = 1.0f,
-    val ttsPitch: Float = 1.0f,
-    val ttsDeviceVoiceName: String = "",
-    val ttsCaching: Boolean = true,
-    val ttsSource: String = "device",
-    val availableDeviceVoices: List<DeviceVoiceInfo> = emptyList(),
-    // TTS preview
-    val isTtsPreviewPlaying: Boolean = false,
-    // Cache / Keys
-    val isCacheClearing: Boolean = false,
-    val isKeyRevoking: Boolean = false,
-    // Language
-    val selectedLanguage: String = SettingsDataStore.DEFAULT_LANGUAGE,
-    val showLanguageDialog: Boolean = false,
-    // Fork settings
-    val forkMode: String = "targetLevel",
-    val showForkSettingsDialog: Boolean = false,
-    // Commands
-    val showCommandsScreen: Boolean = false,
-    val commands: List<SettingsCommand> = DEFAULT_COMMANDS,
-    // Personalization
-    val showPersonalizationDialog: Boolean = false,
-    val personalizationEnabled: Boolean = true,
-    val aboutUser: String = "",
-    val responseStyle: String = "",
-    // Tablet
-    val tabletSidebarGestureEnabled: Boolean = true,
-    // Chat layout
-    val chatLayoutStyle: String = ChatLayoutConstants.THREAD,
-    val showAvatars: Boolean = true,
-    val showBubbles: Boolean = false,
-    val latexRenderer: LatexRenderer = LatexRenderer.KATEX,
-    // Mobile-only: how pinned models/agents surface in the model-selection sheet
-    val starredModelsDisplay: StarredModelsDisplay = StarredModelsDisplay.OFF,
-    // Inline artifact rendering (per-type toggles)
-    val inlineArtifactPrefs: InlineArtifactPrefs = InlineArtifactPrefs(),
-    // Role-permission gates. `serverMemoriesEnabled` is the SERVER-level MEMORIES.USE
-    // gate and is orthogonal to [memoriesEnabled], which is the user's own opt-out
-    // stored on their profile (`user.personalization.memories`).
-    val mcpServersEnabled: Boolean = true,
-    val mcpServersCreateEnabled: Boolean = true,
-    val serverMemoriesEnabled: Boolean = true,
-    val remoteAgentsEnabled: Boolean = true,
-    val remoteAgentsCreateEnabled: Boolean = true,
-)
-
-private fun User.toDisplayData() = UserDisplayData(
-    name = name ?: "",
-    email = email,
-    username = username ?: "",
-    avatar = avatar,
-)
-
-/** Intermediate holder for the combined DataStore preferences. */
-private data class DataStorePreferences(
-    val themeMode: ThemeMode,
-    val serverUrl: String,
-    val chatFontSize: ChatFontSize,
-    val autoScrollEnabled: Boolean,
-    val showThinkingBlocks: Boolean,
-    val autoReadEnabled: Boolean,
-    val selectedVoiceId: String,
-    val accentColor: Int = ThemeDataStore.DEFAULT_ACCENT_COLOR,
-    val useDynamicColor: Boolean = false,
-)
 
 @Suppress("LongParameterList")
 class SettingsViewModel(
-    private val contentReader: ContentReader,
-    private val cacheCleaner: PlatformCacheCleaner,
-    private val userRepository: UserRepository,
-    private val authRepository: AuthRepository,
+    contentReader: ContentReader,
+    cacheCleaner: PlatformCacheCleaner,
+    userRepository: UserRepository,
+    authRepository: AuthRepository,
     conversationRepository: ConversationRepository,
-    private val themeDataStore: ThemeDataStore,
+    themeDataStore: ThemeDataStore,
     serverDataStore: ServerDataStore,
-    private val settingsDataStore: SettingsDataStore,
+    settingsDataStore: SettingsDataStore,
     mcpRepository: McpRepository,
     memoryRepository: MemoryRepository,
     speechSettingsFactory: SpeechSettingsFactory,
-    private val balanceRepository: BalanceRepository,
+    balanceRepository: BalanceRepository,
     shareRepository: ShareRepository,
     keyRepository: KeyRepository,
     private val roleRepository: RoleRepository,
@@ -286,7 +66,7 @@ class SettingsViewModel(
     private val configRepository: ConfigRepository,
     diagnosticLogRepository: DiagnosticLogRepository,
     appInfo: AppInfo,
-    private val ioDispatcher: CoroutineDispatcher,
+    ioDispatcher: CoroutineDispatcher,
 ) : ViewModel() {
 
     /** Raw state for everything not driven by DataStore flows. */
@@ -295,10 +75,6 @@ class SettingsViewModel(
     )
 
     private val stateHandle = SettingsStateHandle(_uiState, viewModelScope)
-
-    // In-flight profile-load job. Cancelled before each retry so a hung 90s request
-    // doesn't continue racing the fresh one.
-    private var loadUserJob: Job? = null
 
     // --- Delegates ---
     private val speechDelegate = speechSettingsFactory.create(stateHandle)
@@ -314,195 +90,25 @@ class SettingsViewModel(
             keyRepository,
             diagnosticLogRepository,
         )
+    private val accountDelegate =
+        AccountDelegate(stateHandle, userRepository, balanceRepository, contentReader, ioDispatcher)
 
-    /** Combined DataStore preferences flow. */
-    private val dataStorePreferences: StateFlow<DataStorePreferences> = combine(
-        themeDataStore.themeMode,
-        serverDataStore.currentUrlFlow,
-        settingsDataStore.chatFontSize,
-        settingsDataStore.autoScrollEnabled,
-        settingsDataStore.showThinkingBlocks,
-    ) { theme, serverUrl, fontSize, autoScroll, showThinking ->
-        DataStorePreferences(
-            themeMode = theme,
-            serverUrl = serverUrl,
-            chatFontSize = fontSize,
-            autoScrollEnabled = autoScroll,
-            showThinkingBlocks = showThinking,
-            autoReadEnabled = false,
-            selectedVoiceId = "",
-        )
-    }.combine(themeDataStore.accentColor) { prefs, accent ->
-        prefs.copy(accentColor = accent)
-    }.combine(themeDataStore.useDynamicColor) { prefs, dynamic ->
-        prefs.copy(useDynamicColor = dynamic)
-    }.stateIn(viewModelScope, SharingStarted.Eagerly, DataStorePreferences(
-        themeMode = ThemeMode.SYSTEM,
-        serverUrl = "",
-        chatFontSize = ChatFontSize.MEDIUM,
-        autoScrollEnabled = true,
-        showThinkingBlocks = true,
-        autoReadEnabled = false,
-        selectedVoiceId = "",
-    ))
-
-    /** Extra DataStore preferences (separate combine since Kotlin combine maxes at 5). */
-    private data class ExtraPreferences(
-        val autoRead: Boolean,
-        val selectedVoiceId: String?,
-        val showImageDescriptions: Boolean,
-        val dismissKeyboardOnSend: Boolean,
-        val ttsSource: String,
+    /** Owns the DataStore read flows + write setters; merges them with [_uiState]. */
+    private val prefsController = SettingsPreferencesController(
+        themeDataStore,
+        serverDataStore,
+        settingsDataStore,
+        _uiState,
+        viewModelScope,
     )
-
-    private val extraPreferences: StateFlow<ExtraPreferences> = combine(
-        settingsDataStore.autoReadEnabled,
-        settingsDataStore.selectedVoiceId,
-        settingsDataStore.showImageDescriptions,
-        settingsDataStore.dismissKeyboardOnSend,
-        settingsDataStore.ttsSource,
-    ) { autoRead, voiceId, showImgDesc, dismissKeyboard, ttsSource ->
-        ExtraPreferences(autoRead, voiceId, showImgDesc, dismissKeyboard, ttsSource)
-    }.stateIn(viewModelScope, SharingStarted.Eagerly, ExtraPreferences(false, null, false, false, "device"))
-
-    /** Device TTS preferences (speech rate, pitch, voice name, engine, voice selection). */
-    private data class DeviceTtsPreferences(
-        val speechRate: Float,
-        val pitch: Float,
-        val voiceName: String,
-        val ttsEngine: String,
-        val ttsVoice: String,
-    )
-
-    private val deviceTtsPreferences: StateFlow<DeviceTtsPreferences> = combine(
-        settingsDataStore.ttsSpeechRate,
-        settingsDataStore.ttsPitch,
-        settingsDataStore.ttsVoiceName,
-        settingsDataStore.ttsEngine,
-        settingsDataStore.ttsVoice,
-    ) { rate, pitch, voiceName, ttsEngine, ttsVoice ->
-        DeviceTtsPreferences(rate, pitch, voiceName, ttsEngine, ttsVoice)
-    }.stateIn(viewModelScope, SharingStarted.Eagerly, DeviceTtsPreferences(1.0f, 1.0f, "", "", ""))
-
-    /** TTS caching preference. Kept as a separate flow to stay within the 5-arg combine limit. */
-    private val ttsCachingPreference: StateFlow<Boolean> = settingsDataStore.ttsCaching
-        .stateIn(viewModelScope, SharingStarted.Eagerly, true)
-
-    /** Tablet-specific preferences. */
-    private val tabletSidebarGestureEnabled: StateFlow<Boolean> = settingsDataStore.tabletSidebarGestureEnabled
-        .stateIn(viewModelScope, SharingStarted.Eagerly, true)
-
-    /** Chat layout preferences. */
-    private val chatLayoutStylePref: StateFlow<String> = settingsDataStore.chatLayoutStyle
-        .stateIn(viewModelScope, SharingStarted.Eagerly, ChatLayoutConstants.THREAD)
-
-    private val showAvatarsPref: StateFlow<Boolean> = settingsDataStore.showAvatars
-        .stateIn(viewModelScope, SharingStarted.Eagerly, true)
-
-    private val showBubblesPref: StateFlow<Boolean> = settingsDataStore.showBubbles
-        .stateIn(viewModelScope, SharingStarted.Eagerly, false)
-
-    private val latexRendererPref: StateFlow<LatexRenderer> = settingsDataStore.latexRenderer
-        .stateIn(viewModelScope, SharingStarted.Eagerly, LatexRenderer.KATEX)
-
-    private val inlineArtifactPrefsFlow: StateFlow<InlineArtifactPrefs> = settingsDataStore.inlineArtifactPrefs
-        .stateIn(viewModelScope, SharingStarted.Eagerly, InlineArtifactPrefs())
-
-    private val starredModelsDisplayPref: StateFlow<StarredModelsDisplay> = settingsDataStore.starredModelsDisplay
-        .stateIn(viewModelScope, SharingStarted.Eagerly, StarredModelsDisplay.OFF)
-
-    private val selectedLanguagePref: StateFlow<String> = settingsDataStore.selectedLanguage
-        .stateIn(viewModelScope, SharingStarted.Eagerly, SettingsDataStore.DEFAULT_LANGUAGE)
-
-    /** Additional preferences combined separately to stay within the 5-arg combine limit. */
-    private data class AdditionalPreferences(
-        val tabletSidebarGestureEnabled: Boolean,
-        val autoSendAfterStt: Boolean,
-        val sttEngine: String,
-        val sttLanguage: String,
-        val ttsCaching: Boolean,
-        val chatLayoutStyle: String = ChatLayoutConstants.THREAD,
-        val showAvatars: Boolean = true,
-        val showBubbles: Boolean = false,
-        val latexRenderer: LatexRenderer = LatexRenderer.KATEX,
-        val inlineArtifactPrefs: InlineArtifactPrefs = InlineArtifactPrefs(),
-        val starredModelsDisplay: StarredModelsDisplay = StarredModelsDisplay.OFF,
-        val selectedLanguage: String = SettingsDataStore.DEFAULT_LANGUAGE,
-    )
-
-    private val baseAdditionalPreferences = combine(
-        tabletSidebarGestureEnabled,
-        settingsDataStore.autoSendAfterStt,
-        settingsDataStore.sttEngine,
-        settingsDataStore.sttLanguage,
-        ttsCachingPreference,
-    ) { tabletGesture, autoSendStt, sttEngine, sttLanguage, ttsCaching ->
-        AdditionalPreferences(tabletGesture, autoSendStt, sttEngine, sttLanguage, ttsCaching)
-    }
-
-    private val additionalPreferences: StateFlow<AdditionalPreferences> = combine(
-        baseAdditionalPreferences,
-        chatLayoutStylePref,
-        showAvatarsPref,
-        showBubblesPref,
-        latexRendererPref,
-    ) { base, layoutStyle, showAvatars, showBubbles, latexRenderer ->
-        base.copy(chatLayoutStyle = layoutStyle, showAvatars = showAvatars, showBubbles = showBubbles, latexRenderer = latexRenderer)
-    }.combine(inlineArtifactPrefsFlow) { additional, inlineArtifact ->
-        additional.copy(inlineArtifactPrefs = inlineArtifact)
-    }.combine(starredModelsDisplayPref) { additional, starredDisplay ->
-        additional.copy(starredModelsDisplay = starredDisplay)
-    }.combine(selectedLanguagePref) { additional, selectedLanguage ->
-        additional.copy(selectedLanguage = selectedLanguage)
-    }.stateIn(viewModelScope, SharingStarted.Eagerly, AdditionalPreferences(true, false, "", "", true))
 
     /** The single public UI state that merges DataStore preferences with imperative state. */
-    val uiState: StateFlow<SettingsUiState> = combine(
-        _uiState,
-        dataStorePreferences,
-        extraPreferences,
-        deviceTtsPreferences,
-        additionalPreferences,
-    ) { state, prefs, extra, deviceTts, additional ->
-        val selectedVoice = extra.selectedVoiceId?.let { id -> state.availableVoices.find { it.id == id } }
-        state.copy(
-            themeMode = prefs.themeMode,
-            accentColor = prefs.accentColor,
-            useDynamicColor = prefs.useDynamicColor,
-            dynamicColorSupported = supportsDynamicColor(),
-            serverUrl = prefs.serverUrl,
-            chatFontSize = prefs.chatFontSize,
-            autoScrollEnabled = prefs.autoScrollEnabled,
-            showThinkingBlocks = prefs.showThinkingBlocks,
-            autoReadEnabled = extra.autoRead,
-            selectedVoice = selectedVoice,
-            showImageDescriptions = extra.showImageDescriptions,
-            dismissKeyboardOnSend = extra.dismissKeyboardOnSend,
-            ttsSource = extra.ttsSource,
-            ttsSpeechRate = deviceTts.speechRate,
-            ttsPitch = deviceTts.pitch,
-            ttsDeviceVoiceName = deviceTts.voiceName,
-            ttsEngine = deviceTts.ttsEngine,
-            ttsVoice = deviceTts.ttsVoice,
-            ttsCaching = additional.ttsCaching,
-            tabletSidebarGestureEnabled = additional.tabletSidebarGestureEnabled,
-            sttAutoSend = additional.autoSendAfterStt,
-            sttEngine = additional.sttEngine,
-            sttLanguage = additional.sttLanguage,
-            chatLayoutStyle = additional.chatLayoutStyle,
-            showAvatars = additional.showAvatars,
-            showBubbles = additional.showBubbles,
-            latexRenderer = additional.latexRenderer,
-            inlineArtifactPrefs = additional.inlineArtifactPrefs,
-            starredModelsDisplay = additional.starredModelsDisplay,
-            selectedLanguage = additional.selectedLanguage,
-        )
-    }.stateIn(viewModelScope, SharingStarted.Eagerly, SettingsUiState())
+    val uiState: StateFlow<SettingsUiState> = prefsController.uiState
 
     init {
-        loadUser()
+        accountDelegate.loadUser()
         speechDelegate.loadVoices()
-        loadBalance()
+        accountDelegate.loadBalance()
         speechDelegate.loadDeviceVoices()
         loadRoleGatedData()
         observePermissionFlags()
@@ -567,104 +173,22 @@ class SettingsViewModel(
 
     // ── Account & user profile ─────────────────────────────────────
 
-    private fun loadUser() {
-        loadUserJob?.cancel()
-        loadUserJob = viewModelScope.launch {
-            _uiState.update { it.copy(profileLoadError = null) }
-            when (val result = userRepository.getUser()) {
-                is Result.Success -> {
-                    _uiState.update {
-                        it.copy(
-                            user = result.data.toDisplayData(),
-                            profileLoadError = null,
-                            isTwoFactorEnabled = result.data.twoFactorEnabled,
-                            // Fail-CLOSED admin gate: the role-skills admin row shows
-                            // only for the ADMIN system role (mirrors the server's
-                            // manageRoles middleware). Server also 403s non-admins.
-                            isAdmin = result.data.role == ADMIN_ROLE,
-                        )
-                    }
-                }
-                is Result.Error -> {
-                    _uiState.update {
-                        it.copy(
-                            profileLoadError = result.message ?: "Failed to load user profile",
-                        )
-                    }
-                }
-                is Result.Loading -> { /* no-op */ }
-            }
-        }
-    }
-
-    // Avatar
-
-    fun showAvatarDialog() {
-        _uiState.update { it.copy(showAvatarDialog = true) }
-    }
-
-    fun dismissAvatarDialog() {
-        _uiState.update { it.copy(showAvatarDialog = false) }
-    }
-
-    fun uploadAvatar(uri: Any) {
-        viewModelScope.launch {
-            _uiState.update { it.copy(isAvatarUploading = true) }
-            // Reading bytes off the URI is blocking I/O — keep it off the Main
-            // dispatcher (viewModelScope = Main.immediate) to avoid an ANR on
-            // large images. Mirrors the FileAttachmentDelegate fix.
-            val bytes = try {
-                withContext(ioDispatcher) { contentReader.readBytes(uri) }
-            } catch (e: CancellationException) {
-                // Cooperative cancellation must propagate (SKIE/iOS requirement).
-                throw e
-            } catch (e: Exception) {
-                _uiState.update {
-                    it.copy(isAvatarUploading = false, error = "Could not read selected image: ${e.message}")
-                }
-                return@launch
-            }
-            if (bytes == null) {
-                _uiState.update {
-                    it.copy(isAvatarUploading = false, error = "Could not read selected image")
-                }
-                return@launch
-            }
-            when (val result = userRepository.uploadAvatar(bytes)) {
-                is Result.Success -> {
-                    _uiState.update {
-                        it.copy(
-                            user = result.data.toDisplayData(),
-                            isAvatarUploading = false,
-                            showAvatarDialog = false,
-                        )
-                    }
-                }
-                is Result.Error -> {
-                    _uiState.update {
-                        it.copy(
-                            isAvatarUploading = false,
-                            error = result.message ?: "Failed to upload avatar",
-                        )
-                    }
-                }
-                is Result.Loading -> { /* no-op */ }
-            }
-        }
-    }
+    fun showAvatarDialog() = accountDelegate.showAvatarDialog()
+    fun dismissAvatarDialog() = accountDelegate.dismissAvatarDialog()
+    fun uploadAvatar(uri: Any) = accountDelegate.uploadAvatar(uri)
 
     // ── Theme & appearance ─────────────────────────────────────────
 
     fun setThemeMode(mode: ThemeMode) {
-        viewModelScope.launch { themeDataStore.setThemeMode(mode) }
+        prefsController.setThemeMode(mode)
     }
 
     fun setAccentColor(argb: Int) {
-        viewModelScope.launch { themeDataStore.setAccentColor(argb) }
+        prefsController.setAccentColor(argb)
     }
 
     fun setUseDynamicColor(enabled: Boolean) {
-        viewModelScope.launch { themeDataStore.setUseDynamicColor(enabled) }
+        prefsController.setUseDynamicColor(enabled)
     }
 
     fun showAccentColorDialog() {
@@ -678,87 +202,69 @@ class SettingsViewModel(
     // ── Chat preferences ───────────────────────────────────────────
 
     fun setChatFontSize(size: ChatFontSize) {
-        viewModelScope.launch { settingsDataStore.setChatFontSize(size) }
+        prefsController.setChatFontSize(size)
     }
 
     fun setStarredModelsDisplay(display: StarredModelsDisplay) {
-        viewModelScope.launch { settingsDataStore.setStarredModelsDisplay(display) }
+        prefsController.setStarredModelsDisplay(display)
     }
 
     fun setAutoScrollEnabled(enabled: Boolean) {
-        viewModelScope.launch { settingsDataStore.setAutoScrollEnabled(enabled) }
+        prefsController.setAutoScrollEnabled(enabled)
     }
 
     fun setShowThinkingBlocks(show: Boolean) {
-        viewModelScope.launch { settingsDataStore.setShowThinkingBlocks(show) }
+        prefsController.setShowThinkingBlocks(show)
     }
 
     fun setShowImageDescriptions(show: Boolean) {
-        viewModelScope.launch { settingsDataStore.setShowImageDescriptions(show) }
+        prefsController.setShowImageDescriptions(show)
     }
 
     fun setDismissKeyboardOnSend(enabled: Boolean) {
-        viewModelScope.launch { settingsDataStore.setDismissKeyboardOnSend(enabled) }
+        prefsController.setDismissKeyboardOnSend(enabled)
     }
 
     fun setChatLayoutStyle(style: String) {
-        viewModelScope.launch { settingsDataStore.setChatLayoutStyle(style) }
+        prefsController.setChatLayoutStyle(style)
     }
 
     fun setShowAvatars(show: Boolean) {
-        viewModelScope.launch { settingsDataStore.setShowAvatars(show) }
+        prefsController.setShowAvatars(show)
     }
 
     fun setShowBubbles(show: Boolean) {
-        viewModelScope.launch { settingsDataStore.setShowBubbles(show) }
+        prefsController.setShowBubbles(show)
     }
 
     fun setLatexRenderer(renderer: LatexRenderer) {
-        viewModelScope.launch { settingsDataStore.setLatexRenderer(renderer) }
+        prefsController.setLatexRenderer(renderer)
     }
 
     fun setInlineArtifactMermaid(enabled: Boolean) {
-        viewModelScope.launch { settingsDataStore.setInlineArtifactMermaid(enabled) }
+        prefsController.setInlineArtifactMermaid(enabled)
     }
 
     fun setInlineArtifactSvg(enabled: Boolean) {
-        viewModelScope.launch { settingsDataStore.setInlineArtifactSvg(enabled) }
+        prefsController.setInlineArtifactSvg(enabled)
     }
 
     fun setInlineArtifactHtml(enabled: Boolean) {
-        viewModelScope.launch { settingsDataStore.setInlineArtifactHtml(enabled) }
+        prefsController.setInlineArtifactHtml(enabled)
     }
 
     fun setInlineArtifactReact(enabled: Boolean) {
-        viewModelScope.launch { settingsDataStore.setInlineArtifactReact(enabled) }
+        prefsController.setInlineArtifactReact(enabled)
     }
 
     fun setInlineArtifactMarkdown(enabled: Boolean) {
-        viewModelScope.launch { settingsDataStore.setInlineArtifactMarkdown(enabled) }
+        prefsController.setInlineArtifactMarkdown(enabled)
     }
 
     // ── Tablet preferences ─────────────────────────────────────────
 
     fun setTabletSidebarGestureEnabled(enabled: Boolean) {
-        viewModelScope.launch { settingsDataStore.setTabletSidebarGestureEnabled(enabled) }
-    }
-
-    // ── Balance ────────────────────────────────────────────────────
-
-    private fun loadBalance() {
-        viewModelScope.launch {
-            _uiState.update { it.copy(isBalanceLoading = true) }
-            when (val result = balanceRepository.getBalance()) {
-                is Result.Success -> {
-                    _uiState.update { it.copy(tokenCredits = result.data.tokenCredits, isBalanceLoading = false) }
-                }
-                is Result.Error -> {
-                    Logger.d(result.exception) { "Failed to load balance: ${result.message}" }
-                    _uiState.update { it.copy(isBalanceLoading = false) }
-                }
-                is Result.Loading -> { /* no-op */ }
-            }
-        }
+        prefsController.setTabletSidebarGestureEnabled(enabled)
     }
 
     // ── Language ───────────────────────────────────────────────────
@@ -772,7 +278,7 @@ class SettingsViewModel(
     }
 
     fun setLanguage(languageCode: String) {
-        viewModelScope.launch { settingsDataStore.setSelectedLanguage(languageCode) }
+        prefsController.setSelectedLanguage(languageCode)
         _uiState.update { it.copy(showLanguageDialog = false) }
     }
 
@@ -833,44 +339,12 @@ class SettingsViewModel(
 
     // ── Auth actions ───────────────────────────────────────────────
 
-    fun logout() {
-        _uiState.update { it.copy(isLoggedOut = true) }
-    }
-
-    fun deleteAccount(token: String? = null, backupCode: String? = null) {
-        viewModelScope.launch {
-            _uiState.update { it.copy(isDeletingAccount = true) }
-            when (val result = userRepository.deleteUser(token = token, backupCode = backupCode)) {
-                is Result.Success -> {
-                    _uiState.update { it.copy(isDeletingAccount = false, isAccountDeleted = true, showDeleteAccountOtpDialog = false) }
-                }
-                is Result.Error -> {
-                    val needsOtp = token == null && backupCode == null &&
-                        result.isHttpStatus(403)
-                    _uiState.update {
-                        it.copy(
-                            isDeletingAccount = false,
-                            showDeleteAccountOtpDialog = if (needsOtp) true else it.showDeleteAccountOtpDialog,
-                            error = if (needsOtp) null else (result.message ?: "Failed to delete account"),
-                        )
-                    }
-                }
-                is Result.Loading -> { /* no-op */ }
-            }
-        }
-    }
-
-    fun dismissDeleteAccountOtpDialog() {
-        _uiState.update { it.copy(showDeleteAccountOtpDialog = false) }
-    }
-
-    fun retry() {
-        loadUser()
-    }
-
-    fun dismissError() {
-        _uiState.update { it.copy(error = null) }
-    }
+    fun logout() = accountDelegate.logout()
+    fun deleteAccount(token: String? = null, backupCode: String? = null) =
+        accountDelegate.deleteAccount(token = token, backupCode = backupCode)
+    fun dismissDeleteAccountOtpDialog() = accountDelegate.dismissDeleteAccountOtpDialog()
+    fun retry() = accountDelegate.retry()
+    fun dismissError() = accountDelegate.dismissError()
 
     // ── Delegated public API ───────────────────────────────────────
 
@@ -957,10 +431,5 @@ class SettingsViewModel(
     override fun onCleared() {
         super.onCleared()
         speechDelegate.release()
-    }
-
-    private companion object {
-        /** Upstream SystemRoles.ADMIN — the role name manageRoles checks. */
-        const val ADMIN_ROLE = "ADMIN"
     }
 }

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/delegate/AccountDelegate.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/delegate/AccountDelegate.kt
@@ -1,0 +1,183 @@
+package com.garfiec.librechat.feature.settings.viewmodel.delegate
+
+import co.touchlab.kermit.Logger
+import com.garfiec.librechat.core.common.result.Result
+import com.garfiec.librechat.core.data.repository.BalanceRepository
+import com.garfiec.librechat.core.data.repository.UserRepository
+import com.garfiec.librechat.feature.settings.util.ContentReader
+import com.garfiec.librechat.feature.settings.viewmodel.SettingsStateHandle
+import com.garfiec.librechat.feature.settings.viewmodel.isHttpStatus
+import com.garfiec.librechat.feature.settings.viewmodel.toDisplayData
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+/**
+ * The account section: user-profile load, avatar upload, balance, sign-out, and
+ * account deletion (with the 403 → OTP step-up). Holds the in-flight profile-load
+ * job so a retry cancels a hung request before starting a fresh one.
+ */
+class AccountDelegate(
+    private val stateHandle: SettingsStateHandle,
+    private val userRepository: UserRepository,
+    private val balanceRepository: BalanceRepository,
+    private val contentReader: ContentReader,
+    private val ioDispatcher: CoroutineDispatcher,
+) {
+
+    // In-flight profile-load job. Cancelled before each retry so a hung 90s request
+    // doesn't continue racing the fresh one.
+    private var loadUserJob: Job? = null
+
+    fun loadUser() {
+        loadUserJob?.cancel()
+        loadUserJob = stateHandle.scope.launch {
+            stateHandle.update { copy(profileLoadError = null) }
+            when (val result = userRepository.getUser()) {
+                is Result.Success -> {
+                    stateHandle.update {
+                        copy(
+                            user = result.data.toDisplayData(),
+                            profileLoadError = null,
+                            isTwoFactorEnabled = result.data.twoFactorEnabled,
+                            // Fail-CLOSED admin gate: the role-skills admin row shows
+                            // only for the ADMIN system role (mirrors the server's
+                            // manageRoles middleware). Server also 403s non-admins.
+                            isAdmin = result.data.role == ADMIN_ROLE,
+                        )
+                    }
+                }
+                is Result.Error -> {
+                    stateHandle.update {
+                        copy(
+                            profileLoadError = result.message ?: "Failed to load user profile",
+                        )
+                    }
+                }
+                is Result.Loading -> { /* no-op */ }
+            }
+        }
+    }
+
+    fun retry() {
+        loadUser()
+    }
+
+    fun loadBalance() {
+        stateHandle.scope.launch {
+            stateHandle.update { copy(isBalanceLoading = true) }
+            when (val result = balanceRepository.getBalance()) {
+                is Result.Success -> {
+                    stateHandle.update { copy(tokenCredits = result.data.tokenCredits, isBalanceLoading = false) }
+                }
+                is Result.Error -> {
+                    Logger.d(result.exception) { "Failed to load balance: ${result.message}" }
+                    stateHandle.update { copy(isBalanceLoading = false) }
+                }
+                is Result.Loading -> { /* no-op */ }
+            }
+        }
+    }
+
+    // ── Avatar ─────────────────────────────────────────────────────
+
+    fun showAvatarDialog() {
+        stateHandle.update { copy(showAvatarDialog = true) }
+    }
+
+    fun dismissAvatarDialog() {
+        stateHandle.update { copy(showAvatarDialog = false) }
+    }
+
+    fun uploadAvatar(uri: Any) {
+        stateHandle.scope.launch {
+            stateHandle.update { copy(isAvatarUploading = true) }
+            // Reading bytes off the URI is blocking I/O — keep it off the Main
+            // dispatcher (viewModelScope = Main.immediate) to avoid an ANR on
+            // large images. Mirrors the FileAttachmentDelegate fix.
+            val bytes = try {
+                withContext(ioDispatcher) { contentReader.readBytes(uri) }
+            } catch (e: CancellationException) {
+                // Cooperative cancellation must propagate (SKIE/iOS requirement).
+                throw e
+            } catch (e: Exception) {
+                stateHandle.update {
+                    copy(isAvatarUploading = false, error = "Could not read selected image: ${e.message}")
+                }
+                return@launch
+            }
+            if (bytes == null) {
+                stateHandle.update {
+                    copy(isAvatarUploading = false, error = "Could not read selected image")
+                }
+                return@launch
+            }
+            when (val result = userRepository.uploadAvatar(bytes)) {
+                is Result.Success -> {
+                    stateHandle.update {
+                        copy(
+                            user = result.data.toDisplayData(),
+                            isAvatarUploading = false,
+                            showAvatarDialog = false,
+                        )
+                    }
+                }
+                is Result.Error -> {
+                    stateHandle.update {
+                        copy(
+                            isAvatarUploading = false,
+                            error = result.message ?: "Failed to upload avatar",
+                        )
+                    }
+                }
+                is Result.Loading -> { /* no-op */ }
+            }
+        }
+    }
+
+    // ── Sign out & deletion ────────────────────────────────────────
+
+    fun logout() {
+        stateHandle.update { copy(isLoggedOut = true) }
+    }
+
+    fun deleteAccount(token: String? = null, backupCode: String? = null) {
+        stateHandle.scope.launch {
+            stateHandle.update { copy(isDeletingAccount = true) }
+            when (val result = userRepository.deleteUser(token = token, backupCode = backupCode)) {
+                is Result.Success -> {
+                    stateHandle.update {
+                        copy(isDeletingAccount = false, isAccountDeleted = true, showDeleteAccountOtpDialog = false)
+                    }
+                }
+                is Result.Error -> {
+                    val needsOtp = token == null && backupCode == null &&
+                        result.isHttpStatus(403)
+                    stateHandle.update {
+                        copy(
+                            isDeletingAccount = false,
+                            showDeleteAccountOtpDialog = if (needsOtp) true else showDeleteAccountOtpDialog,
+                            error = if (needsOtp) null else (result.message ?: "Failed to delete account"),
+                        )
+                    }
+                }
+                is Result.Loading -> { /* no-op */ }
+            }
+        }
+    }
+
+    fun dismissDeleteAccountOtpDialog() {
+        stateHandle.update { copy(showDeleteAccountOtpDialog = false) }
+    }
+
+    fun dismissError() {
+        stateHandle.update { copy(error = null) }
+    }
+
+    private companion object {
+        /** Upstream SystemRoles.ADMIN — the role name manageRoles checks. */
+        const val ADMIN_ROLE = "ADMIN"
+    }
+}


### PR DESCRIPTION
## Summary
Splits the 966-line `SettingsViewModel` into a 435-line orchestrator plus three focused files. Pure refactor — the public constructor and method surface are unchanged, so the DI graph and screen call sites are untouched. Finishes the partial delegation the ViewModel already had (5 write-side delegates) by extracting the DataStore read flows and the account logic.

## Changes
- **`SettingsUiState.kt`** — the `SettingsUiState` data class, `SettingsCommand`/`LogsExportPayload`/`DEFAULT_COMMANDS`, and the `User.toDisplayData` mapper.
- **`SettingsPreferencesController.kt`** — the DataStore layer: the intermediate preference holders, the `stateIn` flows, the `combine` that merges them with imperative state into `uiState`, and the matching write setters (theme / chat / tablet / inline-artifact / language).
- **`AccountDelegate.kt`** — the account section: profile load (cancel-on-retry), avatar upload, balance, sign-out, and account deletion with the 403 → OTP step-up.
- **`SettingsViewModel.kt`** — now just delegate/controller construction, `init`, the role/permission/account-deletion observers, the small dialog-toggle state, and the thin forwarders.
- Records the decomposition in `MODULARIZATION.md`.

## Testing
- `:feature:settings` Android compile, `detektMetadataCommonMain`, and iOS `compileKotlinIosSimulatorArm64` all pass.
- Device-tested on the Pixel 10 Pro Fold emulator: Material You toggle, language switch + revert, chat font size + layout, account profile/balance/avatar dialog, and the Data tab — all work with no regression.
