### PR TITLE
test(network): tolerate quoted multipart param name in SkillsApi test

### DIFF
--- a/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/api/SkillsApiMultipartTest.kt
+++ b/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/api/SkillsApiMultipartTest.kt
@@ -74,8 +74,9 @@ class SkillsApiMultipartTest {
         // The file part carries the filename + declared content type.
         assertThat(body).contains("filename=\"notes.md\"")
         assertThat(body).contains("text/markdown")
-        // The relativePath form field is present with its value.
-        assertThat(body).contains("name=relativePath")
+        // The relativePath form field is present with its value. Ktor may render the
+        // Content-Disposition param name with or without RFC-7578 quotes across versions.
+        assertThat(body).containsMatch("name=\"?relativePath\"?")
         assertThat(body).contains("notes.md")
         assertThat(result.relativePath).isEqualTo("notes.md")
     }


### PR DESCRIPTION
## Summary
Makes the SkillsApi multipart upload test assert the `relativePath`
Content-Disposition param name in a version-tolerant way, so it passes
whether Ktor renders it unquoted (`name=relativePath`) or in the
RFC-7578 quoted form (`name="relativePath"`).

## Changes
- `SkillsApiMultipartTest`: replace the exact `contains("name=relativePath")`
  assertion with `containsMatch("name=\"?relativePath\"?")`.

## Why
Ktor 3.5.0 switches multipart Content-Disposition param names to the
RFC-7578 quoted form. The old exact-substring assertion is the sole CI
failure on the ktor 3.5.0 bump (#124); production multipart behavior is
unchanged and the server parses both forms. Landing this on develop first
unblocks that bump.

## Testing
- `./gradlew :core:network:testDebugUnitTest --tests "*SkillsApiMultipartTest*"`
  passes on current develop (Ktor 3.4.3).
