### PR TITLE
feat(chat): queue follow-up messages while a reply streams

### DIFF
--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/components/ChatInput.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/components/ChatInput.kt
@@ -53,6 +53,7 @@ import androidx.core.content.FileProvider
 import com.garfiec.librechat.feature.chat.model.McpServerDisplayData
 import com.garfiec.librechat.feature.chat.model.PromptMentionDisplayData
 import com.garfiec.librechat.feature.chat.viewmodel.ChatInputGates
+import com.garfiec.librechat.feature.chat.viewmodel.QueuedMessage
 import com.garfiec.librechat.feature.chat.resources.*
 import com.garfiec.librechat.feature.chat.resources.Res
 import org.jetbrains.compose.resources.stringResource
@@ -66,6 +67,18 @@ fun ChatInput(
     onSend: () -> Unit,
     onStop: () -> Unit,
     modifier: Modifier = Modifier,
+    onQueue: () -> Unit = {},
+    canQueue: Boolean = false,
+    queuedPausedCount: Int = 0,
+    onSendQueuedMessages: () -> Unit = {},
+    isEditingQueued: Boolean = false,
+    onCommitEdit: () -> Unit = {},
+    onCancelEdit: () -> Unit = {},
+    queuedMessages: List<QueuedMessage> = emptyList(),
+    onEditQueuedMessage: (localId: String) -> Unit = {},
+    onCancelQueuedMessage: (localId: String) -> Unit = {},
+    onReorderQueuedMessages: (fromIndex: Int, toIndex: Int) -> Unit = { _, _ -> },
+    fontSizeMultiplier: Float = 1f,
     attachedFiles: List<AttachedFile> = emptyList(),
     onFilesSelected: (List<Uri>) -> Unit = {},
     onRemoveFile: (AttachedFile) -> Unit = {},
@@ -226,12 +239,24 @@ fun ChatInput(
         isCodeInterpreterAvailable = isCodeInterpreterAvailable,
         attachedFiles = attachedFiles,
         gates = gates,
+        canQueue = canQueue,
+        isEditingQueued = isEditingQueued,
     )
 
     CommonChatInputCore(
         state = state,
         onSend = onSend,
         onStop = onStop,
+        onQueue = onQueue,
+        queuedPausedCount = queuedPausedCount,
+        onSendQueuedMessages = onSendQueuedMessages,
+        onCommitEdit = onCommitEdit,
+        onCancelEdit = onCancelEdit,
+        queuedMessages = queuedMessages,
+        onEditQueuedMessage = onEditQueuedMessage,
+        onCancelQueuedMessage = onCancelQueuedMessage,
+        onReorderQueuedMessages = onReorderQueuedMessages,
+        fontSizeMultiplier = fontSizeMultiplier,
         onRemoveFile = onRemoveFile,
         modifier = modifier,
         leadingButtons = {

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatContent.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatContent.kt
@@ -9,6 +9,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 import com.garfiec.librechat.core.common.EndpointConstants
 import com.garfiec.librechat.core.model.ContentType
 import com.garfiec.librechat.core.model.content.MessageContentPart
@@ -50,6 +52,7 @@ internal fun ColumnScope.ChatContent(
     showAvatars: Boolean,
     showBubbles: Boolean,
     useKatex: Boolean,
+    bottomContentPadding: Dp,
     onShowSecondaryModelSheet: () -> Unit,
     onComparisonTabChange: (Int) -> Unit,
 ) {
@@ -138,6 +141,7 @@ internal fun ColumnScope.ChatContent(
                             uiState.activeToolCalls
                         },
                         streamingSenderName = senderName,
+                        bottomContentPadding = bottomContentPadding,
                         modifier = Modifier.fillMaxSize(),
                     )
                 }
@@ -164,6 +168,7 @@ internal fun ColumnScope.ChatContent(
                         showAvatars = showAvatars,
                         showBubbles = showBubbles,
                         useKatex = useKatex,
+                        bottomContentPadding = bottomContentPadding,
                         modifier = Modifier.fillMaxSize(),
                     )
                 }
@@ -227,6 +232,7 @@ internal fun ColumnScope.ChatContent(
                     streamingContent = uiState.streamingContent,
                     activeToolCalls = uiState.activeToolCalls,
                     streamingSenderName = senderName,
+                    bottomContentPadding = bottomContentPadding,
                     modifier = Modifier.weight(1f),
                 )
             }
@@ -256,6 +262,7 @@ private fun ChatMessageListPane(
     streamingContent: String,
     activeToolCalls: List<ActiveToolCall>,
     streamingSenderName: String,
+    bottomContentPadding: Dp,
     modifier: Modifier,
 ) {
     MessageList(
@@ -304,6 +311,7 @@ private fun ChatMessageListPane(
         currentSearchMatchIndex = uiState.currentSearchMatchIndex,
         searchScrollToIndex = uiState.searchScrollToIndex,
         onSearchScrollHandle = viewModel::onSearchScrollHandled,
+        bottomContentPadding = bottomContentPadding,
         modifier = modifier,
     )
 }

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatScreen.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatScreen.kt
@@ -13,14 +13,18 @@ import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.garfiec.librechat.core.data.datastore.ChatFontSize
 import com.garfiec.librechat.core.data.datastore.LatexRenderer
@@ -163,6 +167,14 @@ actual fun ChatScreen(
         },
         snackbarHost = { SnackbarHost(snackbarHostState) },
     ) { innerPadding ->
+        // The composer overlays the message list at the bottom; the list reserves a scrollable
+        // bottom inset so its latest content rests above the bar. We measure the bar's actual
+        // height (which grows as queued ghost rows stack above it) so streaming text never hides
+        // behind the ghosts, while the list still scrolls *behind* the translucent overlay.
+        var inputBarHeightPx by remember { mutableIntStateOf(0) }
+        val bottomContentPadding = with(LocalDensity.current) {
+            maxOf(160.dp, inputBarHeightPx.toDp() + 16.dp)
+        }
         Box(
             modifier = Modifier
                 .fillMaxSize()
@@ -183,6 +195,7 @@ actual fun ChatScreen(
                     showAvatars = showAvatars,
                     showBubbles = showBubbles,
                     useKatex = useKatex,
+                    bottomContentPadding = bottomContentPadding,
                     onShowSecondaryModelSheet = { showSecondaryModelSheet = true },
                     onComparisonTabChange = { activeComparisonTab = it },
                 )
@@ -203,6 +216,13 @@ actual fun ChatScreen(
                     }
                 },
                 onStop = viewModel::stopGeneration,
+                onQueue = {
+                    viewModel.queueMessage()
+                    if (dismissKeyboardOnSend) {
+                        keyboardController?.hide()
+                    }
+                },
+                canQueue = uiState.canQueueFollowUp,
                 attachedFiles = attachedFiles,
                 onFilesSelected = viewModel::onFilesSelected,
                 onRemoveFile = viewModel::removeFile,
@@ -239,7 +259,20 @@ actual fun ChatScreen(
                 fileSearchEnabled = uiState.fileSearchEnabled,
                 mcpServersEnabled = uiState.mcpServersEnabled,
                 gates = uiState.chatInputGates,
-                modifier = Modifier.align(Alignment.BottomCenter),
+                // After a Stop/error pause, the queue waits for an explicit nudge.
+                queuedPausedCount = uiState.pausedQueueCount,
+                onSendQueuedMessages = viewModel::sendQueuedNow,
+                isEditingQueued = uiState.isEditingQueued,
+                onCommitEdit = viewModel::commitQueuedEdit,
+                onCancelEdit = viewModel::cancelQueuedEdit,
+                queuedMessages = uiState.messageQueue,
+                onEditQueuedMessage = viewModel::editQueued,
+                onCancelQueuedMessage = viewModel::cancelQueued,
+                onReorderQueuedMessages = viewModel::reorderQueue,
+                fontSizeMultiplier = fontSizeMultiplier,
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .onSizeChanged { inputBarHeightPx = it.height },
             )
         }
     }

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/AndroidFileHandler.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/AndroidFileHandler.kt
@@ -1,7 +1,6 @@
 package com.garfiec.librechat.feature.chat.viewmodel.delegate
 
 import android.net.Uri
-import com.garfiec.librechat.core.model.FileReference
 import com.garfiec.librechat.feature.chat.components.AttachedFile
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.StateFlow
@@ -25,9 +24,9 @@ class AndroidFileHandler(
 
     override fun removeFile(file: AttachedFile) = delegate.removeFile(file)
     override fun retryUpload(file: AttachedFile) = delegate.retryUpload(file)
-    override fun buildFileReferences(): List<FileReference> = delegate.buildFileReferences()
     override suspend fun waitForUploadsAndSend(text: String, doSend: (String) -> Unit) =
         delegate.waitForUploadsAndSend(text, doSend)
     override fun hasPendingUploads(): Boolean = delegate.hasPendingUploads()
     override fun clearAttachedFiles() = delegate.clearAttachedFiles()
+    override fun restoreAttachedFiles(files: List<AttachedFile>) = delegate.restoreAttachedFiles(files)
 }

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/FileAttachmentDelegate.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/FileAttachmentDelegate.kt
@@ -7,7 +7,6 @@ import co.touchlab.kermit.Logger
 import com.garfiec.librechat.core.common.EndpointConstants
 import com.garfiec.librechat.core.common.result.Result
 import com.garfiec.librechat.core.data.repository.FileRepository
-import com.garfiec.librechat.core.model.FileReference
 import com.garfiec.librechat.feature.chat.components.AttachedFile
 import com.garfiec.librechat.feature.chat.util.detectMimeTypeFromBytes
 import com.garfiec.librechat.feature.chat.util.fixFilenameExtension
@@ -253,35 +252,6 @@ class FileAttachmentDelegate(
     }
 
     /**
-     * Builds a list of [FileReference] from successfully uploaded attached files.
-     * Only includes files that have a server-assigned fileId (upload completed).
-     * Files still uploading (fileId == null) are excluded.
-     */
-    fun buildFileReferences(): List<FileReference> {
-        val allFiles = _attachedFiles.value
-        val uploadedFiles = allFiles.filter { it.fileId != null }
-        val pendingFiles = allFiles.filter { it.fileId == null && !it.uploadFailed }
-        if (pendingFiles.isNotEmpty()) {
-            Logger.w {
-                "buildFileReferences: ${pendingFiles.size} file(s) still uploading and will NOT be included: ${pendingFiles.joinToString { it.name }}"
-            }
-        }
-        Logger.d {
-            "buildFileReferences: ${allFiles.size} total, ${uploadedFiles.size} uploaded, ${pendingFiles.size} pending, ${allFiles.count { it.uploadFailed }} failed"
-        }
-        return uploadedFiles.map { file ->
-            FileReference(
-                fileId = file.fileId,
-                filename = file.name,
-                filepath = file.filepath,
-                type = file.type,
-                width = file.width,
-                height = file.height,
-            )
-        }
-    }
-
-    /**
      * Waits for all pending file uploads to complete (up to 30 seconds),
      * then proceeds with sending the message via the provided callback.
      */
@@ -309,5 +279,9 @@ class FileAttachmentDelegate(
 
     fun clearAttachedFiles() {
         _attachedFiles.update { emptyList() }
+    }
+
+    fun restoreAttachedFiles(files: List<AttachedFile>) {
+        _attachedFiles.update { files }
     }
 }

--- a/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/MessageQueueDelegateTest.kt
+++ b/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/MessageQueueDelegateTest.kt
@@ -1,0 +1,267 @@
+package com.garfiec.librechat.feature.chat.viewmodel.delegate
+
+import com.garfiec.librechat.core.data.endpoint.EndpointDispatch
+import com.garfiec.librechat.feature.chat.viewmodel.ChatStateHandle
+import com.garfiec.librechat.feature.chat.viewmodel.ChatUiState
+import com.garfiec.librechat.feature.chat.viewmodel.ComposerSnapshot
+import com.garfiec.librechat.feature.chat.viewmodel.QueuedEditSession
+import com.garfiec.librechat.feature.chat.viewmodel.QueuedMessage
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.TestScope
+import org.junit.Test
+
+/**
+ * Behavior tests for [MessageQueueDelegate]: list mutation (enqueue/cancel/reorder/edit),
+ * FIFO draining with the pause gate, and snapshot honesty (a spec is unaffected by later
+ * state changes because the whole config was captured at queue time).
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class MessageQueueDelegateTest {
+
+    private val stateFlow = MutableStateFlow(ChatUiState())
+    private val scope = TestScope()
+    private val stateHandle = ChatStateHandle(stateFlow, scope)
+
+    private val sent = mutableListOf<QueuedMessage>()
+    private val awaitSettleFlags = mutableListOf<Boolean>()
+    private val delegate = MessageQueueDelegate(
+        stateHandle = stateHandle,
+        sendWithSpec = { spec, awaitSettle ->
+            sent.add(spec)
+            awaitSettleFlags.add(awaitSettle)
+        },
+    )
+
+    private fun spec(id: String, text: String = id, model: String? = "gpt-4") = QueuedMessage(
+        localId = id,
+        text = text,
+        endpoint = "openAI",
+        model = model,
+        agentId = null,
+        dispatch = EndpointDispatch(endpointType = null, key = null, modelDisplayLabel = null),
+    )
+
+    private val queue get() = stateFlow.value.messageQueue
+    private val paused get() = stateFlow.value.isQueuePaused
+
+    /** Puts the delegate's state into queued-edit mode (an item pulled out into the composer). */
+    private fun enterEditMode(original: QueuedMessage = spec("edited")) {
+        stateFlow.value = stateFlow.value.copy(
+            editingQueuedItem = QueuedEditSession(
+                original = original,
+                originalIndex = 0,
+                stashed = ComposerSnapshot(text = "", endpoint = "openAI", model = null),
+            ),
+        )
+    }
+
+    @Test
+    fun `enqueue appends in FIFO order`() {
+        delegate.enqueue(spec("a"))
+        delegate.enqueue(spec("b"))
+
+        assertThat(queue.map { it.localId }).containsExactly("a", "b").inOrder()
+    }
+
+    @Test
+    fun `cancel removes the matching item`() {
+        delegate.enqueue(spec("a"))
+        delegate.enqueue(spec("b"))
+
+        delegate.cancel("a")
+
+        assertThat(queue.map { it.localId }).containsExactly("b")
+    }
+
+    @Test
+    fun `takeForEdit removes and returns the item with its index`() {
+        delegate.enqueue(spec("a"))
+        delegate.enqueue(spec("b", text = "hello"))
+
+        val taken = delegate.takeForEdit("b")
+
+        assertThat(taken?.index).isEqualTo(1)
+        assertThat(taken?.value?.text).isEqualTo("hello")
+        assertThat(queue.map { it.localId }).containsExactly("a")
+    }
+
+    @Test
+    fun `takeForEdit returns null for an unknown id`() {
+        assertThat(delegate.takeForEdit("missing")).isNull()
+    }
+
+    @Test
+    fun `takeForEdit leaves the pause flag untouched`() {
+        delegate.enqueue(spec("a"))
+        delegate.pause()
+
+        delegate.takeForEdit("a")
+
+        // The item is only borrowed for editing, so the queue stays paused.
+        assertThat(paused).isTrue()
+    }
+
+    @Test
+    fun `reinsert restores an item at the original index`() {
+        delegate.enqueue(spec("a"))
+        delegate.enqueue(spec("c"))
+        val taken = delegate.takeForEdit("a") ?: error("missing")
+        delegate.enqueue(spec("b"))
+
+        delegate.reinsert(taken.index, taken.value)
+
+        assertThat(queue.map { it.localId }).containsExactly("a", "c", "b").inOrder()
+    }
+
+    @Test
+    fun `reinsert clamps an out-of-bounds index to the end`() {
+        delegate.enqueue(spec("a"))
+
+        delegate.reinsert(index = 9, item = spec("b"))
+
+        assertThat(queue.map { it.localId }).containsExactly("a", "b").inOrder()
+    }
+
+    @Test
+    fun `clearPauseIfEmpty clears pause only when the queue is empty`() {
+        delegate.enqueue(spec("a"))
+        delegate.pause()
+
+        // Non-empty paused queue: no-op.
+        delegate.clearPauseIfEmpty()
+        assertThat(paused).isTrue()
+
+        // takeForEdit empties the queue but leaves the pause set (item is only borrowed).
+        delegate.takeForEdit("a")
+        assertThat(paused).isTrue()
+
+        delegate.clearPauseIfEmpty()
+        assertThat(paused).isFalse()
+    }
+
+    @Test
+    fun `reorder moves an item to the new index`() {
+        delegate.enqueue(spec("a"))
+        delegate.enqueue(spec("b"))
+        delegate.enqueue(spec("c"))
+
+        delegate.reorder(fromIndex = 0, toIndex = 2)
+
+        assertThat(queue.map { it.localId }).containsExactly("b", "c", "a").inOrder()
+    }
+
+    @Test
+    fun `reorder ignores out-of-bounds indices`() {
+        delegate.enqueue(spec("a"))
+
+        delegate.reorder(fromIndex = 0, toIndex = 5)
+
+        assertThat(queue.map { it.localId }).containsExactly("a")
+    }
+
+    @Test
+    fun `drainNext fires the head and removes it from the queue`() {
+        delegate.enqueue(spec("a"))
+        delegate.enqueue(spec("b"))
+
+        delegate.drainNext()
+
+        assertThat(sent.map { it.localId }).containsExactly("a")
+        assertThat(queue.map { it.localId }).containsExactly("b")
+    }
+
+    @Test
+    fun `drainNext is frozen while a queued item is being edited`() {
+        delegate.enqueue(spec("a"))
+        enterEditMode()
+
+        delegate.drainNext()
+
+        assertThat(sent).isEmpty()
+        assertThat(queue.map { it.localId }).containsExactly("a")
+    }
+
+    @Test
+    fun `pause registers while editing even when the queue is momentarily empty`() {
+        // Mirrors a Stop during the edit of the sole queued item: it's pulled out (queue empty)
+        // but the edit session is active, so the pause must still register.
+        enterEditMode()
+
+        delegate.pause()
+
+        assertThat(paused).isTrue()
+    }
+
+    @Test
+    fun `drainNext is a no-op when paused`() {
+        delegate.enqueue(spec("a"))
+        delegate.pause()
+
+        delegate.drainNext()
+
+        assertThat(sent).isEmpty()
+        assertThat(queue.map { it.localId }).containsExactly("a")
+    }
+
+    @Test
+    fun `drainNext is a no-op on an empty queue`() {
+        delegate.drainNext()
+
+        assertThat(sent).isEmpty()
+    }
+
+    @Test
+    fun `pause is a no-op when the queue is empty`() {
+        delegate.pause()
+
+        assertThat(paused).isFalse()
+    }
+
+    @Test
+    fun `resume lifts the pause and drains the head`() {
+        delegate.enqueue(spec("a"))
+        delegate.pause()
+        assertThat(paused).isTrue()
+
+        delegate.resume()
+
+        assertThat(paused).isFalse()
+        assertThat(sent.map { it.localId }).containsExactly("a")
+        // Resume skips the settle-wait — the reply already landed while paused.
+        assertThat(awaitSettleFlags).containsExactly(false)
+    }
+
+    @Test
+    fun `auto-drain after Final requests the settle-wait`() {
+        delegate.enqueue(spec("a"))
+
+        delegate.drainNext()
+
+        assertThat(awaitSettleFlags).containsExactly(true)
+    }
+
+    @Test
+    fun `cancelling the last paused item clears the pause`() {
+        delegate.enqueue(spec("a"))
+        delegate.pause()
+
+        delegate.cancel("a")
+
+        assertThat(queue).isEmpty()
+        assertThat(paused).isFalse()
+    }
+
+    @Test
+    fun `drained spec retains its queue-time config after state changes`() {
+        delegate.enqueue(spec("a", model = "gpt-4"))
+        // Mutate live state after queueing — must not retro-edit the queued snapshot.
+        stateFlow.value = stateFlow.value.copy(selectedModel = "claude", selectedEndpoint = "anthropic")
+
+        delegate.drainNext()
+
+        assertThat(sent.single().model).isEqualTo("gpt-4")
+        assertThat(sent.single().endpoint).isEqualTo("openAI")
+    }
+}

--- a/feature/chat/src/commonMain/composeResources/values/strings.xml
+++ b/feature/chat/src/commonMain/composeResources/values/strings.xml
@@ -50,6 +50,14 @@
     <string name="cd_start_voice_recording">Start voice recording</string>
     <string name="cd_stop_generation">Stop generation</string>
     <string name="cd_send_message">Send message</string>
+    <string name="cd_add_to_queue">Add message to queue</string>
+    <string name="cd_cancel_queued_message">Remove queued message</string>
+    <string name="cd_reorder_queued_message">Drag to reorder queued message</string>
+    <string name="send_queued_messages">Send queued (%1$d)</string>
+    <string name="queued_attachment_only">Attachment</string>
+    <string name="editing_queued_message">Editing queued message</string>
+    <string name="cd_cancel_edit">Cancel edit</string>
+    <string name="cd_update_queued_message">Update queued message</string>
     <string name="cd_open_drawer">Open navigation drawer</string>
     <string name="cd_more_options">More options</string>
     <string name="cd_more_tools">More tools</string>

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/CommonChatInputCore.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/CommonChatInputCore.kt
@@ -17,13 +17,20 @@ import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.PlaylistAdd
 import androidx.compose.material.icons.automirrored.filled.Send
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Mic
 import androidx.compose.material.icons.filled.Stop
 import androidx.compose.material3.CircularProgressIndicator
@@ -38,19 +45,25 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.garfiec.librechat.feature.chat.model.McpServerDisplayData
 import com.garfiec.librechat.feature.chat.resources.Res
+import com.garfiec.librechat.feature.chat.resources.cd_add_to_queue
+import com.garfiec.librechat.feature.chat.resources.cd_cancel_edit
 import com.garfiec.librechat.feature.chat.resources.cd_send_message
 import com.garfiec.librechat.feature.chat.resources.cd_start_voice_recording
 import com.garfiec.librechat.feature.chat.resources.cd_stop_generation
+import com.garfiec.librechat.feature.chat.resources.cd_update_queued_message
+import com.garfiec.librechat.feature.chat.resources.editing_queued_message
 import com.garfiec.librechat.feature.chat.resources.hint_message
 import com.garfiec.librechat.feature.chat.resources.hint_message_model
 import com.garfiec.librechat.feature.chat.resources.recording
 import com.garfiec.librechat.feature.chat.viewmodel.ChatInputGates
+import com.garfiec.librechat.feature.chat.viewmodel.QueuedMessage
 import org.jetbrains.compose.resources.stringResource
 
 @Immutable
@@ -67,6 +80,12 @@ data class ChatInputState(
     val attachedFiles: List<AttachedFile>,
     /** Ephemeral-tools gate drives local chip display; remaining gates are threaded to the sheet. */
     val gates: ChatInputGates = ChatInputGates(),
+    /** Whether queueing a follow-up mid-stream is allowed (existing conversation only). When
+     *  false, the send button stays plain Stop while streaming. */
+    val canQueue: Boolean = false,
+    /** True while the composer is editing a queued item (queued-edit mode): the send button
+     *  becomes "Update" and an editing banner shows above the input. */
+    val isEditingQueued: Boolean = false,
 )
 
 /**
@@ -83,6 +102,24 @@ fun CommonChatInputCore(
     onStop: () -> Unit,
     onRemoveFile: (AttachedFile) -> Unit,
     modifier: Modifier = Modifier,
+    /** Queue a follow-up while streaming. Null (or [ChatInputState.canQueue] false) keeps the
+     *  button as plain Stop mid-stream (e.g. on a brand-new conversation). */
+    onQueue: (() -> Unit)? = null,
+    /** Number of queued messages held by a Stop/error pause. >0 shows the "Send queued" banner
+     *  above the input; 0 hides it (queue empty or draining normally). */
+    queuedPausedCount: Int = 0,
+    onSendQueuedMessages: () -> Unit = {},
+    /** Commit / cancel the in-progress queued edit (see [ChatInputState.isEditingQueued]). */
+    onCommitEdit: () -> Unit = {},
+    onCancelEdit: () -> Unit = {},
+    /** Queued follow-ups (ghost rows), pinned just above the composer. Hosted here — rather than
+     *  in the scrolling message list — so the list's auto-scroll-to-bottom can't make the ghosts
+     *  bounce as the reply streams. Empty list renders nothing. */
+    queuedMessages: List<QueuedMessage> = emptyList(),
+    onEditQueuedMessage: (localId: String) -> Unit = {},
+    onCancelQueuedMessage: (localId: String) -> Unit = {},
+    onReorderQueuedMessages: (fromIndex: Int, toIndex: Int) -> Unit = { _, _ -> },
+    fontSizeMultiplier: Float = 1f,
     leadingButtons: @Composable RowScope.() -> Unit = {},
     trailingSpacer: @Composable RowScope.() -> Unit = {},
     bottomContent: @Composable BoxScope.() -> Unit = {},
@@ -108,6 +145,31 @@ fun CommonChatInputCore(
                 .navigationBarsPadding()
                 .padding(horizontal = 12.dp, vertical = 8.dp),
         ) {
+            // Ghost queue, pinned directly above the composer. No scroll wrapper: the input bar is
+            // bottom-anchored so the queue grows upward (the text field stays put), and a nested
+            // vertical scroll here would fight the long-press drag-reorder. Self-hides when empty.
+            QueuedMessagesSection(
+                queuedMessages = queuedMessages,
+                onEdit = onEditQueuedMessage,
+                onCancel = onCancelQueuedMessage,
+                onReorder = onReorderQueuedMessages,
+                fontSizeMultiplier = fontSizeMultiplier,
+            )
+
+            // Edit-mode banner takes priority over the paused-queue banner.
+            if (state.isEditingQueued) {
+                EditingQueuedBanner(
+                    onCancel = onCancelEdit,
+                    modifier = Modifier.padding(bottom = 6.dp),
+                )
+            } else if (queuedPausedCount > 0) {
+                SendQueuedBanner(
+                    count = queuedPausedCount,
+                    onClick = onSendQueuedMessages,
+                    modifier = Modifier.padding(bottom = 6.dp),
+                )
+            }
+
             AttachmentChipsRow(
                 attachedFiles = state.attachedFiles,
                 enabledTools = state.enabledTools,
@@ -124,11 +186,18 @@ fun CommonChatInputCore(
                 leadingButtons()
                 textFieldContent()
                 trailingSpacer()
+                val hasComposerContent = state.inputText.isNotBlank() || state.attachedFiles.isNotEmpty()
                 SendStopButton(
                     isStreaming = state.isStreaming,
-                    canSend = state.inputText.isNotBlank() || state.attachedFiles.isNotEmpty(),
+                    canSend = hasComposerContent,
+                    // Mid-stream + typed content + queueing allowed → morph Stop into "add to queue".
+                    canQueue = state.canQueue && hasComposerContent && onQueue != null,
                     onSend = onSend,
                     onStop = onStop,
+                    onQueue = onQueue ?: {},
+                    // In queued-edit mode the button commits the edit instead of send/stop/queue.
+                    isEditingQueued = state.isEditingQueued,
+                    onUpdate = onCommitEdit,
                 )
             }
         }
@@ -136,8 +205,16 @@ fun CommonChatInputCore(
     }
 }
 
+/** Visual mode of the trailing composer button. */
+private enum class SendButtonMode { SEND, STOP, QUEUE, UPDATE }
+
 /**
- * Animated send/stop toggle button shared between platforms.
+ * Animated send / stop / add-to-queue / update button shared between platforms.
+ *
+ * In queued-edit mode ([isEditingQueued]) it is **Update** (commit the edit). Otherwise, while
+ * streaming it is **Stop** by default but morphs into **Add to queue** when the composer has
+ * content and queueing is allowed ([canQueue]) — the "clear the box to reveal Stop" rule. When not
+ * streaming it is the usual **Send** (enabled on [canSend]).
  */
 @Composable
 fun SendStopButton(
@@ -146,17 +223,52 @@ fun SendStopButton(
     onSend: () -> Unit,
     onStop: () -> Unit,
     modifier: Modifier = Modifier,
+    canQueue: Boolean = false,
+    onQueue: () -> Unit = {},
+    isEditingQueued: Boolean = false,
+    onUpdate: () -> Unit = {},
 ) {
+    val mode = when {
+        isEditingQueued -> SendButtonMode.UPDATE
+        !isStreaming -> SendButtonMode.SEND
+        canQueue -> SendButtonMode.QUEUE
+        else -> SendButtonMode.STOP
+    }
     AnimatedContent(
-        targetState = isStreaming,
+        targetState = mode,
         transitionSpec = {
             (fadeIn() + scaleIn()).togetherWith(fadeOut() + scaleOut())
         },
         label = "send_stop_toggle",
         modifier = modifier,
-    ) { streaming ->
-        if (streaming) {
-            IconButton(
+    ) { buttonMode ->
+        when (buttonMode) {
+            SendButtonMode.UPDATE -> IconButton(
+                onClick = onUpdate,
+                modifier = Modifier.size(56.dp),
+                enabled = canSend,
+                colors = IconButtonDefaults.iconButtonColors(
+                    containerColor = if (canSend) {
+                        MaterialTheme.colorScheme.primary
+                    } else {
+                        MaterialTheme.colorScheme.surfaceContainer
+                    },
+                    contentColor = if (canSend) {
+                        MaterialTheme.colorScheme.onPrimary
+                    } else {
+                        MaterialTheme.colorScheme.onSurfaceVariant
+                    },
+                    disabledContainerColor = MaterialTheme.colorScheme.surfaceContainer,
+                    disabledContentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                ),
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Check,
+                    contentDescription = stringResource(Res.string.cd_update_queued_message),
+                )
+            }
+
+            SendButtonMode.STOP -> IconButton(
                 onClick = onStop,
                 modifier = Modifier.size(56.dp),
                 colors = IconButtonDefaults.iconButtonColors(
@@ -175,8 +287,22 @@ fun SendStopButton(
                         ),
                 )
             }
-        } else {
-            IconButton(
+
+            SendButtonMode.QUEUE -> IconButton(
+                onClick = onQueue,
+                modifier = Modifier.size(56.dp),
+                colors = IconButtonDefaults.iconButtonColors(
+                    containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                    contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                ),
+            ) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Filled.PlaylistAdd,
+                    contentDescription = stringResource(Res.string.cd_add_to_queue),
+                )
+            }
+
+            SendButtonMode.SEND -> IconButton(
                 onClick = onSend,
                 modifier = Modifier.size(56.dp),
                 enabled = canSend,
@@ -200,6 +326,47 @@ fun SendStopButton(
                     contentDescription = stringResource(Res.string.cd_send_message),
                 )
             }
+        }
+    }
+}
+
+/**
+ * Banner shown above the composer while editing a queued item, with a cancel affordance that
+ * discards the edit and restores the previous draft.
+ */
+@Composable
+private fun EditingQueuedBanner(
+    onCancel: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .background(MaterialTheme.colorScheme.secondaryContainer)
+            .padding(start = 12.dp, end = 4.dp, top = 2.dp, bottom = 2.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            imageVector = Icons.Default.Edit,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSecondaryContainer,
+            modifier = Modifier.size(18.dp),
+        )
+        Spacer(Modifier.width(8.dp))
+        Text(
+            text = stringResource(Res.string.editing_queued_message),
+            color = MaterialTheme.colorScheme.onSecondaryContainer,
+            style = MaterialTheme.typography.labelLarge,
+            modifier = Modifier.weight(1f),
+        )
+        IconButton(onClick = onCancel) {
+            Icon(
+                imageVector = Icons.Default.Close,
+                contentDescription = stringResource(Res.string.cd_cancel_edit),
+                tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                modifier = Modifier.size(18.dp),
+            )
         }
     }
 }

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/MessageList.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/MessageList.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.boundsInRoot
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.garfiec.librechat.core.common.ChatLayoutConstants
 import com.garfiec.librechat.core.model.Attachment
@@ -92,6 +93,12 @@ fun MessageList(
     currentSearchMatchIndex: Int = 0,
     searchScrollToIndex: Int? = null,
     onSearchScrollHandle: () -> Unit = {},
+    // Scrollable bottom inset that keeps the latest content clear of the overlaid input bar. The
+    // caller measures the actual bar height (which grows as queued ghost rows stack above the
+    // composer) so streaming text rests above the ghosts rather than behind them. It's a
+    // LazyColumn contentPadding, not a solid spacer: content still scrolls up *behind* the
+    // translucent ghosts. Defaults to the single-line bar's reserve.
+    bottomContentPadding: Dp = 160.dp,
 ) {
     val listState = rememberLazyListState()
     val coroutineScope = rememberCoroutineScope()
@@ -314,7 +321,7 @@ fun MessageList(
                     }
                 },
             state = listState,
-            contentPadding = PaddingValues(top = 8.dp, bottom = 160.dp),
+            contentPadding = PaddingValues(top = 8.dp, bottom = bottomContentPadding),
         ) {
             itemsIndexed(
                 items = displayMessages,
@@ -474,7 +481,8 @@ fun MessageList(
             visible = showScrollToBottom,
             modifier = Modifier
                 .align(Alignment.BottomCenter)
-                .padding(bottom = 130.dp),
+                // Float the FAB just above the input bar, tracking the same inset as the content.
+                .padding(bottom = (bottomContentPadding - 30.dp).coerceAtLeast(16.dp)),
             enter = fadeIn(),
             exit = fadeOut(),
         ) {

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/QueuedMessagesSection.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/QueuedMessagesSection.kt
@@ -1,0 +1,222 @@
+package com.garfiec.librechat.feature.chat.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AttachFile
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.DragHandle
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionInParent
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.zIndex
+import com.garfiec.librechat.feature.chat.resources.Res
+import com.garfiec.librechat.feature.chat.resources.cd_cancel_queued_message
+import com.garfiec.librechat.feature.chat.resources.cd_reorder_queued_message
+import com.garfiec.librechat.feature.chat.resources.queued_attachment_only
+import com.garfiec.librechat.feature.chat.viewmodel.QueuedMessage
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * The "ghost" queue pinned directly above the composer: dimmed previews of follow-up messages
+ * the user has queued, waiting to auto-send (FIFO) as each reply completes. These are NOT part
+ * of the message tree — they live purely in [QueuedMessage] UI state. Hosted by the chat input
+ * (not the scrolling message list) so the list's auto-scroll-to-bottom can't make them bounce
+ * as the reply streams.
+ *
+ * Tap a row to pull it back into the composer for editing; the × cancels it; long-press anywhere
+ * on a row (the drag handle marks the affordance) and drag to reorder.
+ *
+ * The drag gesture is owned by the **container** Column — a single [pointerInput] that never gets
+ * torn down as rows reorder — rather than by per-row nodes (which Compose detaches when a keyed
+ * child moves, killing an in-progress gesture). The container hit-tests the grabbed row from
+ * measured row bounds and swaps with a neighbour once the finger passes that neighbour's midpoint,
+ * so variable-height rows reorder correctly. No external reorderable dependency, no nested scroll
+ * to fight: the section is hosted in a bottom-anchored input bar that simply grows upward.
+ */
+@Composable
+fun QueuedMessagesSection(
+    queuedMessages: List<QueuedMessage>,
+    onEdit: (String) -> Unit,
+    onCancel: (String) -> Unit,
+    onReorder: (fromIndex: Int, toIndex: Int) -> Unit,
+    modifier: Modifier = Modifier,
+    fontSizeMultiplier: Float = 1f,
+) {
+    if (queuedMessages.isEmpty()) return
+
+    // Measured per-row geometry (localId -> top Y / height, in this Column's coordinate space),
+    // recorded by each row via onGloballyPositioned and read by the container's drag hit-testing.
+    val rowTops = remember { mutableStateMapOf<String, Float>() }
+    val rowHeights = remember { mutableStateMapOf<String, Float>() }
+    var draggingId by remember { mutableStateOf<String?>(null) }
+    // Live translation of the dragged row from its laid-out slot, so it follows the finger.
+    var dragOffsetY by remember { mutableFloatStateOf(0f) }
+    // Snapshot the list for the gesture closure so it always reads the current order.
+    val currentQueue by rememberUpdatedState(queuedMessages)
+
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 4.dp)
+            .pointerInput(Unit) {
+                detectDragGesturesAfterLongPress(
+                    onDragStart = { offset ->
+                        draggingId = currentQueue.firstOrNull { item ->
+                            val top = rowTops[item.localId] ?: return@firstOrNull false
+                            val height = rowHeights[item.localId] ?: 0f
+                            offset.y >= top && offset.y < top + height
+                        }?.localId
+                        dragOffsetY = 0f
+                    },
+                    onDragEnd = {
+                        draggingId = null
+                        dragOffsetY = 0f
+                    },
+                    onDragCancel = {
+                        draggingId = null
+                        dragOffsetY = 0f
+                    },
+                    onDrag = { change, dragAmount ->
+                        change.consume()
+                        val id = draggingId ?: return@detectDragGesturesAfterLongPress
+                        val list = currentQueue
+                        val from = list.indexOfFirst { it.localId == id }
+                        if (from < 0) return@detectDragGesturesAfterLongPress
+                        dragOffsetY += dragAmount.y
+                        // Swap with a neighbour once the finger crosses that neighbour's midpoint.
+                        if (dragAmount.y > 0 && from < list.lastIndex) {
+                            val nextHeight = rowHeights[list[from + 1].localId] ?: 0f
+                            if (dragOffsetY > nextHeight / 2f) {
+                                onReorder(from, from + 1)
+                                dragOffsetY -= nextHeight
+                            }
+                        } else if (dragAmount.y < 0 && from > 0) {
+                            val prevHeight = rowHeights[list[from - 1].localId] ?: 0f
+                            if (dragOffsetY < -prevHeight / 2f) {
+                                onReorder(from, from - 1)
+                                dragOffsetY += prevHeight
+                            }
+                        }
+                    },
+                )
+            },
+        verticalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        queuedMessages.forEach { item ->
+            val isDragging = draggingId == item.localId
+            QueuedMessageRow(
+                item = item,
+                isDragging = isDragging,
+                fontSizeMultiplier = fontSizeMultiplier,
+                onTap = { onEdit(item.localId) },
+                onCancel = { onCancel(item.localId) },
+                modifier = Modifier
+                    .onGloballyPositioned { coords ->
+                        rowTops[item.localId] = coords.positionInParent().y
+                        rowHeights[item.localId] = coords.size.height.toFloat()
+                    }
+                    // Lift the dragged row above its peers and let it follow the finger.
+                    .zIndex(if (isDragging) 1f else 0f)
+                    .graphicsLayer { translationY = if (isDragging) dragOffsetY else 0f },
+            )
+        }
+    }
+}
+
+@Composable
+private fun QueuedMessageRow(
+    item: QueuedMessage,
+    isDragging: Boolean,
+    fontSizeMultiplier: Float,
+    onTap: () -> Unit,
+    onCancel: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(16.dp),
+        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = if (isDragging) 0.95f else 0.55f),
+        tonalElevation = if (isDragging) 6.dp else 0.dp,
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable(onClick = onTap)
+                .padding(start = 8.dp, end = 4.dp, top = 6.dp, bottom = 6.dp),
+        ) {
+            Icon(
+                imageVector = Icons.Default.DragHandle,
+                contentDescription = stringResource(Res.string.cd_reorder_queued_message),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
+                modifier = Modifier.size(20.dp),
+            )
+            Spacer(Modifier.width(8.dp))
+
+            if (item.attachments.isNotEmpty()) {
+                Icon(
+                    imageVector = Icons.Default.AttachFile,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
+                    modifier = Modifier.size(16.dp),
+                )
+                Spacer(Modifier.width(6.dp))
+            }
+
+            // Attachment-only queued items have no text — show a placeholder so the row isn't blank.
+            val isPlaceholder = item.text.isBlank()
+            Text(
+                text = if (isPlaceholder) stringResource(Res.string.queued_attachment_only) else item.text,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = if (isPlaceholder) 0.6f else 0.85f),
+                fontSize = 14.sp * fontSizeMultiplier,
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(vertical = 2.dp),
+            )
+
+            IconButton(
+                onClick = onCancel,
+                modifier = Modifier.alpha(0.8f),
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Close,
+                    contentDescription = stringResource(Res.string.cd_cancel_queued_message),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(18.dp),
+                )
+            }
+        }
+    }
+}

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/SecondaryMessageList.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/SecondaryMessageList.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.garfiec.librechat.core.common.ChatLayoutConstants
 import com.garfiec.librechat.core.model.Attachment
@@ -45,6 +46,7 @@ fun SecondaryMessageList(
     showAvatars: Boolean = true,
     showBubbles: Boolean = false,
     useKatex: Boolean = false,
+    bottomContentPadding: Dp = 160.dp,
 ) {
     val listState = rememberLazyListState()
     val totalItemCount = displayMessages.size +
@@ -81,7 +83,7 @@ fun SecondaryMessageList(
             LazyColumn(
                 modifier = Modifier.fillMaxSize(),
                 state = listState,
-                contentPadding = PaddingValues(top = 8.dp, bottom = 160.dp),
+                contentPadding = PaddingValues(top = 8.dp, bottom = bottomContentPadding),
             ) {
                 items(
                     items = displayMessages,

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/SendQueuedBanner.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/SendQueuedBanner.kt
@@ -1,0 +1,52 @@
+package com.garfiec.librechat.feature.chat.components
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Send
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.garfiec.librechat.feature.chat.resources.Res
+import com.garfiec.librechat.feature.chat.resources.send_queued_messages
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * Shown above the composer when the queue is paused after a Stop/error: an explicit nudge to
+ * resume draining the queued follow-ups. Nothing auto-sends until the user taps this.
+ */
+@Composable
+fun SendQueuedBanner(
+    count: Int,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Button(
+        onClick = onClick,
+        modifier = modifier,
+        colors = ButtonDefaults.buttonColors(
+            containerColor = MaterialTheme.colorScheme.secondaryContainer,
+            contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+        ),
+        contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.Send,
+                contentDescription = null,
+                modifier = Modifier.size(18.dp),
+            )
+            Spacer(Modifier.width(8.dp))
+            Text(text = stringResource(Res.string.send_queued_messages, count))
+        }
+    }
+}

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatUiState.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatUiState.kt
@@ -8,6 +8,7 @@ import com.garfiec.librechat.core.data.datastore.ChatFontSize
 import com.garfiec.librechat.core.data.datastore.InlineArtifactPrefs
 import com.garfiec.librechat.core.data.datastore.LatexRenderer
 import com.garfiec.librechat.core.data.datastore.StarredModelsDisplay
+import com.garfiec.librechat.core.data.endpoint.EndpointDispatch
 import com.garfiec.librechat.core.model.Agent
 import com.garfiec.librechat.core.model.Attachment
 import com.garfiec.librechat.core.model.EndpointConfig
@@ -15,9 +16,11 @@ import com.garfiec.librechat.core.model.Message
 import com.garfiec.librechat.core.model.SubagentPhase
 import com.garfiec.librechat.core.model.content.MessageContentPart
 import com.garfiec.librechat.core.model.endpoint.KeyState
+import com.garfiec.librechat.core.model.request.EphemeralAgent
 import com.garfiec.librechat.core.model.response.FileUploadConfig
 import com.garfiec.librechat.core.ui.components.ModelParameters
 import com.garfiec.librechat.core.ui.media.MediaPreviewState
+import com.garfiec.librechat.feature.chat.components.AttachedFile
 import com.garfiec.librechat.feature.chat.model.McpServerDisplayData
 import com.garfiec.librechat.feature.chat.model.PresetDisplayData
 import com.garfiec.librechat.feature.chat.model.PromptMentionDisplayData
@@ -86,6 +89,82 @@ data class ActiveToolCall(
 )
 
 /**
+ * A follow-up message the user queued while a response was streaming, waiting to be
+ * auto-sent (FIFO) once the current reply completes. Rendered as a dimmed "ghost" bubble
+ * after the streaming bubble — it is NOT part of the message tree.
+ *
+ * Captures a full snapshot of the send config **at queue time** (model/endpoint/tools/
+ * webSearch/attachments + the resolved [dispatch]/[ephemeralAgent]), so a mid-stream model
+ * switch never retro-edits an already-queued item. The live-lineage fields
+ * (conversationId / parentMessageId / userMessageId) are deliberately NOT snapshotted — they
+ * are recomputed from the current tree when the item actually fires.
+ *
+ * [attachments] holds the already-uploaded [AttachedFile]s (not bare FileReferences) so editing
+ * a queued item restores its composer chips — including the local-uri image thumbnail — intact.
+ */
+@Immutable
+data class QueuedMessage(
+    /** Stable local id for list keying, edit, and reorder. Not a server message id. */
+    val localId: String,
+    val text: String,
+    val attachments: List<AttachedFile> = emptyList(),
+    val endpoint: String,
+    val model: String?,
+    val agentId: String?,
+    val enabledTools: Set<String> = emptySet(),
+    /** Selected ephemeral MCP servers — snapshotted so editing the item restores its tool state. */
+    val mcpServerNames: Set<String> = emptySet(),
+    /** Full composer parameters (web search, reasoning effort, etc.) — restored to the composer on edit. */
+    val modelParameters: ModelParameters = ModelParameters.DEFAULT,
+    val ephemeralAgent: EphemeralAgent? = null,
+    val dispatch: EndpointDispatch,
+    val isTemporary: Boolean = false,
+)
+
+/**
+ * Snapshot of the editable composer surface (the "new message" draft) stashed when entering
+ * queued-edit mode and restored on commit/cancel, so editing a queued item never clobbers what
+ * the user was already composing.
+ *
+ * These fields mirror [QueuedMessage]'s source-config fields (model/endpoint/tools/mcp/params) and
+ * are captured/applied by `ChatViewModel.captureComposer`/`applyComposer`/`toComposerSnapshot` — a
+ * new composer setting must be threaded through all of them (no compiler enforcement).
+ */
+@Immutable
+data class ComposerSnapshot(
+    val text: String,
+    val attachments: List<AttachedFile> = emptyList(),
+    val endpoint: String,
+    val model: String?,
+    val enabledTools: Set<String> = emptySet(),
+    val mcpServerNames: Set<String> = emptySet(),
+    val modelParameters: ModelParameters = ModelParameters.DEFAULT,
+)
+
+/**
+ * Active queued-edit session: the composer is loaded with [original]'s content + config for
+ * editing, while [stashed] holds the new-message draft to restore afterward and [originalIndex]
+ * is the FIFO slot to put the (possibly edited) item back into on commit/cancel.
+ */
+@Immutable
+data class QueuedEditSession(
+    val original: QueuedMessage,
+    val originalIndex: Int,
+    val stashed: ComposerSnapshot,
+)
+
+/** Loads a queued item's content + config onto the composer surface when entering edit mode. */
+fun QueuedMessage.toComposerSnapshot(): ComposerSnapshot = ComposerSnapshot(
+    text = text,
+    attachments = attachments,
+    endpoint = endpoint,
+    model = model,
+    enabledTools = enabledTools,
+    mcpServerNames = mcpServerNames,
+    modelParameters = modelParameters,
+)
+
+/**
  * Live progress of a single child agent's run (v0.8.6 subagents), accumulated
  * from `on_subagent_update` SSE envelopes and keyed in
  * [ChatUiState.subagentProgress] by the parent `subagent` tool_call id.
@@ -145,6 +224,16 @@ data class ChatUiState(
      *  Cleared when streaming ends. Used to provide attachment context while the
      *  final message (with full attachments) has not yet been persisted to Room. */
     val streamingAttachments: List<Attachment> = emptyList(),
+    /** Follow-up messages queued while a reply streams, drained FIFO on each successful
+     *  completion. Rendered as ghost bubbles after the streaming bubble; never part of the
+     *  message tree. In-memory only (dropped on conversation switch / process death). */
+    val messageQueue: List<QueuedMessage> = emptyList(),
+    /** True after Stop/stream-error with a non-empty queue: draining is held until the user
+     *  explicitly taps "Send queued". A successful Final drains automatically instead. */
+    val isQueuePaused: Boolean = false,
+    /** Non-null while a queued item is being edited in the composer (queued-edit mode). Holds the
+     *  stashed new-message draft + the item's slot so both are restored on commit/cancel. */
+    val editingQueuedItem: QueuedEditSession? = null,
     val selectedModel: String? = null,
     val selectedEndpoint: String = EndpointConstants.AGENTS,
     val endpointConfigs: Map<String, EndpointConfig> = emptyMap(),
@@ -321,6 +410,23 @@ data class ChatUiState(
      */
     val showEphemeralTools: Boolean
         get() = selectedEndpoint != EndpointConstants.AGENTS
+
+    /**
+     * Whether a follow-up may be queued mid-stream: only on an existing single-stream
+     * conversation (the queue affordance is hidden on the landing screen and in comparison
+     * mode). Single source of truth for the Android/iOS composer wiring.
+     */
+    val canQueueFollowUp: Boolean
+        get() = conversationId != null && !comparisonState.isEnabled
+
+    /** Number of queued messages a Stop/error pause is holding (0 = none / not paused). Drives
+     *  the "Send queued" banner above the composer. */
+    val pausedQueueCount: Int
+        get() = if (isQueuePaused) messageQueue.size else 0
+
+    /** True while the composer is editing a queued item rather than composing a new message. */
+    val isEditingQueued: Boolean
+        get() = editingQueuedItem != null
 
     /**
      * Bundle of the feature gates that flow into the composer ([ChatInput] →

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModel.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModel.kt
@@ -53,6 +53,7 @@ import com.garfiec.librechat.feature.chat.viewmodel.delegate.EndpointKeyStatusDe
 import com.garfiec.librechat.feature.chat.viewmodel.delegate.FavoritesDelegate
 import com.garfiec.librechat.feature.chat.viewmodel.delegate.InConversationSearchDelegate
 import com.garfiec.librechat.feature.chat.viewmodel.delegate.MessageEditingDelegate
+import com.garfiec.librechat.feature.chat.viewmodel.delegate.MessageQueueDelegate
 import com.garfiec.librechat.feature.chat.viewmodel.delegate.MessageTreeDelegate
 import com.garfiec.librechat.feature.chat.viewmodel.delegate.ModelSelectionDelegate
 import com.garfiec.librechat.feature.chat.viewmodel.delegate.OfficePreviewDelegate
@@ -61,6 +62,7 @@ import com.garfiec.librechat.feature.chat.viewmodel.delegate.PresetPromptDelegat
 import com.garfiec.librechat.feature.chat.viewmodel.delegate.SendCompletionDelegate
 import com.garfiec.librechat.feature.chat.viewmodel.delegate.StreamingManagerDelegate
 import com.garfiec.librechat.feature.chat.viewmodel.delegate.SubagentTraceDelegate
+import com.garfiec.librechat.feature.chat.viewmodel.delegate.toFileReference
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
@@ -174,6 +176,21 @@ class ChatViewModel(
         reloadConversation = ::loadConversation,
     )
 
+    private val queueDelegate = MessageQueueDelegate(
+        stateHandle = stateHandle,
+        // Drained items send with their snapshotted config but LIVE lineage. We first wait for
+        // the previous reply to settle into the tree (the Final-triggered Room reload is async),
+        // so the optimistic insert chains onto the freshly-finalized assistant message rather
+        // than the still-optimistic user turn. No upload-wait is needed — attachments were
+        // already resolved to FileReferences at queue time.
+        sendWithSpec = { spec, awaitSettle ->
+            viewModelScope.launch {
+                if (awaitSettle) awaitReplySettled()
+                runWhenSendReady { doSendWithSpec(spec) }
+            }
+        },
+    )
+
     // --- Delegate-owned flows exposed to the UI ---
     val attachedFiles: StateFlow<List<AttachedFile>> get() = fileDelegate.attachedFiles
     val shareLinkUrl: StateFlow<String?> get() = conversationActionsDelegate.shareLinkUrl
@@ -262,6 +279,7 @@ class ChatViewModel(
         subagentTraceDelegate = subagentTraceDelegate,
         officePreviewDelegate = officePreviewDelegate,
         completionDelegate = completionDelegate,
+        queueDelegate = queueDelegate,
         emitUserKeyError = { _userKeyErrors.trySend(it) },
         reloadConversation = ::loadConversation,
         isNewConversation = { isNewConversation },
@@ -284,6 +302,10 @@ class ChatViewModel(
          *  5 s role-load timeout because this only needs one of role OR availableModels to
          *  satisfy the check. */
         private const val SEND_READY_TIMEOUT_MS = 3_000L
+
+        /** Upper bound on waiting for a finished reply to land in the tree before draining the
+         *  next queued message. Generous so a slow post-Final reload still chains correctly. */
+        private const val REPLY_SETTLE_TIMEOUT_MS = 8_000L
     }
 
     /** True when this ViewModel was opened for a brand-new chat (no conversationId from navigation). */
@@ -552,6 +574,9 @@ class ChatViewModel(
 
     fun onInputChanged(text: String) {
         _uiState.update { it.copy(inputText = text) }
+        // While editing a queued item the composer holds that item, not the persisted draft —
+        // don't overwrite the on-disk new-message draft (it's restored on commit/cancel).
+        if (_uiState.value.isEditingQueued) return
         val draftKey = _uiState.value.conversationId ?: NEW_CHAT_DRAFT_KEY
         viewModelScope.launch {
             draftRepository.saveDraft(draftKey, text)
@@ -574,37 +599,259 @@ class ChatViewModel(
     // --- Message sending ---
 
     fun sendMessage() {
-        val text = _uiState.value.inputText.trim()
+        // In queued-edit mode the composer holds a queued item, not a new message — a send
+        // (e.g. voice auto-send, which bypasses the UPDATE button) commits the edit instead of
+        // live-sending, so the edit session is never orphaned.
+        if (_uiState.value.isEditingQueued) {
+            commitQueuedEdit()
+            return
+        }
         if (_uiState.value.isStreaming) return
+        val text = _uiState.value.inputText.trim()
+        withUploadGate(text) { runWhenSendReady { sendNow(it) } }
+    }
 
-        // Prevent double-send while waiting for uploads to finish
+    /**
+     * Queues a follow-up message while a reply streams, to auto-send (FIFO) when the current
+     * reply completes. Only valid mid-stream and on an existing conversation (the queue
+     * affordance is hidden on the landing/new-chat screen). Shares [sendMessage]'s upload-wait
+     * gate so a queued message with a still-uploading attachment captures it.
+     */
+    fun queueMessage() {
+        if (!_uiState.value.isStreaming) return
+        if (_uiState.value.conversationId == null) return
+        val text = _uiState.value.inputText.trim()
+        withUploadGate(text) { enqueueNow(it) }
+    }
+
+    /**
+     * Runs [action] once any pending file uploads have finished, guarding against a double-send
+     * while a previous wait is still in flight. Shared by the live-send and queue paths so the
+     * upload-wait semantics live in one place.
+     */
+    private fun withUploadGate(text: String, action: (String) -> Unit) {
         if (fileDelegate.pendingUploadSendJob?.isActive == true) return
-
-        // Check if there are files still uploading.
         if (fileDelegate.hasPendingUploads()) {
-            Logger.d { "sendMessage: waiting for pending upload(s) to complete" }
+            Logger.d { "withUploadGate: waiting for pending upload(s) to complete" }
             fileDelegate.pendingUploadSendJob = viewModelScope.launch {
-                fileDelegate.waitForUploadsAndSend(text) { runWhenSendReady { doSendMessage(it) } }
+                fileDelegate.waitForUploadsAndSend(text) { action(it) }
             }
             return
         }
-
-        runWhenSendReady { doSendMessage(text) }
+        action(text)
     }
 
+    private fun enqueueNow(text: String) {
+        val spec = buildSendSpec(text) ?: return
+        queueDelegate.enqueue(spec)
+        clearComposer()
+        // If the in-flight reply already finished, no Final will arrive to drain this — kick it now.
+        tryResumeDrain()
+    }
+
+    /** Resumes FIFO draining when the queue is idle (not mid-stream, not paused). No-op otherwise;
+     *  [MessageQueueDelegate.drainNext] additionally guards the paused / editing / empty cases. */
+    private fun tryResumeDrain() {
+        if (!_uiState.value.isStreaming && !_uiState.value.isQueuePaused) {
+            queueDelegate.drainNext(awaitSettle = false)
+        }
+    }
+
+    /**
+     * Tap a queued ghost bubble: enter queued-edit mode. Stashes the current new-message draft,
+     * pulls the item OUT of the queue, and loads its text + attachments + model/tools/params into
+     * the composer for editing. Commit ([commitQueuedEdit]) or cancel ([cancelQueuedEdit]) puts the
+     * item back in its slot and restores the stashed draft. Ignored if already editing one.
+     */
+    fun editQueued(localId: String) {
+        if (_uiState.value.isEditingQueued) return
+        val taken = queueDelegate.takeForEdit(localId) ?: return
+        val stashed = captureComposer()
+        applyComposer(taken.value.toComposerSnapshot())
+        _uiState.update {
+            it.copy(
+                editingQueuedItem = QueuedEditSession(
+                    original = taken.value,
+                    originalIndex = taken.index,
+                    stashed = stashed,
+                ),
+            )
+        }
+    }
+
+    /** "Update" in queued-edit mode: re-queue the edited item at its original slot (or drop it if
+     *  emptied), then restore the stashed new-message draft. Waits for any attachment added during
+     *  the edit to finish uploading (same gate as send/queue) so it isn't silently dropped. */
+    fun commitQueuedEdit() {
+        val session = _uiState.value.editingQueuedItem ?: return
+        withUploadGate(_uiState.value.inputText.trim()) { text ->
+            // The upload wait is async — bail if the edit was cancelled (or replaced) meanwhile,
+            // so we don't reinsert a duplicate after cancelQueuedEdit already restored the item.
+            if (_uiState.value.editingQueuedItem != session) return@withUploadGate
+            val edited = buildSendSpec(text)?.copy(localId = session.original.localId)
+            if (edited != null) {
+                queueDelegate.reinsert(session.originalIndex, edited)
+            } else {
+                // Composer emptied → treat as delete; the item is simply not put back.
+                queueDelegate.clearPauseIfEmpty()
+            }
+            finishQueuedEdit(session)
+        }
+    }
+
+    /** "Cancel edit": discard composer changes, restore the original item to its slot unchanged,
+     *  and bring back the stashed new-message draft. */
+    fun cancelQueuedEdit() {
+        val session = _uiState.value.editingQueuedItem ?: return
+        queueDelegate.reinsert(session.originalIndex, session.original)
+        finishQueuedEdit(session)
+    }
+
+    private fun finishQueuedEdit(session: QueuedEditSession) {
+        applyComposer(session.stashed)
+        _uiState.update { it.copy(editingQueuedItem = null) }
+        // Draining was frozen during the edit; resume it now if the queue is idle (a reply may
+        // have finished while editing).
+        tryResumeDrain()
+    }
+
+    fun cancelQueued(localId: String) {
+        // Ignore ghost ×/reorder while an edit is in flight, so the queue can't shift under the
+        // session's captured originalIndex.
+        if (_uiState.value.isEditingQueued) return
+        queueDelegate.cancel(localId)
+    }
+
+    fun reorderQueue(fromIndex: Int, toIndex: Int) {
+        if (_uiState.value.isEditingQueued) return
+        queueDelegate.reorder(fromIndex, toIndex)
+    }
+
+    /** "Send queued" control after a Stop/error pause: lift the pause and resume draining. */
+    fun sendQueuedNow() = queueDelegate.resume()
+
+    /** Snapshots the editable composer surface (the new-message draft) for stashing during an edit. */
+    private fun captureComposer(): ComposerSnapshot {
+        val state = _uiState.value
+        return ComposerSnapshot(
+            text = state.inputText,
+            attachments = fileDelegate.attachedFiles.value,
+            endpoint = state.selectedEndpoint,
+            model = state.selectedModel,
+            enabledTools = state.enabledTools,
+            mcpServerNames = state.selectedMcpServerNames,
+            modelParameters = state.modelParameters,
+        )
+    }
+
+    /** Writes a [ComposerSnapshot] back onto the composer (text, attachments, model, tools, params).
+     *  Sets [ChatUiState.inputText] directly rather than via [onInputChanged] so swapping composer
+     *  contents for an edit never overwrites the persisted on-disk new-message draft. */
+    private fun applyComposer(snapshot: ComposerSnapshot) {
+        fileDelegate.restoreAttachedFiles(snapshot.attachments)
+        _uiState.update {
+            it.copy(
+                inputText = snapshot.text,
+                selectedEndpoint = snapshot.endpoint,
+                selectedModel = snapshot.model,
+                enabledTools = snapshot.enabledTools,
+                selectedMcpServerNames = snapshot.mcpServerNames,
+                modelParameters = snapshot.modelParameters,
+            )
+        }
+    }
+
+    /**
+     * Snapshots the current send config into a [QueuedMessage]. Used both for a normal send
+     * (fired immediately) and for queueing (fired later, unchanged by intervening config edits).
+     * Returns null when there is nothing to send (blank text and no uploaded files).
+     */
     @OptIn(ExperimentalUuidApi::class)
-    private fun doSendMessage(text: String) {
-        val fileRefs = fileDelegate.buildFileReferences()
+    private fun buildSendSpec(text: String): QueuedMessage? {
+        // Snapshot the uploaded AttachedFiles (not just FileReferences) so a queued item can
+        // round-trip losslessly back into the composer on edit — keeping its local-uri thumbnail.
+        val allFiles = fileDelegate.attachedFiles.value
+        val files = allFiles.filter { it.fileId != null }
+        // Surface attachments excluded from the send (still uploading or failed) so a dropped
+        // file leaves a diagnostic trail rather than vanishing silently.
+        val dropped = allFiles.filter { it.fileId == null }
+        if (dropped.isNotEmpty()) {
+            Logger.w {
+                "buildSendSpec: ${dropped.size} attachment(s) not yet uploaded, excluded from send: " +
+                    dropped.joinToString { it.name }
+            }
+        }
+        if (text.isBlank() && files.isEmpty()) return null
+        val state = _uiState.value
+        val isAgent = state.selectedEndpoint == EndpointConstants.AGENTS
+        return QueuedMessage(
+            localId = Uuid.random().toString(),
+            text = text,
+            attachments = files,
+            endpoint = state.selectedEndpoint,
+            model = state.selectedModel,
+            agentId = if (isAgent) state.selectedModel else null,
+            enabledTools = state.enabledTools,
+            mcpServerNames = state.selectedMcpServerNames,
+            modelParameters = state.modelParameters,
+            ephemeralAgent = requestBuilder.buildEphemeralAgent(),
+            dispatch = requestBuilder.currentDispatch(),
+            isTemporary = state.isTemporaryChat,
+        )
+    }
+
+    private fun sendNow(text: String) {
+        val spec = buildSendSpec(text) ?: return
+        doSendWithSpec(spec, clearComposerOnSend = true)
+    }
+
+    /**
+     * Suspends until the previous reply has settled into the message tree: streaming is over and
+     * the active path ends in an assistant message (the post-Final Room reload has landed). Used
+     * before draining a queued follow-up so its optimistic insert chains onto that reply. Bounded
+     * by [REPLY_SETTLE_TIMEOUT_MS]; on timeout (e.g. a failed reload) we proceed best-effort.
+     */
+    private suspend fun awaitReplySettled() {
+        withTimeoutOrNull(REPLY_SETTLE_TIMEOUT_MS) {
+            _uiState.first { state ->
+                !state.isStreaming &&
+                    state.displayMessages.lastOrNull()?.message?.isCreatedByUser == false
+            }
+        }
+    }
+
+    /** Clears the input, its persisted draft, and any attached files. */
+    private fun clearComposer() {
+        val draftKey = _uiState.value.conversationId ?: NEW_CHAT_DRAFT_KEY
+        _uiState.update { it.copy(inputText = "") }
+        viewModelScope.launch { draftRepository.deleteDraft(draftKey) }
+        fileDelegate.clearAttachedFiles()
+    }
+
+    /**
+     * Sends one message from a [QueuedMessage] config snapshot. The config (endpoint/model/
+     * tools/webSearch/attachments/dispatch/ephemeralAgent) comes from the spec, but the
+     * lineage — conversationId, parentMessageId, and the minted optimistic user-message id —
+     * is recomputed from the *current* tree, so a drained item chains onto the freshly-
+     * finalized turn.
+     *
+     * [clearComposerOnSend] clears the composer only once the streaming guard has passed — set
+     * true on the live-send path (so a lost readiness race can't wipe an unsent message) and
+     * false for drains (which must leave the user's in-progress composer untouched).
+     */
+    @OptIn(ExperimentalUuidApi::class)
+    private fun doSendWithSpec(spec: QueuedMessage, clearComposerOnSend: Boolean = false) {
+        val fileRefs = spec.attachments.map { it.toFileReference() }
         val hasFiles = fileRefs.isNotEmpty()
-        if ((text.isBlank() && !hasFiles) || _uiState.value.isStreaming) return
+        val messageText = spec.text
+        if ((messageText.isBlank() && !hasFiles) || _uiState.value.isStreaming) return
+        // Guard passed: safe to clear the composer for a live send without risking message loss.
+        if (clearComposerOnSend) clearComposer()
 
         val conversationId = _uiState.value.conversationId
         val lastMessageId = _uiState.value.displayMessages.lastOrNull()?.message?.messageId
 
         // Add optimistic user message to display immediately
-        val messageText = text.ifBlank {
-            if (hasFiles) "" else return
-        }
         val optimisticMessage = Message(
             messageId = Uuid.random().toString(),
             conversationId = conversationId ?: "",
@@ -620,7 +867,6 @@ class ChatViewModel(
             val updatedMessages = it.messages + optimisticMessage
             val updatedDisplay = buildActiveMessagePath(updatedMessages, it.activeBranches, optimisticMessage.messageId)
             it.copy(
-                inputText = "",
                 isStreaming = true,
                 streamingContent = "",
                 activeToolCalls = emptyList(),
@@ -631,50 +877,42 @@ class ChatViewModel(
                 displayMessages = updatedDisplay,
             )
         }
-        // Clear draft
-        val draftKey = conversationId ?: NEW_CHAT_DRAFT_KEY
-        viewModelScope.launch { draftRepository.deleteDraft(draftKey) }
-        // Clear attached files
-        fileDelegate.clearAttachedFiles()
         streamingManager.beginStreaming(isEdit = false)
 
-        val isAgent = _uiState.value.selectedEndpoint == EndpointConstants.AGENTS
-        val webSearchEnabled = _uiState.value.modelParameters.webSearch
-        val ephemeralAgent = requestBuilder.buildEphemeralAgent()
+        val isAgent = spec.endpoint == EndpointConstants.AGENTS
         Logger.d {
-            "sendMessage: webSearch=$webSearchEnabled, " +
-                "endpoint=${_uiState.value.selectedEndpoint}, " +
-                "model=${_uiState.value.selectedModel}, " +
+            "sendMessage: webSearch=${spec.modelParameters.webSearch}, " +
+                "endpoint=${spec.endpoint}, " +
+                "model=${spec.model}, " +
                 "files=${fileRefs.size}, " +
-                "ephemeralAgent=$ephemeralAgent"
+                "ephemeralAgent=${spec.ephemeralAgent}"
         }
 
         // Resolve effective endpoint/agentId for comparison mode.
         // All requests go through api/agents/chat/{endpoint} — the server's
         // middleware creates ephemeral agents for non-agent endpoints, so no
         // swapping is needed. Just keep the primary's original endpoint.
-        val effectiveEndpoint = _uiState.value.selectedEndpoint
-        val effectiveAgentId = if (isAgent) _uiState.value.selectedModel else null
+        val effectiveEndpoint = spec.endpoint
+        val effectiveAgentId = if (isAgent) spec.agentId else null
         comparisonDelegate.onSendStart()
 
         val effectiveAddedConvo = comparisonDelegate.buildAddedConvo(parentMessageId = lastMessageId)
-        val dispatch = requestBuilder.currentDispatch()
         val stream = chatRepository.startChat(
             text = messageText,
             conversationId = conversationId,
             endpoint = effectiveEndpoint,
-            endpointType = dispatch.endpointType,
-            key = dispatch.key,
-            modelDisplayLabel = dispatch.modelDisplayLabel,
-            model = _uiState.value.selectedModel,
+            endpointType = spec.dispatch.endpointType,
+            key = spec.dispatch.key,
+            modelDisplayLabel = spec.dispatch.modelDisplayLabel,
+            model = spec.model,
             userMessageId = optimisticMessage.messageId,
             parentMessageId = lastMessageId,
             agentId = effectiveAgentId,
-            webSearch = webSearchEnabled,
+            webSearch = spec.modelParameters.webSearch,
             files = fileRefs.takeIf { it.isNotEmpty() },
             addedConvo = effectiveAddedConvo,
-            ephemeralAgent = ephemeralAgent,
-            isTemporary = _uiState.value.isTemporaryChat,
+            ephemeralAgent = spec.ephemeralAgent,
+            isTemporary = spec.isTemporary,
         )
         streamingManager.launchStream(stream) {
             // Safety net: if the flow ends without Final or Error, clear streaming
@@ -689,9 +927,15 @@ class ChatViewModel(
         }
     }
 
-    fun editMessage(messageId: String, newText: String) = editingDelegate.editMessage(messageId, newText)
+    fun editMessage(messageId: String, newText: String) {
+        if (_uiState.value.isEditingQueued) return
+        editingDelegate.editMessage(messageId, newText)
+    }
 
-    fun regenerateMessage(messageId: String) = editingDelegate.regenerateMessage(messageId)
+    fun regenerateMessage(messageId: String) {
+        if (_uiState.value.isEditingQueued) return
+        editingDelegate.regenerateMessage(messageId)
+    }
 
     fun getMessageText(messageId: String): String {
         val message = _uiState.value.messages.find { it.messageId == messageId } ?: return ""
@@ -706,7 +950,10 @@ class ChatViewModel(
 
     fun stopGeneration() = streamingManager.stopGeneration()
 
-    fun continueGeneration() = editingDelegate.continueGeneration()
+    fun continueGeneration() {
+        if (_uiState.value.isEditingQueued) return
+        editingDelegate.continueGeneration()
+    }
 
     fun onPause() = streamingManager.onPause()
 
@@ -719,7 +966,12 @@ class ChatViewModel(
         }
     }
 
-    fun startEditing(messageId: String) = editingDelegate.startEditing(messageId)
+    fun startEditing(messageId: String) {
+        // Don't start a tree-message edit while a queued item occupies the composer (it would
+        // build its resubmit from the queued item's loaded model/tools).
+        if (_uiState.value.isEditingQueued) return
+        editingDelegate.startEditing(messageId)
+    }
 
     fun onEditTextChanged(text: String) = editingDelegate.onEditTextChanged(text)
 

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/MessageEditingDelegate.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/MessageEditingDelegate.kt
@@ -172,7 +172,7 @@ class MessageEditingDelegate(
      *
      * Resubmits carry the original user turn's [files] so attachments survive an edit /
      * regenerate / continue (the server otherwise loses them). The new-message send path
-     * (`doSendMessage`) stays in `ChatViewModel`: it additionally carries an added-conversation
+     * (`doSendWithSpec`) stays in `ChatViewModel`: it additionally carries an added-conversation
      * for comparison mode and a bespoke stream-terminated callback this helper deliberately omits.
      */
     @Suppress("LongParameterList")

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/MessageQueueDelegate.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/MessageQueueDelegate.kt
@@ -1,0 +1,108 @@
+package com.garfiec.librechat.feature.chat.viewmodel.delegate
+
+import com.garfiec.librechat.feature.chat.viewmodel.ChatStateHandle
+import com.garfiec.librechat.feature.chat.viewmodel.QueuedMessage
+
+/**
+ * Owns the in-memory FIFO queue of follow-up messages the user staged while a reply was
+ * streaming. Holds only the list + pause flag in [ChatStateHandle]; the actual send is
+ * delegated back to `ChatViewModel` via [sendWithSpec] so all the request-build / optimistic-
+ * insert / lineage logic stays in one place.
+ *
+ * Draining is driven by the stream lifecycle: a successful `Final` calls [drainNext]; a Stop
+ * or stream-error calls [pause] so nothing auto-fires until the user taps "Send queued"
+ * ([resume]). The queue is never persisted — it lives and dies with the ViewModel.
+ */
+class MessageQueueDelegate(
+    private val stateHandle: ChatStateHandle,
+    /** Fires one queued message. Set by `ChatViewModel` to `doSendWithSpec` (wrapped in the
+     *  send-ready gate). Recomputes lineage live; only config comes from the spec. [awaitSettle]
+     *  is true for the auto-drain after a Final (wait for the async reload to land the reply in
+     *  the tree) and false for an explicit resume (the reply has already settled). */
+    private val sendWithSpec: (spec: QueuedMessage, awaitSettle: Boolean) -> Unit,
+) {
+
+    fun enqueue(spec: QueuedMessage) {
+        stateHandle.update { copy(messageQueue = messageQueue + spec) }
+    }
+
+    /**
+     * Pulls a queued item OUT of the queue for editing, returning it with its original index so
+     * the caller can put it back in the same slot on commit/cancel. Does NOT touch the pause flag:
+     * the item is only borrowed, so a paused queue stays paused. Returns null if the id is gone.
+     */
+    fun takeForEdit(localId: String): IndexedValue<QueuedMessage>? {
+        val index = stateHandle.state.messageQueue.indexOfFirst { it.localId == localId }
+        if (index < 0) return null
+        val item = stateHandle.state.messageQueue[index]
+        stateHandle.update { copy(messageQueue = messageQueue.filterNot { it.localId == localId }) }
+        return IndexedValue(index, item)
+    }
+
+    /** Re-inserts an item at [index] (clamped to the current bounds) — the commit/cancel counterpart
+     *  to [takeForEdit]. */
+    fun reinsert(index: Int, item: QueuedMessage) {
+        stateHandle.update {
+            val clamped = index.coerceIn(0, messageQueue.size)
+            copy(messageQueue = messageQueue.toMutableList().apply { add(clamped, item) })
+        }
+    }
+
+    /** Clears a now-meaningless pause when the queue is empty (e.g. an edit was committed empty,
+     *  deleting the last item). */
+    fun clearPauseIfEmpty() {
+        stateHandle.update { if (messageQueue.isEmpty()) copy(isQueuePaused = false) else this }
+    }
+
+    fun cancel(localId: String) {
+        stateHandle.update {
+            val next = messageQueue.filterNot { it.localId == localId }
+            // Clearing the last item while paused lifts the (now meaningless) pause.
+            copy(messageQueue = next, isQueuePaused = isQueuePaused && next.isNotEmpty())
+        }
+    }
+
+    fun reorder(fromIndex: Int, toIndex: Int) {
+        stateHandle.update {
+            val list = messageQueue
+            if (fromIndex !in list.indices || toIndex !in list.indices || fromIndex == toIndex) {
+                return@update this
+            }
+            val mutable = list.toMutableList()
+            mutable.add(toIndex, mutable.removeAt(fromIndex))
+            copy(messageQueue = mutable)
+        }
+    }
+
+    /** Holds the queue after a Stop / stream-error. No-op when nothing is queued — but an item
+     *  currently pulled out for editing still counts (it will return to the queue), so a Stop
+     *  during the edit of the sole queued item correctly registers the pause. */
+    fun pause() {
+        if (stateHandle.state.messageQueue.isEmpty() && !stateHandle.state.isEditingQueued) return
+        stateHandle.update { copy(isQueuePaused = true) }
+    }
+
+    /** User tapped "Send queued": lift the pause and start draining. The reply already settled
+     *  while paused, so no settle-wait is needed. */
+    fun resume() {
+        stateHandle.update { copy(isQueuePaused = false) }
+        drainNext(awaitSettle = false)
+    }
+
+    /**
+     * Pops and fires the head of the queue. No-op when empty or paused. Called from the stream's
+     * `Final` handler (by then `isStreaming` is already false, so firing the next send respects
+     * the load-bearing "no Room write while streaming" invariant). [awaitSettle] defers the send
+     * until the just-finished reply has landed in the tree (see [sendWithSpec]).
+     */
+    fun drainNext(awaitSettle: Boolean = true) {
+        // Freeze the queue while a queued item is being edited: draining now would fire an item
+        // out from under the user and shift the slots the edit session's originalIndex points at.
+        // The edit's commit/cancel re-kicks draining once it completes.
+        if (stateHandle.state.isEditingQueued) return
+        val head = stateHandle.state.messageQueue.firstOrNull() ?: return
+        if (stateHandle.state.isQueuePaused) return
+        stateHandle.update { copy(messageQueue = messageQueue.drop(1)) }
+        sendWithSpec(head, awaitSettle)
+    }
+}

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/PlatformFileHandler.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/PlatformFileHandler.kt
@@ -17,8 +17,27 @@ interface PlatformFileHandler {
     fun onFilesSelected(platformRefs: List<Any>)
     fun removeFile(file: AttachedFile)
     fun retryUpload(file: AttachedFile)
-    fun buildFileReferences(): List<FileReference>
     suspend fun waitForUploadsAndSend(text: String, doSend: (String) -> Unit)
     fun hasPendingUploads(): Boolean
     fun clearAttachedFiles()
+
+    /**
+     * Replaces the attached-file tray with an already-uploaded snapshot (no re-upload). Used when
+     * a queued message is pulled back into the composer for editing — the [AttachedFile]s carry
+     * their original local uri, so the composer chips (and image thumbnails) render unchanged.
+     */
+    fun restoreAttachedFiles(files: List<AttachedFile>)
 }
+
+/**
+ * Maps an uploaded [AttachedFile] to the [FileReference] the chat-send request carries. Callers
+ * must pass only files whose upload completed (`fileId != null`).
+ */
+fun AttachedFile.toFileReference(): FileReference = FileReference(
+    fileId = fileId,
+    filename = name,
+    filepath = filepath,
+    type = type,
+    width = width,
+    height = height,
+)

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/StreamingManagerDelegate.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/StreamingManagerDelegate.kt
@@ -38,6 +38,7 @@ class StreamingManagerDelegate(
     private val subagentTraceDelegate: SubagentTraceDelegate,
     private val officePreviewDelegate: OfficePreviewDelegate,
     private val completionDelegate: SendCompletionDelegate,
+    private val queueDelegate: MessageQueueDelegate,
     /** Emits a typed user-provided-key error for one-shot UI surfacing (snackbar + CTA). */
     private val emitUserKeyError: (UserKeyError) -> Unit,
     /** Reloads the conversation from the server (VM-owned Room observer). */
@@ -138,6 +139,9 @@ class StreamingManagerDelegate(
                 )
             }
             comparisonDelegate.endStreaming()
+            // Don't auto-drain into a failed turn — hold the queue for the user (mirrors the
+            // StreamEvent.Error branch; a flow-level exception ends the stream the same way).
+            queueDelegate.pause()
             // If the server already created a conversation, fetch whatever it persisted
             val conversationId = stateHandle.state.conversationId
             if (conversationId != null) {
@@ -186,6 +190,8 @@ class StreamingManagerDelegate(
                     )
                 }
                 comparisonDelegate.endStreaming()
+                // Don't auto-drain into a failed turn — hold the queue for the user.
+                queueDelegate.pause()
                 if (keyError != null) {
                     emitUserKeyError(keyError)
                 }
@@ -355,6 +361,10 @@ class StreamingManagerDelegate(
             isNewConversation = isNewConversation(),
             isHandedOffNewChat = isHandedOffNewChat(),
         )
+        // Reply finished cleanly: fire the next queued follow-up (if any, and not paused).
+        // isStreaming is already false here, so the next send respects the no-Room-write-
+        // while-streaming invariant.
+        queueDelegate.drainNext()
     }
 
     /**
@@ -394,6 +404,8 @@ class StreamingManagerDelegate(
 
     fun stopGeneration() {
         val conversationId = stateHandle.state.conversationId ?: return
+        // A manual stop usually means "wait" — hold the queue instead of firing the next item.
+        queueDelegate.pause()
         streamJob?.cancel()
         stopStreamingUpdater()
         streamingBuffer.clear()

--- a/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/components/IosChatInput.kt
+++ b/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/components/IosChatInput.kt
@@ -31,6 +31,7 @@ import com.garfiec.librechat.feature.chat.resources.Res
 import com.garfiec.librechat.feature.chat.resources.cd_attach_file
 import com.garfiec.librechat.feature.chat.resources.cd_paste_image
 import com.garfiec.librechat.feature.chat.viewmodel.ChatInputGates
+import com.garfiec.librechat.feature.chat.viewmodel.QueuedMessage
 import org.jetbrains.compose.resources.stringResource
 
 @Composable
@@ -41,6 +42,18 @@ fun IosChatInput(
     onSend: () -> Unit,
     onStop: () -> Unit,
     modifier: Modifier = Modifier,
+    onQueue: () -> Unit = {},
+    canQueue: Boolean = false,
+    queuedPausedCount: Int = 0,
+    onSendQueuedMessages: () -> Unit = {},
+    isEditingQueued: Boolean = false,
+    onCommitEdit: () -> Unit = {},
+    onCancelEdit: () -> Unit = {},
+    queuedMessages: List<QueuedMessage> = emptyList(),
+    onEditQueuedMessage: (localId: String) -> Unit = {},
+    onCancelQueuedMessage: (localId: String) -> Unit = {},
+    onReorderQueuedMessages: (fromIndex: Int, toIndex: Int) -> Unit = { _, _ -> },
+    fontSizeMultiplier: Float = 1f,
     enabledTools: Set<String> = emptySet(),
     onToggleTool: (String) -> Unit = {},
     mcpServers: List<McpServerDisplayData> = emptyList(),
@@ -82,12 +95,24 @@ fun IosChatInput(
         isCodeInterpreterAvailable = isCodeInterpreterAvailable,
         attachedFiles = attachedFiles,
         gates = gates,
+        canQueue = canQueue,
+        isEditingQueued = isEditingQueued,
     )
 
     CommonChatInputCore(
         state = state,
         onSend = onSend,
         onStop = onStop,
+        onQueue = onQueue,
+        queuedPausedCount = queuedPausedCount,
+        onSendQueuedMessages = onSendQueuedMessages,
+        onCommitEdit = onCommitEdit,
+        onCancelEdit = onCancelEdit,
+        queuedMessages = queuedMessages,
+        onEditQueuedMessage = onEditQueuedMessage,
+        onCancelQueuedMessage = onCancelQueuedMessage,
+        onReorderQueuedMessages = onReorderQueuedMessages,
+        fontSizeMultiplier = fontSizeMultiplier,
         onRemoveFile = onRemoveFile,
         modifier = modifier,
         leadingButtons = {

--- a/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/screen/PlatformScreens.ios.kt
+++ b/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/screen/PlatformScreens.ios.kt
@@ -50,12 +50,15 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -425,6 +428,14 @@ actual fun ChatScreen(
             }
         },
     ) { paddingValues ->
+        // The composer overlays the message list at the bottom; the list reserves a scrollable
+        // bottom inset so its latest content rests above the bar. We measure the bar's actual
+        // height (which grows as queued ghost rows stack above it) so streaming text never hides
+        // behind the ghosts, while the list still scrolls *behind* the translucent overlay.
+        var inputBarHeightPx by remember { mutableIntStateOf(0) }
+        val bottomContentPadding = with(LocalDensity.current) {
+            maxOf(160.dp, inputBarHeightPx.toDp() + 16.dp)
+        }
         Box(
             modifier = Modifier
                 .fillMaxSize()
@@ -497,6 +508,7 @@ actual fun ChatScreen(
                         currentSearchMatchIndex = uiState.currentSearchMatchIndex,
                         searchScrollToIndex = uiState.searchScrollToIndex,
                         onSearchScrollHandle = viewModel::onSearchScrollHandled,
+                        bottomContentPadding = bottomContentPadding,
                         modifier = Modifier.fillMaxSize(),
                     )
                 }
@@ -511,6 +523,8 @@ actual fun ChatScreen(
                     viewModel.sendMessage()
                 },
                 onStop = viewModel::stopGeneration,
+                onQueue = { viewModel.queueMessage() },
+                canQueue = uiState.canQueueFollowUp,
                 enabledTools = uiState.effectiveEnabledTools,
                 onToggleTool = viewModel::toggleTool,
                 mcpServers = uiState.mcpServers,
@@ -563,7 +577,19 @@ actual fun ChatScreen(
                 fileSearchEnabled = uiState.fileSearchEnabled,
                 mcpServersEnabled = uiState.mcpServersEnabled,
                 gates = uiState.chatInputGates,
-                modifier = Modifier.align(Alignment.BottomCenter),
+                queuedPausedCount = uiState.pausedQueueCount,
+                isEditingQueued = uiState.isEditingQueued,
+                onCommitEdit = viewModel::commitQueuedEdit,
+                onCancelEdit = viewModel::cancelQueuedEdit,
+                onSendQueuedMessages = viewModel::sendQueuedNow,
+                queuedMessages = uiState.messageQueue,
+                onEditQueuedMessage = viewModel::editQueued,
+                onCancelQueuedMessage = viewModel::cancelQueued,
+                onReorderQueuedMessages = viewModel::reorderQueue,
+                fontSizeMultiplier = fontSizeMultiplier,
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .onSizeChanged { inputBarHeightPx = it.height },
             )
         }
     }

--- a/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/IosFileHandler.kt
+++ b/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/IosFileHandler.kt
@@ -4,7 +4,6 @@ import co.touchlab.kermit.Logger
 import com.garfiec.librechat.core.common.EndpointConstants
 import com.garfiec.librechat.core.common.result.Result
 import com.garfiec.librechat.core.data.repository.FileRepository
-import com.garfiec.librechat.core.model.FileReference
 import com.garfiec.librechat.feature.chat.components.AttachedFile
 import com.garfiec.librechat.feature.chat.util.IosFileData
 import com.garfiec.librechat.feature.chat.util.IosImageData
@@ -218,21 +217,6 @@ class IosFileHandler(
         removeFile(file)
     }
 
-    override fun buildFileReferences(): List<FileReference> {
-        return _attachedFiles.value
-            .filter { it.fileId != null }
-            .map { file ->
-                FileReference(
-                    fileId = file.fileId,
-                    filename = file.name,
-                    filepath = file.filepath,
-                    type = file.type,
-                    width = file.width,
-                    height = file.height,
-                )
-            }
-    }
-
     override suspend fun waitForUploadsAndSend(text: String, doSend: (String) -> Unit) {
         val timeoutMs = 30_000L
         val pollIntervalMs = 200L
@@ -251,5 +235,9 @@ class IosFileHandler(
 
     override fun clearAttachedFiles() {
         _attachedFiles.update { emptyList() }
+    }
+
+    override fun restoreAttachedFiles(files: List<AttachedFile>) {
+        _attachedFiles.update { files }
     }
 }


### PR DESCRIPTION
## Summary

Adds a message queue so you can line up follow-up messages while a reply is
still streaming, instead of being blocked until it finishes. Queued messages
auto-send one at a time (FIFO) as each reply completes. Mobile-only, in-memory,
existing conversations only.

## Behavior

- **Queue while streaming** — typing mid-stream morphs the Stop button into
  **Add to queue**; clearing the composer returns it to **Stop** ("clear the
  box to abort"). Available on existing conversations only.
- **Ghost rows** — queued messages show as dimmed previews pinned just above the
  composer. Tap a row to pull it back into the composer for editing, **×** to
  cancel it, and long-press-drag to reorder.
- **Auto-drain** — each successfully completed reply sends the next queued
  message automatically.
- **Pause on Stop/error** — stopping generation (or a stream error) pauses the
  queue and shows a **Send queued (N)** banner; nothing fires until you tap it.
- **Config snapshot at queue time** — each queued message captures its own
  model/endpoint/tools/parameters/MCP servers/attachments, so a mid-stream model
  switch doesn't retro-edit what's already queued.
- **Bottom spacing tracks the bar** — the message list's bottom inset follows the
  measured input-bar height (which grows as ghost rows stack), so streaming text
  rests above the ghosts while earlier messages still scroll behind them.

## Implementation

- New `MessageQueueDelegate` owns queue list state + pause/drain lifecycle;
  `ChatUiState` gains `messageQueue` / queue-paused / queued-edit fields.
- `doSendMessage` split into `buildSendSpec` (snapshot) + `doSendWithSpec` (send
  from a snapshot), so a normal send and a queue drain share one path.
- Drain/pause hooks added in `StreamingManagerDelegate` (drain after `Final`,
  pause on Stop/Error) — fired only when streaming has already ended, upholding
  the no-mid-stream-Room-write invariant.
- Shared `SendStopButton` is now 3-state (Send/Stop/Queue, plus Update in
  queued-edit mode); new `QueuedMessagesSection` and `SendQueuedBanner`
  components; both platforms thread the new state through `ChatInput`. Ghost-row
  text scales with the chat font-size setting.
- File handlers gain `restoreAttachedFiles` (repopulate the tray when editing a
  queued item) and a shared `AttachedFile.toFileReference()` extension,
  replacing the per-handler `buildFileReferences()`.

## Testing

- `MessageQueueDelegateTest` covers list ops, FIFO drain, pause/resume, snapshot
  honesty, and queued-edit freeze behavior.
- Both platforms compile; detekt (incl. `detektMetadataCommonMain`) clean; unit
  tests green.
- Android device-tested on a Pixel 9 Pro Fold.

## Notes

- The queue is in-memory: switching conversations or process death drops it
  (accepted).
- iOS builds via the Gradle link; not yet smoke-tested on a simulator/device.
