### PR TITLE
fix(ios): adopt official embedAndSignAppleFrameworkForXcode direct integration

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -25,8 +25,7 @@ File: `.github/workflows/ci.yml`
 #### `ios` (Build iOS App)
 - Selects latest stable Xcode
 - Caches `~/.konan`
-- Builds shared KMP framework via `./gradlew :shared:linkDebugFrameworkIosSimulatorArm64`
-- Runs `xcodebuild` for the iOS simulator (arm64-only, no signing)
+- Runs `xcodebuild` for the iOS simulator (arm64-only, no signing). The Kotlin framework is built by the Xcode "Compile Kotlin Framework" build phase (`./gradlew :shared:embedAndSignAppleFrameworkForXcode`) — no separate link step.
 
 ### Environment
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,12 +173,9 @@ jobs:
           key: ${{ runner.os }}-konan-${{ hashFiles('gradle/libs.versions.toml') }}
           restore-keys: ${{ runner.os }}-konan-
 
-      - name: Build shared KMP framework (simulator)
-        run: ./gradlew :shared:linkDebugFrameworkIosSimulatorArm64
-
-      - name: Build shared KMP framework (device)
-        run: ./gradlew :shared:linkDebugFrameworkIosArm64
-
+      # The Kotlin framework is built by the Xcode "Compile Kotlin Framework" build
+      # phase (./gradlew :shared:embedAndSignAppleFrameworkForXcode) — no separate
+      # link step needed. Direct integration; see iosApp/README.md.
       - name: Build iOS app
         run: |
           xcodebuild -project iosApp/iosApp.xcodeproj \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -258,11 +258,9 @@ jobs:
           key: ${{ runner.os }}-konan-${{ hashFiles('gradle/libs.versions.toml') }}
           restore-keys: ${{ runner.os }}-konan-
 
-      # The device framework must exist before xcodebuild — the Xcode project's framework
-      # search path points at shared/build/bin/iosArm64/releaseFramework.
-      - name: Build shared KMP framework (device, release)
-        run: ./gradlew :shared:linkReleaseFrameworkIosArm64
-
+      # The Kotlin framework is built by the Xcode "Compile Kotlin Framework" build phase
+      # (./gradlew :shared:embedAndSignAppleFrameworkForXcode), which runs inside the
+      # archive below — no separate link step needed. Direct integration; see iosApp/README.md.
       - name: Archive & package unsigned IPA
         id: ipa
         env:
@@ -275,8 +273,9 @@ jobs:
           # `CODE_SIGN_STYLE = Automatic`, which on a device archive would otherwise demand a
           # provisioning profile on this account-less runner — so we override the sdk-scoped
           # key, force Manual style, and blank the profile, not just the unscoped identity.
-          # The "Copy Compose Resources" build phase shells out to ./gradlew itself, which is
-          # why JDK + Gradle are set up above.
+          # The "Compile Kotlin Framework" build phase shells out to ./gradlew itself
+          # (embedAndSignAppleFrameworkForXcode, which also syncs Compose resources), which
+          # is why JDK + Gradle are set up above.
           xcodebuild archive \
             -project iosApp/iosApp.xcodeproj \
             -scheme iosApp \

--- a/README.md
+++ b/README.md
@@ -138,10 +138,11 @@ For a release build:
 
 ### iOS
 
+Xcode builds the Kotlin framework itself via a build phase (direct integration), so there is no separate `link*Framework` step to run by hand.
+
 **Simulator:**
 
 ```bash
-./gradlew :shared:linkDebugFrameworkIosSimulatorArm64
 xcodebuild -project iosApp/iosApp.xcodeproj -scheme iosApp \
   -sdk iphonesimulator \
   -destination 'platform=iOS Simulator,name=iPhone 16' \
@@ -151,7 +152,6 @@ xcodebuild -project iosApp/iosApp.xcodeproj -scheme iosApp \
 **Physical device:**
 
 ```bash
-./gradlew :shared:linkDebugFrameworkIosArm64
 open iosApp/iosApp.xcodeproj
 ```
 

--- a/iosApp/README.md
+++ b/iosApp/README.md
@@ -35,32 +35,34 @@ The `:shared` Gradle module exports `core:common`, `core:model`, `core:network`,
 
 ### Build and Run
 
+The Kotlin framework is built automatically by Xcode's **Compile Kotlin Framework**
+build phase, which runs `./gradlew :shared:embedAndSignAppleFrameworkForXcode`
+([direct integration](https://kotlinlang.org/docs/multiplatform/multiplatform-direct-integration.html)).
+That task builds the right framework slice for the active SDK/configuration, sets up
+linking, and syncs Compose resources — so there is no separate `link*Framework` step to
+run by hand. The framework is static (`isStatic = true`), so it is linked directly into
+the app binary and is **not** embedded in `Frameworks/`.
+
+> Because the build phase shells out to Gradle, **User Script Sandboxing must stay
+> disabled** for the `iosApp` target (`ENABLE_USER_SCRIPT_SANDBOXING = NO`). If you ever
+> toggle it on, run `./gradlew --stop` before rebuilding.
+
 #### Simulator
 
 ```bash
-# 1. Build the shared KMP framework
-./gradlew :shared:linkDebugFrameworkIosSimulatorArm64
-
-# 2. Build the Xcode project
+# Build the Xcode project (Gradle builds the framework as a build phase)
 xcodebuild -project iosApp/iosApp.xcodeproj -scheme iosApp \
   -sdk iphonesimulator \
   -destination 'platform=iOS Simulator,name=iPhone 16' \
   -derivedDataPath iosApp/build build
 
-# 3. Boot simulator, install, and launch
+# Boot simulator, install, and launch
 xcrun simctl boot "iPhone 16"
 xcrun simctl install booted iosApp/build/Build/Products/Debug-iphonesimulator/iosApp.app
 xcrun simctl launch booted com.garfiec.librechat.ios
 ```
 
 #### Physical Device
-
-```bash
-# 1. Build the shared KMP framework for device
-./gradlew :shared:linkDebugFrameworkIosArm64
-```
-
-Then open the project in Xcode:
 
 ```bash
 open iosApp/iosApp.xcodeproj
@@ -75,12 +77,7 @@ In Xcode:
 
 ### Known Xcode Behaviour
 
-**Red dot on `Shared.framework` in the navigator** — You may see a red indicator on `Shared.framework` in the Xcode file navigator (left sidebar). This is cosmetic and does not affect builds. It happens because the Xcode project file keeps a static reference path to the framework for display purposes, and that path may not exist if you haven't built that particular target yet. The linker always resolves the framework via `FRAMEWORK_SEARCH_PATHS`, which is set correctly per target — the red dot can be safely ignored. Building the Gradle framework for your active target clears it:
-
-```bash
-./gradlew :shared:linkDebugFrameworkIosSimulatorArm64  # clears it for simulator
-./gradlew :shared:linkDebugFrameworkIosArm64           # clears it for device
-```
+**Red dot on `Shared.framework` in the navigator** — cosmetic, safe to ignore. The Xcode project keeps a static display path for the framework, but the real artifact lives under `shared/build/xcode-frameworks/<Configuration>/<SDK>/` and is produced by the build phase. The linker resolves it via `FRAMEWORK_SEARCH_PATHS`, so builds are unaffected; running a build clears the indicator.
 
 ## Info.plist Permissions
 

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -16,7 +16,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		SSS00004 /* Embed Shared Framework */ = {
+		SSS00004 /* Compile Kotlin Framework */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
@@ -24,26 +24,12 @@
 			);
 			inputPaths = (
 			);
-			name = "Embed Shared Framework";
+			name = "Compile Kotlin Framework";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# Embed the Kotlin/Native Shared.framework matching the active SDK + configuration.\n# FRAMEWORK_SEARCH_PATHS already resolve the framework for *linking*; this phase copies\n# that same framework into the app bundle's Frameworks/ dir. Keyed on PLATFORM_NAME +\n# CONFIGURATION to mirror the search paths, so simulator-debug and device-release both\n# embed the correct slice.\n#\n# Static frameworks (ar archive) are already linked into the app binary by the linker\n# and must NOT be embedded in Frameworks/ -- installd rejects ar archives as malformed\n# Mach-O. Clean up any stale copy then skip for static builds; only embed dynamic ones.\nset -eu\nif [ \"$PLATFORM_NAME\" = \"iphonesimulator\" ]; then\n    ARCH_DIR=\"iosSimulatorArm64\"\nelse\n    ARCH_DIR=\"iosArm64\"\nfi\nif [ \"$CONFIGURATION\" = \"Release\" ]; then\n    FW_DIR=\"releaseFramework\"\nelse\n    FW_DIR=\"debugFramework\"\nfi\nSRC=\"$SRCROOT/../shared/build/bin/$ARCH_DIR/$FW_DIR/Shared.framework\"\nif [ ! -d \"$SRC\" ]; then\n    echo \"error: Shared.framework not found at $SRC -- build the matching :shared:link${CONFIGURATION}Framework task first\"\n    exit 1\nfi\nDST=\"$BUILT_PRODUCTS_DIR/$PRODUCT_NAME.app/Frameworks\"\nrm -rf \"$DST/Shared.framework\"\nif file \"$SRC/Shared\" | grep -q 'ar archive'; then\n    echo \"Shared.framework is a static library -- skipping embed (already linked into app binary)\"\n    exit 0\nfi\nmkdir -p \"$DST\"\ncp -R \"$SRC\" \"$DST/\"\n# Mirror the old RemoveHeadersOnCopy attribute.\nrm -rf \"$DST/Shared.framework/Headers\" \"$DST/Shared.framework/PrivateHeaders\"\n# Code-sign on copy only when signing is enabled (skipped for unsigned sideload/CI builds).\nif [ \"${CODE_SIGNING_ALLOWED:-YES}\" != \"NO\" ] && [ -n \"${EXPANDED_CODE_SIGN_IDENTITY:-}\" ] && [ \"${EXPANDED_CODE_SIGN_IDENTITY}\" != \"-\" ]; then\n    codesign --force --sign \"$EXPANDED_CODE_SIGN_IDENTITY\" \"$DST/Shared.framework\"\nfi\necho \"Embedded Shared.framework from $SRC\"\n";
-		};
-		SSS00001 /* Copy Compose Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Copy Compose Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "# Aggregate and copy Compose Multiplatform resources into the app bundle.\n# Runs the Gradle aggregation task to ensure resources from all feature\n# modules are collected, then copies them into the .app bundle where\n# the Compose resource reader expects them at runtime.\n\nif [ \"$PLATFORM_NAME\" = \"iphonesimulator\" ]; then\n    ARCH_DIR=\"iosSimulatorArm64\"\n    GRADLE_TASK=\":shared:iosSimulatorArm64AggregateResources\"\nelif [ \"$PLATFORM_NAME\" = \"iphoneos\" ]; then\n    ARCH_DIR=\"iosArm64\"\n    GRADLE_TASK=\":shared:iosArm64AggregateResources\"\nelse\n    echo \"error: Unsupported PLATFORM_NAME: $PLATFORM_NAME\"\n    exit 1\nfi\n\nPROJECT_ROOT=\"$SRCROOT/..\"\nSRC=\"$PROJECT_ROOT/shared/build/kotlin-multiplatform-resources/aggregated-resources/$ARCH_DIR/composeResources\"\nDST=\"$BUILT_PRODUCTS_DIR/$PRODUCT_NAME.app/compose-resources/composeResources\"\n\n# Run Gradle aggregation to ensure resources are up to date\necho \"Running $GRADLE_TASK...\"\ncd \"$PROJECT_ROOT\" && ./gradlew \"$GRADLE_TASK\" 2>&1\nGRADLE_EXIT=$?\nif [ $GRADLE_EXIT -ne 0 ]; then\n    echo \"error: Gradle task $GRADLE_TASK failed with exit code $GRADLE_EXIT\"\n    exit $GRADLE_EXIT\nfi\n\n# Clean stale resources before copying fresh ones\nif [ -d \"$DST\" ]; then\n    rm -rf \"$DST\"\nfi\n\nif [ -d \"$SRC\" ]; then\n    mkdir -p \"$DST\"\n    cp -R \"$SRC/\" \"$DST/\"\n    echo \"Copied Compose resources from $SRC to $DST\"\nelse\n    echo \"error: Compose resources not found at $SRC after Gradle aggregation\"\n    exit 1\nfi\n";
+			shellScript = "if [ \"YES\" = \"$OVERRIDE_KOTLIN_BUILD_IDE_SUPPORTED\" ]; then\n  echo \"Skipping Gradle build task invocation due to OVERRIDE_KOTLIN_BUILD_IDE_SUPPORTED environment variable set to \\\"YES\\\"\"\n  exit 0\nfi\ncd \"$SRCROOT/..\"\n./gradlew :shared:embedAndSignAppleFrameworkForXcode\n";
 		};
 		SSS00002 /* Stamp Version from version.properties */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -157,11 +143,10 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = HHH00003 /* Build configuration list for PBXNativeTarget "iosApp" */;
 			buildPhases = (
+				SSS00004 /* Compile Kotlin Framework */,
 				III00001 /* Sources */,
 				RRR00001 /* Resources */,
 				EEE00001 /* Frameworks */,
-				SSS00004 /* Embed Shared Framework */,
-				SSS00001 /* Copy Compose Resources */,
 				SSS00002 /* Stamp Version from version.properties */,
 				SSS00003 /* Stamp Git SHA */,
 			);
@@ -275,16 +260,10 @@
 				CURRENT_PROJECT_VERSION = 103;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-				);
-				"FRAMEWORK_SEARCH_PATHS[sdk=iphonesimulator*]" = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/../shared/build/bin/iosSimulatorArm64/debugFramework",
-				);
-				"FRAMEWORK_SEARCH_PATHS[sdk=iphoneos*]" = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/../shared/build/bin/iosArm64/debugFramework",
+					"$(SRCROOT)/../shared/build/xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)",
 				);
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = iosApp/Info.plist;
@@ -314,16 +293,10 @@
 				CURRENT_PROJECT_VERSION = 103;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-				);
-				"FRAMEWORK_SEARCH_PATHS[sdk=iphonesimulator*]" = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/../shared/build/bin/iosSimulatorArm64/releaseFramework",
-				);
-				"FRAMEWORK_SEARCH_PATHS[sdk=iphoneos*]" = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/../shared/build/bin/iosArm64/releaseFramework",
+					"$(SRCROOT)/../shared/build/xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)",
 				);
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = iosApp/Info.plist;


### PR DESCRIPTION
## Summary

Replaces the hand-rolled iOS framework-embed and Compose-resource copy scripts with Kotlin's official direct-integration task (`embedAndSignAppleFrameworkForXcode`). The previous custom embed script copied the static `Shared.framework` into the app's `Frameworks/` directory, which iOS `installd` rejects ("Failed to iterate on macho slices for input file") — the device-install failure. The official task gates on `isStatic` internally: for a static framework it links directly into the app binary and never copies into `Frameworks/`, so the failure is structurally impossible rather than guarded against.

This replaces the one-line guard merged in #168 with the proper fix.

## Changes

- **pbxproj**: custom "Embed Shared Framework" and "Copy Compose Resources" run-scripts removed. Single "Compile Kotlin Framework" phase runs `./gradlew :shared:embedAndSignAppleFrameworkForXcode` first (before Sources), with the standard `OVERRIDE_KOTLIN_BUILD_IDE_SUPPORTED` guard. `FRAMEWORK_SEARCH_PATHS` simplified to the `xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)` output dir. `ENABLE_USER_SCRIPT_SANDBOXING = NO` (required since the phase shells out to Gradle).
- **CI** (`ci.yml`, `release.yml`): drop the now-redundant `:shared:link*FrameworkIos*` pre-build steps — Xcode builds the framework via the build phase.
- **Docs** (`README.md`, `iosApp/README.md`, `.github/CLAUDE.md`): document direct integration; remove manual `link*Framework` steps.

## Testing

- Simulator Debug `xcodebuild build`: succeeds.
- Unsigned device Release `xcodebuild archive` (mirroring `release.yml`): succeeds; archived `.app` has no `Frameworks/` directory and Compose resources are present.
- Not yet physically installed on a device.

## Notes

The Compose-resource sync the custom script handled is covered by `embedAndSignAppleFrameworkForXcode`'s `syncComposeResourcesForIos` dependency, which runs correctly under real `xcodebuild`.
