### PR TITLE
feat(chat): rework artifact viewer with preview-first sheet and full-screen mode

### DIFF
--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -125,7 +125,7 @@ coroutines:
 Compose:
   CompositionLocalAllowlist:
     active: true
-    allowedCompositionLocals: LocalChatMediaViewer,LocalImmediateMarkdown,LocalInlineArtifactPrefs,LocalMermaidRenderCache,LocalParsedMarkdownCache,LocalSubagentProgress
+    allowedCompositionLocals: LocalChatMediaViewer,LocalImmediateMarkdown,LocalInlineArtifactPrefs,LocalMermaidRenderCache,LocalOpenArtifact,LocalParsedMarkdownCache,LocalSubagentProgress
 
 # detekt-koin rule overrides (defaults ship in plugin jar; buildUponDefaultConfig = true)
 koin-rules:

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/ArtifactDisplayMode.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/ArtifactDisplayMode.kt
@@ -1,0 +1,25 @@
+package com.garfiec.librechat.core.data.datastore
+
+/**
+ * Mobile-only preference controlling how the artifact viewer is presented when a
+ * user opens an artifact from a message.
+ *
+ * - [BOTTOM_SHEET] — a modal bottom sheet (the historical default).
+ * - [FULLSCREEN] — a full-screen page, giving complex artifacts (React apps,
+ *   HTML dashboards, diagrams) the maximum available room.
+ */
+enum class ArtifactDisplayMode {
+    BOTTOM_SHEET, FULLSCREEN;
+
+    companion object {
+        fun fromString(value: String?): ArtifactDisplayMode = when (value) {
+            "fullscreen" -> FULLSCREEN
+            else -> BOTTOM_SHEET
+        }
+    }
+
+    fun toStorageString(): String = when (this) {
+        BOTTOM_SHEET -> "bottom_sheet"
+        FULLSCREEN -> "fullscreen"
+    }
+}

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/ArtifactDisplayPrefs.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/ArtifactDisplayPrefs.kt
@@ -1,0 +1,12 @@
+package com.garfiec.librechat.core.data.datastore
+
+/**
+ * Preferences controlling how the artifact viewer presents content. Configured
+ * via Settings > Chat > Artifacts.
+ *
+ * - [mode] — bottom sheet vs. full-screen presentation. Artifacts open preview-first;
+ *   source is reached via the viewer's source/preview toggle button.
+ */
+data class ArtifactDisplayPrefs(
+    val mode: ArtifactDisplayMode = ArtifactDisplayMode.BOTTOM_SHEET,
+)

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/SettingsDataStore.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/SettingsDataStore.kt
@@ -176,6 +176,12 @@ class SettingsDataStore(
         )
     }
 
+    val artifactDisplayPrefs: Flow<ArtifactDisplayPrefs> = dataStore.data.map { prefs ->
+        ArtifactDisplayPrefs(
+            mode = ArtifactDisplayMode.fromString(prefs[KEY_ARTIFACT_DISPLAY_MODE]),
+        )
+    }
+
     val selectedMcpServers: Flow<Set<String>> = dataStore.data.map { prefs ->
         prefs[KEY_SELECTED_MCP_SERVERS]?.split(",")?.filter { it.isNotBlank() }?.toSet() ?: emptySet()
     }
@@ -369,6 +375,10 @@ class SettingsDataStore(
         dataStore.edit { prefs -> prefs[KEY_INLINE_ARTIFACT_MARKDOWN] = enabled }
     }
 
+    suspend fun setArtifactDisplayMode(mode: ArtifactDisplayMode) {
+        dataStore.edit { prefs -> prefs[KEY_ARTIFACT_DISPLAY_MODE] = mode.toStorageString() }
+    }
+
     /**
      * Saves the backend version for which the user chose "Don't warn again".
      * If the backend later updates to a different version, the warning will reappear.
@@ -439,6 +449,7 @@ class SettingsDataStore(
         private val KEY_INLINE_ARTIFACT_HTML = booleanPreferencesKey("inline_artifact_html")
         private val KEY_INLINE_ARTIFACT_REACT = booleanPreferencesKey("inline_artifact_react")
         private val KEY_INLINE_ARTIFACT_MARKDOWN = booleanPreferencesKey("inline_artifact_markdown")
+        private val KEY_ARTIFACT_DISPLAY_MODE = stringPreferencesKey("artifact_display_mode")
         private val KEY_DISMISSED_VERSION_WARNING = stringPreferencesKey("dismissed_version_warning")
         private val KEY_SELECTED_MCP_SERVERS = stringPreferencesKey("selected_mcp_servers")
         private val KEY_ENABLED_TOOLS = stringPreferencesKey("enabled_tools")

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/ArtifactPanel.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/ArtifactPanel.kt
@@ -11,289 +11,34 @@ import android.webkit.WebResourceError
 import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import android.webkit.WebViewClient
-import androidx.compose.foundation.ScrollState
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.navigationBarsPadding
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Close
-import androidx.compose.material.icons.filled.Fullscreen
-import androidx.compose.material.icons.filled.Share
-import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ModalBottomSheet
-import androidx.compose.material3.SheetState
-import androidx.compose.material3.Tab
-import androidx.compose.material3.TabRow
-import androidx.compose.material3.Text
-import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.toArgb
-import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
-import androidx.compose.ui.input.nestedscroll.NestedScrollSource
-import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
-import androidx.compose.ui.window.Dialog
-import androidx.compose.ui.window.DialogProperties
 import co.touchlab.kermit.Logger
-import com.garfiec.librechat.core.ui.theme.isSurfaceDark
-import com.garfiec.librechat.feature.chat.components.CodeBlock
-import com.garfiec.librechat.feature.chat.resources.*
-import com.garfiec.librechat.feature.chat.resources.Res
 import kotlinx.coroutines.launch
-import org.jetbrains.compose.resources.stringResource
+import androidx.compose.runtime.rememberCoroutineScope
 
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-actual fun ArtifactPanel(
-    artifact: Artifact,
-    onDismiss: () -> Unit,
-    modifier: Modifier,
-    versions: List<Artifact>,
-) {
-    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = false)
-
-    ModalBottomSheet(
-        onDismissRequest = onDismiss,
-        sheetState = sheetState,
-        modifier = modifier.fillMaxSize(),
-        dragHandle = { BottomSheetDefaults.DragHandle() },
-        shape = RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp),
-    ) {
-        ArtifactPanelContent(
-            artifact = artifact,
-            versions = versions,
-            sheetState = sheetState,
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(horizontal = 16.dp)
-                .navigationBarsPadding(),
-        )
-    }
-}
-
-private fun isPreviewableType(type: String): Boolean =
-    when (ArtifactType.from(type)) {
-        ArtifactType.MERMAID,
-        ArtifactType.REACT,
-        ArtifactType.SVG,
-        ArtifactType.MARKDOWN,
-        ArtifactType.HTML,
-        ArtifactType.PLAIN,
-        -> true
-        ArtifactType.CODE -> false
-    }
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun ArtifactPanelContent(
-    artifact: Artifact,
-    versions: List<Artifact>,
-    sheetState: SheetState,
-    modifier: Modifier,
-) {
-    val context = LocalContext.current
-    val scope = rememberCoroutineScope()
-    var selectedTab by remember { mutableIntStateOf(0) }
-    var currentVersionIndex by remember {
-        mutableIntStateOf(versions.indexOfFirst { it.version == artifact.version }.coerceAtLeast(0))
-    }
-    var showFullscreen by remember { mutableIntStateOf(-1) } // -1 = hidden, 0 = code, 1 = preview
-
-    val currentArtifact = versions.getOrElse(currentVersionIndex) { artifact }
-    val isPreviewable = isPreviewableType(currentArtifact.type)
-    val isDarkTheme = isSurfaceDark()
-
-    Column(modifier = modifier.fillMaxWidth()) {
-        // Title row with version nav and action buttons
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Text(
-                text = currentArtifact.title,
-                style = MaterialTheme.typography.titleLarge,
-                modifier = Modifier.weight(1f),
-            )
-            if (versions.size > 1) {
-                ArtifactVersionNav(
-                    currentIndex = currentVersionIndex,
-                    totalVersions = versions.size,
-                    onPrevious = { currentVersionIndex-- },
-                    onNext = { currentVersionIndex++ },
-                )
-            }
-        }
-
-        // Action row: share + fullscreen
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Spacer(modifier = Modifier.weight(1f))
-            IconButton(
-                onClick = {
-                    scope.launch {
-                        ArtifactDownloadHelper.share(
-                            context = context,
-                            artifact = currentArtifact,
-                        )
-                    }
-                },
-                modifier = Modifier.size(36.dp),
-            ) {
-                Icon(
-                    imageVector = Icons.Default.Share,
-                    contentDescription = stringResource(Res.string.cd_share_artifact),
-                    modifier = Modifier.size(18.dp),
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
-            Spacer(modifier = Modifier.width(4.dp))
-            IconButton(
-                onClick = { showFullscreen = selectedTab },
-                modifier = Modifier.size(36.dp),
-            ) {
-                Icon(
-                    imageVector = Icons.Default.Fullscreen,
-                    contentDescription = stringResource(Res.string.cd_fullscreen),
-                    modifier = Modifier.size(18.dp),
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
-        }
-
-        if (isPreviewable) {
-            TabRow(selectedTabIndex = selectedTab) {
-                Tab(
-                    selected = selectedTab == 0,
-                    onClick = { selectedTab = 0 },
-                    text = { Text(stringResource(Res.string.code)) },
-                )
-                Tab(
-                    selected = selectedTab == 1,
-                    onClick = {
-                        selectedTab = 1
-                        scope.launch { sheetState.expand() }
-                    },
-                    text = { Text(stringResource(Res.string.preview)) },
-                )
-            }
-        }
-
-        when {
-            !isPreviewable || selectedTab == 0 -> {
-                val codeScrollState = rememberScrollState()
-                val codeScrollBlocker = remember {
-                    SheetScrollBlocker(codeScrollState)
-                }
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .weight(1f)
-                        .padding(top = 8.dp)
-                        .nestedScroll(codeScrollBlocker)
-                        .verticalScroll(codeScrollState),
-                ) {
-                    CodeBlock(
-                        code = currentArtifact.content,
-                        language = currentArtifact.language,
-                        modifier = Modifier.fillMaxWidth(),
-                    )
-                }
-            }
-            selectedTab == 1 -> {
-                ArtifactPreviewWebView(
-                    content = currentArtifact.content,
-                    type = currentArtifact.type,
-                    isDarkTheme = isDarkTheme,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .weight(1f)
-                        .padding(top = 8.dp),
-                )
-            }
-        }
-    }
-
-    // Fullscreen dialog
-    if (showFullscreen >= 0) {
-        Dialog(
-            onDismissRequest = { showFullscreen = -1 },
-            properties = DialogProperties(usePlatformDefaultWidth = false),
-        ) {
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .background(MaterialTheme.colorScheme.surface),
-            ) {
-                when {
-                    !isPreviewable || showFullscreen == 0 -> {
-                        CodeBlock(
-                            code = currentArtifact.content,
-                            language = currentArtifact.language,
-                            modifier = Modifier
-                                .fillMaxSize()
-                                .padding(top = 48.dp, start = 16.dp, end = 16.dp, bottom = 16.dp),
-                        )
-                    }
-                    showFullscreen == 1 -> {
-                        ArtifactPreviewWebView(
-                            content = currentArtifact.content,
-                            type = currentArtifact.type,
-                            isDarkTheme = isDarkTheme,
-                            modifier = Modifier
-                                .fillMaxSize()
-                                .padding(top = 48.dp),
-                        )
-                    }
-                }
-                IconButton(
-                    onClick = { showFullscreen = -1 },
-                    modifier = Modifier
-                        .align(Alignment.TopEnd)
-                        .padding(8.dp),
-                ) {
-                    Icon(
-                        imageVector = Icons.Default.Close,
-                        contentDescription = stringResource(Res.string.cd_close_fullscreen),
-                        tint = MaterialTheme.colorScheme.onSurface,
-                    )
-                }
-            }
-        }
-    }
-}
-
+/**
+ * Android preview surface — a `WebView` hosting the artifact's rendered HTML.
+ * The shell, header, selector, and code body are shared in the common
+ * `ArtifactPanel`.
+ */
 @SuppressLint("SetJavaScriptEnabled", "ClickableViewAccessibility")
 @Composable
-private fun ArtifactPreviewWebView(
+actual fun ArtifactPreviewSurface(
     content: String,
     type: String,
     isDarkTheme: Boolean,
@@ -398,27 +143,14 @@ private fun ArtifactPreviewWebView(
     }
 }
 
-/**
- * Intercepts all vertical scroll and manually dispatches it to the given [ScrollState],
- * then reports it all as consumed so the parent ModalBottomSheet never receives it.
- * This isolates the content's scrolling from the sheet's drag gesture.
- */
-private class SheetScrollBlocker(private val scrollState: ScrollState) : NestedScrollConnection {
-    override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
-        // Manually scroll the content and consume ALL vertical delta
-        // so none reaches the sheet's drag handler.
-        if (available.y != 0f) {
-            scrollState.dispatchRawDelta(-available.y)
+@Composable
+actual fun rememberShareArtifact(): (Artifact) -> Unit {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    return remember(context) {
+        { artifact ->
+            scope.launch { ArtifactDownloadHelper.share(context = context, artifact = artifact) }
         }
-        return Offset(0f, available.y)
-    }
-
-    override fun onPostScroll(
-        consumed: Offset,
-        available: Offset,
-        source: NestedScrollSource,
-    ): Offset {
-        return Offset(0f, available.y)
     }
 }
 

--- a/feature/chat/src/commonMain/composeResources/values/strings.xml
+++ b/feature/chat/src/commonMain/composeResources/values/strings.xml
@@ -304,6 +304,8 @@
     <string name="cd_next_version">Next version</string>
     <string name="artifact_version">v%1$d/%2$d</string>
     <string name="label_resource">Resource</string>
+    <string name="artifact_view_source">View source</string>
+    <string name="artifact_view_preview">View preview</string>
 
     <!-- Prompts -->
     <string name="prompts_library">Prompts Library</string>

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/MessageList.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/MessageList.kt
@@ -28,6 +28,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
@@ -211,7 +212,10 @@ fun MessageList(
         searchMatchIndices.map { it.messageIndex }.toSet()
     }
 
-    var hasScrolledToBottom by remember { mutableStateOf(false) }
+    // Saveable so it survives the list leaving/re-entering composition (e.g. the
+    // full-screen artifact route disposes the chat entry); otherwise the initial
+    // scroll re-fires on return and overrides the restored scroll position.
+    var hasScrolledToBottom by rememberSaveable { mutableStateOf(false) }
     LaunchedEffect(displayMessages.size) {
         if (!hasScrolledToBottom && displayMessages.isNotEmpty()) {
             listState.scrollToItem(totalItemCount - 1, scrollOffset = Int.MAX_VALUE)

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/TextArtifactContentPart.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/TextArtifactContentPart.kt
@@ -5,17 +5,12 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.LayoutCoordinates
 import androidx.compose.ui.unit.dp
 import com.garfiec.librechat.core.ui.theme.isSurfaceDark
-import com.garfiec.librechat.feature.chat.components.artifact.Artifact
 import com.garfiec.librechat.feature.chat.components.artifact.ArtifactButton
-import com.garfiec.librechat.feature.chat.components.artifact.ArtifactPanel
 import com.garfiec.librechat.feature.chat.components.artifact.ArtifactSegment
 import com.garfiec.librechat.feature.chat.components.artifact.ArtifactType
 import com.garfiec.librechat.feature.chat.components.artifact.InlineArtifactStrategy
@@ -25,6 +20,7 @@ import com.garfiec.librechat.feature.chat.components.artifact.InlineSvgArtifact
 import com.garfiec.librechat.feature.chat.components.artifact.InlineSvgSurface
 import com.garfiec.librechat.feature.chat.components.artifact.LocalInlineArtifactPrefs
 import com.garfiec.librechat.feature.chat.components.artifact.LocalMermaidRenderCache
+import com.garfiec.librechat.feature.chat.components.artifact.LocalOpenArtifact
 import com.garfiec.librechat.feature.chat.components.artifact.detectArtifacts
 import com.garfiec.librechat.feature.chat.components.artifact.groupArtifactVersions
 import com.garfiec.librechat.feature.chat.components.artifact.isCacheableMermaid
@@ -62,9 +58,7 @@ internal fun TextContentPart(
     } else {
         val versionMap = remember(segments) { groupArtifactVersions(segments) }
         val inlinePrefs = LocalInlineArtifactPrefs.current
-        var activeArtifact by remember {
-            mutableStateOf<Artifact?>(null)
-        }
+        val openArtifact = LocalOpenArtifact.current
         Column(modifier = modifier) {
             segments.forEach { segment ->
                 when (segment) {
@@ -88,13 +82,13 @@ internal fun TextContentPart(
                             when (val strategy = selectInlineArtifactStrategy(type, segment.artifact.content, cachedSvg)) {
                                 is InlineArtifactStrategy.CachedMermaidSvg -> InlineSvgSurface(
                                     svg = strategy.svg,
-                                    onTap = { activeArtifact = segment.artifact },
+                                    onTap = { openArtifact?.invoke(segment.artifact, versions) },
                                     modifier = Modifier.fillMaxWidth(),
                                     contentPadding = 4.dp,
                                 )
                                 InlineArtifactStrategy.NativeMarkdown -> InlineMarkdownArtifact(
                                     artifact = segment.artifact,
-                                    onTap = { activeArtifact = segment.artifact },
+                                    onTap = { openArtifact?.invoke(segment.artifact, versions) },
                                     modifier = Modifier.fillMaxWidth(),
                                     fontSizeMultiplier = fontSizeMultiplier,
                                     searchQuery = searchQuery,
@@ -103,19 +97,19 @@ internal fun TextContentPart(
                                 )
                                 InlineArtifactStrategy.IntrinsicSvg -> InlineSvgArtifact(
                                     artifact = segment.artifact,
-                                    onTap = { activeArtifact = segment.artifact },
+                                    onTap = { openArtifact?.invoke(segment.artifact, versions) },
                                     modifier = Modifier.fillMaxWidth(),
                                 )
                                 InlineArtifactStrategy.WebViewSlot -> InlineArtifactView(
                                     artifact = segment.artifact,
-                                    onTap = { activeArtifact = segment.artifact },
+                                    onTap = { openArtifact?.invoke(segment.artifact, versions) },
                                     modifier = Modifier.fillMaxWidth(),
                                 )
                             }
                         } else {
                             ArtifactButton(
                                 artifact = segment.artifact,
-                                onClick = { activeArtifact = segment.artifact },
+                                onClick = { openArtifact?.invoke(segment.artifact, versions) },
                                 versionCount = versions.size,
                             )
                         }
@@ -123,14 +117,6 @@ internal fun TextContentPart(
                     }
                 }
             }
-        }
-        activeArtifact?.let { artifact ->
-            val versions = versionMap[artifact.identifier] ?: listOf(artifact)
-            ArtifactPanel(
-                artifact = artifact,
-                onDismiss = { activeArtifact = null },
-                versions = versions,
-            )
         }
     }
 }

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/ArtifactViewerHandoff.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/ArtifactViewerHandoff.kt
@@ -1,0 +1,24 @@
+package com.garfiec.librechat.feature.chat.components.artifact
+
+/** Keeps large artifact payloads out of the full-screen route key. */
+class ArtifactViewerHandoff {
+
+    data class Entry(val artifact: Artifact, val versions: List<Artifact>)
+
+    private var pending: Entry? = null
+
+    fun put(artifact: Artifact, versions: List<Artifact>) {
+        pending = Entry(artifact, versions)
+    }
+
+    /** Returns the pending entry only when it was staged for [identifier]/[version]. */
+    fun peek(identifier: String, version: Int): Entry? {
+        val current = pending ?: return null
+        val a = current.artifact
+        return if (a.identifier == identifier && a.version == version) current else null
+    }
+
+    fun clear() {
+        pending = null
+    }
+}

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/LocalOpenArtifact.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/LocalOpenArtifact.kt
@@ -1,0 +1,15 @@
+package com.garfiec.librechat.feature.chat.components.artifact
+
+import androidx.compose.runtime.staticCompositionLocalOf
+
+/**
+ * Composition-scoped opener for an artifact viewer. Provided once at the chat/media
+ * navigation entry, which owns the screen-level presentation: it reads the display-mode
+ * pref and either pushes the full-screen `ArtifactFullscreen` route or shows a screen-root
+ * bottom sheet. Call sites deep in the message list (artifact buttons/inline views) just
+ * fire this event with the tapped artifact and its version history.
+ *
+ * Null when no navigation host is in scope (e.g. previews/tests); callers no-op the tap.
+ */
+val LocalOpenArtifact =
+    staticCompositionLocalOf<((Artifact, List<Artifact>) -> Unit)?> { null }

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/PlatformArtifactPanel.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/PlatformArtifactPanel.kt
@@ -1,13 +1,333 @@
 package com.garfiec.librechat.feature.chat.components.artifact
 
+import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Code
+import androidx.compose.material.icons.filled.Fullscreen
+import androidx.compose.material.icons.filled.Share
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material3.BottomSheetDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.garfiec.librechat.core.ui.theme.isSurfaceDark
+import com.garfiec.librechat.feature.chat.components.CodeBlock
+import com.garfiec.librechat.feature.chat.resources.Res
+import com.garfiec.librechat.feature.chat.resources.artifact_view_preview
+import com.garfiec.librechat.feature.chat.resources.artifact_view_source
+import com.garfiec.librechat.feature.chat.resources.cd_close
+import com.garfiec.librechat.feature.chat.resources.cd_fullscreen
+import com.garfiec.librechat.feature.chat.resources.cd_share_artifact
+import org.jetbrains.compose.resources.stringResource
 
-/** Platform-specific artifact panel with WebView preview. */
+/**
+ * The platform-specific preview renderer for an artifact — an Android `WebView`
+ * or an iOS `WKWebView`. Everything else about the artifact viewer (shell,
+ * header, selector, code body) is shared in [ArtifactPanel] below.
+ */
 @Composable
-expect fun ArtifactPanel(
+expect fun ArtifactPreviewSurface(
+    content: String,
+    type: String,
+    isDarkTheme: Boolean,
+    modifier: Modifier = Modifier,
+)
+
+/**
+ * Returns a share action for the current platform. Android routes through
+ * `ArtifactDownloadHelper` (needs a `Context`); iOS uses `UIActivityViewController`.
+ */
+@Composable
+expect fun rememberShareArtifact(): (Artifact) -> Unit
+
+private enum class ArtifactTab { CODE, PREVIEW }
+
+private fun isPreviewableType(type: String): Boolean =
+    when (ArtifactType.from(type)) {
+        ArtifactType.MERMAID,
+        ArtifactType.REACT,
+        ArtifactType.SVG,
+        ArtifactType.MARKDOWN,
+        ArtifactType.HTML,
+        ArtifactType.PLAIN,
+        -> true
+        ArtifactType.CODE -> false
+    }
+
+/**
+ * Bottom-sheet artifact viewer. Rendered at the screen root by the navigation entry's
+ * artifact opener (see `LocalOpenArtifact`), not inline in the message list. Previewable
+ * artifacts open on the Preview tab; the source stays reachable from the header
+ * source/preview toggle. [onExpandFullscreen] (when non-null) backs the expand action,
+ * promoting the currently-viewed version to the full-screen route.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ArtifactPanel(
     artifact: Artifact,
     onDismiss: () -> Unit,
     modifier: Modifier = Modifier,
+    onExpandFullscreen: ((Artifact, List<Artifact>) -> Unit)? = null,
     versions: List<Artifact> = listOf(artifact),
-)
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = false)
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        modifier = modifier.fillMaxSize(),
+        dragHandle = { BottomSheetDefaults.DragHandle() },
+        shape = RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp),
+    ) {
+        ArtifactViewer(
+            artifact = artifact,
+            versions = versions,
+            isFullscreen = false,
+            onClose = onDismiss,
+            // The expand action opens the full-screen route with the currently-viewed version.
+            onExpand = onExpandFullscreen?.let { expand -> { current -> expand(current, versions); onDismiss() } },
+            modifier = Modifier.fillMaxSize().navigationBarsPadding(),
+        )
+    }
+}
+
+/**
+ * Stateful artifact viewer used by both the bottom-sheet shell and the full-screen
+ * route. Holds the selected version and Code/Preview tab; renders [ArtifactViewerBody].
+ *
+ * [onExpand] (null when no expand action is available) receives the currently-viewed
+ * version so the full-screen route opens on the same one.
+ */
+@Composable
+internal fun ArtifactViewer(
+    artifact: Artifact,
+    versions: List<Artifact>,
+    isFullscreen: Boolean,
+    onClose: () -> Unit,
+    onExpand: ((Artifact) -> Unit)?,
+    modifier: Modifier = Modifier,
+) {
+    var currentVersionIndex by remember {
+        mutableIntStateOf(
+            versions.indexOfFirst {
+                it.identifier == artifact.identifier && it.version == artifact.version
+            }.coerceAtLeast(0),
+        )
+    }
+    val currentArtifact = versions.getOrElse(currentVersionIndex) { artifact }
+    val isPreviewable = isPreviewableType(currentArtifact.type)
+
+    // Previewable artifacts open on Preview; code-only artifacts have nothing else to show.
+    var selectedTab by remember {
+        mutableStateOf(if (isPreviewable) ArtifactTab.PREVIEW else ArtifactTab.CODE)
+    }
+
+    val isDarkTheme = isSurfaceDark()
+    val shareArtifact = rememberShareArtifact()
+
+    ArtifactViewerBody(
+        artifact = currentArtifact,
+        versionCount = versions.size,
+        currentVersionIndex = currentVersionIndex,
+        onPreviousVersion = { if (currentVersionIndex > 0) currentVersionIndex-- },
+        onNextVersion = { if (currentVersionIndex < versions.size - 1) currentVersionIndex++ },
+        isPreviewable = isPreviewable,
+        selectedTab = selectedTab,
+        onSelectTab = { selectedTab = it },
+        isDarkTheme = isDarkTheme,
+        isFullscreen = isFullscreen,
+        canExpand = onExpand != null,
+        onExpand = { onExpand?.invoke(currentArtifact) },
+        onClose = onClose,
+        onShare = { shareArtifact(currentArtifact) },
+        modifier = modifier,
+    )
+}
+
+@Composable
+private fun ArtifactViewerBody(
+    artifact: Artifact,
+    versionCount: Int,
+    currentVersionIndex: Int,
+    onPreviousVersion: () -> Unit,
+    onNextVersion: () -> Unit,
+    isPreviewable: Boolean,
+    selectedTab: ArtifactTab,
+    onSelectTab: (ArtifactTab) -> Unit,
+    isDarkTheme: Boolean,
+    isFullscreen: Boolean,
+    canExpand: Boolean,
+    onExpand: () -> Unit,
+    onClose: () -> Unit,
+    onShare: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier.fillMaxWidth()) {
+        // Compact single-row header: [close] title  [version nav]  [action buttons]
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(start = if (isFullscreen) 4.dp else 16.dp, end = 4.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            if (isFullscreen) {
+                IconButton(onClick = onClose) {
+                    Icon(
+                        imageVector = Icons.Default.Close,
+                        contentDescription = stringResource(Res.string.cd_close),
+                        tint = MaterialTheme.colorScheme.onSurface,
+                    )
+                }
+            }
+            Text(
+                text = artifact.title,
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.weight(1f),
+            )
+            if (versionCount > 1) {
+                ArtifactVersionNav(
+                    currentIndex = currentVersionIndex,
+                    totalVersions = versionCount,
+                    onPrevious = onPreviousVersion,
+                    onNext = onNextVersion,
+                )
+            }
+            ArtifactActionButtons(
+                isPreviewable = isPreviewable,
+                selectedTab = selectedTab,
+                onSelectTab = onSelectTab,
+                canExpand = canExpand,
+                onExpand = onExpand,
+                onShare = onShare,
+            )
+        }
+
+        Box(modifier = Modifier.fillMaxWidth().weight(1f)) {
+            // Keep the preview surface mounted across toggles; swapping it out would
+            // recreate the WebView and reload it (a full-panel flash). Code layers on top.
+            if (isPreviewable) {
+                ArtifactPreviewSurface(
+                    content = artifact.content,
+                    type = artifact.type,
+                    isDarkTheme = isDarkTheme,
+                    modifier = Modifier.fillMaxSize(),
+                )
+            }
+            if (!isPreviewable || selectedTab == ArtifactTab.CODE) {
+                val codeScrollState = rememberScrollState()
+                // Edge-to-edge preview, but keep horizontal padding on code for readability.
+                var codeModifier = Modifier
+                    .fillMaxSize()
+                    .background(MaterialTheme.colorScheme.surface)
+                    .padding(horizontal = 16.dp)
+                if (!isFullscreen) {
+                    // Isolate code scrolling from the bottom sheet's drag gesture.
+                    codeModifier = codeModifier.nestedScroll(remember { SheetScrollBlocker(codeScrollState) })
+                }
+                Box(modifier = codeModifier.verticalScroll(codeScrollState)) {
+                    CodeBlock(
+                        code = artifact.content,
+                        language = artifact.language,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun RowScope.ArtifactActionButtons(
+    isPreviewable: Boolean,
+    selectedTab: ArtifactTab,
+    onSelectTab: (ArtifactTab) -> Unit,
+    canExpand: Boolean,
+    onExpand: () -> Unit,
+    onShare: () -> Unit,
+) {
+    val tint = MaterialTheme.colorScheme.onSurfaceVariant
+    // Source/preview toggle for previewable artifacts.
+    if (isPreviewable) {
+        val toCode = selectedTab == ArtifactTab.PREVIEW
+        IconButton(onClick = { onSelectTab(if (toCode) ArtifactTab.CODE else ArtifactTab.PREVIEW) }) {
+            Icon(
+                imageVector = if (toCode) Icons.Default.Code else Icons.Default.Visibility,
+                contentDescription = stringResource(
+                    if (toCode) Res.string.artifact_view_source else Res.string.artifact_view_preview,
+                ),
+                tint = tint,
+            )
+        }
+    }
+    IconButton(onClick = onShare) {
+        Icon(
+            imageVector = Icons.Default.Share,
+            contentDescription = stringResource(Res.string.cd_share_artifact),
+            tint = tint,
+        )
+    }
+    if (canExpand) {
+        IconButton(onClick = onExpand) {
+            Icon(
+                imageVector = Icons.Default.Fullscreen,
+                contentDescription = stringResource(Res.string.cd_fullscreen),
+                tint = tint,
+            )
+        }
+    }
+}
+
+/**
+ * Intercepts all vertical scroll and manually dispatches it to the given [ScrollState],
+ * then reports it all as consumed so the parent ModalBottomSheet never receives it.
+ * This isolates the content's scrolling from the sheet's drag gesture.
+ */
+private class SheetScrollBlocker(private val scrollState: ScrollState) : NestedScrollConnection {
+    override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
+        if (available.y != 0f) {
+            scrollState.dispatchRawDelta(-available.y)
+        }
+        return Offset(0f, available.y)
+    }
+
+    override fun onPostScroll(
+        consumed: Offset,
+        available: Offset,
+        source: NestedScrollSource,
+    ): Offset {
+        return Offset(0f, available.y)
+    }
+}

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/di/ChatModule.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/di/ChatModule.kt
@@ -1,6 +1,7 @@
 package com.garfiec.librechat.feature.chat.di
 
 import com.garfiec.librechat.core.common.di.KoinQualifiers
+import com.garfiec.librechat.feature.chat.components.artifact.ArtifactViewerHandoff
 import com.garfiec.librechat.feature.chat.prompts.PromptEditorViewModel
 import com.garfiec.librechat.feature.chat.prompts.PromptsViewModel
 import com.garfiec.librechat.feature.chat.viewmodel.ConversationMediaViewModel
@@ -13,6 +14,7 @@ import org.koin.dsl.module
 val chatModule = module {
     includes(chatPlatformModule)
     single { NewChatSelectionHandoff() }
+    single { ArtifactViewerHandoff() }
     viewModelOf(::PromptsViewModel)
     // Koin's constructor-DSL (`viewModelOf`) wires every argument via `get()` and cannot read
     // values passed through `parametersOf`. This VM receives its `initialGroupId` from the

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/navigation/ChatNavigation.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/navigation/ChatNavigation.kt
@@ -1,9 +1,24 @@
 package com.garfiec.librechat.feature.chat.navigation
 
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation3.runtime.EntryProviderScope
 import androidx.navigation3.runtime.NavKey
+import com.garfiec.librechat.core.data.datastore.ArtifactDisplayMode
+import com.garfiec.librechat.core.data.datastore.ArtifactDisplayPrefs
+import com.garfiec.librechat.core.data.datastore.SettingsDataStore
+import com.garfiec.librechat.feature.chat.components.artifact.Artifact
+import com.garfiec.librechat.feature.chat.components.artifact.ArtifactPanel
+import com.garfiec.librechat.feature.chat.components.artifact.ArtifactViewerHandoff
+import com.garfiec.librechat.feature.chat.components.artifact.LocalOpenArtifact
 import com.garfiec.librechat.feature.chat.prompts.PromptEditorScreen
 import com.garfiec.librechat.feature.chat.prompts.PromptsLibraryScreen
+import com.garfiec.librechat.feature.chat.screen.ArtifactFullscreenScreen
 import com.garfiec.librechat.feature.chat.screen.ChatScreen
 import com.garfiec.librechat.feature.chat.screen.ConversationMediaScreen
 import com.garfiec.librechat.feature.chat.screen.NewChatScreen
@@ -11,6 +26,7 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.polymorphic
 import kotlinx.serialization.modules.subclass
+import org.koin.compose.koinInject
 
 @Serializable sealed interface ChatRoute : NavKey
 
@@ -27,6 +43,12 @@ import kotlinx.serialization.modules.subclass
 
 /** Telegram-style "Show all media" gallery for a single conversation. */
 @Serializable data class ConversationMedia(val conversationId: String) : ChatRoute
+
+/**
+ * Full-screen artifact viewer. Carries only the lightweight identity; the artifact's
+ * (potentially large) content is handed off in-memory via [ArtifactViewerHandoff].
+ */
+@Serializable data class ArtifactFullscreen(val identifier: String, val version: Int) : ChatRoute
 
 fun EntryProviderScope<NavKey>.chatEntries(
     onNavigate: (NavKey) -> Unit,
@@ -53,21 +75,32 @@ fun EntryProviderScope<NavKey>.chatEntries(
         )
     }
     entry<Chat> { key ->
-        ChatScreen(
-            conversationId = key.conversationId,
-            onOpenDrawer = onOpenDrawer,
-            onNavigateToPromptsLibrary = { onNavigate(PromptsLibrary) },
-            onNavigateBack = onBack,
-            onNavigateToConversation = { conversationId -> onNavigateToChat(conversationId) },
-            // Null on a new chat with no id yet, which hides the overflow menu item.
-            onShowAllMedia = key.conversationId?.let { id -> { onNavigate(ConversationMedia(id)) } },
-            onNavigateToProviderKeys = onNavigateToProviderKeys,
-        )
+        ProvideOpenArtifact(onNavigate) {
+            ChatScreen(
+                conversationId = key.conversationId,
+                onOpenDrawer = onOpenDrawer,
+                onNavigateToPromptsLibrary = { onNavigate(PromptsLibrary) },
+                onNavigateBack = onBack,
+                onNavigateToConversation = { conversationId -> onNavigateToChat(conversationId) },
+                // Null on a new chat with no id yet, which hides the overflow menu item.
+                onShowAllMedia = key.conversationId?.let { id -> { onNavigate(ConversationMedia(id)) } },
+                onNavigateToProviderKeys = onNavigateToProviderKeys,
+            )
+        }
     }
     entry<ConversationMedia> { key ->
-        ConversationMediaScreen(
-            conversationId = key.conversationId,
-            onNavigateBack = onBack,
+        ProvideOpenArtifact(onNavigate) {
+            ConversationMediaScreen(
+                conversationId = key.conversationId,
+                onNavigateBack = onBack,
+            )
+        }
+    }
+    entry<ArtifactFullscreen> { key ->
+        ArtifactFullscreenScreen(
+            identifier = key.identifier,
+            version = key.version,
+            onBack = onBack,
         )
     }
     entry<PromptsLibrary> {
@@ -87,6 +120,57 @@ fun EntryProviderScope<NavKey>.chatEntries(
     }
 }
 
+/**
+ * Owns the screen-level artifact presentation and provides [LocalOpenArtifact] so artifacts
+ * tapped deep in the message list just fire an event. Honoring the display-mode pref it either
+ * pushes the [ArtifactFullscreen] route (payload staged in [ArtifactViewerHandoff]; real nav
+ * destination → predictive back) or shows a bottom sheet rendered here at the screen root —
+ * not inline in the list, so it survives the tapped item scrolling off-screen.
+ */
+@Composable
+private fun ProvideOpenArtifact(
+    onNavigate: (NavKey) -> Unit,
+    content: @Composable () -> Unit,
+) {
+    val handoff = koinInject<ArtifactViewerHandoff>()
+    val settingsDataStore = koinInject<SettingsDataStore>()
+    // Held as State, not read via `by` at composable scope: the mode only matters at tap time, so
+    // reading it inside the lambda keeps a pref change from recomposing the whole content() subtree.
+    val displayPrefs = settingsDataStore.artifactDisplayPrefs
+        .collectAsStateWithLifecycle(ArtifactDisplayPrefs())
+
+    var sheetRequest by remember { mutableStateOf<ArtifactViewerHandoff.Entry?>(null) }
+
+    val openFullscreen = remember(onNavigate, handoff) {
+        { artifact: Artifact, versions: List<Artifact> ->
+            handoff.put(artifact, versions)
+            onNavigate(ArtifactFullscreen(artifact.identifier, artifact.version))
+        }
+    }
+    val openArtifact = remember(openFullscreen) {
+        { artifact: Artifact, versions: List<Artifact> ->
+            if (displayPrefs.value.mode == ArtifactDisplayMode.FULLSCREEN) {
+                openFullscreen(artifact, versions)
+            } else {
+                sheetRequest = ArtifactViewerHandoff.Entry(artifact, versions)
+            }
+        }
+    }
+
+    CompositionLocalProvider(LocalOpenArtifact provides openArtifact) {
+        content()
+    }
+
+    sheetRequest?.let { req ->
+        ArtifactPanel(
+            artifact = req.artifact,
+            versions = req.versions,
+            onDismiss = { sheetRequest = null },
+            onExpandFullscreen = openFullscreen,
+        )
+    }
+}
+
 val chatSerializersModule = SerializersModule {
     polymorphic(NavKey::class) {
         subclass(NewChat::class, NewChat.serializer())
@@ -94,5 +178,6 @@ val chatSerializersModule = SerializersModule {
         subclass(PromptsLibrary::class, PromptsLibrary.serializer())
         subclass(PromptEditor::class, PromptEditor.serializer())
         subclass(ConversationMedia::class, ConversationMedia.serializer())
+        subclass(ArtifactFullscreen::class, ArtifactFullscreen.serializer())
     }
 }

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/screen/ArtifactFullscreenScreen.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/screen/ArtifactFullscreenScreen.kt
@@ -1,0 +1,58 @@
+package com.garfiec.librechat.feature.chat.screen
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.Modifier
+import com.garfiec.librechat.feature.chat.components.artifact.ArtifactViewer
+import com.garfiec.librechat.feature.chat.components.artifact.ArtifactViewerHandoff
+import org.koin.compose.koinInject
+
+/**
+ * Full-screen artifact viewer, presented as a navigation route so it inherits the
+ * NavDisplay's predictive-back gestures. The artifact payload is read from the
+ * in-process [ArtifactViewerHandoff] keyed by the route's [identifier]/[version];
+ * if the slot is empty (e.g. process death restored the route) the screen pops itself.
+ */
+@Composable
+fun ArtifactFullscreenScreen(
+    identifier: String,
+    version: Int,
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val handoff = koinInject<ArtifactViewerHandoff>()
+    val entry = handoff.peek(identifier, version)
+    val latestOnBack by rememberUpdatedState(onBack)
+
+    if (entry == null) {
+        LaunchedEffect(Unit) { latestOnBack() }
+        return
+    }
+
+    // Clear the slot when the route leaves so a stale payload can't linger.
+    DisposableEffect(Unit) {
+        onDispose { handoff.clear() }
+    }
+
+    Surface(
+        modifier = modifier.fillMaxSize(),
+        color = MaterialTheme.colorScheme.surface,
+    ) {
+        ArtifactViewer(
+            artifact = entry.artifact,
+            versions = entry.versions,
+            isFullscreen = true,
+            onClose = onBack,
+            onExpand = null,
+            modifier = Modifier.fillMaxSize().statusBarsPadding().navigationBarsPadding(),
+        )
+    }
+}

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/screen/ConversationMediaScreen.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/screen/ConversationMediaScreen.kt
@@ -35,7 +35,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
@@ -59,7 +58,7 @@ import com.garfiec.librechat.core.ui.media.rememberShareFile
 import com.garfiec.librechat.core.ui.media.rememberShareImage
 import com.garfiec.librechat.feature.chat.components.artifact.Artifact
 import com.garfiec.librechat.feature.chat.components.artifact.ArtifactButton
-import com.garfiec.librechat.feature.chat.components.artifact.ArtifactPanel
+import com.garfiec.librechat.feature.chat.components.artifact.LocalOpenArtifact
 import com.garfiec.librechat.feature.chat.resources.Res
 import com.garfiec.librechat.feature.chat.resources.cd_close
 import com.garfiec.librechat.feature.chat.resources.cd_image
@@ -352,10 +351,9 @@ private fun ArtifactsList(artifacts: List<List<Artifact>>) {
         )
         return
     }
-    // Tapping a card opens the shared ArtifactPanel with that artifact's full version history.
-    // Only the identifier is held (a Saveable String) so the open panel survives rotation; the
-    // version list is re-derived from [artifacts] each composition.
-    var activeIdentifier by rememberSaveable { mutableStateOf<String?>(null) }
+    // Tapping a card hands the artifact (with its full version history) to the screen-level
+    // opener, which presents it as a bottom sheet or full-screen route per the display pref.
+    val openArtifact = LocalOpenArtifact.current
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
         contentPadding = PaddingValues(16.dp),
@@ -364,20 +362,10 @@ private fun ArtifactsList(artifacts: List<List<Artifact>>) {
         items(artifacts, key = { it.first().identifier }) { versions ->
             ArtifactButton(
                 artifact = versions.last(),
-                onClick = { activeIdentifier = versions.first().identifier },
+                onClick = { openArtifact?.invoke(versions.last(), versions) },
                 versionCount = versions.size,
             )
         }
-    }
-    val activeVersions = activeIdentifier?.let { id ->
-        artifacts.firstOrNull { it.first().identifier == id }
-    }
-    activeVersions?.let { versions ->
-        ArtifactPanel(
-            artifact = versions.last(),
-            onDismiss = { activeIdentifier = null },
-            versions = versions,
-        )
     }
 }
 

--- a/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/PlatformArtifactPanel.ios.kt
+++ b/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/PlatformArtifactPanel.ios.kt
@@ -1,212 +1,77 @@
 package com.garfiec.librechat.feature.chat.components.artifact
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Close
-import androidx.compose.material.icons.filled.Share
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Tab
-import androidx.compose.material3.TabRow
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.viewinterop.UIKitView
-import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.window.Dialog
-import androidx.compose.ui.window.DialogProperties
-import com.garfiec.librechat.core.ui.theme.isSurfaceDark
-import com.garfiec.librechat.feature.chat.components.CodeBlock
 import com.garfiec.librechat.feature.chat.components.shareArtifact
-import com.garfiec.librechat.feature.chat.resources.Res
-import com.garfiec.librechat.feature.chat.resources.code
-import com.garfiec.librechat.feature.chat.resources.preview
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.cValue
-import org.jetbrains.compose.resources.stringResource
 import platform.Foundation.NSURL
 import platform.WebKit.WKWebView
 import platform.WebKit.WKWebViewConfiguration
 
-private fun isPreviewableType(type: String): Boolean =
-    when (ArtifactType.from(type)) {
-        ArtifactType.MERMAID,
-        ArtifactType.REACT,
-        ArtifactType.SVG,
-        ArtifactType.MARKDOWN,
-        ArtifactType.HTML,
-        ArtifactType.PLAIN,
-        -> true
-        ArtifactType.CODE -> false
-    }
-
+/**
+ * iOS preview surface — a `WKWebView` hosting the artifact's rendered HTML. The
+ * shell, header, selector, and code body are shared in the common `ArtifactPanel`.
+ */
 @OptIn(ExperimentalForeignApi::class)
 @Composable
-actual fun ArtifactPanel(
-    artifact: Artifact,
-    onDismiss: () -> Unit,
+actual fun ArtifactPreviewSurface(
+    content: String,
+    type: String,
+    isDarkTheme: Boolean,
     modifier: Modifier,
-    versions: List<Artifact>,
 ) {
-    var currentVersionIndex by remember {
-        mutableIntStateOf(versions.indexOfFirst { it.identifier == artifact.identifier && it.version == artifact.version }.coerceAtLeast(0))
-    }
-    val currentArtifact = versions.getOrElse(currentVersionIndex) { artifact }
-    val isPreviewable = isPreviewableType(currentArtifact.type)
-    var selectedTab by remember { mutableIntStateOf(0) }
-
-    val isDarkTheme = isSurfaceDark()
-
-    val html = remember(currentArtifact, isDarkTheme) {
-        ArtifactWebContent.buildHtml(currentArtifact.content, currentArtifact.type, isDarkTheme, inline = false)
+    val html = remember(content, type, isDarkTheme) {
+        ArtifactWebContent.buildHtml(content, type, isDarkTheme, inline = false)
     }
 
-    Dialog(
-        onDismissRequest = onDismiss,
-        properties = DialogProperties(usePlatformDefaultWidth = false),
-    ) {
-        Column(
-            modifier = modifier
-                .fillMaxSize()
-                .background(MaterialTheme.colorScheme.surface),
-        ) {
-            // Header
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .background(MaterialTheme.colorScheme.surfaceContainerHigh)
-                    .padding(horizontal = 8.dp, vertical = 4.dp),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                IconButton(onClick = onDismiss) {
-                    Icon(
-                        imageVector = Icons.Default.Close,
-                        contentDescription = "Close",
-                        tint = MaterialTheme.colorScheme.onSurface,
-                    )
-                }
-                Text(
-                    text = currentArtifact.title,
-                    style = MaterialTheme.typography.titleSmall,
-                    color = MaterialTheme.colorScheme.onSurface,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                    modifier = Modifier.weight(1f),
+    // Track what HTML is currently loaded to avoid reloading on every recomposition —
+    // version-nav swipes and shell animations otherwise re-trigger loadHTMLString and
+    // flash the WebView.
+    var loadedHtml by remember { mutableStateOf("") }
+    UIKitView(
+        modifier = modifier.fillMaxSize(),
+        factory = {
+            val config = WKWebViewConfiguration().apply {
+                defaultWebpagePreferences.allowsContentJavaScript = true
+            }
+            val webView = WKWebView(
+                frame = cValue { },
+                configuration = config,
+            )
+            webView.setOpaque(false)
+            webView.loadHTMLString(
+                html,
+                baseURL = NSURL.URLWithString("https://cdn.jsdelivr.net"),
+            )
+            loadedHtml = html
+            webView
+        },
+        update = { webView ->
+            if (html != loadedHtml) {
+                webView.loadHTMLString(
+                    html,
+                    baseURL = NSURL.URLWithString("https://cdn.jsdelivr.net"),
                 )
-                if (versions.size > 1) {
-                    ArtifactVersionNav(
-                        currentIndex = currentVersionIndex,
-                        totalVersions = versions.size,
-                        onPrevious = {
-                            if (currentVersionIndex > 0) currentVersionIndex--
-                        },
-                        onNext = {
-                            if (currentVersionIndex < versions.size - 1) currentVersionIndex++
-                        },
-                    )
-                }
-                IconButton(
-                    onClick = {
-                        shareArtifact(
-                            title = currentArtifact.title,
-                            content = currentArtifact.content,
-                            language = currentArtifact.language ?: "",
-                        )
-                    },
-                ) {
-                    Icon(
-                        imageVector = Icons.Default.Share,
-                        contentDescription = "Share",
-                        tint = MaterialTheme.colorScheme.onSurface,
-                    )
-                }
+                loadedHtml = html
             }
+        },
+    )
+}
 
-            if (isPreviewable) {
-                TabRow(selectedTabIndex = selectedTab) {
-                    Tab(
-                        selected = selectedTab == 0,
-                        onClick = { selectedTab = 0 },
-                        text = { Text(stringResource(Res.string.code)) },
-                    )
-                    Tab(
-                        selected = selectedTab == 1,
-                        onClick = { selectedTab = 1 },
-                        text = { Text(stringResource(Res.string.preview)) },
-                    )
-                }
-            }
-
-            // Content body
-            Box(modifier = Modifier.weight(1f).fillMaxWidth()) {
-                when {
-                    !isPreviewable || selectedTab == 0 -> {
-                        val codeScrollState = rememberScrollState()
-                        Box(
-                            modifier = Modifier
-                                .fillMaxSize()
-                                .padding(8.dp)
-                                .verticalScroll(codeScrollState),
-                        ) {
-                            CodeBlock(
-                                code = currentArtifact.content,
-                                language = currentArtifact.language,
-                                modifier = Modifier.fillMaxWidth(),
-                            )
-                        }
-                    }
-                    selectedTab == 1 -> {
-                        // Track what HTML is currently loaded to avoid reloading on every
-                        // recomposition — version-nav swipes and Dialog animations otherwise
-                        // re-trigger loadHTMLString and flash the WebView.
-                        var loadedHtml by remember { mutableStateOf("") }
-                        UIKitView(
-                            modifier = Modifier.fillMaxSize(),
-                            factory = {
-                                val config = WKWebViewConfiguration().apply {
-                                    defaultWebpagePreferences.allowsContentJavaScript = true
-                                }
-                                val webView = WKWebView(
-                                    frame = cValue { },
-                                    configuration = config,
-                                )
-                                webView.setOpaque(false)
-                                webView.loadHTMLString(
-                                    html,
-                                    baseURL = NSURL.URLWithString("https://cdn.jsdelivr.net"),
-                                )
-                                loadedHtml = html
-                                webView
-                            },
-                            update = { webView ->
-                                if (html != loadedHtml) {
-                                    webView.loadHTMLString(
-                                        html,
-                                        baseURL = NSURL.URLWithString("https://cdn.jsdelivr.net"),
-                                    )
-                                    loadedHtml = html
-                                }
-                            },
-                        )
-                    }
-                }
-            }
-        }
+@Composable
+actual fun rememberShareArtifact(): (Artifact) -> Unit = remember {
+    { artifact ->
+        shareArtifact(
+            title = artifact.title,
+            content = artifact.content,
+            language = artifact.language ?: "",
+        )
     }
 }

--- a/feature/settings/src/commonMain/composeResources/values/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values/strings.xml
@@ -185,6 +185,13 @@
 
     <!-- Artifacts -->
     <string name="section_artifacts">Artifacts</string>
+    <string name="artifact_viewer_title">Artifact viewer</string>
+    <string name="artifact_viewer_desc">How an artifact opens when you tap it.</string>
+    <string name="artifact_mode_bottom_sheet">Bottom sheet</string>
+    <string name="artifact_mode_bottom_sheet_desc">Slides up from the bottom; swipe down to dismiss.</string>
+    <string name="artifact_mode_fullscreen">Full screen</string>
+    <string name="artifact_mode_fullscreen_desc">Opens as a full-screen page with more room.</string>
+    <string name="artifact_inline_title">Render inline</string>
     <string name="artifacts_section_desc">Render artifacts directly in the chat instead of behind a tap-to-open card. Tap an inline artifact to open the fullscreen view.</string>
     <string name="inline_artifact_mermaid">Mermaid diagrams</string>
     <string name="inline_artifact_mermaid_desc">Render Mermaid flowcharts and diagrams inline</string>

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/ArtifactSettingsSection.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/ArtifactSettingsSection.kt
@@ -7,14 +7,21 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
+import com.garfiec.librechat.core.data.datastore.ArtifactDisplayMode
+import com.garfiec.librechat.core.data.datastore.ArtifactDisplayPrefs
 import com.garfiec.librechat.core.data.datastore.InlineArtifactPrefs
 import com.garfiec.librechat.feature.settings.resources.*
 import com.garfiec.librechat.feature.settings.resources.Res
@@ -23,6 +30,8 @@ import org.jetbrains.compose.resources.stringResource
 @Composable
 internal fun ArtifactSettingsSection(
     prefs: InlineArtifactPrefs,
+    displayPrefs: ArtifactDisplayPrefs,
+    onDisplayModeChange: (ArtifactDisplayMode) -> Unit,
     onMermaidChange: (Boolean) -> Unit,
     onSvgChange: (Boolean) -> Unit,
     onHtmlChange: (Boolean) -> Unit,
@@ -36,6 +45,60 @@ internal fun ArtifactSettingsSection(
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp, vertical = 8.dp),
         ) {
+            Text(
+                text = stringResource(Res.string.artifact_viewer_title),
+                style = MaterialTheme.typography.bodyLarge,
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = stringResource(Res.string.artifact_viewer_desc),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            listOf(
+                ArtifactDisplayMode.BOTTOM_SHEET to (
+                    stringResource(Res.string.artifact_mode_bottom_sheet) to
+                        stringResource(Res.string.artifact_mode_bottom_sheet_desc)
+                ),
+                ArtifactDisplayMode.FULLSCREEN to (
+                    stringResource(Res.string.artifact_mode_fullscreen) to
+                        stringResource(Res.string.artifact_mode_fullscreen_desc)
+                ),
+            ).forEach { (mode, labelAndDesc) ->
+                val (label, description) = labelAndDesc
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clip(RoundedCornerShape(8.dp))
+                        .selectable(
+                            selected = displayPrefs.mode == mode,
+                            onClick = { onDisplayModeChange(mode) },
+                            role = Role.RadioButton,
+                        )
+                        .padding(vertical = 8.dp, horizontal = 4.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    RadioButton(selected = displayPrefs.mode == mode, onClick = null)
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Column {
+                        Text(text = label, style = MaterialTheme.typography.bodyLarge)
+                        Text(
+                            text = description,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+            }
+
+            HorizontalDivider(modifier = Modifier.padding(vertical = 16.dp))
+
+            Text(
+                text = stringResource(Res.string.artifact_inline_title),
+                style = MaterialTheme.typography.bodyLarge,
+            )
+            Spacer(modifier = Modifier.height(4.dp))
             Text(
                 text = stringResource(Res.string.artifacts_section_desc),
                 style = MaterialTheme.typography.bodySmall,

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/ChatSettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/ChatSettingsScreen.kt
@@ -127,6 +127,8 @@ fun ChatSettingsContent(
             item(key = "artifacts_settings") {
                 ArtifactSettingsSection(
                     prefs = uiState.inlineArtifactPrefs,
+                    displayPrefs = uiState.artifactDisplayPrefs,
+                    onDisplayModeChange = viewModel::setArtifactDisplayMode,
                     onMermaidChange = viewModel::setInlineArtifactMermaid,
                     onSvgChange = viewModel::setInlineArtifactSvg,
                     onHtmlChange = viewModel::setInlineArtifactHtml,

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/SettingsPreferencesController.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/SettingsPreferencesController.kt
@@ -1,6 +1,8 @@
 package com.garfiec.librechat.feature.settings.viewmodel
 
 import com.garfiec.librechat.core.common.ChatLayoutConstants
+import com.garfiec.librechat.core.data.datastore.ArtifactDisplayMode
+import com.garfiec.librechat.core.data.datastore.ArtifactDisplayPrefs
 import com.garfiec.librechat.core.data.datastore.ChatFontSize
 import com.garfiec.librechat.core.data.datastore.InlineArtifactPrefs
 import com.garfiec.librechat.core.data.datastore.LatexRenderer
@@ -58,6 +60,7 @@ private data class AdditionalPreferences(
     val showBubbles: Boolean = false,
     val latexRenderer: LatexRenderer = LatexRenderer.KATEX,
     val inlineArtifactPrefs: InlineArtifactPrefs = InlineArtifactPrefs(),
+    val artifactDisplayPrefs: ArtifactDisplayPrefs = ArtifactDisplayPrefs(),
     val starredModelsDisplay: StarredModelsDisplay = StarredModelsDisplay.OFF,
     val selectedLanguage: String = SettingsDataStore.DEFAULT_LANGUAGE,
 )
@@ -147,6 +150,9 @@ class SettingsPreferencesController(
     private val inlineArtifactPrefsFlow: StateFlow<InlineArtifactPrefs> = settingsDataStore.inlineArtifactPrefs
         .stateIn(scope, SharingStarted.Eagerly, InlineArtifactPrefs())
 
+    private val artifactDisplayPrefsFlow: StateFlow<ArtifactDisplayPrefs> = settingsDataStore.artifactDisplayPrefs
+        .stateIn(scope, SharingStarted.Eagerly, ArtifactDisplayPrefs())
+
     private val starredModelsDisplayPref: StateFlow<StarredModelsDisplay> = settingsDataStore.starredModelsDisplay
         .stateIn(scope, SharingStarted.Eagerly, StarredModelsDisplay.OFF)
 
@@ -173,6 +179,8 @@ class SettingsPreferencesController(
         base.copy(chatLayoutStyle = layoutStyle, showAvatars = showAvatars, showBubbles = showBubbles, latexRenderer = latexRenderer)
     }.combine(inlineArtifactPrefsFlow) { additional, inlineArtifact ->
         additional.copy(inlineArtifactPrefs = inlineArtifact)
+    }.combine(artifactDisplayPrefsFlow) { additional, artifactDisplay ->
+        additional.copy(artifactDisplayPrefs = artifactDisplay)
     }.combine(starredModelsDisplayPref) { additional, starredDisplay ->
         additional.copy(starredModelsDisplay = starredDisplay)
     }.combine(selectedLanguagePref) { additional, selectedLanguage ->
@@ -217,6 +225,7 @@ class SettingsPreferencesController(
             showBubbles = additional.showBubbles,
             latexRenderer = additional.latexRenderer,
             inlineArtifactPrefs = additional.inlineArtifactPrefs,
+            artifactDisplayPrefs = additional.artifactDisplayPrefs,
             starredModelsDisplay = additional.starredModelsDisplay,
             selectedLanguage = additional.selectedLanguage,
         )
@@ -294,6 +303,10 @@ class SettingsPreferencesController(
 
     fun setInlineArtifactMarkdown(enabled: Boolean) {
         scope.launch { settingsDataStore.setInlineArtifactMarkdown(enabled) }
+    }
+
+    fun setArtifactDisplayMode(mode: ArtifactDisplayMode) {
+        scope.launch { settingsDataStore.setArtifactDisplayMode(mode) }
     }
 
     fun setTabletSidebarGestureEnabled(enabled: Boolean) {

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/SettingsUiState.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/SettingsUiState.kt
@@ -2,6 +2,7 @@ package com.garfiec.librechat.feature.settings.viewmodel
 
 import androidx.compose.runtime.Immutable
 import com.garfiec.librechat.core.common.ChatLayoutConstants
+import com.garfiec.librechat.core.data.datastore.ArtifactDisplayPrefs
 import com.garfiec.librechat.core.data.datastore.ChatFontSize
 import com.garfiec.librechat.core.data.datastore.InlineArtifactPrefs
 import com.garfiec.librechat.core.data.datastore.LatexRenderer
@@ -192,6 +193,8 @@ data class SettingsUiState(
     val starredModelsDisplay: StarredModelsDisplay = StarredModelsDisplay.OFF,
     // Inline artifact rendering (per-type toggles)
     val inlineArtifactPrefs: InlineArtifactPrefs = InlineArtifactPrefs(),
+    // Artifact viewer presentation (bottom sheet vs full screen + selector visibility)
+    val artifactDisplayPrefs: ArtifactDisplayPrefs = ArtifactDisplayPrefs(),
     // Role-permission gates. `serverMemoriesEnabled` is the SERVER-level MEMORIES.USE
     // gate and is orthogonal to [memoriesEnabled], which is the user's own opt-out
     // stored on their profile (`user.personalization.memories`).

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/SettingsViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/SettingsViewModel.kt
@@ -3,6 +3,7 @@ package com.garfiec.librechat.feature.settings.viewmodel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.garfiec.librechat.core.common.AppInfo
+import com.garfiec.librechat.core.data.datastore.ArtifactDisplayMode
 import com.garfiec.librechat.core.data.datastore.ChatFontSize
 import com.garfiec.librechat.core.data.datastore.LatexRenderer
 import com.garfiec.librechat.core.data.datastore.ServerDataStore
@@ -259,6 +260,10 @@ class SettingsViewModel(
 
     fun setInlineArtifactMarkdown(enabled: Boolean) {
         prefsController.setInlineArtifactMarkdown(enabled)
+    }
+
+    fun setArtifactDisplayMode(mode: ArtifactDisplayMode) {
+        prefsController.setArtifactDisplayMode(mode)
     }
 
     // ── Tablet preferences ─────────────────────────────────────────


### PR DESCRIPTION
## Summary
Reworks the artifact viewer into a preview-first, compact presentation, adds a full-screen viewing mode, and moves artifact presentation to the screen root. A new setting lets users choose how artifacts open.

## What changed
- **Preview-first compact viewer.** Previewable artifacts (Mermaid/SVG/HTML/React/Markdown) open directly on their rendered preview with a single compact header row and edge-to-edge content; source code stays reachable via the header selector / overflow.
- **Full-screen mode.** Artifacts can open as a full-screen page — a real Navigation 3 route (`ArtifactFullscreen`) with predictive back. The (potentially large) artifact content is handed off in memory, so the back stack carries only an identifier + version.
- **Screen-root presentation.** Artifact presentation is lifted out of the message list to the screen root behind a single `LocalOpenArtifact` opener, so an open artifact is no longer tied to its list item and stays put when that item scrolls off-screen.
- **Display-mode setting.** New "Artifact viewer" setting to choose how an artifact opens: **Bottom sheet** (default) or **Full screen**. Applies to both Android and iOS; iOS uses a Compose `ModalBottomSheet` for sheet mode.

## Testing
- Android: device-tested (previewable + code artifacts, Code/Preview toggle, share, full-screen route, settings mode switch). Compiles clean; detekt (commonMain) passes.
- iOS: compiles clean. Not device-tested.
