### PR TITLE
fix(auth): lift server URL and login fields above the keyboard

### DIFF
--- a/feature/auth/src/commonMain/kotlin/com/garfiec/librechat/feature/auth/screen/LoginScreen.kt
+++ b/feature/auth/src/commonMain/kotlin/com/garfiec/librechat/feature/auth/screen/LoginScreen.kt
@@ -7,8 +7,11 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
@@ -72,6 +75,8 @@ fun LoginScreen(
         modifier = modifier
             .fillMaxSize()
             .background(MaterialTheme.colorScheme.background)
+            .imePadding()
+            .verticalScroll(rememberScrollState())
             .padding(24.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,

--- a/feature/auth/src/commonMain/kotlin/com/garfiec/librechat/feature/auth/screen/ServerUrlScreen.kt
+++ b/feature/auth/src/commonMain/kotlin/com/garfiec/librechat/feature/auth/screen/ServerUrlScreen.kt
@@ -7,7 +7,10 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
@@ -57,6 +60,8 @@ fun ServerUrlScreen(
         modifier = modifier
             .fillMaxSize()
             .background(MaterialTheme.colorScheme.background)
+            .imePadding()
+            .verticalScroll(rememberScrollState())
             .padding(24.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,


### PR DESCRIPTION
## Summary
On the server-URL entry and login screens, tapping into a text field left the form centered behind the on-screen keyboard, hiding the field being edited. The content now shifts up so the focused field stays visible.

## Changes
- `ServerUrlScreen` and `LoginScreen`: add `imePadding()` to the root `Column` so the centered content recenters in the space above the IME.
- Add `verticalScroll(rememberScrollState())` to both so taller content (e.g. login with OAuth buttons) scrolls instead of clipping when the keyboard leaves little room.

## Why
The activity already sets `windowSoftInputMode="adjustResize"`, but under `enableEdgeToEdge()` that flag is a no-op — the app draws behind the IME and must consume the inset itself. These screens previously did neither.

## Testing
- Built and installed the debug APK on a physical device; verified content rises above the keyboard on both screens.
- Changes are in `commonMain` using multiplatform Compose modifiers, so iOS gets the same behavior.
