### PR TITLE
fix: lift tool-select search field above the keyboard

### DIFF
--- a/feature/agents/src/commonMain/kotlin/com/garfiec/librechat/feature/agents/components/ToolSelectDialog.kt
+++ b/feature/agents/src/commonMain/kotlin/com/garfiec/librechat/feature/agents/components/ToolSelectDialog.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -86,6 +87,7 @@ fun ToolSelectDialog(
         Surface(
             modifier = modifier
                 .fillMaxSize()
+                .imePadding()
                 .padding(16.dp),
             shape = RoundedCornerShape(16.dp),
             tonalElevation = 6.dp,


### PR DESCRIPTION
## Summary

Follow-up to #178. The IME sweep missed one composable: the agent **Tool Select** dialog. It is a full-screen `Dialog` (`usePlatformDefaultWidth = false`), which does not get the framework's automatic keyboard-lift that single-field centered `AlertDialog`s receive. With edge-to-edge enabled the content draws behind the soft keyboard, so the tool grid the user is filtering is covered while the search field is focused.

## Changes

- `ToolSelectDialog` — add `Modifier.imePadding()` to the full-screen Surface so the search field and tool grid stay above the keyboard.

## Notes

- Not device-tested yet.
