### PR TITLE
refactor(chat): route server-file picker results by conversation

### DIFF
--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/di/ChatPlatformModule.android.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/di/ChatPlatformModule.android.kt
@@ -49,6 +49,7 @@ actual val chatPlatformModule: Module = module {
             json = get(),
             defaultDispatcher = get(KoinQualifiers.Default),
             selectionHandoff = get(),
+            serverFileSelectionHandoff = get(),
         )
     }
 }

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatScreen.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatScreen.kt
@@ -12,7 +12,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -33,9 +32,7 @@ import com.garfiec.librechat.feature.chat.components.ChatInput
 import com.garfiec.librechat.feature.chat.components.ChatRoot
 import com.garfiec.librechat.feature.chat.components.InConvoSearchBar
 import com.garfiec.librechat.feature.chat.viewmodel.ChatViewModel
-import com.garfiec.librechat.feature.chat.viewmodel.ServerFileSelectionHandoff
 import com.garfiec.librechat.feature.chat.viewmodel.asString
-import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.parameter.parametersOf
 
@@ -57,19 +54,6 @@ actual fun ChatScreen(
     val viewModel: ChatViewModel = koinViewModel { parametersOf(conversationId, initialAgentId) }
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val attachedFiles by viewModel.attachedFiles.collectAsStateWithLifecycle()
-
-    // The server-file picker hands its selection back through this singleton (Nav3 has no result
-    // channel). The selection is tagged with the conversation that launched the picker, so we
-    // attach only our own — a selection meant for a different chat is left for that chat (or
-    // dropped) rather than mis-attached here.
-    val serverFileSelection = koinInject<ServerFileSelectionHandoff>()
-    LaunchedEffect(viewModel) {
-        serverFileSelection.selections.collect { selection ->
-            if (selection.targetConversationId == conversationId) {
-                viewModel.attachServerFiles(selection.files)
-            }
-        }
-    }
     val shareLinkUrl by viewModel.shareLinkUrl.collectAsStateWithLifecycle()
     val prefs by viewModel.chatPreferences.collectAsStateWithLifecycle()
     val showImageDescriptions = prefs.showImageDescriptions

--- a/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ServerFileSelectionHandoffTest.kt
+++ b/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ServerFileSelectionHandoffTest.kt
@@ -1,0 +1,61 @@
+package com.garfiec.librechat.feature.chat.viewmodel
+
+import com.garfiec.librechat.core.model.FileObject
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeoutOrNull
+import org.junit.Test
+
+class ServerFileSelectionHandoffTest {
+
+    private val files = listOf(
+        FileObject(
+            fileId = "file-1",
+            filename = "document.pdf",
+            filepath = "/files/user1/document.pdf",
+            type = "application/pdf",
+            bytes = 1024L,
+            createdAt = "2026-02-19T10:00:00.000Z",
+        ),
+    )
+
+    @Test
+    fun publishIsDeliveredToTheMatchingConversationCollector() = runTest {
+        val handoff = ServerFileSelectionHandoff()
+        handoff.publish("conv_A", files)
+
+        assertThat(handoff.selectionsFor("conv_A").first()).isEqualTo(files)
+    }
+
+    @Test
+    fun aDifferentConversationNeverReceivesAnotherConversationsSelection() = runTest {
+        val handoff = ServerFileSelectionHandoff()
+        handoff.publish("conv_A", files)
+
+        // conv_B has its own channel, so it must not consume conv_A's selection.
+        val leaked = withTimeoutOrNull(1_000) { handoff.selectionsFor("conv_B").first() }
+        assertThat(leaked).isNull()
+        // conv_A's selection is still waiting for conv_A.
+        assertThat(handoff.selectionsFor("conv_A").first()).isEqualTo(files)
+    }
+
+    @Test
+    fun nullKeyLandingHasItsOwnChannelSeparateFromIdentifiedChats() = runTest {
+        val handoff = ServerFileSelectionHandoff()
+        handoff.publish(null, files)
+
+        val leaked = withTimeoutOrNull(1_000) { handoff.selectionsFor("conv_A").first() }
+        assertThat(leaked).isNull()
+        assertThat(handoff.selectionsFor(null).first()).isEqualTo(files)
+    }
+
+    @Test
+    fun emptySelectionIsIgnored() = runTest {
+        val handoff = ServerFileSelectionHandoff()
+        handoff.publish("conv_A", emptyList())
+
+        val delivered = withTimeoutOrNull(1_000) { handoff.selectionsFor("conv_A").first() }
+        assertThat(delivered).isNull()
+    }
+}

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModel.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModel.kt
@@ -116,6 +116,7 @@ class ChatViewModel(
     private val json: Json,
     private val defaultDispatcher: CoroutineDispatcher,
     private val selectionHandoff: NewChatSelectionHandoff,
+    private val serverFileSelectionHandoff: ServerFileSelectionHandoff,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(ChatUiState())
@@ -371,6 +372,15 @@ class ChatViewModel(
         viewModelScope.launch {
             shareConsumer.shareAvailable.collect {
                 consumeShareIntent()
+            }
+        }
+
+        // Collect server-file picker results routed to this conversation's own channel
+        // (keyed by id; null for the NewChat landing). Consumed here in common code rather
+        // than per-platform in the screen — mirroring how NewChatSelectionHandoff is wired.
+        viewModelScope.launch {
+            serverFileSelectionHandoff.selectionsFor(initialConversationId).collect { files ->
+                attachServerFiles(files)
             }
         }
 
@@ -1312,7 +1322,7 @@ class ChatViewModel(
      * [AttachedFile] (`uploadProgress = 1f`, real `fileId`); the synthetic `uri = fileId` just gives
      * the chip a stable key for removal (mirrors iOS, which already uses a String uri).
      */
-    fun attachServerFiles(files: List<FileObject>) {
+    private fun attachServerFiles(files: List<FileObject>) {
         if (files.isEmpty()) return
         val baseUrl = uiState.value.serverUrl
         fileDelegate.addPreUploadedFiles(

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ServerFileSelectionHandoff.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ServerFileSelectionHandoff.kt
@@ -3,6 +3,7 @@ package com.garfiec.librechat.feature.chat.viewmodel
 import com.garfiec.librechat.core.model.FileObject
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.receiveAsFlow
 
 /**
@@ -10,36 +11,47 @@ import kotlinx.coroutines.flow.receiveAsFlow
  * (`FilesPicker` route) back to the chat composer that launched it.
  *
  * Why a [Channel] and not a `StateFlow`: the result must be delivered to exactly one consumer,
- * once. Navigation has no built-in result channel here (the pattern mirrors
- * [NewChatSelectionHandoff] / `ArtifactViewerHandoff`).
+ * once. Navigation has no built-in result channel here — this mirrors the event-based result
+ * pattern in the official Navigation 3 recipes (`ResultEventBus`), and the codebase's own
+ * [NewChatSelectionHandoff] / `ArtifactViewerHandoff`.
  *
- * Multiple chat ViewModels can be alive at once (the `NewChat` landing stays in the back stack
- * beneath an active `Chat`). A bare [Channel] fans each element out to whichever collector receives
- * first, with no guarantee it is the launcher — so every [Selection] carries the
- * [targetConversationId][Selection.targetConversationId] captured when the picker was opened, and a
- * chat screen attaches the files only when it matches its own conversation. A buffered channel lets
- * the picker [publish] before the returning screen recomposes; the matching collector consumes it
- * once, and a mismatched/stale selection is dropped rather than mis-attached to the wrong chat.
+ * Why a channel **per launcher** rather than one shared channel filtered by id: multiple chat
+ * screens can collect at once (the `NewChat` landing sits in the back stack beneath an active
+ * `Chat`, and two-pane scenes compose both at once). A single [Channel] fans each element out to
+ * whichever collector receives first; if that is not the launcher, a filtered collector would
+ * consume and drop the element, so the launcher never sees it. Keying a channel to the launching
+ * [conversationId][publish] (matching the recipe's per-key `channelMap`) delivers each selection
+ * straight to its launcher's own collector — no race, no drop.
+ *
+ * Confined to the main thread: [publish] runs from the picker's confirm callback and
+ * [selectionsFor] is collected on the chat ViewModel's main-dispatched scope, so the backing map
+ * needs no synchronization. A buffered channel lets [publish] stage the selection before the
+ * returning chat resumes collecting. Each conversation's channel is evicted when its collector
+ * completes (the ViewModel is destroyed), so the map can't grow for the whole process lifetime.
  */
 class ServerFileSelectionHandoff {
 
+    /** Lazily-created buffered channel per launching conversation (`null` = the `NewChat` landing). */
+    private val channels = mutableMapOf<String?, Channel<List<FileObject>>>()
+
+    private fun channelFor(conversationId: String?): Channel<List<FileObject>> =
+        channels.getOrPut(conversationId) { Channel(Channel.BUFFERED) }
+
     /**
-     * @param targetConversationId the conversation that launched the picker (`null` for the
-     *   `NewChat` landing, which has no id yet). Used to route the result to its launcher.
+     * Files staged for [conversationId]; collected by that conversation's chat screen.
+     *
+     * @param conversationId the conversation collecting results (`null` for the `NewChat` landing).
      */
-    data class Selection(
-        val targetConversationId: String?,
-        val files: List<FileObject>,
-    )
+    fun selectionsFor(conversationId: String?): Flow<List<FileObject>> =
+        channelFor(conversationId).receiveAsFlow()
+            .onCompletion { channels.remove(conversationId) }
 
-    private val channel = Channel<Selection>(Channel.BUFFERED)
-
-    /** Selections emitted by the picker; collected by the foreground chat screen. */
-    val selections: Flow<Selection> = channel.receiveAsFlow()
-
-    /** Stages the picked files for [targetConversationId]. Ignored when the list is empty. */
+    /**
+     * Stages the picked files for [targetConversationId] (the conversation that launched the
+     * picker; `null` for the `NewChat` landing, which has no id yet). Ignored when the list is empty.
+     */
     fun publish(targetConversationId: String?, files: List<FileObject>) {
         if (files.isEmpty()) return
-        channel.trySend(Selection(targetConversationId, files))
+        channelFor(targetConversationId).trySend(files)
     }
 }

--- a/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/di/ChatPlatformModule.ios.kt
+++ b/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/di/ChatPlatformModule.ios.kt
@@ -47,6 +47,7 @@ actual val chatPlatformModule: Module = module {
             json = get(),
             defaultDispatcher = get(KoinQualifiers.Default),
             selectionHandoff = get(),
+            serverFileSelectionHandoff = get(),
         )
     }
 }

--- a/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/screen/PlatformScreens.ios.kt
+++ b/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/screen/PlatformScreens.ios.kt
@@ -83,11 +83,9 @@ import com.garfiec.librechat.feature.chat.util.openPhotoPicker
 import com.garfiec.librechat.feature.chat.util.readClipboardImage
 import com.garfiec.librechat.feature.chat.viewmodel.ChatScreenState
 import com.garfiec.librechat.feature.chat.viewmodel.ChatViewModel
-import com.garfiec.librechat.feature.chat.viewmodel.ServerFileSelectionHandoff
 import com.garfiec.librechat.feature.chat.viewmodel.asString
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
-import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.parameter.parametersOf
 
@@ -109,19 +107,6 @@ actual fun ChatScreen(
     val viewModel: ChatViewModel = koinViewModel { parametersOf(conversationId, initialAgentId) }
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val attachedFiles by viewModel.attachedFiles.collectAsStateWithLifecycle()
-
-    // The server-file picker hands its selection back through this singleton (Nav3 has no result
-    // channel). The selection is tagged with the conversation that launched the picker, so we
-    // attach only our own — a selection meant for a different chat is left for that chat (or
-    // dropped) rather than mis-attached here.
-    val serverFileSelection = koinInject<ServerFileSelectionHandoff>()
-    LaunchedEffect(viewModel) {
-        serverFileSelection.selections.collect { selection ->
-            if (selection.targetConversationId == conversationId) {
-                viewModel.attachServerFiles(selection.files)
-            }
-        }
-    }
     val prefs by viewModel.chatPreferences.collectAsStateWithLifecycle()
 
     val isLandingPage = uiState.screenState == ChatScreenState.LANDING


### PR DESCRIPTION
## Summary

The "From server" file picker (#184) handed its selection back through a single shared channel filtered by conversation id. When more than one chat screen collected at once, the shared channel could deliver a selection to the wrong collector, which then consumed and dropped it. This routes each selection to its launching conversation's own channel and consolidates collection into the ViewModel.

## Changes

- **Per-conversation routing:** `ServerFileSelectionHandoff` keeps one buffered channel per launching conversation id (`null` = the NewChat landing) instead of a single shared channel + collector-side filter. Each selection reaches only the chat that opened the picker. Mirrors the Navigation 3 `ResultEventBus` recipe.
- **Collection in the ViewModel:** moved out of the per-platform chat screens (Android + iOS) into `ChatViewModel`, consumed in common code like `NewChatSelectionHandoff`, removing the duplicated collector block.
- **Bounded map:** each conversation's channel is evicted when its collector completes (ViewModel destroyed), so the backing map doesn't grow for the process lifetime.

## Testing

- New unit tests for `ServerFileSelectionHandoff`: delivery to the matching conversation, isolation between conversations, null-key landing isolation, empty-selection ignored.
- `:app:assembleDebug` (Android) and `:shared:compileKotlinIosSimulatorArm64` (iOS) compile; commonMain detekt passes.

## Notes

Refactor only — no user-facing UI change. The drop it fixes was latent: reachable only with multiple active collectors (NewChat beneath an active Chat, or two-pane); single-pane flows were unaffected.
