### PR TITLE
fix(android): prevent crash when launching OAuth from app context (#183)

### DIFF
--- a/feature/auth/src/androidMain/kotlin/com/garfiec/librechat/feature/auth/oauth/AndroidOAuthLauncher.kt
+++ b/feature/auth/src/androidMain/kotlin/com/garfiec/librechat/feature/auth/oauth/AndroidOAuthLauncher.kt
@@ -1,8 +1,11 @@
 package com.garfiec.librechat.feature.auth.oauth
 
+import android.content.ActivityNotFoundException
 import android.content.Context
+import android.content.Intent
 import android.net.Uri
 import android.webkit.CookieManager
+import android.widget.Toast
 import androidx.browser.customtabs.CustomTabsIntent
 
 class AndroidOAuthLauncher(
@@ -14,7 +17,14 @@ class AndroidOAuthLauncher(
         val customTabsIntent = CustomTabsIntent.Builder()
             .setShowTitle(true)
             .build()
-        customTabsIntent.launchUrl(context, Uri.parse(oauthUrl))
+        // Launched from the application context (not an Activity), so the Custom Tab
+        // intent needs NEW_TASK or startActivity() throws AndroidRuntimeException.
+        customTabsIntent.intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        try {
+            customTabsIntent.launchUrl(context, Uri.parse(oauthUrl))
+        } catch (_: ActivityNotFoundException) {
+            Toast.makeText(context, "No browser available to sign in", Toast.LENGTH_LONG).show()
+        }
     }
 
     override fun extractTokenFromCookies(serverUrl: String): String? {


### PR DESCRIPTION
## Summary

Fixes #183 — the app crashed to the homescreen when starting a social
(e.g. Google) login. The OAuth Custom Tab was launched from the injected
Application context without `FLAG_ACTIVITY_NEW_TASK`, so `startActivity()`
threw an uncaught `AndroidRuntimeException`. The crash is provider-agnostic;
Google was just the provider in the report.

## Changes

- Add `FLAG_ACTIVITY_NEW_TASK` to the Custom Tabs intent before launching,
  since it starts from a non-Activity context.
- Guard the launch against `ActivityNotFoundException` (no browser / Custom
  Tabs provider on device) and surface a Toast instead of crashing.

## Testing

- `./gradlew :feature:auth:compileDebugKotlinAndroid` — passes.
- `./gradlew :feature:auth:testDebugUnitTest` — passes (`LoginViewModel`
  mocks `OAuthLauncher`, so this change sits below the tested layer).
- Not yet device-verified — needs a device check that OAuth login completes
  (returns to the app and logs in), not just that the browser opens.

## Notes

- iOS unaffected (`IosOAuthLauncher` uses `ASWebAuthenticationSession`).
- The "no browser available" Toast string is hardcoded English, consistent
  with the module's other auth error strings; deferred to the i18n pass.
