### PR TITLE
fix(tablet): make hamburger toggle the sidebar in both directions

### DIFF
--- a/app/src/main/kotlin/com/garfiec/librechat/navigation/TabletLayout.kt
+++ b/app/src/main/kotlin/com/garfiec/librechat/navigation/TabletLayout.kt
@@ -199,7 +199,7 @@ fun TabletLayout(
                     dismissedBannerIds = dismissedBannerIds,
                     onDismissBanner = navHostViewModel::dismissBanner,
                     onToggleDrawer = {
-                        navHostViewModel.setTabletSidebarOpen(!isSidebarOpen)
+                        navHostViewModel.toggleTabletSidebar()
                     },
                 )
             },

--- a/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/NavHostViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/NavHostViewModel.kt
@@ -378,6 +378,11 @@ class NavHostViewModel(
         }
     }
 
+    // Toggles via the StateFlow, not a call-site boolean — Nav3 entry closures can capture stale state.
+    fun toggleTabletSidebar() {
+        setTabletSidebarOpen(tabletSidebarOpen.value != true)
+    }
+
     fun dismissBanner(bannerId: String) {
         bannerStateHolder.dismissBanner(bannerId)
     }


### PR DESCRIPTION
## Summary

On tablet / expanded-width layouts, the chat header's hamburger button did not reliably toggle the docked sidebar — it could hide the sidebar but not bring it back. This makes the hamburger toggle the sidebar open and closed on every tap.

## Changes

- Add `NavHostViewModel.toggleTabletSidebar()`, which flips the persisted sidebar state against the ViewModel's own current value (`tabletSidebarOpen.value`) instead of a boolean captured in the hamburger callback. That callback is routed through the Nav3 entry provider, whose entry closures can hold a stale snapshot — toggling against a captured boolean only worked in one direction.
- `TabletLayout`'s hamburger now calls `toggleTabletSidebar()`.

## Testing

- Device-tested on a foldable (unfolded = tablet layout): the hamburger toggles the sidebar open and closed repeatedly.
- Android `assembleDebug` compiles; `commonMain` detekt passes.

## Notes

- Phone layout (`ModalNavigationDrawer`) is unaffected.
