### PR TITLE
fix: render apostrophe in version-mismatch "Don't warn again" button

### DIFF
--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -27,5 +27,5 @@
     <string name="version_mismatch_title">Backend Version Mismatch</string>
     <string name="version_mismatch_message">This app was built for LibreChat v%1$s, but your server is running v%2$s. Some features may not work correctly.</string>
     <string name="dismiss">Dismiss</string>
-    <string name="dont_warn_again">Don\'t warn again</string>
+    <string name="dont_warn_again">Don't warn again</string>
 </resources>


### PR DESCRIPTION
## Summary
The "Backend Version Mismatch" dialog rendered its dismiss-permanently button as `Don\'t warn again` — a literal backslash leaked into the UI.

## Cause
The button text lives in the Compose Multiplatform string resource (`shared/.../composeResources/values/strings.xml`, used at `LibreChatNavHost.kt:168` via `Res.string.dont_warn_again`). It used Android's `\'` apostrophe-escape convention, but CMP's resource parser doesn't process that escape, so the backslash rendered verbatim.

## Changes
- Replace `Don\'t` with a plain `Don't` in the CMP `dont_warn_again` string (a bare apostrophe is valid XML text content).

## Notes
- The separate Android `app/src/main/res/values/strings.xml` copy keeps `\'`, which is correct for standard Android resources and is not the resource that feeds this dialog.
- Not yet verified on device.
