### PR TITLE
feat: configurable chat header (content + bubble alignment)

### DIFF
--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/ChatHeaderAlignment.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/ChatHeaderAlignment.kt
@@ -1,0 +1,27 @@
+package com.garfiec.librechat.core.data.datastore
+
+/**
+ * Mobile-only preference controlling how the chat floating top bar's bubble is positioned
+ * within the region between the hamburger button and the overflow menu.
+ *
+ * - [LEFT] — the bubble hugs its content next to the hamburger (the historical behavior).
+ * - [CENTER] — the bubble hugs its content, centered in the available region.
+ * - [FILL] — the bubble expands to fill the width between the hamburger and the overflow menu.
+ */
+enum class ChatHeaderAlignment {
+    LEFT, CENTER, FILL;
+
+    companion object {
+        fun fromString(value: String?): ChatHeaderAlignment = when (value) {
+            "center" -> CENTER
+            "fill" -> FILL
+            else -> LEFT
+        }
+    }
+
+    fun toStorageString(): String = when (this) {
+        LEFT -> "left"
+        CENTER -> "center"
+        FILL -> "fill"
+    }
+}

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/ChatHeaderContent.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/ChatHeaderContent.kt
@@ -1,0 +1,26 @@
+package com.garfiec.librechat.core.data.datastore
+
+/**
+ * Mobile-only preference controlling what the chat floating top bar's bubble shows.
+ *
+ * - [TITLE] — the conversation title (the historical behavior), with long-press to edit in place.
+ * - [MODEL] — the currently selected model/agent label; tapping opens the model selector.
+ * - [NONE] — no bubble at all (minimal). The hamburger, overflow menu, and scrim still render.
+ */
+enum class ChatHeaderContent {
+    TITLE, MODEL, NONE;
+
+    companion object {
+        fun fromString(value: String?): ChatHeaderContent = when (value) {
+            "model" -> MODEL
+            "none" -> NONE
+            else -> TITLE
+        }
+    }
+
+    fun toStorageString(): String = when (this) {
+        TITLE -> "title"
+        MODEL -> "model"
+        NONE -> "none"
+    }
+}

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/SettingsDataStore.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/SettingsDataStore.kt
@@ -74,6 +74,14 @@ class SettingsDataStore(
         StarredModelsDisplay.fromString(prefs[KEY_STARRED_MODELS_DISPLAY])
     }
 
+    val chatHeaderContent: Flow<ChatHeaderContent> = dataStore.data.map { prefs ->
+        ChatHeaderContent.fromString(prefs[KEY_CHAT_HEADER_CONTENT])
+    }
+
+    val chatHeaderAlignment: Flow<ChatHeaderAlignment> = dataStore.data.map { prefs ->
+        ChatHeaderAlignment.fromString(prefs[KEY_CHAT_HEADER_ALIGNMENT])
+    }
+
     val autoScrollEnabled: Flow<Boolean> = dataStore.data.map { prefs ->
         prefs[KEY_AUTO_SCROLL_ENABLED] ?: true
     }
@@ -219,6 +227,18 @@ class SettingsDataStore(
     suspend fun setStarredModelsDisplay(display: StarredModelsDisplay) {
         dataStore.edit { prefs ->
             prefs[KEY_STARRED_MODELS_DISPLAY] = display.toStorageString()
+        }
+    }
+
+    suspend fun setChatHeaderContent(content: ChatHeaderContent) {
+        dataStore.edit { prefs ->
+            prefs[KEY_CHAT_HEADER_CONTENT] = content.toStorageString()
+        }
+    }
+
+    suspend fun setChatHeaderAlignment(alignment: ChatHeaderAlignment) {
+        dataStore.edit { prefs ->
+            prefs[KEY_CHAT_HEADER_ALIGNMENT] = alignment.toStorageString()
         }
     }
 
@@ -421,6 +441,8 @@ class SettingsDataStore(
         private val KEY_LATEX_RENDERER = stringPreferencesKey("latex_renderer")
         private val KEY_CHAT_FONT_SIZE = stringPreferencesKey("chat_font_size")
         private val KEY_STARRED_MODELS_DISPLAY = stringPreferencesKey("starred_models_display")
+        private val KEY_CHAT_HEADER_CONTENT = stringPreferencesKey("chat_header_content")
+        private val KEY_CHAT_HEADER_ALIGNMENT = stringPreferencesKey("chat_header_alignment")
         private val KEY_AUTO_SCROLL_ENABLED = booleanPreferencesKey("auto_scroll_enabled")
         private val KEY_SHOW_THINKING_BLOCKS = booleanPreferencesKey("show_thinking_blocks")
         private val KEY_AUTO_READ_ENABLED = booleanPreferencesKey("auto_read_enabled")

--- a/feature/chat/src/commonMain/composeResources/values-ar/strings.xml
+++ b/feature/chat/src/commonMain/composeResources/values-ar/strings.xml
@@ -51,6 +51,7 @@
     <string name="cd_stop_generation">إيقاف الإنشاء</string>
     <string name="cd_send_message">إرسال الرسالة</string>
     <string name="cd_open_drawer">فتح درج التنقل</string>
+    <string name="cd_edit_title">تعديل العنوان</string>
     <string name="cd_more_options">خيارات إضافية</string>
     <string name="cd_more_tools">أدوات إضافية</string>
     <string name="cd_scroll_to_bottom">التمرير إلى الأسفل</string>

--- a/feature/chat/src/commonMain/composeResources/values-de/strings.xml
+++ b/feature/chat/src/commonMain/composeResources/values-de/strings.xml
@@ -51,6 +51,7 @@
     <string name="cd_stop_generation">Generierung stoppen</string>
     <string name="cd_send_message">Nachricht senden</string>
     <string name="cd_open_drawer">Navigationsleiste öffnen</string>
+    <string name="cd_edit_title">Titel bearbeiten</string>
     <string name="cd_more_options">Weitere Optionen</string>
     <string name="cd_more_tools">Weitere Tools</string>
     <string name="cd_scroll_to_bottom">Nach unten scrollen</string>

--- a/feature/chat/src/commonMain/composeResources/values-es/strings.xml
+++ b/feature/chat/src/commonMain/composeResources/values-es/strings.xml
@@ -51,6 +51,7 @@
     <string name="cd_stop_generation">Detener generación</string>
     <string name="cd_send_message">Enviar mensaje</string>
     <string name="cd_open_drawer">Abrir el panel de navegación</string>
+    <string name="cd_edit_title">Editar título</string>
     <string name="cd_more_options">Más opciones</string>
     <string name="cd_more_tools">Más herramientas</string>
     <string name="cd_scroll_to_bottom">Desplazar al final</string>

--- a/feature/chat/src/commonMain/composeResources/values-fr/strings.xml
+++ b/feature/chat/src/commonMain/composeResources/values-fr/strings.xml
@@ -51,6 +51,7 @@
     <string name="cd_stop_generation">Arrêter la génération</string>
     <string name="cd_send_message">Envoyer le message</string>
     <string name="cd_open_drawer">Ouvrir le tiroir de navigation</string>
+    <string name="cd_edit_title">Modifier le titre</string>
     <string name="cd_more_options">Plus d\'options</string>
     <string name="cd_more_tools">Plus d\'outils</string>
     <string name="cd_scroll_to_bottom">Défiler vers le bas</string>

--- a/feature/chat/src/commonMain/composeResources/values-ja/strings.xml
+++ b/feature/chat/src/commonMain/composeResources/values-ja/strings.xml
@@ -51,6 +51,7 @@
     <string name="cd_stop_generation">生成を停止</string>
     <string name="cd_send_message">メッセージを送信</string>
     <string name="cd_open_drawer">ナビゲーションドロワーを開く</string>
+    <string name="cd_edit_title">タイトルを編集</string>
     <string name="cd_more_options">その他のオプション</string>
     <string name="cd_more_tools">その他のツール</string>
     <string name="cd_scroll_to_bottom">一番下までスクロール</string>

--- a/feature/chat/src/commonMain/composeResources/values-ko/strings.xml
+++ b/feature/chat/src/commonMain/composeResources/values-ko/strings.xml
@@ -51,6 +51,7 @@
     <string name="cd_stop_generation">생성 중지</string>
     <string name="cd_send_message">메시지 전송</string>
     <string name="cd_open_drawer">탐색 서랍 열기</string>
+    <string name="cd_edit_title">제목 편집</string>
     <string name="cd_more_options">추가 옵션</string>
     <string name="cd_more_tools">추가 도구</string>
     <string name="cd_scroll_to_bottom">맨 아래로 스크롤</string>

--- a/feature/chat/src/commonMain/composeResources/values-pt/strings.xml
+++ b/feature/chat/src/commonMain/composeResources/values-pt/strings.xml
@@ -51,6 +51,7 @@
     <string name="cd_stop_generation">Parar geração</string>
     <string name="cd_send_message">Enviar mensagem</string>
     <string name="cd_open_drawer">Abrir menu de navegação</string>
+    <string name="cd_edit_title">Editar título</string>
     <string name="cd_more_options">Mais opções</string>
     <string name="cd_more_tools">Mais ferramentas</string>
     <string name="cd_scroll_to_bottom">Rolar até o final</string>

--- a/feature/chat/src/commonMain/composeResources/values-ru/strings.xml
+++ b/feature/chat/src/commonMain/composeResources/values-ru/strings.xml
@@ -51,6 +51,7 @@
     <string name="cd_stop_generation">Остановить генерацию</string>
     <string name="cd_send_message">Отправить сообщение</string>
     <string name="cd_open_drawer">Открыть панель навигации</string>
+    <string name="cd_edit_title">Изменить название</string>
     <string name="cd_more_options">Дополнительно</string>
     <string name="cd_more_tools">Ещё инструменты</string>
     <string name="cd_scroll_to_bottom">Прокрутить вниз</string>

--- a/feature/chat/src/commonMain/composeResources/values-zh/strings.xml
+++ b/feature/chat/src/commonMain/composeResources/values-zh/strings.xml
@@ -51,6 +51,7 @@
     <string name="cd_stop_generation">停止生成</string>
     <string name="cd_send_message">发送消息</string>
     <string name="cd_open_drawer">打开导航抽屉</string>
+    <string name="cd_edit_title">编辑标题</string>
     <string name="cd_more_options">更多选项</string>
     <string name="cd_more_tools">更多工具</string>
     <string name="cd_scroll_to_bottom">滚动到底部</string>

--- a/feature/chat/src/commonMain/composeResources/values/strings.xml
+++ b/feature/chat/src/commonMain/composeResources/values/strings.xml
@@ -59,6 +59,7 @@
     <string name="cd_cancel_edit">Cancel edit</string>
     <string name="cd_update_queued_message">Update queued message</string>
     <string name="cd_open_drawer">Open navigation drawer</string>
+    <string name="cd_edit_title">Edit title</string>
     <string name="cd_more_options">More options</string>
     <string name="cd_more_tools">More tools</string>
     <string name="cd_scroll_to_bottom">Scroll to bottom</string>

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ChatFloatingTopBar.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ChatFloatingTopBar.kt
@@ -8,46 +8,68 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
+import com.garfiec.librechat.core.data.datastore.ChatHeaderAlignment
+import com.garfiec.librechat.core.data.datastore.ChatHeaderContent
 import com.garfiec.librechat.feature.chat.resources.Res
+import com.garfiec.librechat.feature.chat.resources.cd_edit_title
 import com.garfiec.librechat.feature.chat.resources.cd_more_options
 import com.garfiec.librechat.feature.chat.resources.cd_open_drawer
+import com.garfiec.librechat.feature.chat.resources.select_model
+import com.garfiec.librechat.feature.chat.screen.rememberChatModelLabel
 import com.garfiec.librechat.feature.chat.viewmodel.ChatUiState
 import com.garfiec.librechat.feature.chat.viewmodel.ChatViewModel
 import org.jetbrains.compose.resources.stringResource
 
 /**
- * The chat screen's floating top bar, shared by Android and iOS. Chips (hamburger, conversation
- * title, optional temp-chat toggle, options) are drawn over a top-down [chatTopBarScrim] so chat
- * content scrolls up *behind* a gently dimmed status-bar region rather than being capped by an
- * opaque app bar — a ChatGPT/Telegram-style header. The in-conversation search bar is pinned
+ * The chat screen's floating top bar, shared by Android and iOS. Chips (hamburger, the configurable
+ * content bubble, optional temp-chat toggle, options) are drawn over a top-down [chatTopBarScrim]
+ * so chat content scrolls up *behind* a gently dimmed status-bar region rather than being capped by
+ * an opaque app bar — a ChatGPT/Telegram-style header. The in-conversation search bar is pinned
  * directly beneath the chips so the overlay measures as one unit.
  *
+ * The bubble is configurable along two mobile-only axes ([ChatUiState.chatHeaderContent] /
+ * [ChatUiState.chatHeaderAlignment]): it shows the conversation title (long-press to edit in place),
+ * the selected model (tap to open the model selector), or nothing. Showing the model here is an
+ * opt-in that partially reverses the default decluttering choice of keeping model/params on the
+ * composer "+" menu; the title remains the default.
+ *
  * Most actions are wired straight to [viewModel]; only the triggers whose dialog hosting differs by
- * platform (preset load/save, rename) and the navigation callbacks are passed in. The header
- * intentionally has no model selector — model/params stay reachable from the composer "+" menu, a
- * deliberate mobile decluttering choice that diverges from web's header model selector.
+ * platform (preset load/save, rename) and the navigation callbacks are passed in.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -70,6 +92,12 @@ internal fun ChatFloatingTopBar(
     val showTempChatToggle = (conversationId == null || uiState.isTemporaryChat) &&
         uiState.temporaryChatEnabled
 
+    val fillWidth = uiState.chatHeaderAlignment == ChatHeaderAlignment.FILL
+    val contentAlignment = when (uiState.chatHeaderAlignment) {
+        ChatHeaderAlignment.LEFT, ChatHeaderAlignment.FILL -> Alignment.CenterStart
+        ChatHeaderAlignment.CENTER -> Alignment.Center
+    }
+
     Column(modifier = modifier) {
         Row(
             modifier = Modifier
@@ -89,29 +117,38 @@ internal fun ChatFloatingTopBar(
                 Spacer(modifier = Modifier.width(8.dp))
             }
 
-            // Conversation title in its own chip, left-aligned next to the hamburger. The flexible
-            // region also right-pins the options control. The chip hugs its content but is bounded
-            // by the region, so long titles ellipsize at the full available width.
+            // The configurable content bubble. The flexible region always reserves the space between
+            // the hamburger and the right-pinned controls, so the bubble can hug its content
+            // (left/center) or fill the region, and `NONE` simply leaves the region empty.
             Box(
                 modifier = Modifier.weight(1f),
-                contentAlignment = Alignment.CenterStart,
+                contentAlignment = contentAlignment,
             ) {
-                if (conversationId != null && !conversationTitle.isNullOrBlank()) {
-                    FloatingBarChip(modifier = Modifier.height(FloatingBarChipSize)) {
-                        Box(
-                            modifier = Modifier.fillMaxHeight(),
-                            contentAlignment = Alignment.Center,
-                        ) {
-                            Text(
-                                text = conversationTitle,
-                                style = MaterialTheme.typography.titleSmall,
-                                color = MaterialTheme.colorScheme.onSurface,
-                                maxLines = 1,
-                                overflow = TextOverflow.Ellipsis,
-                                modifier = Modifier.padding(horizontal = 16.dp),
+                when (uiState.chatHeaderContent) {
+                    ChatHeaderContent.TITLE ->
+                        if (conversationId != null && !conversationTitle.isNullOrBlank()) {
+                            HeaderTitleChip(
+                                title = conversationTitle,
+                                conversationKey = conversationId,
+                                fillWidth = fillWidth,
+                                onCommit = viewModel::renameConversation,
                             )
                         }
+
+                    ChatHeaderContent.MODEL -> {
+                        val label = rememberChatModelLabel(
+                            selectedEndpoint = uiState.selectedEndpoint,
+                            selectedModel = uiState.selectedModel,
+                            agents = uiState.agents,
+                        )
+                        FloatingBarLabelChip(
+                            text = label.displayModel ?: stringResource(Res.string.select_model),
+                            fillWidth = fillWidth,
+                            onClick = viewModel::openModelSheet,
+                        )
                     }
+
+                    ChatHeaderContent.NONE -> Unit
                 }
             }
             Spacer(modifier = Modifier.width(8.dp))
@@ -174,4 +211,106 @@ internal fun ChatFloatingTopBar(
             )
         }
     }
+}
+
+/**
+ * The conversation-title bubble. Renders the title (ellipsized) and, on long-press, swaps in an
+ * inline editor that commits via [onCommit] (the same [ChatViewModel.renameConversation] path as the
+ * overflow Rename dialog). Edit state resets when [conversationKey] changes so switching chats never
+ * leaves a stale editor open.
+ */
+@Composable
+private fun HeaderTitleChip(
+    title: String,
+    conversationKey: String,
+    fillWidth: Boolean,
+    onCommit: (String) -> Unit,
+) {
+    var isEditing by remember(conversationKey) { mutableStateOf(false) }
+
+    if (isEditing) {
+        FloatingBarContentChip(fillWidth = fillWidth) {
+            HeaderTitleEditor(
+                initial = title,
+                fillWidth = fillWidth,
+                onCommit = {
+                    isEditing = false
+                    onCommit(it)
+                },
+                onCancel = { isEditing = false },
+            )
+        }
+    } else {
+        FloatingBarLabelChip(
+            text = title,
+            fillWidth = fillWidth,
+            onLongClick = { isEditing = true },
+            onLongClickLabel = stringResource(Res.string.cd_edit_title),
+        )
+    }
+}
+
+/**
+ * Inline single-line title editor. Commit happens ONLY on the explicit IME Done action; any focus
+ * loss (tapping the composer, opening the overflow menu, switching conversations, config change) or
+ * the Escape key DISCARDS the edit. This makes a rename an explicit, confirmed action — the bar's
+ * scrim ([consumeFloatingBarTouches]) swallows background taps, so a commit-on-blur would otherwise
+ * persist abandoned, half-typed titles. Done with an unchanged or blank value also discards, which
+ * covers the case where the title updated underneath an untouched editor (e.g. async gen_title).
+ */
+@Composable
+private fun HeaderTitleEditor(
+    initial: String,
+    fillWidth: Boolean,
+    onCommit: (String) -> Unit,
+    onCancel: () -> Unit,
+) {
+    val focusRequester = remember { FocusRequester() }
+    var value by remember { mutableStateOf(TextFieldValue(initial, TextRange(initial.length))) }
+    var settled by remember { mutableStateOf(false) }
+    var everFocused by remember { mutableStateOf(false) }
+
+    fun commit() {
+        if (settled) return
+        settled = true
+        val trimmed = value.text.trim()
+        if (trimmed.isNotEmpty() && trimmed != initial) onCommit(trimmed) else onCancel()
+    }
+    fun cancel() {
+        if (settled) return
+        settled = true
+        onCancel()
+    }
+
+    BasicTextField(
+        value = value,
+        onValueChange = { value = it },
+        singleLine = true,
+        textStyle = MaterialTheme.typography.titleSmall.copy(color = MaterialTheme.colorScheme.onSurface),
+        cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
+        keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+        keyboardActions = KeyboardActions(onDone = { commit() }),
+        modifier = Modifier
+            .then(if (fillWidth) Modifier.fillMaxWidth() else Modifier.widthIn(min = 120.dp, max = 240.dp))
+            .padding(horizontal = 16.dp)
+            .focusRequester(focusRequester)
+            .onPreviewKeyEvent { event ->
+                if (event.key == Key.Escape && event.type == KeyEventType.KeyUp) {
+                    cancel()
+                    true
+                } else {
+                    false
+                }
+            }
+            .onFocusChanged { state ->
+                if (state.isFocused) {
+                    everFocused = true
+                } else if (everFocused) {
+                    // Focus left (composer, overflow, chat switch) — discard the unconfirmed edit.
+                    cancel()
+                }
+            },
+    )
+
+    LaunchedEffect(Unit) { focusRequester.requestFocus() }
 }

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/FloatingTopBarChip.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/FloatingTopBarChip.kt
@@ -1,15 +1,23 @@
 package com.garfiec.librechat.feature.chat.components
 
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
@@ -17,6 +25,9 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.semantics.onLongClick
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 
 /**
@@ -43,6 +54,77 @@ internal fun FloatingBarChip(
         Surface(onClick = onClick, shape = shape, color = color, border = border, modifier = modifier, content = content)
     } else {
         Surface(shape = shape, color = color, border = border, modifier = modifier, content = content)
+    }
+}
+
+/**
+ * The shared frame for a floating-bar content bubble: a [FloatingBarChip] sized to the bar's chip
+ * height with its [content] vertically centered. [fillWidth] expands the chip across the available
+ * region (the FILL alignment); otherwise it hugs its content. [contentModifier] is applied to the
+ * centered interior so callers can attach gestures spanning the whole bubble.
+ */
+@Composable
+internal fun FloatingBarContentChip(
+    fillWidth: Boolean,
+    modifier: Modifier = Modifier,
+    contentModifier: Modifier = Modifier,
+    onClick: (() -> Unit)? = null,
+    content: @Composable () -> Unit,
+) {
+    FloatingBarChip(
+        modifier = modifier.height(FloatingBarChipSize)
+            .then(if (fillWidth) Modifier.fillMaxWidth() else Modifier),
+        onClick = onClick,
+    ) {
+        Box(
+            modifier = Modifier.fillMaxHeight().then(contentModifier),
+            contentAlignment = Alignment.Center,
+        ) {
+            content()
+        }
+    }
+}
+
+/**
+ * A [FloatingBarContentChip] wrapping a single centered, ellipsized label — the bar's title/model
+ * content bubble. Shared so the two content modes render identically. A tap is wired through
+ * [onClick] as a proper button (model selector); [onLongClick] is wired via a tap-gesture detector
+ * plus a long-click semantics action (the in-place title edit), so it adds neither a no-op click
+ * role nor a ripple to a label whose only action is long-press. The detector is keyed on `Unit` and
+ * reads the latest callback via [rememberUpdatedState], so an unstable caller lambda doesn't restart
+ * the gesture coroutine on every recomposition.
+ */
+@Composable
+internal fun FloatingBarLabelChip(
+    text: String,
+    modifier: Modifier = Modifier,
+    fillWidth: Boolean = false,
+    onClick: (() -> Unit)? = null,
+    onLongClick: (() -> Unit)? = null,
+    onLongClickLabel: String? = null,
+) {
+    val latestLongClick by rememberUpdatedState(onLongClick)
+    val contentModifier = if (onLongClick != null) {
+        Modifier
+            .pointerInput(Unit) { detectTapGestures(onLongPress = { latestLongClick?.invoke() }) }
+            .semantics { onLongClick(label = onLongClickLabel) { latestLongClick?.invoke(); true } }
+    } else {
+        Modifier
+    }
+    FloatingBarContentChip(
+        fillWidth = fillWidth,
+        modifier = modifier,
+        onClick = onClick,
+        contentModifier = contentModifier,
+    ) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.titleSmall,
+            color = MaterialTheme.colorScheme.onSurface,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.padding(horizontal = 16.dp),
+        )
     }
 }
 

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatModelLabel.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatModelLabel.kt
@@ -1,6 +1,7 @@
 package com.garfiec.librechat.feature.chat.screen
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import com.garfiec.librechat.core.common.EndpointConstants
 import com.garfiec.librechat.core.model.Agent
 import com.garfiec.librechat.feature.chat.resources.Res
@@ -32,12 +33,17 @@ fun rememberChatModelLabel(
     selectedEndpoint: String?,
     selectedModel: String?,
     agents: List<Agent>,
-): ChatModelLabel = chatModelLabel(
-    selectedEndpoint = selectedEndpoint,
-    selectedModel = selectedModel,
-    agents = agents,
-    agentFallbackLabel = stringResource(Res.string.chat_agent_fallback_label),
-)
+): ChatModelLabel {
+    val agentFallbackLabel = stringResource(Res.string.chat_agent_fallback_label)
+    return remember(selectedEndpoint, selectedModel, agents, agentFallbackLabel) {
+        chatModelLabel(
+            selectedEndpoint = selectedEndpoint,
+            selectedModel = selectedModel,
+            agents = agents,
+            agentFallbackLabel = agentFallbackLabel,
+        )
+    }
+}
 
 /**
  * Pure (non-Composable) label derivation, split out so the agent-vs-model and F4

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatUiState.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatUiState.kt
@@ -5,6 +5,8 @@ import com.garfiec.librechat.core.common.ChatLayoutConstants
 import com.garfiec.librechat.core.common.EndpointConstants
 import com.garfiec.librechat.core.common.ToolConstants
 import com.garfiec.librechat.core.data.datastore.ChatFontSize
+import com.garfiec.librechat.core.data.datastore.ChatHeaderAlignment
+import com.garfiec.librechat.core.data.datastore.ChatHeaderContent
 import com.garfiec.librechat.core.data.datastore.InlineArtifactPrefs
 import com.garfiec.librechat.core.data.datastore.LatexRenderer
 import com.garfiec.librechat.core.data.datastore.StarredModelsDisplay
@@ -58,6 +60,16 @@ data class ChatPreferences(
     val sttEngine: String = "",
     val sttLanguage: String = "",
     val inlineArtifactPrefs: InlineArtifactPrefs = InlineArtifactPrefs(),
+)
+
+/**
+ * The chat floating top bar's mobile-only display preferences, bundled into a single
+ * flow so [ChatViewModel]'s `uiState` combine stays within Kotlin's 5-arg typed limit.
+ */
+@Immutable
+data class ChatHeaderPrefs(
+    val content: ChatHeaderContent = ChatHeaderContent.TITLE,
+    val alignment: ChatHeaderAlignment = ChatHeaderAlignment.LEFT,
 )
 
 /**
@@ -300,6 +312,13 @@ data class ChatUiState(
      * section), or top (flat top list). Read from [SettingsDataStore].
      */
     val starredModelsDisplay: StarredModelsDisplay = StarredModelsDisplay.OFF,
+    /**
+     * Mobile-only preferences for the chat floating top bar: what its bubble shows
+     * ([chatHeaderContent]) and how the bubble is positioned ([chatHeaderAlignment]).
+     * Read from [SettingsDataStore].
+     */
+    val chatHeaderContent: ChatHeaderContent = ChatHeaderContent.TITLE,
+    val chatHeaderAlignment: ChatHeaderAlignment = ChatHeaderAlignment.LEFT,
     val forkedConversationId: String? = null,
     val showForkOptionsForMessageId: String? = null,
     val isForkInProgress: Boolean = false,

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModel.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModel.kt
@@ -258,16 +258,26 @@ class ChatViewModel(
         )
     }.stateIn(viewModelScope, SharingStarted.Eagerly, ChatPreferences())
 
+    // Bundled into one source so the uiState combine below stays within Kotlin's
+    // 5-argument typed `combine` ceiling.
+    private val chatHeaderPrefs: Flow<ChatHeaderPrefs> = combine(
+        settingsDataStore.chatHeaderContent,
+        settingsDataStore.chatHeaderAlignment,
+    ) { content, alignment -> ChatHeaderPrefs(content, alignment) }
+
     val uiState: StateFlow<ChatUiState> = combine(
         _uiState,
         serverDataStore.currentUrlFlow,
         settingsDataStore.chatFontSize,
         settingsDataStore.starredModelsDisplay,
-    ) { state, url, fontSize, starredDisplay ->
+        chatHeaderPrefs,
+    ) { state, url, fontSize, starredDisplay, headerPrefs ->
         state.copy(
             serverUrl = url,
             chatFontSize = fontSize,
             starredModelsDisplay = starredDisplay,
+            chatHeaderContent = headerPrefs.content,
+            chatHeaderAlignment = headerPrefs.alignment,
         )
     }.stateIn(viewModelScope, SharingStarted.Eagerly, ChatUiState())
 

--- a/feature/settings/src/commonMain/composeResources/values-ar/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-ar/strings.xml
@@ -165,6 +165,16 @@
     <string name="starred_models_off">إيقاف</string>
     <string name="starred_models_grouped">مجموعة قابلة للطي في الأعلى</string>
     <string name="starred_models_top">في الأعلى بدون تجميع</string>
+    <string name="chat_header_content_title">محتوى رأس المحادثة</string>
+    <string name="chat_header_content_desc">اختر ما يعرضه الشريط العلوي للمحادثة</string>
+    <string name="chat_header_content_title_option">عنوان المحادثة</string>
+    <string name="chat_header_content_model">النموذج المحدد</string>
+    <string name="chat_header_content_none">لا شيء</string>
+    <string name="chat_header_alignment_title">محاذاة رأس المحادثة</string>
+    <string name="chat_header_alignment_desc">اختر كيفية وضع فقاعة الشريط العلوي للمحادثة</string>
+    <string name="chat_header_alignment_left">يسار</string>
+    <string name="chat_header_alignment_center">وسط</string>
+    <string name="chat_header_alignment_fill">بعرض كامل</string>
     <string name="font_size">حجم الخط</string>
     <string name="font_size_small">صغير</string>
     <string name="font_size_medium">متوسط</string>

--- a/feature/settings/src/commonMain/composeResources/values-de/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-de/strings.xml
@@ -165,6 +165,16 @@
     <string name="starred_models_off">Aus</string>
     <string name="starred_models_grouped">Einklappbare Gruppe oben</string>
     <string name="starred_models_top">Oben, ohne Gruppierung</string>
+    <string name="chat_header_content_title">Inhalt der Chat-Kopfzeile</string>
+    <string name="chat_header_content_desc">Wählen Sie, was die Chat-Leiste anzeigt</string>
+    <string name="chat_header_content_title_option">Unterhaltungstitel</string>
+    <string name="chat_header_content_model">Ausgewähltes Modell</string>
+    <string name="chat_header_content_none">Nichts</string>
+    <string name="chat_header_alignment_title">Ausrichtung der Chat-Kopfzeile</string>
+    <string name="chat_header_alignment_desc">Wählen Sie, wie die Sprechblase der Chat-Leiste positioniert wird</string>
+    <string name="chat_header_alignment_left">Links</string>
+    <string name="chat_header_alignment_center">Zentriert</string>
+    <string name="chat_header_alignment_fill">Volle Breite</string>
     <string name="font_size">Schriftgröße</string>
     <string name="font_size_small">Klein</string>
     <string name="font_size_medium">Mittel</string>

--- a/feature/settings/src/commonMain/composeResources/values-es/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-es/strings.xml
@@ -165,6 +165,16 @@
     <string name="starred_models_off">Desactivado</string>
     <string name="starred_models_grouped">Grupo plegable en la parte superior</string>
     <string name="starred_models_top">En la parte superior, sin agrupar</string>
+    <string name="chat_header_content_title">Contenido del encabezado del chat</string>
+    <string name="chat_header_content_desc">Elige qué muestra la barra superior del chat</string>
+    <string name="chat_header_content_title_option">Título de la conversación</string>
+    <string name="chat_header_content_model">Modelo seleccionado</string>
+    <string name="chat_header_content_none">Nada</string>
+    <string name="chat_header_alignment_title">Alineación del encabezado del chat</string>
+    <string name="chat_header_alignment_desc">Elige cómo se posiciona la burbuja de la barra superior del chat</string>
+    <string name="chat_header_alignment_left">Izquierda</string>
+    <string name="chat_header_alignment_center">Centro</string>
+    <string name="chat_header_alignment_fill">Ancho completo</string>
     <string name="font_size">Tamaño de fuente</string>
     <string name="font_size_small">Pequeño</string>
     <string name="font_size_medium">Mediano</string>

--- a/feature/settings/src/commonMain/composeResources/values-fr/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-fr/strings.xml
@@ -165,6 +165,16 @@
     <string name="starred_models_off">Désactivé</string>
     <string name="starred_models_grouped">Groupe repliable en haut</string>
     <string name="starred_models_top">En haut, sans regroupement</string>
+    <string name="chat_header_content_title">Contenu de l'en-tête du chat</string>
+    <string name="chat_header_content_desc">Choisissez ce qu'affiche la barre supérieure du chat</string>
+    <string name="chat_header_content_title_option">Titre de la conversation</string>
+    <string name="chat_header_content_model">Modèle sélectionné</string>
+    <string name="chat_header_content_none">Rien</string>
+    <string name="chat_header_alignment_title">Alignement de l'en-tête du chat</string>
+    <string name="chat_header_alignment_desc">Choisissez la position de la bulle de la barre supérieure du chat</string>
+    <string name="chat_header_alignment_left">Gauche</string>
+    <string name="chat_header_alignment_center">Centre</string>
+    <string name="chat_header_alignment_fill">Pleine largeur</string>
     <string name="font_size">Taille de police</string>
     <string name="font_size_small">Petite</string>
     <string name="font_size_medium">Moyenne</string>

--- a/feature/settings/src/commonMain/composeResources/values-ja/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-ja/strings.xml
@@ -165,6 +165,16 @@
     <string name="starred_models_off">オフ</string>
     <string name="starred_models_grouped">上部に折りたたみ可能なグループ</string>
     <string name="starred_models_top">上部に表示、グループ化なし</string>
+    <string name="chat_header_content_title">チャットヘッダーの内容</string>
+    <string name="chat_header_content_desc">チャット上部バーに表示する内容を選択</string>
+    <string name="chat_header_content_title_option">会話のタイトル</string>
+    <string name="chat_header_content_model">選択中のモデル</string>
+    <string name="chat_header_content_none">なし</string>
+    <string name="chat_header_alignment_title">チャットヘッダーの配置</string>
+    <string name="chat_header_alignment_desc">チャット上部バーのバブルの位置を選択</string>
+    <string name="chat_header_alignment_left">左</string>
+    <string name="chat_header_alignment_center">中央</string>
+    <string name="chat_header_alignment_fill">幅いっぱい</string>
     <string name="font_size">フォントサイズ</string>
     <string name="font_size_small">小</string>
     <string name="font_size_medium">中</string>

--- a/feature/settings/src/commonMain/composeResources/values-ko/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-ko/strings.xml
@@ -165,6 +165,16 @@
     <string name="starred_models_off">끔</string>
     <string name="starred_models_grouped">상단에 접을 수 있는 그룹</string>
     <string name="starred_models_top">상단에 표시, 그룹화 없음</string>
+    <string name="chat_header_content_title">채팅 헤더 내용</string>
+    <string name="chat_header_content_desc">채팅 상단 바에 표시할 내용을 선택하세요</string>
+    <string name="chat_header_content_title_option">대화 제목</string>
+    <string name="chat_header_content_model">선택한 모델</string>
+    <string name="chat_header_content_none">없음</string>
+    <string name="chat_header_alignment_title">채팅 헤더 정렬</string>
+    <string name="chat_header_alignment_desc">채팅 상단 바 버블의 위치를 선택하세요</string>
+    <string name="chat_header_alignment_left">왼쪽</string>
+    <string name="chat_header_alignment_center">가운데</string>
+    <string name="chat_header_alignment_fill">전체 너비</string>
     <string name="font_size">글자 크기</string>
     <string name="font_size_small">작게</string>
     <string name="font_size_medium">보통</string>

--- a/feature/settings/src/commonMain/composeResources/values-pt/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-pt/strings.xml
@@ -165,6 +165,16 @@
     <string name="starred_models_off">Desativado</string>
     <string name="starred_models_grouped">Grupo recolhível no topo</string>
     <string name="starred_models_top">No topo, sem agrupamento</string>
+    <string name="chat_header_content_title">Conteúdo do cabeçalho do chat</string>
+    <string name="chat_header_content_desc">Escolha o que a barra superior do chat mostra</string>
+    <string name="chat_header_content_title_option">Título da conversa</string>
+    <string name="chat_header_content_model">Modelo selecionado</string>
+    <string name="chat_header_content_none">Nada</string>
+    <string name="chat_header_alignment_title">Alinhamento do cabeçalho do chat</string>
+    <string name="chat_header_alignment_desc">Escolha como a bolha da barra superior do chat é posicionada</string>
+    <string name="chat_header_alignment_left">Esquerda</string>
+    <string name="chat_header_alignment_center">Centro</string>
+    <string name="chat_header_alignment_fill">Largura total</string>
     <string name="font_size">Tamanho da fonte</string>
     <string name="font_size_small">Pequeno</string>
     <string name="font_size_medium">Médio</string>

--- a/feature/settings/src/commonMain/composeResources/values-ru/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-ru/strings.xml
@@ -165,6 +165,16 @@
     <string name="starred_models_off">Выключено</string>
     <string name="starred_models_grouped">Сворачиваемая группа вверху</string>
     <string name="starred_models_top">Вверху, без группировки</string>
+    <string name="chat_header_content_title">Содержимое заголовка чата</string>
+    <string name="chat_header_content_desc">Выберите, что показывает верхняя панель чата</string>
+    <string name="chat_header_content_title_option">Название беседы</string>
+    <string name="chat_header_content_model">Выбранная модель</string>
+    <string name="chat_header_content_none">Ничего</string>
+    <string name="chat_header_alignment_title">Выравнивание заголовка чата</string>
+    <string name="chat_header_alignment_desc">Выберите расположение плашки верхней панели чата</string>
+    <string name="chat_header_alignment_left">Слева</string>
+    <string name="chat_header_alignment_center">По центру</string>
+    <string name="chat_header_alignment_fill">На всю ширину</string>
     <string name="font_size">Размер шрифта</string>
     <string name="font_size_small">Мелкий</string>
     <string name="font_size_medium">Средний</string>

--- a/feature/settings/src/commonMain/composeResources/values-zh/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-zh/strings.xml
@@ -165,6 +165,16 @@
     <string name="starred_models_off">关闭</string>
     <string name="starred_models_grouped">顶部可折叠分组</string>
     <string name="starred_models_top">置于顶部，不分组</string>
+    <string name="chat_header_content_title">聊天标题栏内容</string>
+    <string name="chat_header_content_desc">选择聊天顶栏显示的内容</string>
+    <string name="chat_header_content_title_option">对话标题</string>
+    <string name="chat_header_content_model">所选模型</string>
+    <string name="chat_header_content_none">无</string>
+    <string name="chat_header_alignment_title">聊天标题栏对齐</string>
+    <string name="chat_header_alignment_desc">选择聊天顶栏气泡的位置</string>
+    <string name="chat_header_alignment_left">左对齐</string>
+    <string name="chat_header_alignment_center">居中</string>
+    <string name="chat_header_alignment_fill">填满宽度</string>
     <string name="font_size">字体大小</string>
     <string name="font_size_small">小</string>
     <string name="font_size_medium">中</string>

--- a/feature/settings/src/commonMain/composeResources/values/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values/strings.xml
@@ -165,6 +165,16 @@
     <string name="starred_models_off">Off</string>
     <string name="starred_models_grouped">Collapsible group at top</string>
     <string name="starred_models_top">At top, no grouping</string>
+    <string name="chat_header_content_title">Chat header content</string>
+    <string name="chat_header_content_desc">Choose what the chat top bar shows</string>
+    <string name="chat_header_content_title_option">Conversation title</string>
+    <string name="chat_header_content_model">Selected model</string>
+    <string name="chat_header_content_none">Nothing</string>
+    <string name="chat_header_alignment_title">Chat header alignment</string>
+    <string name="chat_header_alignment_desc">Choose how the chat top bar bubble is positioned</string>
+    <string name="chat_header_alignment_left">Left</string>
+    <string name="chat_header_alignment_center">Center</string>
+    <string name="chat_header_alignment_fill">Fill width</string>
     <string name="font_size">Font size</string>
     <string name="font_size_small">Small</string>
     <string name="font_size_medium">Medium</string>

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/ChatSettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/ChatSettingsScreen.kt
@@ -107,6 +107,8 @@ fun ChatSettingsContent(
                     showBubbles = uiState.showBubbles,
                     latexRenderer = uiState.latexRenderer,
                     starredModelsDisplay = uiState.starredModelsDisplay,
+                    chatHeaderContent = uiState.chatHeaderContent,
+                    chatHeaderAlignment = uiState.chatHeaderAlignment,
                     onFontSizeChange = viewModel::setChatFontSize,
                     onAutoScrollChange = viewModel::setAutoScrollEnabled,
                     onShowThinkingChange = viewModel::setShowThinkingBlocks,
@@ -117,6 +119,8 @@ fun ChatSettingsContent(
                     onShowBubblesChange = viewModel::setShowBubbles,
                     onLatexRendererChange = viewModel::setLatexRenderer,
                     onStarredModelsDisplayChange = viewModel::setStarredModelsDisplay,
+                    onChatHeaderContentChange = viewModel::setChatHeaderContent,
+                    onChatHeaderAlignmentChange = viewModel::setChatHeaderAlignment,
                 )
             }
 

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/ChatSettingsSection.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/ChatSettingsSection.kt
@@ -22,6 +22,8 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
 import com.garfiec.librechat.core.common.ChatLayoutConstants
 import com.garfiec.librechat.core.data.datastore.ChatFontSize
+import com.garfiec.librechat.core.data.datastore.ChatHeaderAlignment
+import com.garfiec.librechat.core.data.datastore.ChatHeaderContent
 import com.garfiec.librechat.core.data.datastore.LatexRenderer
 import com.garfiec.librechat.core.data.datastore.StarredModelsDisplay
 import com.garfiec.librechat.feature.settings.resources.*
@@ -40,6 +42,8 @@ internal fun ChatSettingsSection(
     showBubbles: Boolean,
     latexRenderer: LatexRenderer,
     starredModelsDisplay: StarredModelsDisplay,
+    chatHeaderContent: ChatHeaderContent,
+    chatHeaderAlignment: ChatHeaderAlignment,
     onFontSizeChange: (ChatFontSize) -> Unit,
     onAutoScrollChange: (Boolean) -> Unit,
     onShowThinkingChange: (Boolean) -> Unit,
@@ -50,6 +54,8 @@ internal fun ChatSettingsSection(
     onShowBubblesChange: (Boolean) -> Unit,
     onLatexRendererChange: (LatexRenderer) -> Unit,
     onStarredModelsDisplayChange: (StarredModelsDisplay) -> Unit,
+    onChatHeaderContentChange: (ChatHeaderContent) -> Unit,
+    onChatHeaderAlignmentChange: (ChatHeaderAlignment) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(modifier = modifier) {
@@ -337,45 +343,101 @@ internal fun ChatSettingsSection(
             Spacer(modifier = Modifier.height(12.dp))
 
             // Starred models display selector (mobile-only model-picker behavior)
-            Text(
-                text = stringResource(Res.string.starred_models_title),
-                style = MaterialTheme.typography.bodyLarge,
-            )
-            Text(
-                text = stringResource(Res.string.starred_models_desc),
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-            Spacer(modifier = Modifier.height(4.dp))
-            StarredModelsDisplay.entries.forEach { option ->
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .clip(RoundedCornerShape(8.dp))
-                        .selectable(
-                            selected = starredModelsDisplay == option,
-                            onClick = { onStarredModelsDisplayChange(option) },
-                            role = Role.RadioButton,
-                        )
-                        .padding(vertical = 8.dp, horizontal = 4.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    RadioButton(
-                        selected = starredModelsDisplay == option,
-                        onClick = null,
-                    )
-                    Spacer(modifier = Modifier.width(8.dp))
-                    Text(
-                        text = when (option) {
-                            StarredModelsDisplay.OFF -> stringResource(Res.string.starred_models_off)
-                            StarredModelsDisplay.GROUPED -> stringResource(Res.string.starred_models_grouped)
-                            StarredModelsDisplay.TOP -> stringResource(Res.string.starred_models_top)
-                        },
-                        style = MaterialTheme.typography.bodyLarge,
-                    )
+            SettingsRadioGroup(
+                title = stringResource(Res.string.starred_models_title),
+                description = stringResource(Res.string.starred_models_desc),
+                options = StarredModelsDisplay.entries,
+                selected = starredModelsDisplay,
+                onSelect = onStarredModelsDisplayChange,
+            ) { option ->
+                when (option) {
+                    StarredModelsDisplay.OFF -> stringResource(Res.string.starred_models_off)
+                    StarredModelsDisplay.GROUPED -> stringResource(Res.string.starred_models_grouped)
+                    StarredModelsDisplay.TOP -> stringResource(Res.string.starred_models_top)
+                }
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            // Chat header content selector (mobile-only floating-top-bar behavior)
+            SettingsRadioGroup(
+                title = stringResource(Res.string.chat_header_content_title),
+                description = stringResource(Res.string.chat_header_content_desc),
+                options = ChatHeaderContent.entries,
+                selected = chatHeaderContent,
+                onSelect = onChatHeaderContentChange,
+            ) { option ->
+                when (option) {
+                    ChatHeaderContent.TITLE -> stringResource(Res.string.chat_header_content_title_option)
+                    ChatHeaderContent.MODEL -> stringResource(Res.string.chat_header_content_model)
+                    ChatHeaderContent.NONE -> stringResource(Res.string.chat_header_content_none)
+                }
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            // Chat header bubble alignment selector (mobile-only floating-top-bar behavior)
+            SettingsRadioGroup(
+                title = stringResource(Res.string.chat_header_alignment_title),
+                description = stringResource(Res.string.chat_header_alignment_desc),
+                options = ChatHeaderAlignment.entries,
+                selected = chatHeaderAlignment,
+                onSelect = onChatHeaderAlignmentChange,
+            ) { option ->
+                when (option) {
+                    ChatHeaderAlignment.LEFT -> stringResource(Res.string.chat_header_alignment_left)
+                    ChatHeaderAlignment.CENTER -> stringResource(Res.string.chat_header_alignment_center)
+                    ChatHeaderAlignment.FILL -> stringResource(Res.string.chat_header_alignment_fill)
                 }
             }
         }
         HorizontalDivider(modifier = Modifier.padding(top = 8.dp))
+    }
+}
+
+private val RadioRowShape = RoundedCornerShape(8.dp)
+
+/**
+ * A titled single-select radio group over an enum's [options]. Shared by the chat-settings
+ * selectors (starred-models display, chat-header content, chat-header alignment) so the row
+ * styling and selection a11y stay in one place. [optionLabel] resolves each option's display
+ * string (a `@Composable` so callers can use `stringResource`).
+ */
+@Composable
+private fun <T> SettingsRadioGroup(
+    title: String,
+    description: String,
+    options: List<T>,
+    selected: T,
+    onSelect: (T) -> Unit,
+    modifier: Modifier = Modifier,
+    optionLabel: @Composable (T) -> String,
+) {
+    Column(modifier = modifier) {
+        Text(text = title, style = MaterialTheme.typography.bodyLarge)
+        Text(
+            text = description,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Spacer(modifier = Modifier.height(4.dp))
+        options.forEach { option ->
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clip(RadioRowShape)
+                    .selectable(
+                        selected = selected == option,
+                        onClick = { onSelect(option) },
+                        role = Role.RadioButton,
+                    )
+                    .padding(vertical = 8.dp, horizontal = 4.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                RadioButton(selected = selected == option, onClick = null)
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(text = optionLabel(option), style = MaterialTheme.typography.bodyLarge)
+            }
+        }
     }
 }

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/SettingsPreferencesController.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/SettingsPreferencesController.kt
@@ -4,6 +4,8 @@ import com.garfiec.librechat.core.common.ChatLayoutConstants
 import com.garfiec.librechat.core.data.datastore.ArtifactDisplayMode
 import com.garfiec.librechat.core.data.datastore.ArtifactDisplayPrefs
 import com.garfiec.librechat.core.data.datastore.ChatFontSize
+import com.garfiec.librechat.core.data.datastore.ChatHeaderAlignment
+import com.garfiec.librechat.core.data.datastore.ChatHeaderContent
 import com.garfiec.librechat.core.data.datastore.InlineArtifactPrefs
 import com.garfiec.librechat.core.data.datastore.LatexRenderer
 import com.garfiec.librechat.core.data.datastore.ServerDataStore
@@ -63,6 +65,8 @@ private data class AdditionalPreferences(
     val artifactDisplayPrefs: ArtifactDisplayPrefs = ArtifactDisplayPrefs(),
     val starredModelsDisplay: StarredModelsDisplay = StarredModelsDisplay.OFF,
     val selectedLanguage: String = SettingsDataStore.DEFAULT_LANGUAGE,
+    val chatHeaderContent: ChatHeaderContent = ChatHeaderContent.TITLE,
+    val chatHeaderAlignment: ChatHeaderAlignment = ChatHeaderAlignment.LEFT,
 )
 
 /**
@@ -159,6 +163,12 @@ class SettingsPreferencesController(
     private val selectedLanguagePref: StateFlow<String> = settingsDataStore.selectedLanguage
         .stateIn(scope, SharingStarted.Eagerly, SettingsDataStore.DEFAULT_LANGUAGE)
 
+    private val chatHeaderContentPref: StateFlow<ChatHeaderContent> = settingsDataStore.chatHeaderContent
+        .stateIn(scope, SharingStarted.Eagerly, ChatHeaderContent.TITLE)
+
+    private val chatHeaderAlignmentPref: StateFlow<ChatHeaderAlignment> = settingsDataStore.chatHeaderAlignment
+        .stateIn(scope, SharingStarted.Eagerly, ChatHeaderAlignment.LEFT)
+
     private val baseAdditionalPreferences = combine(
         tabletSidebarGestureEnabled,
         settingsDataStore.autoSendAfterStt,
@@ -185,6 +195,10 @@ class SettingsPreferencesController(
         additional.copy(starredModelsDisplay = starredDisplay)
     }.combine(selectedLanguagePref) { additional, selectedLanguage ->
         additional.copy(selectedLanguage = selectedLanguage)
+    }.combine(chatHeaderContentPref) { additional, headerContent ->
+        additional.copy(chatHeaderContent = headerContent)
+    }.combine(chatHeaderAlignmentPref) { additional, headerAlignment ->
+        additional.copy(chatHeaderAlignment = headerAlignment)
     }.stateIn(scope, SharingStarted.Eagerly, AdditionalPreferences(true, false, "", "", true))
 
     /** The single public UI state that merges DataStore preferences with imperative state. */
@@ -228,6 +242,8 @@ class SettingsPreferencesController(
             artifactDisplayPrefs = additional.artifactDisplayPrefs,
             starredModelsDisplay = additional.starredModelsDisplay,
             selectedLanguage = additional.selectedLanguage,
+            chatHeaderContent = additional.chatHeaderContent,
+            chatHeaderAlignment = additional.chatHeaderAlignment,
         )
     }.stateIn(scope, SharingStarted.Eagerly, SettingsUiState())
 
@@ -251,6 +267,14 @@ class SettingsPreferencesController(
 
     fun setStarredModelsDisplay(display: StarredModelsDisplay) {
         scope.launch { settingsDataStore.setStarredModelsDisplay(display) }
+    }
+
+    fun setChatHeaderContent(content: ChatHeaderContent) {
+        scope.launch { settingsDataStore.setChatHeaderContent(content) }
+    }
+
+    fun setChatHeaderAlignment(alignment: ChatHeaderAlignment) {
+        scope.launch { settingsDataStore.setChatHeaderAlignment(alignment) }
     }
 
     fun setAutoScrollEnabled(enabled: Boolean) {

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/SettingsUiState.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/SettingsUiState.kt
@@ -4,6 +4,8 @@ import androidx.compose.runtime.Immutable
 import com.garfiec.librechat.core.common.ChatLayoutConstants
 import com.garfiec.librechat.core.data.datastore.ArtifactDisplayPrefs
 import com.garfiec.librechat.core.data.datastore.ChatFontSize
+import com.garfiec.librechat.core.data.datastore.ChatHeaderAlignment
+import com.garfiec.librechat.core.data.datastore.ChatHeaderContent
 import com.garfiec.librechat.core.data.datastore.InlineArtifactPrefs
 import com.garfiec.librechat.core.data.datastore.LatexRenderer
 import com.garfiec.librechat.core.data.datastore.SettingsDataStore
@@ -191,6 +193,9 @@ data class SettingsUiState(
     val latexRenderer: LatexRenderer = LatexRenderer.KATEX,
     // Mobile-only: how pinned models/agents surface in the model-selection sheet
     val starredModelsDisplay: StarredModelsDisplay = StarredModelsDisplay.OFF,
+    // Mobile-only: what the chat floating top bar shows + how its bubble is aligned
+    val chatHeaderContent: ChatHeaderContent = ChatHeaderContent.TITLE,
+    val chatHeaderAlignment: ChatHeaderAlignment = ChatHeaderAlignment.LEFT,
     // Inline artifact rendering (per-type toggles)
     val inlineArtifactPrefs: InlineArtifactPrefs = InlineArtifactPrefs(),
     // Artifact viewer presentation (bottom sheet vs full screen + selector visibility)

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/SettingsViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/SettingsViewModel.kt
@@ -5,6 +5,8 @@ import androidx.lifecycle.viewModelScope
 import com.garfiec.librechat.core.common.AppInfo
 import com.garfiec.librechat.core.data.datastore.ArtifactDisplayMode
 import com.garfiec.librechat.core.data.datastore.ChatFontSize
+import com.garfiec.librechat.core.data.datastore.ChatHeaderAlignment
+import com.garfiec.librechat.core.data.datastore.ChatHeaderContent
 import com.garfiec.librechat.core.data.datastore.LatexRenderer
 import com.garfiec.librechat.core.data.datastore.ServerDataStore
 import com.garfiec.librechat.core.data.datastore.SettingsDataStore
@@ -208,6 +210,14 @@ class SettingsViewModel(
 
     fun setStarredModelsDisplay(display: StarredModelsDisplay) {
         prefsController.setStarredModelsDisplay(display)
+    }
+
+    fun setChatHeaderContent(content: ChatHeaderContent) {
+        prefsController.setChatHeaderContent(content)
+    }
+
+    fun setChatHeaderAlignment(alignment: ChatHeaderAlignment) {
+        prefsController.setChatHeaderAlignment(alignment)
     }
 
     fun setAutoScrollEnabled(enabled: Boolean) {


### PR DESCRIPTION
## Summary

Makes the chat floating top bar (added in #193) configurable from chat settings instead of always showing the conversation title. Users can choose **what the bubble shows** and **how it is aligned**, as two independent settings. Closes #198.

## Changes

- **New chat-settings selectors** (mobile-only), persisted via DataStore:
  - **Header content** — `Conversation title` (default), `Selected model`, or `Nothing`.
  - **Header alignment** — `Left` (default), `Center`, or `Fill width` (expands between the hamburger and overflow controls).
- **Floating top bar** now renders the chosen content/alignment:
  - *Title* — shows the conversation title; **long-press to edit it in place**. The inline editor commits only on the keyboard's Done action; tapping away, switching chats, or Escape discards the edit. Renames go through the existing rename path.
  - *Model* — shows the selected model (agent chats show the agent's name, not a raw id) and opens the model selector on tap; visible on the new-chat landing too.
  - *Nothing* — hides the bubble while keeping the hamburger, overflow menu, temp-chat toggle, in-conversation search, and scrim.
- **Shared `FloatingBarContentChip` / `FloatingBarLabelChip`** so the title and model bubbles render identically; the title/alignment radio groups are unified behind a single `SettingsRadioGroup` helper (also adopted by the existing starred-models selector).
- Settings strings added across all 10 supported locales.

## Testing / verification

- Android device test on Pixel 9 Pro Fold (debug build) — settings selectors persist; title/model/none content modes and left/center/fill alignment verified, including the inline title editor (Done commits, tap-away/switch discards).
- Builds verified on both platforms: `:feature:chat` / `:feature:settings` / `:core:data` Android compile, `detektMetadataCommonMain`, and the iOS (`:shared:compileKotlinIosSimulatorArm64`) target.

## Notes

- The "show model" option is an opt-in that partially reverses the deliberate decluttering choice of keeping the model selector off the header; the title remains the default.
