### PR TITLE
fix(ci): pin ktor to 3.4.3 to keep the iOS release link under the CI heap limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,11 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      # Pinned to ktor 3.4.3: 3.5.0 OOMs the Kotlin/Native Release link on the 7 GB
+      # CI runner (KT-80367, fixed in Kotlin 2.4.0). Remove this ignore when we move
+      # to Kotlin 2.4.x and unpin ktor in libs.versions.toml.
+      - dependency-name: "io.ktor:*"
 
   # Third-party actions in the release workflow are pinned to commit SHAs (not moving
   # tags) so a compromised action can't slip into the secret-bearing job; this keeps

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,7 +16,10 @@ lifecycle-viewmodel-nav3-kmp = "2.11.0-beta01"
 koin = "4.2.2"
 
 # Network
-ktor = "3.5.0"
+# Pinned to 3.4.3 (do not bump). 3.5.0 enlarges the iOS framework enough that the
+# Kotlin/Native Release link OOMs in DevirtualizationAnalysis on the 7 GB CI runner
+# (JetBrains KT-80367, fixed in Kotlin 2.4.0). Unpin once we upgrade to Kotlin 2.4.x.
+ktor = "3.4.3"
 kotlinx-serialization = "1.11.0"
 kotlinx-datetime = "0.8.0"
 


### PR DESCRIPTION
## Summary
The iOS release archive fails on CI: the Kotlin/Native Release framework link runs out of JVM heap during the LTO devirtualization pass on GitHub's 7 GB macOS runner. The Dependabot ktor 3.5.0 bump enlarged the framework enough to cross that limit. This pins ktor back to 3.4.3 — the last version that links within the runner's memory — until we move to Kotlin 2.4.x, which carries the upstream fix.

## Changes
- Pin `ktor` to `3.4.3` in `libs.versions.toml` (was 3.5.0), with an inline comment explaining the constraint and the unpin condition.
- Add a Dependabot `ignore` for `io.ktor:*` so the bump isn't immediately re-raised while the pin is in place.

## Background
The failure is `java.lang.OutOfMemoryError: Java heap space` in `DevirtualizationAnalysis` during `:shared:linkReleaseFrameworkIosArm64`. It only manifests in the Release/device archive — PR CI builds Debug/simulator, which skips LTO — which is why it surfaced only at release time. Tracked upstream as [KT-80367](https://youtrack.jetbrains.com/issue/KT-80367) ("Reduce memory consumption of DevirtualizationAnalysis"), fixed in Kotlin 2.4.0.

## Testing
- `./gradlew :core:network:dependencies` confirms ktor resolves to **3.4.3** for `iosArm64`.
- Restores the exact ktor version of the last green iOS release (v2026.06.7), whose IPA archive built successfully on the same runner.

## Follow-up
- Unpin ktor and remove the Dependabot ignore when upgrading to Kotlin 2.4.x ([KT-80367](https://youtrack.jetbrains.com/issue/KT-80367)).
