### PR TITLE
chore: add GitHub issue templates for bug reports and feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,130 @@
+name: Bug report
+description: Something in the mobile app is broken or behaving unexpectedly.
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a report. The fields below are what we need to actually reproduce and fix the problem — vague reports usually can't be acted on.
+
+        **Before posting:** scrub your server URL, auth tokens, and email out of any screenshots, logs, or text you paste. The log export redacts most of this automatically, but double-check.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: What happened?
+      description: Describe the actual behavior — what went wrong.
+      placeholder: When I tap X, the app does Y instead of...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Numbered steps from a known starting point (e.g. fresh launch / a specific screen). If you can't reproduce it reliably, describe what you were doing when it happened.
+      placeholder: |
+        1. Open the app on the conversation list
+        2. Tap '...'
+        3. See error
+    validations:
+      required: true
+
+  - type: dropdown
+    id: frequency
+    attributes:
+      label: How often does it happen?
+      options:
+        - Every time
+        - Intermittently
+        - Happened once
+    validations:
+      required: true
+
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform
+      options:
+        - Android
+        - iOS
+        - Both Android and iOS
+    validations:
+      required: true
+
+  - type: input
+    id: os_version
+    attributes:
+      label: OS version
+      placeholder: "Android 16 / iOS 26"
+    validations:
+      required: true
+
+  - type: input
+    id: device
+    attributes:
+      label: Device model
+      description: Include whether it's a phone, tablet, or foldable — the app's layout adapts to screen size.
+      placeholder: "Pixel 10 Pro Fold (foldable) / iPhone 17 Pro"
+    validations:
+      required: true
+
+  - type: input
+    id: app_version
+    attributes:
+      label: App version
+      description: "Found in Settings → General → About (the \"App version\" row)."
+      placeholder: "2026.06.8"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: install_source
+    attributes:
+      label: How did you install the app?
+      description: Debug and release builds, and different sideload paths, can behave differently.
+      options:
+        - GitHub release (APK)
+        - Obtainium
+        - Sideloaded IPA (AltStore / TrollStore)
+        - Built it myself (debug)
+        - Other (describe below)
+    validations:
+      required: true
+
+  - type: input
+    id: server_version
+    attributes:
+      label: LibreChat server version
+      description: "Leave blank if you don't know it. If your server exposes it, Settings → General → About shows the server build commit/branch/date; otherwise the version you deployed."
+      placeholder: "v0.8.7 / self-hosted Docker"
+    validations:
+      required: false
+
+  - type: textarea
+    id: attachments
+    attributes:
+      label: Screenshots, recording, or diagnostic log
+      description: |
+        Optional but it speeds up diagnosis a lot.
+        - A screenshot or screen recording of the problem.
+        - A diagnostic log: Settings → Data → Diagnostic Logs → "Export diagnostic logs" (auto-redacted), then attach the file here.
+    validations:
+      required: false
+
+  - type: input
+    id: regression
+    attributes:
+      label: Did this work in a previous version?
+      description: If it's a regression, which app version last worked?
+      placeholder: "Worked in 2026.06.5, broke in 2026.06.8 / Not sure"
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions & general help
+    url: https://github.com/garfiec/Librechat-Mobile/discussions
+    about: For usage questions or anything that isn't a specific bug or feature request. This is the mobile client — questions about running or configuring the LibreChat server belong upstream.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,84 @@
+name: Feature request
+description: Suggest a new capability or improvement for the mobile app.
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        This is the **mobile client** for LibreChat. The best requests start with the problem you're trying to solve, not just a proposed solution.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What are you trying to do that you can't (or that's painful) today? Describe the underlying need, not the solution.
+      placeholder: When I'm on the conversation list I can't... so I end up...
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: What would you like the app to do?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: web_parity
+    attributes:
+      label: Does the LibreChat web client already do this?
+      description: If web already has it, this is likely a parity gap the mobile app should pick up during an upstream sync.
+      options:
+        - "Yes — web already does this"
+        - "No — this would be new to LibreChat"
+        - "Not sure"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: platform_scope
+    attributes:
+      label: Which platforms?
+      options:
+        - Both Android and iOS
+        - Android only
+        - iOS only
+        - Not sure
+    validations:
+      required: true
+
+  - type: textarea
+    id: mobile_angle
+    attributes:
+      label: Mobile-specific angle (optional)
+      description: |
+        Is this something that only makes sense on mobile (push notifications, offline use, biometric lock, share sheet, widgets), or a general LibreChat feature that happens to be missing here? Helps decide whether to build it in the app or upstream it.
+    validations:
+      required: false
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered (optional)
+      description: Workarounds you've tried, or other ways this could be solved.
+    validations:
+      required: false
+
+  - type: input
+    id: server_version
+    attributes:
+      label: Server version (optional)
+      description: Only relevant if the feature depends on a specific backend capability or version.
+      placeholder: "v0.8.7"
+    validations:
+      required: false
+
+  - type: textarea
+    id: mockup
+    attributes:
+      label: Mockup / reference (optional)
+      description: A sketch, screenshot of the web behavior you want matched, or a link.
+    validations:
+      required: false


### PR DESCRIPTION
## Summary
Adds structured GitHub issue forms so reports arrive with the context needed to act on them. The tracker currently has no templates, so reports can be submitted with no environment or reproduction detail.

## Changes
- **`bug_report.yml`** — required fields for actual vs. expected behavior, reproduction steps, frequency, platform, OS version, device model, app version, and install source (release / Obtainium / sideloaded IPA / self-built debug). Server version, screenshot/recording, diagnostic-log attachment, and a regression field are optional. The repro field accepts "couldn't reproduce reliably" so intermittent bugs aren't blocked. Field hints point at the real in-app locations (version at Settings → General → About; log export at Settings → Data → Diagnostic Logs).
- **`feature_request.yml`** — problem-first form with a "does the web client already do this?" dropdown to separate upstream parity gaps from mobile-only ideas, plus platform scope and a mobile-specific-angle field.
- **`config.yml`** — disables blank issues and adds a "Questions & general help" off-ramp to this repo's own Discussions, keeping the tracker scoped to actual mobile-client bugs and features.

## Notes
- Required fields are limited to ones a reporter can always provide; server version is optional since users on shared or hosted instances often can't know it.
- Forms auto-apply `bug` / `enhancement` labels; these already exist in the repo.
- Requires GitHub Discussions to be enabled on the repo (now enabled) so the contact link resolves.
- The diagnostic-log export referenced in the bug form is on `develop` but not yet in a tagged release, so reporters on older builds won't have that button — wording is conditional so it degrades gracefully.
