### PR TITLE
feat: activate and harden the account-scoped DAO Detekt rule

### DIFF
--- a/build-logic/convention/src/main/kotlin/DetektConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/DetektConventionPlugin.kt
@@ -26,6 +26,9 @@ class DetektConventionPlugin : Plugin<Project> {
                 add("detektPlugins", libs.findLibrary("detekt-formatting").get())
                 add("detektPlugins", libs.findLibrary("detekt-koin").get())
                 add("detektPlugins", libs.findLibrary("detekt-compose").get())
+                // Custom row-tenancy ruleset (AccountScopedDao). :detekt-rules deliberately does not
+                // apply this convention, so wiring it here can't create a self-analysis cycle.
+                add("detektPlugins", project(":detekt-rules"))
             }
         }
     }

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -176,3 +176,9 @@ formatting:
   SpacingAroundParens:
     excludes:
       - "**/build/generated/compose/resourceGenerator/**"
+
+# Custom row-tenancy ruleset (:detekt-rules). Enforces that account-scoped Room DAOs filter every
+# tenant-table statement by accountId. See AccountScopedDaoRule.
+librechat:
+  AccountScopedDao:
+    active: true

--- a/core/common/src/commonMain/kotlin/com/garfiec/librechat/core/common/identity/CrossAccount.kt
+++ b/core/common/src/commonMain/kotlin/com/garfiec/librechat/core/common/identity/CrossAccount.kt
@@ -1,0 +1,20 @@
+package com.garfiec.librechat.core.common.identity
+
+/**
+ * Marks a Room DAO method whose statement is **deliberately not single-account-scoped at the SQL
+ * level**, so the `AccountScopedDao` Detekt rule must not flag it. The annotation has one meaning —
+ * "the matcher cannot prove this is account-safe; safety is established elsewhere and verified by a
+ * test" — and the existing uses are all instances of it:
+ *
+ * - an `@Transaction` Kotlin default whose body threads `accountId` into the scoped statements it
+ *   calls (the matcher can't see into the body);
+ * - a legacy-claim statement scoped by `accountId IS NULL` (a negative predicate, deliberately not
+ *   accepted as positive single-account scoping).
+ *
+ * It suppresses the *lint*, never the SQL: an annotated method is still responsible for being
+ * account-safe at runtime, so every use must be paired with an isolation test that proves rows
+ * don't cross accounts. Source-retained because the rule reads source PSI, not bytecode.
+ */
+@Retention(AnnotationRetention.SOURCE)
+@Target(AnnotationTarget.FUNCTION)
+annotation class CrossAccount

--- a/core/data/src/androidInstrumentedTest/kotlin/com/garfiec/librechat/core/data/db/RoomMigrationTest.kt
+++ b/core/data/src/androidInstrumentedTest/kotlin/com/garfiec/librechat/core/data/db/RoomMigrationTest.kt
@@ -10,7 +10,6 @@ import androidx.test.platform.app.InstrumentationRegistry
 import com.garfiec.librechat.core.data.db.migration.MIGRATION_3_4
 import com.garfiec.librechat.core.data.db.migration.MIGRATION_4_5
 import com.google.common.truth.Truth.assertThat
-import kotlinx.coroutines.runBlocking
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -253,12 +252,13 @@ class RoomMigrationTest {
             .addMigrations(MIGRATION_3_4, MIGRATION_4_5)
             .build()
 
-        // Verify we can read the migrated data via DAO
-        val conversation = runBlocking {
-            roomDb.conversationDao().getById("conv-api-test")
-        }
-        assertThat(conversation).isNotNull()
-        assertThat(conversation!!.title).isEqualTo("Room API Test")
+        // Verify we can read the migrated data (raw query: the migrated row carries a null accountId,
+        // so the account-scoped DAO reads can't see it).
+        val title = roomDb.query(
+            "SELECT title FROM conversations WHERE conversationId = ?",
+            arrayOf("conv-api-test"),
+        ).use { if (it.moveToFirst()) it.getString(0) else null }
+        assertThat(title).isEqualTo("Room API Test")
 
         roomDb.close()
     }

--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/db/AccountIsolationTestBase.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/db/AccountIsolationTestBase.kt
@@ -1,0 +1,71 @@
+package com.garfiec.librechat.core.data.db
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.garfiec.librechat.core.data.db.entity.ConversationEntity
+import com.garfiec.librechat.core.data.db.entity.ConversationTagEntity
+import com.garfiec.librechat.core.data.db.entity.MessageEntity
+import org.junit.After
+import org.junit.Before
+
+/**
+ * Shared Robolectric harness + entity builders for the two-account isolation suites
+ * ([AccountReadIsolationTest], [AccountWriteIsolationTest]). Centralizing the in-memory DB setup and
+ * the fixture builders keeps those two suites exercising identical DB config and entity shapes.
+ *
+ * `AccountClaimReconcilerTest` deliberately keeps its own builders rather than extending this base: it
+ * seeds *legacy* rows (nullable `accountId`, a per-row `user` column, null `parentMessageId`), a shape
+ * these always-attributed builders don't model.
+ */
+abstract class AccountIsolationTestBase {
+
+    protected val accountA = "srv:userA"
+    protected val accountB = "srv:userB"
+
+    protected lateinit var db: LibreChatDatabase
+
+    @Before
+    fun setUpDb() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        db = Room.inMemoryDatabaseBuilder(context, LibreChatDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+    }
+
+    @After
+    fun tearDownDb() {
+        db.close()
+    }
+
+    protected fun conversation(
+        id: String,
+        accountId: String,
+        title: String = "t-$id",
+        isArchived: Boolean = false,
+        tags: String = "[]",
+    ) = ConversationEntity(
+        conversationId = id, title = title, user = "u", endpoint = null, endpointType = null,
+        model = null, agentId = null, isArchived = isArchived, tags = tags, iconURL = null, greeting = null,
+        modelParams = null, createdAt = 0L, updatedAt = 0L, accountId = accountId,
+    )
+
+    protected fun message(
+        id: String,
+        conversationId: String,
+        accountId: String,
+        parentMessageId: String = "p",
+        text: String? = null,
+        feedback: String? = null,
+    ) = MessageEntity(
+        messageId = id, conversationId = conversationId, parentMessageId = parentMessageId, sender = null,
+        text = text, content = null, isCreatedByUser = false, model = null, endpoint = null,
+        iconURL = null, finishReason = null, tokenCount = null, feedback = feedback, files = null,
+        attachments = null, metadata = null, createdAt = 0L, updatedAt = 0L, accountId = accountId,
+    )
+
+    protected fun tag(tag: String, accountId: String) = ConversationTagEntity(
+        tag = tag, user = "u", description = null, count = 0, position = 0, createdAt = 0L,
+        updatedAt = 0L, accountId = accountId,
+    )
+}

--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/db/AccountReadIsolationTest.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/db/AccountReadIsolationTest.kt
@@ -1,17 +1,9 @@
 package com.garfiec.librechat.core.data.db
 
-import android.content.Context
-import androidx.room.Room
-import androidx.test.core.app.ApplicationProvider
-import com.garfiec.librechat.core.data.db.entity.ConversationEntity
-import com.garfiec.librechat.core.data.db.entity.ConversationTagEntity
 import com.garfiec.librechat.core.data.db.entity.DraftEntity
-import com.garfiec.librechat.core.data.db.entity.MessageEntity
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
-import org.junit.After
-import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -19,31 +11,13 @@ import org.robolectric.annotation.Config
 
 /**
  * Host-JVM (Robolectric) proof that the `accountId`-filtered tenant reads never cross accounts — the
- * read half of the leak fix. Two accounts' rows share
- * the one DB; each filtered read for account A must return only A's rows, and **by-PK reads must return
- * null for a foreign id** (the deep-link / stale-id leak), not the foreign row.
+ * read half of the leak fix. Two accounts' rows share the one DB; each filtered read for account A
+ * must return only A's rows, and **by-PK reads must return null for a foreign id** (the deep-link /
+ * stale-id leak), not the foreign row. Harness + entity builders come from [AccountIsolationTestBase].
  */
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [34])
-class AccountReadIsolationTest {
-
-    private val accountA = "srv:userA"
-    private val accountB = "srv:userB"
-
-    private lateinit var db: LibreChatDatabase
-
-    @Before
-    fun setUp() {
-        val context = ApplicationProvider.getApplicationContext<Context>()
-        db = Room.inMemoryDatabaseBuilder(context, LibreChatDatabase::class.java)
-            .allowMainThreadQueries()
-            .build()
-    }
-
-    @After
-    fun tearDown() {
-        db.close()
-    }
+class AccountReadIsolationTest : AccountIsolationTestBase() {
 
     @Test
     fun conversations_areAccountScoped_listAndByPk() = runTest {
@@ -65,8 +39,8 @@ class AccountReadIsolationTest {
     fun messages_areAccountScoped_listSiblingsAndByPk() = runTest {
         val msgDao = db.messageDao()
         // Same conversationId across accounts to prove the filter is accountId, not just conv.
-        msgDao.upsert(message("mA", conversationId = "conv", parentMessageId = "p", accountId = accountA))
-        msgDao.upsert(message("mB", conversationId = "conv", parentMessageId = "p", accountId = accountB))
+        msgDao.upsert(message("mA", conversationId = "conv", accountId = accountA))
+        msgDao.upsert(message("mB", conversationId = "conv", accountId = accountB))
 
         val listA = msgDao.observeMessagesForAccount("conv", accountA).first()
         assertThat(listA.map { it.messageId }).containsExactly("mA")
@@ -103,23 +77,4 @@ class AccountReadIsolationTest {
         val tagsA = tagDao.observeTagsForAccount(accountA).first()
         assertThat(tagsA.map { it.tag }).containsExactly("work")
     }
-
-    private fun conversation(id: String, accountId: String) = ConversationEntity(
-        conversationId = id, title = "t-$id", user = "u", endpoint = null, endpointType = null,
-        model = null, agentId = null, isArchived = false, tags = "[]", iconURL = null, greeting = null,
-        modelParams = null, createdAt = 0L, updatedAt = 0L, accountId = accountId,
-    )
-
-    private fun message(id: String, conversationId: String, parentMessageId: String, accountId: String) =
-        MessageEntity(
-            messageId = id, conversationId = conversationId, parentMessageId = parentMessageId, sender = null,
-            text = null, content = null, isCreatedByUser = false, model = null, endpoint = null,
-            iconURL = null, finishReason = null, tokenCount = null, feedback = null, files = null,
-            attachments = null, metadata = null, createdAt = 0L, updatedAt = 0L, accountId = accountId,
-        )
-
-    private fun tag(tag: String, accountId: String) = ConversationTagEntity(
-        tag = tag, user = "u", description = null, count = 0, position = 0, createdAt = 0L,
-        updatedAt = 0L, accountId = accountId,
-    )
 }

--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/db/AccountWriteIsolationTest.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/db/AccountWriteIsolationTest.kt
@@ -1,0 +1,130 @@
+package com.garfiec.librechat.core.data.db
+
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Host-JVM (Robolectric) proof that the `accountId`-scoped tenant *writes* never touch another
+ * account's rows — the write half of the leak fix that PR1-A scopes and the Detekt rule enforces.
+ * Harness + entity builders come from [AccountIsolationTestBase].
+ *
+ * Covers both kinds the rule treats differently:
+ * - **by-PK `@Query` writes** (`updateTitle` / `updateArchived` / `updateTags` / `deleteById` /
+ *   `updateFeedback` / `updateText`) — a write addressed to a foreign id must be a no-op.
+ * - **`@Transaction` defaults** (`upsertPreservingTags` / `replaceAllForConversation` /
+ *   `replaceAllForAccount`) — the per-statement isolation each body relies on (PLAN.md R6-4/R9-16).
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class AccountWriteIsolationTest : AccountIsolationTestBase() {
+
+    // region by-PK @Query writes: addressing a foreign id is a no-op
+
+    @Test
+    fun conversationByPkWrites_doNotTouchForeignAccountsRow() = runTest {
+        val dao = db.conversationDao()
+        dao.upsert(conversation("convB", accountB, title = "B-title", isArchived = false, tags = "[\"home\"]"))
+
+        // Account A tries to mutate B's row by id. Every by-PK write is scoped `AND accountId = A`,
+        // so each must match zero rows and leave B's row untouched.
+        dao.updateTitle("convB", "hacked", updatedAt = 1L, accountId = accountA)
+        dao.updateArchived("convB", isArchived = true, updatedAt = 1L, accountId = accountA)
+        dao.updateTags("convB", tagsJson = "[\"hacked\"]", updatedAt = 1L, accountId = accountA)
+        dao.deleteById("convB", accountId = accountA)
+
+        val b = dao.getByIdForAccount("convB", accountB)
+        assertThat(b).isNotNull()
+        assertThat(b!!.title).isEqualTo("B-title")
+        assertThat(b.isArchived).isFalse()
+        assertThat(b.tags).isEqualTo("[\"home\"]")
+    }
+
+    @Test
+    fun conversationByPkWrites_doMutateOwnRow() = runTest {
+        val dao = db.conversationDao()
+        dao.upsert(conversation("convA", accountA, title = "old", isArchived = false, tags = "[]"))
+
+        dao.updateTitle("convA", "new", updatedAt = 1L, accountId = accountA)
+        assertThat(dao.getByIdForAccount("convA", accountA)?.title).isEqualTo("new")
+
+        dao.deleteById("convA", accountId = accountA)
+        assertThat(dao.getByIdForAccount("convA", accountA)).isNull()
+    }
+
+    @Test
+    fun messageByPkWrites_doNotTouchForeignAccountsRow() = runTest {
+        val dao = db.messageDao()
+        dao.upsert(message("mB", conversationId = "conv", accountId = accountB, text = "B-text", feedback = "up"))
+
+        dao.updateText("mB", text = "hacked", accountId = accountA)
+        dao.updateFeedback("mB", feedback = "down", accountId = accountA)
+
+        val b = dao.getByIdForAccount("mB", accountB)
+        assertThat(b).isNotNull()
+        assertThat(b!!.text).isEqualTo("B-text")
+        assertThat(b.feedback).isEqualTo("up")
+    }
+
+    // endregion
+
+    // region @Transaction defaults: per-statement isolation
+
+    @Test
+    fun upsertPreservingTags_doesNotInheritForeignAccountsTags() = runTest {
+        val dao = db.conversationDao()
+        // A owns convA with tags; preserving-upsert of the same row under A keeps them.
+        dao.upsert(conversation("convA", accountA, title = "t", isArchived = false, tags = "[\"work\"]"))
+        dao.upsertPreservingTags(accountA, conversation("convA", accountA, title = "t2", isArchived = false, tags = "[]"))
+        assertThat(dao.getByIdForAccount("convA", accountA)?.tags).isEqualTo("[\"work\"]")
+
+        // B owns convB with tags. When A preserving-upserts an id that exists only under B, the inner
+        // read is `getByIdForAccount(id, A)` -> null, so A must NOT inherit B's tags.
+        dao.upsert(conversation("convB", accountB, title = "t", isArchived = false, tags = "[\"home\"]"))
+        dao.upsertPreservingTags(accountA, conversation("convB", accountA, title = "t", isArchived = false, tags = "[]"))
+        assertThat(dao.getByIdForAccount("convB", accountA)?.tags).isEqualTo("[]")
+
+        // KNOWN LIMITATION (documented, accepted): conversationId is the PK alone, so this same-id
+        // upsert reassigns convB to A — B's row is gone. This is harmless in practice (server
+        // conversationIds are unique per user, so a cross-account id collision doesn't occur); the
+        // isolation guarantee that matters here is the no-tag-bleed asserted above, not row survival.
+        assertThat(dao.getByIdForAccount("convB", accountB)).isNull()
+    }
+
+    @Test
+    fun replaceAllForConversation_onlyReplacesOwnAccountsMessages() = runTest {
+        val dao = db.messageDao()
+        // Same conversationId across accounts (messages PK is messageId, so rows coexist).
+        dao.upsert(message("mA", conversationId = "conv", accountId = accountA, text = "A-old"))
+        dao.upsert(message("mB", conversationId = "conv", accountId = accountB, text = "B-keep"))
+
+        dao.replaceAllForConversation(
+            "conv",
+            accountA,
+            listOf(message("mA2", conversationId = "conv", accountId = accountA, text = "A-new")),
+        )
+
+        // A's old message gone, A's new present; B's message for the same conversation survives.
+        assertThat(dao.observeMessagesForAccount("conv", accountA).first().map { it.messageId })
+            .containsExactly("mA2")
+        assertThat(dao.observeMessagesForAccount("conv", accountB).first().map { it.messageId })
+            .containsExactly("mB")
+    }
+
+    @Test
+    fun replaceAllForAccount_onlyReplacesOwnAccountsTags() = runTest {
+        val dao = db.conversationTagDao()
+        dao.upsertAll(listOf(tag("work", accountA), tag("home", accountB)))
+
+        dao.replaceAllForAccount(accountA, listOf(tag("play", accountA)))
+
+        assertThat(dao.observeTagsForAccount(accountA).first().map { it.tag }).containsExactly("play")
+        assertThat(dao.observeTagsForAccount(accountB).first().map { it.tag }).containsExactly("home")
+    }
+
+    // endregion
+}

--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/db/RoomHostJvmSmokeTest.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/db/RoomHostJvmSmokeTest.kt
@@ -40,7 +40,7 @@ class RoomHostJvmSmokeTest {
             .build()
         try {
             db.conversationDao().upsert(sampleConversation(id = "c1", title = "host-jvm-ok"))
-            val read = db.conversationDao().getById("c1")
+            val read = db.conversationDao().getByIdForAccount("c1", "acct")
             assertEquals("host-jvm-ok", read?.title)
         } finally {
             db.close()
@@ -62,5 +62,6 @@ class RoomHostJvmSmokeTest {
         modelParams = null,
         createdAt = 0L,
         updatedAt = 0L,
+        accountId = "acct",
     )
 }

--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/repository/AccountClaimReconcilerTest.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/repository/AccountClaimReconcilerTest.kt
@@ -15,7 +15,6 @@ import com.garfiec.librechat.core.data.db.entity.MessageEntity
 import com.garfiec.librechat.core.model.NEW_CHAT_DRAFT_KEY
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.After
@@ -64,6 +63,25 @@ class AccountClaimReconcilerTest {
     private fun reconciler(name: String) =
         AccountClaimReconciler(db.accountClaimDao(), dataStore(name), dispatcher)
 
+    // Account-agnostic raw reads for assertions: these tests must inspect rows regardless of which
+    // account owns them (to verify what accountId the claim stamped, or that foreign rows were swept),
+    // which the account-scoped DAO reads deliberately can't do. Query the DB directly instead of
+    // exposing an unscoped read on the production DAO.
+    private fun rowExists(table: String, pkCol: String, id: String): Boolean =
+        db.query("SELECT 1 FROM $table WHERE $pkCol = ?", arrayOf(id)).use { it.moveToFirst() }
+
+    private fun accountIdOf(table: String, pkCol: String, id: String): String? =
+        db.query("SELECT accountId FROM $table WHERE $pkCol = ?", arrayOf(id)).use {
+            if (it.moveToFirst() && !it.isNull(0)) it.getString(0) else null
+        }
+
+    private data class TagRow(val tag: String, val accountId: String?)
+
+    private fun allTags(): List<TagRow> =
+        db.query("SELECT tag, accountId FROM conversation_tags ORDER BY position ASC", null).use { c ->
+            buildList { while (c.moveToNext()) add(TagRow(c.getString(0), if (c.isNull(1)) null else c.getString(1))) }
+        }
+
     @Test
     fun claimsOwnerRowsByUser_stampsTransitively_deletesForeignAndConvLess() = runTest(dispatcher) {
         seedLegacyRows()
@@ -71,25 +89,25 @@ class AccountClaimReconcilerTest {
         reconciler("claim").claimIfNeeded(AccountId("srv:userA"), userKey = "userA")
 
         // Owner (userA) rows are stamped...
-        assertThat(db.conversationDao().getById("convA")?.accountId).isEqualTo("srv:userA")
-        assertThat(db.messageDao().getById("mA")?.accountId).isEqualTo("srv:userA")
-        assertThat(db.draftDao().getDraft("convA")?.accountId).isEqualTo("srv:userA")
-        val tags = db.conversationTagDao().getAllTags().first()
+        assertThat(accountIdOf("conversations", "conversationId", "convA")).isEqualTo("srv:userA")
+        assertThat(accountIdOf("messages", "messageId", "mA")).isEqualTo("srv:userA")
+        assertThat(accountIdOf("drafts", "conversation_id", "convA")).isEqualTo("srv:userA")
+        val tags = allTags()
         assertThat(tags.map { it.tag }).containsExactly("work")
         assertThat(tags.single().accountId).isEqualTo("srv:userA")
 
         // ...foreign (userB) rows are deleted, not visible, not re-attributed.
-        assertThat(db.conversationDao().getById("convB")).isNull()
-        assertThat(db.messageDao().getById("mB")).isNull()
-        assertThat(db.draftDao().getDraft("convB")).isNull()
+        assertThat(rowExists("conversations", "conversationId", "convB")).isFalse()
+        assertThat(rowExists("messages", "messageId", "mB")).isFalse()
+        assertThat(rowExists("drafts", "conversation_id", "convB")).isFalse()
 
         // ...un-attributable conv-less message is deleted (fail-safe).
-        assertThat(db.messageDao().getById("mOrphan")).isNull()
+        assertThat(rowExists("messages", "messageId", "mOrphan")).isFalse()
 
         // ...the conv-less new-chat draft survives, claimed for the upgrading account (unsent text kept)...
-        assertThat(db.draftDao().getDraft(NEW_CHAT_DRAFT_KEY)?.accountId).isEqualTo("srv:userA")
+        assertThat(accountIdOf("drafts", "conversation_id", NEW_CHAT_DRAFT_KEY)).isEqualTo("srv:userA")
         // ...but a stale conv-less draft (owning conversation already gone) is still swept.
-        assertThat(db.draftDao().getDraft("deleted-conv")).isNull()
+        assertThat(rowExists("drafts", "conversation_id", "deleted-conv")).isFalse()
     }
 
     @Test
@@ -100,9 +118,9 @@ class AccountClaimReconcilerTest {
         dao.claimLegacyRows(accountId = "srv:userA", userKey = "userA", newChatKey = NEW_CHAT_DRAFT_KEY)
         dao.claimLegacyRows(accountId = "srv:userA", userKey = "userA", newChatKey = NEW_CHAT_DRAFT_KEY)
 
-        assertThat(db.conversationDao().getById("convA")?.accountId).isEqualTo("srv:userA")
-        assertThat(db.conversationDao().getById("convB")).isNull()
-        assertThat(db.messageDao().getById("mA")?.accountId).isEqualTo("srv:userA")
+        assertThat(accountIdOf("conversations", "conversationId", "convA")).isEqualTo("srv:userA")
+        assertThat(rowExists("conversations", "conversationId", "convB")).isFalse()
+        assertThat(accountIdOf("messages", "messageId", "mA")).isEqualTo("srv:userA")
     }
 
     @Test
@@ -118,7 +136,8 @@ class AccountClaimReconcilerTest {
         // ...a second call is short-circuited by the marker, so it neither stamps nor deletes it.
         gated.claimIfNeeded(AccountId("srv:userA"), userKey = "userA")
 
-        assertThat(db.conversationDao().getById("convLate")?.accountId).isNull()
+        assertThat(rowExists("conversations", "conversationId", "convLate")).isTrue()
+        assertThat(accountIdOf("conversations", "conversationId", "convLate")).isNull()
     }
 
     private suspend fun seedLegacyRows() {

--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/repository/AccountSessionEstablisherTest.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/repository/AccountSessionEstablisherTest.kt
@@ -1,0 +1,66 @@
+package com.garfiec.librechat.core.data.repository
+
+import com.garfiec.librechat.core.data.datastore.AccountRegistry
+import com.garfiec.librechat.core.model.User
+import com.garfiec.librechat.core.network.client.ServerUrlProvider
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.coVerifyOrder
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AccountSessionEstablisherTest {
+
+    private val accountRegistry = mockk<AccountRegistry>(relaxed = true)
+    private val claimReconciler = mockk<AccountClaimReconciler>(relaxed = true)
+    private val serverUrlProvider = mockk<ServerUrlProvider>(relaxed = true)
+
+    private val establisher = AccountSessionEstablisher(
+        accountRegistry = accountRegistry,
+        claimReconciler = claimReconciler,
+        serverUrlProvider = serverUrlProvider,
+        ioDispatcher = UnconfinedTestDispatcher(),
+    )
+
+    /**
+     * Regression guard: the legacy claim must stamp NULL-accountId rows BEFORE the account is published.
+     * If publish happened first, a sync in that window would overwrite still-unclaimed legacy rows and
+     * drop their locally-stored tags (`upsertPreservingTags` reads `getByIdForAccount`, which misses a
+     * NULL row).
+     */
+    @Test
+    fun claimsLegacyRowsBeforePublishingAccount() = runTest {
+        coEvery { serverUrlProvider.awaitBaseUrl() } returns "https://chat.example.com"
+        val user = mockk<User>(relaxed = true)
+        every { user.id } returns "mongoUserId"
+
+        establisher.establish(user)
+
+        coVerifyOrder {
+            claimReconciler.claimIfNeeded(any(), "mongoUserId")
+            accountRegistry.setActiveAccount(any())
+        }
+    }
+
+    /**
+     * The claim is best-effort: a failure must not strand the user at `Resolved(null)`. Even when the
+     * claim throws, the account must still be published so scoped reads/writes go live (the claim
+     * retries on the next establish).
+     */
+    @Test
+    fun publishesAccountEvenWhenClaimFails() = runTest {
+        coEvery { serverUrlProvider.awaitBaseUrl() } returns "https://chat.example.com"
+        coEvery { claimReconciler.claimIfNeeded(any(), any()) } throws IllegalStateException("db error")
+        val user = mockk<User>(relaxed = true)
+        every { user.id } returns "mongoUserId"
+
+        establisher.establish(user)
+
+        coVerify { accountRegistry.setActiveAccount(any()) }
+    }
+}

--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/repository/ConversationRepositoryImplTest.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/repository/ConversationRepositoryImplTest.kt
@@ -70,7 +70,7 @@ class ConversationRepositoryImplTest {
             ConversationListResponse(conversations = listOf(serverConvo), nextCursor = null)
 
         val captured = slot<List<ConversationEntity>>()
-        coEvery { conversationDao.upsertPreservingTags(capture(captured)) } answers {}
+        coEvery { conversationDao.upsertPreservingTags(account.value, capture(captured)) } answers {}
 
         val result = repository.loadNextPage(cursor = null)
 
@@ -85,7 +85,7 @@ class ConversationRepositoryImplTest {
         val streamingConvo = Conversation(conversationId = "convo-1", title = "Updated mid-stream")
 
         val captured = slot<ConversationEntity>()
-        coEvery { conversationDao.upsertPreservingTags(capture(captured)) } answers {}
+        coEvery { conversationDao.upsertPreservingTags(account.value, capture(captured)) } answers {}
 
         repository.saveConversation(streamingConvo)
 
@@ -99,7 +99,7 @@ class ConversationRepositoryImplTest {
 
         repository.saveConversation(blank)
 
-        coVerify(exactly = 0) { conversationDao.upsertPreservingTags(any<ConversationEntity>()) }
+        coVerify(exactly = 0) { conversationDao.upsertPreservingTags(any(), any<ConversationEntity>()) }
     }
 
     @Test
@@ -110,13 +110,13 @@ class ConversationRepositoryImplTest {
         } returns ConversationListResponse(conversations = listOf(serverConvo), nextCursor = null)
         coEvery { conversationDao.getByIdForAccount("convo-1", account.value) } returns entity("convo-1", """["work"]""")
         coEvery { conversationDao.observeConversationsForAccount(account.value, false) } returns flowOf(emptyList())
-        coEvery { conversationDao.updateTags(any(), any(), any()) } just Runs
+        coEvery { conversationDao.updateTags(any(), any(), any(), any()) } just Runs
 
         repository.syncFavoritesFromServer()
 
         val tagsCaptor = slot<String>()
         coVerify(exactly = 1) {
-            conversationDao.updateTags("convo-1", capture(tagsCaptor), any())
+            conversationDao.updateTags("convo-1", capture(tagsCaptor), any(), any())
         }
         assertThat(json.decodeFromString<List<String>>(tagsCaptor.captured))
             .containsExactly("work", SAVED_TAG).inOrder()
@@ -129,13 +129,13 @@ class ConversationRepositoryImplTest {
         } returns ConversationListResponse(conversations = emptyList(), nextCursor = null)
         val staleFav = entity("convo-stale", """["work","Saved"]""")
         coEvery { conversationDao.observeConversationsForAccount(account.value, false) } returns flowOf(listOf(staleFav))
-        coEvery { conversationDao.updateTags(any(), any(), any()) } just Runs
+        coEvery { conversationDao.updateTags(any(), any(), any(), any()) } just Runs
 
         repository.syncFavoritesFromServer()
 
         val tagsCaptor = slot<String>()
         coVerify(exactly = 1) {
-            conversationDao.updateTags("convo-stale", capture(tagsCaptor), any())
+            conversationDao.updateTags("convo-stale", capture(tagsCaptor), any(), any())
         }
         assertThat(json.decodeFromString<List<String>>(tagsCaptor.captured))
             .containsExactly("work")
@@ -204,7 +204,7 @@ class ConversationRepositoryImplTest {
 
         repository.syncFavoritesFromServer()
 
-        coVerify(exactly = 0) { conversationDao.updateTags(any(), any(), any()) }
+        coVerify(exactly = 0) { conversationDao.updateTags(any(), any(), any(), any()) }
         coVerify(exactly = 0) { conversationDao.upsert(any()) }
     }
 }

--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/repository/RepositoryCacheMutexTest.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/repository/RepositoryCacheMutexTest.kt
@@ -1,5 +1,8 @@
 package com.garfiec.librechat.core.data.repository
 
+import com.garfiec.librechat.core.common.identity.AccountId
+import com.garfiec.librechat.core.common.identity.AccountState
+import com.garfiec.librechat.core.common.identity.InMemoryActiveAccountProvider
 import com.garfiec.librechat.core.common.result.Result
 import com.garfiec.librechat.core.model.Agent
 import com.garfiec.librechat.core.model.Preset
@@ -30,7 +33,10 @@ class RepositoryCacheMutexTest {
                 AgentListResponse(data = responseAgents)
             }
 
-            val repository = AgentRepositoryImpl(agentsApi = agentsApi)
+            val repository = AgentRepositoryImpl(
+                agentsApi = agentsApi,
+                activeAccountProvider = InMemoryActiveAccountProvider(),
+            )
 
             val first = async { repository.getAgents(category = null) }
             val second = async { repository.getAgents(category = null) }
@@ -52,7 +58,10 @@ class RepositoryCacheMutexTest {
         val responseAgents = listOf(Agent(id = "a1"))
         coEvery { agentsApi.getAgents(null) } returns AgentListResponse(data = responseAgents)
 
-        val repository = AgentRepositoryImpl(agentsApi = agentsApi)
+        val repository = AgentRepositoryImpl(
+                agentsApi = agentsApi,
+                activeAccountProvider = InMemoryActiveAccountProvider(),
+            )
         repository.getAgents(category = null)
         repository.getAgents(category = null)
         repository.getAgents(category = null)
@@ -69,7 +78,10 @@ class RepositoryCacheMutexTest {
             coEvery { agentsApi.getAgents("writing") } returns AgentListResponse(data = filteredAgents)
             coEvery { agentsApi.getAgents(null) } returns AgentListResponse(data = allAgents)
 
-            val repository = AgentRepositoryImpl(agentsApi = agentsApi)
+            val repository = AgentRepositoryImpl(
+                agentsApi = agentsApi,
+                activeAccountProvider = InMemoryActiveAccountProvider(),
+            )
             repository.getAgents(category = "writing")
             // Cache must still be cold — next call with category=null must hit the API.
             repository.getAgents(category = null)
@@ -77,6 +89,27 @@ class RepositoryCacheMutexTest {
 
             coVerify(exactly = 1) { agentsApi.getAgents("writing") }
             coVerify(exactly = 1) { agentsApi.getAgents(null) }
+        }
+
+    @Test
+    fun `AgentRepositoryImpl - identity change makes next getAgents re-fetch (no stale cross-account serve)`() =
+        runTest {
+            val agentsApi = mockk<AgentsApi>()
+            coEvery { agentsApi.getAgents(null) } returns AgentListResponse(data = listOf(Agent(id = "a1")))
+            val provider = InMemoryActiveAccountProvider(AccountState.Resolved(AccountId("srv:userA")))
+
+            val repository = AgentRepositoryImpl(
+                agentsApi = agentsApi,
+                activeAccountProvider = provider,
+            )
+
+            repository.getAgents(category = null) // populates cache under account A
+            provider.set(AccountId("srv:userB")) // now active account is B
+            // Read-time owner keying: the cache belongs to A, so B's read must NOT be served it; it
+            // re-fetches synchronously (no async clear to wait on).
+            repository.getAgents(category = null)
+
+            coVerify(exactly = 2) { agentsApi.getAgents(null) }
         }
 
     @Test
@@ -92,7 +125,10 @@ class RepositoryCacheMutexTest {
                 responsePresets
             }
 
-            val repository = PresetRepositoryImpl(presetsApi = presetsApi)
+            val repository = PresetRepositoryImpl(
+            presetsApi = presetsApi,
+            activeAccountProvider = InMemoryActiveAccountProvider(),
+        )
 
             val first = async { repository.getAll() }
             val second = async { repository.getAll() }
@@ -119,7 +155,10 @@ class RepositoryCacheMutexTest {
         coEvery { presetsApi.getPresets() } returnsMany listOf(first, second)
         coEvery { presetsApi.createPreset(any()) } returns Preset(presetId = "p2", title = "Two")
 
-        val repository = PresetRepositoryImpl(presetsApi = presetsApi)
+        val repository = PresetRepositoryImpl(
+            presetsApi = presetsApi,
+            activeAccountProvider = InMemoryActiveAccountProvider(),
+        )
         repository.getAll()
         repository.create(Preset(presetId = "p2", title = "Two"))
         val result = repository.getAll()

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/db/dao/AccountClaimDao.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/db/dao/AccountClaimDao.kt
@@ -3,6 +3,7 @@ package com.garfiec.librechat.core.data.db.dao
 import androidx.room.Dao
 import androidx.room.Query
 import androidx.room.Transaction
+import com.garfiec.librechat.core.common.identity.CrossAccount
 
 /**
  * One-time *claim* of legacy (pre-row-tenancy) data for the first resolved account.
@@ -19,24 +20,32 @@ import androidx.room.Transaction
  * deletes nothing that survived), so the persisted "claim done" marker is only an optimization, not a
  * correctness dependency.
  *
- * Not a tenant DAO by name, so the AccountScopedDao Detekt rule doesn't force `@CrossAccount` on the
- * transaction default; the individual statements all carry an `accountId IS NULL` predicate and pass.
+ * Every statement here touches a tenant table without a positive single-account predicate — the
+ * stamps scope by `accountId IS NULL` (claiming, not reading one account), the sweeps delete all
+ * remaining NULL rows. Both are deliberate cross-account operations, so each carries [CrossAccount]:
+ * the AccountScopedDao Detekt rule's tightened matcher (which accepts only a positive `accountId =`
+ * WHERE predicate as scoping) would otherwise flag them. Annotating all of them uniformly keeps the
+ * rule's verdict consistent across the claim methods regardless of subquery shape.
  */
 @Dao
 interface AccountClaimDao {
 
+    @CrossAccount
     @Query("UPDATE conversations SET accountId = :accountId WHERE accountId IS NULL AND user = :userKey")
     suspend fun stampConversations(accountId: String, userKey: String)
 
+    @CrossAccount
     @Query("UPDATE conversation_tags SET accountId = :accountId WHERE accountId IS NULL AND user = :userKey")
     suspend fun stampConversationTags(accountId: String, userKey: String)
 
+    @CrossAccount
     @Query(
         "UPDATE messages SET accountId = :accountId WHERE accountId IS NULL AND conversationId IN " +
             "(SELECT conversationId FROM conversations WHERE accountId = :accountId)",
     )
     suspend fun stampMessagesOfClaimedConversations(accountId: String)
 
+    @CrossAccount
     @Query(
         "UPDATE drafts SET accountId = :accountId WHERE accountId IS NULL AND conversation_id IN " +
             "(SELECT conversationId FROM conversations WHERE accountId = :accountId)",
@@ -50,18 +59,23 @@ interface AccountClaimDao {
      * row to the first post-upgrade account preserves it; isolation still holds afterward because every
      * read is account-filtered. Bounded leak surface: one local compose box on a shared device.
      */
+    @CrossAccount
     @Query("UPDATE drafts SET accountId = :accountId WHERE accountId IS NULL AND conversation_id = :newChatKey")
     suspend fun stampNewChatDraft(accountId: String, newChatKey: String)
 
+    @CrossAccount
     @Query("DELETE FROM messages WHERE accountId IS NULL")
     suspend fun deleteUnclaimedMessages()
 
+    @CrossAccount
     @Query("DELETE FROM drafts WHERE accountId IS NULL")
     suspend fun deleteUnclaimedDrafts()
 
+    @CrossAccount
     @Query("DELETE FROM conversations WHERE accountId IS NULL")
     suspend fun deleteUnclaimedConversations()
 
+    @CrossAccount
     @Query("DELETE FROM conversation_tags WHERE accountId IS NULL")
     suspend fun deleteUnclaimedConversationTags()
 
@@ -71,6 +85,7 @@ interface AccountClaimDao {
      * (and the conv-less new-chat draft via [newChatKey]) before the sweep removes the remaining NULL
      * rows.
      */
+    @CrossAccount
     @Transaction
     suspend fun claimLegacyRows(accountId: String, userKey: String, newChatKey: String) {
         stampConversations(accountId, userKey)

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/db/dao/ConversationDao.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/db/dao/ConversationDao.kt
@@ -4,32 +4,20 @@ import androidx.room.Dao
 import androidx.room.Query
 import androidx.room.Transaction
 import androidx.room.Upsert
+import com.garfiec.librechat.core.common.identity.CrossAccount
 import com.garfiec.librechat.core.data.db.entity.ConversationEntity
 import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface ConversationDao {
-    @Query(
-        "SELECT * FROM conversations WHERE user = :userId AND isArchived = :isArchived " +
-            "ORDER BY pinned DESC, updatedAt DESC LIMIT :limit",
-    )
-    fun getConversations(userId: String, isArchived: Boolean = false, limit: Int = 25): Flow<List<ConversationEntity>>
-
-    @Query("SELECT * FROM conversations WHERE isArchived = :isArchived ORDER BY pinned DESC, updatedAt DESC")
-    fun getAllConversations(isArchived: Boolean = false): Flow<List<ConversationEntity>>
-
-    @Query("SELECT * FROM conversations WHERE conversationId = :id")
-    suspend fun getById(id: String): ConversationEntity?
-
-    @Query("SELECT * FROM conversations WHERE conversationId = :id")
-    fun observeById(id: String): Flow<ConversationEntity?>
 
     // --- Account-scoped reads (row-tenancy). Every read filters accountId, incl. by-PK:
-    // a known/stale/deep-linked id from the shared DB must not let account B read A's row. These
-    // are the forms the AccountScopedDb facade calls; the unfiltered forms above are removed once
-    // repos migrate + the Detekt rule turns on. ---
+    // a known/stale/deep-linked id from the shared DB must not let account B read A's row. ---
 
-    @Query("SELECT * FROM conversations WHERE accountId = :accountId AND isArchived = :isArchived ORDER BY updatedAt DESC")
+    @Query(
+        "SELECT * FROM conversations WHERE accountId = :accountId AND isArchived = :isArchived " +
+            "ORDER BY pinned DESC, updatedAt DESC",
+    )
     fun observeConversationsForAccount(accountId: String, isArchived: Boolean): Flow<List<ConversationEntity>>
 
     @Query("SELECT * FROM conversations WHERE conversationId = :id AND accountId = :accountId")
@@ -44,51 +32,51 @@ interface ConversationDao {
     @Upsert
     suspend fun upsertAll(conversations: List<ConversationEntity>)
 
-    // Atomic read-merge-write that preserves locally-stored tags when a row
-    // already exists. Used by paths that receive server responses without the
-    // `tags` field (list endpoint + streaming save). Must run inside a single
-    // transaction so it can't be interleaved by a concurrent updateTags write
-    // from `syncFavoritesFromServer` (which would otherwise get clobbered).
+    // Atomic read-merge-write that preserves locally-stored tags when a row already exists for this
+    // account. Used by paths that receive server responses without the `tags` field (list endpoint +
+    // streaming save). Must run inside a single transaction so it can't be interleaved by a concurrent
+    // updateTags write from `syncFavoritesFromServer` (which would otherwise get clobbered). The body
+    // threads `accountId` (reads via `getByIdForAccount`), so it is account-safe despite @CrossAccount
+    // suppressing the concrete-body lint.
+    @CrossAccount
     @Transaction
-    suspend fun upsertPreservingTags(entities: List<ConversationEntity>) {
+    suspend fun upsertPreservingTags(accountId: String, entities: List<ConversationEntity>) {
         for (entity in entities) {
             if (entity.conversationId.isBlank()) {
                 upsert(entity)
                 continue
             }
-            val existing = getById(entity.conversationId)
+            val existing = getByIdForAccount(entity.conversationId, accountId)
             val toUpsert = if (existing != null) entity.copy(tags = existing.tags) else entity
             upsert(toUpsert)
         }
     }
 
-    suspend fun upsertPreservingTags(entity: ConversationEntity) {
-        upsertPreservingTags(listOf(entity))
+    @CrossAccount
+    suspend fun upsertPreservingTags(accountId: String, entity: ConversationEntity) {
+        upsertPreservingTags(accountId, listOf(entity))
     }
 
-    @Query("DELETE FROM conversations WHERE conversationId = :id")
-    suspend fun deleteById(id: String)
+    @Query("DELETE FROM conversations WHERE conversationId = :id AND accountId = :accountId")
+    suspend fun deleteById(id: String, accountId: String)
 
-    @Query("DELETE FROM conversations WHERE user = :userId")
-    suspend fun deleteAllForUser(userId: String)
+    @Query("UPDATE conversations SET title = :title, updatedAt = :updatedAt WHERE conversationId = :id AND accountId = :accountId")
+    suspend fun updateTitle(id: String, title: String, updatedAt: Long, accountId: String)
 
-    @Query("UPDATE conversations SET title = :title, updatedAt = :updatedAt WHERE conversationId = :id")
-    suspend fun updateTitle(id: String, title: String, updatedAt: Long)
+    @Query(
+        "UPDATE conversations SET isArchived = :isArchived, updatedAt = :updatedAt " +
+            "WHERE conversationId = :id AND accountId = :accountId",
+    )
+    suspend fun updateArchived(id: String, isArchived: Boolean, updatedAt: Long, accountId: String)
 
-    @Query("UPDATE conversations SET isArchived = :isArchived, updatedAt = :updatedAt WHERE conversationId = :id")
-    suspend fun updateArchived(id: String, isArchived: Boolean, updatedAt: Long)
+    @Query("UPDATE conversations SET pinned = :pinned WHERE conversationId = :id AND accountId = :accountId")
+    suspend fun updatePinned(id: String, pinned: Boolean, accountId: String)
 
-    @Query("UPDATE conversations SET pinned = :pinned WHERE conversationId = :id")
-    suspend fun updatePinned(id: String, pinned: Boolean)
+    @Query("UPDATE conversations SET tags = :tagsJson, updatedAt = :updatedAt WHERE conversationId = :id AND accountId = :accountId")
+    suspend fun updateTags(id: String, tagsJson: String, updatedAt: Long, accountId: String)
 
-    @Query("UPDATE conversations SET tags = :tagsJson, updatedAt = :updatedAt WHERE conversationId = :id")
-    suspend fun updateTags(id: String, tagsJson: String, updatedAt: Long)
-
-    @Query("UPDATE conversations SET chatProjectId = :chatProjectId WHERE conversationId = :id")
-    suspend fun updateChatProjectId(id: String, chatProjectId: String?)
-
-    @Query("DELETE FROM conversations")
-    suspend fun deleteAll()
+    @Query("UPDATE conversations SET chatProjectId = :chatProjectId WHERE conversationId = :id AND accountId = :accountId")
+    suspend fun updateChatProjectId(id: String, chatProjectId: String?, accountId: String)
 
     // Logout / account-remove scoped purge (the leak fix): delete only this account's rows.
     @Query("DELETE FROM conversations WHERE accountId = :accountId")

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/db/dao/ConversationTagDao.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/db/dao/ConversationTagDao.kt
@@ -4,13 +4,12 @@ import androidx.room.Dao
 import androidx.room.Query
 import androidx.room.Transaction
 import androidx.room.Upsert
+import com.garfiec.librechat.core.common.identity.CrossAccount
 import com.garfiec.librechat.core.data.db.entity.ConversationTagEntity
 import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface ConversationTagDao {
-    @Query("SELECT * FROM conversation_tags ORDER BY position ASC")
-    fun getAllTags(): Flow<List<ConversationTagEntity>>
 
     // --- Account-scoped read (row-tenancy): a tag refresh for B must not surface A's tags. ---
 
@@ -20,14 +19,14 @@ interface ConversationTagDao {
     @Upsert
     suspend fun upsertAll(tags: List<ConversationTagEntity>)
 
-    @Query("DELETE FROM conversation_tags")
-    suspend fun deleteAll()
-
     // --- Account-scoped writes (row-tenancy): a refresh/clear for B must not wipe A's tags. ---
 
     @Query("DELETE FROM conversation_tags WHERE accountId = :accountId")
     suspend fun deleteAllForAccount(accountId: String)
 
+    // Scoped replace: the delete leg threads accountId, so a refresh for one account never wipes
+    // another's tags. @CrossAccount suppresses the concrete-body lint; the body is account-safe.
+    @CrossAccount
     @Transaction
     suspend fun replaceAllForAccount(accountId: String, tags: List<ConversationTagEntity>) {
         deleteAllForAccount(accountId)

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/db/dao/DraftDao.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/db/dao/DraftDao.kt
@@ -8,14 +8,9 @@ import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface DraftDao {
-    @Query("SELECT * FROM drafts WHERE conversation_id = :conversationId")
-    suspend fun getDraft(conversationId: String): DraftEntity?
 
     @Upsert
     suspend fun upsertDraft(draft: DraftEntity)
-
-    @Query("SELECT * FROM drafts ORDER BY updated_at DESC")
-    fun observeAllDrafts(): Flow<List<DraftEntity>>
 
     // --- Account-scoped reads (row-tenancy): filter accountId on every read incl. by-PK. ---
 

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/db/dao/MessageDao.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/db/dao/MessageDao.kt
@@ -4,19 +4,12 @@ import androidx.room.Dao
 import androidx.room.Query
 import androidx.room.Transaction
 import androidx.room.Upsert
+import com.garfiec.librechat.core.common.identity.CrossAccount
 import com.garfiec.librechat.core.data.db.entity.MessageEntity
 import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface MessageDao {
-    @Query("SELECT * FROM messages WHERE conversationId = :conversationId ORDER BY createdAt ASC")
-    fun getMessagesForConversation(conversationId: String): Flow<List<MessageEntity>>
-
-    @Query("SELECT * FROM messages WHERE messageId = :messageId")
-    suspend fun getById(messageId: String): MessageEntity?
-
-    @Query("SELECT * FROM messages WHERE conversationId = :conversationId AND parentMessageId = :parentMessageId ORDER BY createdAt ASC")
-    suspend fun getSiblings(conversationId: String, parentMessageId: String): List<MessageEntity>
 
     // --- Account-scoped reads (row-tenancy): filter accountId on every read incl. by-PK. ---
 
@@ -42,23 +35,24 @@ interface MessageDao {
     @Upsert
     suspend fun upsertAll(messages: List<MessageEntity>)
 
-    @Query("DELETE FROM messages WHERE messageId = :messageId")
-    suspend fun deleteById(messageId: String)
+    @Query("DELETE FROM messages WHERE conversationId = :conversationId AND accountId = :accountId")
+    suspend fun deleteAllForConversation(conversationId: String, accountId: String)
 
-    @Query("DELETE FROM messages WHERE conversationId = :conversationId")
-    suspend fun deleteAllForConversation(conversationId: String)
-
+    // Full replace of a conversation's cached messages, scoped to the account: the delete leg threads
+    // accountId so it can't wipe another account's rows for the same conversationId. @CrossAccount
+    // suppresses the concrete-body lint; the body is account-safe.
+    @CrossAccount
     @Transaction
-    suspend fun replaceAllForConversation(conversationId: String, messages: List<MessageEntity>) {
-        deleteAllForConversation(conversationId)
+    suspend fun replaceAllForConversation(conversationId: String, accountId: String, messages: List<MessageEntity>) {
+        deleteAllForConversation(conversationId, accountId)
         upsertAll(messages)
     }
 
-    @Query("UPDATE messages SET feedback = :feedback WHERE messageId = :messageId")
-    suspend fun updateFeedback(messageId: String, feedback: String?)
+    @Query("UPDATE messages SET feedback = :feedback WHERE messageId = :messageId AND accountId = :accountId")
+    suspend fun updateFeedback(messageId: String, feedback: String?, accountId: String)
 
-    @Query("UPDATE messages SET text = :text, content = NULL WHERE messageId = :messageId")
-    suspend fun updateText(messageId: String, text: String)
+    @Query("UPDATE messages SET text = :text, content = NULL WHERE messageId = :messageId AND accountId = :accountId")
+    suspend fun updateText(messageId: String, text: String, accountId: String)
 
     // Logout / account-remove scoped purge (the leak fix): delete only this account's rows.
     @Query("DELETE FROM messages WHERE accountId = :accountId")

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/AccountKeyedCache.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/AccountKeyedCache.kt
@@ -1,0 +1,42 @@
+package com.garfiec.librechat.core.data.repository
+
+import com.garfiec.librechat.core.common.identity.ActiveAccountProvider
+import com.garfiec.librechat.core.common.identity.currentAccountId
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * A single-slot in-memory cache keyed on the active account. Serving the cached value is gated on the
+ * key matching the *currently* active account, so account B can never read account A's cached value —
+ * for endpoints with no Room/accountId scoping (agents, presets) this is the only isolation tier.
+ *
+ * The account key is read **under the lock** at serve time, not captured by the caller beforehand:
+ * capturing earlier opens a TOCTOU where a coroutine that snapshotted account A before an identity flip
+ * is served A's value while B is now active. Read-time keying also closes the window an async
+ * clear-on-identity-change collector would leave open: a collector dispatched on a separate coroutine
+ * has no happens-before vs the next read, so B's read could beat the clear.
+ */
+class AccountKeyedCache<T>(private val activeAccountProvider: ActiveAccountProvider) {
+
+    private val mutex = Mutex()
+    private var value: T? = null
+    private var cachedFor: String? = null
+
+    /** Returns the value for the active account, fetching + caching it on a cold/foreign-key miss. */
+    suspend fun getOrFetch(fetch: suspend () -> T): T = mutex.withLock {
+        val account = activeAccountProvider.currentAccountId()?.value
+        value?.takeIf { cachedFor == account }?.let { return it }
+        val fetched = fetch()
+        value = fetched
+        cachedFor = account
+        fetched
+    }
+
+    /** Reads the cached value for the active account without fetching; `null` on cold/foreign-key miss. */
+    suspend fun <R> peek(block: (T) -> R?): R? = mutex.withLock {
+        val account = activeAccountProvider.currentAccountId()?.value
+        value?.takeIf { cachedFor == account }?.let(block)
+    }
+
+    suspend fun invalidate() = mutex.withLock { value = null }
+}

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/AccountSessionEstablisher.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/AccountSessionEstablisher.kt
@@ -1,5 +1,6 @@
 package com.garfiec.librechat.core.data.repository
 
+import co.touchlab.kermit.Logger
 import com.garfiec.librechat.core.common.identity.AccountId
 import com.garfiec.librechat.core.common.identity.deriveAccountId
 import com.garfiec.librechat.core.common.identity.deriveServerId
@@ -8,6 +9,7 @@ import com.garfiec.librechat.core.model.User
 import com.garfiec.librechat.core.network.client.ServerUrlProvider
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
+import kotlin.coroutines.cancellation.CancellationException
 
 /**
  * Turns a freshly-authenticated (or cold-start-restored) [User] into the active [AccountId] and
@@ -30,9 +32,32 @@ class AccountSessionEstablisher(
 ) {
 
     /**
-     * Resolves the [AccountId] for [user], persists + publishes it, then runs the one-time legacy
-     * claim. Idempotent: re-establishing the already-active account just re-publishes it and the
-     * marker-guarded claim short-circuits. Returns the resolved id.
+     * Resolves the [AccountId] for [user], runs the one-time legacy claim, then persists + publishes
+     * it. Idempotent: re-establishing the already-active account re-publishes it and the marker-guarded
+     * claim short-circuits. Returns the resolved id.
+     *
+     * **Claim before publish** is load-bearing: publishing flips `ActiveAccountProvider` to
+     * `Resolved(accountId)`, after which account-scoped reads/writes go live. Legacy pre-migration rows
+     * still carry `accountId IS NULL` until the claim stamps them, so a sync running in the window
+     * between publish and claim would read them as foreign (`getByIdForAccount` misses a NULL row) and
+     * an `upsertPreservingTags` would overwrite the row, dropping locally-stored tags. Claiming first
+     * keeps the provider at `Resolved(null)` (writes skip when unresolved) until every legacy row is
+     * attributed, closing that window.
+     *
+     * The claim is nonetheless **best-effort**: a *failure* must never abort establishment. It is
+     * idempotent and only writes its done-marker on success, so a failure (e.g. a transient DB error)
+     * retries on the next establish. Letting it propagate would skip [AccountRegistry.setActiveAccount]
+     * and strand an authenticated user at `Resolved(null)` — every scoped read/write silently skipped
+     * for the session — so a claim failure is caught here and the account is published regardless.
+     * **Cancellation is the exception**: a `CancellationException` is rethrown, so a session torn down
+     * mid-claim aborts cleanly instead of publishing an account for a coroutine that is being cancelled.
+     *
+     * The cost: the still-unclaimed legacy rows stay at `accountId IS NULL`, invisible to every
+     * account-filtered read, and the overwrite window above stays open. Recovery is coupled to the next
+     * establish (cold-start restore or a re-login). A session that logs in once and stays logged in
+     * never re-establishes, so on that path the orphaned pre-migration history is hidden until the user
+     * re-auths — not just for a brief window. That is still strictly better than a dead session;
+     * bounding it with a foreground/sync-time claim retry is left to a follow-up (SessionWriter / PR1-B).
      */
     suspend fun establish(user: User): AccountId = withContext(ioDispatcher) {
         val baseUrl = serverUrlProvider.awaitBaseUrl()
@@ -41,8 +66,14 @@ class AccountSessionEstablisher(
             "Authenticated user has no id; cannot derive an account owner"
         }
         val accountId = deriveAccountId(deriveServerId(baseUrl), userKey)
+        runCatching { claimReconciler.claimIfNeeded(accountId, userKey) }
+            .onFailure { error ->
+                // A cancelled establish (logout / teardown during cold-start restore) must abort, not
+                // publish the account for a session being torn down — rethrow rather than swallow it.
+                if (error is CancellationException) throw error
+                Logger.w(error) { "Legacy account claim failed; publishing account anyway (will retry)" }
+            }
         accountRegistry.setActiveAccount(accountId)
-        claimReconciler.claimIfNeeded(accountId, userKey)
         accountId
     }
 }

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/AgentRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/AgentRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package com.garfiec.librechat.core.data.repository
 
+import com.garfiec.librechat.core.common.identity.ActiveAccountProvider
 import com.garfiec.librechat.core.common.result.Result
 import com.garfiec.librechat.core.common.result.safeApiCall
 import com.garfiec.librechat.core.model.Agent
@@ -17,16 +18,15 @@ import com.garfiec.librechat.core.model.request.RevertAgentRequest
 import com.garfiec.librechat.core.model.request.ToolCallRequest
 import com.garfiec.librechat.core.model.request.UpdateAgentRequest
 import com.garfiec.librechat.core.network.api.AgentsApi
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.json.Json
 
 class AgentRepositoryImpl(
     private val agentsApi: AgentsApi,
+    activeAccountProvider: ActiveAccountProvider,
 ) : AgentRepository {
 
-    private val cacheMutex = Mutex()
-    private var cachedAgents: List<Agent>? = null
+    // Account-keyed in-memory cache: the only isolation tier for agents (no Room/accountId scoping).
+    private val cache = AccountKeyedCache<List<Agent>>(activeAccountProvider)
 
     // --- Agent CRUD ---
 
@@ -35,12 +35,7 @@ class AgentRepositoryImpl(
             if (category != null) {
                 return@safeApiCall agentsApi.getAgents(category).data
             }
-            cacheMutex.withLock {
-                cachedAgents?.let { return@withLock it }
-                val agents = agentsApi.getAgents(null).data
-                cachedAgents = agents
-                agents
-            }
+            cache.getOrFetch { agentsApi.getAgents(null).data }
         }
     }
 
@@ -67,7 +62,7 @@ class AgentRepositoryImpl(
 
     override suspend fun getAgent(id: String): Result<Agent> {
         return safeApiCall {
-            cacheMutex.withLock { cachedAgents?.find { it.id == id } }
+            cache.peek { agents -> agents.find { it.id == id } }
                 ?.let { return@safeApiCall it }
             agentsApi.getAgent(id)
         }
@@ -212,7 +207,5 @@ class AgentRepositoryImpl(
         }
     }
 
-    private suspend fun invalidateCache() {
-        cacheMutex.withLock { cachedAgents = null }
-    }
+    private suspend fun invalidateCache() = cache.invalidate()
 }

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/ConversationRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/ConversationRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package com.garfiec.librechat.core.data.repository
 
+import co.touchlab.kermit.Logger
 import com.garfiec.librechat.core.common.identity.ActiveAccountProvider
 import com.garfiec.librechat.core.common.identity.currentAccountId
 import com.garfiec.librechat.core.common.identity.flatMapAccountOrEmpty
@@ -58,6 +59,7 @@ class ConversationRepositoryImpl(
             )
             if (accountId != null) {
                 conversationDao.upsertPreservingTags(
+                    accountId,
                     response.conversations.map { it.toEntity().copy(accountId = accountId) },
                 )
             }
@@ -89,6 +91,7 @@ class ConversationRepositoryImpl(
             // the project-filtered LIST view is network-direct by design, not a Room query.
             if (accountId != null) {
                 conversationDao.upsertPreservingTags(
+                    accountId,
                     response.conversations.map { it.toEntity().copy(accountId = accountId) },
                 )
             }
@@ -111,7 +114,7 @@ class ConversationRepositoryImpl(
             val accountId = activeAccountProvider.currentAccountId()?.value
             val conversation = conversationsApi.getConversation(id)
             if (accountId != null) {
-                conversationDao.upsertPreservingTags(conversation.toEntity().copy(accountId = accountId))
+                conversationDao.upsertPreservingTags(accountId, conversation.toEntity().copy(accountId = accountId))
             }
             conversation
         }
@@ -119,40 +122,64 @@ class ConversationRepositoryImpl(
 
     override suspend fun updateTitle(id: String, title: String): Result<Conversation> {
         return safeApiCall {
+            // Capture identity before the network suspend; skip the local cache update when unresolved
+            // rather than running an account-blind by-PK write.
+            val accountId = activeAccountProvider.currentAccountId()?.value
             val updated = conversationsApi.updateTitle(id, title)
-            conversationDao.updateTitle(id, title, Clock.System.now().toEpochMilliseconds())
+            if (accountId != null) {
+                conversationDao.updateTitle(id, title, Clock.System.now().toEpochMilliseconds(), accountId)
+            }
             updated
         }
     }
 
     override suspend fun generateTitle(conversationId: String): Result<String> {
         return safeApiCall {
+            val accountId = activeAccountProvider.currentAccountId()?.value
             val response = conversationsApi.generateTitle(conversationId)
-            conversationDao.updateTitle(conversationId, response.title, Clock.System.now().toEpochMilliseconds())
+            if (accountId != null) {
+                conversationDao.updateTitle(conversationId, response.title, Clock.System.now().toEpochMilliseconds(), accountId)
+            }
             response.title
         }
     }
 
     override suspend fun archive(id: String, isArchived: Boolean): Result<Conversation> {
         return safeApiCall {
+            val accountId = activeAccountProvider.currentAccountId()?.value
             val updated = conversationsApi.archive(id, isArchived)
-            conversationDao.updateArchived(id, isArchived, Clock.System.now().toEpochMilliseconds())
+            if (accountId != null) {
+                conversationDao.updateArchived(id, isArchived, Clock.System.now().toEpochMilliseconds(), accountId)
+            }
             updated
         }
     }
 
     override suspend fun pin(id: String, pinned: Boolean): Result<Conversation> {
         return safeApiCall {
+            // Capture identity before the network suspend; skip the local cache update when unresolved
+            // rather than running an account-blind by-PK write.
+            val accountId = activeAccountProvider.currentAccountId()?.value
             val updated = conversationsApi.pin(id, pinned)
-            conversationDao.updatePinned(id, pinned)
+            if (accountId != null) {
+                conversationDao.updatePinned(id, pinned, accountId)
+            }
             updated
         }
     }
 
     override suspend fun delete(id: String): Result<Unit> {
         return safeApiCall {
+            val accountId = activeAccountProvider.currentAccountId()?.value
             conversationsApi.deleteConversation(id)
-            conversationDao.deleteById(id)
+            // The local delete must be account-scoped, so it can't run while unresolved. The server row
+            // is already gone, so the stale local row lingers in the list until a resolved-account wipe;
+            // log it. In practice a delete is a foreground action where the account is resolved.
+            if (accountId != null) {
+                conversationDao.deleteById(id, accountId)
+            } else {
+                Logger.w { "Server-deleted $id but kept local row: no resolved account to scope the delete" }
+            }
         }
     }
 
@@ -220,11 +247,19 @@ class ConversationRepositoryImpl(
         val id = conversation.conversationId ?: return
         if (id.isBlank()) return
         val accountId = activeAccountProvider.currentAccountId()?.value ?: return
-        conversationDao.upsertPreservingTags(conversation.toEntity().copy(accountId = accountId))
+        conversationDao.upsertPreservingTags(accountId, conversation.toEntity().copy(accountId = accountId))
     }
 
     override suspend fun updateConversationTagsLocal(id: String, tags: List<String>) {
-        conversationDao.updateTags(id, encodeTags(tags), Clock.System.now().toEpochMilliseconds())
+        // Local-only tag write; skip when unresolved rather than running an account-blind by-PK update.
+        // Unlike the server-backed writes there is no remote copy to recover from, so a drop loses the
+        // edit outright — log it. In practice the account is resolved during active use; an unresolved
+        // window here only happens mid warming / soft-expiry re-auth.
+        val accountId = activeAccountProvider.currentAccountId()?.value ?: run {
+            Logger.w { "Dropping local tag update for $id: no resolved account" }
+            return
+        }
+        conversationDao.updateTags(id, encodeTags(tags), Clock.System.now().toEpochMilliseconds(), accountId)
     }
 
     // Reconciles SAVED_TAG attachment between the local Room cache and server by

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/MessageRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/MessageRepositoryImpl.kt
@@ -71,8 +71,8 @@ class MessageRepositoryImpl(
             val accountId = activeAccountProvider.currentAccountId()?.value
             val messages = messagesApi.getMessages(conversationId)
             if (accountId != null) {
-                // Full replace: delete stale cache then insert fresh server data
-                messageDao.replaceAllForConversation(conversationId, messages.entitiesFor(accountId))
+                // Full replace: delete stale cache then insert fresh server data (delete leg scoped to account)
+                messageDao.replaceAllForConversation(conversationId, accountId, messages.entitiesFor(accountId))
             }
             messages
         }
@@ -84,9 +84,10 @@ class MessageRepositoryImpl(
         feedback: String?,
     ): Result<Unit> {
         return safeApiCall {
+            val accountId = activeAccountProvider.currentAccountId()?.value
             messagesApi.updateFeedback(conversationId, messageId, feedback)
-            // Update local cache
-            messageDao.updateFeedback(messageId, feedback)
+            // Update local cache, scoped to the active account; skip when unresolved.
+            if (accountId != null) messageDao.updateFeedback(messageId, feedback, accountId)
         }
     }
 
@@ -96,8 +97,9 @@ class MessageRepositoryImpl(
         text: String,
     ): Result<Unit> {
         return safeApiCall {
+            val accountId = activeAccountProvider.currentAccountId()?.value
             messagesApi.updateMessage(conversationId, messageId, UpdateMessageRequest(text = text))
-            messageDao.updateText(messageId, text)
+            if (accountId != null) messageDao.updateText(messageId, text, accountId)
         }
     }
 

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/PresetRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/PresetRepositoryImpl.kt
@@ -1,34 +1,29 @@
 package com.garfiec.librechat.core.data.repository
 
+import com.garfiec.librechat.core.common.identity.ActiveAccountProvider
 import com.garfiec.librechat.core.common.result.Result
 import com.garfiec.librechat.core.common.result.safeApiCall
 import com.garfiec.librechat.core.model.Preset
 import com.garfiec.librechat.core.network.api.PresetsApi
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
 
 class PresetRepositoryImpl(
     private val presetsApi: PresetsApi,
+    activeAccountProvider: ActiveAccountProvider,
 ) : PresetRepository {
 
-    private val cacheMutex = Mutex()
-    private var cachedPresets: List<Preset>? = null
+    // Account-keyed in-memory cache: the only isolation tier for presets (no Room/accountId scoping).
+    private val cache = AccountKeyedCache<List<Preset>>(activeAccountProvider)
 
     override suspend fun getAll(): Result<List<Preset>> {
         return safeApiCall {
-            cacheMutex.withLock {
-                cachedPresets?.let { return@withLock it }
-                val presets = presetsApi.getPresets()
-                cachedPresets = presets
-                presets
-            }
+            cache.getOrFetch { presetsApi.getPresets() }
         }
     }
 
     override suspend fun create(preset: Preset): Result<Preset> {
         return safeApiCall {
             val created = presetsApi.createPreset(preset)
-            cacheMutex.withLock { cachedPresets = null }
+            invalidateCache()
             created
         }
     }
@@ -36,7 +31,7 @@ class PresetRepositoryImpl(
     override suspend fun update(preset: Preset): Result<Preset> {
         return safeApiCall {
             val updated = presetsApi.updatePreset(preset)
-            cacheMutex.withLock { cachedPresets = null }
+            invalidateCache()
             updated
         }
     }
@@ -44,7 +39,9 @@ class PresetRepositoryImpl(
     override suspend fun delete(presetId: String): Result<Unit> {
         return safeApiCall {
             presetsApi.deletePreset(presetId)
-            cacheMutex.withLock { cachedPresets = null }
+            invalidateCache()
         }
     }
+
+    private suspend fun invalidateCache() = cache.invalidate()
 }

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/ProjectRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/ProjectRepositoryImpl.kt
@@ -1,5 +1,7 @@
 package com.garfiec.librechat.core.data.repository
 
+import com.garfiec.librechat.core.common.identity.ActiveAccountProvider
+import com.garfiec.librechat.core.common.identity.currentAccountId
 import com.garfiec.librechat.core.common.result.Result
 import com.garfiec.librechat.core.common.result.safeApiCall
 import com.garfiec.librechat.core.data.db.dao.ConversationDao
@@ -10,6 +12,7 @@ import com.garfiec.librechat.core.network.api.ProjectsApi
 class ProjectRepositoryImpl(
     private val projectsApi: ProjectsApi,
     private val conversationDao: ConversationDao,
+    private val activeAccountProvider: ActiveAccountProvider,
 ) : ProjectRepository {
 
     override suspend fun listProjects(cursor: String?): Result<ProjectListResponse> =
@@ -34,15 +37,18 @@ class ProjectRepositoryImpl(
     override suspend fun assignConversation(
         conversationId: String,
         projectId: String?,
-    ): Result<Unit> =
+    ): Result<Unit> {
         // The assign endpoint is API-only, but the cached row carries chatProjectId (read by the
         // drawer move-picker to pre-select the current folder). Mirror the new assignment into Room
         // on success so the picker self-corrects immediately instead of lagging until the next full
-        // sync. projectId == null is an unassign and clears the column.
-        safeApiCall<Unit> { projectsApi.assignConversation(conversationId, projectId) }
+        // sync. projectId == null is an unassign and clears the column. Capture identity before the
+        // network suspend; skip the account-scoped local write when unresolved.
+        val accountId = activeAccountProvider.currentAccountId()?.value
+        return safeApiCall<Unit> { projectsApi.assignConversation(conversationId, projectId) }
             .also { result ->
-                if (result is Result.Success) {
-                    conversationDao.updateChatProjectId(conversationId, projectId)
+                if (result is Result.Success && accountId != null) {
+                    conversationDao.updateChatProjectId(conversationId, projectId, accountId)
                 }
             }
+    }
 }

--- a/detekt-rules/src/main/kotlin/com/garfiec/librechat/detekt/AccountScopedDaoRule.kt
+++ b/detekt-rules/src/main/kotlin/com/garfiec/librechat/detekt/AccountScopedDaoRule.kt
@@ -7,8 +7,14 @@ import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import org.jetbrains.kotlin.lexer.KtTokens
+import org.jetbrains.kotlin.psi.KtBinaryExpression
+import org.jetbrains.kotlin.psi.KtClassOrObject
+import org.jetbrains.kotlin.psi.KtEscapeStringTemplateEntry
+import org.jetbrains.kotlin.psi.KtExpression
 import org.jetbrains.kotlin.psi.KtLiteralStringTemplateEntry
 import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.KtParenthesizedExpression
 import org.jetbrains.kotlin.psi.KtStringTemplateExpression
 import org.jetbrains.kotlin.psi.psiUtil.containingClassOrObject
 
@@ -18,20 +24,43 @@ import org.jetbrains.kotlin.psi.psiUtil.containingClassOrObject
  * mode of the whole design is a query that forgets its `accountId` filter, leaking one account's
  * rows into another.
  *
- * Two detection paths, because the leak is broader than `@Query` SELECTs:
+ * It is **fail-closed**: anything it can't statically prove account-safe is reported, and the only
+ * escape hatch is an explicit `@CrossAccount` annotation (paired, by convention, with an isolation
+ * test). Five things trip it:
  *
- * 1. **`@Query` statements** — the SQL string is parsed (no type resolution required). Any
- *    SELECT / UPDATE / DELETE touching a tenant table whose text lacks an `accountId` predicate is
- *    reported. This catches by-PK reads (`getById`), targeted updates (`updateText`), and no-WHERE
- *    deletes (`deleteAll`).
- * 2. **Concrete (block-body) methods** — `@Transaction` defaults like `upsertPreservingTags` /
- *    `replaceAll` carry their logic in Kotlin, not a `@Query` string. Without type resolution the
- *    rule cannot prove the body is account-safe, so every concrete method in a tenant DAO must be
- *    reviewed and explicitly opted out with `@CrossAccount` once it threads `accountId`.
+ * 1. **`@Query` statements** — the SQL string is reconstructed from compile-time constants (single
+ *    literals *and* `"a" + "b"` concatenations). Any statement touching a tenant table whose *outer*
+ *    WHERE clause lacks a *positive, top-level* `accountId = ...` / `accountId IN ...` predicate is
+ *    reported. Subqueries are stripped before the outer WHERE is located, so a predicate (or WHERE)
+ *    buried in a subquery in the `SET`/`FROM` clause can't masquerade as scoping the statement; a
+ *    validly-grouped `(accountId = :a)` predicate *is* accepted. `SET accountId = ...`, `accountId IS
+ *    NULL`, and an `accountId` term joined by a top-level `OR` are **not** accepted. A statement that
+ *    spans more than one tenant table or uses a `JOIN` is fail-closed: a regex can't prove which
+ *    table's `accountId` the predicate scopes, so it must be split or annotated `@CrossAccount`.
+ * 2. **`@Query` with non-constant SQL** (string interpolation / dynamic expression) — can't be
+ *    inspected, so a tenant-DAO method carrying one is reported.
+ * 3. **`@RawQuery`** in a tenant DAO — opaque to static analysis, so reported.
+ * 4. **Entity-based `@Delete` / `@Update`** — Room matches the row by primary key alone (no `accountId`
+ *    in the generated WHERE), so a by-PK delete/update can hit another account's row. A SQL-text rule
+ *    can't add the predicate, so these must become a scoped `@Query` or be annotated `@CrossAccount`.
+ * 5. **Concrete (block-body) methods** — `@Transaction` defaults like `upsertPreservingTags` /
+ *    `replaceAll*` carry their logic in Kotlin, not a `@Query` string. Without type resolution the
+ *    rule can't prove the body is account-safe, so every concrete method in a tenant DAO must thread
+ *    `accountId` and be explicitly opted out with `@CrossAccount`.
  *
- * Opt out a genuinely cross-account statement with an `@CrossAccount` annotation on the method.
- * The rule runs without a binding context, so it works on the `detektMetadataCommonMain` source
- * set (where commonMain DAOs live).
+ * **Out of scope:** `@Insert` / `@Upsert` attribute the account through the `accountId` *field* of the
+ * entity being written, set by hand at the callsite (`.copy(accountId = …)`). A SQL-text rule can't see
+ * or enforce that field, so these are deliberately not flagged; correct attribution rests on the
+ * capture-before-suspend repo convention today and is the job of the deferred `SessionWriter` facade.
+ *
+ * A DAO is "tenant" if its name is in [TENANT_DAOS] **or** it carries any `@Query` whose *constant* SQL
+ * touches a tenant table. Inference therefore covers a renamed/new DAO that has at least one constant
+ * tenant `@Query`. A DAO whose *only* tenant-table access is a `@RawQuery` or interpolated `@Query`
+ * (no constant SQL to read the table name from) can't be inferred and must be added to [TENANT_DAOS]
+ * explicitly; until then its opaque statements are not flagged.
+ *
+ * The rule runs without a binding context, so it works on the `detektMetadataCommonMain` source set
+ * (where commonMain DAOs live).
  */
 class AccountScopedDaoRule(config: Config) : Rule(config) {
 
@@ -47,19 +76,67 @@ class AccountScopedDaoRule(config: Config) : Rule(config) {
 
         if (function.hasAnnotation(CROSS_ACCOUNT)) return
 
-        val sql = function.queryAnnotationSql()
-        if (sql != null) {
-            val table = sql.tenantTableTouched() ?: return
-            if (sql.isStatementNeedingScope() && !sql.hasAccountIdPredicate()) {
+        val daoName = function.containingClassOrObject?.name
+        val inTenantDao = daoName in TENANT_DAOS || function.containingDaoTouchesTenantTable()
+
+        // @RawQuery hands raw SQL to Room at runtime — nothing to inspect statically.
+        if (inTenantDao && function.hasAnnotation(RAW_QUERY)) {
+            report(
+                function,
+                "@RawQuery `${function.name}()` in tenant DAO `$daoName` can't be statically scoped by " +
+                    "accountId. Use a scoped @Query or annotate @CrossAccount with a paired isolation test.",
+            )
+            return
+        }
+
+        val queryArg = function.queryAnnotationArg()
+        if (queryArg != null) {
+            val sql = queryArg.constStringOrNull()
+            if (sql == null) {
+                // @Query whose SQL isn't a compile-time constant (interpolation / dynamic expression).
+                // Fail closed for tenant DAOs: we can't prove it's scoped.
+                if (inTenantDao) {
+                    report(
+                        function,
+                        "@Query `${function.name}()` in tenant DAO `$daoName` uses non-constant SQL and " +
+                            "can't be verified. Build it from string constants or annotate @CrossAccount.",
+                    )
+                }
+                return
+            }
+            val tables = sql.tenantTablesTouched()
+            if (tables.isEmpty()) return
+            if (tables.size > 1 || JOIN_KEYWORD.containsMatchIn(sql)) {
                 report(
-                    CodeSmell(
-                        issue,
-                        Entity.from(function),
-                        "DAO @Query on tenant table `$table` is not scoped by accountId: " +
-                            "${function.name}(). Add an `accountId` predicate or annotate @CrossAccount.",
-                    ),
+                    function,
+                    "@Query `${function.name}()` in tenant DAO `$daoName` spans multiple tables " +
+                        "(${tables.joinToString()}) or uses a JOIN; a regex can't prove which table's accountId " +
+                        "scopes the write. Split into a single-table scoped @Query or annotate @CrossAccount.",
+                )
+                return
+            }
+            if (!sql.hasAccountIdPredicate()) {
+                report(
+                    function,
+                    "DAO @Query on tenant table `${tables.first()}` is not scoped by accountId: ${function.name}(). " +
+                        "Add an `accountId = ...` predicate to the WHERE clause or annotate @CrossAccount.",
                 )
             }
+            return
+        }
+
+        // Entity-based @Delete / @Update match rows by PRIMARY KEY only — Room generates no WHERE beyond
+        // the PK, so account A could delete or overwrite account B's row by passing an entity carrying
+        // B's id. A SQL-text rule can't inject a predicate here, so these must be replaced with a scoped
+        // @Query (`... WHERE <pk> = :id AND accountId = :a`) or explicitly opted out with @CrossAccount.
+        // @Insert/@Upsert are intentionally NOT flagged: they carry accountId in the entity itself —
+        // attribution-by-field this rule can't verify, owned by the callsite (and, later, SessionWriter).
+        if (inTenantDao && (function.hasAnnotation(DELETE) || function.hasAnnotation(UPDATE))) {
+            report(
+                function,
+                "Entity-based @Delete/@Update `${function.name}()` in tenant DAO `$daoName` matches by " +
+                    "primary key only and isn't scoped by accountId. Use a scoped @Query or annotate @CrossAccount.",
+            )
             return
         }
 
@@ -67,46 +144,137 @@ class AccountScopedDaoRule(config: Config) : Rule(config) {
         // leak in its Kotlin body. Can't verify safety without type resolution -> require review.
         // `bodyBlockExpression != null` (not `hasBlockBody()`, which returns true for abstract
         // members) is what distinguishes a concrete `{ ... }` default from an abstract DAO method.
-        val daoName = function.containingClassOrObject?.name
-        if (daoName in TENANT_DAOS && function.bodyBlockExpression != null) {
+        if (inTenantDao && function.bodyBlockExpression != null) {
             report(
-                CodeSmell(
-                    issue,
-                    Entity.from(function),
-                    "Concrete method `${function.name}()` in tenant DAO `$daoName` is not a scoped " +
-                        "@Query/@Upsert. Thread accountId through its body and annotate @CrossAccount.",
-                ),
+                function,
+                "Concrete method `${function.name}()` in tenant DAO `$daoName` is not a scoped " +
+                    "@Query/@Upsert. Thread accountId through its body and annotate @CrossAccount.",
             )
         }
+    }
+
+    private fun report(function: KtNamedFunction, message: String) {
+        report(CodeSmell(issue, Entity.from(function), message))
     }
 
     private fun KtNamedFunction.hasAnnotation(shortName: String): Boolean =
         annotationEntries.any { it.shortName?.asString() == shortName }
 
-    /** Returns the SQL of a `@Query` annotation, or null if the function has no `@Query`. */
-    private fun KtNamedFunction.queryAnnotationSql(): String? {
+    // Tenant-ness of a DAO is a per-class fact, but visitNamedFunction fires once per method. Memoize
+    // by the enclosing class so the member scan runs once per DAO instead of once per method (O(n) not
+    // O(n^2)).
+    private val tenantDaoMemo = HashMap<KtClassOrObject, Boolean>()
+
+    /** True if the enclosing DAO has any `@Query` whose constant SQL touches a tenant table. */
+    private fun KtNamedFunction.containingDaoTouchesTenantTable(): Boolean {
+        val owner = containingClassOrObject ?: return false
+        return tenantDaoMemo.getOrPut(owner) {
+            owner.declarations.filterIsInstance<KtNamedFunction>().any { member ->
+                val sql = member.queryAnnotationArg()?.constStringOrNull() ?: return@any false
+                sql.tenantTablesTouched().isNotEmpty()
+            }
+        }
+    }
+
+    /** The value-argument expression of a `@Query` annotation, or null if the function has none. */
+    private fun KtNamedFunction.queryAnnotationArg(): KtExpression? {
         val query = annotationEntries.firstOrNull { it.shortName?.asString() == "Query" } ?: return null
-        val expr = query.valueArguments.firstOrNull()?.getArgumentExpression() as? KtStringTemplateExpression
-            ?: return null
-        // No @Query in this codebase uses template interpolation, so concatenating literal entries
-        // reconstructs the SQL faithfully.
-        return expr.entries.joinToString("") { (it as? KtLiteralStringTemplateEntry)?.text ?: it.text }
+        return query.valueArguments.firstOrNull()?.getArgumentExpression()
     }
 
-    private fun String.tenantTableTouched(): String? =
-        TENANT_TABLES.firstOrNull { table -> Regex("\\b$table\\b").containsMatchIn(this) }
-
-    private fun String.isStatementNeedingScope(): Boolean {
-        val head = trim().takeWhile { !it.isWhitespace() }.uppercase()
-        return head == "SELECT" || head == "UPDATE" || head == "DELETE"
+    /**
+     * Reconstructs the SQL text from compile-time-constant string expressions: a single string
+     * literal, or any `+` concatenation of constant strings. Returns null for anything non-constant
+     * (`$x`/`${x}` interpolation, function calls, identifiers) so the caller can fail closed.
+     */
+    private fun KtExpression.constStringOrNull(): String? = when (this) {
+        is KtStringTemplateExpression -> {
+            val sb = StringBuilder()
+            for (entry in entries) {
+                when (entry) {
+                    is KtLiteralStringTemplateEntry -> sb.append(entry.text)
+                    is KtEscapeStringTemplateEntry -> sb.append(entry.unescapedValue)
+                    else -> return null // interpolation — not a compile-time constant
+                }
+            }
+            sb.toString()
+        }
+        is KtParenthesizedExpression -> expression?.constStringOrNull()
+        is KtBinaryExpression -> {
+            if (operationToken != KtTokens.PLUS) return null
+            val left = left?.constStringOrNull() ?: return null
+            val right = right?.constStringOrNull() ?: return null
+            left + right
+        }
+        else -> null
     }
 
-    private fun String.hasAccountIdPredicate(): Boolean =
-        Regex("(?i)accountId\\s*(=|<>|!=|\\bin\\b|\\bis\\b)").containsMatchIn(this)
+    /** Every distinct tenant table the statement references (for multi-table fail-closed detection). */
+    private fun String.tenantTablesTouched(): List<String> =
+        TENANT_TABLE_REGEXES.filter { (_, regex) -> regex.containsMatchIn(this) }.map { it.first }
+
+    /**
+     * A positive single-account predicate (`accountId = ...` / `accountId IN ...`) in the *outer* WHERE
+     * clause. The transform order matters:
+     * 1. Unwrap a *pure* parenthesized accountId predicate (`(accountId = :a)`) to its bare content so a
+     *    validly-grouped scope survives the stripping below (otherwise it's a false positive).
+     * 2. Strip every remaining parenthesized group (subqueries — including their inner WHERE — and
+     *    grouped sub-conditions / `IN (...)` value-lists). With subqueries gone, the first WHERE in what
+     *    remains is the statement's *outer* WHERE, so a subquery WHERE in a `SET`/`FROM` clause can't be
+     *    mistaken for it.
+     * 3. A surviving top-level `OR` fails closed: the `accountId` term may be non-restrictive (e.g.
+     *    `id = :x OR accountId = :a` returns foreign rows).
+     */
+    private fun String.hasAccountIdPredicate(): Boolean {
+        val unwrapped = PURE_ACCOUNT_ID_GROUP.replace(this) { " ${it.groupValues[1]} " }
+        val outer = unwrapped.stripParenGroups().whereClause() ?: return false
+        if (TOP_LEVEL_OR.containsMatchIn(outer)) return false
+        return ACCOUNT_ID_PREDICATE.containsMatchIn(outer)
+    }
+
+    /** Everything after the first `WHERE` keyword, or null when the statement has no WHERE clause. */
+    private fun String.whereClause(): String? {
+        val match = WHERE_KEYWORD.find(this) ?: return null
+        return substring(match.range.last + 1)
+    }
+
+    /** Removes parenthesized groups (subqueries, `IN (...)` value lists), innermost-first, to handle nesting. */
+    private fun String.stripParenGroups(): String {
+        var current = this
+        while (true) {
+            val next = PAREN_GROUP.replace(current, " ")
+            if (next == current) return current
+            current = next
+        }
+    }
 
     private companion object {
         val TENANT_TABLES = listOf("conversations", "messages", "drafts", "conversation_tags")
+        // Case-insensitive: SQLite identifiers are case-insensitive, so `FROM Messages` / `FROM
+        // CONVERSATIONS` hit the real tenant table and must not slip past the matcher as "no table".
+        val TENANT_TABLE_REGEXES: List<Pair<String, Regex>> = TENANT_TABLES.map { it to Regex("(?i)\\b$it\\b") }
         val TENANT_DAOS = setOf("ConversationDao", "MessageDao", "DraftDao", "ConversationTagDao")
         const val CROSS_ACCOUNT = "CrossAccount"
+        const val RAW_QUERY = "RawQuery"
+        const val DELETE = "Delete"
+        const val UPDATE = "Update"
+        val WHERE_KEYWORD = Regex("(?i)\\bWHERE\\b")
+        val PAREN_GROUP = Regex("\\([^()]*\\)")
+        val TOP_LEVEL_OR = Regex("(?i)\\bOR\\b")
+        val JOIN_KEYWORD = Regex("(?i)\\bJOIN\\b")
+
+        // The positive single-account operator fragment, shared by the two regexes below so they can't
+        // drift: equality/membership on the exact `accountId` column. `IS NULL`, `<>`, `!=` are excluded.
+        private const val ACCOUNT_ID_OP = "accountId\\s*(?:=|\\bIN\\b)"
+
+        // A parenthesized group whose entire content is a single accountId predicate, e.g.
+        // `(accountId = :a)`. Group 1 is the bare predicate so it can be unwrapped and survive paren
+        // stripping. A group containing more (an OR, another column, a subquery) does NOT match and is
+        // stripped instead — fail-closed.
+        val PURE_ACCOUNT_ID_GROUP = Regex("(?i)\\(\\s*($ACCOUNT_ID_OP[^()]*?)\\s*\\)")
+
+        // Positive equality/membership on the exact `accountId` column (leading \b rejects e.g.
+        // `userAccountId`).
+        val ACCOUNT_ID_PREDICATE = Regex("(?i)\\b$ACCOUNT_ID_OP")
     }
 }

--- a/detekt-rules/src/test/kotlin/com/garfiec/librechat/detekt/AccountScopedDaoRuleTest.kt
+++ b/detekt-rules/src/test/kotlin/com/garfiec/librechat/detekt/AccountScopedDaoRuleTest.kt
@@ -51,9 +51,87 @@ class AccountScopedDaoRuleTest {
         )
     }
 
+    @Test
+    fun firesOnEntityDelete() {
+        val findings = lint(
+            """
+            import androidx.room.Dao
+            import androidx.room.Delete
+
+            @Dao
+            interface ConversationDao {
+                @Delete
+                suspend fun delete(entity: Any)
+            }
+            """.trimIndent(),
+        )
+        assertTrue(
+            findings.flagged("delete"),
+            "entity @Delete matches by PK only (no accountId) and must be flagged",
+        )
+    }
+
+    @Test
+    fun firesOnEntityUpdate() {
+        val findings = lint(
+            """
+            import androidx.room.Dao
+            import androidx.room.Update
+
+            @Dao
+            interface MessageDao {
+                @Update
+                suspend fun update(entity: Any)
+            }
+            """.trimIndent(),
+        )
+        assertTrue(
+            findings.flagged("update"),
+            "entity @Update matches by PK only (no accountId) and must be flagged",
+        )
+    }
+
     // endregion
 
     // region must NOT fire (no false positives)
+
+    @Test
+    fun ignoresEntityInsert() {
+        // @Insert/@Upsert attribute the account through the entity's accountId field, which a SQL-text
+        // rule can't see; they are deliberately out of scope (callsite + SessionWriter own attribution).
+        val findings = lint(
+            """
+            import androidx.room.Dao
+            import androidx.room.Insert
+
+            @Dao
+            interface ConversationDao {
+                @Insert
+                suspend fun insert(entity: Any)
+            }
+            """.trimIndent(),
+        )
+        assertFalse(findings.flagged("insert"), "@Insert must not be flagged (field-attributed)")
+    }
+
+    @Test
+    fun acceptsCrossAccountOnEntityDelete() {
+        val findings = lint(
+            """
+            import androidx.room.Dao
+            import androidx.room.Delete
+            import com.garfiec.librechat.core.common.identity.CrossAccount
+
+            @Dao
+            interface ConversationDao {
+                @CrossAccount
+                @Delete
+                suspend fun delete(entity: Any)
+            }
+            """.trimIndent(),
+        )
+        assertFalse(findings.flagged("delete"), "@CrossAccount must opt an entity @Delete out")
+    }
 
     @Test
     fun ignoresPlainUpsert() {
@@ -115,6 +193,307 @@ class AccountScopedDaoRuleTest {
             """.trimIndent(),
         )
         assertFalse(findings.flagged("getById"), "non-tenant table must be ignored")
+    }
+
+    @Test
+    fun tenantTableMatchIsCaseInsensitive_firesWhenUnscoped() {
+        // SQLite identifiers are case-insensitive, so `FROM Messages` / `FROM CONVERSATIONS` hit the
+        // real tenant table and an unscoped statement must still be flagged regardless of casing.
+        val findings = lint(
+            """
+            import androidx.room.Dao
+            import androidx.room.Query
+
+            @Dao
+            interface MessageDao {
+                @Query("DELETE FROM Messages WHERE messageId = :id")
+                suspend fun nukeByCasing(id: String)
+            }
+            """.trimIndent(),
+        )
+        assertTrue(findings.flagged("nukeByCasing"), "case-variant tenant table must still be flagged when unscoped")
+    }
+
+    // endregion
+
+    // region hardened matcher (R5-D): WHERE-scoped predicate, concatenation, @RawQuery, interpolation
+
+    @Test
+    fun parsesConcatenatedSql_firesWhenUnscoped() {
+        // A `"a" + "b"` concatenated query must be matched as one SQL string, not just single literals.
+        val findings = lint(
+            """
+            import androidx.room.Dao
+            import androidx.room.Query
+
+            @Dao
+            interface MessageDao {
+                @Query(
+                    "SELECT * FROM messages WHERE conversationId = :c " +
+                        "AND parentMessageId = :p ORDER BY createdAt ASC",
+                )
+                suspend fun getSiblings(c: String, p: String): Any
+            }
+            """.trimIndent(),
+        )
+        assertTrue(findings.flagged("getSiblings"), "unscoped concatenated SQL must be flagged")
+    }
+
+    @Test
+    fun parsesConcatenatedSql_passesWhenScoped() {
+        val findings = lint(
+            """
+            import androidx.room.Dao
+            import androidx.room.Query
+
+            @Dao
+            interface MessageDao {
+                @Query(
+                    "SELECT * FROM messages WHERE conversationId = :c AND accountId = :a " +
+                        "ORDER BY createdAt ASC",
+                )
+                suspend fun getSiblingsForAccount(c: String, a: String): Any
+            }
+            """.trimIndent(),
+        )
+        assertFalse(findings.flagged("getSiblingsForAccount"), "scoped concatenated SQL must pass")
+    }
+
+    @Test
+    fun setAccountIdIsNotScoping() {
+        // `SET accountId = :x` writes the column; it does not restrict which rows are touched. Only a
+        // WHERE-clause predicate scopes, so this must be flagged despite containing "accountId =".
+        val findings = lint(
+            """
+            import androidx.room.Dao
+            import androidx.room.Query
+
+            @Dao
+            interface ConversationDao {
+                @Query("UPDATE conversations SET accountId = :a WHERE conversationId = :id")
+                suspend fun reassign(a: String, id: String)
+            }
+            """.trimIndent(),
+        )
+        assertTrue(findings.flagged("reassign"), "accountId in SET (not WHERE) must not count as scoping")
+    }
+
+    @Test
+    fun isNullIsNotPositiveScoping() {
+        // `accountId IS NULL` is the legacy-claim shape, not single-account scoping -> must be flagged
+        // (the real claim DAO opts out with @CrossAccount instead).
+        val findings = lint(
+            """
+            import androidx.room.Dao
+            import androidx.room.Query
+
+            @Dao
+            interface ConversationDao {
+                @Query("DELETE FROM conversations WHERE accountId IS NULL")
+                suspend fun deleteUnclaimed()
+            }
+            """.trimIndent(),
+        )
+        assertTrue(findings.flagged("deleteUnclaimed"), "accountId IS NULL must not count as scoping")
+    }
+
+    @Test
+    fun acceptsAccountIdInPredicate() {
+        val findings = lint(
+            """
+            import androidx.room.Dao
+            import androidx.room.Query
+
+            @Dao
+            interface ConversationDao {
+                @Query("SELECT * FROM conversations WHERE accountId IN (:a, :b)")
+                suspend fun forAccounts(a: String, b: String): Any
+            }
+            """.trimIndent(),
+        )
+        assertFalse(findings.flagged("forAccounts"), "accountId IN (...) must count as scoping")
+    }
+
+    @Test
+    fun firesOnRawQueryInTenantDao() {
+        val findings = lint(
+            """
+            import androidx.room.Dao
+            import androidx.room.RawQuery
+
+            @Dao
+            interface ConversationDao {
+                @RawQuery
+                suspend fun raw(query: Any): Any
+            }
+            """.trimIndent(),
+        )
+        assertTrue(findings.flagged("raw"), "@RawQuery in a tenant DAO must be flagged")
+    }
+
+    @Test
+    fun firesOnInterpolatedQueryInTenantDao() {
+        val findings = lint(
+            """
+            import androidx.room.Dao
+            import androidx.room.Query
+
+            @Dao
+            interface MessageDao {
+                @Query("SELECT * FROM messages WHERE messageId = ${'$'}id")
+                suspend fun byId(id: String): Any
+            }
+            """.trimIndent(),
+        )
+        assertTrue(findings.flagged("byId"), "non-constant (interpolated) @Query in a tenant DAO must be flagged")
+    }
+
+    @Test
+    fun subqueryScopedPredicateIsNotOuterScoping() {
+        // accountId appears only inside a subquery; the outer messages statement is unscoped.
+        val findings = lint(
+            """
+            import androidx.room.Dao
+            import androidx.room.Query
+
+            @Dao
+            interface MessageDao {
+                @Query(
+                    "DELETE FROM messages WHERE conversationId IN " +
+                        "(SELECT conversationId FROM conversations WHERE accountId = :a)",
+                )
+                suspend fun deleteForConv(a: String)
+            }
+            """.trimIndent(),
+        )
+        assertTrue(findings.flagged("deleteForConv"), "subquery-only accountId must not count as outer scoping")
+    }
+
+    @Test
+    fun topLevelOrIsNotScoping() {
+        val findings = lint(
+            """
+            import androidx.room.Dao
+            import androidx.room.Query
+
+            @Dao
+            interface MessageDao {
+                @Query("SELECT * FROM messages WHERE messageId = :id OR accountId = :a")
+                suspend fun byIdOrAccount(id: String, a: String): Any
+            }
+            """.trimIndent(),
+        )
+        assertTrue(findings.flagged("byIdOrAccount"), "accountId joined by a top-level OR is not restrictive scoping")
+    }
+
+    @Test
+    fun differentlyNamedColumnEndingInAccountIdIsNotScoping() {
+        val findings = lint(
+            """
+            import androidx.room.Dao
+            import androidx.room.Query
+
+            @Dao
+            interface ConversationDao {
+                @Query("SELECT * FROM conversations WHERE userAccountId = :a")
+                suspend fun byWrongColumn(a: String): Any
+            }
+            """.trimIndent(),
+        )
+        assertTrue(findings.flagged("byWrongColumn"), "a column merely ending in 'accountId' must not count as scoping")
+    }
+
+    @Test
+    fun inferredTenantDao_concreteBodyFlagged_evenWhenNotInNameList() {
+        // A DAO not named in TENANT_DAOS but carrying a tenant @Query is inferred to be a tenant DAO,
+        // so its unscoped concrete @Transaction body is still flagged.
+        val findings = lint(
+            """
+            import androidx.room.Dao
+            import androidx.room.Query
+            import androidx.room.Transaction
+            import androidx.room.Upsert
+
+            @Dao
+            interface MessageSearchDao {
+                @Query("SELECT * FROM messages WHERE accountId = :a")
+                fun forAccount(a: String): Any
+
+                @Transaction
+                suspend fun rebuild(a: String, rows: List<Any>) {
+                    upsertAll(rows)
+                }
+
+                @Upsert
+                suspend fun upsertAll(rows: List<Any>)
+            }
+            """.trimIndent(),
+        )
+        assertTrue(findings.flagged("rebuild"), "concrete body in an inferred tenant DAO must be flagged")
+        assertFalse(findings.flagged("forAccount"), "the scoped @Query that triggered inference must itself pass")
+    }
+
+    @Test
+    fun acceptsParenthesizedAccountIdPredicate() {
+        // A validly-grouped accountId predicate must pass; the matcher must not strip it as if it were a
+        // subquery / value-list (that was a false positive that would push authors to a needless opt-out).
+        val findings = lint(
+            """
+            import androidx.room.Dao
+            import androidx.room.Query
+
+            @Dao
+            interface MessageDao {
+                @Query("DELETE FROM messages WHERE (accountId = :a) AND conversationId = :c")
+                suspend fun deleteForConv(a: String, c: String)
+            }
+            """.trimIndent(),
+        )
+        assertFalse(findings.flagged("deleteForConv"), "a parenthesized (accountId = :a) predicate must count as scoping")
+    }
+
+    @Test
+    fun subqueryWhereBeforeOuterWhere_isNotScoping() {
+        // The accountId WHERE lives in a subquery in the SET clause, textually before the outer WHERE.
+        // The outer UPDATE is scoped only by messageId -> must be flagged (the first-WHERE trap).
+        val findings = lint(
+            """
+            import androidx.room.Dao
+            import androidx.room.Query
+
+            @Dao
+            interface MessageDao {
+                @Query(
+                    "UPDATE messages SET text = " +
+                        "(SELECT text FROM messages WHERE accountId = :a LIMIT 1) WHERE messageId = :id",
+                )
+                suspend fun copyText(a: String, id: String)
+            }
+            """.trimIndent(),
+        )
+        assertTrue(findings.flagged("copyText"), "a subquery WHERE must not be mistaken for the outer scoping WHERE")
+    }
+
+    @Test
+    fun multiTableJoinStatement_isFailClosed() {
+        // A statement spanning two tenant tables / a JOIN is fail-closed: a regex can't prove which
+        // table the accountId predicate scopes, so even a qualified `c.accountId` must not pass.
+        val findings = lint(
+            """
+            import androidx.room.Dao
+            import androidx.room.Query
+
+            @Dao
+            interface MessageDao {
+                @Query(
+                    "SELECT m.* FROM messages m JOIN conversations c " +
+                        "ON m.conversationId = c.conversationId WHERE c.accountId = :a",
+                )
+                suspend fun joinedForAccount(a: String): Any
+            }
+            """.trimIndent(),
+        )
+        assertTrue(findings.flagged("joinedForAccount"), "a multi-table/JOIN statement must be fail-closed")
     }
 
     // endregion


### PR DESCRIPTION
## Summary

PR #196 landed account row-tenancy (accountId-scoped local persistence + the logout leak fix) along with a **dormant** `AccountScopedDaoRule`. This PR turns that rule on and brings the code into compliance: it wires the rule into the Detekt convention plugin and enables it, adds a `@CrossAccount` opt-out for the deliberate cross-account paths, hardens the SQL matcher, and scopes the remaining unscoped by-PK DAO mutations so the now-enforced invariant holds.

## Changes

- **Activate the rule** — wire `:detekt-rules` into the `librechat.detekt` convention plugin and enable `AccountScopedDaoRule` in `config/detekt/detekt.yml`, so it runs in the `detektMetadataCommonMain` gate. (It shipped dormant in #196 and never executed.)
- **`@CrossAccount` opt-out annotation** (new, `core/common`, KMP commonMain) — marks the deliberate cross-account paths so activating the rule doesn't flag them: the legacy-claim sweep (scoped by `accountId IS NULL`) and account-safe `@Transaction` helpers that thread `accountId` internally (e.g. the tag-preserving upsert).
- **Harden the matcher** — the rule now handles concatenated SQL, `@RawQuery`/string interpolation, WHERE-clause predicate scoping (not just column presence), by-PK entity `@Delete`/`@Update`, multi-table/JOIN statements (fail-closed), and case-insensitive table names; the test suite is expanded to cover these.
- **Scope the remaining tenant-DAO mutations** — bring the by-PK conversation/message mutations under `accountId` scoping (`deleteById`, `updateTitle`, `updateArchived`, `updatePinned`, `updateChatProjectId`, `updateTags`, message `updateFeedback`/`updateText`), thread `accountId` through the tag-preserving upsert, and remove the dead unscoped legacy reads and deletes — the code changes needed to satisfy the now-active rule.
- **Repositories** capture the active `accountId` before each network suspend and skip the local cache write when it's unresolved, so an in-flight account switch can't mis-attribute rows.
- **`AccountKeyedCache<T>`** — extract the agents/presets in-memory cache (their only isolation tier) into one helper keyed on the owning account, with the key read under the lock at serve time so one account is never served another's cached list.
- **`AccountSessionEstablisher`** runs the legacy-row claim before publishing the active account; the claim is best-effort (publishes even if it fails so the session isn't stranded) but rethrows cancellation.

## Testing

- Host-JVM unit tests: read/write isolation (`AccountReadIsolationTest`, `AccountWriteIsolationTest`), cache-mutex / identity-change (`RepositoryCacheMutexTest`), session establisher (`AccountSessionEstablisherTest`), and the rule's own suite (`AccountScopedDaoRuleTest`).
- `:core:data:detektMetadataCommonMain`, `:app:assembleDebug`, and `:shared:linkDebugFrameworkIosSimulatorArm64` all pass.
- Device-tested on a Pixel 10 Pro Fold against a LibreChat v0.8.7 backend: cross-account isolation, conversation pin, project assignment, and agent/preset cache switching.

## Notes / known limitations

- The rule's tenant-table set is an explicit allowlist — a newly added tenant table must be added to it (not auto-discovered).
- `@Insert`/`@Upsert` attribution still rests on the repository stamping `accountId` at the call site; the rule checks scoped `@Query` predicates, not insert/upsert values.
- Token storage and DataStore key prefixing are not account-scoped in this PR.
