### PR TITLE
feat: account-key the token store + scope config/role/last-used prefs

### DIFF
--- a/core/data/src/androidMain/kotlin/com/garfiec/librechat/core/data/datastore/TokenDataStore.kt
+++ b/core/data/src/androidMain/kotlin/com/garfiec/librechat/core/data/datastore/TokenDataStore.kt
@@ -28,26 +28,25 @@ class TokenDataStore(
         initializeTokenCache()
     }
 
-    override fun readAccessToken(): String? = prefs.getString(KEY_ACCESS_TOKEN, null)
+    override fun readValue(key: String): String? = prefs.getString(key, null)
 
-    override fun readRefreshToken(): String? = prefs.getString(KEY_REFRESH_TOKEN, null)
-
-    override fun writeTokens(accessToken: String, refreshToken: String) {
-        prefs.edit()
-            .putString(KEY_ACCESS_TOKEN, accessToken)
-            .putString(KEY_REFRESH_TOKEN, refreshToken)
-            .apply()
+    override fun writeValue(key: String, value: String) {
+        prefs.edit().putString(key, value).apply()
     }
 
-    override fun removeTokens() {
-        prefs.edit()
-            .remove(KEY_ACCESS_TOKEN)
-            .remove(KEY_REFRESH_TOKEN)
-            .apply()
+    override fun writeValues(values: Map<String, String>) {
+        val editor = prefs.edit()
+        values.forEach { (key, value) -> editor.putString(key, value) }
+        editor.apply()
+    }
+
+    override fun removeValue(key: String) {
+        prefs.edit().remove(key).apply()
     }
 
     override fun onKeystoreCorruption() {
-        removeTokens()
+        // The encrypted store is unreadable; wipe it wholesale so a fresh master key can back new writes.
+        prefs.edit().clear().apply()
     }
 
     override fun isKeystoreException(e: Exception): Boolean = e is KeyStoreException

--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/datastore/CommonTokenDataStoreAccountKeyingTest.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/datastore/CommonTokenDataStoreAccountKeyingTest.kt
@@ -1,0 +1,205 @@
+package com.garfiec.librechat.core.data.datastore
+
+import com.google.common.truth.Truth.assertThat
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.defaultRequest
+import io.ktor.client.request.url
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+/**
+ * Verifies the account-keying of [CommonTokenDataStore]: keys are namespaced by the active account,
+ * the sync mirror seeds the right bearer at construction, and the identity hooks migrate/clear the
+ * keyed slots. Uses a plain in-memory key/value store so no `EncryptedSharedPreferences`/Keychain.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class CommonTokenDataStoreAccountKeyingTest {
+
+    private class FakeKeyedStore(
+        refreshClient: Lazy<HttpClient>,
+        seed: Map<String, String> = emptyMap(),
+    ) : CommonTokenDataStore(refreshClient) {
+        val store = seed.toMutableMap()
+
+        init {
+            initializeTokenCache()
+        }
+
+        override fun readValue(key: String): String? = store[key]
+        override fun writeValue(key: String, value: String) {
+            store[key] = value
+        }
+
+        override fun writeValues(values: Map<String, String>) {
+            store.putAll(values)
+        }
+
+        override fun removeValue(key: String) {
+            store.remove(key)
+        }
+
+        override fun onKeystoreCorruption() = Unit
+    }
+
+    private val noRefresh: Lazy<HttpClient> = lazy { error("refresh client not expected in this test") }
+
+    private fun accessKey(account: String) = "acct:$account:access_token"
+    private fun refreshKeyOf(account: String) = "acct:$account:refresh_token"
+
+    @Test
+    fun `init seeds cached bearer from the mirror's keyed slot`() = runTest {
+        val store = FakeKeyedStore(
+            noRefresh,
+            seed = mapOf(
+                "active_account_id" to "acctA",
+                accessKey("acctA") to "A-access",
+            ),
+        )
+
+        assertThat(store.isAuthenticated).isTrue()
+        assertThat(store.getAccessToken()).isEqualTo("A-access")
+    }
+
+    @Test
+    fun `init falls back to the bare key for a legacy pre-keying install`() = runTest {
+        val store = FakeKeyedStore(noRefresh, seed = mapOf("access_token" to "legacy-access"))
+
+        assertThat(store.isAuthenticated).isTrue()
+        assertThat(store.getAccessToken()).isEqualTo("legacy-access")
+    }
+
+    @Test
+    fun `init reports logged out when storage is empty`() = runTest {
+        val store = FakeKeyedStore(noRefresh)
+
+        assertThat(store.isAuthenticated).isFalse()
+        assertThat(store.getAccessToken()).isNull()
+    }
+
+    @Test
+    fun `onAccountResolved migrates bare tokens into the keyed slot and writes the mirror`() = runTest {
+        val store = FakeKeyedStore(noRefresh)
+        // Fresh login: no account resolved yet, so setTokens lands under the bare keys.
+        store.setTokens(accessToken = "A-access", refreshToken = "A-refresh")
+
+        store.onAccountResolved("acctA")
+
+        assertThat(store.store[accessKey("acctA")]).isEqualTo("A-access")
+        assertThat(store.store[refreshKeyOf("acctA")]).isEqualTo("A-refresh")
+        assertThat(store.store["active_account_id"]).isEqualTo("acctA")
+        assertThat(store.store).doesNotContainKey("access_token")
+        assertThat(store.store).doesNotContainKey("refresh_token")
+        assertThat(store.getAccessToken()).isEqualTo("A-access")
+    }
+
+    @Test
+    fun `onAccountResolved is a no-op when the account is unchanged`() = runTest {
+        val store = FakeKeyedStore(
+            noRefresh,
+            seed = mapOf("active_account_id" to "acctA", accessKey("acctA") to "A-access"),
+        )
+
+        store.onAccountResolved("acctA")
+
+        assertThat(store.getAccessToken()).isEqualTo("A-access")
+        assertThat(store.store[accessKey("acctA")]).isEqualTo("A-access")
+    }
+
+    @Test
+    fun `switching account without logout re-homes tokens and drops the previous slot`() = runTest {
+        val store = FakeKeyedStore(
+            noRefresh,
+            seed = mapOf(
+                "active_account_id" to "acctA",
+                accessKey("acctA") to "A-access",
+                refreshKeyOf("acctA") to "A-refresh",
+            ),
+        )
+        // Soft-expiry → login B without an explicit logout: setTokens for B lands under A's key
+        // (activeAccountKey still A) until the establish hook re-homes it.
+        store.setTokens(accessToken = "B-access", refreshToken = "B-refresh")
+
+        store.onAccountResolved("acctB")
+
+        assertThat(store.store[accessKey("acctB")]).isEqualTo("B-access")
+        assertThat(store.store[refreshKeyOf("acctB")]).isEqualTo("B-refresh")
+        assertThat(store.store).doesNotContainKey(accessKey("acctA"))
+        assertThat(store.store).doesNotContainKey(refreshKeyOf("acctA"))
+        assertThat(store.store["active_account_id"]).isEqualTo("acctB")
+        assertThat(store.getAccessToken()).isEqualTo("B-access")
+    }
+
+    @Test
+    fun `onAccountCleared removes the active account's tokens and the mirror`() = runTest {
+        val store = FakeKeyedStore(
+            noRefresh,
+            seed = mapOf(
+                "active_account_id" to "acctA",
+                accessKey("acctA") to "A-access",
+                refreshKeyOf("acctA") to "A-refresh",
+            ),
+        )
+
+        store.onAccountCleared()
+
+        assertThat(store.store).doesNotContainKey(accessKey("acctA"))
+        assertThat(store.store).doesNotContainKey(refreshKeyOf("acctA"))
+        assertThat(store.store).doesNotContainKey("active_account_id")
+        assertThat(store.getAccessToken()).isNull()
+    }
+
+    @Test
+    fun `setTokens after resolve writes under the keyed slot`() = runTest {
+        val store = FakeKeyedStore(noRefresh)
+        store.setTokens("bootstrap", "bootstrap-refresh")
+        store.onAccountResolved("acctA")
+
+        store.setTokens("A-access-2", "A-refresh-2")
+
+        assertThat(store.store[accessKey("acctA")]).isEqualTo("A-access-2")
+        assertThat(store.store[refreshKeyOf("acctA")]).isEqualTo("A-refresh-2")
+    }
+
+    @Test
+    fun `refresh reads and writes the active account's keyed tokens`() = runTest {
+        val engine = MockEngine {
+            respond(
+                content = """{"token":"A-access-refreshed","user":null}""",
+                status = HttpStatusCode.OK,
+                headers = headersOf("Content-Type", listOf("application/json")),
+            )
+        }
+        val refreshClient = lazy {
+            HttpClient(engine) {
+                install(ContentNegotiation) { json() }
+                defaultRequest {
+                    url("https://chat.example.com")
+                    contentType(ContentType.Application.Json)
+                }
+            }
+        }
+        val store = FakeKeyedStore(
+            refreshClient,
+            seed = mapOf(
+                "active_account_id" to "acctA",
+                accessKey("acctA") to "A-access",
+                refreshKeyOf("acctA") to "A-refresh",
+            ),
+        )
+
+        val ok = store.refreshAccessToken()
+
+        assertThat(ok).isTrue()
+        assertThat(store.store[accessKey("acctA")]).isEqualTo("A-access-refreshed")
+        assertThat(store.getAccessToken()).isEqualTo("A-access-refreshed")
+    }
+}

--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/datastore/CommonTokenDataStoreConcurrencyTest.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/datastore/CommonTokenDataStoreConcurrencyTest.kt
@@ -37,35 +37,37 @@ class CommonTokenDataStoreConcurrencyTest {
         initialRefresh: String? = "initial-refresh",
     ) : CommonTokenDataStore(refreshClient) {
 
-        @Volatile
-        private var storedAccess: String? = initialAccess
-
-        @Volatile
-        private var storedRefresh: String? = initialRefresh
+        private val store = mutableMapOf<String, String>()
 
         val writeLog = mutableListOf<Pair<String, String>>()
         var removeCount = 0
 
-        fun persistedAccess(): String? = storedAccess
-        fun persistedRefresh(): String? = storedRefresh
+        // No account is resolved in these tests, so the store uses the bare token keys.
+        fun persistedAccess(): String? = store[KEY_ACCESS_TOKEN]
+        fun persistedRefresh(): String? = store[KEY_REFRESH_TOKEN]
 
         init {
+            initialAccess?.let { store[KEY_ACCESS_TOKEN] = it }
+            initialRefresh?.let { store[KEY_REFRESH_TOKEN] = it }
             initializeTokenCache()
         }
 
-        override fun readAccessToken(): String? = storedAccess
-        override fun readRefreshToken(): String? = storedRefresh
+        override fun readValue(key: String): String? = store[key]
 
-        override fun writeTokens(accessToken: String, refreshToken: String) {
-            storedAccess = accessToken
-            storedRefresh = refreshToken
-            writeLog += accessToken to refreshToken
+        override fun writeValue(key: String, value: String) {
+            store[key] = value
+            // setTokens writes access then refresh; log the pair once, keyed off the access write.
+            if (key == KEY_ACCESS_TOKEN) writeLog += value to (store[KEY_REFRESH_TOKEN] ?: "")
         }
 
-        override fun removeTokens() {
-            storedAccess = null
-            storedRefresh = null
-            removeCount++
+        override fun writeValues(values: Map<String, String>) {
+            values.forEach { (key, value) -> writeValue(key, value) }
+        }
+
+        override fun removeValue(key: String) {
+            store.remove(key)
+            // clearTokens removes access then refresh; count the logical clear off the access removal.
+            if (key == KEY_ACCESS_TOKEN) removeCount++
         }
 
         override fun onKeystoreCorruption() = Unit

--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/datastore/DataStoreRoundTripTest.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/datastore/DataStoreRoundTripTest.kt
@@ -3,11 +3,17 @@ package com.garfiec.librechat.core.data.datastore
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.Preferences
+import com.garfiec.librechat.core.common.identity.AccountId
+import com.garfiec.librechat.core.common.identity.ActiveAccountProvider
+import com.garfiec.librechat.core.common.identity.InMemoryActiveAccountProvider
+import com.garfiec.librechat.core.network.client.ServerUrlProvider
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
 import org.junit.Rule
@@ -33,6 +39,20 @@ class DataStoreRoundTripTest {
             File(tmpFolder.root, "$name.preferences_pb")
         }
     }
+
+    // A resolved account so the account-scoped stores (SettingsDataStore last_used_*, RoleCache) select
+    // a keyed slot rather than reading null; server provider so ConfigCache can derive a serverId.
+    private fun resolvedAccountProvider(id: String = "srv:test-account"): ActiveAccountProvider =
+        InMemoryActiveAccountProvider().apply { set(AccountId(id)) }
+
+    private val fakeServerUrlProvider = object : ServerUrlProvider {
+        override fun getBaseUrl(): String = "https://chat.example.com"
+    }
+
+    private fun settingsStore(
+        ds: DataStore<Preferences>,
+        accountProvider: ActiveAccountProvider = resolvedAccountProvider(),
+    ) = SettingsDataStore(ds, accountProvider, CoroutineScope(testDispatcher), testDispatcher)
 
     // --- ServerDataStore ---
 
@@ -108,7 +128,7 @@ class DataStoreRoundTripTest {
     @Test
     fun settingsDataStore_defaults() = runTest(testDispatcher) {
         val ds = createDataStore("settings")
-        val store = SettingsDataStore(ds, CoroutineScope(testDispatcher), testDispatcher)
+        val store = settingsStore(ds)
 
         assertThat(store.autoScrollEnabled.first()).isTrue()
         assertThat(store.showThinkingBlocks.first()).isTrue()
@@ -124,7 +144,7 @@ class DataStoreRoundTripTest {
     @Test
     fun settingsDataStore_roundTrip_booleans() = runTest(testDispatcher) {
         val ds = createDataStore("settings-bool")
-        val store = SettingsDataStore(ds, CoroutineScope(testDispatcher), testDispatcher)
+        val store = settingsStore(ds)
 
         store.setAutoScrollEnabled(false)
         store.setShowThinkingBlocks(false)
@@ -142,7 +162,7 @@ class DataStoreRoundTripTest {
     @Test
     fun settingsDataStore_roundTrip_enums() = runTest(testDispatcher) {
         val ds = createDataStore("settings-enums")
-        val store = SettingsDataStore(ds, CoroutineScope(testDispatcher), testDispatcher)
+        val store = settingsStore(ds)
 
         store.setLatexRenderer(LatexRenderer.NATIVE)
         assertThat(store.latexRenderer.first()).isEqualTo(LatexRenderer.NATIVE)
@@ -157,7 +177,7 @@ class DataStoreRoundTripTest {
     @Test
     fun settingsDataStore_roundTrip_strings() = runTest(testDispatcher) {
         val ds = createDataStore("settings-strings")
-        val store = SettingsDataStore(ds, CoroutineScope(testDispatcher), testDispatcher)
+        val store = settingsStore(ds)
 
         store.setLastUsedModel("anthropic", "claude-3.5-sonnet")
         assertThat(store.lastUsedEndpoint.first()).isEqualTo("anthropic")
@@ -171,9 +191,30 @@ class DataStoreRoundTripTest {
     }
 
     @Test
+    fun settingsDataStore_lastUsed_suppressedWhileWarming_thenEmitsOnResolve() = runTest(testDispatcher) {
+        val ds = createDataStore("settings-lastused-warming")
+        val provider = InMemoryActiveAccountProvider() // starts Warming
+        val store = SettingsDataStore(ds, provider, CoroutineScope(testDispatcher), testDispatcher)
+
+        val emissions = mutableListOf<String?>()
+        val job = launch { store.lastUsedModel.collect { emissions.add(it) } }
+        advanceUntilIdle()
+        // While the account is Warming the flow is suppressed (no null emission that a seeder would
+        // mistake for "no last-used saved").
+        assertThat(emissions).isEmpty()
+
+        provider.set(AccountId("srv:acctX"))
+        store.setLastUsedModel("openAI", "gpt-4o")
+        advanceUntilIdle()
+        assertThat(emissions.last()).isEqualTo("gpt-4o")
+
+        job.cancel()
+    }
+
+    @Test
     fun settingsDataStore_roundTrip_floats() = runTest(testDispatcher) {
         val ds = createDataStore("settings-floats")
-        val store = SettingsDataStore(ds, CoroutineScope(testDispatcher), testDispatcher)
+        val store = settingsStore(ds)
 
         store.setTtsSpeechRate(1.5f)
         store.setTtsPitch(0.8f)
@@ -184,7 +225,7 @@ class DataStoreRoundTripTest {
     @Test
     fun settingsDataStore_roundTrip_mcpServers() = runTest(testDispatcher) {
         val ds = createDataStore("settings-mcp")
-        val store = SettingsDataStore(ds, CoroutineScope(testDispatcher), testDispatcher)
+        val store = settingsStore(ds)
 
         store.setSelectedMcpServers(setOf("server-a", "server-b"))
         assertThat(store.selectedMcpServers.first()).containsExactly("server-a", "server-b")
@@ -199,7 +240,7 @@ class DataStoreRoundTripTest {
     fun configCacheDataStore_roundTrip_availableModels() = runTest(testDispatcher) {
         val ds = createDataStore("config-cache")
         val json = Json { ignoreUnknownKeys = true; isLenient = true }
-        val store = ConfigCacheDataStore(ds, json)
+        val store = ConfigCacheDataStore(ds, json, fakeServerUrlProvider)
 
         val models = mapOf(
             "openAI" to listOf("gpt-4o", "gpt-4o-mini"),
@@ -218,7 +259,7 @@ class DataStoreRoundTripTest {
     fun configCacheDataStore_returnsNullWhenEmpty() = runTest(testDispatcher) {
         val ds = createDataStore("config-empty")
         val json = Json { ignoreUnknownKeys = true }
-        val store = ConfigCacheDataStore(ds, json)
+        val store = ConfigCacheDataStore(ds, json, fakeServerUrlProvider)
 
         assertThat(store.loadStartupConfig()).isNull()
         assertThat(store.loadEndpointConfigs()).isNull()

--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/repository/AccountSessionEstablisherTest.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/repository/AccountSessionEstablisherTest.kt
@@ -3,6 +3,7 @@ package com.garfiec.librechat.core.data.repository
 import com.garfiec.librechat.core.data.datastore.AccountRegistry
 import com.garfiec.librechat.core.model.User
 import com.garfiec.librechat.core.network.client.ServerUrlProvider
+import com.garfiec.librechat.core.network.client.TokenManager
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.coVerifyOrder
@@ -19,11 +20,13 @@ class AccountSessionEstablisherTest {
     private val accountRegistry = mockk<AccountRegistry>(relaxed = true)
     private val claimReconciler = mockk<AccountClaimReconciler>(relaxed = true)
     private val serverUrlProvider = mockk<ServerUrlProvider>(relaxed = true)
+    private val tokenManager = mockk<TokenManager>(relaxed = true)
 
     private val establisher = AccountSessionEstablisher(
         accountRegistry = accountRegistry,
         claimReconciler = claimReconciler,
         serverUrlProvider = serverUrlProvider,
+        tokenManager = tokenManager,
         ioDispatcher = UnconfinedTestDispatcher(),
     )
 
@@ -62,5 +65,24 @@ class AccountSessionEstablisherTest {
         establisher.establish(user)
 
         coVerify { accountRegistry.setActiveAccount(any()) }
+    }
+
+    /**
+     * The token store must be bound to the resolved account (re-homing tokens into its keyed slot +
+     * writing the sync mirror) before the account is published, so a scoped read/write going live on
+     * publish already sees keyed tokens.
+     */
+    @Test
+    fun bindsTokensToResolvedAccountBeforePublishing() = runTest {
+        coEvery { serverUrlProvider.awaitBaseUrl() } returns "https://chat.example.com"
+        val user = mockk<User>(relaxed = true)
+        every { user.id } returns "mongoUserId"
+
+        val accountId = establisher.establish(user)
+
+        coVerifyOrder {
+            tokenManager.onAccountResolved(accountId.value)
+            accountRegistry.setActiveAccount(any())
+        }
     }
 }

--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/repository/RoleRepositoryImplTest.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/repository/RoleRepositoryImplTest.kt
@@ -1,5 +1,7 @@
 package com.garfiec.librechat.core.data.repository
 
+import com.garfiec.librechat.core.common.identity.AccountId
+import com.garfiec.librechat.core.common.identity.InMemoryActiveAccountProvider
 import com.garfiec.librechat.core.common.result.Result
 import com.garfiec.librechat.core.data.datastore.RoleCacheDataStore
 import com.garfiec.librechat.core.model.User
@@ -42,12 +44,16 @@ class RoleRepositoryImplTest {
         permissions = mapOf("PROMPTS" to mapOf("USE" to true)),
     )
 
+    // Resolved so the init prime-collector fires cacheDataStore.load() once (as the old one-shot did).
+    private val activeAccountProvider = InMemoryActiveAccountProvider().apply { set(AccountId("srv:test")) }
+
     private fun TestScope.newRepo(): RoleRepositoryImpl {
         val scope = CoroutineScope(StandardTestDispatcher(testScheduler))
         return RoleRepositoryImpl(
             rolesApi = rolesApi,
             userRepository = userRepository,
             cacheDataStore = cacheDataStore,
+            activeAccountProvider = activeAccountProvider,
             applicationScope = scope,
         )
     }

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/CommonTokenDataStore.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/CommonTokenDataStore.kt
@@ -21,6 +21,21 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlin.concurrent.Volatile
 
+/**
+ * Account-keyed secure token store. Tokens are namespaced by the active account
+ * (`acct:<accountId>:access_token`) so one account's cached credentials are never **read** under
+ * another — the precursor for holding several accounts' sessions at once (multi-account, issue #179).
+ * Under the current single-active model only one account's tokens are retained at a time: a direct
+ * account switch re-homes the newest sign-in into its keyed slot and drops the previous one (full
+ * multi-account retention is a later step).
+ *
+ * The active account is mirrored into the same synchronously-readable secure storage (key
+ * [KEY_ACTIVE_ACCOUNT]) rather than the async account registry, so the bearer for the right account
+ * is seeded in the constructor — the first-frame `isAuthenticated` check and the first authed request
+ * never read a blind bearer at cold start. When no account is resolved (fresh install, logged out, or
+ * a legacy pre-keying upgrade) the keys fall back to their bare form, which is also how tokens from an
+ * older build are read until [onAccountResolved] re-homes them.
+ */
 abstract class CommonTokenDataStore(
     private val refreshClient: Lazy<HttpClient>,
 ) : TokenManager, SecureTokenStorage {
@@ -28,36 +43,53 @@ abstract class CommonTokenDataStore(
     @Volatile
     private var cachedAccessToken: String? = null
 
+    /**
+     * The account whose tokens are currently active, or `null` when logged out or on a legacy install
+     * whose tokens still live under the bare keys. Seeded synchronously from [KEY_ACTIVE_ACCOUNT] at
+     * construction. All key selection reads this, so the hot-path bearer read stays keyed without an
+     * async account lookup.
+     */
+    @Volatile
+    private var activeAccountKey: String? = null
+
     private var tokenInitialized = false
 
-    /**
-     * Eagerly load tokens from platform storage into the in-memory cache.
-     * Must be called from each platform subclass's `init {}` block (not from
-     * the super constructor, which runs before subclass properties are initialised).
-     */
-    protected fun initializeTokenCache() {
-        cachedAccessToken = readAccessToken()
+    private fun loadCacheFromStorage() {
+        activeAccountKey = readValue(KEY_ACTIVE_ACCOUNT)
+        cachedAccessToken = readValue(accessKey(activeAccountKey))
         tokenInitialized = true
     }
 
+    /**
+     * Eagerly load the active account + its cached access token from platform storage.
+     * Must be called from each platform subclass's `init {}` block (not from the super constructor,
+     * which runs before subclass properties are initialised).
+     */
+    protected fun initializeTokenCache() = loadCacheFromStorage()
+
     private fun ensureTokenLoaded(): String? {
-        if (!tokenInitialized) {
-            cachedAccessToken = readAccessToken()
-            tokenInitialized = true
-        }
+        if (!tokenInitialized) loadCacheFromStorage()
         return cachedAccessToken
     }
+
+    private fun accessKey(account: String?): String =
+        if (account == null) KEY_ACCESS_TOKEN else accountScopedName(account, KEY_ACCESS_TOKEN)
+
+    private fun refreshKey(account: String?): String =
+        if (account == null) KEY_REFRESH_TOKEN else accountScopedName(account, KEY_REFRESH_TOKEN)
 
     private val refreshMutex = Mutex()
 
     private val _sessionExpired = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
     override val sessionExpiredFlow: SharedFlow<Unit> = _sessionExpired.asSharedFlow()
 
-    // Platform implementations provide these
-    protected abstract fun readAccessToken(): String?
-    protected abstract fun readRefreshToken(): String?
-    protected abstract fun writeTokens(accessToken: String, refreshToken: String)
-    protected abstract fun removeTokens()
+    // Platform implementations provide a plain synchronously-readable key/value secure store.
+    protected abstract fun readValue(key: String): String?
+    protected abstract fun writeValue(key: String, value: String)
+
+    /** Persist several keys in one commit, so an access+refresh pair is written all-or-nothing. */
+    protected abstract fun writeValues(values: Map<String, String>)
+    protected abstract fun removeValue(key: String)
     protected abstract fun onKeystoreCorruption()
 
     // --- TokenManager ---
@@ -69,11 +101,49 @@ abstract class CommonTokenDataStore(
 
     override suspend fun setTokens(accessToken: String, refreshToken: String) {
         cachedAccessToken = accessToken
-        writeTokens(accessToken, refreshToken)
+        // One commit so a crash never persists a new access token with a stale/absent refresh token.
+        writeValues(
+            mapOf(
+                accessKey(activeAccountKey) to accessToken,
+                refreshKey(activeAccountKey) to refreshToken,
+            ),
+        )
+    }
+
+    override suspend fun onAccountResolved(accountId: String) = refreshMutex.withLock {
+        if (activeAccountKey == accountId) return@withLock
+        // Identity just became known (fresh login, upgrade, or a re-login). The tokens written by the
+        // preceding setTokens live under the previous effective key — the bare keys on a legacy/first
+        // install, or the prior account on a switch. Re-home them into this account's keyed slot (only
+        // when empty, so we never clobber existing keyed tokens), drop the old slot, and repoint the
+        // mirror so the next cold start seeds this account.
+        val previous = activeAccountKey
+        val access = readValue(accessKey(previous))
+        val refresh = readValue(refreshKey(previous))
+        // Crash-safe ordering: write the new keyed slot (atomically, only when empty so existing keyed
+        // tokens are never clobbered), THEN repoint the mirror, and only after that remove the old slot.
+        // An interruption before the mirror write leaves the old slot intact (seeds `previous`, retried
+        // next resolve); after it, the tokens are already safe under `accountId`.
+        if (access != null && refresh != null && readValue(accessKey(accountId)) == null) {
+            writeValues(mapOf(accessKey(accountId) to access, refreshKey(accountId) to refresh))
+        }
+        writeValue(KEY_ACTIVE_ACCOUNT, accountId)
+        activeAccountKey = accountId
+        removeValue(accessKey(previous))
+        removeValue(refreshKey(previous))
+        cachedAccessToken = readValue(accessKey(accountId))
+    }
+
+    override suspend fun onAccountCleared() = refreshMutex.withLock {
+        removeValue(accessKey(activeAccountKey))
+        removeValue(refreshKey(activeAccountKey))
+        removeValue(KEY_ACTIVE_ACCOUNT)
+        activeAccountKey = null
+        cachedAccessToken = null
     }
 
     override suspend fun refreshAccessToken(): Boolean = refreshMutex.withLock {
-        val storedRefreshToken = readRefreshToken()
+        val storedRefreshToken = readValue(refreshKey(activeAccountKey))
         if (storedRefreshToken.isNullOrBlank()) {
             Diag.w(
                 "Auth",
@@ -139,7 +209,8 @@ abstract class CommonTokenDataStore(
 
     private fun clearTokensLocked() {
         cachedAccessToken = null
-        removeTokens()
+        removeValue(accessKey(activeAccountKey))
+        removeValue(refreshKey(activeAccountKey))
     }
 
     override fun emitSessionExpired() {
@@ -148,7 +219,7 @@ abstract class CommonTokenDataStore(
 
     // --- SecureTokenStorage ---
 
-    override suspend fun getRefreshToken(): String? = readRefreshToken()
+    override suspend fun getRefreshToken(): String? = readValue(refreshKey(activeAccountKey))
 
     override suspend fun storeTokens(accessToken: String, refreshToken: String) {
         setTokens(accessToken, refreshToken)
@@ -163,5 +234,6 @@ abstract class CommonTokenDataStore(
     companion object {
         const val KEY_ACCESS_TOKEN = "access_token"
         const val KEY_REFRESH_TOKEN = "refresh_token"
+        private const val KEY_ACTIVE_ACCOUNT = "active_account_id"
     }
 }

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/ConfigCacheDataStore.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/ConfigCacheDataStore.kt
@@ -5,104 +5,93 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import co.touchlab.kermit.Logger
+import com.garfiec.librechat.core.common.identity.deriveServerId
 import com.garfiec.librechat.core.model.EndpointConfig
 import com.garfiec.librechat.core.model.config.StartupConfig
+import com.garfiec.librechat.core.network.client.ServerUrlProvider
 import kotlinx.coroutines.flow.first
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.builtins.MapSerializer
 import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.Json
 
+/**
+ * Server-scoped config cache. Startup config / endpoint configs / available models are cached under
+ * `srv:<serverId>:<name>` so switching servers (multi-server, issue #179) never surfaces another
+ * deployment's endpoints or models. `serverId` is derived from the warmed base URL — config is only
+ * ever read/written after a server is selected, so the URL is available.
+ */
 class ConfigCacheDataStore(
     private val dataStore: DataStore<Preferences>,
     private val json: Json,
+    private val serverUrlProvider: ServerUrlProvider,
 ) {
 
-    suspend fun saveStartupConfig(config: StartupConfig) {
-        try {
-            val serialized = json.encodeToString(StartupConfig.serializer(), config)
-            dataStore.edit { prefs -> prefs[KEY_STARTUP_CONFIG] = serialized }
-        } catch (e: Exception) {
-            Logger.w(e) { "Failed to cache startup config" }
+    suspend fun saveStartupConfig(config: StartupConfig) =
+        save(STARTUP_CONFIG, "startup config") {
+            json.encodeToString(StartupConfig.serializer(), config)
         }
-    }
 
-    suspend fun loadStartupConfig(): StartupConfig? {
-        return try {
-            val prefs = dataStore.data.first()
-            val serialized = prefs[KEY_STARTUP_CONFIG] ?: return null
-            json.decodeFromString(StartupConfig.serializer(), serialized)
-        } catch (e: Exception) {
-            Logger.w(e) { "Failed to load cached startup config" }
-            null
-        }
-    }
+    suspend fun loadStartupConfig(): StartupConfig? =
+        load(STARTUP_CONFIG, "startup config") { json.decodeFromString(StartupConfig.serializer(), it) }
 
-    suspend fun saveEndpointConfigs(endpoints: Map<String, EndpointConfig>) {
-        try {
-            val serializer = MapSerializer(String.serializer(), EndpointConfig.serializer())
-            val serialized = json.encodeToString(serializer, endpoints)
-            dataStore.edit { prefs -> prefs[KEY_ENDPOINT_CONFIGS] = serialized }
-        } catch (e: Exception) {
-            Logger.w(e) { "Failed to cache endpoint configs" }
-        }
-    }
+    suspend fun saveEndpointConfigs(endpoints: Map<String, EndpointConfig>) =
+        save(ENDPOINT_CONFIGS, "endpoint configs") { json.encodeToString(endpointSerializer, endpoints) }
 
-    suspend fun loadEndpointConfigs(): Map<String, EndpointConfig>? {
-        return try {
-            val prefs = dataStore.data.first()
-            val serialized = prefs[KEY_ENDPOINT_CONFIGS] ?: return null
-            val serializer = MapSerializer(String.serializer(), EndpointConfig.serializer())
-            json.decodeFromString(serializer, serialized)
-        } catch (e: Exception) {
-            Logger.w(e) { "Failed to load cached endpoint configs" }
-            null
-        }
-    }
+    suspend fun loadEndpointConfigs(): Map<String, EndpointConfig>? =
+        load(ENDPOINT_CONFIGS, "endpoint configs") { json.decodeFromString(endpointSerializer, it) }
 
-    suspend fun saveAvailableModels(models: Map<String, List<String>>) {
-        try {
-            val serializer = MapSerializer(
-                String.serializer(),
-                ListSerializer(String.serializer()),
-            )
-            val serialized = json.encodeToString(serializer, models)
-            dataStore.edit { prefs -> prefs[KEY_AVAILABLE_MODELS] = serialized }
-        } catch (e: Exception) {
-            Logger.w(e) { "Failed to cache available models" }
-        }
-    }
+    suspend fun saveAvailableModels(models: Map<String, List<String>>) =
+        save(AVAILABLE_MODELS, "available models") { json.encodeToString(modelsSerializer, models) }
 
-    suspend fun loadAvailableModels(): Map<String, List<String>>? {
-        return try {
-            val prefs = dataStore.data.first()
-            val serialized = prefs[KEY_AVAILABLE_MODELS] ?: return null
-            val serializer = MapSerializer(
-                String.serializer(),
-                ListSerializer(String.serializer()),
-            )
-            json.decodeFromString(serializer, serialized)
-        } catch (e: Exception) {
-            Logger.w(e) { "Failed to load cached available models" }
-            null
-        }
-    }
+    suspend fun loadAvailableModels(): Map<String, List<String>>? =
+        load(AVAILABLE_MODELS, "available models") { json.decodeFromString(modelsSerializer, it) }
 
     suspend fun clear() {
         try {
-            dataStore.edit { prefs ->
-                prefs.remove(KEY_STARTUP_CONFIG)
-                prefs.remove(KEY_ENDPOINT_CONFIGS)
-                prefs.remove(KEY_AVAILABLE_MODELS)
-            }
+            // Logout keeps the server URL, but remove every server's config entry (at most one under
+            // single-active) so this stays correct even if identity has already flipped.
+            dataStore.edit { prefs -> prefs.removeScoped(BASES) }
         } catch (e: Exception) {
             Logger.w(e) { "Failed to clear cached config" }
         }
     }
 
-    companion object {
-        private val KEY_STARTUP_CONFIG = stringPreferencesKey("cached_startup_config")
-        private val KEY_ENDPOINT_CONFIGS = stringPreferencesKey("cached_endpoint_configs")
-        private val KEY_AVAILABLE_MODELS = stringPreferencesKey("cached_available_models")
+    private suspend fun save(base: String, label: String, serialize: () -> String) {
+        val serverId = serverId() ?: return
+        try {
+            val serialized = serialize()
+            dataStore.edit { prefs ->
+                prefs[key(serverId, base)] = serialized
+                prefs.remove(stringPreferencesKey(base)) // drop the pre-keying bare entry once
+            }
+        } catch (e: Exception) {
+            Logger.w(e) { "Failed to cache $label" }
+        }
+    }
+
+    private suspend fun <T> load(base: String, label: String, deserialize: (String) -> T): T? {
+        val serverId = serverId() ?: return null
+        return try {
+            dataStore.data.first()[key(serverId, base)]?.let(deserialize)
+        } catch (e: Exception) {
+            Logger.w(e) { "Failed to load cached $label" }
+            null
+        }
+    }
+
+    private suspend fun serverId(): String? =
+        serverUrlProvider.awaitBaseUrl().takeIf { it.isNotBlank() }?.let { deriveServerId(it).value }
+
+    private fun key(serverId: String, base: String) = serverScopedKey(serverId, base)
+
+    private companion object {
+        const val STARTUP_CONFIG = "cached_startup_config"
+        const val ENDPOINT_CONFIGS = "cached_endpoint_configs"
+        const val AVAILABLE_MODELS = "cached_available_models"
+        val BASES = listOf(STARTUP_CONFIG, ENDPOINT_CONFIGS, AVAILABLE_MODELS)
+
+        val endpointSerializer = MapSerializer(String.serializer(), EndpointConfig.serializer())
+        val modelsSerializer = MapSerializer(String.serializer(), ListSerializer(String.serializer()))
     }
 }

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/RoleCacheDataStore.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/RoleCacheDataStore.kt
@@ -5,28 +5,44 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import co.touchlab.kermit.Logger
+import com.garfiec.librechat.core.common.identity.ActiveAccountProvider
+import com.garfiec.librechat.core.common.identity.currentAccountId
 import com.garfiec.librechat.core.model.permissions.UserRolePermissions
 import kotlinx.coroutines.flow.first
 import kotlinx.serialization.json.Json
 
+/**
+ * Account-scoped role/permissions cache. Cached under `acct:<accountId>:<name>` so one account's
+ * permissions can't be read under another (multi-account, issue #179). The role is fetched post-login
+ * (account resolved), so a write while unresolved is skipped; a read while unresolved returns null and
+ * the live fetch repopulates it.
+ */
 class RoleCacheDataStore(
     private val dataStore: DataStore<Preferences>,
     private val json: Json,
+    private val activeAccountProvider: ActiveAccountProvider,
 ) {
 
     suspend fun save(role: UserRolePermissions) {
+        val accountId = activeAccountProvider.currentAccountId()?.value ?: run {
+            Logger.w { "No active account; skipping role cache write" }
+            return
+        }
         try {
             val serialized = json.encodeToString(UserRolePermissions.serializer(), role)
-            dataStore.edit { prefs -> prefs[KEY_ROLE] = serialized }
+            dataStore.edit { prefs ->
+                prefs[key(accountId)] = serialized
+                prefs.remove(stringPreferencesKey(ROLE_BASE)) // drop the pre-keying bare entry once
+            }
         } catch (e: Exception) {
             Logger.w(e) { "Failed to cache user role permissions" }
         }
     }
 
     suspend fun load(): UserRolePermissions? {
+        val accountId = activeAccountProvider.currentAccountId()?.value ?: return null
         return try {
-            val prefs = dataStore.data.first()
-            val serialized = prefs[KEY_ROLE] ?: return null
+            val serialized = dataStore.data.first()[key(accountId)] ?: return null
             json.decodeFromString(UserRolePermissions.serializer(), serialized)
         } catch (e: Exception) {
             Logger.w(e) { "Failed to load cached user role permissions" }
@@ -36,13 +52,17 @@ class RoleCacheDataStore(
 
     suspend fun clear() {
         try {
-            dataStore.edit { prefs -> prefs.remove(KEY_ROLE) }
+            // Logout flips the active account to null before this runs, so remove every account's role
+            // entry (at most one under single-active) rather than the current key.
+            dataStore.edit { prefs -> prefs.removeScoped(listOf(ROLE_BASE)) }
         } catch (e: Exception) {
             Logger.w(e) { "Failed to clear cached user role permissions" }
         }
     }
 
+    private fun key(accountId: String) = accountScopedKey(accountId, ROLE_BASE)
+
     private companion object {
-        val KEY_ROLE = stringPreferencesKey("cached_user_role_permissions")
+        const val ROLE_BASE = "cached_user_role_permissions"
     }
 }

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/ScopedPreferenceKeys.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/ScopedPreferenceKeys.kt
@@ -1,0 +1,34 @@
+package com.garfiec.librechat.core.data.datastore
+
+import androidx.datastore.preferences.core.MutablePreferences
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.stringPreferencesKey
+
+/**
+ * The single definition of the row-tenancy persistence-key namespace (`acct:<accountId>:<base>` /
+ * `srv:<serverId>:<base>`), shared by the token store and the account/server-scoped preference
+ * stores. Keeping the scheme in one place means the writer and the reader can never drift onto
+ * different key formats — a drift would silently read the wrong (or no) account's value.
+ */
+
+internal fun accountScopedName(accountId: String, base: String): String = "acct:$accountId:$base"
+
+internal fun serverScopedName(serverId: String, base: String): String = "srv:$serverId:$base"
+
+internal fun accountScopedKey(accountId: String, base: String): Preferences.Key<String> =
+    stringPreferencesKey(accountScopedName(accountId, base))
+
+internal fun serverScopedKey(serverId: String, base: String): Preferences.Key<String> =
+    stringPreferencesKey(serverScopedName(serverId, base))
+
+/**
+ * Removes every entry whose name is the bare [bases] name or any `<scope>:<id>:<base>` variant of it.
+ * Logout uses this to purge a base across all accounts/servers (single-active: at most one exists),
+ * staying correct even when the active-account pointer has already been flipped to null.
+ */
+internal fun MutablePreferences.removeScoped(bases: List<String>) {
+    asMap().keys
+        .filter { key -> bases.any { key.name == it || key.name.endsWith(":$it") } }
+        .toList()
+        .forEach { remove(it) }
+}

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/SettingsDataStore.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/SettingsDataStore.kt
@@ -6,20 +6,28 @@ import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.floatPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
+import com.garfiec.librechat.core.common.identity.AccountState
+import com.garfiec.librechat.core.common.identity.ActiveAccountProvider
+import com.garfiec.librechat.core.common.identity.currentAccountId
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlin.concurrent.Volatile
 
 class SettingsDataStore(
     private val dataStore: DataStore<Preferences>,
+    private val activeAccountProvider: ActiveAccountProvider,
     appScope: CoroutineScope,
     ioDispatcher: CoroutineDispatcher,
 ) {
@@ -107,13 +115,13 @@ class SettingsDataStore(
         prefs[KEY_SELECTED_VOICE_ID]
     }
 
-    val lastUsedEndpoint: Flow<String?> = dataStore.data.map { prefs ->
-        prefs[KEY_LAST_USED_ENDPOINT]
-    }
+    // Account-scoped: the last endpoint/model is per-account (server A's pick must not seed server B).
+    // Emits nothing while the account is Warming (NOT null) so a one-shot/wait-on-unresolved consumer
+    // — the model seeder — blocks for the real value instead of mistaking Warming for "none saved" and
+    // seeding a lower tier; emits null only once the account resolves (logged out or genuinely absent).
+    val lastUsedEndpoint: Flow<String?> = scopedString(::endpointKey)
 
-    val lastUsedModel: Flow<String?> = dataStore.data.map { prefs ->
-        prefs[KEY_LAST_USED_MODEL]
-    }
+    val lastUsedModel: Flow<String?> = scopedString(::modelKey)
 
     val dismissKeyboardOnSend: Flow<Boolean> = dataStore.data.map { prefs ->
         prefs[KEY_DISMISS_KEYBOARD_ON_SEND] ?: true
@@ -295,11 +303,31 @@ class SettingsDataStore(
     }
 
     suspend fun setLastUsedModel(endpoint: String, model: String) {
+        val accountId = activeAccountProvider.currentAccountId()?.value ?: return
         dataStore.edit { prefs ->
-            prefs[KEY_LAST_USED_ENDPOINT] = endpoint
-            prefs[KEY_LAST_USED_MODEL] = model
+            prefs[endpointKey(accountId)] = endpoint
+            prefs[modelKey(accountId)] = model
+            // Reset migration: drop the pre-keying bare entries (they'd mis-attribute A's model to B).
+            prefs.remove(stringPreferencesKey(LAST_USED_ENDPOINT))
+            prefs.remove(stringPreferencesKey(LAST_USED_MODEL))
         }
     }
+
+    // Suspends (emits nothing) while Warming; once Resolved emits the account's scoped value, or null
+    // when logged out. flatMapLatest re-subscribes on every identity transition so a switch re-emits.
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private fun scopedString(keyFor: (String) -> Preferences.Key<String>): Flow<String?> =
+        activeAccountProvider.state.flatMapLatest { state ->
+            when (state) {
+                AccountState.Warming -> emptyFlow()
+                is AccountState.Resolved ->
+                    state.id?.let { id -> dataStore.data.map { it[keyFor(id.value)] } } ?: flowOf(null)
+            }
+        }
+
+    private fun endpointKey(accountId: String) = accountScopedKey(accountId, LAST_USED_ENDPOINT)
+
+    private fun modelKey(accountId: String) = accountScopedKey(accountId, LAST_USED_MODEL)
 
     suspend fun setTtsSource(source: String) {
         dataStore.edit { prefs ->
@@ -471,8 +499,8 @@ class SettingsDataStore(
         private val KEY_AUTO_READ_ENABLED = booleanPreferencesKey("auto_read_enabled")
         private val KEY_SHOW_IMAGE_DESCRIPTIONS = booleanPreferencesKey("show_image_descriptions")
         private val KEY_SELECTED_VOICE_ID = stringPreferencesKey("selected_voice_id")
-        private val KEY_LAST_USED_ENDPOINT = stringPreferencesKey("last_used_endpoint")
-        private val KEY_LAST_USED_MODEL = stringPreferencesKey("last_used_model")
+        private const val LAST_USED_ENDPOINT = "last_used_endpoint"
+        private const val LAST_USED_MODEL = "last_used_model"
         private val KEY_DISMISS_KEYBOARD_ON_SEND = booleanPreferencesKey("dismiss_keyboard_on_send")
         private val KEY_TTS_SOURCE = stringPreferencesKey("tts_source")
         private val KEY_TTS_SPEECH_RATE = floatPreferencesKey("tts_speech_rate")

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/di/DataModule.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/di/DataModule.kt
@@ -127,6 +127,7 @@ val dataModule = module {
             accountRegistry = get(),
             claimReconciler = get(),
             serverUrlProvider = get(),
+            tokenManager = get(),
             ioDispatcher = get(KoinQualifiers.IO),
         )
     }
@@ -171,6 +172,7 @@ val dataModule = module {
     single {
         SettingsDataStore(
             dataStore = get(),
+            activeAccountProvider = get(),
             appScope = get<CoroutineScope>(KoinQualifiers.ApplicationScope),
             ioDispatcher = get(KoinQualifiers.IO),
         )
@@ -198,6 +200,7 @@ val dataModule = module {
             rolesApi = get(),
             userRepository = get(),
             cacheDataStore = get(),
+            activeAccountProvider = get(),
             applicationScope = get<CoroutineScope>(KoinQualifiers.ApplicationScope),
         )
     }

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/AccountSessionEstablisher.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/AccountSessionEstablisher.kt
@@ -7,6 +7,7 @@ import com.garfiec.librechat.core.common.identity.deriveServerId
 import com.garfiec.librechat.core.data.datastore.AccountRegistry
 import com.garfiec.librechat.core.model.User
 import com.garfiec.librechat.core.network.client.ServerUrlProvider
+import com.garfiec.librechat.core.network.client.TokenManager
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
 import kotlin.coroutines.cancellation.CancellationException
@@ -28,6 +29,7 @@ class AccountSessionEstablisher(
     private val accountRegistry: AccountRegistry,
     private val claimReconciler: AccountClaimReconciler,
     private val serverUrlProvider: ServerUrlProvider,
+    private val tokenManager: TokenManager,
     private val ioDispatcher: CoroutineDispatcher,
 ) {
 
@@ -73,6 +75,10 @@ class AccountSessionEstablisher(
                 if (error is CancellationException) throw error
                 Logger.w(error) { "Legacy account claim failed; publishing account anyway (will retry)" }
             }
+        // Bind token storage to this account (re-homes bare/legacy or prior-account tokens into the
+        // keyed slot + repoints the sync mirror) before publishing identity, so a cold-start restore
+        // resolving the same account is a no-op and the next launch seeds the right bearer.
+        tokenManager.onAccountResolved(accountId.value)
         accountRegistry.setActiveAccount(accountId)
         accountId
     }

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/AuthRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/AuthRepositoryImpl.kt
@@ -126,7 +126,9 @@ class AuthRepositoryImpl(
                 // file caches/tokens.
                 accountRegistry.clearActiveAccount()
                 account?.let { accountDataPurger.purge(it) }
-                tokenManager.clearTokens()
+                // Clears the active account's keyed tokens AND drops the persisted mirror (vs
+                // clearTokens, the refresh-failure path, which leaves the account pointer intact).
+                tokenManager.onAccountCleared()
                 sessionCacheCleaner.clearSessionCaches()
             }
         }

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/RoleRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/RoleRepositoryImpl.kt
@@ -1,6 +1,8 @@
 package com.garfiec.librechat.core.data.repository
 
 import co.touchlab.kermit.Logger
+import com.garfiec.librechat.core.common.identity.AccountState
+import com.garfiec.librechat.core.common.identity.ActiveAccountProvider
 import com.garfiec.librechat.core.common.result.Result
 import com.garfiec.librechat.core.common.result.safeApiCall
 import com.garfiec.librechat.core.data.datastore.RoleCacheDataStore
@@ -11,12 +13,15 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.launch
 
 class RoleRepositoryImpl(
     private val rolesApi: RolesApi,
     private val userRepository: UserRepository,
     private val cacheDataStore: RoleCacheDataStore,
+    private val activeAccountProvider: ActiveAccountProvider,
     applicationScope: CoroutineScope,
 ) : RoleRepository {
 
@@ -24,10 +29,15 @@ class RoleRepositoryImpl(
     override val userPermissions: StateFlow<UserRolePermissions?> = _userPermissions.asStateFlow()
 
     init {
-        // Async DataStore prime — never runBlocking. The StateFlow briefly emits null
-        // then populates from disk; PermissionGate's permissive default covers the flash.
+        // Prime the cached role from disk once the account resolves — the cache is account-scoped, so a
+        // one-shot read during the cold-start Warming window (before the account is known) would read
+        // null and never re-prime. Re-primes per account; PermissionGate's permissive default covers the
+        // gap until this lands or the live fetch repopulates.
         applicationScope.launch {
-            cacheDataStore.load()?.let { _userPermissions.value = it }
+            activeAccountProvider.state
+                .mapNotNull { (it as? AccountState.Resolved)?.id }
+                .distinctUntilChanged()
+                .collect { cacheDataStore.load()?.let { role -> _userPermissions.value = role } }
         }
     }
 

--- a/core/data/src/iosMain/kotlin/com/garfiec/librechat/core/data/datastore/IosTokenDataStore.kt
+++ b/core/data/src/iosMain/kotlin/com/garfiec/librechat/core/data/datastore/IosTokenDataStore.kt
@@ -44,19 +44,16 @@ class IosTokenDataStore(
         initializeTokenCache()
     }
 
-    override fun readAccessToken(): String? = keychainGet(KEY_ACCESS_TOKEN)
+    override fun readValue(key: String): String? = keychainGet(key)
 
-    override fun readRefreshToken(): String? = keychainGet(KEY_REFRESH_TOKEN)
+    override fun writeValue(key: String, value: String) = keychainSet(key, value)
 
-    override fun writeTokens(accessToken: String, refreshToken: String) {
-        keychainSet(KEY_ACCESS_TOKEN, accessToken)
-        keychainSet(KEY_REFRESH_TOKEN, refreshToken)
+    // Keychain has no batch API; writes are sequential (as the prior writeTokens already was).
+    override fun writeValues(values: Map<String, String>) {
+        values.forEach { (key, value) -> keychainSet(key, value) }
     }
 
-    override fun removeTokens() {
-        keychainDelete(KEY_ACCESS_TOKEN)
-        keychainDelete(KEY_REFRESH_TOKEN)
-    }
+    override fun removeValue(key: String) = keychainDelete(key)
 
     override fun readServerUrl(): String? = keychainGet(KEY_SERVER_URL)
 
@@ -73,7 +70,10 @@ class IosTokenDataStore(
     }
 
     override fun onKeystoreCorruption() {
-        removeTokens()
+        // Keychain access rarely "corrupts" like the Android keystore (isKeystoreException stays false
+        // on iOS, so this isn't reached); clear the bare token slots defensively if it ever is.
+        keychainDelete(KEY_ACCESS_TOKEN)
+        keychainDelete(KEY_REFRESH_TOKEN)
     }
 
     // ---- Keychain helpers using CFDictionary directly ----

--- a/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/client/AuthInterceptorTest.kt
+++ b/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/client/AuthInterceptorTest.kt
@@ -48,6 +48,12 @@ class AuthInterceptorTest {
             accessToken = null
         }
 
+        override suspend fun onAccountResolved(accountId: String) = Unit
+
+        override suspend fun onAccountCleared() {
+            accessToken = null
+        }
+
         override fun emitSessionExpired() {
             sessionExpiredCount++
         }

--- a/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/TokenManager.kt
+++ b/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/TokenManager.kt
@@ -9,6 +9,22 @@ interface TokenManager {
     suspend fun setTokens(accessToken: String, refreshToken: String)
     suspend fun refreshAccessToken(): Boolean
     suspend fun clearTokens()
+
+    /**
+     * Bind token storage to [accountId] once identity resolves (login, cold-start restore, upgrade).
+     * Re-homes tokens written under the previous key (the bare keys on a legacy/first install, or the
+     * prior account) into this account's keyed slot and repoints the synchronously-readable mirror, so
+     * subsequent cold starts seed the right account's bearer with no blind window. Idempotent when the
+     * account is unchanged.
+     */
+    suspend fun onAccountResolved(accountId: String)
+
+    /**
+     * Clear the active account's tokens and the mirror on logout. Distinct from [clearTokens] (the
+     * refresh-failure path) in that it also drops the persisted active-account pointer.
+     */
+    suspend fun onAccountCleared()
+
     fun emitSessionExpired()
     val sessionExpiredFlow: SharedFlow<Unit>
 }


### PR DESCRIPTION
## Summary
Groundwork for multi-account / multi-server support (#179). Binds persisted credentials and per-account/server preferences to the active identity, so one account's tokens and cached state are never read under another — the prerequisite for eventually holding several accounts at once.

## Changes
- **Token store** — access/refresh tokens are stored under `acct:<accountId>:…` keys, with the active account mirrored into the same synchronously-readable secure storage so the correct account's bearer is seeded at construction (no blind-bearer window at cold start). Tokens written by an older build under the bare keys are read as a fallback and re-homed into the keyed slot once identity resolves. Two new `TokenManager` hooks (`onAccountResolved` / `onAccountCleared`) drive this from the login/cold-start and logout paths. Access and refresh are written in a single batched commit on Android so a crash can't persist one without the other.
- **Preferences** — `last_used_endpoint` / `last_used_model` and the role cache are scoped by account (`acct:<accountId>`); the config cache is scoped by server (`srv:<serverId>`, derived from the URL so it resolves pre-login). Pre-keying bare entries are dropped on first keyed write. Logout sweeps the scoped config and role entries; `last_used_*` is retained per account (restored on next sign-in) and filtered by account on read. The role cache is primed from disk once the account resolves. `last_used_*` reads are suppressed while the account is warming so the model seeder waits for the real value instead of a null.
- A shared `ScopedPreferenceKeys` helper centralizes the `acct:`/`srv:` key namespace.

## Testing
- Host-JVM unit tests: token keyed round-trip, bare→keyed migration + mirror, clear, cold-start seeding (mirror / bare-legacy / none), keyed refresh; last-used warming suppression and round-trip; DataStore round-trips.
- Both platforms build (`:app:assembleDebug`, `:shared:linkDebugFrameworkIosSimulatorArm64`); detekt clean.
- Device-tested on Android (Pixel 10 Pro Fold + LibreChat backend): fresh login stamps per-account/server keys; cold restart stays signed in with no blind bearer; logout clears local data and switching accounts shows no cross-account residue; in-place upgrade from a bare-token build keeps the session (no forced re-login) and functions offline.

## Notes
- Single active account for now: a direct account switch re-homes the newest sign-in into its keyed slot and drops the previous account's tokens (multi-account retention is a later step).
- iOS keychain writes are sequential (no batch API); Android batches the pair.
- Android keystore-corruption recovery now clears the whole encrypted token store (previously only the two token keys), matching the multi-key layout.
