### PR TITLE
fix: back gesture dismisses phone drawer instead of popping nav stack

### DIFF
--- a/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/LibreChatNavHost.kt
+++ b/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/LibreChatNavHost.kt
@@ -196,7 +196,7 @@ fun PhoneLayout(
         drawerState = drawerState,
         gesturesEnabled = !navigator.isInAuthFlow,
         drawerContent = {
-            ModalDrawerSheet {
+            ModalDrawerSheet(drawerState = drawerState) {
                 SidebarScaffold(
                     onNewChat = {
                         scope.launch { drawerState.close() }


### PR DESCRIPTION
## Summary
On phone layouts, opening the sidebar drawer and then triggering back (gesture or hardware button) popped the underlying navigation screen (e.g. existing chat → new chat, settings → chat) instead of dismissing the drawer first. Back now closes the open drawer, matching the tablet layout's existing behavior.

## Changes
- `PhoneLayout` now passes `drawerState` to `ModalDrawerSheet`, which installs Material3's predictive-back handler. While the drawer is open it intercepts back and closes the drawer; when closed, back falls through to normal navigation as before.

## Testing
- Verified on device (phone posture): drawer open + back gesture → drawer closes, screen unchanged; drawer open + hardware back → same; drawer closed → back navigates/exits normally.
- `:shared:compileDebugKotlinAndroid` and `:shared:compileKotlinIosSimulatorArm64` compile clean.

## Notes
- Phone-only. Tablet uses a persistent sidebar with its own `BackHandler`, unaffected by this change. Since `PhoneLayout` is shared KMP, the fix applies to iOS phone as well.
