### PR TITLE
fix(chat): retry failed agent load when opening the model selector

### DIFF
--- a/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/ModelSelectionDelegateTest.kt
+++ b/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/ModelSelectionDelegateTest.kt
@@ -336,6 +336,64 @@ class ModelSelectionDelegateTest {
         assertThat(delegate.agentsLoaded.value).isTrue()
     }
 
+    @Test
+    fun retryAgentsIfFailedRefetchesAfterErrorThenPopulates() = runTest {
+        // The cold-start-failure fix: a transient getAgents() error leaves the list empty.
+        // retryAgentsIfFailed (wired to opening the selector) must re-fetch and fill it.
+        val scope = TestScope(StandardTestDispatcher(testScheduler))
+        val handle = newHandle(scope)
+        val delegate = newDelegate(handle)
+        allowAgents()
+        coEvery { agentRepository.getAgents() } returns Result.Error(RuntimeException("boom"))
+
+        delegate.loadAgents(isNewConversation = false)
+        advanceUntilIdle()
+        assertThat(handle.state.agents).isEmpty()
+
+        // Network recovers; the retry re-hits it (the error was never cached) and populates.
+        coEvery { agentRepository.getAgents() } returns Result.Success(listOf(Agent(id = "agent_1")))
+        delegate.retryAgentsIfFailed(isNewConversation = false)
+        advanceUntilIdle()
+
+        assertThat(handle.state.agents).hasSize(1)
+        coVerify(exactly = 2) { agentRepository.getAgents() }
+    }
+
+    @Test
+    fun retryAgentsIfFailedIsNoOpAfterSuccess() = runTest {
+        // A successful load must not be re-fetched on selector open (no needless network).
+        val scope = TestScope(StandardTestDispatcher(testScheduler))
+        val handle = newHandle(scope)
+        val delegate = newDelegate(handle)
+        allowAgents()
+        coEvery { agentRepository.getAgents() } returns Result.Success(listOf(Agent(id = "agent_1")))
+
+        delegate.loadAgents(isNewConversation = false)
+        advanceUntilIdle()
+        delegate.retryAgentsIfFailed(isNewConversation = false)
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { agentRepository.getAgents() }
+    }
+
+    @Test
+    fun retryAgentsIfFailedIsNoOpForCleanEmptyAccount() = runTest {
+        // A cleanly-resolved zero-agent account (success, empty list) must not re-fetch —
+        // only genuine errors are retried.
+        val scope = TestScope(StandardTestDispatcher(testScheduler))
+        val handle = newHandle(scope)
+        val delegate = newDelegate(handle)
+        allowAgents()
+        coEvery { agentRepository.getAgents() } returns Result.Success(emptyList())
+
+        delegate.loadAgents(isNewConversation = false)
+        advanceUntilIdle()
+        delegate.retryAgentsIfFailed(isNewConversation = false)
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { agentRepository.getAgents() }
+    }
+
     // ── Group C: seedInitialSelection precedence + race determinism ──────────
 
     @Test

--- a/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/ModelSelectionDelegateTest.kt
+++ b/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/ModelSelectionDelegateTest.kt
@@ -360,6 +360,45 @@ class ModelSelectionDelegateTest {
     }
 
     @Test
+    fun retryAgentsSuccessClearsFailureBanner() = runTest {
+        // A successful retry must clear the "Could not load available agents" banner
+        // the failed attempt published — otherwise the sheet shows the populated list
+        // alongside a stale error.
+        val scope = TestScope(StandardTestDispatcher(testScheduler))
+        val handle = newHandle(scope)
+        val delegate = newDelegate(handle)
+        allowAgents()
+        coEvery { agentRepository.getAgents() } returns Result.Error(RuntimeException("boom"))
+
+        delegate.loadAgents(isNewConversation = false)
+        advanceUntilIdle()
+        assertThat(handle.state.error).isEqualTo("Could not load available agents")
+
+        coEvery { agentRepository.getAgents() } returns Result.Success(listOf(Agent(id = "agent_1")))
+        delegate.retryAgentsIfFailed(isNewConversation = false)
+        advanceUntilIdle()
+
+        assertThat(handle.state.error).isNull()
+        assertThat(handle.state.agents).hasSize(1)
+    }
+
+    @Test
+    fun loadAgentsSuccessPreservesUnrelatedError() = runTest {
+        // The error slot is shared with other delegates — a successful agent load must
+        // clear only its own failure banner, never someone else's message.
+        val scope = TestScope(StandardTestDispatcher(testScheduler))
+        val handle = newHandle(scope, ChatUiState(error = "Failed to rename conversation"))
+        val delegate = newDelegate(handle)
+        allowAgents()
+        coEvery { agentRepository.getAgents() } returns Result.Success(listOf(Agent(id = "agent_1")))
+
+        delegate.loadAgents(isNewConversation = false)
+        advanceUntilIdle()
+
+        assertThat(handle.state.error).isEqualTo("Failed to rename conversation")
+    }
+
+    @Test
     fun retryAgentsIfFailedIsNoOpAfterSuccess() = runTest {
         // A successful load must not be re-fetched on selector open (no needless network).
         val scope = TestScope(StandardTestDispatcher(testScheduler))

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModel.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModel.kt
@@ -1369,10 +1369,7 @@ class ChatViewModel(
     private fun runWhenSendReady(action: () -> Unit) {
         val current = _uiState.value
         preflightSendBlockReason(current)?.let { reason ->
-            // These auto-opens surface the selector to resolve the block; if the agent
-            // list failed to load, retry so the user can actually pick one.
-            modelDelegate.retryAgentsIfFailed(isNewConversation)
-            _uiState.update { it.copy(sendBlockReason = reason, showModelSheet = true) }
+            surfaceModelSheet(reason)
             return
         }
         if (current.isSendReady) {
@@ -1383,13 +1380,7 @@ class ChatViewModel(
             if (awaitSendReady()) {
                 action()
             } else {
-                modelDelegate.retryAgentsIfFailed(isNewConversation)
-                _uiState.update {
-                    it.copy(
-                        sendBlockReason = sendReadinessTimeoutReason(it),
-                        showModelSheet = true,
-                    )
-                }
+                surfaceModelSheet(sendReadinessTimeoutReason(_uiState.value))
             }
         }
     }
@@ -1433,9 +1424,23 @@ class ChatViewModel(
     }
 
     /** Opens the model-selector sheet. Called when the user taps the model chip. */
-    fun openModelSheet() {
+    fun openModelSheet() = surfaceModelSheet()
+
+    /**
+     * Single choke point for showing the model-selector sheet — user-initiated (model
+     * chip) and send-blocked auto-opens alike. Opening the selector retries a failed
+     * agent load so the user can actually pick an agent; routing every open through
+     * here keeps that retry from being forgotten on a future open path. A null
+     * [reason] leaves the current sendBlockReason untouched.
+     */
+    private fun surfaceModelSheet(reason: SendBlockReason? = null) {
         modelDelegate.retryAgentsIfFailed(isNewConversation)
-        _uiState.update { it.copy(showModelSheet = true) }
+        _uiState.update {
+            it.copy(
+                sendBlockReason = reason ?: it.sendBlockReason,
+                showModelSheet = true,
+            )
+        }
     }
 
     /** Dismisses the model-selector sheet. Called on sheet dismiss and model selection. */

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModel.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModel.kt
@@ -1369,6 +1369,9 @@ class ChatViewModel(
     private fun runWhenSendReady(action: () -> Unit) {
         val current = _uiState.value
         preflightSendBlockReason(current)?.let { reason ->
+            // These auto-opens surface the selector to resolve the block; if the agent
+            // list failed to load, retry so the user can actually pick one.
+            modelDelegate.retryAgentsIfFailed(isNewConversation)
             _uiState.update { it.copy(sendBlockReason = reason, showModelSheet = true) }
             return
         }
@@ -1380,6 +1383,7 @@ class ChatViewModel(
             if (awaitSendReady()) {
                 action()
             } else {
+                modelDelegate.retryAgentsIfFailed(isNewConversation)
                 _uiState.update {
                     it.copy(
                         sendBlockReason = sendReadinessTimeoutReason(it),
@@ -1430,6 +1434,7 @@ class ChatViewModel(
 
     /** Opens the model-selector sheet. Called when the user taps the model chip. */
     fun openModelSheet() {
+        modelDelegate.retryAgentsIfFailed(isNewConversation)
         _uiState.update { it.copy(showModelSheet = true) }
     }
 

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/ModelSelectionDelegate.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/ModelSelectionDelegate.kt
@@ -123,6 +123,19 @@ class ModelSelectionDelegate(
     internal val agentsLoaded = MutableStateFlow(false)
 
     /**
+     * True when the last [loadAgents] attempt ended in a network error (not a
+     * permission denial or a genuinely-empty account). Gates [retryAgentsIfFailed]
+     * so a transient cold-start failure — e.g. the token still settling right after
+     * login — doesn't strand the "My Agents" group empty until the app is recreated,
+     * without needlessly re-fetching for accounts that simply have no agents.
+     *
+     * [loadAgents] clears this up front, so it also doubles as the in-flight guard:
+     * a retry firing while an attempt is still running sees it already false and is a
+     * no-op. Only touched on the ViewModel's main dispatcher, so a plain var suffices.
+     */
+    private var agentsLoadFailed = false
+
+    /**
      * The last-used (endpoint, model) pair this delegate last applied as the
      * active selection. Lets [seedInitialSelection] re-apply a *changed* last-used
      * even over an already-valid selection (the retained-landing resync) without
@@ -559,6 +572,7 @@ class ModelSelectionDelegate(
      * still loading" (wait) from "agents loaded and empty" (fall through).
      */
     fun loadAgents(isNewConversation: Boolean) {
+        agentsLoadFailed = false
         stateHandle.scope.launch {
             // Skip the fetch entirely when the role denies AGENTS.USE; otherwise
             // the server would return 403 and we'd have to decide whether it's a
@@ -580,6 +594,10 @@ class ModelSelectionDelegate(
                 }
                 is Result.Error -> {
                     Logger.e(result.exception) { "Failed to load agents" }
+                    // Mark the attempt as failed so retryAgentsIfFailed can re-fetch
+                    // when the user next opens the selector. The AccountKeyedCache only
+                    // stores successes, so the retry genuinely re-hits the network.
+                    agentsLoadFailed = true
                     stateHandle.update { copy(error = "Could not load available agents") }
                     agentsLoaded.value = true
                 }
@@ -591,6 +609,19 @@ class ModelSelectionDelegate(
             // AND denial — so the hold is always released; an error/denied load (empty
             // list) correctly falls through to a config model instead of staying stuck.
             refilterModels(isNewConversation)
+        }
+    }
+
+    /**
+     * Re-attempts the agent fetch when the initial [loadAgents] ended in a network
+     * error, so a transient cold-start failure doesn't leave the "My Agents" group
+     * permanently empty. Wired to the model-selector open so the list refreshes on the
+     * user's next glance. No-op when a load is already in flight, the last load
+     * succeeded, or the account was cleanly resolved to zero agents.
+     */
+    fun retryAgentsIfFailed(isNewConversation: Boolean) {
+        if (agentsLoadFailed) {
+            loadAgents(isNewConversation)
         }
     }
 

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/ModelSelectionDelegate.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/ModelSelectionDelegate.kt
@@ -19,12 +19,16 @@ import com.garfiec.librechat.core.model.permissions.PermissionType
 import com.garfiec.librechat.core.ui.components.ModelParameters
 import com.garfiec.librechat.feature.chat.model.McpServerDisplayData
 import com.garfiec.librechat.feature.chat.viewmodel.ChatStateHandle
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
+
+/** Failure banner published by [ModelSelectionDelegate.loadAgents]; cleared by a later success. */
+private const val AGENTS_LOAD_ERROR = "Could not load available agents"
 
 class ModelSelectionDelegate(
     private val stateHandle: ChatStateHandle,
@@ -128,12 +132,15 @@ class ModelSelectionDelegate(
      * so a transient cold-start failure — e.g. the token still settling right after
      * login — doesn't strand the "My Agents" group empty until the app is recreated,
      * without needlessly re-fetching for accounts that simply have no agents.
-     *
-     * [loadAgents] clears this up front, so it also doubles as the in-flight guard:
-     * a retry firing while an attempt is still running sees it already false and is a
-     * no-op. Only touched on the ViewModel's main dispatcher, so a plain var suffices.
+     * Only touched on the ViewModel's main dispatcher, so a plain var suffices.
      */
     private var agentsLoadFailed = false
+
+    /**
+     * The in-flight [loadAgents] attempt. Guards [retryAgentsIfFailed] against
+     * launching a duplicate concurrent fetch while one is still running.
+     */
+    private var agentsLoadJob: Job? = null
 
     /**
      * The last-used (endpoint, model) pair this delegate last applied as the
@@ -573,7 +580,7 @@ class ModelSelectionDelegate(
      */
     fun loadAgents(isNewConversation: Boolean) {
         agentsLoadFailed = false
-        stateHandle.scope.launch {
+        agentsLoadJob = stateHandle.scope.launch {
             // Skip the fetch entirely when the role denies AGENTS.USE; otherwise
             // the server would return 403 and we'd have to decide whether it's a
             // genuine 403 (rate limit, tenancy) vs. permission denial.
@@ -590,7 +597,16 @@ class ModelSelectionDelegate(
                     // otherwise tier 2 could fall through to a config model in the
                     // one-emission window before the flag flips.
                     agentsLoaded.value = true
-                    stateHandle.update { copy(agents = result.data) }
+                    stateHandle.update {
+                        copy(
+                            agents = result.data,
+                            // A successful retry must not leave the failure banner from
+                            // the attempt it just recovered next to the populated list.
+                            // Clear only our own message — the error slot is shared
+                            // with other delegates.
+                            error = error.takeUnless { it == AGENTS_LOAD_ERROR },
+                        )
+                    }
                 }
                 is Result.Error -> {
                     Logger.e(result.exception) { "Failed to load agents" }
@@ -598,7 +614,7 @@ class ModelSelectionDelegate(
                     // when the user next opens the selector. The AccountKeyedCache only
                     // stores successes, so the retry genuinely re-hits the network.
                     agentsLoadFailed = true
-                    stateHandle.update { copy(error = "Could not load available agents") }
+                    stateHandle.update { copy(error = AGENTS_LOAD_ERROR) }
                     agentsLoaded.value = true
                 }
                 is Result.Loading -> return@launch
@@ -620,7 +636,7 @@ class ModelSelectionDelegate(
      * succeeded, or the account was cleanly resolved to zero agents.
      */
     fun retryAgentsIfFailed(isNewConversation: Boolean) {
-        if (agentsLoadFailed) {
+        if (agentsLoadFailed && agentsLoadJob?.isActive != true) {
             loadAgents(isNewConversation)
         }
     }


### PR DESCRIPTION
## Summary
The chat model selector's "My Agents" group could stay empty until the app was recreated when the initial agent fetch failed at cold start (e.g. a transient network error while the auth token is still settling right after login). This retries the fetch when the user next opens the model selector, so a failed load self-heals.

## Changes
- **`ModelSelectionDelegate`**: track whether the last agent load ended in a network error — distinct from a permission denial or a genuinely empty account — and add `retryAgentsIfFailed()` that re-fetches only in that case. The flag is cleared at the start of each load, so it also guards against a duplicate in-flight fetch.
- **`ChatViewModel`**: fire the retry from the three model-selector open paths — the user tapping the model chip, and the two send-block auto-opens that surface the selector to resolve a block.
- Retry is a no-op after a successful load or for accounts that legitimately have no agents, so it adds no needless network calls.

## Testing
- New unit tests in `ModelSelectionDelegateTest`: error → retry re-fetches and populates; no-op after success; no-op for a cleanly-empty account.
- `:feature:chat` Android compile, `detektMetadataCommonMain`, and iOS `compileKotlinIosSimulatorArm64` all pass.
