### PR TITLE
fix(chat): keep temporary chats out of local history and persistence

### DIFF
--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/di/ChatPlatformModule.android.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/di/ChatPlatformModule.android.kt
@@ -26,6 +26,8 @@ actual val chatPlatformModule: Module = module {
             // type-based getOrNull() is ambiguous; read by index from values.
             initialConversationId = params.values.getOrNull(0) as String?,
             initialAgentId = params.values.getOrNull(1) as String?,
+            // [2] isTemporary route flag (temp-chat data-at-rest guard); absent on non-temp callers.
+            initialIsTemporary = params.values.getOrNull(2) as? Boolean ?: false,
             agentRepository = get(),
             chatRepository = get(),
             messageRepository = get(),

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatScreen.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatScreen.kt
@@ -44,8 +44,9 @@ import org.koin.core.parameter.parametersOf
 actual fun ChatScreen(
     modifier: Modifier,
     conversationId: String?,
+    isTemporaryRoute: Boolean,
     initialAgentId: String?,
-    onConversationStart: ((String) -> Unit)?,
+    onConversationStart: ((conversationId: String, isTemporary: Boolean) -> Unit)?,
     onNavigateToConversation: ((String) -> Unit)?,
     onOpenDrawer: (() -> Unit)?,
     onNavigateToPromptsLibrary: (() -> Unit)?,
@@ -54,7 +55,8 @@ actual fun ChatScreen(
     onAttachFromServer: () -> Unit,
     onNavigateToProviderKeys: (endpointName: String?) -> Unit,
 ) {
-    val viewModel: ChatViewModel = koinViewModel { parametersOf(conversationId, initialAgentId) }
+    val viewModel: ChatViewModel =
+        koinViewModel { parametersOf(conversationId, initialAgentId, isTemporaryRoute) }
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val attachedFiles by viewModel.attachedFiles.collectAsStateWithLifecycle()
     val shareLinkUrl by viewModel.shareLinkUrl.collectAsStateWithLifecycle()

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatScreenEffects.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatScreenEffects.kt
@@ -27,7 +27,7 @@ internal fun ChatScreenEffects(
     viewModel: ChatViewModel,
     snackbarHostState: SnackbarHostState,
     clipboardManager: ClipboardManager,
-    onConversationStart: ((String) -> Unit)?,
+    onConversationStart: ((conversationId: String, isTemporary: Boolean) -> Unit)?,
     onNavigateToConversation: ((String) -> Unit)?,
     onNavigateBack: (() -> Unit)?,
     onNavigateToProviderKeys: (endpointName: String?) -> Unit,
@@ -39,7 +39,9 @@ internal fun ChatScreenEffects(
     LaunchedEffect(uiState.pendingNavigationConversationId) {
         val pendingId = uiState.pendingNavigationConversationId
         if (pendingId != null && onConversationStart != null) {
-            onConversationStart(pendingId)
+            // Carry temp-ness onto the Chat(id) route so the new (and any process-death-restored)
+            // VM stays temp-aware and never persists the server-hidden conversation to Room.
+            onConversationStart(pendingId, uiState.isTemporaryChat)
             viewModel.onPendingNavigationHandled()
         }
     }
@@ -71,7 +73,8 @@ internal fun ChatScreenEffects(
             if (onNavigateToConversation != null) {
                 onNavigateToConversation(forkId)
             } else if (onConversationStart != null) {
-                onConversationStart(forkId)
+                // Forks are always real (non-temp) conversations.
+                onConversationStart(forkId, false)
             }
         }
     }
@@ -83,7 +86,8 @@ internal fun ChatScreenEffects(
             if (onNavigateToConversation != null) {
                 onNavigateToConversation(dupId)
             } else if (onConversationStart != null) {
-                onConversationStart(dupId)
+                // Duplicates are always real (non-temp) conversations.
+                onConversationStart(dupId, false)
             }
         }
     }

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/NewChatScreen.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/NewChatScreen.kt
@@ -11,7 +11,7 @@ import androidx.compose.ui.Modifier
  */
 @Composable
 actual fun NewChatScreen(
-    onConversationStart: (String) -> Unit,
+    onConversationStart: (conversationId: String, isTemporary: Boolean) -> Unit,
     modifier: Modifier,
     initialAgentId: String?,
     onOpenDrawer: (() -> Unit)?,

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/navigation/ChatNavigation.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/navigation/ChatNavigation.kt
@@ -35,7 +35,13 @@ import org.koin.compose.koinInject
  *  that agent rather than falling back to last-used/first-agent/first-model. */
 @Serializable data class NewChat(val agentId: String? = null) : ChatRoute
 
-@Serializable data class Chat(val conversationId: String? = null) : ChatRoute
+/**
+ * [isTemporary] marks a conversation the user started as a temporary chat. It rides on the
+ * route (not just the in-memory NewChatSelectionHandoff) so it survives process death: a restored
+ * Chat(id) entry re-initializes temp-aware and never persists the server-hidden conversation to
+ * Room. SECURITY: this is the temp-chat data-at-rest guard for the handed-off / restored Chat VM.
+ */
+@Serializable data class Chat(val conversationId: String? = null, val isTemporary: Boolean = false) : ChatRoute
 
 @Serializable data object PromptsLibrary : ChatRoute
 
@@ -53,7 +59,7 @@ import org.koin.compose.koinInject
 fun EntryProviderScope<NavKey>.chatEntries(
     onNavigate: (NavKey) -> Unit,
     onBack: () -> Unit,
-    onNavigateToChat: (String) -> Unit,
+    onNavigateToChat: (conversationId: String, isTemporary: Boolean) -> Unit,
     onOpenDrawer: (() -> Unit)? = null,
     /**
      * Deep-link target for the user-provided-key error CTA snackbar and
@@ -68,8 +74,8 @@ fun EntryProviderScope<NavKey>.chatEntries(
     entry<NewChat> { key ->
         NewChatScreen(
             initialAgentId = key.agentId,
-            onConversationStart = { conversationId ->
-                onNavigateToChat(conversationId)
+            onConversationStart = { conversationId, isTemporary ->
+                onNavigateToChat(conversationId, isTemporary)
             },
             onOpenDrawer = onOpenDrawer,
             onNavigateToPromptsLibrary = { onNavigate(PromptsLibrary) },
@@ -81,10 +87,14 @@ fun EntryProviderScope<NavKey>.chatEntries(
         ProvideOpenArtifact(onNavigate) {
             ChatScreen(
                 conversationId = key.conversationId,
+                // A restored temp Chat(id) entry carries isTemporary=true so the VM re-initializes
+                // temp-aware (never persists the server-hidden conversation). See ChatViewModel.init.
+                isTemporaryRoute = key.isTemporary,
                 onOpenDrawer = onOpenDrawer,
                 onNavigateToPromptsLibrary = { onNavigate(PromptsLibrary) },
                 onNavigateBack = onBack,
-                onNavigateToConversation = { conversationId -> onNavigateToChat(conversationId) },
+                // Fork/duplicate produce real (non-temp) conversations.
+                onNavigateToConversation = { conversationId -> onNavigateToChat(conversationId, false) },
                 // Null on a new chat with no id yet, which hides the overflow menu item.
                 onShowAllMedia = key.conversationId?.let { id -> { onNavigate(ConversationMedia(id)) } },
                 onNavigateToProviderKeys = onNavigateToProviderKeys,

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/screen/PlatformScreens.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/screen/PlatformScreens.kt
@@ -8,8 +8,11 @@ import androidx.compose.ui.Modifier
 expect fun ChatScreen(
     modifier: Modifier = Modifier,
     conversationId: String? = null,
+    /** True when this Chat(id) entry was created as (or restored as) a temporary chat. Seeds the
+     *  VM temp-aware so it never persists the server-hidden conversation. See Chat.isTemporary. */
+    isTemporaryRoute: Boolean = false,
     initialAgentId: String? = null,
-    onConversationStart: ((String) -> Unit)? = null,
+    onConversationStart: ((conversationId: String, isTemporary: Boolean) -> Unit)? = null,
     onNavigateToConversation: ((String) -> Unit)? = null,
     onOpenDrawer: (() -> Unit)? = null,
     onNavigateToPromptsLibrary: (() -> Unit)? = null,
@@ -32,7 +35,7 @@ expect fun ChatScreen(
  *  that agent for the new chat (set when starting from an agent detail/card). */
 @Composable
 expect fun NewChatScreen(
-    onConversationStart: (String) -> Unit,
+    onConversationStart: (conversationId: String, isTemporary: Boolean) -> Unit,
     modifier: Modifier = Modifier,
     initialAgentId: String? = null,
     onOpenDrawer: (() -> Unit)? = null,

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/util/TemporaryChatMerge.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/util/TemporaryChatMerge.kt
@@ -9,7 +9,7 @@ import com.garfiec.librechat.core.model.Message
  * placeholder) is replaced in place; genuinely new messages are appended, keeping
  * insertion order stable.
  *
- * Temporary chats (v0.8.6) are never persisted to Room (a data-at-rest leak would
+ * Temporary chats are never persisted to Room (a data-at-rest leak would
  * otherwise survive even though the conversation is hidden from history), so the
  * normal `loadConversation` read-through is bypassed and the display is driven from
  * this pure merge instead.

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModel.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModel.kt
@@ -96,6 +96,10 @@ import kotlin.uuid.Uuid
 class ChatViewModel(
     initialConversationId: String? = null,
     initialAgentId: String? = null,
+    /** True when this Chat(id) entry is a temporary chat. Rides on the Chat route so it
+     *  survives process death: a restored entry re-initializes temp-aware and never persists the
+     *  server-hidden conversation to Room. SECURITY: temp-chat data-at-rest guard — see init. */
+    initialIsTemporary: Boolean = false,
     private val agentRepository: AgentRepository,
     private val chatRepository: ChatRepository,
     private val messageRepository: MessageRepository,
@@ -365,7 +369,16 @@ class ChatViewModel(
             _uiState.update {
                 it.copy(
                     conversationId = conversationId,
-                    screenState = ChatScreenState.LOADING,
+                    // SECURITY: do not remove — temp-chat data-at-rest guard. Seeded from the Chat
+                    // route (durable across process death), so a restored temp Chat(id) stays
+                    // temp-aware from the first frame: this short-circuits loadConversation and
+                    // loadConversationModel below, both of which would otherwise upsert the
+                    // server-hidden conversation to Room, and makes follow-up sends temporary.
+                    isTemporaryChat = initialIsTemporary,
+                    // A temp chat restored across process death has no in-memory handoff to seed its
+                    // messages (they're gone with the session), and its Room read is guarded off — so
+                    // land on an empty ACTIVE chat rather than a LOADING spinner that never resolves.
+                    screenState = if (initialIsTemporary) ChatScreenState.ACTIVE else ChatScreenState.LOADING,
                 )
             }
             // If we arrived here straight from the NewChat landing (the common case for a
@@ -546,7 +559,7 @@ class ChatViewModel(
 
     private fun loadConversation(conversationId: String) {
         // SECURITY: do not remove — temp-chat data-at-rest guard.
-        // Defense-in-depth for temporary chats (v0.8.6): never route a temp conversation
+        // Defense-in-depth for temporary chats: never route a temp conversation
         // through the Room read-through, which would upsert its message rows to disk (the
         // convo is hidden from history but the text would persist). The temp chat's
         // display is finalized in memory by finalizeChatDisplay; any stray
@@ -774,6 +787,15 @@ class ChatViewModel(
     }
 
     private fun loadConversationModel(conversationId: String) {
+        // SECURITY: do not remove — temp-chat data-at-rest guard. getConversation below
+        // round-trips through refreshConversation, which upserts the conversation row to Room.
+        // Temp chats must never persist, and their model/endpoint was already seeded from the
+        // NewChatSelectionHandoff in init — so there is nothing to load and nothing to write.
+        if (_uiState.value.isTemporaryChat) {
+            modelDelegate.conversationModelLoaded = true
+            modelDelegate.refilterModels(isNewConversation)
+            return
+        }
         viewModelScope.launch {
             val result = conversationRepository.getConversation(conversationId)
             val conversation = result.getOrNull()

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/SendCompletionDelegate.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/SendCompletionDelegate.kt
@@ -48,12 +48,24 @@ class SendCompletionDelegate(
      * list even if the stream later fails.
      */
     fun onConversationCreated(conversationId: String, isNewConversation: Boolean) {
+        // SECURITY: temp-chat data-at-rest guard. Temporary chats still navigate to a
+        // Chat(id) so Back returns to the landing screen (they're a real, streaming conversation
+        // for the session) — but they must never be written to Room. Two Room-write paths in this
+        // landing VM are gated on this flag: the draft migration below (persists the composer draft
+        // keyed to the real id) and the eager cache-warm at the end (GETs + upserts the
+        // conversation — the write that would otherwise surface a temp chat in history). Temp-ness reaches the
+        // new Chat(id) VM via the Chat route's isTemporary flag (durable across process death), so
+        // that VM starts temp-aware and skips its own loadConversation / loadConversationModel
+        // upserts — see ChatViewModel.init and Navigator.navigateToChat.
+        val isTemporary = stateHandle.state.isTemporaryChat
         if (isNewConversation) {
-            stateHandle.scope.launch {
-                val existingDraft = draftRepository.getDraft(NEW_CHAT_DRAFT_KEY)
-                if (existingDraft != null) {
-                    draftRepository.saveDraft(conversationId, existingDraft)
-                    draftRepository.deleteDraft(NEW_CHAT_DRAFT_KEY)
+            if (!isTemporary) {
+                stateHandle.scope.launch {
+                    val existingDraft = draftRepository.getDraft(NEW_CHAT_DRAFT_KEY)
+                    if (existingDraft != null) {
+                        draftRepository.saveDraft(conversationId, existingDraft)
+                        draftRepository.deleteDraft(NEW_CHAT_DRAFT_KEY)
+                    }
                 }
             }
             // Stage the selection we actually sent so the about-to-be-created Chat(id) VM can
@@ -74,10 +86,12 @@ class SendCompletionDelegate(
                 }
             }
         }
-        // Eagerly fetch and cache the conversation the server just created,
-        // so it appears in the conversation list even if the stream fails later
-        stateHandle.scope.launch {
-            conversationRepository.getConversation(conversationId)
+        // Eagerly fetch and cache the conversation the server just created, so it appears in the
+        // conversation list even if the stream fails later — but never for temp chats (see guard).
+        if (!isTemporary) {
+            stateHandle.scope.launch {
+                conversationRepository.getConversation(conversationId)
+            }
         }
     }
 
@@ -112,7 +126,7 @@ class SendCompletionDelegate(
             ) { "handleFinal re-derived conversation model" }
         }
         // SECURITY: do not remove — temp-chat data-at-rest guard.
-        // Temporary chats (v0.8.6) are kept out of normal history — the server excludes
+        // Temporary chats are kept out of normal history — the server excludes
         // them from the conversation list, so don't cache them to Room either (it would
         // leak a temp chat into the local list the server hides).
         val isTemporary = stateHandle.state.isTemporaryChat || finalConversation?.isTemporary == true

--- a/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/di/ChatPlatformModule.ios.kt
+++ b/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/di/ChatPlatformModule.ios.kt
@@ -24,6 +24,8 @@ actual val chatPlatformModule: Module = module {
             // type-based getOrNull() is ambiguous; read by index from values.
             initialConversationId = params.values.getOrNull(0) as String?,
             initialAgentId = params.values.getOrNull(1) as String?,
+            // [2] isTemporary route flag (temp-chat data-at-rest guard); absent on non-temp callers.
+            initialIsTemporary = params.values.getOrNull(2) as? Boolean ?: false,
             agentRepository = get(),
             chatRepository = get(),
             messageRepository = get(),

--- a/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/screen/PlatformScreens.ios.kt
+++ b/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/screen/PlatformScreens.ios.kt
@@ -70,8 +70,9 @@ import org.koin.core.parameter.parametersOf
 actual fun ChatScreen(
     modifier: Modifier,
     conversationId: String?,
+    isTemporaryRoute: Boolean,
     initialAgentId: String?,
-    onConversationStart: ((String) -> Unit)?,
+    onConversationStart: ((conversationId: String, isTemporary: Boolean) -> Unit)?,
     onNavigateToConversation: ((String) -> Unit)?,
     onOpenDrawer: (() -> Unit)?,
     onNavigateToPromptsLibrary: (() -> Unit)?,
@@ -80,7 +81,8 @@ actual fun ChatScreen(
     onAttachFromServer: () -> Unit,
     onNavigateToProviderKeys: (endpointName: String?) -> Unit,
 ) {
-    val viewModel: ChatViewModel = koinViewModel { parametersOf(conversationId, initialAgentId) }
+    val viewModel: ChatViewModel =
+        koinViewModel { parametersOf(conversationId, initialAgentId, isTemporaryRoute) }
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val attachedFiles by viewModel.attachedFiles.collectAsStateWithLifecycle()
     val prefs by viewModel.chatPreferences.collectAsStateWithLifecycle()
@@ -111,7 +113,9 @@ actual fun ChatScreen(
         LaunchedEffect(uiState.pendingNavigationConversationId) {
             val navId = uiState.pendingNavigationConversationId
             if (navId != null) {
-                onConversationStart(navId)
+                // Carry temp-ness onto the Chat(id) route so the new VM stays temp-aware and
+                // never persists the server-hidden conversation to Room.
+                onConversationStart(navId, uiState.isTemporaryChat)
                 viewModel.onPendingNavigationHandled()
             }
         }
@@ -507,7 +511,7 @@ actual fun ChatScreen(
 
 @Composable
 actual fun NewChatScreen(
-    onConversationStart: (String) -> Unit,
+    onConversationStart: (conversationId: String, isTemporary: Boolean) -> Unit,
     modifier: Modifier,
     initialAgentId: String?,
     onOpenDrawer: (() -> Unit)?,

--- a/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/LibreChatNavHost.kt
+++ b/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/LibreChatNavHost.kt
@@ -312,7 +312,9 @@ fun MainNavDisplay(
             chatEntries(
                 onNavigate = { navigator.navigate(it) },
                 onBack = { navigator.goBack() },
-                onNavigateToChat = { navigator.navigateToChat(it) },
+                onNavigateToChat = { conversationId, isTemporary ->
+                    navigator.navigateToChat(conversationId, isTemporary)
+                },
                 onOpenDrawer = onMenuClick,
                 onNavigateToProviderKeys = { endpointName ->
                     navigator.navigateToProviderKeys(endpointName)

--- a/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/Navigator.kt
+++ b/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/Navigator.kt
@@ -28,12 +28,14 @@ class Navigator(val backStack: NavBackStack<NavKey>) {
         backStack.removeLastOrNull()
     }
 
-    /** Navigate to a chat, replacing any current chat on the stack. */
-    fun navigateToChat(conversationId: String) {
+    /** Navigate to a chat, replacing any current chat on the stack. [isTemporary] marks a
+     *  temporary chat so a restored Chat(id) entry stays temp-aware and never persists
+     *  the server-hidden conversation to Room — see [Chat.isTemporary]. */
+    fun navigateToChat(conversationId: String, isTemporary: Boolean = false) {
         if (backStack.lastOrNull() is Chat) {
             backStack.removeLastOrNull()
         }
-        backStack.add(Chat(conversationId))
+        backStack.add(Chat(conversationId, isTemporary))
     }
 
     /**


### PR DESCRIPTION
## Summary
Temporary chats were being written to the local Room cache and so surfaced in conversation history — the server hides them, but the client persisted them anyway. This closes the remaining client-side persistence paths for a temporary chat and carries the temporary flag on the navigation route so the guard survives process death.

## Changes
- Gate the landing ViewModel's Room writes for temporary chats in `onConversationCreated`: skip the new-chat draft migration and the eager conversation cache-warm (the write that surfaced a temp chat in history).
- Carry `isTemporary` on the `Chat` navigation route and thread it through `Navigator.navigateToChat`, the chat screens, and into `ChatViewModel` (`initialIsTemporary`). Because it rides the route, a `Chat(id)` entry restored after process death re-initializes temp-aware.
- Seed `isTemporaryChat` in `ChatViewModel.init` before the conversation loads, so the Room-backed load paths (`loadConversation`, plus a new guard on `loadConversationModel`) short-circuit and never upsert the server-hidden conversation, and follow-up sends stay temporary.
- A temporary chat restored with no in-memory session lands on an empty active screen instead of a loading spinner that never resolves.

## Testing
- Android: device-tested on Pixel 9 Pro Fold against a LibreChat backend.
- Unit tests: `feature:chat` and `app` (Navigator / selection-handoff) suites pass.
- Compiles on both platforms (Android + iOS Kotlin).

## Notes
- Temporary-chat state is intentionally session-scoped: a temporary chat restored after process death shows no prior messages (its in-memory content is gone), consistent with temporary-chat semantics.
