### PR TITLE
fix(chat): show starred models on cold start

### DIFF
--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModel.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModel.kt
@@ -1451,12 +1451,14 @@ class ChatViewModel(
     /**
      * Single choke point for showing the model-selector sheet — user-initiated (model
      * chip) and send-blocked auto-opens alike. Opening the selector retries a failed
-     * agent load so the user can actually pick an agent; routing every open through
-     * here keeps that retry from being forgotten on a future open path. A null
-     * [reason] leaves the current sendBlockReason untouched.
+     * agent load so the user can actually pick an agent, and refetches favorites to
+     * self-heal a failed cold-start fetch (see [FavoritesDelegate.refresh]); routing
+     * every open through here keeps both from being forgotten on a future open path. A
+     * null [reason] leaves the current sendBlockReason untouched.
      */
     private fun surfaceModelSheet(reason: SendBlockReason? = null) {
         modelDelegate.retryAgentsIfFailed(isNewConversation)
+        favoritesDelegate.refresh()
         _uiState.update {
             it.copy(
                 sendBlockReason = reason ?: it.sendBlockReason,

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/FavoritesDelegate.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/FavoritesDelegate.kt
@@ -27,6 +27,17 @@ class FavoritesDelegate(
 
     fun load() {
         observeFavorites()
+        refresh()
+    }
+
+    /**
+     * Re-fetches favorites from the server. Called at VM init and again whenever the
+     * model sheet opens: the init fetch is single-shot and its failure is swallowed,
+     * so a cold-start fetch that races auth/network warm-up would otherwise leave the
+     * picker starless (no top Starred section, unfilled stars) until a pin is toggled.
+     * The sheet-open refetch self-heals that and also picks up pins made elsewhere.
+     */
+    fun refresh() {
         stateHandle.scope.launch {
             when (val result = favoritesRepository.refresh()) {
                 is Result.Success -> Unit


### PR DESCRIPTION
## Summary

The model picker's dedicated "Starred" section (and the filled star icons)
could fail to appear on a fresh app launch, staying hidden until the user
toggled a pin. This makes favorites load reliably so the section renders on
cold start.

## Changes

- **`FavoritesDelegate`**: extract a public `refresh()` out of `load()`. The
  favorites fetch was single-shot at ViewModel init with its failure silently
  swallowed, so a cold-start fetch that raced auth/network warm-up left the
  favorites list empty with no retry path.
- **`ChatViewModel`**: refetch favorites whenever the model sheet opens. All
  three open paths (model-chip tap and the two send-block auto-opens) now route
  through a single `revealModelSheet()` helper, so the refetch can't be
  forgotten on a future entry point. This self-heals a failed cold-start fetch
  and also picks up pins made on other devices.

## Testing

- Android + iOS compile; detekt clean.
- Installed on a Pixel Fold and cold-started without favorites errors.
