### PR TITLE
feat: multi-account and multi-server support

### DIFF
--- a/app/src/main/kotlin/com/garfiec/librechat/navigation/TabletLayout.kt
+++ b/app/src/main/kotlin/com/garfiec/librechat/navigation/TabletLayout.kt
@@ -31,6 +31,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.garfiec.librechat.core.model.Banner
 import com.garfiec.librechat.core.ui.components.BannerDisplay
 import com.garfiec.librechat.feature.agents.navigation.AgentMarketplace
+import com.garfiec.librechat.feature.auth.navigation.AddAccountServerUrl
 import com.garfiec.librechat.feature.chat.navigation.NewChat
 import com.garfiec.librechat.feature.conversations.navigation.ProjectChats
 import com.garfiec.librechat.feature.conversations.navigation.Projects
@@ -190,6 +191,12 @@ fun TabletLayout(
                         },
                         onOpenProjectsIndex = {
                             navigator.navigate(Projects)
+                        },
+                        onSwitchAccount = { accountId ->
+                            navHostViewModel.switchAccount(accountId)
+                        },
+                        onAddAccount = {
+                            navigator.navigate(AddAccountServerUrl)
                         },
                         modifier = Modifier
                             .width(SidebarWidth)

--- a/app/src/test/kotlin/com/garfiec/librechat/KoinGraphVerificationTest.kt
+++ b/app/src/test/kotlin/com/garfiec/librechat/KoinGraphVerificationTest.kt
@@ -4,12 +4,15 @@ import android.app.Application
 import android.content.Context
 import com.garfiec.librechat.core.common.AppInfo
 import com.garfiec.librechat.core.common.di.commonModule
+import com.garfiec.librechat.core.common.identity.ActiveAccountProvider
 import com.garfiec.librechat.core.common.network.ConnectivityObserver
+import com.garfiec.librechat.core.data.datastore.AccountRoster
 import com.garfiec.librechat.core.data.datastore.ConfigCacheDataStore
 import com.garfiec.librechat.core.data.datastore.ServerDataStore
 import com.garfiec.librechat.core.data.datastore.SettingsDataStore
 import com.garfiec.librechat.core.data.datastore.ThemeDataStore
 import com.garfiec.librechat.core.data.di.dataModule
+import com.garfiec.librechat.core.data.repository.AccountSwitcher
 import com.garfiec.librechat.core.data.repository.AgentRepository
 import com.garfiec.librechat.core.data.repository.AgentToolsRepository
 import com.garfiec.librechat.core.data.repository.ApiKeyRepository
@@ -70,8 +73,10 @@ import com.garfiec.librechat.core.network.api.SkillsApi
 import com.garfiec.librechat.core.network.api.SpeechApi
 import com.garfiec.librechat.core.network.api.TagsApi
 import com.garfiec.librechat.core.network.api.UserApi
+import com.garfiec.librechat.core.network.client.AccountReadyGate
 import com.garfiec.librechat.core.network.client.SecureTokenStorage
 import com.garfiec.librechat.core.network.client.ServerUrlProvider
+import com.garfiec.librechat.core.network.client.SwitchGate
 import com.garfiec.librechat.core.network.client.TokenManager
 import com.garfiec.librechat.core.network.di.networkModule
 import com.garfiec.librechat.core.network.sse.SseClient
@@ -131,6 +136,7 @@ class KoinGraphVerificationTest {
             CoroutineDispatcher::class,
             CoroutineScope::class,
             ConnectivityObserver::class,
+            ActiveAccountProvider::class,
             AppInfo::class,
             // core:logging provides
             DiagnosticLogRepository::class,
@@ -138,6 +144,8 @@ class KoinGraphVerificationTest {
             TokenManager::class,
             SecureTokenStorage::class,
             ServerUrlProvider::class,
+            AccountReadyGate::class,
+            SwitchGate::class,
             SseClient::class,
             AgentToolsApi::class,
             AgentsApi::class,
@@ -169,6 +177,8 @@ class KoinGraphVerificationTest {
             // core:data provides
             ConfigCacheDataStore::class,
             ServerDataStore::class,
+            AccountRoster::class,
+            AccountSwitcher::class,
             SettingsDataStore::class,
             ThemeDataStore::class,
             AgentRepository::class,
@@ -211,6 +221,8 @@ class KoinGraphVerificationTest {
             // Wrappers/DSL types that verify can't resolve via constructor
             Lazy::class,
             File::class,
+            // ServerUrlViewModel's addAccount mode flag, injected via parametersOf
+            Boolean::class,
         )
 
         // Types whose libraries aren't on the app test classpath (transitive

--- a/core/common/src/androidUnitTest/kotlin/com/garfiec/librechat/core/common/identity/AccountTransitionsTest.kt
+++ b/core/common/src/androidUnitTest/kotlin/com/garfiec/librechat/core/common/identity/AccountTransitionsTest.kt
@@ -1,0 +1,54 @@
+package com.garfiec.librechat.core.common.identity
+
+import app.cash.turbine.test
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+
+class AccountTransitionsTest {
+
+    private val accountA = AccountId("srv-1:user-a")
+    private val accountB = AccountId("srv-1:user-b")
+
+    @Test
+    fun `cold start resolution never emits`() = runTest {
+        val provider = InMemoryActiveAccountProvider(AccountState.Warming)
+        provider.accountTransitions().test {
+            provider.set(accountA) // Warming -> first Resolved: the seed, not a transition
+            expectNoEvents()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `account to account flip emits Switched`() = runTest {
+        val provider = InMemoryActiveAccountProvider(AccountState.Resolved(accountA))
+        provider.accountTransitions().test {
+            provider.set(accountB)
+            assertThat(awaitItem()).isEqualTo(AccountTransition.Switched)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `account to logged-out flip emits Ended`() = runTest {
+        val provider = InMemoryActiveAccountProvider(AccountState.Resolved(accountA))
+        provider.accountTransitions().test {
+            provider.clear()
+            assertThat(awaitItem()).isEqualTo(AccountTransition.Ended)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `logout then login as another account emits Ended only`() = runTest {
+        val provider = InMemoryActiveAccountProvider(AccountState.Resolved(accountA))
+        provider.accountTransitions().test {
+            provider.clear()
+            assertThat(awaitItem()).isEqualTo(AccountTransition.Ended)
+            provider.set(accountB) // login from logged-out: auth flow owns this navigation
+            expectNoEvents()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+}

--- a/core/common/src/commonMain/kotlin/com/garfiec/librechat/core/common/extensions/StringExt.kt
+++ b/core/common/src/commonMain/kotlin/com/garfiec/librechat/core/common/extensions/StringExt.kt
@@ -5,6 +5,12 @@ fun String.trimTrailingSlash(): String = trimEnd('/')
 fun String.isValidUrl(): Boolean =
     startsWith("http://") || startsWith("https://")
 
+/**
+ * The host portion of a base URL, for a display label (switcher chip / roster row): the text
+ * between `://` and the first `/`, falling back to the whole string when there is no host to strip.
+ */
+fun String.serverHostLabel(): String = substringAfter("://").substringBefore('/').ifBlank { this }
+
 fun String.ensureHttps(): String = when {
     startsWith("https://") -> this
     startsWith("http://") -> replaceFirst("http://", "https://")

--- a/core/common/src/commonMain/kotlin/com/garfiec/librechat/core/common/identity/AccountTransitions.kt
+++ b/core/common/src/commonMain/kotlin/com/garfiec/librechat/core/common/identity/AccountTransitions.kt
@@ -1,0 +1,36 @@
+package com.garfiec.librechat.core.common.identity
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+
+/**
+ * A change of resolved identity, as the UI layer needs to see it. Cold-start resolution
+ * (Warming → first Resolved) and logins from the logged-out state are NOT transitions — the auth flow
+ * owns that navigation; these fire only when an *established* identity changes underneath the UI.
+ */
+sealed interface AccountTransition {
+    /** Account-to-account flip (switch / add-completion / remove-active-with-remaining): the back
+     *  stack still shows the outgoing account's routes and must be reset. */
+    data object Switched : AccountTransition
+
+    /** Account-to-logged-out flip (logout / remove-last). Navigation is owned by the initiating flow
+     *  (or the session-expired signal); consumers use this for cache hygiene only. */
+    data object Ended : AccountTransition
+}
+
+/**
+ * Emits an [AccountTransition] for every change of an established resolved identity. [Warming][AccountState.Warming]
+ * is ignored entirely (it only precedes the first resolution and never separates two resolved states),
+ * so the cold-start seed can never fire a transition.
+ */
+fun ActiveAccountProvider.accountTransitions(): Flow<AccountTransition> = flow {
+    var previous: String? = null
+    state.collect { accountState ->
+        if (accountState !is AccountState.Resolved) return@collect
+        val current = accountState.id?.value
+        if (previous != null && current != previous) {
+            emit(if (current != null) AccountTransition.Switched else AccountTransition.Ended)
+        }
+        previous = current
+    }
+}

--- a/core/data/CLAUDE.md
+++ b/core/data/CLAUDE.md
@@ -33,14 +33,25 @@ All impls take constructor parameters (api, dao, mapper, dispatcher) wired via K
 3. Upsert into Room. The Room `Flow` auto-emits the updated list.
 4. On network error, the cached data remains visible; error is surfaced separately.
 
-### Token Refresh with Mutex
+### Account-keyed token store (`CommonTokenDataStore`)
 
-```kotlin
-private val refreshMutex = Mutex()
-override suspend fun refreshAccessToken(): Boolean = refreshMutex.withLock {
-    // Single refresh attempt, all concurrent callers wait on this lock
-}
-```
+Tokens are namespaced by account (`acct:<accountId>:access_token`) and several accounts' tokens are
+retained at rest at once (multi-account, issue #179). Concurrency uses three cooperating pieces, not a
+single refresh mutex:
+
+- **`stateMutex`** — guards the in-memory identity + cached bearer and short storage reads/writes of
+  it. Held only for brief critical sections, **never across the refresh network POST**, so a switch or
+  logout never stalls behind a slow refresh.
+- **per-account `flightMutex`/`flights`** — single-flights refreshes of the *same* account across their
+  POST, so a second 401 reads the rotated token instead of re-POSTing a spent one.
+- **`tokenEpoch`** — bumped by every op that invalidates token truth (logout, clear, removal, a new
+  authentication, an identity re-home). A refresh captures it before its POST and discards its result
+  if it changed, so a refresh racing a teardown can't resurrect a cleared session even with no lock
+  held across the POST.
+
+Interactive sign-in (`setTokens`) **stages** the pair under the bare keys and drops the active binding;
+`onAccountResolved` re-homes it into the account's keyed slot. This makes a re-login while another
+account is active unable to corrupt/leak into that account's slot.
 
 Wrap `EncryptedSharedPreferences` in try/catch -- some OEM devices have broken Keystore implementations. On `KeyStoreException`, clear tokens and force re-login.
 

--- a/core/data/src/androidMain/kotlin/com/garfiec/librechat/core/data/di/DataPlatformModule.android.kt
+++ b/core/data/src/androidMain/kotlin/com/garfiec/librechat/core/data/di/DataPlatformModule.android.kt
@@ -10,13 +10,13 @@ import com.garfiec.librechat.core.data.datastore.TokenDataStore
 import com.garfiec.librechat.core.data.db.LibreChatDatabase
 import com.garfiec.librechat.core.data.db.migration.MIGRATION_3_4
 import com.garfiec.librechat.core.data.db.migration.MIGRATION_4_5
+import com.garfiec.librechat.core.data.repository.AndroidSwitchCacheCleaner
 import com.garfiec.librechat.core.data.repository.CommonSessionCacheCleaner
-import com.garfiec.librechat.core.data.repository.RoleRepository
 import com.garfiec.librechat.core.data.repository.SessionCacheCleaner
+import com.garfiec.librechat.core.data.repository.SwitchCacheCleaner
 import com.garfiec.librechat.core.network.client.SecureTokenStorage
 import com.garfiec.librechat.core.network.client.TokenManager
 import io.ktor.client.HttpClient
-import kotlinx.coroutines.CoroutineScope
 import org.koin.android.ext.koin.androidContext
 import org.koin.core.module.Module
 import org.koin.dsl.binds
@@ -50,8 +50,9 @@ actual val dataPlatformModule: Module = module {
     single<SessionCacheCleaner> {
         CommonSessionCacheCleaner(
             cacheRoot = androidContext().cacheDir.absolutePath,
-            roleRepository = get<RoleRepository>(),
-            applicationScope = get<CoroutineScope>(KoinQualifiers.ApplicationScope),
         )
     }
+
+    // --- Switch Cache Cleaner (account switch, non-partitionable caches) ---
+    single<SwitchCacheCleaner> { AndroidSwitchCacheCleaner() }
 }

--- a/core/data/src/androidMain/kotlin/com/garfiec/librechat/core/data/repository/AndroidSwitchCacheCleaner.kt
+++ b/core/data/src/androidMain/kotlin/com/garfiec/librechat/core/data/repository/AndroidSwitchCacheCleaner.kt
@@ -1,0 +1,29 @@
+package com.garfiec.librechat.core.data.repository
+
+import android.webkit.CookieManager
+import android.webkit.WebStorage
+import co.touchlab.kermit.Logger
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * Android switch-cache clear: WebView storage (localStorage/IndexedDB behind inline artifacts) and
+ * the process-global WebView cookie jar. The jar holds the OAuth `refreshToken` cookie for every
+ * server the user has OAuth'd against — per-URL clearing would leave the outgoing account's cookie
+ * live (it would be read against the *current* URL), so clear it whole; an interactive OAuth
+ * re-issues on demand. WebView instances themselves die with their composables when the switch pops
+ * the back stack. Best-effort: a clear failure must never abort the switch itself.
+ */
+class AndroidSwitchCacheCleaner : SwitchCacheCleaner {
+    override suspend fun clearOnSwitch() {
+        runCatching {
+            withContext(Dispatchers.Main) {
+                WebStorage.getInstance().deleteAllData()
+                CookieManager.getInstance().apply {
+                    removeAllCookies(null)
+                    flush()
+                }
+            }
+        }.onFailure { Logger.w(it) { "Switch cache clear failed" } }
+    }
+}

--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/datastore/AccountRegistryTest.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/datastore/AccountRegistryTest.kt
@@ -3,15 +3,22 @@ package com.garfiec.librechat.core.data.datastore
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
 import com.garfiec.librechat.core.common.identity.AccountId
 import com.garfiec.librechat.core.common.identity.AccountState.Resolved
 import com.garfiec.librechat.core.common.identity.InMemoryActiveAccountProvider
-import com.garfiec.librechat.core.network.client.ServerUrlProvider
+import com.garfiec.librechat.core.common.identity.deriveAccountId
+import com.garfiec.librechat.core.common.identity.deriveServerId
+import com.garfiec.librechat.core.network.client.TokenManager
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -24,70 +31,128 @@ class AccountRegistryTest {
     val tmpFolder = TemporaryFolder()
 
     private val testDispatcher = UnconfinedTestDispatcher()
+    private val json = Json { ignoreUnknownKeys = true }
+    private val serverUrl = "https://chat.example.com"
+    private val accountId = deriveAccountId(deriveServerId(serverUrl), "user-1")
+    private val activeKey = stringPreferencesKey("active_account_id")
 
     private fun createDataStore(name: String): DataStore<Preferences> =
         PreferenceDataStoreFactory.create { File(tmpFolder.root, "$name.preferences_pb") }
 
-    private val serverUrlProvider = object : ServerUrlProvider {
-        override fun getBaseUrl(): String = "https://chat.example.com"
-        override suspend fun awaitBaseUrl(): String = "https://chat.example.com"
-    }
+    private fun serverDataStore(ds: DataStore<Preferences>) =
+        ServerDataStore(ds, CoroutineScope(testDispatcher), testDispatcher, null)
+
+    private fun registry(
+        ds: DataStore<Preferences>,
+        provider: InMemoryActiveAccountProvider,
+        server: ServerDataStore,
+        token: TokenManager = FakeTokenManager(),
+    ) = AccountRegistry(
+        roster = AccountRoster(ds, json),
+        activeAccountProvider = provider,
+        serverDataStore = server,
+        tokenManager = token,
+        appScope = CoroutineScope(testDispatcher),
+        ioDispatcher = testDispatcher,
+    )
+
+    private fun entry() = AccountEntry(
+        accountId = accountId.value,
+        serverUrl = serverUrl,
+        displayLabel = "Alice",
+        avatarUrl = null,
+        lastActiveAt = 1L,
+    )
 
     @Test
-    fun coldStart_emptyRegistry_seedsLoggedOut() = runTest(testDispatcher) {
+    fun coldStart_emptyRoster_seedsLoggedOut_withoutTouchingTokens() = runTest(testDispatcher) {
+        val ds = createDataStore("empty")
         val provider = InMemoryActiveAccountProvider()
-        val registry = AccountRegistry(
-            dataStore = createDataStore("acct-empty"),
-            activeAccountProvider = provider,
-            serverUrlProvider = serverUrlProvider,
-            appScope = CoroutineScope(testDispatcher),
-            ioDispatcher = testDispatcher,
-        )
-        registry.awaitSeeded()
-        // Resolved(null) = known logged-out, NOT left Warming.
+        val token = FakeTokenManager()
+        registry(ds, provider, serverDataStore(ds), token).awaitReady()
+
         assertThat(provider.state.value).isEqualTo(Resolved(null))
+        // An empty roster must NOT clear the token store: a pre-tenancy upgrade has an empty roster
+        // while the live session sits under the bare keys, waiting for restoreAccountIfNeeded.
+        assertThat(token.cleared).isFalse()
+        assertThat(token.selected).isNull()
     }
 
     @Test
-    fun coldStart_persistedId_seedsThatAccount() = runTest(testDispatcher) {
-        val ds = createDataStore("acct-persisted")
-        // First instance persists an active account...
-        AccountRegistry(ds, InMemoryActiveAccountProvider(), serverUrlProvider, CoroutineScope(testDispatcher), testDispatcher)
-            .apply { awaitSeeded() }
-            .setActiveAccount(AccountId("srv:user-1"))
+    fun coldStart_migratesLegacyPointer_publishesAndReconcilesMirror() = runTest(testDispatcher) {
+        val ds = createDataStore("legacy")
+        val server = serverDataStore(ds)
+        server.setServerUrl(serverUrl)
+        ds.edit { it[activeKey] = accountId.value } // pre-roster (#206) install: pointer + URL only
 
-        // ...a fresh instance over the same store seeds it at cold start.
         val provider = InMemoryActiveAccountProvider()
-        AccountRegistry(ds, provider, serverUrlProvider, CoroutineScope(testDispatcher), testDispatcher)
-            .awaitSeeded()
-        assertThat(provider.state.value).isEqualTo(Resolved(AccountId("srv:user-1")))
+        val token = FakeTokenManager()
+        registry(ds, provider, server, token).awaitReady()
+
+        assertThat(provider.state.value).isEqualTo(Resolved(accountId))
+        // Mirror reconciled to the authority, not cleared.
+        assertThat(token.selected).isEqualTo(accountId.value)
+        assertThat(token.cleared).isFalse()
+        // Migration produced a one-entry roster.
+        assertThat(AccountRoster(ds, json).snapshot().entries.map { it.accountId })
+            .containsExactly(accountId.value)
     }
 
     @Test
-    fun setActiveAccount_persistsAndPublishes() = runTest(testDispatcher) {
+    fun upsertActive_persistsRosterEntry_survivesColdRestart() = runTest(testDispatcher) {
+        val ds = createDataStore("login")
+        val server = serverDataStore(ds)
+        server.setServerUrl(serverUrl)
         val provider = InMemoryActiveAccountProvider()
-        val registry = AccountRegistry(
-            createDataStore("acct-set"), provider, serverUrlProvider, CoroutineScope(testDispatcher), testDispatcher,
-        )
-        registry.awaitSeeded()
-        registry.setActiveAccount(AccountId("srv:user-A"))
-        assertThat(provider.state.value).isEqualTo(Resolved(AccountId("srv:user-A")))
+        val reg = registry(ds, provider, server)
+        reg.awaitReady()
+
+        reg.upsertActive(entry())
+        assertThat(provider.state.value).isEqualTo(Resolved(accountId))
+
+        // Fresh instance over the same store re-seeds the account (marker already set -> no clobber).
+        val provider2 = InMemoryActiveAccountProvider()
+        registry(ds, provider2, serverDataStore(ds)).awaitReady()
+        assertThat(provider2.state.value).isEqualTo(Resolved(accountId))
     }
 
     @Test
-    fun clearActiveAccount_flipsToNullAndForgetsOnDisk() = runTest(testDispatcher) {
-        val ds = createDataStore("acct-clear")
+    fun clearActiveAccount_flipsToNull_andStaysLoggedOutOnRestart() = runTest(testDispatcher) {
+        val ds = createDataStore("clear")
+        val server = serverDataStore(ds)
+        server.setServerUrl(serverUrl)
         val provider = InMemoryActiveAccountProvider()
-        val registry = AccountRegistry(ds, provider, serverUrlProvider, CoroutineScope(testDispatcher), testDispatcher)
-        registry.awaitSeeded()
-        registry.setActiveAccount(AccountId("srv:user-A"))
+        val reg = registry(ds, provider, server)
+        reg.awaitReady()
+        reg.upsertActive(entry())
 
-        registry.clearActiveAccount()
+        reg.clearActiveAccount()
         assertThat(provider.state.value).isEqualTo(Resolved(null))
 
-        // A fresh cold start over the same store stays logged-out (disk was cleared).
-        val reSeed = InMemoryActiveAccountProvider()
-        AccountRegistry(ds, reSeed, serverUrlProvider, CoroutineScope(testDispatcher), testDispatcher).awaitSeeded()
-        assertThat(reSeed.state.value).isEqualTo(Resolved(null))
+        val provider2 = InMemoryActiveAccountProvider()
+        registry(ds, provider2, serverDataStore(ds)).awaitReady()
+        assertThat(provider2.state.value).isEqualTo(Resolved(null))
+    }
+
+    /** Records the reconcile calls the seed makes; every other method is an inert stub. */
+    private class FakeTokenManager : TokenManager {
+        var selected: String? = null
+        var cleared = false
+
+        override val isAuthenticated: Boolean = false
+        override suspend fun getAccessToken(): String? = null
+        override suspend fun setTokens(accessToken: String, refreshToken: String) {}
+        override suspend fun refreshAccessToken(): Boolean = false
+        override suspend fun clearTokens() {}
+        override suspend fun getAccessTokenFor(accountId: String): String? = null
+        override suspend fun getStagedAccessToken(): String? = null
+        override suspend fun clearStagedTokens() {}
+        override suspend fun selectAccount(accountId: String) { selected = accountId }
+        override suspend fun removeAccount(accountId: String) {}
+        override suspend fun refreshAccessTokenFor(accountId: String, baseUrl: String): Boolean = false
+        override suspend fun onAccountResolved(accountId: String) {}
+        override suspend fun onAccountCleared() { cleared = true }
+        override fun emitSessionExpired(expiredAccountId: String?) {}
+        override val sessionExpiredFlow: SharedFlow<Unit> = MutableSharedFlow()
     }
 }

--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/datastore/AccountRosterTest.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/datastore/AccountRosterTest.kt
@@ -1,0 +1,144 @@
+package com.garfiec.librechat.core.data.datastore
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import com.garfiec.librechat.core.common.identity.deriveAccountId
+import com.garfiec.librechat.core.common.identity.deriveServerId
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AccountRosterTest {
+
+    @get:Rule
+    val tmpFolder = TemporaryFolder()
+
+    private val json = Json { ignoreUnknownKeys = true }
+    private val serverUrl = "https://chat.example.com"
+    private val accountId = deriveAccountId(deriveServerId(serverUrl), "user-1").value
+    private val activeKey = stringPreferencesKey("active_account_id")
+
+    private fun createDataStore(name: String): DataStore<Preferences> =
+        PreferenceDataStoreFactory.create { File(tmpFolder.root, "$name.preferences_pb") }
+
+    private fun entry(id: String = accountId, label: String = "Alice") =
+        AccountEntry(
+            accountId = id,
+            serverUrl = serverUrl,
+            displayLabel = label,
+            avatarUrl = null,
+            lastActiveAt = 1L,
+        )
+
+    @Test
+    fun upsertAndActivate_addsEntryAndPointer_replacingSameId() = runTest {
+        val roster = AccountRoster(createDataStore("upsert"), json)
+        roster.upsertAndActivate(entry(label = "Alice"))
+        roster.upsertAndActivate(entry(label = "Alice Renamed")) // same accountId -> replace, not dup
+
+        val snap = roster.snapshot()
+        assertThat(snap.activeId).isEqualTo(accountId)
+        assertThat(snap.entries).hasSize(1)
+        assertThat(snap.activeEntry?.displayLabel).isEqualTo("Alice Renamed")
+    }
+
+    @Test
+    fun updateDisplay_refreshesLabelAndAvatar_withoutTouchingActivationOrRecency() = runTest {
+        val roster = AccountRoster(createDataStore("update-display"), json)
+        roster.upsertAndActivate(entry(label = "chat.example.com")) // migration-style host fallback
+
+        roster.updateDisplay(accountId, displayLabel = "Alice", avatarUrl = "https://a/avatar.png")
+
+        val snap = roster.snapshot()
+        assertThat(snap.activeEntry?.displayLabel).isEqualTo("Alice")
+        assertThat(snap.activeEntry?.avatarUrl).isEqualTo("https://a/avatar.png")
+        assertThat(snap.activeEntry?.lastActiveAt).isEqualTo(1L) // recency untouched
+        assertThat(snap.activeId).isEqualTo(accountId)
+    }
+
+    @Test
+    fun updateDisplay_unknownAccount_isNoOp() = runTest {
+        val roster = AccountRoster(createDataStore("update-display-miss"), json)
+        roster.upsertAndActivate(entry(label = "Alice"))
+
+        roster.updateDisplay("other:account", displayLabel = "Mallory", avatarUrl = null)
+
+        val snap = roster.snapshot()
+        assertThat(snap.entries).hasSize(1)
+        assertThat(snap.activeEntry?.displayLabel).isEqualTo("Alice")
+    }
+
+    @Test
+    fun removeAndDeactivate_dropsEntry_andClearsPointerWhenActive() = runTest {
+        val roster = AccountRoster(createDataStore("remove"), json)
+        roster.upsertAndActivate(entry())
+
+        roster.removeAndDeactivate(accountId)
+
+        val snap = roster.snapshot()
+        assertThat(snap.entries).isEmpty()
+        assertThat(snap.activeId).isNull()
+    }
+
+    @Test
+    fun migrateIfNeeded_serverIdMatch_seedsOneEntryFromLegacyPointer() = runTest {
+        val ds = createDataStore("migrate-match")
+        ds.edit { it[activeKey] = accountId } // a pre-roster (#206) install: pointer only
+        val roster = AccountRoster(ds, json)
+
+        roster.migrateIfNeeded(serverUrl)
+
+        val snap = roster.snapshot()
+        assertThat(snap.activeId).isEqualTo(accountId)
+        assertThat(snap.entries.map { it.accountId }).containsExactly(accountId)
+        assertThat(snap.activeEntry?.serverUrl).isEqualTo(serverUrl)
+    }
+
+    @Test
+    fun migrateIfNeeded_serverIdMismatch_dropsPointerAndSeedsNoEntry() = runTest {
+        val ds = createDataStore("migrate-mismatch")
+        ds.edit { it[activeKey] = accountId } // accountId's serverId derives from `serverUrl`...
+        val roster = AccountRoster(ds, json)
+
+        roster.migrateIfNeeded("https://different-server.example.org") // ...but the URL drifted
+
+        val snap = roster.snapshot()
+        assertThat(snap.activeId).isNull() // unrepairable -> route to login
+        assertThat(snap.entries).isEmpty()
+    }
+
+    @Test
+    fun migrateIfNeeded_isOneTime_doesNotResurrectARemovedAccount() = runTest {
+        val ds = createDataStore("migrate-once")
+        ds.edit { it[activeKey] = accountId }
+        val roster = AccountRoster(ds, json)
+
+        roster.migrateIfNeeded(serverUrl) // seeds the entry + marker
+        roster.removeAndDeactivate(accountId) // user later removes it
+        roster.migrateIfNeeded(serverUrl) // marker present -> must NOT re-seed from the (gone) pointer
+
+        val snap = roster.snapshot()
+        assertThat(snap.entries).isEmpty()
+        assertThat(snap.activeId).isNull()
+    }
+
+    @Test
+    fun migrateIfNeeded_noLegacyPointer_seedsEmptyRoster() = runTest {
+        val roster = AccountRoster(createDataStore("migrate-empty"), json)
+
+        roster.migrateIfNeeded(serverUrl)
+
+        val snap = roster.snapshot()
+        assertThat(snap.entries).isEmpty()
+        assertThat(snap.activeId).isNull()
+    }
+}

--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/datastore/CommonTokenDataStoreAccountKeyingTest.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/datastore/CommonTokenDataStoreAccountKeyingTest.kt
@@ -13,6 +13,8 @@ import io.ktor.http.contentType
 import io.ktor.http.headersOf
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
@@ -102,6 +104,29 @@ class CommonTokenDataStoreAccountKeyingTest {
     }
 
     @Test
+    fun `onAccountResolved with a torn staging pair does not cache an unpersisted bearer`() = runTest {
+        val store = FakeKeyedStore(
+            noRefresh,
+            seed = mapOf(
+                // Torn staging: a bare access token survived but its refresh partner didn't (e.g. a
+                // partial keychain write). The keyed slot still holds the prior value.
+                "access_token" to "torn-access",
+                accessKey("acctA") to "A-access",
+                refreshKeyOf("acctA") to "A-refresh",
+            ),
+        )
+
+        store.onAccountResolved("acctA")
+
+        // The keyed slot is NOT overwritten from the torn pair, and the cached bearer matches storage
+        // (the keyed value), never the unpersisted staged token.
+        assertThat(store.store[accessKey("acctA")]).isEqualTo("A-access")
+        assertThat(store.getAccessToken()).isEqualTo("A-access")
+        // Bare staging keys are cleared regardless.
+        assertThat(store.store).doesNotContainKey("access_token")
+    }
+
+    @Test
     fun `onAccountResolved is a no-op when the account is unchanged`() = runTest {
         val store = FakeKeyedStore(
             noRefresh,
@@ -115,7 +140,7 @@ class CommonTokenDataStoreAccountKeyingTest {
     }
 
     @Test
-    fun `switching account without logout re-homes tokens and drops the previous slot`() = runTest {
+    fun `authenticating a different account while one is active retains the previous account's tokens`() = runTest {
         val store = FakeKeyedStore(
             noRefresh,
             seed = mapOf(
@@ -124,18 +149,151 @@ class CommonTokenDataStoreAccountKeyingTest {
                 refreshKeyOf("acctA") to "A-refresh",
             ),
         )
-        // Soft-expiry → login B without an explicit logout: setTokens for B lands under A's key
-        // (activeAccountKey still A) until the establish hook re-homes it.
+        // Soft-expiry → login B without an explicit logout: setTokens stages B under the bare keys
+        // (never A's keyed slot), then the establish hook re-homes the staged pair into acctB.
         store.setTokens(accessToken = "B-access", refreshToken = "B-refresh")
 
         store.onAccountResolved("acctB")
 
         assertThat(store.store[accessKey("acctB")]).isEqualTo("B-access")
         assertThat(store.store[refreshKeyOf("acctB")]).isEqualTo("B-refresh")
-        assertThat(store.store).doesNotContainKey(accessKey("acctA"))
-        assertThat(store.store).doesNotContainKey(refreshKeyOf("acctA"))
+        // A's tokens are RETAINED (multi-account) — a switch back needs no re-login.
+        assertThat(store.store[accessKey("acctA")]).isEqualTo("A-access")
+        assertThat(store.store[refreshKeyOf("acctA")]).isEqualTo("A-refresh")
+        assertThat(store.store).doesNotContainKey("access_token")
+        assertThat(store.store).doesNotContainKey("refresh_token")
         assertThat(store.store["active_account_id"]).isEqualTo("acctB")
         assertThat(store.getAccessToken()).isEqualTo("B-access")
+    }
+
+    @Test
+    fun `staged tokens are readable while staged and clearStagedTokens drops only the bare keys`() = runTest {
+        val store = FakeKeyedStore(
+            noRefresh,
+            seed = mapOf(
+                "active_account_id" to "acctA",
+                accessKey("acctA") to "A-access",
+                refreshKeyOf("acctA") to "A-refresh",
+            ),
+        )
+        assertThat(store.getStagedAccessToken()).isNull()
+
+        // An add-account sign-in stages B under the bare keys.
+        store.setTokens(accessToken = "B-access", refreshToken = "B-refresh")
+        assertThat(store.getStagedAccessToken()).isEqualTo("B-access")
+
+        // Abandoning the flow clears the staging but never a keyed slot.
+        store.clearStagedTokens()
+        assertThat(store.getStagedAccessToken()).isNull()
+        assertThat(store.store).doesNotContainKey("access_token")
+        assertThat(store.store).doesNotContainKey("refresh_token")
+        assertThat(store.store[accessKey("acctA")]).isEqualTo("A-access")
+        assertThat(store.store[refreshKeyOf("acctA")]).isEqualTo("A-refresh")
+    }
+
+    @Test
+    fun `getAccessTokenFor reads an account's own slot even while another sign-in is staged`() = runTest {
+        val store = FakeKeyedStore(
+            noRefresh,
+            seed = mapOf(
+                "active_account_id" to "acctA",
+                accessKey("acctA") to "A-access",
+                refreshKeyOf("acctA") to "A-refresh",
+            ),
+        )
+        // Mid add-account: B's fresh pair is staged, the live cache now holds B's token.
+        store.setTokens(accessToken = "B-access", refreshToken = "B-refresh")
+        assertThat(store.getAccessToken()).isEqualTo("B-access")
+
+        // A's in-flight requests still read A's own keyed token — the barrier's keyed bearer path.
+        assertThat(store.getAccessTokenFor("acctA")).isEqualTo("A-access")
+        // And an account with no slot yields null, never the staged cache.
+        assertThat(store.getAccessTokenFor("acctC")).isNull()
+    }
+
+    @Test
+    fun `selectAccount switches to an already-keyed account without writing or deleting tokens`() = runTest {
+        val store = FakeKeyedStore(
+            noRefresh,
+            seed = mapOf(
+                "active_account_id" to "acctA",
+                accessKey("acctA") to "A-access",
+                refreshKeyOf("acctA") to "A-refresh",
+                accessKey("acctB") to "B-access",
+                refreshKeyOf("acctB") to "B-refresh",
+            ),
+        )
+
+        store.selectAccount("acctB")
+
+        assertThat(store.store["active_account_id"]).isEqualTo("acctB")
+        assertThat(store.getAccessToken()).isEqualTo("B-access")
+        // Neither slot is written or deleted; no bare staging keys appear.
+        assertThat(store.store[accessKey("acctA")]).isEqualTo("A-access")
+        assertThat(store.store[refreshKeyOf("acctA")]).isEqualTo("A-refresh")
+        assertThat(store.store[accessKey("acctB")]).isEqualTo("B-access")
+        assertThat(store.store).doesNotContainKey("access_token")
+
+        // Switch back is cold-free.
+        store.selectAccount("acctA")
+        assertThat(store.getAccessToken()).isEqualTo("A-access")
+    }
+
+    @Test
+    fun `removeAccount drops a non-active account and leaves the active one untouched`() = runTest {
+        val store = FakeKeyedStore(
+            noRefresh,
+            seed = mapOf(
+                "active_account_id" to "acctA",
+                accessKey("acctA") to "A-access",
+                refreshKeyOf("acctA") to "A-refresh",
+                accessKey("acctB") to "B-access",
+                refreshKeyOf("acctB") to "B-refresh",
+            ),
+        )
+
+        store.removeAccount("acctB")
+
+        assertThat(store.store).doesNotContainKey(accessKey("acctB"))
+        assertThat(store.store).doesNotContainKey(refreshKeyOf("acctB"))
+        assertThat(store.store["active_account_id"]).isEqualTo("acctA")
+        assertThat(store.getAccessToken()).isEqualTo("A-access")
+    }
+
+    @Test
+    fun `removeAccount of the active account clears the mirror and cached bearer`() = runTest {
+        val store = FakeKeyedStore(
+            noRefresh,
+            seed = mapOf(
+                "active_account_id" to "acctA",
+                accessKey("acctA") to "A-access",
+                refreshKeyOf("acctA") to "A-refresh",
+            ),
+        )
+
+        store.removeAccount("acctA")
+
+        assertThat(store.store).doesNotContainKey(accessKey("acctA"))
+        assertThat(store.store).doesNotContainKey("active_account_id")
+        assertThat(store.getAccessToken()).isNull()
+    }
+
+    @Test
+    fun `getAccessTokenFor reads a non-active account's keyed slot`() = runTest {
+        val store = FakeKeyedStore(
+            noRefresh,
+            seed = mapOf(
+                "active_account_id" to "acctA",
+                accessKey("acctA") to "A-access",
+                accessKey("acctB") to "B-access",
+            ),
+        )
+
+        assertThat(store.getAccessTokenFor("acctB")).isEqualTo("B-access")
+        assertThat(store.getAccessTokenFor("acctA")).isEqualTo("A-access")
+        assertThat(store.getAccessTokenFor("acctC")).isNull()
+        // The active bearer is unchanged by the out-of-band reads.
+        assertThat(store.getAccessToken()).isEqualTo("A-access")
     }
 
     @Test
@@ -158,15 +316,70 @@ class CommonTokenDataStoreAccountKeyingTest {
     }
 
     @Test
-    fun `setTokens after resolve writes under the keyed slot`() = runTest {
+    fun `setTokens stages under the bare keys even when an account is active`() = runTest {
         val store = FakeKeyedStore(noRefresh)
         store.setTokens("bootstrap", "bootstrap-refresh")
         store.onAccountResolved("acctA")
 
+        // A re-auth (e.g. soft-expiry) stages under the bare keys, leaving acctA's keyed slot intact
+        // until the establish hook re-homes it.
         store.setTokens("A-access-2", "A-refresh-2")
 
+        assertThat(store.store["access_token"]).isEqualTo("A-access-2")
+        assertThat(store.store[accessKey("acctA")]).isEqualTo("bootstrap")
+        assertThat(store.getAccessToken()).isEqualTo("A-access-2")
+
+        // Re-home overwrites the account's slot with the freshly-staged pair.
+        store.onAccountResolved("acctA")
         assertThat(store.store[accessKey("acctA")]).isEqualTo("A-access-2")
         assertThat(store.store[refreshKeyOf("acctA")]).isEqualTo("A-refresh-2")
+        assertThat(store.store).doesNotContainKey("access_token")
+    }
+
+    @Test
+    fun `setTokens clears the persisted mirror so a staging-window cold start can't resurrect the previous account`() =
+        runTest {
+            val store = FakeKeyedStore(
+                noRefresh,
+                seed = mapOf(
+                    "active_account_id" to "acctA",
+                    accessKey("acctA") to "A-access",
+                    refreshKeyOf("acctA") to "A-refresh",
+                ),
+            )
+            // Soft-expiry re-auth as B stages under the bare keys. The mirror must NOT still point at
+            // A — otherwise a crash before onAccountResolved would cold-start back into A next launch.
+            store.setTokens("B-access", "B-refresh")
+
+            assertThat(store.store).doesNotContainKey("active_account_id")
+            assertThat(store.store["access_token"]).isEqualTo("B-access")
+            // A's keyed tokens are still retained for a later switch back.
+            assertThat(store.store[accessKey("acctA")]).isEqualTo("A-access")
+        }
+
+    @Test
+    fun `clearTokens fully tears down the active session including any leftover bare staging keys`() = runTest {
+        val store = FakeKeyedStore(
+            noRefresh,
+            seed = mapOf(
+                "active_account_id" to "acctA",
+                accessKey("acctA") to "A-access",
+                refreshKeyOf("acctA") to "A-refresh",
+                // A stale staged pair left behind by an abandoned/killed login.
+                "access_token" to "orphan-access",
+                "refresh_token" to "orphan-refresh",
+            ),
+        )
+
+        store.clearTokens()
+
+        assertThat(store.store).doesNotContainKey(accessKey("acctA"))
+        assertThat(store.store).doesNotContainKey(refreshKeyOf("acctA"))
+        assertThat(store.store).doesNotContainKey("active_account_id")
+        // The orphaned staging pair is purged too, so it can't cold-start a phantom session.
+        assertThat(store.store).doesNotContainKey("access_token")
+        assertThat(store.store).doesNotContainKey("refresh_token")
+        assertThat(store.getAccessToken()).isNull()
     }
 
     @Test
@@ -201,5 +414,83 @@ class CommonTokenDataStoreAccountKeyingTest {
         assertThat(ok).isTrue()
         assertThat(store.store[accessKey("acctA")]).isEqualTo("A-access-refreshed")
         assertThat(store.getAccessToken()).isEqualTo("A-access-refreshed")
+    }
+
+    @Test
+    fun `refreshAccessTokenFor posts to the pinned base url and writes that account's slot`() = runTest {
+        var requestedUrl: String? = null
+        val engine = MockEngine { request ->
+            requestedUrl = request.url.toString()
+            respond(
+                content = """{"token":"B-access-refreshed","user":null}""",
+                status = HttpStatusCode.OK,
+                headers = headersOf("Content-Type", listOf("application/json")),
+            )
+        }
+        val refreshClient = lazy {
+            HttpClient(engine) {
+                install(ContentNegotiation) { json() }
+                // The client's default host is A's server; the pinned URL must win so B's refresh
+                // token is never sent to A's host.
+                defaultRequest {
+                    url("https://a.example.com")
+                    contentType(ContentType.Application.Json)
+                }
+            }
+        }
+        val store = FakeKeyedStore(
+            refreshClient,
+            seed = mapOf(
+                "active_account_id" to "acctA",
+                accessKey("acctA") to "A-access",
+                refreshKeyOf("acctA") to "A-refresh",
+                accessKey("acctB") to "B-access",
+                refreshKeyOf("acctB") to "B-refresh",
+            ),
+        )
+
+        val ok = store.refreshAccessTokenFor("acctB", "https://b.example.com")
+
+        assertThat(ok).isTrue()
+        assertThat(requestedUrl).startsWith("https://b.example.com/api/auth/refresh")
+        assertThat(store.store[accessKey("acctB")]).isEqualTo("B-access-refreshed")
+        // acctB is not the active account, so the cached bearer (A's) is untouched.
+        assertThat(store.getAccessToken()).isEqualTo("A-access")
+    }
+
+    @Test
+    fun `session expiry scoped to the active account emits`() = runTest {
+        val store = FakeKeyedStore(
+            noRefresh,
+            seed = mapOf("active_account_id" to "acctA", accessKey("acctA") to "A-access"),
+        )
+        var emissions = 0
+        val job = backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            store.sessionExpiredFlow.collect { emissions++ }
+        }
+
+        store.emitSessionExpired("acctA")
+        store.emitSessionExpired() // unscoped (legacy/active) always emits
+
+        assertThat(emissions).isEqualTo(2)
+        job.cancel()
+    }
+
+    @Test
+    fun `session expiry for a non-active account is suppressed`() = runTest {
+        val store = FakeKeyedStore(
+            noRefresh,
+            seed = mapOf("active_account_id" to "acctA", accessKey("acctA") to "A-access"),
+        )
+        var emissions = 0
+        val job = backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            store.sessionExpiredFlow.collect { emissions++ }
+        }
+
+        // A switched-away account's straggler failure must not tear down the live session.
+        store.emitSessionExpired("acctB")
+
+        assertThat(emissions).isEqualTo(0)
+        job.cancel()
     }
 }

--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/datastore/CommonTokenDataStoreConcurrencyTest.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/datastore/CommonTokenDataStoreConcurrencyTest.kt
@@ -104,7 +104,7 @@ class CommonTokenDataStoreConcurrencyTest {
     private val jsonHeaders = headersOf("Content-Type", ContentType.Application.Json.toString())
 
     @Test
-    fun `clearTokens blocks until in-flight refresh releases the mutex`() =
+    fun `clearTokens does not block on an in-flight refresh and the refresh discards its result`() =
         runTest(UnconfinedTestDispatcher()) {
             val release = CompletableDeferred<Unit>()
             val engine = mockEngine {
@@ -118,9 +118,8 @@ class CommonTokenDataStoreConcurrencyTest {
             val store = FakeTokenDataStore(mockRefreshClient(engine))
 
             val refreshJob = async { store.refreshAccessToken() }
-            // Give the refresh coroutine a chance to acquire the mutex and
-            // suspend inside the MockEngine's release.await() before we start
-            // the concurrent clear.
+            // Give the refresh coroutine a chance to read the stored token and suspend inside the
+            // MockEngine's release.await() (the network POST) before we start the concurrent clear.
             yield()
             advanceUntilIdle()
 
@@ -128,18 +127,18 @@ class CommonTokenDataStoreConcurrencyTest {
             yield()
             advanceUntilIdle()
 
-            // Clear must still be suspended on the mutex while refresh waits on HTTP.
+            // The POST no longer holds a lock, so clear runs to completion immediately while the
+            // refresh is still parked on HTTP — a switch/logout never stalls behind a slow refresh.
             assertThat(refreshJob.isCompleted).isFalse()
-            assertThat(clearJob.isCompleted).isFalse()
-            assertThat(store.removeCount).isEqualTo(0)
+            assertThat(clearJob.isCompleted).isTrue()
+            assertThat(store.removeCount).isEqualTo(1)
 
             release.complete(Unit)
             advanceUntilIdle()
 
-            // Refresh completes and transiently writes the new token, but the
-            // queued clearTokens immediately wipes it. Final state: logged out.
-            assertThat(refreshJob.await()).isTrue()
-            assertThat(clearJob.isCompleted).isTrue()
+            // The refresh detects the epoch bump from clearTokens and discards its result (returns
+            // false), so it can never resurrect the cleared session. Final state: logged out.
+            assertThat(refreshJob.await()).isFalse()
             assertThat(store.persistedAccess()).isNull()
             assertThat(store.persistedRefresh()).isNull()
             assertThat(store.removeCount).isEqualTo(1)

--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/di/DataModuleVerificationTest.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/di/DataModuleVerificationTest.kt
@@ -32,6 +32,7 @@ import com.garfiec.librechat.core.network.api.SkillsApi
 import com.garfiec.librechat.core.network.api.SpeechApi
 import com.garfiec.librechat.core.network.api.TagsApi
 import com.garfiec.librechat.core.network.api.UserApi
+import com.garfiec.librechat.core.network.client.SwitchGate
 import com.garfiec.librechat.core.network.sse.SseClient
 import io.ktor.client.HttpClient
 import kotlinx.coroutines.CoroutineDispatcher
@@ -83,6 +84,8 @@ class DataModuleVerificationTest {
                 SpeechApi::class,
                 BannerApi::class,
                 DataStore::class,
+                // AccountSwitcher pulls the switch barrier from :core:network (cross-module).
+                SwitchGate::class,
             ),
         )
     }

--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/repository/AccountSessionEstablisherTest.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/repository/AccountSessionEstablisherTest.kt
@@ -46,7 +46,7 @@ class AccountSessionEstablisherTest {
 
         coVerifyOrder {
             claimReconciler.claimIfNeeded(any(), "mongoUserId")
-            accountRegistry.setActiveAccount(any())
+            accountRegistry.upsertActive(any())
         }
     }
 
@@ -64,7 +64,7 @@ class AccountSessionEstablisherTest {
 
         establisher.establish(user)
 
-        coVerify { accountRegistry.setActiveAccount(any()) }
+        coVerify { accountRegistry.upsertActive(any()) }
     }
 
     /**
@@ -82,7 +82,7 @@ class AccountSessionEstablisherTest {
 
         coVerifyOrder {
             tokenManager.onAccountResolved(accountId.value)
-            accountRegistry.setActiveAccount(any())
+            accountRegistry.upsertActive(any())
         }
     }
 }

--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/repository/AccountSwitcherAddTest.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/repository/AccountSwitcherAddTest.kt
@@ -1,0 +1,177 @@
+package com.garfiec.librechat.core.data.repository
+
+import com.garfiec.librechat.core.common.identity.AccountState
+import com.garfiec.librechat.core.common.identity.AccountState.Resolved
+import com.garfiec.librechat.core.common.identity.deriveAccountId
+import com.garfiec.librechat.core.common.identity.deriveServerId
+import com.garfiec.librechat.core.data.datastore.AccountRoster
+import com.garfiec.librechat.core.model.User
+import com.google.common.truth.Truth.assertThat
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.IOException
+import kotlin.test.assertFailsWith
+
+/**
+ * Behavior tests for [AccountSwitcher]'s add-account flow: staging hygiene at begin, the atomic
+ * URL+token+roster+identity completion (derived from the *pending* URL, never the live one),
+ * rollback on a failed completion, and cancel restoring the outgoing account's binding.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class AccountSwitcherAddTest {
+
+    @get:Rule
+    val tmpFolder = TemporaryFolder()
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private val json = Json { ignoreUnknownKeys = true }
+
+    private val serverA = "https://a.example.com"
+    private val serverB = "https://b.example.com"
+    private val accountA = deriveAccountId(deriveServerId(serverA), "user-a")
+    private val accountB = deriveAccountId(deriveServerId(serverB), "user-b")
+
+    private fun harness(
+        initialState: AccountState = Resolved(accountA),
+        roster: AccountRoster? = null,
+    ) = SwitcherHarness(tmpFolder.root, testDispatcher, json, initialState, roster)
+
+    private fun userB() = User(id = "user-b", name = "Bea", email = "bea@example.com")
+
+    @Test
+    fun `beginAdd requires a resolved active account`() = runTest(testDispatcher) {
+        val h = harness(initialState = AccountState.Warming)
+
+        assertFailsWith<IllegalStateException> { h.switcher.beginAdd(serverB) }
+    }
+
+    @Test
+    fun `beginAdd purges stale staging and rebinds the active account`() = runTest(testDispatcher) {
+        val h = harness()
+        h.tokenManager.stagedAccess = "stale-abandoned-login" // an earlier killed sign-in
+
+        val session = h.switcher.beginAdd("$serverB/")
+
+        assertThat(h.tokenManager.stagedAccess).isNull()
+        assertThat(h.tokenManager.selections).containsExactly(accountA.value)
+        assertThat(session.serverUrl).isEqualTo(serverB)
+        assertThat(h.switcher.pendingAdd).isSameInstanceAs(session)
+    }
+
+    @Test
+    fun `completeAdd derives from the pending URL and flips url+token+roster+identity`() =
+        runTest(testDispatcher) {
+            val h = harness()
+            h.serverDataStore.setServerUrl(serverA)
+            h.switcher.beginAdd(serverB)
+            h.tokenManager.setTokens("b-access", "b-refresh") // the flow's sign-in staged B
+
+            val added = h.switcher.completeAdd(userB())
+
+            // Identity derives from the server being ADDED, not the still-live outgoing URL.
+            assertThat(added).isEqualTo(accountB)
+            assertThat(h.serverDataStore.getBaseUrl()).isEqualTo(serverB)
+            assertThat(h.tokenManager.resolvedAccount).isEqualTo(accountB.value)
+            val snapshot = h.roster.snapshot()
+            assertThat(snapshot.activeId).isEqualTo(accountB.value)
+            assertThat(snapshot.entries.single().displayLabel).isEqualTo("Bea")
+            assertThat(h.provider.state.value).isEqualTo(Resolved(accountB))
+            assertThat(h.switcher.pendingAdd).isNull()
+        }
+
+    @Test
+    fun `completeAdd replaces the entry when the account is already in the roster`() =
+        runTest(testDispatcher) {
+            val h = harness()
+            h.roster.upsertAndActivate(
+                com.garfiec.librechat.core.data.datastore.AccountEntry(
+                    accountId = accountB.value,
+                    serverUrl = serverB,
+                    displayLabel = "Old Label",
+                    avatarUrl = null,
+                    lastActiveAt = 1L,
+                ),
+            )
+            h.switcher.beginAdd(serverB)
+
+            h.switcher.completeAdd(userB())
+
+            // Re-adding = switch-with-fresh-login: one entry, refreshed fields, no duplicate.
+            val entries = h.roster.snapshot().entries.filter { it.accountId == accountB.value }
+            assertThat(entries).hasSize(1)
+            assertThat(entries.single().displayLabel).isEqualTo("Bea")
+        }
+
+    @Test
+    fun `completeAdd rolls back the URL and token binding when the flip fails`() =
+        runTest(testDispatcher) {
+            val failingRoster = mockk<AccountRoster>()
+            coEvery { failingRoster.upsertAndActivate(any()) } throws IOException("disk full")
+            val h = harness(roster = failingRoster)
+            h.serverDataStore.setServerUrl(serverA)
+            h.switcher.beginAdd(serverB)
+            h.tokenManager.setTokens("b-access", "b-refresh")
+
+            assertFailsWith<IOException> { h.switcher.completeAdd(userB()) }
+
+            // The half-applied flip was undone: URL back to A, binding re-selected to A, identity
+            // never published, and the pending session retained for a retry/cancel.
+            assertThat(h.serverDataStore.getBaseUrl()).isEqualTo(serverA)
+            assertThat(h.tokenManager.selections.last()).isEqualTo(accountA.value)
+            assertThat(h.provider.state.value).isEqualTo(Resolved(accountA))
+            assertThat(h.switcher.pendingAdd).isNotNull()
+        }
+
+    @Test
+    fun `cancelAdd drops the staged tokens and rebinds the active account`() = runTest(testDispatcher) {
+        val h = harness()
+        h.switcher.beginAdd(serverB)
+        h.tokenManager.setTokens("b-access", "b-refresh")
+
+        h.switcher.cancelAdd()
+
+        assertThat(h.tokenManager.stagedAccess).isNull()
+        assertThat(h.tokenManager.selections.last()).isEqualTo(accountA.value)
+        assertThat(h.switcher.pendingAdd).isNull()
+    }
+
+    @Test
+    fun `attachPendingConfig rides on the pending session and no-ops after cancel`() =
+        runTest(testDispatcher) {
+            val h = harness()
+            val session = h.switcher.beginAdd(serverB)
+            val config = com.garfiec.librechat.core.model.config.StartupConfig(serverDomain = serverB)
+
+            h.switcher.attachPendingConfig(config)
+            assertThat(session.startupConfig.value).isEqualTo(config)
+
+            h.switcher.cancelAdd()
+            h.switcher.attachPendingConfig(config.copy(serverDomain = "other"))
+            // The cancelled session keeps whatever it had; nothing new is attached anywhere.
+            assertThat(session.startupConfig.value).isEqualTo(config)
+        }
+
+    @Test
+    fun `pending request identity serves the staged bearer once sign-in stages it`() =
+        runTest(testDispatcher) {
+            val h = harness()
+            val session = h.switcher.beginAdd(serverB)
+
+            // Before the sign-in call: no bearer (config validation / the login POST itself).
+            assertThat(session.requestIdentity.identity().bearer).isNull()
+
+            h.tokenManager.setTokens("b-access", "b-refresh")
+            val identity = session.requestIdentity.identity()
+            assertThat(identity.bearer).isEqualTo("b-access")
+            assertThat(identity.baseUrl).isEqualTo(serverB)
+            assertThat(identity.accountId).isNull()
+            assertThat(identity.isPending).isTrue()
+        }
+}

--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/repository/AccountSwitcherRemoveTest.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/repository/AccountSwitcherRemoveTest.kt
@@ -1,0 +1,142 @@
+package com.garfiec.librechat.core.data.repository
+
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import com.garfiec.librechat.core.common.identity.AccountId
+import com.garfiec.librechat.core.common.identity.AccountState
+import com.garfiec.librechat.core.common.identity.AccountState.Resolved
+import com.garfiec.librechat.core.common.identity.deriveAccountId
+import com.garfiec.librechat.core.common.identity.deriveServerId
+import com.garfiec.librechat.core.data.datastore.AccountEntry
+import com.google.common.truth.Truth.assertThat
+import io.mockk.coVerify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * Behavior tests for [AccountSwitcher.remove]: full teardown of one account (roster + tokens +
+ * scoped prefs + Room purge), the flip-away-first ordering when the removed account is active
+ * (switch to the most-recently-active survivor, or logout-shaped teardown + session-expired signal
+ * when it was the last), and the no-op guard for unknown accounts.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class AccountSwitcherRemoveTest {
+
+    @get:Rule
+    val tmpFolder = TemporaryFolder()
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private val json = Json { ignoreUnknownKeys = true }
+
+    private val serverA = "https://a.example.com"
+    private val serverB = "https://b.example.com"
+    private val accountA = deriveAccountId(deriveServerId(serverA), "user-a")
+    private val accountB = deriveAccountId(deriveServerId(serverB), "user-b")
+
+    private fun entry(accountId: AccountId, serverUrl: String, lastActiveAt: Long) = AccountEntry(
+        accountId = accountId.value,
+        serverUrl = serverUrl,
+        displayLabel = accountId.value,
+        avatarUrl = null,
+        lastActiveAt = lastActiveAt,
+    )
+
+    private fun harness(initialState: AccountState = Resolved(accountA)) =
+        SwitcherHarness(tmpFolder.root, testDispatcher, json, initialState)
+
+    private fun scopedPrefKey(accountId: AccountId) =
+        stringPreferencesKey("acct:${accountId.value}:last_used_model")
+
+    @Test
+    fun `removing a non-active account purges its slots and leaves the active one untouched`() =
+        runTest(testDispatcher) {
+            val h = harness()
+            h.roster.upsertAndActivate(entry(accountB, serverB, lastActiveAt = 1L))
+            h.roster.upsertAndActivate(entry(accountA, serverA, lastActiveAt = 2L))
+            h.serverDataStore.setServerUrl(serverA)
+            h.dataStore.edit { prefs ->
+                prefs[scopedPrefKey(accountA)] = "model-a"
+                prefs[scopedPrefKey(accountB)] = "model-b"
+            }
+
+            h.switcher.remove(accountB.value)
+
+            val snapshot = h.roster.snapshot()
+            assertThat(snapshot.entries.map { it.accountId }).containsExactly(accountA.value)
+            assertThat(snapshot.activeId).isEqualTo(accountA.value)
+            assertThat(h.tokenManager.removedAccounts).containsExactly(accountB.value)
+            coVerify(exactly = 1) { h.dataPurger.purge(accountB) }
+            val prefs = h.dataStore.data.first()
+            assertThat(prefs[scopedPrefKey(accountB)]).isNull()
+            assertThat(prefs[scopedPrefKey(accountA)]).isEqualTo("model-a")
+            // The active account never flipped, so no switch-cache clear and no expiry signal.
+            assertThat(h.provider.state.value).isEqualTo(Resolved(accountA))
+            assertThat(h.switchCacheCleaner.clearCount).isEqualTo(0)
+            assertThat(h.tokenManager.expiredEmissions).isEmpty()
+        }
+
+    @Test
+    fun `removing the active account switches to the most recently active survivor first`() =
+        runTest(testDispatcher) {
+            val h = harness()
+            val accountC = deriveAccountId(deriveServerId(serverB), "user-c")
+            h.roster.upsertAndActivate(entry(accountC, serverB, lastActiveAt = 5L))
+            h.roster.upsertAndActivate(entry(accountB, serverB, lastActiveAt = 10L))
+            h.roster.upsertAndActivate(entry(accountA, serverA, lastActiveAt = 20L))
+            h.serverDataStore.setServerUrl(serverA)
+
+            h.switcher.remove(accountA.value)
+
+            // B (lastActiveAt=10) outranks C (5): full switch to B before A's teardown.
+            assertThat(h.serverDataStore.getBaseUrl()).isEqualTo(serverB)
+            assertThat(h.tokenManager.selections).containsExactly(accountB.value)
+            assertThat(h.provider.state.value).isEqualTo(Resolved(accountB))
+            assertThat(h.switchCacheCleaner.clearCount).isEqualTo(1)
+            val snapshot = h.roster.snapshot()
+            assertThat(snapshot.activeId).isEqualTo(accountB.value)
+            assertThat(snapshot.entries.map { it.accountId })
+                .containsExactly(accountB.value, accountC.value)
+            assertThat(h.tokenManager.removedAccounts).containsExactly(accountA.value)
+            coVerify(exactly = 1) { h.dataPurger.purge(accountA) }
+            assertThat(h.tokenManager.expiredEmissions).isEmpty()
+        }
+
+    @Test
+    fun `removing the last account tears down to logged-out and signals session expiry`() =
+        runTest(testDispatcher) {
+            val h = harness()
+            h.roster.upsertAndActivate(entry(accountA, serverA, lastActiveAt = 1L))
+            h.serverDataStore.setServerUrl(serverA)
+
+            h.switcher.remove(accountA.value)
+
+            assertThat(h.provider.state.value).isEqualTo(Resolved(null))
+            assertThat(h.tokenManager.clearedActive).isTrue()
+            assertThat(h.switchCacheCleaner.clearCount).isEqualTo(1)
+            assertThat(h.sessionCacheCleaner.fileClearCount).isEqualTo(1)
+            assertThat(h.roster.snapshot().entries).isEmpty()
+            assertThat(h.tokenManager.expiredEmissions).containsExactly(null)
+            coVerify(exactly = 1) { h.dataPurger.purge(accountA) }
+            // The URL is deliberately retained (logout parity) so the login screen comes back prefilled.
+            assertThat(h.serverDataStore.getBaseUrl()).isEqualTo(serverA)
+        }
+
+    @Test
+    fun `removing an unknown account is a no-op`() = runTest(testDispatcher) {
+        val h = harness()
+        h.roster.upsertAndActivate(entry(accountA, serverA, lastActiveAt = 1L))
+
+        h.switcher.remove("srv-x:nobody")
+
+        assertThat(h.roster.snapshot().entries).hasSize(1)
+        assertThat(h.tokenManager.removedAccounts).isEmpty()
+        coVerify(exactly = 0) { h.dataPurger.purge(any()) }
+        assertThat(h.provider.state.value).isEqualTo(Resolved(accountA))
+    }
+}

--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/repository/AccountSwitcherTestHarness.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/repository/AccountSwitcherTestHarness.kt
@@ -1,0 +1,109 @@
+package com.garfiec.librechat.core.data.repository
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import com.garfiec.librechat.core.common.identity.AccountState
+import com.garfiec.librechat.core.common.identity.InMemoryActiveAccountProvider
+import com.garfiec.librechat.core.data.datastore.AccountRoster
+import com.garfiec.librechat.core.data.datastore.AccountScopedPrefsPurger
+import com.garfiec.librechat.core.data.datastore.ServerDataStore
+import com.garfiec.librechat.core.network.client.SwitchGate
+import com.garfiec.librechat.core.network.client.TokenManager
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.serialization.json.Json
+import java.io.File
+
+/** Records the staging/binding/removal operations the switch/add/remove flows drive; everything
+ *  else is inert. Shared by the [AccountSwitcher] behavior tests. */
+internal class RecordingTokenManager : TokenManager {
+    var stagedAccess: String? = null
+    var resolvedAccount: String? = null
+    var clearedActive = false
+    val selections = mutableListOf<String>()
+    val removedAccounts = mutableListOf<String>()
+    val expiredEmissions = mutableListOf<String?>()
+
+    override val isAuthenticated: Boolean = true
+    override suspend fun getAccessToken(): String? = null
+    override suspend fun setTokens(accessToken: String, refreshToken: String) {
+        stagedAccess = accessToken
+    }
+    override suspend fun refreshAccessToken(): Boolean = false
+    override suspend fun clearTokens() {}
+    override suspend fun getAccessTokenFor(accountId: String): String? = null
+    override suspend fun getStagedAccessToken(): String? = stagedAccess
+    override suspend fun clearStagedTokens() {
+        stagedAccess = null
+    }
+    override suspend fun selectAccount(accountId: String) {
+        selections += accountId
+    }
+    override suspend fun removeAccount(accountId: String) {
+        removedAccounts += accountId
+    }
+    override suspend fun refreshAccessTokenFor(accountId: String, baseUrl: String): Boolean = false
+    override suspend fun onAccountResolved(accountId: String) {
+        resolvedAccount = accountId
+        stagedAccess = null
+    }
+    override suspend fun onAccountCleared() {
+        clearedActive = true
+    }
+    override fun emitSessionExpired(expiredAccountId: String?) {
+        expiredEmissions += expiredAccountId
+    }
+    override val sessionExpiredFlow: SharedFlow<Unit> = MutableSharedFlow()
+}
+
+internal class RecordingSwitchCacheCleaner : SwitchCacheCleaner {
+    var clearCount = 0
+    override suspend fun clearOnSwitch() {
+        clearCount++
+    }
+}
+
+internal class RecordingSessionCacheCleaner : SessionCacheCleaner {
+    var fileClearCount = 0
+    override fun clearFileCaches() {
+        fileClearCount++
+    }
+}
+
+/** Real roster/server/prefs stores over a tmp DataStore file + recording fakes, wired into a real
+ *  [AccountSwitcher] under a real [SwitchGate]. */
+internal class SwitcherHarness(
+    tmp: File,
+    dispatcher: TestDispatcher,
+    json: Json,
+    initialState: AccountState,
+    rosterOverride: AccountRoster? = null,
+) {
+    val dataStore: DataStore<Preferences> =
+        PreferenceDataStoreFactory.create { File(tmp, "switcher.preferences_pb") }
+    val roster = rosterOverride ?: AccountRoster(dataStore, json)
+    val serverDataStore = ServerDataStore(dataStore, CoroutineScope(dispatcher), dispatcher, null)
+    val tokenManager = RecordingTokenManager()
+    val provider = InMemoryActiveAccountProvider(initialState)
+    val claimReconciler = mockk<AccountClaimReconciler>(relaxed = true)
+    val switchCacheCleaner = RecordingSwitchCacheCleaner()
+    val dataPurger = mockk<AccountDataPurger>(relaxed = true)
+    val prefsPurger = AccountScopedPrefsPurger(dataStore)
+    val sessionCacheCleaner = RecordingSessionCacheCleaner()
+    val switcher = AccountSwitcher(
+        roster = roster,
+        serverDataStore = serverDataStore,
+        tokenManager = tokenManager,
+        activeAccountProvider = provider,
+        switchGate = SwitchGate(provider, serverDataStore, tokenManager, accountReadyGate = null),
+        claimReconciler = claimReconciler,
+        switchCacheCleaner = switchCacheCleaner,
+        accountDataPurger = dataPurger,
+        prefsPurger = prefsPurger,
+        sessionCacheCleaner = sessionCacheCleaner,
+    )
+}

--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/repository/ConfigRepositoryImplTest.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/repository/ConfigRepositoryImplTest.kt
@@ -1,0 +1,107 @@
+package com.garfiec.librechat.core.data.repository
+
+import com.garfiec.librechat.core.common.result.Result
+import com.garfiec.librechat.core.data.datastore.ConfigCacheDataStore
+import com.garfiec.librechat.core.model.EndpointConfig
+import com.garfiec.librechat.core.model.config.StartupConfig
+import com.garfiec.librechat.core.network.api.ConfigApi
+import com.google.common.truth.Truth.assertThat
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+/**
+ * The probe/reload seams added for multi-account (issue #179): validation for a server being ADDED
+ * must not leak into the live server's config state or cache, and a switch must reseed the
+ * in-memory state from the incoming server's cache.
+ */
+class ConfigRepositoryImplTest {
+
+    private val configApi = mockk<ConfigApi>()
+    private val configCache = mockk<ConfigCacheDataStore>(relaxed = true)
+
+    private fun repository() = ConfigRepositoryImpl(
+        configApi = configApi,
+        configCache = configCache,
+        dispatcher = UnconfinedTestDispatcher(),
+    )
+
+    private val validConfig = StartupConfig(serverDomain = "https://b.example.com")
+
+    @Test
+    fun `probeServerUrl validates without publishing in-memory state or writing the cache`() = runTest {
+        coEvery { configApi.getStartupConfig() } returns validConfig
+        val repo = repository()
+
+        val result = repo.probeServerUrl()
+
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+        // The live session's config must be untouched: an add-mode probe runs while another
+        // account is active, and the cache key would derive from the LIVE url (poisoning it).
+        assertThat(repo.startupConfig.value).isNull()
+        coVerify(exactly = 0) { configCache.saveStartupConfig(any()) }
+    }
+
+    @Test
+    fun `probeServerUrl rejects a non-LibreChat response`() = runTest {
+        coEvery { configApi.getStartupConfig() } returns StartupConfig(serverDomain = "")
+        val repo = repository()
+
+        val result = repo.probeServerUrl()
+
+        assertThat(result).isInstanceOf(Result.Error::class.java)
+        assertThat((result as Result.Error).message).contains("LibreChat")
+    }
+
+    @Test
+    fun `validateServerUrl still publishes and caches`() = runTest {
+        coEvery { configApi.getStartupConfig() } returns validConfig
+        val repo = repository()
+
+        val result = repo.validateServerUrl("https://b.example.com")
+
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+        assertThat(repo.startupConfig.value).isEqualTo(validConfig)
+        coVerify(exactly = 1) { configCache.saveStartupConfig(validConfig) }
+    }
+
+    @Test
+    fun `reloadForActiveServer replaces in-memory state from the cache without network`() = runTest {
+        coEvery { configApi.getStartupConfig() } returns validConfig
+        val repo = repository()
+        repo.validateServerUrl("https://a.example.com") // in-memory now holds the outgoing server
+
+        val incoming = StartupConfig(serverDomain = "https://b.example.com", version = "9.9.9")
+        val incomingEndpoints = mapOf("openAI" to EndpointConfig())
+        coEvery { configCache.loadStartupConfig() } returns incoming
+        coEvery { configCache.loadEndpointConfigs() } returns incomingEndpoints
+        coEvery { configCache.loadAvailableModels() } returns null
+
+        repo.reloadForActiveServer()
+
+        assertThat(repo.startupConfig.value).isEqualTo(incoming)
+        assertThat(repo.endpointConfigs.value).isEqualTo(incomingEndpoints)
+        assertThat(repo.availableModels.value).isEmpty()
+        assertThat(repo.detectedBackendVersion.value).isNull() // re-detected on the next check
+    }
+
+    @Test
+    fun `reloadForActiveServer empties state when the incoming server has no cache`() = runTest {
+        coEvery { configApi.getStartupConfig() } returns validConfig
+        val repo = repository()
+        repo.validateServerUrl("https://a.example.com")
+
+        coEvery { configCache.loadStartupConfig() } returns null
+        coEvery { configCache.loadEndpointConfigs() } returns null
+        coEvery { configCache.loadAvailableModels() } returns null
+
+        repo.reloadForActiveServer()
+
+        assertThat(repo.startupConfig.value).isNull()
+        assertThat(repo.endpointConfigs.value).isEmpty()
+        assertThat(repo.availableModels.value).isEmpty()
+    }
+}

--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/repository/ConversationRepositoryImplTest.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/repository/ConversationRepositoryImplTest.kt
@@ -4,6 +4,7 @@ import com.garfiec.librechat.core.common.identity.AccountId
 import com.garfiec.librechat.core.common.identity.AccountState
 import com.garfiec.librechat.core.common.identity.InMemoryActiveAccountProvider
 import com.garfiec.librechat.core.common.result.Result
+import com.garfiec.librechat.core.data.datastore.AccountRoster
 import com.garfiec.librechat.core.data.db.dao.ConversationDao
 import com.garfiec.librechat.core.data.db.entity.ConversationEntity
 import com.garfiec.librechat.core.model.Conversation
@@ -29,6 +30,7 @@ class ConversationRepositoryImplTest {
 
     private val conversationsApi = mockk<ConversationsApi>(relaxed = true)
     private val conversationDao = mockk<ConversationDao>(relaxed = true)
+    private val roster = mockk<AccountRoster>(relaxed = true)
     private val json = Json { ignoreUnknownKeys = true }
     private val account = AccountId("srv:user-1")
     private val activeAccountProvider = InMemoryActiveAccountProvider(AccountState.Resolved(account))
@@ -41,6 +43,7 @@ class ConversationRepositoryImplTest {
             conversationsApi = conversationsApi,
             conversationDao = conversationDao,
             activeAccountProvider = activeAccountProvider,
+            roster = roster,
             json = json,
         )
     }
@@ -87,7 +90,7 @@ class ConversationRepositoryImplTest {
         val captured = slot<ConversationEntity>()
         coEvery { conversationDao.upsertPreservingTags(account.value, capture(captured)) } answers {}
 
-        repository.saveConversation(streamingConvo)
+        repository.saveConversation(streamingConvo, originAccount = null)
 
         assertThat(captured.captured.conversationId).isEqualTo("convo-1")
         assertThat(captured.captured.title).isEqualTo("Updated mid-stream")
@@ -97,8 +100,35 @@ class ConversationRepositoryImplTest {
     fun `saveConversation no-op for blank conversationId`() = runTest {
         val blank = Conversation(conversationId = "", title = "Blank")
 
-        repository.saveConversation(blank)
+        repository.saveConversation(blank, originAccount = null)
 
+        coVerify(exactly = 0) { conversationDao.upsertPreservingTags(any(), any<ConversationEntity>()) }
+    }
+
+    @Test
+    fun `saveConversation stamps the captured origin account, not the live active one`() = runTest {
+        // The stream started under account A; the user has since switched so B is now active.
+        val origin = AccountId("srv:origin-A")
+        activeAccountProvider.set(AccountId("srv:active-B"))
+        coEvery { roster.contains(origin.value) } returns true // A is still a known account
+        val captured = slot<ConversationEntity>()
+        coEvery { conversationDao.upsertPreservingTags(origin.value, capture(captured)) } answers {}
+
+        repository.saveConversation(Conversation(conversationId = "c1", title = "A's reply"), originAccount = origin)
+
+        // Row is attributed to A (the origin), never to the live active B.
+        assertThat(captured.captured.accountId).isEqualTo(origin.value)
+        coVerify(exactly = 0) { conversationDao.upsertPreservingTags("srv:active-B", any<ConversationEntity>()) }
+    }
+
+    @Test
+    fun `saveConversation skips when the captured origin account was removed since capture`() = runTest {
+        val origin = AccountId("srv:removed-A")
+        coEvery { roster.contains(origin.value) } returns false // A was removed (logout / remove-account)
+
+        repository.saveConversation(Conversation(conversationId = "c1", title = "orphan"), originAccount = origin)
+
+        // Don't resurrect a removed account's purged rows.
         coVerify(exactly = 0) { conversationDao.upsertPreservingTags(any(), any<ConversationEntity>()) }
     }
 

--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/util/AccountLabelBackfillSessionTaskTest.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/util/AccountLabelBackfillSessionTaskTest.kt
@@ -1,0 +1,100 @@
+package com.garfiec.librechat.core.data.util
+
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import com.garfiec.librechat.core.common.identity.AccountState
+import com.garfiec.librechat.core.common.identity.InMemoryActiveAccountProvider
+import com.garfiec.librechat.core.common.identity.deriveAccountId
+import com.garfiec.librechat.core.common.identity.deriveServerId
+import com.garfiec.librechat.core.common.result.Result
+import com.garfiec.librechat.core.data.datastore.AccountEntry
+import com.garfiec.librechat.core.data.datastore.AccountRoster
+import com.garfiec.librechat.core.data.repository.UserRepository
+import com.garfiec.librechat.core.model.User
+import com.garfiec.librechat.core.network.client.ServerUrlProvider
+import com.google.common.truth.Truth.assertThat
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+class AccountLabelBackfillSessionTaskTest {
+
+    @get:Rule
+    val tmpFolder = TemporaryFolder()
+
+    private val serverUrl = "https://chat.example.com"
+    private val accountId = deriveAccountId(deriveServerId(serverUrl), "user-1")
+
+    private val userRepository = mockk<UserRepository>()
+    private val serverUrlProvider = mockk<ServerUrlProvider> {
+        coEvery { awaitBaseUrl() } returns serverUrl
+    }
+
+    private fun roster() = AccountRoster(
+        PreferenceDataStoreFactory.create { File(tmpFolder.root, "backfill.preferences_pb") },
+        Json { ignoreUnknownKeys = true },
+    )
+
+    @Test
+    fun `backfills the migrated host-fallback label from the live user`() = runTest {
+        val roster = roster()
+        roster.upsertAndActivate(
+            AccountEntry(
+                accountId = accountId.value,
+                serverUrl = serverUrl,
+                displayLabel = "chat.example.com", // migration seeded the host fallback
+                avatarUrl = null,
+                lastActiveAt = 1L,
+            ),
+        )
+        coEvery { userRepository.getUser() } returns
+            Result.Success(User(id = "user-1", name = "Alice", email = "alice@example.com", avatar = "https://a/p.png"))
+
+        AccountLabelBackfillSessionTask(
+            userRepository = userRepository,
+            accountRoster = roster,
+            activeAccountProvider = InMemoryActiveAccountProvider(AccountState.Resolved(accountId)),
+            serverUrlProvider = serverUrlProvider,
+        ).run()
+
+        val entry = roster.snapshot().activeEntry
+        assertThat(entry?.displayLabel).isEqualTo("Alice")
+        assertThat(entry?.avatarUrl).isEqualTo("https://a/p.png")
+    }
+
+    @Test
+    fun `skips when the account is unresolved or the user fetch fails`() = runTest {
+        val roster = roster()
+        roster.upsertAndActivate(
+            AccountEntry(
+                accountId = accountId.value,
+                serverUrl = serverUrl,
+                displayLabel = "chat.example.com",
+                avatarUrl = null,
+                lastActiveAt = 1L,
+            ),
+        )
+        coEvery { userRepository.getUser() } returns Result.Error(message = "offline")
+
+        // Unresolved account: getUser must not even matter.
+        AccountLabelBackfillSessionTask(
+            userRepository = userRepository,
+            accountRoster = roster,
+            activeAccountProvider = InMemoryActiveAccountProvider(AccountState.Warming),
+            serverUrlProvider = serverUrlProvider,
+        ).run()
+        // Resolved but the fetch failed: keep the fallback label.
+        AccountLabelBackfillSessionTask(
+            userRepository = userRepository,
+            accountRoster = roster,
+            activeAccountProvider = InMemoryActiveAccountProvider(AccountState.Resolved(accountId)),
+            serverUrlProvider = serverUrlProvider,
+        ).run()
+
+        assertThat(roster.snapshot().activeEntry?.displayLabel).isEqualTo("chat.example.com")
+    }
+}

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/AccountEntry.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/AccountEntry.kt
@@ -1,0 +1,35 @@
+package com.garfiec.librechat.core.data.datastore
+
+import kotlinx.serialization.Serializable
+
+/**
+ * One signed-in account in the persisted roster (multi-account, issue #179). Device-global metadata
+ * — it carries no tenant data, only what the switcher UI and the switch transition need:
+ *
+ * - [accountId] — the `serverId:userKey` identity; the roster key and the token/prefs scope prefix.
+ *   The `serverId` half is derivable from here (`accountId.substringBefore(':')`) so it is not stored.
+ * - [serverUrl] — the deployment's base URL. **The only place the `serverId → serverUrl` map lives**:
+ *   `serverId` is an irreversible hash, so a switch reads the target's URL from here to repoint the
+ *   network layer.
+ * - [displayLabel] / [avatarUrl] — what the switcher chip shows; seeded from the `User` payload at
+ *   login, or the server host as a fallback on the migration path (no `User` available then).
+ * - [lastActiveAt] — epoch millis of the last activation; drives "switch to most-recently-active" when
+ *   the active account is removed.
+ */
+@Serializable
+data class AccountEntry(
+    val accountId: String,
+    val serverUrl: String,
+    val displayLabel: String,
+    val avatarUrl: String? = null,
+    val lastActiveAt: Long,
+)
+
+/** A consistent read of the roster: its [entries] plus the [activeId] pointer. */
+data class RosterSnapshot(
+    val entries: List<AccountEntry>,
+    val activeId: String?,
+) {
+    /** The active entry, or null while logged out / when the pointer has no backing entry. */
+    val activeEntry: AccountEntry? get() = entries.firstOrNull { it.accountId == activeId }
+}

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/AccountRegistry.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/AccountRegistry.kt
@@ -1,55 +1,72 @@
 package com.garfiec.librechat.core.data.datastore
 
-import androidx.datastore.core.DataStore
-import androidx.datastore.preferences.core.Preferences
-import androidx.datastore.preferences.core.edit
-import androidx.datastore.preferences.core.stringPreferencesKey
 import com.garfiec.librechat.core.common.identity.AccountId
 import com.garfiec.librechat.core.common.identity.ActiveAccountProvider
-import com.garfiec.librechat.core.network.client.ServerUrlProvider
+import com.garfiec.librechat.core.network.client.AccountReadyGate
+import com.garfiec.librechat.core.network.client.TokenManager
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 
 /**
- * Device-global persistence of the **active account id**, and the cold-start seeder of
- * [ActiveAccountProvider].
+ * Owns the account **roster** cold-start seed and is the single [AccountReadyGate] every request /
+ * route waits on. Persistence itself lives in [AccountRoster]; this class orchestrates the seed.
  *
- * There is exactly one active account at a time. The id is the single persisted identity
- * fact (the leak persists because today *nothing* records who the cached rows belong to);
- * establishing it is the prerequisite the rest of row-tenancy builds on.
+ * There are three "active account" facts and they **cannot** be unified: the token store's
+ * synchronously-seeded secure-storage mirror (the fast bearer path), the durable roster active pointer,
+ * and the `serverId` derived from the persisted server URL. **The roster active pointer is the
+ * authority**; the mirror is a bearer-seed cache. At cold start this seed reconciles them:
  *
- * Cold start mirrors [ServerDataStore]'s async warm-up so Koin can instantiate this on Main without
- * blocking: it reads the persisted id off the IO dispatcher and resolves [ActiveAccountProvider] from
- * [AccountState.Warming] to the right [AccountState.Resolved]. The read **chains the URL warm-up**
- * — `awaitBaseUrl()` first — so identity never resolves before the server it belongs to is
- * known. A missing/blank id or any failure resolves to the logged-out state `Resolved(null)`, never
- * left [AccountState.Warming] and never failing open to a wrong account.
+ * 1. Read the persisted server URL (awaiting [ServerDataStore]'s own warm-up) — the migration input.
+ * 2. One-time migrate the pre-roster single-active pointer into a one-entry roster ([AccountRoster.migrateIfNeeded]).
+ * 3. Read the roster snapshot (authority).
+ * 4. If an active entry exists: **drive** the server URL from it (enforcing the url↔account invariant
+ *    even if the persisted URL drifted), reconcile the token mirror to it ([TokenManager.selectAccount],
+ *    idempotent + non-destructive), then publish identity. If none: publish `Resolved(null)` and touch
+ *    **no** tokens — an empty roster with tokens at rest is either a legacy pre-tenancy upgrade (bare
+ *    tokens the restore safety net must claim, `restoreAccountIfNeeded`) or a crash mid-establish
+ *    (keyed tokens the same safety net re-establishes); destroying them here would force a re-login.
+ *
+ * The publish uses the **low-level** [ActiveAccountProvider.set] / [ActiveAccountProvider.clear], never
+ * [upsertActive] / [clearActiveAccount] — those await [seeded] and would self-deadlock this coroutine.
+ * The whole body is inside the `try/finally` so [seeded] always completes and the [AccountReadyGate]
+ * never hangs, even on an unexpected failure.
  */
 class AccountRegistry(
-    private val dataStore: DataStore<Preferences>,
+    private val roster: AccountRoster,
     private val activeAccountProvider: ActiveAccountProvider,
-    private val serverUrlProvider: ServerUrlProvider,
+    private val serverDataStore: ServerDataStore,
+    private val tokenManager: TokenManager,
     appScope: CoroutineScope,
     ioDispatcher: CoroutineDispatcher,
-) {
+) : AccountReadyGate {
 
     private val seeded = CompletableDeferred<Unit>()
 
     init {
         appScope.launch(ioDispatcher) {
             try {
-                // Chain the URL warm-up: identity resolves only after the server is known.
-                serverUrlProvider.awaitBaseUrl()
-                val stored = dataStore.data.map { prefs -> prefs[KEY_ACTIVE_ACCOUNT_ID] }.first()
-                if (stored.isNullOrBlank()) {
+                // The persisted URL warm-up feeds migration and is the pre-roster fallback for the
+                // login screen. awaitBaseUrl() resolves ServerDataStore's own async warm-up.
+                val legacyUrl = serverDataStore.awaitBaseUrl()
+                roster.migrateIfNeeded(legacyUrl)
+                val activeEntry = roster.snapshot().activeEntry
+                if (activeEntry == null) {
+                    // Authority says no account — publish logged-out, but leave the token store
+                    // alone: on a pre-tenancy upgrade the roster is empty while the user's session
+                    // lives under the bare keys, and clearing here would destroy it before the
+                    // restore safety net (restoreAccountIfNeeded) can claim it.
                     activeAccountProvider.clear()
                 } else {
-                    activeAccountProvider.set(AccountId(stored))
+                    // Drive the URL from the active entry BEFORE publishing identity: the token bearer
+                    // and the server it is sent to must agree from the first admitted request.
+                    serverDataStore.setServerUrl(activeEntry.serverUrl)
+                    // Point the sync mirror at the authority. Idempotent when already aligned (the
+                    // common case); re-homes a crash-diverged mirror. Writes/deletes nothing.
+                    tokenManager.selectAccount(activeEntry.accountId)
+                    activeAccountProvider.set(AccountId(activeEntry.accountId))
                 }
             } catch (e: CancellationException) {
                 throw e
@@ -62,38 +79,28 @@ class AccountRegistry(
         }
     }
 
-    /** Suspends until the cold-start seed has resolved the provider (for ordered consumers / tests). */
-    suspend fun awaitSeeded() {
-        seeded.await()
-    }
+    /** [AccountReadyGate]: suspends until the cold-start seed + reconcile has resolved. */
+    override suspend fun awaitReady() = seeded.await()
 
     /**
-     * Records [id] as the active account and publishes it. Persist-then-publish: disk is the source
-     * of truth, so a crash between the two is reconciled (re-seeded) on the next cold start. Called by
-     * the login paths and the account-switch transition.
+     * Records [entry] as the active account (upsert + activate) and publishes it. Called by the login
+     * paths and cold-start restore via [AccountSessionEstablisher]. Ordered after the seed so its async
+     * resolve can't land after this set and clobber the just-established account back to stale.
      */
-    suspend fun setActiveAccount(id: AccountId) {
-        // Order after the cold-start seed: otherwise its async resolve can land *after* this set
-        // and clobber the just-established account back to null/stale (a spurious logout). The
-        // login paths don't await the seed themselves, so the gate lives here.
+    suspend fun upsertActive(entry: AccountEntry) {
         seeded.await()
-        dataStore.edit { prefs -> prefs[KEY_ACTIVE_ACCOUNT_ID] = id.value }
-        activeAccountProvider.set(id)
+        roster.upsertAndActivate(entry)
+        activeAccountProvider.set(AccountId(entry.accountId))
     }
 
     /**
-     * Clears the active account (logout / account-remove). **Flip-to-null first** (collectors
-     * must tear down their account-scoped query before any row delete), then drop it from disk.
+     * Clears the active account (logout / remove-active). **Flip-to-null first** (collectors must tear
+     * down their account-scoped query before any row delete), then drop the entry from the roster.
      */
     suspend fun clearActiveAccount() {
-        // Same ordering guard as setActiveAccount: don't let a late seed re-publish a stale account
-        // after we've cleared it.
         seeded.await()
+        val activeId = roster.snapshot().activeId
         activeAccountProvider.clear()
-        dataStore.edit { prefs -> prefs.remove(KEY_ACTIVE_ACCOUNT_ID) }
-    }
-
-    private companion object {
-        val KEY_ACTIVE_ACCOUNT_ID = stringPreferencesKey("active_account_id")
+        if (activeId != null) roster.removeAndDeactivate(activeId)
     }
 }

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/AccountRoster.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/AccountRoster.kt
@@ -1,0 +1,165 @@
+package com.garfiec.librechat.core.data.datastore
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import com.garfiec.librechat.core.common.extensions.serverHostLabel
+import com.garfiec.librechat.core.common.identity.deriveServerId
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.json.Json
+import kotlin.time.Clock
+
+/**
+ * Device-global persistence of the **account roster** (multi-account, issue #179): the serialized list
+ * of [AccountEntry] plus the single `active_account_id` pointer.
+ *
+ * The active pointer **reuses the pre-roster key** (`active_account_id`, written by the single-active
+ * builds through #206), so the roster *subsumes* it — there is exactly one active-account pointer, not
+ * a roster pointer diverging from a legacy one. Every mutation is a single [DataStore.edit] transform
+ * (deserialize → modify → reserialize inside the block) so concurrent writers can't lose an update to a
+ * read-modify-write race.
+ *
+ * This class is pure storage. Cold-start reconciliation (mirror-follows-roster), URL driving, and
+ * identity publishing live in [AccountRegistry], which owns the seed coroutine.
+ */
+class AccountRoster(
+    private val dataStore: DataStore<Preferences>,
+    private val json: Json,
+) {
+
+    /** A consistent point-in-time read of the entries + active pointer. */
+    suspend fun snapshot(): RosterSnapshot =
+        dataStore.data.map { prefs -> prefs.toSnapshot() }.first()
+
+    /** True when [accountId] is still a known account (present in the roster). Drives the
+     *  origin-capture "stamp only if still live, else skip" rule so a write captured for an account
+     *  that has since been removed doesn't resurrect its purged rows. */
+    suspend fun contains(accountId: String): Boolean =
+        dataStore.data.map { prefs -> prefs.readEntries().any { it.accountId == accountId } }.first()
+
+    /** The roster entries, for the switcher UI. Decodes only when the serialized roster actually
+     *  changes — this maps the app's *shared* settings DataStore, so an unrelated preference write
+     *  would otherwise re-parse the roster JSON on every emission while the drawer is subscribed. */
+    fun entriesFlow(): Flow<List<AccountEntry>> =
+        dataStore.data
+            .map { prefs -> prefs[KEY_ROSTER] }
+            .distinctUntilChanged()
+            .map { serialized -> decodeEntries(serialized) }
+
+    /**
+     * Upsert [entry] (replacing any existing entry with the same [AccountEntry.accountId]) and mark it
+     * active — one atomic edit. The login / add / switch-target write path.
+     */
+    suspend fun upsertAndActivate(entry: AccountEntry) {
+        dataStore.edit { prefs ->
+            val entries = prefs.readEntries().filterNot { it.accountId == entry.accountId } + entry
+            prefs[KEY_ROSTER] = json.encodeToString(listSerializer, entries)
+            prefs[KEY_ACTIVE_ACCOUNT_ID] = entry.accountId
+        }
+    }
+
+    /**
+     * Mark [accountId] active and bump its `lastActiveAt` — one atomic edit. The switch-target write
+     * path: the entry already exists, so (unlike [upsertAndActivate]) this only repoints the active
+     * pointer and refreshes recency, never adds or overwrites entry fields. No-op if [accountId] isn't
+     * in the roster.
+     */
+    suspend fun activate(accountId: String) {
+        dataStore.edit { prefs ->
+            val entries = prefs.readEntries()
+            if (entries.none { it.accountId == accountId }) return@edit
+            val now = Clock.System.now().toEpochMilliseconds()
+            val updated = entries.map { if (it.accountId == accountId) it.copy(lastActiveAt = now) else it }
+            prefs[KEY_ROSTER] = json.encodeToString(listSerializer, updated)
+            prefs[KEY_ACTIVE_ACCOUNT_ID] = accountId
+        }
+    }
+
+    /**
+     * Refresh [accountId]'s display label + avatar — one atomic edit, touching nothing else (no
+     * activation, no recency bump). The session-start backfill path: a migrated pre-roster entry is
+     * seeded with the server-host fallback (no `User` payload exists at migration time), and a
+     * stay-logged-in user never re-runs the login path that would overwrite it. No-op if
+     * [accountId] isn't in the roster.
+     */
+    suspend fun updateDisplay(accountId: String, displayLabel: String, avatarUrl: String?) {
+        dataStore.edit { prefs ->
+            val entries = prefs.readEntries()
+            if (entries.none { it.accountId == accountId }) return@edit
+            val updated = entries.map {
+                if (it.accountId == accountId) it.copy(displayLabel = displayLabel, avatarUrl = avatarUrl) else it
+            }
+            prefs[KEY_ROSTER] = json.encodeToString(listSerializer, updated)
+        }
+    }
+
+    /**
+     * Remove [accountId] from the roster; if it was the active account, clear the active pointer too —
+     * one atomic edit. The logout / remove-account write path.
+     */
+    suspend fun removeAndDeactivate(accountId: String) {
+        dataStore.edit { prefs ->
+            val entries = prefs.readEntries().filterNot { it.accountId == accountId }
+            prefs[KEY_ROSTER] = json.encodeToString(listSerializer, entries)
+            if (prefs[KEY_ACTIVE_ACCOUNT_ID] == accountId) prefs.remove(KEY_ACTIVE_ACCOUNT_ID)
+        }
+    }
+
+    /**
+     * One-time migration from the pre-roster single-active pointer into a one-entry roster. Guarded by a
+     * durable [KEY_MIGRATED] marker written in the **same edit**, so it (a) never resurrects a removed
+     * account from the still-present legacy pointer on a later launch, and (b) never runs twice.
+     *
+     * Seeds an entry only when both the legacy [KEY_ACTIVE_ACCOUNT_ID] and a non-blank [legacyServerUrl]
+     * are present **and** `deriveServerId(legacyServerUrl)` still matches the account's own serverId
+     * (its `serverId:userKey` prefix). A mismatch (the server URL was edited, or an iOS keychain
+     * reinstall left an id whose server can't be re-derived) can't be repaired — `serverId` is an
+     * irreversible hash — so the only honest action is to drop the active pointer and let the user log
+     * in again, orphaning that account's at-rest tokens/rows rather than binding them to the wrong URL.
+     */
+    suspend fun migrateIfNeeded(legacyServerUrl: String) {
+        dataStore.edit { prefs ->
+            if (prefs[KEY_MIGRATED] != null) return@edit
+            prefs[KEY_MIGRATED] = MIGRATED_VALUE
+            val legacyActive = prefs[KEY_ACTIVE_ACCOUNT_ID]?.takeIf { it.isNotBlank() } ?: return@edit
+            val serverId = legacyActive.substringBefore(':')
+            if (legacyServerUrl.isBlank() || deriveServerId(legacyServerUrl).value != serverId) {
+                // Unrepairable url↔account mismatch → route to login instead of binding a wrong server.
+                prefs.remove(KEY_ACTIVE_ACCOUNT_ID)
+                return@edit
+            }
+            val entry = AccountEntry(
+                accountId = legacyActive,
+                serverUrl = legacyServerUrl,
+                displayLabel = legacyServerUrl.serverHostLabel(),
+                avatarUrl = null,
+                lastActiveAt = 0L,
+            )
+            prefs[KEY_ROSTER] = json.encodeToString(listSerializer, listOf(entry))
+        }
+    }
+
+    private fun Preferences.readEntries(): List<AccountEntry> = decodeEntries(this[KEY_ROSTER])
+
+    private fun decodeEntries(serialized: String?): List<AccountEntry> =
+        serialized?.let {
+            runCatching { json.decodeFromString(listSerializer, it) }.getOrDefault(emptyList())
+        } ?: emptyList()
+
+    private fun Preferences.toSnapshot(): RosterSnapshot =
+        RosterSnapshot(readEntries(), this[KEY_ACTIVE_ACCOUNT_ID]?.takeIf { it.isNotBlank() })
+
+    private companion object {
+        // Reuse the pre-roster pointer key so #206 installs upgrade with the active account intact.
+        val KEY_ACTIVE_ACCOUNT_ID = stringPreferencesKey("active_account_id")
+        val KEY_ROSTER = stringPreferencesKey("account_roster")
+        val KEY_MIGRATED = stringPreferencesKey("account_roster_migrated")
+        const val MIGRATED_VALUE = "1"
+        val listSerializer = ListSerializer(AccountEntry.serializer())
+    }
+}

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/AccountScopedPrefsPurger.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/AccountScopedPrefsPurger.kt
@@ -1,0 +1,19 @@
+package com.garfiec.librechat.core.data.datastore
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+
+/**
+ * Drops every `acct:<accountId>:*` preference for one account (last-used model/endpoint, cached role
+ * permissions, and any future account-scoped key) — the preferences leg of account removal. Prefix-
+ * matched rather than base-enumerated, so a newly added account-scoped preference is covered without
+ * remembering to register it here. Server-scoped (`srv:`) config caches are deliberately untouched:
+ * they belong to the server, which other retained accounts may share.
+ */
+class AccountScopedPrefsPurger(private val dataStore: DataStore<Preferences>) {
+
+    suspend fun purge(accountId: String) {
+        dataStore.edit { prefs -> prefs.removeAllForAccount(accountId) }
+    }
+}

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/CommonTokenDataStore.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/CommonTokenDataStore.kt
@@ -1,6 +1,7 @@
 package com.garfiec.librechat.core.data.datastore
 
 import co.touchlab.kermit.Logger
+import com.garfiec.librechat.core.common.extensions.trimTrailingSlash
 import com.garfiec.librechat.core.logging.Diag
 import com.garfiec.librechat.core.logging.LogOrigin
 import com.garfiec.librechat.core.model.response.RefreshResponse
@@ -22,12 +23,12 @@ import kotlinx.coroutines.sync.withLock
 import kotlin.concurrent.Volatile
 
 /**
- * Account-keyed secure token store. Tokens are namespaced by the active account
- * (`acct:<accountId>:access_token`) so one account's cached credentials are never **read** under
- * another — the precursor for holding several accounts' sessions at once (multi-account, issue #179).
- * Under the current single-active model only one account's tokens are retained at a time: a direct
- * account switch re-homes the newest sign-in into its keyed slot and drops the previous one (full
- * multi-account retention is a later step).
+ * Account-keyed secure token store. Tokens are namespaced by account
+ * (`acct:<accountId>:access_token`) and **several accounts' tokens are retained at rest at once** —
+ * the foundation for switching accounts without re-login (multi-account, issue #179). A switch
+ * ([selectAccount]) repoints the active binding to another already-keyed account without touching any
+ * token slot; account removal ([removeAccount]) drops exactly one account's slot; and logout
+ * ([onAccountCleared]) drops only the active account's slot.
  *
  * The active account is mirrored into the same synchronously-readable secure storage (key
  * [KEY_ACTIVE_ACCOUNT]) rather than the async account registry, so the bearer for the right account
@@ -35,6 +36,24 @@ import kotlin.concurrent.Volatile
  * never read a blind bearer at cold start. When no account is resolved (fresh install, logged out, or
  * a legacy pre-keying upgrade) the keys fall back to their bare form, which is also how tokens from an
  * older build are read until [onAccountResolved] re-homes them.
+ *
+ * **Authentication staging.** An interactive sign-in ([setTokens] from login/OAuth/2FA) always writes
+ * the freshly-issued pair to the **bare** keys and drops the active binding, even when another account
+ * is active. [onAccountResolved] then re-homes that staged pair into the resolved account's keyed
+ * slot. This makes it structurally impossible for a re-login (e.g. a soft-expiry re-auth as a
+ * different user) to overwrite the currently-active account's keyed tokens or leave its slot holding
+ * another account's credentials. Steady-state token rotation does **not** go through [setTokens] —
+ * refresh writes the keyed slot directly.
+ *
+ * **Locking.** [stateMutex] guards the in-memory identity/cache and short storage reads/writes of it;
+ * it is held only for brief critical sections and **never across the refresh network POST**, so a
+ * switch or logout never stalls behind a slow refresh. A per-account [flightMutex] serializes
+ * refreshes of the *same* account across their POST (single-flight, so a second 401 reads the rotated
+ * token instead of re-POSTing a spent one). [tokenEpochs] holds a per-slot epoch bumped by every
+ * operation that invalidates THAT slot's token truth (logout, clear, removal, a new authentication,
+ * an identity re-home); a refresh captures its slot's epoch before its POST and discards its result
+ * if it changed, so a refresh that races a teardown can never resurrect the cleared session even
+ * though the POST holds no lock — while another account's changes leave it valid.
  */
 abstract class CommonTokenDataStore(
     private val refreshClient: Lazy<HttpClient>,
@@ -72,13 +91,43 @@ abstract class CommonTokenDataStore(
         return cachedAccessToken
     }
 
-    private fun accessKey(account: String?): String =
-        if (account == null) KEY_ACCESS_TOKEN else accountScopedName(account, KEY_ACCESS_TOKEN)
+    // The bare key (null account) is the logged-out / legacy / mid-auth-staging fallback; a resolved
+    // account namespaces to `acct:<id>:<base>`. One helper so both token bases scope identically.
+    private fun scopedKey(account: String?, base: String): String =
+        if (account == null) base else accountScopedName(account, base)
 
-    private fun refreshKey(account: String?): String =
-        if (account == null) KEY_REFRESH_TOKEN else accountScopedName(account, KEY_REFRESH_TOKEN)
+    private fun accessKey(account: String?): String = scopedKey(account, KEY_ACCESS_TOKEN)
 
-    private val refreshMutex = Mutex()
+    private fun refreshKey(account: String?): String = scopedKey(account, KEY_REFRESH_TOKEN)
+
+    /** Guards the in-memory identity/cache + short storage reads/writes of it. Never held across a POST. */
+    private val stateMutex = Mutex()
+
+    /** Guards [flights] while a per-account single-flight lock is looked up / created. */
+    private val flightMutex = Mutex()
+
+    /** Per-account refresh single-flight locks, held across the refresh POST. Keyed by account (bare = ""). */
+    private val flights = mutableMapOf<String, Mutex>()
+
+    /**
+     * Per-slot token epochs, keyed like [flights] (bare = [BARE_FLIGHT_KEY]). A slot's epoch is bumped
+     * whenever ITS token truth changes (teardown, removal, an authentication's staging, an identity
+     * re-home, an invalidate). A refresh captures its own slot's epoch before the POST and discards its
+     * result if it changed, so a refresh racing a teardown can't resurrect a cleared session — while
+     * another slot's changes (e.g. an add-account login staging B mid-flight of A's refresh, whose
+     * server has already rotated A's refresh token) leave it untouched. A global epoch here would
+     * discard A's rotated pair and strand A's slot on the spent pre-rotation token. A plain
+     * [selectAccount] switch bumps nothing — an in-flight refresh of the outgoing account stays valid
+     * because that account's tokens are retained. Guarded by [stateMutex].
+     */
+    private val tokenEpochs = mutableMapOf<String, Int>()
+
+    private fun epochOf(account: String?): Int = tokenEpochs[account ?: BARE_FLIGHT_KEY] ?: 0
+
+    private fun bumpEpoch(account: String?) {
+        val key = account ?: BARE_FLIGHT_KEY
+        tokenEpochs[key] = (tokenEpochs[key] ?: 0) + 1
+    }
 
     private val _sessionExpired = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
     override val sessionExpiredFlow: SharedFlow<Unit> = _sessionExpired.asSharedFlow()
@@ -99,121 +148,235 @@ abstract class CommonTokenDataStore(
 
     override suspend fun getAccessToken(): String? = ensureTokenLoaded()
 
-    override suspend fun setTokens(accessToken: String, refreshToken: String) {
+    override suspend fun setTokens(accessToken: String, refreshToken: String) = stateMutex.withLock {
+        // Authentication path only (login / OAuth / 2FA). Stage the freshly-issued pair under the bare
+        // keys and drop the active binding, so a re-login while another account is active never writes
+        // into that account's keyed slot. onAccountResolved re-homes the staged pair once identity is
+        // known. Steady-state rotation does NOT come here — refresh writes the keyed slot directly.
+        // Only the bare (staging) slot's truth changes; keyed slots (and their in-flight refreshes,
+        // which write their own slot) stay valid.
+        bumpEpoch(null)
         cachedAccessToken = accessToken
+        activeAccountKey = null
+        // Drop the persisted mirror BEFORE staging, so a crash in the staging window (before
+        // onAccountResolved re-homes) can never cold-start back into the previously-active account —
+        // the mirror must never outlive the in-memory identity. A crash after this remove but before
+        // the stage write just cold-starts logged-out (safe), never as the wrong account.
+        removeValue(KEY_ACTIVE_ACCOUNT)
         // One commit so a crash never persists a new access token with a stale/absent refresh token.
-        writeValues(
-            mapOf(
-                accessKey(activeAccountKey) to accessToken,
-                refreshKey(activeAccountKey) to refreshToken,
-            ),
-        )
+        writeValues(mapOf(KEY_ACCESS_TOKEN to accessToken, KEY_REFRESH_TOKEN to refreshToken))
     }
 
-    override suspend fun onAccountResolved(accountId: String) = refreshMutex.withLock {
+    override suspend fun onAccountResolved(accountId: String) = stateMutex.withLock {
         if (activeAccountKey == accountId) return@withLock
-        // Identity just became known (fresh login, upgrade, or a re-login). The tokens written by the
-        // preceding setTokens live under the previous effective key — the bare keys on a legacy/first
-        // install, or the prior account on a switch. Re-home them into this account's keyed slot (only
-        // when empty, so we never clobber existing keyed tokens), drop the old slot, and repoint the
-        // mirror so the next cold start seeds this account.
-        val previous = activeAccountKey
-        val access = readValue(accessKey(previous))
-        val refresh = readValue(refreshKey(previous))
-        // Crash-safe ordering: write the new keyed slot (atomically, only when empty so existing keyed
-        // tokens are never clobbered), THEN repoint the mirror, and only after that remove the old slot.
-        // An interruption before the mirror write leaves the old slot intact (seeds `previous`, retried
-        // next resolve); after it, the tokens are already safe under `accountId`.
-        if (access != null && refresh != null && readValue(accessKey(accountId)) == null) {
-            writeValues(mapOf(accessKey(accountId) to access, refreshKey(accountId) to refresh))
+        // Re-home the staged (bare-key) authentication tokens into this account's keyed slot. A fresh
+        // sign-in is the account's new truth, so overwrite. If none are staged (a pure cold-start
+        // restore of already-keyed tokens whose mirror diverged), leave the keyed slot intact.
+        // Crash-safe ordering: write the keyed slot, THEN the mirror, and only then drop the staging
+        // keys — an interruption before the mirror write re-stages on the next resolve.
+        val stagedAccess = readValue(KEY_ACCESS_TOKEN)
+        val stagedRefresh = readValue(KEY_REFRESH_TOKEN)
+        val rehomed = stagedAccess != null && stagedRefresh != null
+        if (rehomed) {
+            // Both the keyed slot (overwritten with the new truth) and the bare slot (staging
+            // consumed) change; a no-staging mirror re-home changes neither, so nothing is bumped.
+            bumpEpoch(accountId)
+            bumpEpoch(null)
+            writeValues(mapOf(accessKey(accountId) to stagedAccess, refreshKey(accountId) to stagedRefresh))
         }
         writeValue(KEY_ACTIVE_ACCOUNT, accountId)
         activeAccountKey = accountId
-        removeValue(accessKey(previous))
-        removeValue(refreshKey(previous))
-        cachedAccessToken = readValue(accessKey(accountId))
+        // De-fanged: remove ONLY the bare staging keys, never another account's keyed slot — a
+        // previously-active account's tokens are retained for a later switch back.
+        removeValue(KEY_ACCESS_TOKEN)
+        removeValue(KEY_REFRESH_TOKEN)
+        // Trust the staged access in-memory only when we actually persisted it (rehomed); otherwise
+        // (torn/absent staging, e.g. a partial keychain write) read the keyed slot so the cached
+        // bearer can never diverge from storage across a cold start.
+        cachedAccessToken = if (rehomed) stagedAccess else readValue(accessKey(accountId))
     }
 
-    override suspend fun onAccountCleared() = refreshMutex.withLock {
+    /**
+     * Full teardown of the active session: drop its keyed tokens, purge any leftover bare staging
+     * pair (an abandoned/killed login), clear the mirror + in-memory identity, and bump the epoch so
+     * an in-flight refresh discards its result. Backs [clearTokens] (and thus its logout-named alias
+     * [TokenManager.onAccountCleared], which delegates to it). Caller holds [stateMutex].
+     */
+    private fun tearDownActiveSessionLocked() {
+        bumpEpoch(activeAccountKey)
+        // The bare staging slot is purged below too (when the active slot is keyed) — bump it so an
+        // in-flight bare refresh can't resurrect the staged pair.
+        if (activeAccountKey != null) bumpEpoch(null)
         removeValue(accessKey(activeAccountKey))
         removeValue(refreshKey(activeAccountKey))
+        if (activeAccountKey != null) {
+            // The active slot is keyed, so the bare keys can only hold a stale staged pair — purge it
+            // so a killed login can't be cold-started back into an apparently-authenticated state.
+            removeValue(KEY_ACCESS_TOKEN)
+            removeValue(KEY_REFRESH_TOKEN)
+        }
         removeValue(KEY_ACTIVE_ACCOUNT)
         activeAccountKey = null
         cachedAccessToken = null
     }
 
-    override suspend fun refreshAccessToken(): Boolean = refreshMutex.withLock {
-        val storedRefreshToken = readValue(refreshKey(activeAccountKey))
-        if (storedRefreshToken.isNullOrBlank()) {
-            Diag.w(
-                "Auth",
-                origin = LogOrigin.CLIENT,
-                attrs = mapOf("event" to "session_expired", "reason" to "no_refresh_token"),
-            ) { "No refresh token available" }
-            return false
+    override suspend fun getAccessTokenFor(accountId: String): String? = stateMutex.withLock {
+        // Serve the active account from the in-memory cache (the per-request hot path via the switch
+        // barrier's keyed bearer read); fall to storage only for a non-active account's slot. Under
+        // stateMutex so the account check and the cache read can't interleave with a select/teardown.
+        if (accountId == activeAccountKey) cachedAccessToken else readValue(accessKey(accountId))
+    }
+
+    override suspend fun getStagedAccessToken(): String? = stateMutex.withLock {
+        readValue(KEY_ACCESS_TOKEN)
+    }
+
+    override suspend fun clearStagedTokens() = stateMutex.withLock {
+        // Bare keys only — no keyed slot, no mirror, no epoch bump. Not bumping the epoch is
+        // deliberate: an in-flight refresh of a *keyed* account (the active one, mid-add) is
+        // legitimate and must not discard its result; nothing refreshes the bare slot while an
+        // account binding exists (pending add-flow 401s never trigger a refresh).
+        removeValue(KEY_ACCESS_TOKEN)
+        removeValue(KEY_REFRESH_TOKEN)
+    }
+
+    override suspend fun selectAccount(accountId: String) = stateMutex.withLock {
+        if (activeAccountKey == accountId) return@withLock
+        // Non-destructive switch: repoint the active binding + mirror + cached bearer to an already-keyed
+        // account. Writes no token slot and deletes none; bumps no epoch (an in-flight refresh
+        // of the outgoing account stays valid — its request keeps flowing to that account under the
+        // switch barrier).
+        writeValue(KEY_ACTIVE_ACCOUNT, accountId)
+        activeAccountKey = accountId
+        cachedAccessToken = readValue(accessKey(accountId))
+    }
+
+    override suspend fun removeAccount(accountId: String) = stateMutex.withLock {
+        bumpEpoch(accountId)
+        removeValue(accessKey(accountId))
+        removeValue(refreshKey(accountId))
+        // Evict the account's single-flight lock so [flights] doesn't retain a Mutex per removed
+        // account. Safe: removeAccount bumps the epoch, so any in-flight refresh of this account
+        // discards its result on commit regardless.
+        flightMutex.withLock { flights.remove(accountId) }
+        if (activeAccountKey == accountId) {
+            removeValue(KEY_ACTIVE_ACCOUNT)
+            activeAccountKey = null
+            cachedAccessToken = null
         }
+    }
 
-        return try {
-            val httpResponse: HttpResponse = refreshClient.value
-                .post("/api/auth/refresh") {
-                    header("Cookie", "refreshToken=$storedRefreshToken")
-                    setBody(mapOf("refreshToken" to storedRefreshToken))
-                }
+    override suspend fun refreshAccessToken(): Boolean =
+        // The live active account, against the live base URL (the refresh client's defaultRequest).
+        performRefresh(accountKey = activeAccountKey, absoluteRefreshUrl = null)
 
-            val body: RefreshResponse = httpResponse.body()
-            val newRefreshToken = CookieHelper.extractRefreshToken(httpResponse.headers)
-                ?: storedRefreshToken
+    override suspend fun refreshAccessTokenFor(accountId: String, baseUrl: String): Boolean =
+        // URL-pinned: post to an absolute URL so a concurrent server switch can't redirect this
+        // account's refresh token to another server.
+        performRefresh(accountKey = accountId, absoluteRefreshUrl = "${baseUrl.trimTrailingSlash()}$REFRESH_PATH")
 
-            setTokens(body.token, newRefreshToken)
-            Logger.d { "Token refreshed successfully" }
-            true
-        } catch (e: ClientRequestException) {
-            Diag.w(
-                "Auth",
-                origin = LogOrigin.SERVER,
-                throwable = e,
-                attrs = mapOf(
-                    "event" to "refresh_failed",
-                    "status" to e.response.status.value.toString(),
-                ),
-            ) { "Auth error during token refresh" }
-            clearTokensLocked()
-            false
-        } catch (e: Exception) {
-            if (isKeystoreException(e)) {
-                Diag.e(
-                    "Auth",
-                    origin = LogOrigin.CLIENT,
-                    throwable = e,
-                    attrs = mapOf("event" to "keystore_corruption"),
-                ) { "Keystore corruption—clearing tokens" }
-                onKeystoreCorruption()
-                clearTokensLocked()
-            } else {
+    private suspend fun performRefresh(accountKey: String?, absoluteRefreshUrl: String?): Boolean =
+        flightFor(accountKey).withLock {
+            // Capture the slot's epoch BEFORE the stored-token read, so any teardown of THIS slot that
+            // races the POST below is detected (and its result discarded) with no lock held across the
+            // network call. Under stateMutex only for the map read — released before the POST.
+            val epochAtStart = stateMutex.withLock { epochOf(accountKey) }
+            val storedRefreshToken = readValue(refreshKey(accountKey))
+            if (storedRefreshToken.isNullOrBlank()) {
                 Diag.w(
                     "Auth",
-                    origin = LogOrigin.NETWORK,
-                    throwable = e,
-                    attrs = mapOf("event" to "refresh_failed"),
-                ) { "Error during token refresh" }
+                    origin = LogOrigin.CLIENT,
+                    attrs = mapOf("event" to "session_expired", "reason" to "no_refresh_token"),
+                ) { "No refresh token available" }
+                return@withLock false
             }
-            false
+
+            try {
+                val httpResponse: HttpResponse = refreshClient.value
+                    .post(absoluteRefreshUrl ?: REFRESH_PATH) {
+                        header("Cookie", "refreshToken=$storedRefreshToken")
+                        setBody(mapOf("refreshToken" to storedRefreshToken))
+                    }
+
+                val body: RefreshResponse = httpResponse.body()
+                val newRefreshToken = CookieHelper.extractRefreshToken(httpResponse.headers)
+                    ?: storedRefreshToken
+
+                commitRefresh(accountKey, epochAtStart, body.token, newRefreshToken)
+            } catch (e: ClientRequestException) {
+                Diag.w(
+                    "Auth",
+                    origin = LogOrigin.SERVER,
+                    throwable = e,
+                    attrs = mapOf(
+                        "event" to "refresh_failed",
+                        "status" to e.response.status.value.toString(),
+                    ),
+                ) { "Auth error during token refresh" }
+                invalidateRefresh(accountKey, epochAtStart)
+                false
+            } catch (e: Exception) {
+                if (isKeystoreException(e)) {
+                    Diag.e(
+                        "Auth",
+                        origin = LogOrigin.CLIENT,
+                        throwable = e,
+                        attrs = mapOf("event" to "keystore_corruption"),
+                    ) { "Keystore corruption—clearing tokens" }
+                    onKeystoreCorruption()
+                    invalidateRefresh(accountKey, epochAtStart)
+                } else {
+                    Diag.w(
+                        "Auth",
+                        origin = LogOrigin.NETWORK,
+                        throwable = e,
+                        attrs = mapOf("event" to "refresh_failed"),
+                    ) { "Error during token refresh" }
+                }
+                false
+            }
         }
-    }
 
-    override suspend fun clearTokens() {
-        refreshMutex.withLock {
-            clearTokensLocked()
+    /** Persist a successful refresh — unless a teardown changed the epoch while the POST was in flight. */
+    private suspend fun commitRefresh(
+        accountKey: String?,
+        epochAtStart: Int,
+        access: String,
+        refresh: String,
+    ): Boolean = stateMutex.withLock {
+        if (epochOf(accountKey) != epochAtStart) {
+            // A logout / clear / removal / re-authentication of THIS slot landed mid-POST — discard so
+            // the refresh can never resurrect a session that was torn down. Changes to other slots
+            // (another account's login/teardown) don't invalidate this slot's rotated pair.
+            Logger.d { "Token refresh discarded: session changed during refresh" }
+            return@withLock false
         }
+        writeValues(mapOf(accessKey(accountKey) to access, refreshKey(accountKey) to refresh))
+        if (accountKey == activeAccountKey) cachedAccessToken = access
+        Logger.d { "Token refreshed successfully" }
+        true
     }
 
-    private fun clearTokensLocked() {
-        cachedAccessToken = null
-        removeValue(accessKey(activeAccountKey))
-        removeValue(refreshKey(activeAccountKey))
+    /** Drop [accountKey]'s slot after a hard auth failure — unless a teardown already owns the slot. */
+    private suspend fun invalidateRefresh(accountKey: String?, epochAtStart: Int) = stateMutex.withLock {
+        if (epochOf(accountKey) != epochAtStart) return@withLock
+        bumpEpoch(accountKey)
+        removeValue(accessKey(accountKey))
+        removeValue(refreshKey(accountKey))
+        if (accountKey == activeAccountKey) cachedAccessToken = null
     }
 
-    override fun emitSessionExpired() {
+    private suspend fun flightFor(accountKey: String?): Mutex = flightMutex.withLock {
+        flights.getOrPut(accountKey ?: BARE_FLIGHT_KEY) { Mutex() }
+    }
+
+    override suspend fun clearTokens() = stateMutex.withLock { tearDownActiveSessionLocked() }
+
+    override fun emitSessionExpired(expiredAccountId: String?) {
+        // Scoped emit: only the ACTIVE binding's expiry routes the app to re-auth. A straggler
+        // failure for a switched-away (retained) account is not a live-session event — its slot is
+        // just stale until that account is selected again. Null = active/legacy session: always emit.
+        if (expiredAccountId != null && expiredAccountId != activeAccountKey) return
         _sessionExpired.tryEmit(Unit)
     }
 
@@ -235,5 +398,9 @@ abstract class CommonTokenDataStore(
         const val KEY_ACCESS_TOKEN = "access_token"
         const val KEY_REFRESH_TOKEN = "refresh_token"
         private const val KEY_ACTIVE_ACCOUNT = "active_account_id"
+        private const val REFRESH_PATH = "/api/auth/refresh"
+
+        /** [flights] key for the bare (null-account) refresh path. */
+        private const val BARE_FLIGHT_KEY = ""
     }
 }

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/ConfigCacheDataStore.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/ConfigCacheDataStore.kt
@@ -49,9 +49,16 @@ class ConfigCacheDataStore(
 
     suspend fun clear() {
         try {
-            // Logout keeps the server URL, but remove every server's config entry (at most one under
-            // single-active) so this stays correct even if identity has already flipped.
-            dataStore.edit { prefs -> prefs.removeScoped(BASES) }
+            // Scope to the logged-out server only: logout keeps the base URL, so serverId() still
+            // resolves to it. Other retained accounts may sit on different servers whose cached
+            // config must survive — a blanket wipe across all servers would strip a retained
+            // account's endpoints/models. Legacy bare (pre-keying) entries are dropped
+            // unconditionally.
+            val serverId = serverId()
+            dataStore.edit { prefs ->
+                serverId?.let { id -> BASES.forEach { prefs.remove(key(id, it)) } }
+                BASES.forEach { prefs.remove(stringPreferencesKey(it)) }
+            }
         } catch (e: Exception) {
             Logger.w(e) { "Failed to clear cached config" }
         }

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/RoleCacheDataStore.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/RoleCacheDataStore.kt
@@ -52,9 +52,13 @@ class RoleCacheDataStore(
 
     suspend fun clear() {
         try {
-            // Logout flips the active account to null before this runs, so remove every account's role
-            // entry (at most one under single-active) rather than the current key.
-            dataStore.edit { prefs -> prefs.removeScoped(listOf(ROLE_BASE)) }
+            // Scope to the resolved account only: other roster accounts' cached roles are retained
+            // multi-account state, not session garbage — a blanket wipe here would strip a retained
+            // account's permissions on someone else's logout. On the logout/remove paths the active
+            // account is already flipped to null when this runs; there its on-disk entry is reaped
+            // by AccountScopedPrefsPurger instead, so an unresolved clear has nothing left to do.
+            val accountId = activeAccountProvider.currentAccountId()?.value ?: return
+            dataStore.edit { prefs -> prefs.remove(key(accountId)) }
         } catch (e: Exception) {
             Logger.w(e) { "Failed to clear cached user role permissions" }
         }

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/ScopedPreferenceKeys.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/ScopedPreferenceKeys.kt
@@ -22,13 +22,13 @@ internal fun serverScopedKey(serverId: String, base: String): Preferences.Key<St
     stringPreferencesKey(serverScopedName(serverId, base))
 
 /**
- * Removes every entry whose name is the bare [bases] name or any `<scope>:<id>:<base>` variant of it.
- * Logout uses this to purge a base across all accounts/servers (single-active: at most one exists),
- * staying correct even when the active-account pointer has already been flipped to null.
+ * Removes every `acct:<accountId>:*` entry for one account, whatever its base — complete by
+ * construction, so a new account-scoped preference can never be forgotten by the removal path.
  */
-internal fun MutablePreferences.removeScoped(bases: List<String>) {
+internal fun MutablePreferences.removeAllForAccount(accountId: String) {
+    val prefix = accountScopedName(accountId, "")
     asMap().keys
-        .filter { key -> bases.any { key.name == it || key.name.endsWith(":$it") } }
+        .filter { it.name.startsWith(prefix) }
         .toList()
         .forEach { remove(it) }
 }

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/di/DataModule.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/di/DataModule.kt
@@ -5,6 +5,8 @@ import com.garfiec.librechat.core.common.identity.ActiveAccountProvider
 import com.garfiec.librechat.core.common.identity.InMemoryActiveAccountProvider
 import com.garfiec.librechat.core.common.identity.SessionManager
 import com.garfiec.librechat.core.data.datastore.AccountRegistry
+import com.garfiec.librechat.core.data.datastore.AccountRoster
+import com.garfiec.librechat.core.data.datastore.AccountScopedPrefsPurger
 import com.garfiec.librechat.core.data.datastore.ConfigCacheDataStore
 import com.garfiec.librechat.core.data.datastore.RoleCacheDataStore
 import com.garfiec.librechat.core.data.datastore.ServerDataStore
@@ -14,6 +16,7 @@ import com.garfiec.librechat.core.data.db.LibreChatDatabase
 import com.garfiec.librechat.core.data.repository.AccountClaimReconciler
 import com.garfiec.librechat.core.data.repository.AccountDataPurger
 import com.garfiec.librechat.core.data.repository.AccountSessionEstablisher
+import com.garfiec.librechat.core.data.repository.AccountSwitcher
 import com.garfiec.librechat.core.data.repository.AgentRepository
 import com.garfiec.librechat.core.data.repository.AgentRepositoryImpl
 import com.garfiec.librechat.core.data.repository.AgentToolsRepository
@@ -70,6 +73,7 @@ import com.garfiec.librechat.core.data.repository.TagRepository
 import com.garfiec.librechat.core.data.repository.TagRepositoryImpl
 import com.garfiec.librechat.core.data.repository.UserRepository
 import com.garfiec.librechat.core.data.repository.UserRepositoryImpl
+import com.garfiec.librechat.core.data.util.AccountLabelBackfillSessionTask
 import com.garfiec.librechat.core.data.util.EndpointConfigFetchSessionTask
 import com.garfiec.librechat.core.data.util.PermissionGate
 import com.garfiec.librechat.core.data.util.RefreshTagsSessionTask
@@ -77,6 +81,7 @@ import com.garfiec.librechat.core.data.util.RoleFetchSessionTask
 import com.garfiec.librechat.core.data.util.SessionTask
 import com.garfiec.librechat.core.data.util.SessionTaskRunner
 import com.garfiec.librechat.core.data.util.SyncFavoritesSessionTask
+import com.garfiec.librechat.core.network.client.AccountReadyGate
 import com.garfiec.librechat.core.network.client.ServerUrlProvider
 import kotlinx.coroutines.CoroutineScope
 import org.koin.core.module.Module
@@ -104,17 +109,21 @@ val dataModule = module {
 
     // The in-memory active-account holder every identity-dependent subsystem will read.
     single<ActiveAccountProvider> { InMemoryActiveAccountProvider() }
-    // Eager: at cold start it must seed the provider from the persisted id (chaining the URL
-    // warm-up) even before any consumer asks for it.
+    // Persisted account roster (list + single active pointer). Pure storage.
+    single { AccountRoster(dataStore = get(), json = get()) }
+    // Eager: at cold start it must migrate + reconcile + seed the provider (driving the URL from the
+    // active roster entry) even before any consumer asks for it. Bound as the AccountReadyGate the
+    // HTTP clients + first-frame routing await.
     single(createdAtStart = true) {
         AccountRegistry(
-            dataStore = get(),
+            roster = get(),
             activeAccountProvider = get(),
-            serverUrlProvider = get(),
+            serverDataStore = get(),
+            tokenManager = get(),
             appScope = get<CoroutineScope>(KoinQualifiers.ApplicationScope),
             ioDispatcher = get(KoinQualifiers.IO),
         )
-    }
+    } bind AccountReadyGate::class
     single {
         AccountClaimReconciler(
             claimDao = get(),
@@ -131,6 +140,24 @@ val dataModule = module {
             ioDispatcher = get(KoinQualifiers.IO),
         )
     }
+    // Coordinates switch-without-re-login, the add-account flow, and account removal: URL + token key
+    // + roster pointer + identity flip, atomic under the SwitchGate barrier. The auth repository
+    // routes add-mode sign-ins through it; the switcher UI drives switch/add/remove.
+    single {
+        AccountSwitcher(
+            roster = get(),
+            serverDataStore = get(),
+            tokenManager = get(),
+            activeAccountProvider = get(),
+            switchGate = get(),
+            claimReconciler = get(),
+            switchCacheCleaner = get(),
+            accountDataPurger = get(),
+            prefsPurger = get(),
+            sessionCacheCleaner = get(),
+        )
+    }
+    single { AccountScopedPrefsPurger(dataStore = get()) }
     single {
         AccountDataPurger(
             conversationDao = get(),
@@ -191,7 +218,8 @@ val dataModule = module {
             accountRegistry = get(),
             activeAccountProvider = get(),
             sessionManager = get(),
-            accountDataPurger = get(),
+            accountSwitcher = get(),
+            switchGate = get(),
         )
     }
 
@@ -216,6 +244,7 @@ val dataModule = module {
     singleOf(::RefreshTagsSessionTask) bind SessionTask::class
     singleOf(::SyncFavoritesSessionTask) bind SessionTask::class
     singleOf(::EndpointConfigFetchSessionTask) bind SessionTask::class
+    singleOf(::AccountLabelBackfillSessionTask) bind SessionTask::class
     single {
         SessionTaskRunner(
             tasks = getAll<SessionTask>(),
@@ -238,6 +267,7 @@ val dataModule = module {
             messagesApi = get(),
             messageDao = get(),
             activeAccountProvider = get(),
+            roster = get(),
             dispatcher = get(KoinQualifiers.Default),
         )
     }

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/AccountSessionEstablisher.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/AccountSessionEstablisher.kt
@@ -1,9 +1,11 @@
 package com.garfiec.librechat.core.data.repository
 
 import co.touchlab.kermit.Logger
+import com.garfiec.librechat.core.common.extensions.serverHostLabel
 import com.garfiec.librechat.core.common.identity.AccountId
 import com.garfiec.librechat.core.common.identity.deriveAccountId
 import com.garfiec.librechat.core.common.identity.deriveServerId
+import com.garfiec.librechat.core.data.datastore.AccountEntry
 import com.garfiec.librechat.core.data.datastore.AccountRegistry
 import com.garfiec.librechat.core.model.User
 import com.garfiec.librechat.core.network.client.ServerUrlProvider
@@ -11,6 +13,7 @@ import com.garfiec.librechat.core.network.client.TokenManager
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
 import kotlin.coroutines.cancellation.CancellationException
+import kotlin.time.Clock
 
 /**
  * Turns a freshly-authenticated (or cold-start-restored) [User] into the active [AccountId] and
@@ -48,7 +51,7 @@ class AccountSessionEstablisher(
      *
      * The claim is nonetheless **best-effort**: a *failure* must never abort establishment. It is
      * idempotent and only writes its done-marker on success, so a failure (e.g. a transient DB error)
-     * retries on the next establish. Letting it propagate would skip [AccountRegistry.setActiveAccount]
+     * retries on the next establish. Letting it propagate would skip [AccountRegistry.upsertActive]
      * and strand an authenticated user at `Resolved(null)` — every scoped read/write silently skipped
      * for the session — so a claim failure is caught here and the account is published regardless.
      * **Cancellation is the exception**: a `CancellationException` is rethrown, so a session torn down
@@ -63,11 +66,9 @@ class AccountSessionEstablisher(
      */
     suspend fun establish(user: User): AccountId = withContext(ioDispatcher) {
         val baseUrl = serverUrlProvider.awaitBaseUrl()
-        val userKey = user.id ?: user.mongoId
-        require(!userKey.isNullOrBlank()) {
-            "Authenticated user has no id; cannot derive an account owner"
-        }
-        val accountId = deriveAccountId(deriveServerId(baseUrl), userKey)
+        val userKey = user.accountUserKey()
+        val serverId = deriveServerId(baseUrl)
+        val accountId = deriveAccountId(serverId, userKey)
         runCatching { claimReconciler.claimIfNeeded(accountId, userKey) }
             .onFailure { error ->
                 // A cancelled establish (logout / teardown during cold-start restore) must abort, not
@@ -79,7 +80,36 @@ class AccountSessionEstablisher(
         // keyed slot + repoints the sync mirror) before publishing identity, so a cold-start restore
         // resolving the same account is a no-op and the next launch seeds the right bearer.
         tokenManager.onAccountResolved(accountId.value)
-        accountRegistry.setActiveAccount(accountId)
+        // Record the roster entry (with the display label/avatar from the live user) and publish it.
+        accountRegistry.upsertActive(
+            AccountEntry(
+                accountId = accountId.value,
+                serverUrl = baseUrl,
+                displayLabel = user.displayLabel(baseUrl),
+                avatarUrl = user.avatar?.takeIf { it.isNotBlank() },
+                lastActiveAt = Clock.System.now().toEpochMilliseconds(),
+            ),
+        )
         accountId
     }
 }
+
+/**
+ * The stable per-user key an [AccountId] is derived from — the user's Mongo `_id` (see the class
+ * KDoc above for why it must never be the email). Shared by the login/cold-start establish and the
+ * add-account completion so both derive identity identically.
+ */
+internal fun User.accountUserKey(): String {
+    val userKey = id ?: mongoId
+    require(!userKey.isNullOrBlank()) {
+        "Authenticated user has no id; cannot derive an account owner"
+    }
+    return userKey
+}
+
+/** Best display name for the switcher chip, falling back to the server host when the user is unnamed. */
+internal fun User.displayLabel(baseUrl: String): String =
+    name?.takeIf { it.isNotBlank() }
+        ?: username?.takeIf { it.isNotBlank() }
+        ?: email.takeIf { it.isNotBlank() }
+        ?: baseUrl.serverHostLabel()

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/AccountSwitcher.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/AccountSwitcher.kt
@@ -1,0 +1,359 @@
+package com.garfiec.librechat.core.data.repository
+
+import co.touchlab.kermit.Logger
+import com.garfiec.librechat.core.common.extensions.trimTrailingSlash
+import com.garfiec.librechat.core.common.identity.AccountId
+import com.garfiec.librechat.core.common.identity.ActiveAccountProvider
+import com.garfiec.librechat.core.common.identity.currentAccountId
+import com.garfiec.librechat.core.common.identity.deriveAccountId
+import com.garfiec.librechat.core.common.identity.deriveServerId
+import com.garfiec.librechat.core.data.datastore.AccountEntry
+import com.garfiec.librechat.core.data.datastore.AccountRoster
+import com.garfiec.librechat.core.data.datastore.AccountScopedPrefsPurger
+import com.garfiec.librechat.core.data.datastore.ServerDataStore
+import com.garfiec.librechat.core.model.User
+import com.garfiec.librechat.core.model.config.StartupConfig
+import com.garfiec.librechat.core.network.client.PendingRequestIdentity
+import com.garfiec.librechat.core.network.client.SwitchGate
+import com.garfiec.librechat.core.network.client.TokenManager
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.withContext
+import kotlin.concurrent.Volatile
+import kotlin.coroutines.cancellation.CancellationException
+import kotlin.time.Clock
+
+/**
+ * An in-progress add-account flow: the target server plus the coroutine-context element that routes
+ * the flow's HTTP calls to it (see [PendingRequestIdentity]). Created by [AccountSwitcher.beginAdd];
+ * consumed by [AccountSwitcher.completeAdd] on auth success or [AccountSwitcher.cancelAdd] on
+ * abandon. Held in memory only — a process death mid-add self-cancels (the cold-start seed
+ * reconciles the token binding back to the roster authority).
+ */
+class PendingAddSession internal constructor(
+    val serverUrl: String,
+    internal val requestIdentity: PendingRequestIdentity,
+) {
+    private val _startupConfig = MutableStateFlow<StartupConfig?>(null)
+
+    /** The pending server's validated startup config, probed under the pending identity and never
+     *  written to the live server's config state/cache ([ConfigRepository.probeServerUrl]) — the
+     *  add-mode login screen reads its feature flags (registration, social logins) from here. */
+    val startupConfig: StateFlow<StartupConfig?> = _startupConfig.asStateFlow()
+
+    internal fun attachConfig(config: StartupConfig) {
+        _startupConfig.value = config
+    }
+}
+
+/**
+ * Runs [block] under this pending add flow's request identity — routing its HTTP calls to the server
+ * being added, with the staged bearer — or straight through when there is no add in progress. The one
+ * definition of "route through the pending identity", shared by [AccountSwitcher.withPendingIdentity]
+ * and the auth repository's per-call routing so the rule can't drift between them. Callers that need
+ * routing and completion to agree pass the same captured [PendingAddSession] to both.
+ */
+internal suspend fun <T> PendingAddSession?.withRequestIdentity(block: suspend () -> T): T =
+    if (this != null) withContext(requestIdentity) { block() } else block()
+
+/**
+ * The single coordinator that switches the active account without re-login (issue #179). It owns the
+ * *data-layer* transition — server URL, token key, roster pointer, published identity — sequenced
+ * atomically under the [SwitchGate] barrier. It does **not** own session-scope teardown; that stays
+ * reactive in `SessionManager`, driven by the identity flip this publishes.
+ *
+ * The switch is deliberately *lighter* than logout: it deletes **no** Room rows (retaining the other
+ * account's data is the whole point) and re-keys **no** tokens ([TokenManager.selectAccount] is
+ * non-destructive). It repoints identity/URL/token-key so the outgoing account's data + tokens stay at
+ * rest for an instant switch back.
+ *
+ * **In-flight refresh safety:** an A-refresh already in flight when the switch runs is harmless —
+ * the account-keyed, URL-pinned refresh path writes A's own slot and skips the active-cache
+ * mutation once A is no longer active, so it can neither corrupt B nor stall the switch (the refresh
+ * POST runs outside the token store's state lock). No refresh cancellation is needed or buildable.
+ *
+ * **Add-account** (signing in B while A stays live) is the second transition this owns, and it is
+ * non-destructive toward A by construction: the flow's HTTP calls run under a [PendingRequestIdentity]
+ * (B's URL + B's *staged* bearer — the global URL and A's identity are never touched), B's
+ * freshly-issued tokens bare-stage (A's keyed slot untouched), and only the successful completion
+ * flips URL/token/roster/identity to B atomically under the same [SwitchGate] barrier a switch uses.
+ * At most one add is pending at a time (the auth screens drive exactly one flow); the pending state
+ * lives in memory only, so a killed app self-cancels.
+ *
+ * **Remove-account** ([remove]) is the third owned transition: the destructive counterpart that
+ * purges one account's roster entry, tokens, scoped preferences, and tenant rows — flipping the
+ * active identity to a successor (or the logged-out state) first when the removed account was live.
+ */
+class AccountSwitcher(
+    private val roster: AccountRoster,
+    private val serverDataStore: ServerDataStore,
+    private val tokenManager: TokenManager,
+    private val activeAccountProvider: ActiveAccountProvider,
+    private val switchGate: SwitchGate,
+    private val claimReconciler: AccountClaimReconciler,
+    private val switchCacheCleaner: SwitchCacheCleaner,
+    private val accountDataPurger: AccountDataPurger,
+    private val prefsPurger: AccountScopedPrefsPurger,
+    private val sessionCacheCleaner: SessionCacheCleaner,
+) {
+
+    /** The in-progress add-account flow, or null. The auth repository reads this to route sign-in
+     *  calls through the pending identity and their success through [completeAdd]. */
+    @Volatile
+    var pendingAdd: PendingAddSession? = null
+        private set
+
+    /**
+     * Switch the active account to [accountId]. No-op when it isn't in the roster or is already active.
+     * The URL + token-key + roster pointer + identity repoint runs inside [SwitchGate.withSwitch], so
+     * new requests park until it completes and in-flight requests finish against the account they were
+     * snapshotted for. Publishing identity last (inside the gate) makes `SessionManager` reconcile the
+     * old session away only once the flip is atomic and complete.
+     */
+    suspend fun switch(accountId: String) {
+        switchGate.withSwitch {
+            // Resolve the target and the no-op guards INSIDE the barrier: reading the roster / active
+            // pointer outside it opens a TOCTOU window where a concurrent logout could remove the entry
+            // (or flip the active account) between the check and the flip, leaving the live identity
+            // pointing at an account the persisted roster no longer marks active. Under the gate the
+            // read and the repoint are atomic with respect to any other switch/teardown.
+            val entry = roster.snapshot().entries.firstOrNull { it.accountId == accountId }
+                ?: return@withSwitch
+            if (activeAccountProvider.currentAccountId()?.value == accountId) return@withSwitch
+            flipTo(entry)
+        }
+    }
+
+    /**
+     * The atomic five-step repoint to [entry]: URL → token binding → roster pointer → cache clear →
+     * identity publish. Shared by [switch] and [remove]'s successor flip. NonCancellable because the
+     * callers run in UI scopes: a cancellation between the URL flip (persisted synchronously) and the
+     * identity publish would otherwise leave a torn `(url=B, tokens/identity=A)` state that survives
+     * an app restart — A's bearer sent to B's host. Caller holds the [SwitchGate] barrier.
+     */
+    private suspend fun flipTo(entry: AccountEntry) {
+        withContext(NonCancellable) {
+            serverDataStore.setServerUrl(entry.serverUrl)
+            tokenManager.selectAccount(entry.accountId)
+            roster.activate(entry.accountId)
+            // Quiesce → clear → publish: the non-partitionable caches (WebView storage + cookie jar)
+            // clear while requests are still parked and before the new identity is observable, so the
+            // incoming account never sees the outgoing one's web state or OAuth cookie. Best-effort
+            // inside the cleaner — a clear failure doesn't abort the switch.
+            switchCacheCleaner.clearOnSwitch()
+            activeAccountProvider.set(AccountId(entry.accountId))
+        }
+    }
+
+    /**
+     * Start an add-account flow against [serverUrl] (scheme-qualified; trailing slash trimmed).
+     * Requires a resolved active account — adding is "sign in another account while one is live";
+     * a logged-out user takes the plain login path. Purges any bare-key staging left by an earlier
+     * abandoned sign-in (it would otherwise leak into this flow's pending bearer) and re-asserts the
+     * active account's token binding, then exposes the [PendingAddSession] whose [PendingRequestIdentity]
+     * the flow's calls must run under.
+     *
+     * Callers own the lifecycle: exactly one flow at a time, ended by [completeAdd] (auth success)
+     * or [cancelAdd] (user abandons / flow fails). Calling again while one is pending restarts it.
+     */
+    suspend fun beginAdd(serverUrl: String): PendingAddSession {
+        val active = checkNotNull(activeAccountProvider.currentAccountId()) {
+            "add-account requires a resolved active account; use the plain login flow when logged out"
+        }
+        val normalizedUrl = serverUrl.trimTrailingSlash()
+        require(normalizedUrl.isNotBlank()) { "add-account requires a server URL" }
+        // A previously abandoned sign-in (killed app / dropped flow) may have left a staged pair and
+        // a dropped active binding. Clear the stale staging so this flow's pending bearer can only
+        // ever be a token issued by THIS flow, and re-bind the active account (idempotent no-op when
+        // already bound).
+        tokenManager.clearStagedTokens()
+        tokenManager.selectAccount(active.value)
+        val session = PendingAddSession(
+            serverUrl = normalizedUrl,
+            requestIdentity = PendingRequestIdentity(
+                baseUrl = normalizedUrl,
+                bearer = { tokenManager.getStagedAccessToken() },
+            ),
+        )
+        pendingAdd = session
+        return session
+    }
+
+    /**
+     * Records the pending server's validated config on the add session (see
+     * [PendingAddSession.startupConfig]). No-op when no add is pending (the flow was cancelled
+     * between validation and this call).
+     */
+    fun attachPendingConfig(config: StartupConfig) {
+        pendingAdd?.attachConfig(config)
+    }
+
+    /**
+     * Runs [block] under the pending add flow's request identity, so its HTTP calls target the
+     * server being added (config validation, social-login checks) instead of the live server.
+     * Passthrough when no add is pending. The auth repository handles its own routing; this is for
+     * feature-layer callers (the add-mode auth screens).
+     */
+    suspend fun <T> withPendingIdentity(block: suspend () -> T): T =
+        pendingAdd.withRequestIdentity(block)
+
+    /**
+     * Abandon the pending add-account flow: drop the staged tokens the flow's sign-in may have
+     * issued and re-assert the active account's token binding (sign-in staging drops it). Every step
+     * is best-effort and non-throwing — a cancel must always leave the app on the active account.
+     * No-op when nothing is pending.
+     */
+    suspend fun cancelAdd() {
+        if (pendingAdd == null) return
+        pendingAdd = null
+        withContext(NonCancellable) {
+            runCatching { tokenManager.clearStagedTokens() }
+                .onFailure { Logger.w(it) { "cancelAdd: staged-token clear failed" } }
+            val active = activeAccountProvider.currentAccountId()
+            if (active != null) {
+                runCatching { tokenManager.selectAccount(active.value) }
+                    .onFailure { Logger.w(it) { "cancelAdd: active-account rebind failed" } }
+            }
+        }
+    }
+
+    /**
+     * Complete the pending add-account flow for the authenticated [user]: derive the new account's
+     * identity from the **pending** server URL (never the live one), run the one-time legacy claim,
+     * then atomically — under the switch barrier — point the server URL at the new server, re-home
+     * the staged tokens into the account's keyed slot, upsert-and-activate its roster entry, and
+     * publish it. The outgoing account keeps its tokens and rows; this is "add, then switch to it".
+     *
+     * Re-adding an account already in the roster is inherently a switch-with-fresh-login: the upsert
+     * replaces its entry and the re-home overwrites its keyed slot with the just-issued pair.
+     *
+     * On failure the half-applied flip is rolled back (URL + token binding restored to the outgoing
+     * account, non-throwing, inside the still-closed gate) and the pending session stays set so the
+     * flow can retry or cancel.
+     */
+    suspend fun completeAdd(user: User): AccountId {
+        val pending = checkNotNull(pendingAdd) { "completeAdd without a pending add-account flow" }
+        val userKey = user.accountUserKey()
+        val serverId = deriveServerId(pending.serverUrl)
+        val accountId = deriveAccountId(serverId, userKey)
+        // Same claim-before-publish discipline as AccountSessionEstablisher.establish: stamp any
+        // legacy unowned rows for this user before scoped reads/writes go live for the account.
+        // Best-effort (marker-guarded, retried by a later establish); only cancellation aborts.
+        runCatching { claimReconciler.claimIfNeeded(accountId, userKey) }
+            .onFailure { error ->
+                if (error is CancellationException) throw error
+                Logger.w(error) { "Legacy account claim failed; completing add anyway (will retry)" }
+            }
+        switchGate.withSwitch {
+            val rollbackUrl = serverDataStore.getBaseUrl()
+            val rollbackAccount = activeAccountProvider.currentAccountId()
+            var flipped = false
+            try {
+                serverDataStore.setServerUrl(pending.serverUrl)
+                tokenManager.onAccountResolved(accountId.value)
+                roster.upsertAndActivate(
+                    AccountEntry(
+                        accountId = accountId.value,
+                        serverUrl = pending.serverUrl,
+                        displayLabel = user.displayLabel(pending.serverUrl),
+                        avatarUrl = user.avatar?.takeIf { it.isNotBlank() },
+                        lastActiveAt = Clock.System.now().toEpochMilliseconds(),
+                    ),
+                )
+                // Same quiesce → clear → publish discipline as switch(): the outgoing account's web
+                // state/cookies clear before the added account becomes observable. (The add flow has
+                // already consumed its own OAuth cookie, so clearing it here is safe.)
+                switchCacheCleaner.clearOnSwitch()
+                activeAccountProvider.set(accountId)
+                flipped = true
+            } finally {
+                if (!flipped) {
+                    // Restore a coherent outgoing-account state before reopening the gate, so parked
+                    // requests never snapshot a half-applied flip. Non-throwing, and NonCancellable so
+                    // a cancelled completion still rolls back. (The staged pair may already be
+                    // re-homed into the new account's keyed slot; that is harmless at rest and a
+                    // retry's re-home no-ops onto it.)
+                    withContext(NonCancellable) {
+                        runCatching { serverDataStore.setServerUrl(rollbackUrl) }
+                            .onFailure { Logger.w(it) { "completeAdd rollback: URL restore failed" } }
+                        if (rollbackAccount != null) {
+                            runCatching { tokenManager.selectAccount(rollbackAccount.value) }
+                                .onFailure { Logger.w(it) { "completeAdd rollback: token rebind failed" } }
+                        }
+                    }
+                }
+            }
+        }
+        pendingAdd = null
+        return accountId
+    }
+
+    /**
+     * Remove [accountId] and every trace of its data: roster entry, keyed tokens, `acct:` preferences,
+     * and (outside the gate — the deletes are the slow leg, and the account is already unreachable by
+     * then) its tenant Room rows. No-op when it isn't in the roster.
+     *
+     * Removing the **active** account first flips to the most-recently-active remaining account —
+     * a full switch (URL + token binding + cache clear + publish) so the app stays signed in — or,
+     * when it was the last account, tears down to the logged-out state (logout-shaped: active tokens +
+     * staging + mirror cleared, session file caches cleared) and fires the session-expired signal to
+     * route the app to auth. The server URL is deliberately retained on remove-last, matching logout,
+     * so the login screen comes back prefilled.
+     *
+     * Ordering mirrors logout: identity is flipped away from the account *before* its rows are
+     * deleted, so no read collector or origin-captured write can observe the purge mid-flight (the
+     * roster removal also flips origin-captured stragglers to skip — `resolveWriteAccountId`).
+     */
+    suspend fun remove(accountId: String) {
+        var removed = false
+        var removedLastAccount = false
+        switchGate.withSwitch {
+            val entries = roster.snapshot().entries
+            if (entries.none { it.accountId == accountId }) return@withSwitch
+            removed = true
+            // NonCancellable like [flipTo]: a cancellation between the successor flip / teardown and
+            // the roster+token removal below would leave a half-removed account (roster entry with
+            // deleted tokens, or vice versa) at rest.
+            withContext(NonCancellable) {
+                if (activeAccountProvider.currentAccountId()?.value == accountId) {
+                    val successor = entries
+                        .filterNot { it.accountId == accountId }
+                        .maxByOrNull { it.lastActiveAt }
+                    if (successor != null) {
+                        flipTo(successor)
+                    } else {
+                        removedLastAccount = true
+                        // Publish logged-out first: read collectors tear down their account-scoped
+                        // queries before the token/cache teardown, same order as logout. Only the fast
+                        // identity flip + token clear run under the gate; the slow WebKit / file-cache
+                        // wipes run after it reopens (below).
+                        activeAccountProvider.clear()
+                        tokenManager.onAccountCleared()
+                    }
+                }
+                roster.removeAndDeactivate(accountId)
+                tokenManager.removeAccount(accountId)
+                prefsPurger.purge(accountId)
+            }
+        }
+        if (removedLastAccount) {
+            // Slow, non-partitionable wipes run OUTSIDE the gate (it has reopened) — a ≤3s WebKit
+            // clear held under the gate would park every in-flight request for its whole duration.
+            // Still NonCancellable so a scope cancellation can't abort the teardown half-done. The
+            // cache cleaner is account-blind (file caches only) — prefsPurger.purge(accountId) above
+            // already reaped this account's keyed role cache and other acct:-scoped prefs.
+            withContext(NonCancellable) {
+                switchCacheCleaner.clearOnSwitch()
+                sessionCacheCleaner.clearFileCaches()
+            }
+            // Reuse the session-expired channel to drive nav-to-auth reactively; the settings screen
+            // that triggered the removal has no navigator reference of its own.
+            tokenManager.emitSessionExpired()
+        }
+        if (removed) {
+            accountDataPurger.purge(AccountId(accountId))
+        }
+    }
+}

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/AuthRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/AuthRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package com.garfiec.librechat.core.data.repository
 
+import com.garfiec.librechat.core.common.identity.AccountId
 import com.garfiec.librechat.core.common.identity.AccountState
 import com.garfiec.librechat.core.common.identity.ActiveAccountProvider
 import com.garfiec.librechat.core.common.identity.SessionManager
@@ -13,7 +14,11 @@ import com.garfiec.librechat.core.model.User
 import com.garfiec.librechat.core.model.response.TwoFactorSetupResponse
 import com.garfiec.librechat.core.network.api.AuthApi
 import com.garfiec.librechat.core.network.api.UserApi
+import com.garfiec.librechat.core.network.client.PendingRequestIdentity
+import com.garfiec.librechat.core.network.client.SwitchGate
 import com.garfiec.librechat.core.network.client.TokenManager
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.withContext
 
 class AuthRepositoryImpl(
     private val authApi: AuthApi,
@@ -25,7 +30,8 @@ class AuthRepositoryImpl(
     private val accountRegistry: AccountRegistry,
     private val activeAccountProvider: ActiveAccountProvider,
     private val sessionManager: SessionManager,
-    private val accountDataPurger: AccountDataPurger,
+    private val accountSwitcher: AccountSwitcher,
+    private val switchGate: SwitchGate,
 ) : AuthRepository {
 
     /**
@@ -34,61 +40,131 @@ class AuthRepositoryImpl(
      * sign-in, but `login()`'s `LoginOutcome.TwoFactorRequired` is a pending state (user
      * isn't authenticated yet) so tasks defer to `verifyTwoFactor()`.
      */
-    private fun <T> Result<T>.fireSessionTasksIfLoggedIn(isAuthenticated: (T) -> Boolean = { true }): Result<T> =
-        also { if (it is Result.Success && isAuthenticated(it.data)) sessionTaskRunner.runAll() }
+    private fun <T> Result<T>.fireSessionTasksIfLoggedIn(
+        previousAccountId: AccountId?,
+        isAuthenticated: (T) -> Boolean = { true },
+    ): Result<T> =
+        also {
+            if (it is Result.Success && isAuthenticated(it.data)) {
+                // The NavHost's accountTransitions (Switched) collector already runs the session tasks
+                // for any account→different-account flip — an add-completion (A→B) AND a soft-expiry
+                // re-auth as a different account (A→B). Firing here too would double every post-login
+                // fetch and race two writers onto the same acct: keys. Fire here only when this sign-in
+                // was NOT such a transition and the collector therefore won't cover it: a fresh login
+                // from logged-out (null→B) or a re-auth as the same account (A→A). [previousAccountId]
+                // is captured before establishSession; the current id reflects the post-establish flip.
+                // The one window where a transition could slip past the collector — the NavHost VM being
+                // re-created (process death) exactly across the flip — is backstopped by the cold-start
+                // path (NavHostViewModel.init calls sessionTaskRunner.runAll for the resolved account),
+                // so no resolved login is ever left without its session tasks.
+                val current = activeAccountProvider.currentAccountId()
+                val handledByCollector =
+                    previousAccountId != null && current != null && previousAccountId != current
+                if (!handledByCollector) sessionTaskRunner.runAll()
+            }
+        }
+
+    /**
+     * Runs [block] under the pending add-account identity when an add flow is in progress, so its
+     * HTTP calls target the server being added (with the staged bearer) instead of the active
+     * account's server. Passes [pending] explicitly so one capture drives both the request routing
+     * and the completion dispatch — the two can't disagree mid-call.
+     */
+    private suspend fun <T> withAuthIdentity(pending: PendingAddSession?, block: suspend () -> T): T =
+        pending.withRequestIdentity(block)
+
+    /**
+     * Turns the authenticated [user] into the active account: through the add-completion (atomic
+     * URL+token+roster+identity flip to the new account) when [pending] is an add flow, else through
+     * the normal establish path.
+     */
+    private suspend fun establishSession(pending: PendingAddSession?, user: User) {
+        if (pending != null) accountSwitcher.completeAdd(user) else accountSessionEstablisher.establish(user)
+    }
+
+    /**
+     * Fetches the just-authenticated user's profile carrying the *staged* bearer. After
+     * [TokenManager.setTokens] the fresh pair sits under the bare staging keys with no active
+     * binding — but a re-login after a hard session expiry still has the previous account
+     * Resolved, so the switch barrier would key this request's bearer to that account's (now
+     * empty) slot and deliberately never fall back to staging ([SwitchGate.captureSnapshot]),
+     * turning every OAuth re-login into a 401 loop. Route the fetch under an explicit
+     * staged-bearer identity instead. In add mode the surrounding pending identity already
+     * carries the staged bearer.
+     */
+    private suspend fun fetchAuthenticatedUser(pending: PendingAddSession?): User {
+        if (pending != null) return userApi.getUser()
+        val baseUrl = switchGate.captureSnapshot().baseUrl
+        return withContext(
+            PendingRequestIdentity(baseUrl = baseUrl, bearer = { tokenManager.getStagedAccessToken() }),
+        ) { userApi.getUser() }
+    }
 
     override suspend fun login(email: String, password: String): Result<LoginOutcome> {
+        val pending = accountSwitcher.pendingAdd
+        val previousAccountId = activeAccountProvider.currentAccountId()
         return safeApiCall {
-            val result = authApi.login(email, password)
-            if (result.response.twoFactorRequired && result.response.tempToken != null) {
-                LoginOutcome.TwoFactorRequired(
-                    result.response.tempToken
-                        ?: throw IllegalStateException("Server indicated 2FA required but tempToken was null"),
+            withAuthIdentity(pending) {
+                val result = authApi.login(email, password)
+                if (result.response.twoFactorRequired && result.response.tempToken != null) {
+                    LoginOutcome.TwoFactorRequired(
+                        result.response.tempToken
+                            ?: throw IllegalStateException("Server indicated 2FA required but tempToken was null"),
+                    )
+                } else {
+                    tokenManager.setTokens(
+                        accessToken = result.response.token ?: "",
+                        refreshToken = result.refreshToken ?: "",
+                    )
+                    val user = result.response.user
+                        ?: throw IllegalStateException("Login succeeded but user was null in response")
+                    // Establish identity (+ run the legacy claim) before session tasks fire, so their
+                    // tenant writes are stamped to this account and reads filter to it.
+                    establishSession(pending, user)
+                    LoginOutcome.Success(user)
+                }
+            }
+        }.fireSessionTasksIfLoggedIn(previousAccountId) { outcome ->
+            outcome is LoginOutcome.Success
+        }
+    }
+
+    override suspend fun loginWithOAuthToken(refreshToken: String): Result<User> {
+        val pending = accountSwitcher.pendingAdd
+        val previousAccountId = activeAccountProvider.currentAccountId()
+        return safeApiCall {
+            withAuthIdentity(pending) {
+                val result = authApi.refresh(refreshToken)
+                // If the backend rotated the refresh token, use the new one;
+                // otherwise keep the original OAuth-provided token.
+                val effectiveRefreshToken = result.newRefreshToken ?: refreshToken
+                tokenManager.setTokens(
+                    accessToken = result.response.token,
+                    refreshToken = effectiveRefreshToken,
                 )
-            } else {
+                // Fetch the user profile, then establish identity before session tasks fire.
+                val user = fetchAuthenticatedUser(pending)
+                establishSession(pending, user)
+                user
+            }
+        }.fireSessionTasksIfLoggedIn(previousAccountId)
+    }
+
+    override suspend fun verifyTwoFactor(tempToken: String, code: String): Result<User> {
+        val pending = accountSwitcher.pendingAdd
+        val previousAccountId = activeAccountProvider.currentAccountId()
+        return safeApiCall {
+            withAuthIdentity(pending) {
+                val result = authApi.verifyTempToken(tempToken = tempToken, totpCode = code)
                 tokenManager.setTokens(
                     accessToken = result.response.token ?: "",
                     refreshToken = result.refreshToken ?: "",
                 )
-                val user = result.response.user
-                    ?: throw IllegalStateException("Login succeeded but user was null in response")
-                // Establish identity (+ run the legacy claim) before session tasks fire, so their
-                // tenant writes are stamped to this account and reads filter to it.
-                accountSessionEstablisher.establish(user)
-                LoginOutcome.Success(user)
+                val user = result.response.user ?: throw IllegalStateException("No user in 2FA response")
+                establishSession(pending, user)
+                user
             }
-        }.fireSessionTasksIfLoggedIn { outcome -> outcome is LoginOutcome.Success }
-    }
-
-    override suspend fun loginWithOAuthToken(refreshToken: String): Result<User> {
-        return safeApiCall {
-            // Use the refresh token to get an access token from the server
-            val result = authApi.refresh(refreshToken)
-            // If the backend rotated the refresh token, use the new one;
-            // otherwise keep the original OAuth-provided token.
-            val effectiveRefreshToken = result.newRefreshToken ?: refreshToken
-            tokenManager.setTokens(
-                accessToken = result.response.token,
-                refreshToken = effectiveRefreshToken,
-            )
-            // Fetch the user profile, then establish identity before session tasks fire.
-            val user = userApi.getUser()
-            accountSessionEstablisher.establish(user)
-            user
-        }.fireSessionTasksIfLoggedIn()
-    }
-
-    override suspend fun verifyTwoFactor(tempToken: String, code: String): Result<User> {
-        return safeApiCall {
-            val result = authApi.verifyTempToken(tempToken = tempToken, totpCode = code)
-            tokenManager.setTokens(
-                accessToken = result.response.token ?: "",
-                refreshToken = result.refreshToken ?: "",
-            )
-            val user = result.response.user ?: throw IllegalStateException("No user in 2FA response")
-            accountSessionEstablisher.establish(user)
-            user
-        }.fireSessionTasksIfLoggedIn()
+        }.fireSessionTasksIfLoggedIn(previousAccountId)
     }
 
     override suspend fun register(
@@ -98,7 +174,9 @@ class AuthRepositoryImpl(
         password: String,
     ): Result<Unit> {
         return safeApiCall {
-            authApi.register(name, email, username, password, password)
+            withAuthIdentity(accountSwitcher.pendingAdd) {
+                authApi.register(name, email, username, password, password)
+            }
         }
     }
 
@@ -106,30 +184,53 @@ class AuthRepositoryImpl(
         return safeApiCall {
             // Let the cold-start seed resolve identity first: a logout during the warming window
             // would otherwise read a null account and skip the scoped Room purge below (the leak).
-            accountRegistry.awaitSeeded()
-            // Capture the account to purge before any teardown flips identity to null.
-            val account = activeAccountProvider.currentAccountId()
+            accountRegistry.awaitReady()
+            // One atomic snapshot drives both the server-side revocation and the local teardown
+            // target: the POST otherwise captures its identity at request-build time, so a switch
+            // landing between entry and the request would revoke the server session of the account
+            // the user just switched TO (and never revoke this one). Pinning via a pending-style
+            // identity also skips the 401-refresh — revocation is best-effort; the teardown below
+            // is what must not miss.
+            val snapshot = switchGate.captureSnapshot()
+            val account = snapshot.accountId?.let { AccountId(it) }
             try {
-                authApi.logout()
+                withContext(
+                    PendingRequestIdentity(baseUrl = snapshot.baseUrl, bearer = { snapshot.bearer }),
+                ) { authApi.logout() }
             } finally {
-                // Logout drives teardown — end the account session before its rows are deleted.
-                // NOTE: tenant writes are not yet bound to Session.scope (the structural SessionWriter
-                // is deferred), so this does not by itself fence a debounced/in-flight write against the
-                // purge below. Mitigated per-path instead: the draft debounce re-checks identity before
-                // it lands and drops on a flip (DraftRepositoryImpl), and the conversation/message cache
-                // writes capture+guard the account at request time. The remaining narrow
-                // streaming-write-after-purge window is the SessionWriter's job.
-                sessionManager.endCurrentSession()
-                // Flip identity to null first (read collectors tear down their account-scoped
-                // queries), purge the active account from the registry (disk + in-memory), then
-                // scoped-DELETE its tenant rows — the leak fix: logout finally clears Room, not just
-                // file caches/tokens.
-                accountRegistry.clearActiveAccount()
-                account?.let { accountDataPurger.purge(it) }
-                // Clears the active account's keyed tokens AND drops the persisted mirror (vs
-                // clearTokens, the refresh-failure path, which leaves the account pointer intact).
-                tokenManager.onAccountCleared()
-                sessionCacheCleaner.clearSessionCaches()
+                // Teardown must finish even if this coroutine is cancelled mid-way (e.g. the Activity
+                // finishes during the WebView wipe). Without NonCancellable a cancellation could abort
+                // after the identity flip but before the cookie/WebView wipe, leaving the server's OAuth
+                // refreshToken cookie alive for the next resume's checkOAuthResult() to re-consume —
+                // silently signing the just-logged-out user back in. The switch/remove paths already
+                // run their teardown under NonCancellable; logout must too.
+                withContext(NonCancellable) {
+                    // End the account session scope only if the captured account is still the live one.
+                    // A switch/add landing during the slow revocation POST flips the live identity;
+                    // remove() below then reaps only the captured account without touching the
+                    // switched-to session, so we must not end that session. NOTE: tenant writes are not
+                    // yet bound to Session.scope (the structural SessionWriter is deferred), so this does
+                    // not by itself fence a debounced/in-flight write against the purge; it is mitigated
+                    // per-path (draft debounce re-checks identity; cache writes capture+guard the account
+                    // at request time).
+                    if (account == null || activeAccountProvider.currentAccountId() == account) {
+                        sessionManager.endCurrentSession()
+                    }
+                    if (account != null) {
+                        // One teardown owner: remove() promotes the most-recently-used survivor (the user
+                        // stays signed in) or, when this was the last account, tears down to logged-out
+                        // and emits session-expired to route to auth — the same path the account-switcher's
+                        // remove-account uses. It serializes the identity flip under the SwitchGate itself
+                        // and runs the slow cache/WebView wipes after the gate reopens. The switched-away
+                        // case (a switch landed mid-POST, so the captured account is no longer active) is
+                        // handled inside remove(): it reaps just that account without touching the live one.
+                        accountSwitcher.remove(account.value)
+                    } else {
+                        // Unresolved identity (should not happen after awaitReady) — no account to reap;
+                        // clear the account-blind file caches so nothing is left behind.
+                        sessionCacheCleaner.clearFileCaches()
+                    }
+                }
             }
         }
     }
@@ -141,7 +242,7 @@ class AuthRepositoryImpl(
     override suspend fun restoreAccountIfNeeded(): Boolean {
         if (!isLoggedIn()) return true
         // Let the registry's cold-start seed finish, then act only if it found no persisted account.
-        accountRegistry.awaitSeeded()
+        accountRegistry.awaitReady()
         val state = activeAccountProvider.state.value
         if (state is AccountState.Resolved && state.id != null) return true
         // Logged in but unaccounted → fresh upgrade. Derive identity from the current user. Wrap the
@@ -181,7 +282,10 @@ class AuthRepositoryImpl(
 
     override suspend fun requestPasswordReset(email: String): Result<Unit> {
         return safeApiCall {
-            authApi.requestPasswordReset(email)
+            // Reachable from an add-mode login screen too — route to the pending server when set.
+            withAuthIdentity(accountSwitcher.pendingAdd) {
+                authApi.requestPasswordReset(email)
+            }
         }
     }
 

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/CacheDirectory.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/CacheDirectory.kt
@@ -1,8 +1,6 @@
 package com.garfiec.librechat.core.data.repository
 
 import co.touchlab.kermit.Logger
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.launch
 
 /**
  * Subdirectories under the platform cache root that are cleared on logout.
@@ -11,6 +9,7 @@ internal val CACHE_SUBDIRECTORIES = listOf(
     "image_cache",
     "artifacts",
     "shared_images",
+    "shared_files",
     "camera_photos",
     "pdf_preview",
     "voice_recording",
@@ -25,16 +24,14 @@ internal val CACHE_SUBDIRECTORIES = listOf(
 internal expect fun deleteDirectoryRecursively(path: String)
 
 /**
- * Common implementation of [SessionCacheCleaner] that iterates [CACHE_SUBDIRECTORIES]
- * and deletes each from the provided [cacheRoot] directory. Also clears the cached
- * role permissions so permission gates don't leak across user sessions.
+ * Common implementation of [SessionCacheCleaner] that iterates [CACHE_SUBDIRECTORIES] and deletes
+ * each from the provided [cacheRoot] directory. Account-blind: role permissions and other
+ * account-scoped state are reaped by the account teardown, not here.
  */
 class CommonSessionCacheCleaner(
     private val cacheRoot: String,
-    private val roleRepository: RoleRepository,
-    private val applicationScope: CoroutineScope,
 ) : SessionCacheCleaner {
-    override fun clearSessionCaches() {
+    override fun clearFileCaches() {
         try {
             for (subdir in CACHE_SUBDIRECTORIES) {
                 deleteDirectoryRecursively("$cacheRoot/$subdir")
@@ -42,8 +39,5 @@ class CommonSessionCacheCleaner(
         } catch (e: Exception) {
             Logger.w(e) { "Failed to clear session caches on logout" }
         }
-        // roleRepository.clear() is a suspend function; dispatch it into the app scope so
-        // logout remains synchronous and can't be stalled by DataStore write latency.
-        applicationScope.launch { roleRepository.clear() }
     }
 }

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/ConfigRepository.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/ConfigRepository.kt
@@ -35,6 +35,25 @@ interface ConfigRepository {
     val detectedBackendVersion: StateFlow<String?>
 
     suspend fun validateServerUrl(url: String): Result<StartupConfig>
+
+    /**
+     * Validates that the request pipeline's current target is a LibreChat server WITHOUT
+     * publishing the fetched config to the in-memory state or the srv:-keyed disk cache.
+     * For add-account validation: the call runs under the pending server's request identity
+     * while the live account stays active, so [validateServerUrl]'s writes would surface the
+     * pending server's config to the live session and poison the live server's cache entry
+     * (the cache key derives from the live URL, not the probed one).
+     */
+    suspend fun probeServerUrl(): Result<StartupConfig>
+
+    /**
+     * Replaces the in-memory config state with the active server's cached entries (empty when
+     * none), leaving every server's disk cache untouched. Called after an account switch: the
+     * in-memory StateFlows are server-blind, so once the URL flips they still hold the outgoing
+     * server's config until this reseeds them from the incoming server's srv:-keyed cache.
+     */
+    suspend fun reloadForActiveServer()
+
     suspend fun fetchStartupConfig(): Result<StartupConfig>
     suspend fun fetchEndpoints(): Result<Map<String, EndpointConfig>>
     suspend fun fetchModels(): Result<Map<String, List<String>>>

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/ConfigRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/ConfigRepositoryImpl.kt
@@ -76,15 +76,27 @@ class ConfigRepositoryImpl(
         ) { "server config snapshot" }
     }
 
-    override suspend fun validateServerUrl(url: String): Result<StartupConfig> {
+    override suspend fun validateServerUrl(url: String): Result<StartupConfig> =
+        fetchAndValidateConfig { config ->
+            _startupConfig.value = config
+            configCache.saveStartupConfig(config)
+            logConfigSnapshot(config)
+        }
+
+    override suspend fun probeServerUrl(): Result<StartupConfig> =
+        // Validation only — publishing/caching would attribute the probed server's config to the
+        // live one (see the interface KDoc); the add flow carries the result on its pending session.
+        fetchAndValidateConfig { }
+
+    private suspend fun fetchAndValidateConfig(
+        onValid: suspend (StartupConfig) -> Unit,
+    ): Result<StartupConfig> {
         return try {
             val config = configApi.getStartupConfig()
             if (!isValidLibreChatConfig(config)) {
                 Result.Error(message = "This doesn't appear to be a LibreChat server")
             } else {
-                _startupConfig.value = config
-                configCache.saveStartupConfig(config)
-                logConfigSnapshot(config)
+                onValid(config)
                 Result.Success(config)
             }
         } catch (e: SerializationException) {
@@ -111,6 +123,15 @@ class ConfigRepositoryImpl(
      */
     private fun isValidLibreChatConfig(config: StartupConfig): Boolean {
         return config.serverDomain.isNotBlank()
+    }
+
+    override suspend fun reloadForActiveServer() {
+        _startupConfig.value = configCache.loadStartupConfig()
+        _endpointConfigs.value = configCache.loadEndpointConfigs().orEmpty()
+        _availableModels.value = configCache.loadAvailableModels().orEmpty()
+        // Version re-detects from the reloaded config on the next checkBackendVersion pass.
+        _detectedBackendVersion.value = null
+        loggedConfigSignature = null
     }
 
     override suspend fun fetchStartupConfig(): Result<StartupConfig> {

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/ConversationRepository.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/ConversationRepository.kt
@@ -1,5 +1,6 @@
 package com.garfiec.librechat.core.data.repository
 
+import com.garfiec.librechat.core.common.identity.AccountId
 import com.garfiec.librechat.core.common.result.Result
 import com.garfiec.librechat.core.model.Conversation
 import com.garfiec.librechat.core.model.ConversationPage
@@ -15,7 +16,20 @@ interface ConversationRepository {
         sortDirection: String? = null,
         isArchived: Boolean = false,
     ): Result<String?>
-    suspend fun getConversation(id: String): Result<Conversation>
+
+    /**
+     * Cache-first read of [id]. [originAccount] (origin-capture provenance) scopes both the cache
+     * read and the fallback [refreshConversation] write to the account that started the operation, so
+     * a read-through landing after a switch doesn't miss-then-refetch under the new account. Null
+     * (foreground callers) uses the live active account.
+     *
+     * Deliberately no default on [originAccount] (here and on the other provenance-carrying methods):
+     * every caller must decide between a send-time capture (any write that can land after a switch —
+     * streamed finalize, debounced or queued work) and an explicit null (foreground, where entry *is*
+     * land time). A silent default would let new deferred-write paths compile with land-time
+     * attribution — the mis-attribution bug this parameter exists to prevent.
+     */
+    suspend fun getConversation(id: String, originAccount: AccountId?): Result<Conversation>
 
     /**
      * Fetches a cursor page of conversations filtered by [projectId] (a project id or
@@ -37,9 +51,9 @@ interface ConversationRepository {
      * [getConversation]'s cache-first read. Use when the local row is known to be
      * stale (e.g. picking up a server-generated title).
      */
-    suspend fun refreshConversation(id: String): Result<Conversation>
+    suspend fun refreshConversation(id: String, originAccount: AccountId?): Result<Conversation>
     suspend fun updateTitle(id: String, title: String): Result<Conversation>
-    suspend fun generateTitle(conversationId: String): Result<String>
+    suspend fun generateTitle(conversationId: String, originAccount: AccountId?): Result<String>
     suspend fun archive(id: String, isArchived: Boolean): Result<Conversation>
     suspend fun pin(id: String, pinned: Boolean): Result<Conversation>
     suspend fun delete(id: String): Result<Unit>
@@ -53,7 +67,7 @@ interface ConversationRepository {
     suspend fun duplicateConversation(conversationId: String, title: String?): Result<Conversation>
     suspend fun importConversation(jsonContent: String): Result<Conversation>
     suspend fun deleteAll(): Result<Unit>
-    suspend fun saveConversation(conversation: Conversation)
+    suspend fun saveConversation(conversation: Conversation, originAccount: AccountId?)
     suspend fun updateConversationTagsLocal(id: String, tags: List<String>)
     suspend fun syncFavoritesFromServer(): Result<Unit>
 }

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/ConversationRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/ConversationRepositoryImpl.kt
@@ -1,11 +1,13 @@
 package com.garfiec.librechat.core.data.repository
 
 import co.touchlab.kermit.Logger
+import com.garfiec.librechat.core.common.identity.AccountId
 import com.garfiec.librechat.core.common.identity.ActiveAccountProvider
 import com.garfiec.librechat.core.common.identity.currentAccountId
 import com.garfiec.librechat.core.common.identity.flatMapAccountOrEmpty
 import com.garfiec.librechat.core.common.result.Result
 import com.garfiec.librechat.core.common.result.safeApiCall
+import com.garfiec.librechat.core.data.datastore.AccountRoster
 import com.garfiec.librechat.core.data.db.dao.ConversationDao
 import com.garfiec.librechat.core.data.mapper.toEntity
 import com.garfiec.librechat.core.data.mapper.toModel
@@ -27,6 +29,7 @@ class ConversationRepositoryImpl(
     private val conversationsApi: ConversationsApi,
     private val conversationDao: ConversationDao,
     private val activeAccountProvider: ActiveAccountProvider,
+    private val roster: AccountRoster,
     private val json: Json,
 ) : ConversationRepository {
 
@@ -102,16 +105,25 @@ class ConversationRepositoryImpl(
         }
     }
 
-    override suspend fun getConversation(id: String): Result<Conversation> {
-        val cached = activeAccountProvider.currentAccountId()
-            ?.let { conversationDao.getByIdForAccount(id, it.value) }
+    override suspend fun getConversation(id: String, originAccount: AccountId?): Result<Conversation> {
+        val account = resolveWriteAccountId(originAccount, activeAccountProvider, roster)
+        val cached = account?.let { conversationDao.getByIdForAccount(id, it) }
         if (cached != null) return Result.Success(cached.toModel())
-        return refreshConversation(id)
+        return refreshConversation(id, originAccount)
     }
 
-    override suspend fun refreshConversation(id: String): Result<Conversation> {
+    override suspend fun refreshConversation(id: String, originAccount: AccountId?): Result<Conversation> {
+        // Origin-capture: this finalize may land after a switch. When the origin account is no longer
+        // live, skip the network refresh (the GET rides the LIVE snapshot and would carry this id to
+        // the new account's server) and serve the cached copy — a routine post-switch skip, not a bug.
+        if (!originTransportAllowed(originAccount, activeAccountProvider)) {
+            val account = resolveWriteAccountId(originAccount, activeAccountProvider, roster)
+            val cached = account?.let { conversationDao.getByIdForAccount(id, it)?.toModel() }
+            return cached?.let { Result.Success(it) }
+                ?: Result.Error(IllegalStateException("Skipped refresh for a non-active account's conversation"))
+        }
         return safeApiCall {
-            val accountId = activeAccountProvider.currentAccountId()?.value
+            val accountId = resolveWriteAccountId(originAccount, activeAccountProvider, roster)
             val conversation = conversationsApi.getConversation(id)
             if (accountId != null) {
                 conversationDao.upsertPreservingTags(accountId, conversation.toEntity().copy(accountId = accountId))
@@ -133,9 +145,18 @@ class ConversationRepositoryImpl(
         }
     }
 
-    override suspend fun generateTitle(conversationId: String): Result<String> {
+    override suspend fun generateTitle(conversationId: String, originAccount: AccountId?): Result<String> {
+        // Origin-capture: the gen_title long-poll returns minutes later, possibly post-switch — stamp
+        // the account that started the send, not the live active one. The POST rides the LIVE snapshot,
+        // so it must not fire once the origin is no longer active (it would carry this conversation id
+        // to the new account's server under its bearer). A benign skip, not a thrown invariant.
+        if (!originTransportAllowed(originAccount, activeAccountProvider)) {
+            return Result.Error(
+                IllegalStateException("Skipped title generation for a non-active account's conversation"),
+            )
+        }
         return safeApiCall {
-            val accountId = activeAccountProvider.currentAccountId()?.value
+            val accountId = resolveWriteAccountId(originAccount, activeAccountProvider, roster)
             val response = conversationsApi.generateTitle(conversationId)
             if (accountId != null) {
                 conversationDao.updateTitle(conversationId, response.title, Clock.System.now().toEpochMilliseconds(), accountId)
@@ -243,10 +264,12 @@ class ConversationRepositoryImpl(
         }
     }
 
-    override suspend fun saveConversation(conversation: Conversation) {
+    override suspend fun saveConversation(conversation: Conversation, originAccount: AccountId?) {
         val id = conversation.conversationId ?: return
         if (id.isBlank()) return
-        val accountId = activeAccountProvider.currentAccountId()?.value ?: return
+        // Origin-capture: the final-event save lands after the stream, possibly post-switch — stamp
+        // the originating account, and skip when unresolved or removed-since-capture.
+        val accountId = resolveWriteAccountId(originAccount, activeAccountProvider, roster) ?: return
         conversationDao.upsertPreservingTags(accountId, conversation.toEntity().copy(accountId = accountId))
     }
 

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/MessageRepository.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/MessageRepository.kt
@@ -1,5 +1,6 @@
 package com.garfiec.librechat.core.data.repository
 
+import com.garfiec.librechat.core.common.identity.AccountId
 import com.garfiec.librechat.core.common.result.Result
 import com.garfiec.librechat.core.model.Message
 import kotlinx.coroutines.flow.Flow
@@ -12,8 +13,13 @@ interface MessageRepository {
      * Persists [messages] to the local cache only — no network call. Records what a completed
      * stream already delivered (the SSE Final event is authoritative) so reopening shows it,
      * without a redundant `GET /messages` round-trip. The Room flow auto-emits.
+     *
+     * [originAccount] is the account captured at send time (origin-capture provenance): this write
+     * lands after the stream, possibly after an account switch, so the rows are stamped with the
+     * originating account rather than the live active one. Null (foreground callers) stamps the live
+     * active account. See `resolveWriteAccountId`.
      */
-    suspend fun cacheMessages(messages: List<Message>)
+    suspend fun cacheMessages(messages: List<Message>, originAccount: AccountId?)
     suspend fun refreshMessages(conversationId: String): Result<List<Message>>
     suspend fun updateFeedback(conversationId: String, messageId: String, feedback: String?): Result<Unit>
     suspend fun updateMessageText(conversationId: String, messageId: String, text: String): Result<Unit>

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/MessageRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/MessageRepositoryImpl.kt
@@ -1,11 +1,13 @@
 package com.garfiec.librechat.core.data.repository
 
 import co.touchlab.kermit.Logger
+import com.garfiec.librechat.core.common.identity.AccountId
 import com.garfiec.librechat.core.common.identity.ActiveAccountProvider
 import com.garfiec.librechat.core.common.identity.currentAccountId
 import com.garfiec.librechat.core.common.identity.flatMapAccountOrEmpty
 import com.garfiec.librechat.core.common.result.Result
 import com.garfiec.librechat.core.common.result.safeApiCall
+import com.garfiec.librechat.core.data.datastore.AccountRoster
 import com.garfiec.librechat.core.data.db.dao.MessageDao
 import com.garfiec.librechat.core.data.mapper.toEntity
 import com.garfiec.librechat.core.data.mapper.toModels
@@ -23,6 +25,7 @@ class MessageRepositoryImpl(
     private val messagesApi: MessagesApi,
     private val messageDao: MessageDao,
     private val activeAccountProvider: ActiveAccountProvider,
+    private val roster: AccountRoster,
     private val dispatcher: CoroutineDispatcher,
 ) : MessageRepository {
 
@@ -58,11 +61,14 @@ class MessageRepositoryImpl(
         return result
     }
 
-    override suspend fun cacheMessages(messages: List<Message>) {
+    override suspend fun cacheMessages(messages: List<Message>, originAccount: AccountId?) {
         if (messages.isEmpty()) return
-        // Don't persist when no account is resolved (warming / logged out): a null-stamped row is
-        // invisible to every account-filtered read and unreapable by the scoped logout purge.
-        val accountId = activeAccountProvider.currentAccountId()?.value ?: return
+        // Origin-capture: stamp the account that started the stream (threaded from send time), so a
+        // finalize landing after a switch attributes to it — not the live active account. Skip when
+        // unresolved (warming / logged out) or when the origin account was removed since capture: a
+        // null-stamped row is invisible to every account-filtered read and unreapable by the scoped
+        // logout purge, and resurrecting a removed account's rows would leak purged data.
+        val accountId = resolveWriteAccountId(originAccount, activeAccountProvider, roster) ?: return
         messageDao.upsertAll(messages.entitiesFor(accountId))
     }
 

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/OriginAccount.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/OriginAccount.kt
@@ -1,0 +1,47 @@
+package com.garfiec.librechat.core.data.repository
+
+import com.garfiec.librechat.core.common.identity.AccountId
+import com.garfiec.librechat.core.common.identity.ActiveAccountProvider
+import com.garfiec.librechat.core.common.identity.currentAccountId
+import com.garfiec.librechat.core.data.datastore.AccountRoster
+
+/**
+ * Resolves the account id to stamp on a read-through cache write, applying the origin-capture
+ * provenance rule (multi-account, issue #179).
+ *
+ * A streamed finalize (`cacheMessages` / `saveConversation` / `generateTitle` / `refreshConversation`)
+ * lands minutes after the send, potentially after the user switched accounts — so reading the *live*
+ * active account at land time would mis-attribute A's reply to B. The fix is origin-capture: the
+ * account is captured at the operation's entry (send time, in the chat streaming delegate) and threaded
+ * down as [origin]. This helper turns that captured origin into the id to stamp:
+ *
+ * - **No [origin]** (foreground read-through / CRUD, where entry *is* land time): stamp the live active
+ *   account; skip (null) when unresolved, exactly as before.
+ * - **[origin] present**: stamp it **iff it is still a known roster account**. If the account was
+ *   removed since capture, skip — a blanket stamp would resurrect its purged rows, while a blanket skip
+ *   (the draft template) would drop a valid finalize for an account that is merely non-active after a
+ *   switch. "Still known" threads that needle.
+ */
+internal suspend fun resolveWriteAccountId(
+    origin: AccountId?,
+    activeAccountProvider: ActiveAccountProvider,
+    roster: AccountRoster,
+): String? =
+    if (origin == null) {
+        activeAccountProvider.currentAccountId()?.value
+    } else {
+        origin.value.takeIf { roster.contains(it) }
+    }
+
+/**
+ * True when an origin-captured finalize's *network* leg may proceed. [resolveWriteAccountId] scopes
+ * the DB stamp, but the transport still snapshots the LIVE identity at request-build time — a
+ * finalize landing after a switch would send the origin account's conversation id to the NEW
+ * account's server under its bearer (cross-server id disclosure plus a guaranteed 404). Entry-time
+ * calls (null origin) always proceed; origin-captured ones only while that origin is still the
+ * live account.
+ */
+internal suspend fun originTransportAllowed(
+    origin: AccountId?,
+    activeAccountProvider: ActiveAccountProvider,
+): Boolean = origin == null || origin.value == activeAccountProvider.currentAccountId()?.value

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/SessionCacheCleaner.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/SessionCacheCleaner.kt
@@ -1,5 +1,11 @@
 package com.garfiec.librechat.core.data.repository
 
 interface SessionCacheCleaner {
-    fun clearSessionCaches()
+    /**
+     * Clears the account-blind file caches (image / artifact / shared-file dirs under the platform
+     * cache root). Account-scoped state — role permissions, keyed tokens, `acct:`-scoped prefs — is
+     * reaped separately by the account teardown (`AccountScopedPrefsPurger` + the token store), so
+     * this cleaner is deliberately account-blind and never touches a live account's permissions.
+     */
+    fun clearFileCaches()
 }

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/SwitchCacheCleaner.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/SwitchCacheCleaner.kt
@@ -1,0 +1,17 @@
+package com.garfiec.librechat.core.data.repository
+
+/**
+ * Clears the caches that cannot be account-partitioned when the active account changes without a
+ * logout (switch / add-completion / remove-active): WebView storage and the WebView cookie jar —
+ * both process-global, holding the outgoing account's artifact state and its OAuth `refreshToken`
+ * cookie. Runs inside the closed switch gate (requests are parked), after the outgoing account is
+ * quiesced and before the new identity publishes, so the incoming account never observes them.
+ *
+ * The Coil image cache is the other non-partitionable cache; it is cleared reactively in the UI
+ * layer (which owns the `ImageLoader` singleton) on the same identity transition. File caches under
+ * [CACHE_SUBDIRECTORIES] are NOT cleared on switch — same-owner stale content is accepted; they
+ * clear on logout as before.
+ */
+fun interface SwitchCacheCleaner {
+    suspend fun clearOnSwitch()
+}

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/util/AccountLabelBackfillSessionTask.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/util/AccountLabelBackfillSessionTask.kt
@@ -1,0 +1,34 @@
+package com.garfiec.librechat.core.data.util
+
+import com.garfiec.librechat.core.common.identity.ActiveAccountProvider
+import com.garfiec.librechat.core.common.identity.currentAccountId
+import com.garfiec.librechat.core.common.result.Result
+import com.garfiec.librechat.core.data.datastore.AccountRoster
+import com.garfiec.librechat.core.data.repository.UserRepository
+import com.garfiec.librechat.core.data.repository.displayLabel
+import com.garfiec.librechat.core.network.client.ServerUrlProvider
+
+/**
+ * Refreshes the active account's roster display label + avatar from the live user profile when a
+ * session starts. Fresh logins already write these (establish / add-completion); this covers the
+ * entries those paths never touch: a migrated pre-roster account (seeded with the server-host
+ * fallback because no `User` payload exists at migration time) and server-side profile changes for
+ * a stay-logged-in user. Best-effort — the runner swallows failures, and the switcher UI falls
+ * back to whatever label the roster already holds.
+ */
+class AccountLabelBackfillSessionTask(
+    private val userRepository: UserRepository,
+    private val accountRoster: AccountRoster,
+    private val activeAccountProvider: ActiveAccountProvider,
+    private val serverUrlProvider: ServerUrlProvider,
+) : SessionTask {
+    override suspend fun run() {
+        val active = activeAccountProvider.currentAccountId() ?: return
+        val user = (userRepository.getUser() as? Result.Success)?.data ?: return
+        accountRoster.updateDisplay(
+            accountId = active.value,
+            displayLabel = user.displayLabel(serverUrlProvider.awaitBaseUrl()),
+            avatarUrl = user.avatar?.takeIf { it.isNotBlank() },
+        )
+    }
+}

--- a/core/data/src/iosMain/kotlin/com/garfiec/librechat/core/data/di/DataPlatformModule.ios.kt
+++ b/core/data/src/iosMain/kotlin/com/garfiec/librechat/core/data/di/DataPlatformModule.ios.kt
@@ -12,13 +12,13 @@ import com.garfiec.librechat.core.data.db.LibreChatDatabase
 import com.garfiec.librechat.core.data.db.migration.MIGRATION_3_4
 import com.garfiec.librechat.core.data.db.migration.MIGRATION_4_5
 import com.garfiec.librechat.core.data.repository.CommonSessionCacheCleaner
-import com.garfiec.librechat.core.data.repository.RoleRepository
+import com.garfiec.librechat.core.data.repository.IosSwitchCacheCleaner
 import com.garfiec.librechat.core.data.repository.SessionCacheCleaner
+import com.garfiec.librechat.core.data.repository.SwitchCacheCleaner
 import com.garfiec.librechat.core.network.client.SecureTokenStorage
 import com.garfiec.librechat.core.network.client.TokenManager
 import io.ktor.client.HttpClient
 import kotlinx.cinterop.ExperimentalForeignApi
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import okio.Path.Companion.toPath
@@ -76,8 +76,9 @@ actual val dataPlatformModule: Module = module {
         ).firstOrNull() as? String ?: error("Unable to resolve NSCachesDirectory")
         CommonSessionCacheCleaner(
             cacheRoot = cachePath,
-            roleRepository = get<RoleRepository>(),
-            applicationScope = get<CoroutineScope>(KoinQualifiers.ApplicationScope),
         )
     }
+
+    // --- Switch Cache Cleaner (account switch, non-partitionable caches) ---
+    single<SwitchCacheCleaner> { IosSwitchCacheCleaner() }
 }

--- a/core/data/src/iosMain/kotlin/com/garfiec/librechat/core/data/repository/IosSwitchCacheCleaner.kt
+++ b/core/data/src/iosMain/kotlin/com/garfiec/librechat/core/data/repository/IosSwitchCacheCleaner.kt
@@ -1,0 +1,51 @@
+package com.garfiec.librechat.core.data.repository
+
+import co.touchlab.kermit.Logger
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
+import platform.Foundation.NSDate
+import platform.Foundation.NSHTTPCookie
+import platform.Foundation.NSHTTPCookieStorage
+import platform.Foundation.dateWithTimeIntervalSince1970
+import platform.WebKit.WKWebsiteDataStore
+
+/**
+ * iOS switch-cache clear: the shared cookie storage (holds the OAuth `refreshToken` cookie the
+ * launcher reads back — cleared whole so the outgoing account's cookie can't be re-read under the
+ * incoming one) and WKWebView website data (localStorage etc. behind inline artifacts, plus WK's own
+ * cookies). WebKit requires main-thread access. Best-effort: a clear failure must never abort the
+ * switch itself.
+ */
+class IosSwitchCacheCleaner : SwitchCacheCleaner {
+    override suspend fun clearOnSwitch() {
+        runCatching {
+            withContext(Dispatchers.Main) {
+                val storage = NSHTTPCookieStorage.sharedHTTPCookieStorage
+                storage.cookies?.forEach { cookie ->
+                    (cookie as? NSHTTPCookie)?.let { storage.deleteCookie(it) }
+                }
+                // Deferred + timeout rather than suspending on the WebKit callback directly: this
+                // runs inside the closed SwitchGate under NonCancellable, so a completion handler
+                // WebKit never invokes (its data-store process dying mid-operation) would otherwise
+                // never resume — the gate never reopens and every request in the app parks forever.
+                // complete() is idempotent, so a callback firing after the timeout is harmless.
+                val done = CompletableDeferred<Unit>()
+                WKWebsiteDataStore.defaultDataStore().removeDataOfTypes(
+                    dataTypes = WKWebsiteDataStore.allWebsiteDataTypes(),
+                    modifiedSince = NSDate.dateWithTimeIntervalSince1970(0.0),
+                ) { done.complete(Unit) }
+                if (withTimeoutOrNull(WEBKIT_CLEAR_TIMEOUT_MS) { done.await() } == null) {
+                    Logger.w { "Switch cache clear: WebKit data wipe timed out; continuing switch" }
+                }
+            }
+        }.onFailure { Logger.w(it) { "Switch cache clear failed" } }
+    }
+
+    private companion object {
+        /** Generous for a wipe that normally completes in tens of ms, small enough that a wedged
+         *  WebKit can't stall the switch (and all parked requests) noticeably longer. */
+        const val WEBKIT_CLEAR_TIMEOUT_MS = 3_000L
+    }
+}

--- a/core/network/CLAUDE.md
+++ b/core/network/CLAUDE.md
@@ -6,7 +6,7 @@ Ktor HttpClient, API service classes, SSE streaming client, auth interceptor. Al
 
 - **Ktor HttpClient factory** (`di/NetworkModule.kt`): Provides singleton `HttpClient(OkHttp)` with ContentNegotiation, Logging, HttpTimeout, HttpRequestRetry, and AuthInterceptorPlugin via Koin module.
 - **AuthInterceptorPlugin** (`client/AuthInterceptor.kt`): Custom Ktor plugin that injects `Authorization: Bearer` on outgoing requests and retries on 401 after refreshing tokens. Skips auth endpoints (`auth/login`, `auth/register`, `auth/refresh`, etc.).
-- **TokenManager interface** (`client/TokenManager.kt`): `getAccessToken()`, `setTokens()`, `refreshAccessToken()` (Mutex-guarded), `clearTokens()`, `sessionExpiredFlow`. Implemented in `:core:data`.
+- **TokenManager interface** (`client/TokenManager.kt`): `getAccessToken()`, `setTokens()`, `refreshAccessToken()` (single-flighted, epoch-guarded), `clearTokens()`, `sessionExpiredFlow`, plus the account-keyed `getAccessTokenFor()` / `selectAccount()` / `removeAccount()` / `refreshAccessTokenFor()`. Implemented in `:core:data`.
 - **ServerUrlProvider interface** (`client/ServerUrlProvider.kt`): Resolves the user-configured base URL. Implemented in `:core:data`.
 - **API services** (`api/`): One class per domain -- `AuthApi`, `ConversationsApi`, `MessagesApi`, `ChatStreamApi`, `FilesApi`, `AgentsApi`, `PresetsApi`, `PromptsApi`, `TagsApi`, `ShareApi`, `ConfigApi`, `EndpointsApi`, `BalanceApi`, `UserApi`, `SearchApi`. Each takes `HttpClient` as a constructor parameter, wired via Koin.
 - **SSE client** (`sse/`): `SseClient`, `SseEvent`, `SseEventParser`, `SseConnectionManager`.

--- a/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/client/AuthInterceptorTest.kt
+++ b/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/client/AuthInterceptorTest.kt
@@ -1,5 +1,8 @@
 package com.garfiec.librechat.core.network.client
 
+import com.garfiec.librechat.core.common.identity.AccountId
+import com.garfiec.librechat.core.common.identity.AccountState
+import com.garfiec.librechat.core.common.identity.InMemoryActiveAccountProvider
 import com.google.common.truth.Truth.assertThat
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
@@ -14,6 +17,7 @@ import io.ktor.serialization.kotlinx.json.json
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
 import org.junit.Test
 
 class AuthInterceptorTest {
@@ -25,6 +29,7 @@ class AuthInterceptorTest {
     ) : TokenManager {
         var refreshCallCount = 0
         var sessionExpiredCount = 0
+        var lastExpiredAccountId: String? = null
         private val _sessionExpiredFlow = MutableSharedFlow<Unit>()
         override val sessionExpiredFlow: SharedFlow<Unit> = _sessionExpiredFlow
         override val isAuthenticated: Boolean get() = accessToken != null
@@ -48,14 +53,30 @@ class AuthInterceptorTest {
             accessToken = null
         }
 
+        override suspend fun getAccessTokenFor(accountId: String): String? = accessToken
+
+        override suspend fun getStagedAccessToken(): String? = null
+
+        override suspend fun clearStagedTokens() = Unit
+
+        override suspend fun selectAccount(accountId: String) = Unit
+
+        override suspend fun removeAccount(accountId: String) {
+            accessToken = null
+        }
+
+        override suspend fun refreshAccessTokenFor(accountId: String, baseUrl: String): Boolean =
+            refreshAccessToken()
+
         override suspend fun onAccountResolved(accountId: String) = Unit
 
         override suspend fun onAccountCleared() {
             accessToken = null
         }
 
-        override fun emitSessionExpired() {
+        override fun emitSessionExpired(expiredAccountId: String?) {
             sessionExpiredCount++
+            lastExpiredAccountId = expiredAccountId
         }
     }
 
@@ -328,6 +349,70 @@ class AuthInterceptorTest {
 
         client.get("https://anyhost.example.org/api/data")
         assertThat(capturedAuth).isEqualTo("Bearer my-token")
+    }
+
+    @Test
+    fun `pending-identity request carries the staged bearer and its 401 passes through untouched`() = runTest {
+        // Add-account flow: the pending snapshot routes URL + bearer; a 401 must neither refresh any
+        // account nor emit the global session-expired signal (which would tear down the live account).
+        val tokenManager = FakeTokenManager(accessToken = "live-a-token", refreshSucceeds = true)
+        var requestCount = 0
+        var capturedAuth: String? = null
+        var capturedHost: String? = null
+        val engine = MockEngine { request ->
+            requestCount++
+            capturedAuth = request.headers[HttpHeaders.Authorization]
+            capturedHost = request.url.host
+            respond("Unauthorized", HttpStatusCode.Unauthorized)
+        }
+        val gate = SwitchGate(
+            activeAccountProvider = InMemoryActiveAccountProvider(AccountState.Resolved(AccountId("acct-a"))),
+            serverUrlProvider = FakeServerUrlProvider("https://a.example.com"),
+            tokenManager = tokenManager,
+            accountReadyGate = null,
+        )
+        val client = HttpClient(engine) {
+            install(ContentNegotiation) { json() }
+            install(SwitchBarrierPlugin) { switchGate = gate }
+            install(AuthInterceptorPlugin) { this.tokenManager = tokenManager }
+        }
+
+        val response = withContext(PendingRequestIdentity("https://b.example.com") { "staged-b" }) {
+            client.get("/api/user")
+        }
+
+        assertThat(capturedHost).isEqualTo("b.example.com")
+        assertThat(capturedAuth).isEqualTo("Bearer staged-b")
+        assertThat(response.status).isEqualTo(HttpStatusCode.Unauthorized)
+        assertThat(requestCount).isEqualTo(1)
+        assertThat(tokenManager.refreshCallCount).isEqualTo(0)
+        assertThat(tokenManager.sessionExpiredCount).isEqualTo(0)
+    }
+
+    @Test
+    fun `refresh failure on a snapshot request scopes the expiry signal to the snapshot account`() = runTest {
+        // The store decides whether a scoped expiry still matters (it suppresses non-active
+        // accounts); the plugin's contract is to pass the snapshot's account along, never a blanket
+        // global signal.
+        val tokenManager = FakeTokenManager(accessToken = "a-token", refreshSucceeds = false)
+        val engine = MockEngine { respond("Unauthorized", HttpStatusCode.Unauthorized) }
+        val gate = SwitchGate(
+            activeAccountProvider = InMemoryActiveAccountProvider(AccountState.Resolved(AccountId("acct-a"))),
+            serverUrlProvider = FakeServerUrlProvider("https://a.example.com"),
+            tokenManager = tokenManager,
+            accountReadyGate = null,
+        )
+        val client = HttpClient(engine) {
+            install(ContentNegotiation) { json() }
+            install(SwitchBarrierPlugin) { switchGate = gate }
+            install(AuthInterceptorPlugin) { this.tokenManager = tokenManager }
+        }
+
+        val response = client.get("/api/user")
+
+        assertThat(response.status).isEqualTo(HttpStatusCode.Unauthorized)
+        assertThat(tokenManager.sessionExpiredCount).isEqualTo(1)
+        assertThat(tokenManager.lastExpiredAccountId).isEqualTo("acct-a")
     }
 
     @Test

--- a/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/client/SwitchGateTest.kt
+++ b/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/client/SwitchGateTest.kt
@@ -1,0 +1,153 @@
+package com.garfiec.librechat.core.network.client
+
+import com.garfiec.librechat.core.common.identity.AccountId
+import com.garfiec.librechat.core.common.identity.AccountState.Resolved
+import com.garfiec.librechat.core.common.identity.InMemoryActiveAccountProvider
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.yield
+import org.junit.Test
+
+/**
+ * Snapshot semantics of [SwitchGate.captureSnapshot]: the bearer is keyed to the snapshot's account
+ * (immune to another account's sign-in staging), and a [PendingRequestIdentity] in the coroutine
+ * context short-circuits to the pending identity without touching the live providers or the gate.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class SwitchGateTest {
+
+    private class FakeTokenManager(
+        private val liveToken: String?,
+        private val keyed: Map<String, String> = emptyMap(),
+    ) : TokenManager {
+        override val isAuthenticated: Boolean get() = liveToken != null
+        override suspend fun getAccessToken(): String? = liveToken
+        override suspend fun setTokens(accessToken: String, refreshToken: String) = Unit
+        override suspend fun refreshAccessToken(): Boolean = false
+        override suspend fun clearTokens() = Unit
+        override suspend fun getAccessTokenFor(accountId: String): String? = keyed[accountId]
+        override suspend fun getStagedAccessToken(): String? = null
+        override suspend fun clearStagedTokens() = Unit
+        override suspend fun selectAccount(accountId: String) = Unit
+        override suspend fun removeAccount(accountId: String) = Unit
+        override suspend fun refreshAccessTokenFor(accountId: String, baseUrl: String): Boolean = false
+        override suspend fun onAccountResolved(accountId: String) = Unit
+        override suspend fun onAccountCleared() = Unit
+        override fun emitSessionExpired(expiredAccountId: String?) = Unit
+        override val sessionExpiredFlow: SharedFlow<Unit> = MutableSharedFlow()
+    }
+
+    private class FakeServerUrlProvider(private val baseUrl: String) : ServerUrlProvider {
+        override fun getBaseUrl(): String = baseUrl
+    }
+
+    @Test
+    fun `snapshot bearer is keyed to the snapshot account, not the live cache`() = runTest {
+        // Sign-in staging in progress: the live cache holds the STAGED account's token, but the
+        // resolved account A must snapshot its own keyed token.
+        val gate = SwitchGate(
+            activeAccountProvider = InMemoryActiveAccountProvider(Resolved(AccountId("acct-a"))),
+            serverUrlProvider = FakeServerUrlProvider("https://a.example.com"),
+            tokenManager = FakeTokenManager(liveToken = "staged-b", keyed = mapOf("acct-a" to "a-keyed")),
+            accountReadyGate = null,
+        )
+
+        val snapshot = gate.captureSnapshot()
+
+        assertThat(snapshot.accountId).isEqualTo("acct-a")
+        assertThat(snapshot.bearer).isEqualTo("a-keyed")
+        assertThat(snapshot.isPending).isFalse()
+    }
+
+    @Test
+    fun `snapshot bearer is null for a resolved account with an empty keyed slot`() = runTest {
+        // Must not fall through to the live cache (which may hold another account's staged token).
+        val gate = SwitchGate(
+            activeAccountProvider = InMemoryActiveAccountProvider(Resolved(AccountId("acct-a"))),
+            serverUrlProvider = FakeServerUrlProvider("https://a.example.com"),
+            tokenManager = FakeTokenManager(liveToken = "staged-b", keyed = emptyMap()),
+            accountReadyGate = null,
+        )
+
+        assertThat(gate.captureSnapshot().bearer).isNull()
+    }
+
+    @Test
+    fun `snapshot falls back to the live token when no account is resolved`() = runTest {
+        // Legacy pre-migration / logged-out-with-bare-tokens path.
+        val gate = SwitchGate(
+            activeAccountProvider = InMemoryActiveAccountProvider(Resolved(null)),
+            serverUrlProvider = FakeServerUrlProvider("https://a.example.com"),
+            tokenManager = FakeTokenManager(liveToken = "bare-legacy"),
+            accountReadyGate = null,
+        )
+
+        assertThat(gate.captureSnapshot().bearer).isEqualTo("bare-legacy")
+    }
+
+    @Test
+    fun `pending identity short-circuits without reading the live providers`() = runTest {
+        // Live providers that would fail the test if consulted.
+        val gate = SwitchGate(
+            activeAccountProvider = InMemoryActiveAccountProvider(Resolved(AccountId("acct-a"))),
+            serverUrlProvider = object : ServerUrlProvider {
+                override fun getBaseUrl(): String = error("live URL must not be read for a pending request")
+            },
+            tokenManager = object : TokenManager by FakeTokenManager(null) {
+                override suspend fun getAccessToken(): String? = error("live token must not be read")
+                override suspend fun getAccessTokenFor(accountId: String): String? = error("keyed token must not be read")
+            },
+            accountReadyGate = object : AccountReadyGate {
+                override suspend fun awaitReady() = error("ready gate must not be awaited for a pending request")
+            },
+        )
+
+        val snapshot = withContext(PendingRequestIdentity("https://b.example.com") { "staged-b" }) {
+            gate.captureSnapshot()
+        }
+
+        assertThat(snapshot.baseUrl).isEqualTo("https://b.example.com")
+        assertThat(snapshot.accountId).isNull()
+        assertThat(snapshot.bearer).isEqualTo("staged-b")
+        assertThat(snapshot.isPending).isTrue()
+    }
+
+    @Test
+    fun `pending identity bypasses a closed switch gate`() = runTest {
+        val gate = SwitchGate(
+            activeAccountProvider = InMemoryActiveAccountProvider(Resolved(AccountId("acct-a"))),
+            serverUrlProvider = FakeServerUrlProvider("https://a.example.com"),
+            tokenManager = FakeTokenManager(liveToken = "a-token", keyed = mapOf("acct-a" to "a-token")),
+            accountReadyGate = null,
+        )
+        val flipStarted = CompletableDeferred<Unit>()
+        val releaseFlip = CompletableDeferred<Unit>()
+        val switch = launch {
+            gate.withSwitch {
+                flipStarted.complete(Unit)
+                releaseFlip.await()
+            }
+        }
+        flipStarted.await()
+
+        // A pending capture completes while the gate is closed; a live capture would park.
+        val pending = async {
+            withContext(PendingRequestIdentity("https://b.example.com") { null }) {
+                gate.captureSnapshot()
+            }
+        }
+        yield()
+        assertThat(pending.isCompleted).isTrue()
+        assertThat(pending.await().baseUrl).isEqualTo("https://b.example.com")
+
+        releaseFlip.complete(Unit)
+        switch.join()
+    }
+}

--- a/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/di/NetworkModuleVerificationTest.kt
+++ b/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/di/NetworkModuleVerificationTest.kt
@@ -2,6 +2,8 @@ package com.garfiec.librechat.core.network.di
 
 import android.app.Application
 import android.content.Context
+import com.garfiec.librechat.core.common.identity.ActiveAccountProvider
+import com.garfiec.librechat.core.network.client.AccountReadyGate
 import com.garfiec.librechat.core.network.client.ServerUrlProvider
 import com.garfiec.librechat.core.network.client.TokenManager
 import io.ktor.client.engine.HttpClientEngine
@@ -20,6 +22,10 @@ class NetworkModuleVerificationTest {
                 HttpClientEngineFactory::class,
                 TokenManager::class,
                 ServerUrlProvider::class,
+                // SwitchGate consumes the active-account signal (bound in :core:data) + the account
+                // ready gate (getOrNull) — cross-module, so whitelist them for the isolated verify.
+                ActiveAccountProvider::class,
+                AccountReadyGate::class,
             ),
         )
     }

--- a/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/sse/SseClientOriginBindingTest.kt
+++ b/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/sse/SseClientOriginBindingTest.kt
@@ -11,6 +11,8 @@ import io.ktor.client.engine.mock.respond
 import io.ktor.client.plugins.defaultRequest
 import io.ktor.client.request.url
 import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
 import org.junit.Test
@@ -21,6 +23,7 @@ import org.junit.Test
  * otherwise resume the outgoing account's stream path under the new account's URL and bearer — a
  * cross-account resume. The guard aborts the retry loop instead.
  */
+@OptIn(ExperimentalCoroutinesApi::class)
 class SseClientOriginBindingTest {
 
     private val accountA = AccountId("srv-1:user-a")
@@ -37,7 +40,7 @@ class SseClientOriginBindingTest {
     }
 
     @Test
-    fun `reconnect aborts when the active account changed since the stream started`() = runTest {
+    fun `reconnect aborts when the active account changed since the stream started`() = runTest(UnconfinedTestDispatcher()) {
         val provider = InMemoryActiveAccountProvider(AccountState.Resolved(accountA))
         var requestCount = 0
         val client = SseClient(
@@ -59,7 +62,7 @@ class SseClientOriginBindingTest {
     }
 
     @Test
-    fun `reconnect proceeds while the account is unchanged`() = runTest {
+    fun `reconnect proceeds while the account is unchanged`() = runTest(UnconfinedTestDispatcher()) {
         val provider = InMemoryActiveAccountProvider(AccountState.Resolved(accountA))
         var requestCount = 0
         val client = SseClient(

--- a/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/sse/SseClientOriginBindingTest.kt
+++ b/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/sse/SseClientOriginBindingTest.kt
@@ -1,0 +1,76 @@
+package com.garfiec.librechat.core.network.sse
+
+import com.garfiec.librechat.core.common.identity.AccountId
+import com.garfiec.librechat.core.common.identity.AccountState
+import com.garfiec.librechat.core.common.identity.InMemoryActiveAccountProvider
+import com.garfiec.librechat.core.model.StreamEvent
+import com.google.common.truth.Truth.assertThat
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.defaultRequest
+import io.ktor.client.request.url
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import org.junit.Test
+
+/**
+ * The reconnect loop must stay bound to the account the stream started under: every transport
+ * (re)connect captures a fresh identity snapshot, so a retry attempted after an account switch would
+ * otherwise resume the outgoing account's stream path under the new account's URL and bearer — a
+ * cross-account resume. The guard aborts the retry loop instead.
+ */
+class SseClientOriginBindingTest {
+
+    private val accountA = AccountId("srv-1:user-a")
+    private val accountB = AccountId("srv-1:user-b")
+
+    private fun failingTransportClient(onRequest: () -> Unit): HttpClient {
+        val engine = MockEngine {
+            onRequest()
+            respond("boom", HttpStatusCode.InternalServerError)
+        }
+        return HttpClient(engine) {
+            defaultRequest { url("https://a.example.com") }
+        }
+    }
+
+    @Test
+    fun `reconnect aborts when the active account changed since the stream started`() = runTest {
+        val provider = InMemoryActiveAccountProvider(AccountState.Resolved(accountA))
+        var requestCount = 0
+        val client = SseClient(
+            json = Json { ignoreUnknownKeys = true },
+            transport = SseHttpTransport(failingTransportClient { requestCount++ }),
+            activeAccountProvider = provider,
+        )
+
+        val events = mutableListOf<StreamEvent>()
+        client.connect("api/agents/chat/stream/abc").collect { event ->
+            events += event
+            // Simulate a switch landing between the failed attempt and the retry.
+            provider.set(accountB)
+        }
+
+        // One real attempt, one Retrying signal, then the guard ends the flow — no reconnect as B.
+        assertThat(requestCount).isEqualTo(1)
+        assertThat(events.filterIsInstance<StreamEvent.Retrying>()).hasSize(1)
+    }
+
+    @Test
+    fun `reconnect proceeds while the account is unchanged`() = runTest {
+        val provider = InMemoryActiveAccountProvider(AccountState.Resolved(accountA))
+        var requestCount = 0
+        val client = SseClient(
+            json = Json { ignoreUnknownKeys = true },
+            transport = SseHttpTransport(failingTransportClient { requestCount++ }),
+            activeAccountProvider = provider,
+        )
+
+        client.connect("api/agents/chat/stream/abc").collect { }
+
+        // All retries exhausted under the same identity (initial attempt + retries).
+        assertThat(requestCount).isGreaterThan(1)
+    }
+}

--- a/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/AccountReadyGate.kt
+++ b/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/AccountReadyGate.kt
@@ -1,0 +1,17 @@
+package com.garfiec.librechat.core.network.client
+
+/**
+ * Completes once the account roster has been seeded and the token mirror reconciled at cold start.
+ *
+ * The token store seeds its cached bearer synchronously from a secure-storage mirror at construction —
+ * fast, but possibly *stale* if a crash left the mirror diverged from the durable roster pointer. The
+ * roster seed reconciles them (mirror-follows-roster) and drives the server URL from the active entry.
+ * HTTP admission ([ServerUrlReadyPlugin]) and first-frame routing await this gate so no request flies —
+ * and no auth route is chosen — against an unreconciled mirror bearer or a pre-roster server URL.
+ *
+ * Implemented by the account registry in `:core:data`; this interface lives here so the network layer
+ * can depend on it without a `:core:data` back-edge.
+ */
+interface AccountReadyGate {
+    suspend fun awaitReady()
+}

--- a/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/AuthInterceptorPlugin.kt
+++ b/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/AuthInterceptorPlugin.kt
@@ -32,16 +32,17 @@ class AuthInterceptorPlugin private constructor(
     }
 
     /**
-     * True when [requestHost] belongs to the configured server (so the bearer
-     * token is safe to attach). Returns true when host-scoping is disabled
-     * (no [serverUrlProvider]) or the base URL isn't resolved yet (empty host) —
-     * the latter only happens during cold-start warm-up, before any cross-host
-     * CDN fetch can occur, so it preserves same-origin auth without leaking.
+     * True when [requestHost] belongs to the server [baseUrl] (so the bearer token is safe to attach).
+     * Returns true when host-scoping is disabled ([baseUrl] null — no provider and no snapshot) or the
+     * base URL isn't resolved yet (empty host) — the latter only happens during cold-start warm-up,
+     * before any cross-host CDN fetch can occur, so it preserves same-origin auth without leaking.
+     *
+     * [baseUrl] is the request's snapshotted server URL when the [SwitchBarrierPlugin] is installed, so
+     * an account switch mid-request scopes the bearer to the account the request was snapshotted for
+     * (never the live one), keeping A's bearer off B's host.
      */
-    private fun isSameHostAsServer(requestHost: String): Boolean {
-        val provider = serverUrlProvider ?: return true
-        val baseUrl = provider.getBaseUrl()
-        if (baseUrl.isEmpty()) return true
+    private fun isSameHostAsServer(requestHost: String, baseUrl: String?): Boolean {
+        if (baseUrl.isNullOrEmpty()) return true
         val baseHost = runCatching { Url(baseUrl).host }.getOrNull()
         if (baseHost.isNullOrEmpty()) return true
         return requestHost.equals(baseHost, ignoreCase = true)
@@ -63,15 +64,28 @@ class AuthInterceptorPlugin private constructor(
             )
 
             // Attach token to outgoing requests. Runs at State, which is after
-            // defaultRequest (Before) has applied the base URL — so for the
-            // common relative-path call `context.url.host` is already the base
-            // host, and for an absolute cross-host URL (e.g. a presigned CDN
-            // download) it is that foreign host.
+            // the SwitchBarrier/defaultRequest phases have applied the base URL —
+            // so for the common relative-path call `context.url.host` is already
+            // the base host, and for an absolute cross-host URL (e.g. a presigned
+            // CDN download) it is that foreign host.
+            //
+            // When the SwitchBarrierPlugin is installed the request carries a
+            // RequestIdentity snapshot: the bearer, its account, and the server
+            // URL, all captured atomically. Read the bearer and host-scope from
+            // that snapshot so a switch mid-request can't tear the (url, token)
+            // pair. Without the barrier (refresh client / tests) fall back to the
+            // live active account, preserving legacy behavior.
             scope.requestPipeline.intercept(HttpRequestPipeline.State) {
                 val path = context.url.buildString()
                 val isSkipPath = skipPaths.any { path.contains(it) }
-                if (!isSkipPath && plugin.isSameHostAsServer(context.url.host)) {
-                    val token = plugin.tokenManager.getAccessToken()
+                val snapshot = context.attributes.getOrNull(RequestIdentityKey)
+                val serverBaseUrl = snapshot?.baseUrl ?: plugin.serverUrlProvider?.getBaseUrl()
+                if (!isSkipPath && plugin.isSameHostAsServer(context.url.host, serverBaseUrl)) {
+                    // Explicit branch (not `?:`): a snapshot whose bearer is null must attach
+                    // nothing — a pending add-account probe before sign-in has no token yet, and
+                    // falling through to the live cache would send the ACTIVE account's bearer to
+                    // the arbitrary host being added.
+                    val token = if (snapshot != null) snapshot.bearer else plugin.tokenManager.getAccessToken()
                     if (token != null) {
                         context.headers.append(HttpHeaders.Authorization, "Bearer $token")
                     }
@@ -90,31 +104,41 @@ class AuthInterceptorPlugin private constructor(
                 // attach: never refresh a token and re-send it to a foreign host
                 // (e.g. a presigned CDN URL). For a non-base host, pass the
                 // original 401 straight through with no token on the retry.
-                if (!plugin.isSameHostAsServer(request.url.host)) {
+                val snapshot = request.attributes.getOrNull(RequestIdentityKey)
+                val serverBaseUrl = snapshot?.baseUrl ?: plugin.serverUrlProvider?.getBaseUrl()
+                if (!plugin.isSameHostAsServer(request.url.host, serverBaseUrl)) {
                     return@intercept originalCall
                 }
 
+                // A pending-identity request (add-account flow) has no keyed account to refresh, and
+                // its auth failures belong to the add flow's UI: pass the 401 through without a
+                // refresh and without the global session-expired signal, which would tear down the
+                // *active* account's session over another account's failed sign-in.
+                if (snapshot?.isPending == true) {
+                    return@intercept originalCall
+                }
+
+                // Session-expiry emissions below are scoped to the snapshot's account: a straggler
+                // request of a switched-away (retained, still-valid-in-roster) account must not tear
+                // down the live account's session over its own dead credentials.
                 val alreadyRetried = request.attributes.getOrNull(RetryFlag) == true
                 if (alreadyRetried) {
                     Logger.w("Auth") { "401 after retry - session expired" }
-                    plugin.tokenManager.emitSessionExpired()
+                    plugin.tokenManager.emitSessionExpired(snapshot?.accountId)
                     return@intercept originalCall
                 }
 
                 Logger.d("Auth") { "401 received, attempting token refresh" }
-                val refreshed = plugin.tokenManager.refreshAccessToken()
-                if (!refreshed) {
+                val newToken = plugin.tokenManager.refreshBearerFor(snapshot)
+                if (newToken == null) {
                     Logger.w("Auth") { "Token refresh failed - session expired" }
-                    plugin.tokenManager.emitSessionExpired()
+                    plugin.tokenManager.emitSessionExpired(snapshot?.accountId)
                     return@intercept originalCall
                 }
 
-                val newToken = plugin.tokenManager.getAccessToken()
                 request.headers {
                     remove(HttpHeaders.Authorization)
-                    if (newToken != null) {
-                        append(HttpHeaders.Authorization, "Bearer $newToken")
-                    }
+                    append(HttpHeaders.Authorization, "Bearer $newToken")
                 }
                 request.attributes.put(RetryFlag, true)
 

--- a/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/LibreChatHttpClient.kt
+++ b/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/LibreChatHttpClient.kt
@@ -33,6 +33,8 @@ object LibreChatHttpClient {
         tokenManager: TokenManager,
         serverUrlProvider: ServerUrlProvider,
         redactor: LogRedactor,
+        accountReadyGate: AccountReadyGate? = null,
+        switchGate: SwitchGate? = null,
         debug: Boolean = false,
     ): HttpClient = HttpClient(engineFactory) {
         install(ContentNegotiation) {
@@ -70,10 +72,19 @@ object LibreChatHttpClient {
             this.serverUrlProvider = serverUrlProvider
         }
 
-        // Resolve the server-URL warm-up before defaultRequest reads getBaseUrl(), so a
-        // cold-start request can't be built against an empty base URL.
-        install(ServerUrlReadyPlugin) {
-            this.serverUrlProvider = serverUrlProvider
+        // The SwitchBarrierPlugin (when a SwitchGate is wired) captures a consistent
+        // (url, bearer, account) snapshot per request and resolves the URL against it, subsuming
+        // ServerUrlReadyPlugin's cold-start await. Without a gate (tests) fall back to the plain
+        // readiness plugin so a cold-start request can't be built against an empty base URL.
+        if (switchGate != null) {
+            install(SwitchBarrierPlugin) {
+                this.switchGate = switchGate
+            }
+        } else {
+            install(ServerUrlReadyPlugin) {
+                this.serverUrlProvider = serverUrlProvider
+                this.accountReadyGate = accountReadyGate
+            }
         }
 
         HttpResponseValidator {
@@ -95,7 +106,15 @@ object LibreChatHttpClient {
                     ) { "HTTP $statusCode" }
 
                     if (isBanned) {
-                        tokenManager.emitSessionExpired()
+                        // Scoped to the request's snapshot account: a ban landing on a switched-away
+                        // account's straggler request must not tear down the live session. A pending
+                        // add-flow request passes through entirely (its accountId is null, which
+                        // emitSessionExpired treats as "active session, always emit") — a ban from
+                        // the server being ADDED belongs to the add flow, mirroring the 401 path.
+                        val identity = response.call.request.attributes.getOrNull(RequestIdentityKey)
+                        if (identity?.isPending != true) {
+                            tokenManager.emitSessionExpired(identity?.accountId)
+                        }
                     }
 
                     throw ApiException(

--- a/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/RequestIdentityAuth.kt
+++ b/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/RequestIdentityAuth.kt
@@ -1,0 +1,22 @@
+package com.garfiec.librechat.core.network.client
+
+/**
+ * The one 401-recovery path shared by every transport (Ktor [AuthInterceptorPlugin] and the iOS raw
+ * SSE transport): refresh the account the request was snapshotted for — keyed and URL-pinned to the
+ * snapshot, so a switch that raced the request refreshes the right account against the right server,
+ * never the live one — and return the refreshed bearer. Without a snapshot (refresh client / tests)
+ * falls back to the live active account, preserving legacy behavior.
+ *
+ * Returns null when the refresh failed or the refreshed slot came back empty (a logout/removal raced
+ * the refresh); callers treat null as session-expired for `identity?.accountId`.
+ */
+suspend fun TokenManager.refreshBearerFor(identity: RequestIdentity?): String? {
+    val account = identity?.accountId
+    val refreshed = if (account != null) {
+        refreshAccessTokenFor(account, identity.baseUrl)
+    } else {
+        refreshAccessToken()
+    }
+    if (!refreshed) return null
+    return if (account != null) getAccessTokenFor(account) else getAccessToken()
+}

--- a/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/ServerUrlReadyPlugin.kt
+++ b/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/ServerUrlReadyPlugin.kt
@@ -7,7 +7,7 @@ import io.ktor.util.AttributeKey
 import io.ktor.util.pipeline.PipelinePhase
 
 /**
- * Awaits the server URL's async warm-up before each request is built.
+ * Awaits the account/server cold-start readiness before each request is built.
  *
  * [ServerDataStore] resolves the persisted base URL asynchronously off the Main thread, so
  * during a narrow cold-start window [ServerUrlProvider.getBaseUrl] (which the non-suspend
@@ -16,12 +16,21 @@ import io.ktor.util.pipeline.PipelinePhase
  * network layer: it runs in a phase inserted *before* [HttpRequestPipeline.Before] — where
  * Ktor's `DefaultRequest` applies the URL — so by the time `defaultRequest` reads
  * `getBaseUrl()` the warm-up has completed. After warm-up it is a no-op suspension point.
+ *
+ * When an [AccountReadyGate] is configured it is awaited **first**: the roster seed reconciles the
+ * token mirror to the durable active pointer and drives the server URL from the active entry, so
+ * gating on it closes the cold-start window where a request would fly with a stale mirror bearer or a
+ * pre-roster server URL. The gate's own seed awaits the same URL warm-up, so `awaitBaseUrl()` after it
+ * is a no-op. The token-refresh client is deliberately left ungated so a seed-time mirror reconcile
+ * can never deadlock behind an in-flight refresh.
  */
 class ServerUrlReadyPlugin private constructor(
     private val serverUrlProvider: ServerUrlProvider,
+    private val accountReadyGate: AccountReadyGate?,
 ) {
     class Config {
         lateinit var serverUrlProvider: ServerUrlProvider
+        var accountReadyGate: AccountReadyGate? = null
     }
 
     companion object : HttpClientPlugin<Config, ServerUrlReadyPlugin> {
@@ -30,12 +39,13 @@ class ServerUrlReadyPlugin private constructor(
 
         override fun prepare(block: Config.() -> Unit): ServerUrlReadyPlugin {
             val config = Config().apply(block)
-            return ServerUrlReadyPlugin(config.serverUrlProvider)
+            return ServerUrlReadyPlugin(config.serverUrlProvider, config.accountReadyGate)
         }
 
         override fun install(plugin: ServerUrlReadyPlugin, scope: HttpClient) {
             scope.requestPipeline.insertPhaseBefore(HttpRequestPipeline.Before, AwaitServerUrlPhase)
             scope.requestPipeline.intercept(AwaitServerUrlPhase) {
+                plugin.accountReadyGate?.awaitReady()
                 plugin.serverUrlProvider.awaitBaseUrl()
             }
         }

--- a/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/SwitchBarrierPlugin.kt
+++ b/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/SwitchBarrierPlugin.kt
@@ -1,0 +1,89 @@
+package com.garfiec.librechat.core.network.client
+
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.HttpClientPlugin
+import io.ktor.client.request.HttpRequestPipeline
+import io.ktor.http.DEFAULT_PORT
+import io.ktor.http.URLBuilder
+import io.ktor.http.Url
+import io.ktor.http.takeFrom
+import io.ktor.util.AttributeKey
+import io.ktor.util.pipeline.PipelinePhase
+
+/**
+ * Installs the [SwitchGate] as a per-request barrier: in a phase inserted *before*
+ * [HttpRequestPipeline.Before], it captures the `(baseUrl, accountId, bearer)` snapshot, stores it in
+ * the request attributes ([RequestIdentityKey]) for the auth phase to read, and resolves the request
+ * URL against the snapshot's base URL right here — before `defaultRequest` runs.
+ *
+ * Because the base URL is applied here (setting a non-empty host), Ktor's `DefaultRequest.mergeUrls`
+ * at [HttpRequestPipeline.Before] early-returns (`requestUrl.host.isNotEmpty()`), so `defaultRequest`
+ * never overwrites the snapshot URL with the *live* provider value — closing the window where a switch
+ * between the barrier and `Before` would send a request to the new server carrying the old snapshot's
+ * bearer. Absolute (cross-host) request URLs already carry a host, so the base is not applied to them,
+ * exactly as before.
+ *
+ * This barrier subsumes [ServerUrlReadyPlugin]'s role on the clients it is installed on:
+ * [SwitchGate.captureSnapshot] awaits the account/URL readiness itself. The refresh client stays on
+ * [ServerUrlReadyPlugin] (ungated) so a seed/switch-time token operation can't deadlock behind it.
+ */
+class SwitchBarrierPlugin private constructor(
+    private val switchGate: SwitchGate,
+) {
+    class Config {
+        lateinit var switchGate: SwitchGate
+    }
+
+    companion object : HttpClientPlugin<Config, SwitchBarrierPlugin> {
+        override val key = AttributeKey<SwitchBarrierPlugin>("SwitchBarrier")
+        private val SwitchBarrierPhase = PipelinePhase("SwitchBarrier")
+
+        override fun prepare(block: Config.() -> Unit): SwitchBarrierPlugin =
+            SwitchBarrierPlugin(Config().apply(block).switchGate)
+
+        override fun install(plugin: SwitchBarrierPlugin, scope: HttpClient) {
+            scope.requestPipeline.insertPhaseBefore(HttpRequestPipeline.Before, SwitchBarrierPhase)
+            scope.requestPipeline.intercept(SwitchBarrierPhase) {
+                val snapshot = plugin.switchGate.captureSnapshot()
+                context.attributes.put(RequestIdentityKey, snapshot)
+                if (snapshot.baseUrl.isNotEmpty()) {
+                    applyBaseUrl(context.url, snapshot.baseUrl)
+                }
+            }
+        }
+
+        /**
+         * Merge [baseUrlString] into [requestUrl] with the same semantics as Ktor's
+         * `DefaultRequest.mergeUrls`: only fill a request that has no host of its own (a relative API
+         * call), preserving the request's path (concatenated onto any base path), fragment, and query.
+         * An absolute request URL (host already set — a presigned CDN fetch) is left untouched.
+         */
+        private fun applyBaseUrl(requestUrl: URLBuilder, baseUrlString: String) {
+            if (requestUrl.host.isNotEmpty()) return
+            val resultUrl = URLBuilder(Url(baseUrlString))
+            if (requestUrl.port != DEFAULT_PORT) {
+                resultUrl.port = requestUrl.port
+            }
+            resultUrl.encodedPathSegments =
+                concatenatePath(resultUrl.encodedPathSegments, requestUrl.encodedPathSegments)
+            if (requestUrl.encodedFragment.isNotEmpty()) {
+                resultUrl.encodedFragment = requestUrl.encodedFragment
+            }
+            // Preserve the request's own query (e.g. the SSE `?resume=true`). LibreChat base URLs are
+            // host-root with no query of their own, so there is nothing to merge from the base side.
+            resultUrl.encodedParameters = requestUrl.encodedParameters
+            requestUrl.takeFrom(resultUrl)
+        }
+
+        private fun concatenatePath(parent: List<String>, child: List<String>): List<String> {
+            if (child.isEmpty()) return parent
+            if (parent.isEmpty()) return child
+            // Child path is absolute (starts from "/") — it replaces the base path entirely.
+            if (child.first().isEmpty()) return child
+            return buildList(parent.size + child.size - 1) {
+                for (index in 0 until parent.size - 1) add(parent[index])
+                addAll(child)
+            }
+        }
+    }
+}

--- a/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/SwitchGate.kt
+++ b/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/SwitchGate.kt
@@ -1,0 +1,135 @@
+package com.garfiec.librechat.core.network.client
+
+import com.garfiec.librechat.core.common.identity.ActiveAccountProvider
+import com.garfiec.librechat.core.common.identity.currentAccountId
+import io.ktor.util.AttributeKey
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlin.coroutines.AbstractCoroutineContextElement
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.coroutineContext
+
+/**
+ * The consistent `(baseUrl, accountId, bearer)` triple a single request/stream is bound to for its
+ * whole life. Captured once at the [SwitchGate] barrier and stored in the request attributes under
+ * [RequestIdentityKey]; every URL / bearer / host read downstream reads *this* instead of the live
+ * providers, so an account switch that flips the providers mid-request can't tear the triple apart.
+ *
+ * [isPending] marks a snapshot minted from a [PendingRequestIdentity] (an add-account flow
+ * authenticating against a server that is not yet active). A pending request has no keyed account to
+ * refresh, and its failures belong to the add flow, not the app: the 401-retry passes it through
+ * without refreshing anything or emitting the global session-expired signal.
+ */
+data class RequestIdentity(
+    val baseUrl: String,
+    val accountId: String?,
+    val bearer: String?,
+    val isPending: Boolean = false,
+)
+
+/**
+ * Coroutine-scoped override of the request identity, for the **add-account** flow: run the flow's
+ * calls in `withContext(pendingRequestIdentity)` and every HTTP request they issue snapshots
+ * `(baseUrl = the server being added, accountId = null, bearer = the staged sign-in token)` instead
+ * of the live active account. Ktor's request pipeline executes in the caller's coroutine, so the
+ * element reaches [SwitchGate.captureSnapshot] with no per-call plumbing — and because the *live*
+ * providers are never touched, the active account's own traffic keeps flowing under its own identity
+ * while another account authenticates.
+ *
+ * [bearer] is read per request (not captured once) because the staged token only exists after the
+ * flow's sign-in call succeeds; earlier calls (config validation, the login POST itself) carry none.
+ */
+class PendingRequestIdentity(
+    private val baseUrl: String,
+    private val bearer: suspend () -> String?,
+) : AbstractCoroutineContextElement(PendingRequestIdentity) {
+    companion object Key : CoroutineContext.Key<PendingRequestIdentity>
+
+    suspend fun identity(): RequestIdentity =
+        RequestIdentity(baseUrl = baseUrl, accountId = null, bearer = bearer(), isPending = true)
+}
+
+/** Attribute carrying the per-request [RequestIdentity] snapshot from the barrier to the URL/auth phases. */
+val RequestIdentityKey = AttributeKey<RequestIdentity>("RequestIdentity")
+
+/**
+ * The account-switch barrier. Two jobs, both closing the torn-pair race that a naive switch opens:
+ *
+ * 1. **Atomic snapshot.** The HTTP pipeline reads the base URL at one phase and the bearer at a later
+ *    one, from two independent providers under two different locks. A switch flipping them between the
+ *    two reads would send a mismatched `(urlB, bearerA)` — same-server → A's data served as B;
+ *    different-server → A's bearer transmitted to B's host (credential exposure). [captureSnapshot]
+ *    reads all three under [lock] in one shot so a request holds one coherent identity.
+ * 2. **Park-during-flip.** [withSwitch] closes [open] and mutates the providers under the same [lock],
+ *    so a new request either snapshots fully *before* the flip (and completes against the old account —
+ *    whose tokens are retained, so that's correct) or parks until the flip finishes and snapshots the
+ *    new account. No request ever observes a half-applied switch.
+ *
+ * [lock] is held only for the snapshot reads / the flip mutation — never across network I/O — so
+ * per-request contention is negligible. The coordinator ([AccountSwitcher]) is the sole caller of
+ * [withSwitch]; the [SwitchBarrierPlugin] (and the iOS SSE transport) are the callers of
+ * [captureSnapshot].
+ */
+class SwitchGate(
+    private val activeAccountProvider: ActiveAccountProvider,
+    private val serverUrlProvider: ServerUrlProvider,
+    private val tokenManager: TokenManager,
+    private val accountReadyGate: AccountReadyGate?,
+) {
+    private val lock = Mutex()
+    private val open = MutableStateFlow(true)
+
+    /**
+     * Snapshot the live identity for a request about to be built. Awaits the cold-start seed + URL
+     * warm-up first (so a snapshot can never freeze `baseUrl=""` / `accountId=null` before the roster
+     * reconcile has run), parks while a switch is mid-flip, then reads the triple atomically. The
+     * bearer is read **keyed to the snapshot's account** (not the live cached token), so a resolved
+     * account's request always carries that account's own token even while another account's sign-in
+     * is staged (add-account / soft-expiry re-auth) — the triple can't tear at the token store either.
+     *
+     * A caller running under a [PendingRequestIdentity] (the add-account flow) short-circuits to the
+     * pending identity: no gates, no live-provider reads — the pending flow is self-contained and a
+     * concurrent switch doesn't affect it.
+     */
+    suspend fun captureSnapshot(): RequestIdentity {
+        coroutineContext[PendingRequestIdentity]?.let { return it.identity() }
+        accountReadyGate?.awaitReady()
+        serverUrlProvider.awaitBaseUrl()
+        // The gate is open >99.9% of the time (a switch is rare and user-initiated); reading the value
+        // directly avoids allocating a flow collector on every request and only suspends when a switch
+        // is actually mid-flip.
+        if (!open.value) open.first { it }
+        return lock.withLock {
+            val accountId = activeAccountProvider.currentAccountId()?.value
+            RequestIdentity(
+                baseUrl = serverUrlProvider.getBaseUrl(),
+                accountId = accountId,
+                // Explicit branch (not `?: fallback`): a resolved account with an empty keyed slot
+                // must yield a null bearer, never fall through to the live cache — during sign-in
+                // staging the cache holds the *staged* account's token.
+                bearer = if (accountId != null) {
+                    tokenManager.getAccessTokenFor(accountId)
+                } else {
+                    tokenManager.getAccessToken()
+                },
+            )
+        }
+    }
+
+    /**
+     * Run [flip] (the URL + token-key + identity repoint) with the gate closed and under [lock], so it
+     * is atomic with respect to [captureSnapshot]. New requests park until it returns; in-flight
+     * requests already holding a snapshot are unaffected (they complete against the account they
+     * snapshotted, whose tokens are retained). [flip] must not perform network I/O.
+     */
+    suspend fun <T> withSwitch(flip: suspend () -> T): T {
+        open.value = false
+        return try {
+            lock.withLock { flip() }
+        } finally {
+            open.value = true
+        }
+    }
+}

--- a/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/TokenManager.kt
+++ b/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/TokenManager.kt
@@ -8,23 +8,88 @@ interface TokenManager {
     suspend fun getAccessToken(): String?
     suspend fun setTokens(accessToken: String, refreshToken: String)
     suspend fun refreshAccessToken(): Boolean
+
+    /**
+     * Full teardown of the active session — keyed tokens, any bare staging keys, and the persisted
+     * active-account pointer — bumping the refresh epoch so an in-flight refresh discards its result.
+     * The single teardown implementation; [onAccountCleared] is the logout-named alias that delegates
+     * here.
+     */
     suspend fun clearTokens()
 
     /**
+     * The access token stored in [accountId]'s keyed slot, independent of which account is active.
+     * Multi-account callers (the switch barrier) read the bearer for a specific request's account
+     * rather than the live active one.
+     */
+    suspend fun getAccessTokenFor(accountId: String): String?
+
+    /**
+     * The access token currently **staged** under the bare keys by an interactive sign-in
+     * ([setTokens]) that has not yet been re-homed by [onAccountResolved] — i.e. the token of an
+     * account mid-authentication. Null outside that window. The add-account flow's pending request
+     * identity reads its bearer from here.
+     */
+    suspend fun getStagedAccessToken(): String?
+
+    /**
+     * Drop any bare-key staged pair left by an abandoned or crashed sign-in, without touching any
+     * account's keyed slot, the mirror, or the refresh epoch. Callers must hold a resolved active
+     * account (whose real session is keyed) — when logged out or on a legacy pre-keying install the
+     * bare keys ARE the live session and must not be cleared through this.
+     */
+    suspend fun clearStagedTokens()
+
+    /**
+     * Non-destructive switch to an already-keyed account: repoints the active binding, the
+     * synchronously-readable mirror, and the cached bearer to [accountId] **without writing or
+     * deleting any token slot**. The previously active account's tokens are retained so a switch back
+     * needs no re-login. Unlike [onAccountResolved] this does not consume staged tokens — the target
+     * must already have keyed tokens.
+     */
+    suspend fun selectAccount(accountId: String)
+
+    /**
+     * Delete [accountId]'s keyed tokens (account removal). When [accountId] is the active account this
+     * also clears the mirror + cached bearer, like [onAccountCleared]; otherwise the active account is
+     * left untouched.
+     */
+    suspend fun removeAccount(accountId: String)
+
+    /**
+     * Refresh [accountId]'s tokens against [baseUrl] (an **absolute** URL, so a server-URL switch that
+     * races this call can never send this account's refresh token to a different server). Writes
+     * [accountId]'s keyed slot and updates the cached bearer only while [accountId] is still the active
+     * account. Distinct from [refreshAccessToken], which refreshes the live active account against the
+     * live base URL.
+     */
+    suspend fun refreshAccessTokenFor(accountId: String, baseUrl: String): Boolean
+
+    /**
      * Bind token storage to [accountId] once identity resolves (login, cold-start restore, upgrade).
-     * Re-homes tokens written under the previous key (the bare keys on a legacy/first install, or the
-     * prior account) into this account's keyed slot and repoints the synchronously-readable mirror, so
-     * subsequent cold starts seed the right account's bearer with no blind window. Idempotent when the
-     * account is unchanged.
+     * Re-homes the staged (bare-key) authentication tokens into this account's keyed slot and repoints
+     * the synchronously-readable mirror, so subsequent cold starts seed the right account's bearer with
+     * no blind window. Removes only the bare staging keys — never another account's keyed slot — so a
+     * previously-active account's tokens survive for a later switch. Idempotent when the account is
+     * unchanged.
      */
     suspend fun onAccountResolved(accountId: String)
 
     /**
-     * Clear the active account's tokens and the mirror on logout. Distinct from [clearTokens] (the
-     * refresh-failure path) in that it also drops the persisted active-account pointer.
+     * Clear the active account's tokens, any bare staging keys, and the persisted mirror on logout.
+     * The semantic logout entry point; delegates to [clearTokens] — same teardown, named for the
+     * identity-transition call site so implementers get one behaviour, not two that can drift.
      */
-    suspend fun onAccountCleared()
+    suspend fun onAccountCleared() = clearTokens()
 
-    fun emitSessionExpired()
+    /**
+     * Signal that a session's credentials are irrecoverably invalid (refresh failed / banned), which
+     * routes the app to re-auth. [expiredAccountId] scopes the signal to the account whose request
+     * failed: it emits only while that account is still the active binding, so a retained-but-inactive
+     * account's failed refresh (a straggler request landing after a switch) can't tear down the *live*
+     * account's session. The expired account keeps its rows and roster entry — re-auth restores it
+     * without data loss. Null = the active/legacy session; always emits.
+     */
+    fun emitSessionExpired(expiredAccountId: String? = null)
     val sessionExpiredFlow: SharedFlow<Unit>
 }

--- a/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/di/NetworkModule.kt
+++ b/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/di/NetworkModule.kt
@@ -1,6 +1,7 @@
 package com.garfiec.librechat.core.network.di
 
 import com.garfiec.librechat.core.common.di.KoinQualifiers
+import com.garfiec.librechat.core.common.identity.ActiveAccountProvider
 import com.garfiec.librechat.core.network.api.AgentToolsApi
 import com.garfiec.librechat.core.network.api.AgentsApi
 import com.garfiec.librechat.core.network.api.ApiKeysApi
@@ -33,6 +34,8 @@ import com.garfiec.librechat.core.network.client.AuthInterceptorPlugin
 import com.garfiec.librechat.core.network.client.LibreChatHttpClient
 import com.garfiec.librechat.core.network.client.ServerUrlProvider
 import com.garfiec.librechat.core.network.client.ServerUrlReadyPlugin
+import com.garfiec.librechat.core.network.client.SwitchBarrierPlugin
+import com.garfiec.librechat.core.network.client.SwitchGate
 import com.garfiec.librechat.core.network.client.TokenManager
 import com.garfiec.librechat.core.network.sse.SseClient
 import io.ktor.client.HttpClient
@@ -65,6 +68,17 @@ val networkModule = module {
         }
     }
 
+    // The switch barrier: one gate shared by both HTTP clients and (on iOS) the SSE transport, so a
+    // single account switch flips URL + token key + identity atomically for all transports at once.
+    single {
+        SwitchGate(
+            activeAccountProvider = get<ActiveAccountProvider>(),
+            serverUrlProvider = get(),
+            tokenManager = get(),
+            accountReadyGate = getOrNull(),
+        )
+    }
+
     single {
         LibreChatHttpClient.create(
             engineFactory = get<HttpClientEngineFactory<*>>(),
@@ -72,6 +86,8 @@ val networkModule = module {
             tokenManager = get(),
             serverUrlProvider = get(),
             redactor = get(),
+            accountReadyGate = getOrNull(),
+            switchGate = get(),
         )
     }
 
@@ -79,13 +95,14 @@ val networkModule = module {
         val tokenManager = get<TokenManager>()
         val serverUrlProvider = get<ServerUrlProvider>()
         val engineFactory = get<HttpClientEngineFactory<*>>()
+        val switchGate = get<SwitchGate>()
         HttpClient(engineFactory) {
             install(AuthInterceptorPlugin) {
                 this.tokenManager = tokenManager
                 this.serverUrlProvider = serverUrlProvider
             }
-            install(ServerUrlReadyPlugin) {
-                this.serverUrlProvider = serverUrlProvider
+            install(SwitchBarrierPlugin) {
+                this.switchGate = switchGate
             }
             install(HttpTimeout) {
                 connectTimeoutMillis = 10_000
@@ -128,7 +145,7 @@ val networkModule = module {
     // SSE — SseHttpTransport is provided by networkPlatformModule because its
     // constructor signature differs between Android (takes the Ktor streaming
     // HttpClient) and iOS (takes NWConnection dependencies in Phase 2).
-    singleOf(::SseClient)
+    single { SseClient(json = get(), transport = get(), activeAccountProvider = get()) }
 
     // API services
     singleOf(::AgentsApi)

--- a/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/sse/SseClient.kt
+++ b/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/sse/SseClient.kt
@@ -1,6 +1,8 @@
 package com.garfiec.librechat.core.network.sse
 
 import co.touchlab.kermit.Logger
+import com.garfiec.librechat.core.common.identity.ActiveAccountProvider
+import com.garfiec.librechat.core.common.identity.currentAccountId
 import com.garfiec.librechat.core.logging.Diag
 import com.garfiec.librechat.core.logging.LogOrigin
 import com.garfiec.librechat.core.model.StreamEvent
@@ -20,6 +22,7 @@ import kotlin.math.min
 class SseClient(
     private val json: Json,
     private val transport: SseHttpTransport,
+    private val activeAccountProvider: ActiveAccountProvider? = null,
 ) {
     private val mapper = SseEventMapper(json)
     private val lineParser = SseLineParser()
@@ -39,6 +42,11 @@ class SseClient(
         // so any Kotlin exception that escapes this flow will crash the iOS app.
         try {
         mapper.resetState()
+        // Bind the stream to the account it started under. Each transport (re)connect captures a
+        // FRESH identity snapshot, so without this guard a retry/resume attempted after an account
+        // switch would reconnect A's stream path as B — a cross-account resume. The stream aborts
+        // instead; the outgoing account's UI is gone (routes popped on switch) so nobody is watching.
+        val originAccountId = activeAccountProvider?.currentAccountId()?.value
         var attempt = 0
         var shouldResume = resume
         var done = false
@@ -47,6 +55,16 @@ class SseClient(
         val maxDelayMs = 30_000L
 
         while (attempt <= maxRetries && !done) {
+            if (activeAccountProvider != null &&
+                activeAccountProvider.currentAccountId()?.value != originAccountId
+            ) {
+                Diag.w(
+                    "SSE",
+                    origin = LogOrigin.CLIENT,
+                    attrs = mapOf("attempt" to attempt.toString()),
+                ) { "account changed mid-stream — aborting reconnect" }
+                break
+            }
             try {
                 val byteChannel = ByteChannel(autoFlush = true)
                 coroutineScope {

--- a/core/network/src/iosMain/kotlin/com/garfiec/librechat/core/network/sse/SseHttpTransport.ios.kt
+++ b/core/network/src/iosMain/kotlin/com/garfiec/librechat/core/network/sse/SseHttpTransport.ios.kt
@@ -2,8 +2,9 @@ package com.garfiec.librechat.core.network.sse
 
 import co.touchlab.kermit.Logger
 import com.garfiec.librechat.core.network.client.LibreChatHttpClient
-import com.garfiec.librechat.core.network.client.ServerUrlProvider
+import com.garfiec.librechat.core.network.client.SwitchGate
 import com.garfiec.librechat.core.network.client.TokenManager
+import com.garfiec.librechat.core.network.client.refreshBearerFor
 import kotlinx.cinterop.BetaInteropApi
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.addressOf
@@ -94,32 +95,36 @@ import platform.posix.size_tVar
 //   engine.
 @OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
 actual class SseHttpTransport(
-    private val serverUrlProvider: ServerUrlProvider,
     private val tokenManager: TokenManager,
+    private val switchGate: SwitchGate,
 ) {
 
     actual fun stream(streamPath: String, resume: Boolean): Flow<ByteArray> = flow {
-        // 401-retry wrapper: resolve token in the suspend scope (we can't touch
-        // TokenManager from inside the NWConnection callback), open the connection,
-        // let it run to completion. If it throws SseHttpStatusException(401) and
-        // we haven't already retried, refresh the token and loop once. This
-        // replicates AuthInterceptorPlugin's 401 handling for the raw-socket path.
+        // Capture the (baseUrl, account, bearer) triple ONCE before opening the raw connection. This
+        // is the SwitchBarrierPlugin equivalent for the NWConnection path (which can't use Ktor
+        // plugins): a switch mid-stream can't tear the URL and token apart — the stream keeps running
+        // against the account and server it started on, whose tokens are retained.
+        val snapshot = switchGate.captureSnapshot()
+        var token = snapshot.bearer
         var triedRefresh = false
         while (true) {
-            val token = tokenManager.getAccessToken()
             try {
-                emitAll(openConnection(streamPath, resume, token))
+                emitAll(openConnection(streamPath, resume, snapshot.baseUrl, token))
                 return@flow
             } catch (e: SseHttpStatusException) {
                 if (e.statusCode == 401 && !triedRefresh) {
                     Logger.w("SSE-iOS") { "401 on SSE stream, attempting token refresh" }
                     triedRefresh = true
-                    val refreshed = tokenManager.refreshAccessToken()
-                    if (!refreshed) {
+                    // Refresh the snapshot's account (keyed + URL-pinned), never the live active one;
+                    // an expiry is likewise scoped to the snapshot's account, so a switched-away
+                    // stream's dead credentials can't tear down the live account's session.
+                    val refreshedToken = tokenManager.refreshBearerFor(snapshot)
+                    if (refreshedToken == null) {
                         Logger.w("SSE-iOS") { "token refresh failed — session expired" }
-                        tokenManager.emitSessionExpired()
+                        tokenManager.emitSessionExpired(snapshot.accountId)
                         throw e
                     }
+                    token = refreshedToken
                     // loop to retry with new token
                 } else {
                     throw e
@@ -131,15 +136,16 @@ actual class SseHttpTransport(
     private fun openConnection(
         streamPath: String,
         resume: Boolean,
+        snapshotBaseUrl: String,
         bearerToken: String?,
     ): Flow<ByteArray> = callbackFlow {
         // Normalize base URL + stream path so there's exactly one slash between
-        // them. ServerUrlProvider may or may not return a trailing slash, and
-        // SseClient passes the stream path without a leading slash, matching
-        // how ChatRepositoryImpl builds it ("api/agents/chat/stream/$streamId").
-        // awaitBaseUrl (not getBaseUrl) so a reconnect during the warm-up window can't
-        // build the SSE URL against an empty host.
-        val baseUrl = serverUrlProvider.awaitBaseUrl().trimEnd('/')
+        // them. The base URL comes from the snapshot captured before this connection
+        // (already awaited past cold-start warm-up in SwitchGate.captureSnapshot), so
+        // a switch can't repoint it under a live stream. SseClient passes the stream
+        // path without a leading slash, matching how ChatRepositoryImpl builds it
+        // ("api/agents/chat/stream/$streamId").
+        val baseUrl = snapshotBaseUrl.trimEnd('/')
         val normalizedPath = streamPath.trimStart('/')
         val queryString = if (resume) "?resume=true" else ""
         val fullUrl = "$baseUrl/$normalizedPath$queryString"

--- a/feature/auth/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/auth/di/AuthModuleVerificationTest.kt
+++ b/feature/auth/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/auth/di/AuthModuleVerificationTest.kt
@@ -3,6 +3,7 @@ package com.garfiec.librechat.feature.auth.di
 import android.app.Application
 import android.content.Context
 import com.garfiec.librechat.core.data.datastore.ServerDataStore
+import com.garfiec.librechat.core.data.repository.AccountSwitcher
 import com.garfiec.librechat.core.data.repository.AuthRepository
 import com.garfiec.librechat.core.data.repository.ConfigRepository
 import com.garfiec.librechat.core.data.repository.UserRepository
@@ -24,6 +25,9 @@ class AuthModuleVerificationTest {
                 UserRepository::class,
                 SecureTokenStorage::class,
                 OAuthLauncher::class,
+                AccountSwitcher::class,
+                // ServerUrlViewModel's addAccount mode flag, injected via parametersOf.
+                Boolean::class,
             ),
         )
     }

--- a/feature/auth/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/auth/viewmodel/LoginViewModelTest.kt
+++ b/feature/auth/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/auth/viewmodel/LoginViewModelTest.kt
@@ -2,6 +2,7 @@ package com.garfiec.librechat.feature.auth.viewmodel
 
 import com.garfiec.librechat.core.common.result.Result
 import com.garfiec.librechat.core.data.datastore.ServerDataStore
+import com.garfiec.librechat.core.data.repository.AccountSwitcher
 import com.garfiec.librechat.core.data.repository.AuthRepository
 import com.garfiec.librechat.core.data.repository.ConfigRepository
 import com.garfiec.librechat.core.model.LoginOutcome
@@ -33,6 +34,7 @@ class LoginViewModelTest {
     private val configRepository = mockk<ConfigRepository>(relaxed = true)
     private val oAuthLauncher = mockk<OAuthLauncher>(relaxed = true)
     private val serverDataStore = mockk<ServerDataStore>(relaxed = true)
+    private val accountSwitcher = mockk<AccountSwitcher>(relaxed = true)
 
     private val configFlow = MutableStateFlow<StartupConfig?>(null)
 
@@ -42,6 +44,8 @@ class LoginViewModelTest {
     fun setup() {
         Dispatchers.setMain(testDispatcher)
         every { configRepository.startupConfig } returns configFlow
+        // No add-account flow pending: the VM reads the global config + live server URL.
+        every { accountSwitcher.pendingAdd } returns null
     }
 
     @After
@@ -54,6 +58,7 @@ class LoginViewModelTest {
         configRepository = configRepository,
         oAuthLauncher = oAuthLauncher,
         serverDataStore = serverDataStore,
+        accountSwitcher = accountSwitcher,
     )
 
     @Test

--- a/feature/auth/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/auth/viewmodel/ServerUrlViewModelTest.kt
+++ b/feature/auth/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/auth/viewmodel/ServerUrlViewModelTest.kt
@@ -1,0 +1,124 @@
+package com.garfiec.librechat.feature.auth.viewmodel
+
+import com.garfiec.librechat.core.common.result.Result
+import com.garfiec.librechat.core.data.datastore.ServerDataStore
+import com.garfiec.librechat.core.data.repository.AccountSwitcher
+import com.garfiec.librechat.core.data.repository.ConfigRepository
+import com.garfiec.librechat.core.model.config.StartupConfig
+import com.google.common.truth.Truth.assertThat
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * The add-account mode contract: validating a server being ADDED must never touch the live
+ * account's state — no global URL write (the bearer-to-wrong-host leak) and no config
+ * publish/cache (that's the srv:-key poisoning) — while the normal mode keeps its original
+ * set-then-validate behavior.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class ServerUrlViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    private val serverDataStore = mockk<ServerDataStore>(relaxed = true)
+    private val configRepository = mockk<ConfigRepository>(relaxed = true)
+    private val accountSwitcher = mockk<AccountSwitcher>(relaxed = true)
+
+    private val pendingUrl = "https://b.example.com"
+    private val config = StartupConfig(serverDomain = pendingUrl)
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        // Pass block-running calls through so the probe actually executes.
+        coEvery { accountSwitcher.withPendingIdentity(any<suspend () -> Result<StartupConfig>>()) } coAnswers {
+            firstArg<suspend () -> Result<StartupConfig>>().invoke()
+        }
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun createViewModel(addAccount: Boolean) = ServerUrlViewModel(
+        serverDataStore = serverDataStore,
+        configRepository = configRepository,
+        accountSwitcher = accountSwitcher,
+        addAccount = addAccount,
+    )
+
+    @Test
+    fun `add mode probes under the pending identity and never touches the global URL`() = runTest(testDispatcher) {
+        coEvery { configRepository.probeServerUrl() } returns Result.Success(config)
+        val viewModel = createViewModel(addAccount = true)
+        advanceUntilIdle()
+
+        viewModel.onUrlChanged(pendingUrl)
+        viewModel.validateAndConnect()
+        advanceUntilIdle()
+
+        assertThat(viewModel.uiState.value.isValidated).isTrue()
+        coVerify(exactly = 1) { accountSwitcher.beginAdd(pendingUrl) }
+        coVerify(exactly = 1) { accountSwitcher.attachPendingConfig(config) }
+        coVerify(exactly = 0) { serverDataStore.setServerUrl(any()) }
+        coVerify(exactly = 0) { configRepository.validateServerUrl(any()) }
+    }
+
+    @Test
+    fun `add mode validation failure cancels the pending session and surfaces the error`() =
+        runTest(testDispatcher) {
+            coEvery { configRepository.probeServerUrl() } returns Result.Error(message = "not librechat")
+            val viewModel = createViewModel(addAccount = true)
+            advanceUntilIdle()
+
+            viewModel.onUrlChanged(pendingUrl)
+            viewModel.validateAndConnect()
+            advanceUntilIdle()
+
+            assertThat(viewModel.uiState.value.isValidated).isFalse()
+            assertThat(viewModel.uiState.value.error).isEqualTo("not librechat")
+            coVerify(exactly = 1) { accountSwitcher.cancelAdd() }
+            coVerify(exactly = 0) { serverDataStore.setServerUrl(any()) }
+        }
+
+    @Test
+    fun `add mode surfaces a beginAdd failure as an error instead of crashing`() = runTest(testDispatcher) {
+        coEvery { accountSwitcher.beginAdd(any()) } throws IllegalStateException("no active account")
+        val viewModel = createViewModel(addAccount = true)
+        advanceUntilIdle()
+
+        viewModel.onUrlChanged(pendingUrl)
+        viewModel.validateAndConnect()
+        advanceUntilIdle()
+
+        assertThat(viewModel.uiState.value.isValidated).isFalse()
+        assertThat(viewModel.uiState.value.error).isNotNull()
+    }
+
+    @Test
+    fun `normal mode sets the URL then validates, resetting it on failure`() = runTest(testDispatcher) {
+        coEvery { configRepository.validateServerUrl(pendingUrl) } returns Result.Error(message = "nope")
+        val viewModel = createViewModel(addAccount = false)
+        advanceUntilIdle()
+
+        viewModel.onUrlChanged(pendingUrl)
+        viewModel.validateAndConnect()
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { serverDataStore.setServerUrl(pendingUrl) }
+        coVerify(exactly = 1) { serverDataStore.setServerUrl("") }
+        coVerify(exactly = 0) { accountSwitcher.beginAdd(any()) }
+    }
+}

--- a/feature/auth/src/commonMain/kotlin/com/garfiec/librechat/feature/auth/di/AuthModule.kt
+++ b/feature/auth/src/commonMain/kotlin/com/garfiec/librechat/feature/auth/di/AuthModule.kt
@@ -17,7 +17,17 @@ expect val authPlatformModule: Module
 
 val authModule = module {
     includes(authPlatformModule)
-    viewModelOf(::ServerUrlViewModel)
+    // Lambda form (not viewModelOf) for the addAccount mode flag the add-account nav entry passes
+    // via parametersOf — see the DeprecatedKoinApi note below.
+    @Suppress("DeprecatedKoinApi")
+    viewModel { params ->
+        ServerUrlViewModel(
+            serverDataStore = get(),
+            configRepository = get(),
+            accountSwitcher = get(),
+            addAccount = params.getOrNull() ?: false,
+        )
+    }
     viewModelOf(::LoginViewModel)
     viewModelOf(::RegisterViewModel)
     // Koin's constructor-DSL (`viewModelOf`) wires every argument via `get()` and cannot read

--- a/feature/auth/src/commonMain/kotlin/com/garfiec/librechat/feature/auth/navigation/AuthNavigation.kt
+++ b/feature/auth/src/commonMain/kotlin/com/garfiec/librechat/feature/auth/navigation/AuthNavigation.kt
@@ -14,12 +14,31 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.polymorphic
 import kotlinx.serialization.modules.subclass
+import org.koin.compose.viewmodel.koinViewModel
+import org.koin.core.parameter.parametersOf
 
 @Serializable sealed interface AuthRoute : NavKey
 
 @Serializable data object ServerUrl : AuthRoute
 
 @Serializable data object Login : AuthRoute
+
+/**
+ * Add-account (multi-account) variants of the server-URL + login screens: reached from the account
+ * switcher while another account stays live, so their ViewModels run in add mode (pending request
+ * identity — the live account's URL/tokens/config are never touched). Distinct routes rather than a
+ * flag on [ServerUrl]/[Login], so the NavHost can tell from the back stack alone whether an add
+ * flow is still in progress and cancel the pending session once its routes are gone.
+ */
+@Serializable data object AddAccountServerUrl : AuthRoute
+
+@Serializable data object AddAccountLogin : AuthRoute
+
+/** True for the routes that constitute an in-progress add-account flow. Follow-on screens reached
+ *  from add-mode login (register, 2FA, forgot password) are shared routes and intentionally
+ *  excluded — they only ever sit above an [AddAccountLogin] entry, so checking these two is enough. */
+val NavKey.isAddAccountFlowRoute: Boolean
+    get() = this is AddAccountServerUrl || this is AddAccountLogin
 
 @Serializable data object Register : AuthRoute
 
@@ -41,6 +60,29 @@ fun EntryProviderScope<NavKey>.authEntries(
     entry<ServerUrl> {
         ServerUrlScreen(
             onServerValidate = { onNavigate(Login) },
+        )
+    }
+    entry<AddAccountServerUrl> {
+        // Unlike the onboarding root, this is pushed on top of the live account's stack, so it
+        // gets a back affordance to abandon the add flow (popping it cancels the pending session).
+        ServerUrlScreen(
+            onServerValidate = { onNavigate(AddAccountLogin) },
+            onBack = onBack,
+            viewModel = koinViewModel(parameters = { parametersOf(true) }),
+        )
+    }
+    entry<AddAccountLogin> {
+        // Same screen + ViewModel class as Login; the VM detects add mode via the pending add
+        // session (set by the AddAccountServerUrl step) and the auth repository routes the sign-in
+        // to the pending server. Success completes the add and lands on the new account's chat.
+        LoginScreen(
+            onLoginSuccess = onAuthComplete,
+            onNavigateToRegister = { onNavigate(Register) },
+            onNavigateToForgotPassword = { onNavigate(ForgotPassword) },
+            onNavigateToTwoFactor = { tempToken ->
+                onNavigate(TwoFactor(tempToken = tempToken))
+            },
+            onBack = onBack,
         )
     }
     entry<Login> {
@@ -98,6 +140,8 @@ val authSerializersModule = SerializersModule {
     polymorphic(NavKey::class) {
         subclass(ServerUrl::class, ServerUrl.serializer())
         subclass(Login::class, Login.serializer())
+        subclass(AddAccountServerUrl::class, AddAccountServerUrl.serializer())
+        subclass(AddAccountLogin::class, AddAccountLogin.serializer())
         subclass(Register::class, Register.serializer())
         subclass(ForgotPassword::class, ForgotPassword.serializer())
         subclass(TwoFactor::class, TwoFactor.serializer())

--- a/feature/auth/src/commonMain/kotlin/com/garfiec/librechat/feature/auth/screen/BackAffordanceOverlay.kt
+++ b/feature/auth/src/commonMain/kotlin/com/garfiec/librechat/feature/auth/screen/BackAffordanceOverlay.kt
@@ -1,0 +1,40 @@
+package com.garfiec.librechat.feature.auth.screen
+
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.garfiec.librechat.feature.auth.resources.Res
+import com.garfiec.librechat.feature.auth.resources.back
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * Top-start back affordance shown only in the add-account variant of the auth screens (the
+ * onboarding roots pass a null [onBack], so nothing renders there). Popping the pending add
+ * route cancels the flow. Shared by [LoginScreen] and [ServerUrlScreen] so the padding, icon,
+ * hit target, and accessibility label stay in one place.
+ */
+@Composable
+fun BoxScope.BackAffordanceOverlay(onBack: (() -> Unit)?, modifier: Modifier = Modifier) {
+    if (onBack != null) {
+        IconButton(
+            onClick = onBack,
+            modifier = modifier
+                .align(Alignment.TopStart)
+                .statusBarsPadding()
+                .padding(4.dp),
+        ) {
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                contentDescription = stringResource(Res.string.back),
+            )
+        }
+    }
+}

--- a/feature/auth/src/commonMain/kotlin/com/garfiec/librechat/feature/auth/screen/LoginScreen.kt
+++ b/feature/auth/src/commonMain/kotlin/com/garfiec/librechat/feature/auth/screen/LoginScreen.kt
@@ -2,6 +2,7 @@ package com.garfiec.librechat.feature.auth.screen
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -47,6 +48,7 @@ fun LoginScreen(
     modifier: Modifier = Modifier,
     onNavigateToForgotPassword: () -> Unit = {},
     onNavigateToTwoFactor: (String) -> Unit = {},
+    onBack: (() -> Unit)? = null,
     viewModel: LoginViewModel = koinViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -71,125 +73,131 @@ fun LoginScreen(
         }
     }
 
-    Column(
+    Box(
         modifier = modifier
             .fillMaxSize()
-            .background(MaterialTheme.colorScheme.background)
-            .imePadding()
-            .verticalScroll(rememberScrollState())
-            .padding(24.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center,
+            .background(MaterialTheme.colorScheme.background),
     ) {
-        Text(
-            text = stringResource(Res.string.login_title),
-            style = MaterialTheme.typography.headlineMedium,
-            color = MaterialTheme.colorScheme.onBackground,
-            modifier = Modifier.semantics { heading() },
-        )
-
-        Spacer(modifier = Modifier.height(32.dp))
-
-        OutlinedTextField(
-            value = uiState.email,
-            onValueChange = viewModel::onEmailChanged,
-            label = { Text(stringResource(Res.string.email_label)) },
-            modifier = Modifier.fillMaxWidth(),
-            singleLine = true,
-            keyboardOptions = KeyboardOptions(
-                keyboardType = KeyboardType.Email,
-                autoCorrectEnabled = false,
-            ),
-            enabled = !uiState.isLoading,
-        )
-
-        Spacer(modifier = Modifier.height(16.dp))
-
-        OutlinedTextField(
-            value = uiState.password,
-            onValueChange = viewModel::onPasswordChanged,
-            label = { Text(stringResource(Res.string.password_label)) },
-            modifier = Modifier.fillMaxWidth(),
-            singleLine = true,
-            visualTransformation = passwordMaskTransformation(),
-            keyboardOptions = KeyboardOptions(
-                keyboardType = KeyboardType.Password,
-                autoCorrectEnabled = false,
-            ),
-            enabled = !uiState.isLoading,
-        )
-
-        if (uiState.error != null) {
-            Spacer(modifier = Modifier.height(8.dp))
-            Text(
-                text = uiState.error!!,
-                color = MaterialTheme.colorScheme.error,
-                style = MaterialTheme.typography.bodySmall,
-            )
-        }
-
-        Spacer(modifier = Modifier.height(24.dp))
-
-        Button(
-            onClick = viewModel::login,
-            modifier = Modifier.fillMaxWidth(),
-            enabled = !uiState.isLoading,
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .imePadding()
+                .verticalScroll(rememberScrollState())
+                .padding(24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
         ) {
-            if (uiState.isLoading) {
-                CircularProgressIndicator(
-                    modifier = Modifier.height(20.dp),
-                    color = MaterialTheme.colorScheme.onPrimary,
-                    strokeWidth = 2.dp,
-                )
-            } else {
-                Text(stringResource(Res.string.continue_button))
-            }
-        }
+            Text(
+                text = stringResource(Res.string.login_title),
+                style = MaterialTheme.typography.headlineMedium,
+                color = MaterialTheme.colorScheme.onBackground,
+                modifier = Modifier.semantics { heading() },
+            )
 
-        Spacer(modifier = Modifier.height(8.dp))
+            Spacer(modifier = Modifier.height(32.dp))
 
-        TextButton(onClick = onNavigateToForgotPassword) {
-            Text(stringResource(Res.string.forgot_password))
-        }
+            OutlinedTextField(
+                value = uiState.email,
+                onValueChange = viewModel::onEmailChanged,
+                label = { Text(stringResource(Res.string.email_label)) },
+                modifier = Modifier.fillMaxWidth(),
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Email,
+                    autoCorrectEnabled = false,
+                ),
+                enabled = !uiState.isLoading,
+            )
 
-        Spacer(modifier = Modifier.height(8.dp))
-
-        if (uiState.registrationEnabled) {
-            TextButton(onClick = onNavigateToRegister) {
-                Text(stringResource(Res.string.no_account_sign_up))
-            }
-        }
-
-        // OAuth social login buttons
-        val socialLogins = uiState.socialLogins
-        if (uiState.socialLoginEnabled && socialLogins.isNotEmpty()) {
             Spacer(modifier = Modifier.height(16.dp))
 
-            HorizontalDivider(modifier = Modifier.fillMaxWidth())
-
-            Spacer(modifier = Modifier.height(8.dp))
-
-            Text(
-                text = stringResource(Res.string.or_continue_with),
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                textAlign = TextAlign.Center,
+            OutlinedTextField(
+                value = uiState.password,
+                onValueChange = viewModel::onPasswordChanged,
+                label = { Text(stringResource(Res.string.password_label)) },
                 modifier = Modifier.fillMaxWidth(),
+                singleLine = true,
+                visualTransformation = passwordMaskTransformation(),
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Password,
+                    autoCorrectEnabled = false,
+                ),
+                enabled = !uiState.isLoading,
             )
 
+            if (uiState.error != null) {
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = uiState.error!!,
+                    color = MaterialTheme.colorScheme.error,
+                    style = MaterialTheme.typography.bodySmall,
+                )
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            Button(
+                onClick = viewModel::login,
+                modifier = Modifier.fillMaxWidth(),
+                enabled = !uiState.isLoading,
+            ) {
+                if (uiState.isLoading) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.height(20.dp),
+                        color = MaterialTheme.colorScheme.onPrimary,
+                        strokeWidth = 2.dp,
+                    )
+                } else {
+                    Text(stringResource(Res.string.continue_button))
+                }
+            }
+
             Spacer(modifier = Modifier.height(8.dp))
 
-            socialLogins.forEach { provider ->
-                OutlinedButton(
-                    onClick = { viewModel.launchOAuth(provider) },
-                    modifier = Modifier.fillMaxWidth(),
-                    enabled = !uiState.isLoading,
-                ) {
-                    Text(oAuthProviderLabel(provider))
+            TextButton(onClick = onNavigateToForgotPassword) {
+                Text(stringResource(Res.string.forgot_password))
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            if (uiState.registrationEnabled) {
+                TextButton(onClick = onNavigateToRegister) {
+                    Text(stringResource(Res.string.no_account_sign_up))
                 }
+            }
+
+            val socialLogins = uiState.socialLogins
+            if (uiState.socialLoginEnabled && socialLogins.isNotEmpty()) {
+                Spacer(modifier = Modifier.height(16.dp))
+
+                HorizontalDivider(modifier = Modifier.fillMaxWidth())
+
                 Spacer(modifier = Modifier.height(8.dp))
+
+                Text(
+                    text = stringResource(Res.string.or_continue_with),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                socialLogins.forEach { provider ->
+                    OutlinedButton(
+                        onClick = { viewModel.launchOAuth(provider) },
+                        modifier = Modifier.fillMaxWidth(),
+                        enabled = !uiState.isLoading,
+                    ) {
+                        Text(oAuthProviderLabel(provider))
+                    }
+                    Spacer(modifier = Modifier.height(8.dp))
+                }
             }
         }
+
+        BackAffordanceOverlay(onBack)
     }
 }
 

--- a/feature/auth/src/commonMain/kotlin/com/garfiec/librechat/feature/auth/screen/ServerUrlScreen.kt
+++ b/feature/auth/src/commonMain/kotlin/com/garfiec/librechat/feature/auth/screen/ServerUrlScreen.kt
@@ -2,6 +2,7 @@ package com.garfiec.librechat.feature.auth.screen
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -38,6 +39,7 @@ import org.koin.compose.viewmodel.koinViewModel
 fun ServerUrlScreen(
     onServerValidate: () -> Unit,
     modifier: Modifier = Modifier,
+    onBack: (() -> Unit)? = null,
     viewModel: ServerUrlViewModel = koinViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -56,64 +58,71 @@ fun ServerUrlScreen(
         )
     }
 
-    Column(
+    Box(
         modifier = modifier
             .fillMaxSize()
-            .background(MaterialTheme.colorScheme.background)
-            .imePadding()
-            .verticalScroll(rememberScrollState())
-            .padding(24.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center,
+            .background(MaterialTheme.colorScheme.background),
     ) {
-        Text(
-            text = stringResource(Res.string.connect_to_librechat),
-            style = MaterialTheme.typography.headlineMedium,
-            color = MaterialTheme.colorScheme.onBackground,
-            modifier = Modifier.semantics { heading() },
-        )
-
-        Spacer(modifier = Modifier.height(8.dp))
-
-        Text(
-            text = stringResource(Res.string.enter_server_url_hint),
-            style = MaterialTheme.typography.bodyLarge,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-
-        Spacer(modifier = Modifier.height(32.dp))
-
-        OutlinedTextField(
-            value = uiState.url,
-            onValueChange = viewModel::onUrlChanged,
-            label = { Text(stringResource(Res.string.server_url_label)) },
-            placeholder = { Text(stringResource(Res.string.server_url_placeholder)) },
-            modifier = Modifier.fillMaxWidth(),
-            singleLine = true,
-            isError = uiState.error != null,
-            supportingText = uiState.error?.let { error ->
-                { Text(text = error, color = MaterialTheme.colorScheme.error) }
-            },
-            enabled = !uiState.isLoading,
-        )
-
-        Spacer(modifier = Modifier.height(24.dp))
-
-        Button(
-            onClick = viewModel::validateAndConnect,
-            modifier = Modifier.fillMaxWidth(),
-            enabled = !uiState.isLoading && uiState.url.isNotBlank(),
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .imePadding()
+                .verticalScroll(rememberScrollState())
+                .padding(24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
         ) {
-            if (uiState.isLoading) {
-                CircularProgressIndicator(
-                    modifier = Modifier.height(20.dp),
-                    color = MaterialTheme.colorScheme.onPrimary,
-                    strokeWidth = 2.dp,
-                )
-            } else {
-                Text(stringResource(Res.string.server_url_connect))
+            Text(
+                text = stringResource(Res.string.connect_to_librechat),
+                style = MaterialTheme.typography.headlineMedium,
+                color = MaterialTheme.colorScheme.onBackground,
+                modifier = Modifier.semantics { heading() },
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            Text(
+                text = stringResource(Res.string.enter_server_url_hint),
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            Spacer(modifier = Modifier.height(32.dp))
+
+            OutlinedTextField(
+                value = uiState.url,
+                onValueChange = viewModel::onUrlChanged,
+                label = { Text(stringResource(Res.string.server_url_label)) },
+                placeholder = { Text(stringResource(Res.string.server_url_placeholder)) },
+                modifier = Modifier.fillMaxWidth(),
+                singleLine = true,
+                isError = uiState.error != null,
+                supportingText = uiState.error?.let { error ->
+                    { Text(text = error, color = MaterialTheme.colorScheme.error) }
+                },
+                enabled = !uiState.isLoading,
+            )
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            Button(
+                onClick = viewModel::validateAndConnect,
+                modifier = Modifier.fillMaxWidth(),
+                enabled = !uiState.isLoading && uiState.url.isNotBlank(),
+            ) {
+                if (uiState.isLoading) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.height(20.dp),
+                        color = MaterialTheme.colorScheme.onPrimary,
+                        strokeWidth = 2.dp,
+                    )
+                } else {
+                    Text(stringResource(Res.string.server_url_connect))
+                }
             }
         }
+
+        BackAffordanceOverlay(onBack)
     }
 }
 

--- a/feature/auth/src/commonMain/kotlin/com/garfiec/librechat/feature/auth/viewmodel/LoginViewModel.kt
+++ b/feature/auth/src/commonMain/kotlin/com/garfiec/librechat/feature/auth/viewmodel/LoginViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.garfiec.librechat.core.common.result.Result
 import com.garfiec.librechat.core.data.datastore.ServerDataStore
+import com.garfiec.librechat.core.data.repository.AccountSwitcher
 import com.garfiec.librechat.core.data.repository.AuthRepository
 import com.garfiec.librechat.core.data.repository.ConfigRepository
 import com.garfiec.librechat.core.model.LoginOutcome
@@ -32,14 +33,20 @@ class LoginViewModel(
     private val configRepository: ConfigRepository,
     private val oAuthLauncher: OAuthLauncher,
     private val serverDataStore: ServerDataStore,
+    private val accountSwitcher: AccountSwitcher,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(LoginUiState())
     val uiState: StateFlow<LoginUiState> = _uiState.asStateFlow()
 
     init {
+        // In an add-account flow this screen signs into the PENDING server while another account is
+        // live, so its feature flags (registration, social logins) must come from the pending
+        // session's probed config — the global startupConfig still describes the live server. The
+        // repository layer routes the sign-in calls themselves via the same pending session.
+        val configSource = accountSwitcher.pendingAdd?.startupConfig ?: configRepository.startupConfig
         viewModelScope.launch {
-            configRepository.startupConfig.collect { config ->
+            configSource.collect { config ->
                 if (config != null) {
                     _uiState.value = _uiState.value.copy(
                         registrationEnabled = config.registrationEnabled,
@@ -50,6 +57,10 @@ class LoginViewModel(
             }
         }
     }
+
+    /** The server this screen is signing into: the pending add target when set, else the live one. */
+    private fun signInServerUrl(): String =
+        accountSwitcher.pendingAdd?.serverUrl ?: serverDataStore.getBaseUrl()
 
     fun onEmailChanged(email: String) {
         _uiState.value = _uiState.value.copy(email = email, error = null)
@@ -97,13 +108,32 @@ class LoginViewModel(
         }
     }
 
+    /** Set once this screen launches its own OAuth round-trip; gates add-mode cookie consumption. */
+    private var oAuthLaunched = false
+
     fun launchOAuth(provider: String) {
-        val serverUrl = serverDataStore.getBaseUrl()
+        oAuthLaunched = true
+        val serverUrl = signInServerUrl()
+        // Drop any stale refreshToken cookie for this host BEFORE launching. In add mode the cookie
+        // jar is process-global and nothing clears it on add-flow entry, so a launch that the user then
+        // cancels would otherwise leave a pre-existing cookie for checkOAuthResult() to consume as the
+        // wrong user (the oAuthLaunched guard only blocks the never-launched case). Clearing here means
+        // only a cookie minted by THIS round-trip can be present on return.
+        oAuthLauncher.clearOAuthCookie(serverUrl)
         oAuthLauncher.launchOAuth(provider, serverUrl)
     }
 
     fun checkOAuthResult() {
-        val serverUrl = serverDataStore.getBaseUrl()
+        // In add mode, only consume a cookie minted by THIS screen's own launchOAuth round-trip:
+        // the cookie jar is process-global and nothing clears it on add-flow entry, so a stale
+        // refreshToken cookie for this host would otherwise be auto-consumed on first ON_RESUME
+        // and silently complete the add as the wrong user. The normal login screen keeps the
+        // unconditional consume — it must survive process death during the Custom Tab round-trip,
+        // which an add flow never does (its pending session is memory-only, so a killed add flow
+        // is stripped by the NavHost, not resumed).
+        if (accountSwitcher.pendingAdd != null && !oAuthLaunched) return
+
+        val serverUrl = signInServerUrl()
         if (serverUrl.isBlank()) return
 
         val refreshToken = oAuthLauncher.extractTokenFromCookies(serverUrl) ?: return

--- a/feature/auth/src/commonMain/kotlin/com/garfiec/librechat/feature/auth/viewmodel/ServerUrlViewModel.kt
+++ b/feature/auth/src/commonMain/kotlin/com/garfiec/librechat/feature/auth/viewmodel/ServerUrlViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.garfiec.librechat.core.common.result.Result
 import com.garfiec.librechat.core.data.datastore.ServerDataStore
+import com.garfiec.librechat.core.data.repository.AccountSwitcher
 import com.garfiec.librechat.core.data.repository.ConfigRepository
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -21,9 +22,23 @@ data class ServerUrlUiState(
     val showHttpWarning: Boolean = false,
 )
 
+/**
+ * Validates a server URL and selects it for the sign-in flow. Two modes:
+ *
+ * - **Normal** (`addAccount = false`): the pre-login screen. Sets the process-global server URL and
+ *   validates + caches the config through the live pipeline.
+ * - **Add-account** (`addAccount = true`): reached from the account switcher while another account
+ *   is live. Must never touch the live account's state: the URL goes into a pending add session
+ *   ([AccountSwitcher.beginAdd]) instead of the global store, and validation runs under the pending
+ *   identity without publishing to the live server's config state/cache
+ *   ([ConfigRepository.probeServerUrl]). The validated config rides on the pending session for the
+ *   add-mode login screen.
+ */
 class ServerUrlViewModel(
     private val serverDataStore: ServerDataStore,
     private val configRepository: ConfigRepository,
+    private val accountSwitcher: AccountSwitcher,
+    private val addAccount: Boolean = false,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(ServerUrlUiState())
@@ -33,6 +48,8 @@ class ServerUrlViewModel(
         viewModelScope.launch {
             // awaitBaseUrl (not getBaseUrl) so a cold-start relaunch doesn't read "" before
             // ServerDataStore's async warm-up resolves, which would skip pre-filling the saved URL.
+            // In add mode this pre-fills the ACTIVE server so the common same-server-different-user
+            // add is a single tap; typing a different URL adds a new server.
             val existingUrl = serverDataStore.awaitBaseUrl()
             if (existingUrl.isNotBlank()) {
                 _uiState.value = _uiState.value.copy(
@@ -86,10 +103,9 @@ class ServerUrlViewModel(
         viewModelScope.launch {
             _uiState.value = _uiState.value.copy(isLoading = true, error = null)
 
-            // Set the URL first so API calls use it
-            serverDataStore.setServerUrl(url)
+            val result = if (addAccount) validatePendingServer(url) else validateLiveServer(url)
 
-            when (val result = configRepository.validateServerUrl(url)) {
+            when (result) {
                 is Result.Success -> {
                     _uiState.value = _uiState.value.copy(
                         isLoading = false,
@@ -97,8 +113,6 @@ class ServerUrlViewModel(
                     )
                 }
                 is Result.Error -> {
-                    // Reset URL on failure
-                    serverDataStore.setServerUrl("")
                     _uiState.value = _uiState.value.copy(
                         isLoading = false,
                         error = result.message ?: "Could not connect to server",
@@ -107,5 +121,36 @@ class ServerUrlViewModel(
                 is Result.Loading -> { /* no-op */ }
             }
         }
+    }
+
+    private suspend fun validateLiveServer(url: String): Result<*> {
+        // Set the URL first so API calls use it
+        serverDataStore.setServerUrl(url)
+        val result = configRepository.validateServerUrl(url)
+        if (result is Result.Error) {
+            serverDataStore.setServerUrl("")
+        }
+        return result
+    }
+
+    private suspend fun validatePendingServer(url: String): Result<*> {
+        // beginAdd requires a resolved active account; the switcher only offers "add" while one is
+        // live, but a logout/expiry racing the tap must surface as an error, not a crash.
+        val begun = runCatching { accountSwitcher.beginAdd(url) }
+        if (begun.isFailure) {
+            return Result.Error(
+                begun.exceptionOrNull(),
+                "Could not start adding an account. Try again.",
+            )
+        }
+        val result = accountSwitcher.withPendingIdentity { configRepository.probeServerUrl() }
+        when (result) {
+            is Result.Success -> accountSwitcher.attachPendingConfig(result.data)
+            // Drop the pending session so an abandoned attempt leaves no staged state; a retry
+            // begins a fresh one.
+            is Result.Error -> accountSwitcher.cancelAdd()
+            is Result.Loading -> Unit
+        }
+        return result
     }
 }

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/di/ChatPlatformModule.android.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/di/ChatPlatformModule.android.kt
@@ -46,6 +46,7 @@ actual val chatPlatformModule: Module = module {
             roleRepository = get(),
             permissionGate = get(),
             connectivityObserver = get(),
+            activeAccountProvider = get(),
             serverDataStore = get(),
             settingsDataStore = get(),
             platformDelegateFactory = get(),

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatScreenEffects.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatScreenEffects.kt
@@ -63,6 +63,11 @@ internal fun ChatScreenEffects(
         onNavigateToProviderKeys = onNavigateToProviderKeys,
     )
 
+    QueuedMessageDroppedSnackbarEffect(
+        viewModel = viewModel,
+        snackbarHostState = snackbarHostState,
+    )
+
     LifecycleEventEffect(Lifecycle.Event.ON_PAUSE) { viewModel.onPause() }
     LifecycleEventEffect(Lifecycle.Event.ON_RESUME) { viewModel.onResume() }
 

--- a/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/di/ChatModuleVerificationTest.kt
+++ b/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/di/ChatModuleVerificationTest.kt
@@ -2,6 +2,7 @@ package com.garfiec.librechat.feature.chat.di
 
 import android.app.Application
 import android.content.Context
+import com.garfiec.librechat.core.common.identity.ActiveAccountProvider
 import com.garfiec.librechat.core.common.network.ConnectivityObserver
 import com.garfiec.librechat.core.data.datastore.ServerDataStore
 import com.garfiec.librechat.core.data.datastore.SettingsDataStore
@@ -54,6 +55,7 @@ class ChatModuleVerificationTest {
                 McpRepository::class,
                 UserRepository::class,
                 ConnectivityObserver::class,
+                ActiveAccountProvider::class,
                 ServerDataStore::class,
                 SettingsDataStore::class,
                 // Dispatchers are supplied via Koin qualifiers in explicit blocks; verify()

--- a/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModelContextProjectionInitTest.kt
+++ b/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModelContextProjectionInitTest.kt
@@ -1,6 +1,9 @@
 package com.garfiec.librechat.feature.chat.viewmodel
 
 import com.garfiec.librechat.core.common.EndpointConstants
+import com.garfiec.librechat.core.common.identity.AccountId
+import com.garfiec.librechat.core.common.identity.AccountState
+import com.garfiec.librechat.core.common.identity.InMemoryActiveAccountProvider
 import com.garfiec.librechat.core.common.result.Result
 import com.garfiec.librechat.core.data.repository.AgentRepository
 import com.garfiec.librechat.core.data.repository.ChatRepository
@@ -133,7 +136,7 @@ class ChatViewModelContextProjectionInitTest {
         // the projection. Left to relaxed mockk this is load-bearing but implicit — an Error keeps the
         // precondition explicit so a change in relaxed handling of the sealed Result can't silently
         // flip the selection off AGENTS and fail this test on correct code.
-        coEvery { conversationRepository.getConversation(any()) } returns Result.Error(message = "test")
+        coEvery { conversationRepository.getConversation(any(), any()) } returns Result.Error(message = "test")
     }
 
     @After
@@ -206,5 +209,6 @@ class ChatViewModelContextProjectionInitTest {
             defaultDispatcher = testDispatcher,
             selectionHandoff = selectionHandoff,
             serverFileSelectionHandoff = serverFileSelectionHandoff,
+            activeAccountProvider = InMemoryActiveAccountProvider(AccountState.Resolved(AccountId("srv:user-1"))),
         )
 }

--- a/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/MessageQueueDelegateTest.kt
+++ b/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/MessageQueueDelegateTest.kt
@@ -1,5 +1,8 @@
 package com.garfiec.librechat.feature.chat.viewmodel.delegate
 
+import com.garfiec.librechat.core.common.identity.AccountId
+import com.garfiec.librechat.core.common.identity.AccountState
+import com.garfiec.librechat.core.common.identity.InMemoryActiveAccountProvider
 import com.garfiec.librechat.core.data.endpoint.EndpointDispatch
 import com.garfiec.librechat.feature.chat.viewmodel.ChatStateHandle
 import com.garfiec.librechat.feature.chat.viewmodel.ChatUiState
@@ -26,12 +29,16 @@ class MessageQueueDelegateTest {
 
     private val sent = mutableListOf<QueuedMessage>()
     private val awaitSettleFlags = mutableListOf<Boolean>()
+    private val droppedCounts = mutableListOf<Int>()
+    private val activeAccount = InMemoryActiveAccountProvider(AccountState.Resolved(AccountId("srv:user-1")))
     private val delegate = MessageQueueDelegate(
         stateHandle = stateHandle,
+        activeAccountProvider = activeAccount,
         sendWithSpec = { spec, awaitSettle ->
             sent.add(spec)
             awaitSettleFlags.add(awaitSettle)
         },
+        onQueuedDropped = { droppedCounts.add(it) },
     )
 
     private fun spec(id: String, text: String = id, model: String? = "gpt-4") = QueuedMessage(
@@ -263,5 +270,66 @@ class MessageQueueDelegateTest {
 
         assertThat(sent.single().model).isEqualTo("gpt-4")
         assertThat(sent.single().endpoint).isEqualTo("openAI")
+    }
+
+    @Test
+    fun `drainNext drops items composed under a now-inactive account and signals the count`() {
+        // Two items queued under account A, one under the live account. The user switched to the live
+        // account (srv:user-1) since queueing the A items.
+        delegate.enqueue(spec("a1").copy(accountId = "srv:user-A"))
+        delegate.enqueue(spec("a2").copy(accountId = "srv:user-A"))
+        delegate.enqueue(spec("live").copy(accountId = "srv:user-1"))
+
+        delegate.drainNext(awaitSettle = false)
+
+        // The two foreign items are purged (never sent); the live item drains normally.
+        assertThat(sent.map { it.localId }).containsExactly("live")
+        assertThat(queue).isEmpty()
+        assertThat(droppedCounts).containsExactly(2)
+    }
+
+    @Test
+    fun `drainNext sends items with a null accountId (pre-multi-account) without dropping`() {
+        delegate.enqueue(spec("a")) // spec() leaves accountId null
+
+        delegate.drainNext(awaitSettle = false)
+
+        assertThat(sent.map { it.localId }).containsExactly("a")
+        assertThat(droppedCounts).isEmpty()
+    }
+
+    @Test
+    fun `drainNext leaves foreign items untouched (no purge, no signal) while paused`() {
+        // A foreign item on a paused queue: the pause is the user parking the queue, so drainNext must
+        // not mutate it or fire the "discarded" snackbar. The purge happens later, on resume.
+        delegate.enqueue(spec("a").copy(accountId = "srv:user-A"))
+        delegate.pause()
+
+        delegate.drainNext()
+
+        assertThat(sent).isEmpty()
+        assertThat(queue.map { it.localId }).containsExactly("a")
+        assertThat(droppedCounts).isEmpty()
+    }
+
+    @Test
+    fun `drainNext keeps stamped items when the active account is unresolved`() {
+        // A null current account (Warming / logged-out) is "identity not yet known", not "account B".
+        // Treating every stamped item as foreign then would wipe the whole queue for no real mismatch.
+        val warming = InMemoryActiveAccountProvider(AccountState.Warming)
+        val warmingSent = mutableListOf<QueuedMessage>()
+        val warmingDropped = mutableListOf<Int>()
+        val warmingDelegate = MessageQueueDelegate(
+            stateHandle = stateHandle,
+            activeAccountProvider = warming,
+            sendWithSpec = { spec, _ -> warmingSent.add(spec) },
+            onQueuedDropped = { warmingDropped.add(it) },
+        )
+        warmingDelegate.enqueue(spec("a").copy(accountId = "srv:user-A"))
+
+        warmingDelegate.drainNext(awaitSettle = false)
+
+        assertThat(warmingSent.map { it.localId }).containsExactly("a")
+        assertThat(warmingDropped).isEmpty()
     }
 }

--- a/feature/chat/src/commonMain/composeResources/values/strings.xml
+++ b/feature/chat/src/commonMain/composeResources/values/strings.xml
@@ -374,6 +374,9 @@
     <!-- Snackbar action label that deep-links to Settings → Provider Keys -->
     <string name="provider_keys_chat_error_cta">Open key settings</string>
 
+    <!-- Snackbar shown when queued follow-up messages are discarded because the user switched accounts -->
+    <string name="queued_messages_dropped_account_switch">Queued messages discarded after switching accounts</string>
+
     <!-- Send block reasons (shown in error snackbar when send can't proceed) -->
     <string name="send_block_select_agent">Select an agent before sending your message.</string>
     <string name="send_block_select_model">Select a model before sending your message.</string>

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/screen/QueuedMessageDroppedSnackbarEffect.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/screen/QueuedMessageDroppedSnackbarEffect.kt
@@ -1,0 +1,29 @@
+package com.garfiec.librechat.feature.chat.screen
+
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import com.garfiec.librechat.feature.chat.resources.Res
+import com.garfiec.librechat.feature.chat.resources.queued_messages_dropped_account_switch
+import com.garfiec.librechat.feature.chat.viewmodel.ChatViewModel
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * Collects [ChatViewModel.queuedMessagesDropped] and surfaces a snackbar when queued follow-up
+ * messages were discarded on drain because they were composed under an account the user has since
+ * switched away from. Without this the drop would be silent — the user would just never see their
+ * queued message send. The count is carried on the signal for logic but the message stays generic
+ * (no per-locale plural handling needed).
+ */
+@Composable
+fun QueuedMessageDroppedSnackbarEffect(
+    viewModel: ChatViewModel,
+    snackbarHostState: SnackbarHostState,
+) {
+    val message = stringResource(Res.string.queued_messages_dropped_account_switch)
+    LaunchedEffect(viewModel) {
+        viewModel.queuedMessagesDropped.collect {
+            snackbarHostState.showSnackbar(message = message)
+        }
+    }
+}

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatUiState.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatUiState.kt
@@ -141,6 +141,13 @@ data class QueuedMessage(
     val ephemeralAgent: EphemeralAgent? = null,
     val dispatch: EndpointDispatch,
     val isTemporary: Boolean = false,
+    /**
+     * The active account when this item was queued. A drain guard drops any item whose account no
+     * longer matches the active one (the user switched accounts since queueing), so a follow-up
+     * composed under account A can never be POSTed to account B's server under B's bearer. Null for
+     * items composed before multi-account (or in tests) — treated as "matches any", never dropped.
+     */
+    val accountId: String? = null,
 )
 
 /**

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModel.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModel.kt
@@ -6,6 +6,8 @@ import co.touchlab.kermit.Logger
 import com.garfiec.librechat.core.common.BackendVersion
 import com.garfiec.librechat.core.common.EndpointConstants
 import com.garfiec.librechat.core.common.ToolConstants
+import com.garfiec.librechat.core.common.identity.ActiveAccountProvider
+import com.garfiec.librechat.core.common.identity.currentAccountId
 import com.garfiec.librechat.core.common.network.ConnectivityObserver
 import com.garfiec.librechat.core.common.result.Result
 import com.garfiec.librechat.core.common.result.getOrNull
@@ -118,6 +120,7 @@ class ChatViewModel(
     private val roleRepository: RoleRepository,
     private val permissionGate: PermissionGate,
     private val connectivityObserver: ConnectivityObserver,
+    private val activeAccountProvider: ActiveAccountProvider,
     serverDataStore: ServerDataStore,
     private val settingsDataStore: SettingsDataStore,
     platformDelegateFactory: PlatformDelegateFactory,
@@ -190,6 +193,11 @@ class ChatViewModel(
         reloadConversation = ::loadConversation,
     )
 
+    // Channel-backed one-shot signal: N queued follow-ups were dropped on drain because they were
+    // composed under an account the user has since switched away from. Surfaced as a snackbar.
+    private val _queuedMessagesDropped = Channel<Int>(Channel.BUFFERED)
+    val queuedMessagesDropped: Flow<Int> = _queuedMessagesDropped.receiveAsFlow()
+
     private val queueDelegate = MessageQueueDelegate(
         stateHandle = stateHandle,
         // Drained items send with their snapshotted config but LIVE lineage. We first wait for
@@ -203,6 +211,8 @@ class ChatViewModel(
                 runWhenSendReady { doSendWithSpec(spec) }
             }
         },
+        activeAccountProvider = activeAccountProvider,
+        onQueuedDropped = { count -> _queuedMessagesDropped.trySend(count) },
     )
 
     // --- Delegate-owned flows exposed to the UI ---
@@ -300,6 +310,7 @@ class ChatViewModel(
     private val streamingManager = StreamingManagerDelegate(
         stateHandle = stateHandle,
         chatRepository = chatRepository,
+        activeAccountProvider = activeAccountProvider,
         connectivityObserver = connectivityObserver,
         comparisonDelegate = comparisonDelegate,
         subagentTraceDelegate = subagentTraceDelegate,
@@ -797,7 +808,7 @@ class ChatViewModel(
             return
         }
         viewModelScope.launch {
-            val result = conversationRepository.getConversation(conversationId)
+            val result = conversationRepository.getConversation(conversationId, originAccount = null)
             val conversation = result.getOrNull()
             if (conversation != null) {
                 _uiState.update { it.copy(conversationTitle = conversation.title) }
@@ -1056,6 +1067,9 @@ class ChatViewModel(
             ephemeralAgent = requestBuilder.buildEphemeralAgent(),
             dispatch = requestBuilder.currentDispatch(),
             isTemporary = state.isTemporaryChat,
+            // Capture the composing account so a drain after an account switch drops this item rather
+            // than POSTing it to the newly-active account's server.
+            accountId = activeAccountProvider.currentAccountId()?.value,
         )
     }
 

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/MessageQueueDelegate.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/MessageQueueDelegate.kt
@@ -1,5 +1,7 @@
 package com.garfiec.librechat.feature.chat.viewmodel.delegate
 
+import com.garfiec.librechat.core.common.identity.ActiveAccountProvider
+import com.garfiec.librechat.core.common.identity.currentAccountId
 import com.garfiec.librechat.feature.chat.viewmodel.ChatStateHandle
 import com.garfiec.librechat.feature.chat.viewmodel.QueuedMessage
 
@@ -15,11 +17,16 @@ import com.garfiec.librechat.feature.chat.viewmodel.QueuedMessage
  */
 class MessageQueueDelegate(
     private val stateHandle: ChatStateHandle,
+    private val activeAccountProvider: ActiveAccountProvider,
     /** Fires one queued message. Set by `ChatViewModel` to `doSendWithSpec` (wrapped in the
      *  send-ready gate). Recomputes lineage live; only config comes from the spec. [awaitSettle]
      *  is true for the auto-drain after a Final (wait for the async reload to land the reply in
      *  the tree) and false for an explicit resume (the reply has already settled). */
     private val sendWithSpec: (spec: QueuedMessage, awaitSettle: Boolean) -> Unit,
+    /** Called with the number of queued items dropped because they belonged to a now-inactive
+     *  account (a switch happened since queueing). Set by `ChatViewModel` to surface a snackbar so a
+     *  silently-discarded follow-up leaves a user-visible trail. */
+    private val onQueuedDropped: (count: Int) -> Unit,
 ) {
 
     fun enqueue(spec: QueuedMessage) {
@@ -100,8 +107,29 @@ class MessageQueueDelegate(
         // out from under the user and shift the slots the edit session's originalIndex points at.
         // The edit's commit/cancel re-kicks draining once it completes.
         if (stateHandle.state.isEditingQueued) return
-        val head = stateHandle.state.messageQueue.firstOrNull() ?: return
+        // A paused queue must not be mutated: leave every item (foreign ones included) in place until
+        // the user resumes, which re-enters here with the pause lifted and runs the purge below. Guard
+        // before the purge so a stray drain trigger can't silently drop items — and fire a snackbar —
+        // on a queue the user has deliberately parked.
         if (stateHandle.state.isQueuePaused) return
+        // Purge items composed under a different account (the user switched accounts since queueing).
+        // Sending one would POST account A's content to account B's server under B's bearer — a
+        // content-to-wrong-server leak the same-owner reframe does not excuse. Surface a count so the
+        // discard isn't silent. Only purge when the active account is resolved: a null current means the
+        // identity is still unresolved (cold-start warm-up / logged-out), not "some other account", so
+        // dropping every stamped item then would wipe the queue for no real mismatch. Items with no
+        // accountId (pre-multi-account / tests) match any account.
+        val current = activeAccountProvider.currentAccountId()?.value
+        if (current != null) {
+            val foreign = stateHandle.state.messageQueue.count { it.accountId != null && it.accountId != current }
+            if (foreign > 0) {
+                stateHandle.update {
+                    copy(messageQueue = messageQueue.filter { it.accountId == null || it.accountId == current })
+                }
+                onQueuedDropped(foreign)
+            }
+        }
+        val head = stateHandle.state.messageQueue.firstOrNull() ?: return
         stateHandle.update { copy(messageQueue = messageQueue.drop(1)) }
         sendWithSpec(head, awaitSettle)
     }

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/SendCompletionDelegate.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/SendCompletionDelegate.kt
@@ -1,6 +1,7 @@
 package com.garfiec.librechat.feature.chat.viewmodel.delegate
 
 import co.touchlab.kermit.Logger
+import com.garfiec.librechat.core.common.identity.AccountId
 import com.garfiec.librechat.core.common.result.Result
 import com.garfiec.librechat.core.common.result.getOrNull
 import com.garfiec.librechat.core.data.repository.ConversationRepository
@@ -47,7 +48,7 @@ class SendCompletionDelegate(
      * arms deferred navigation, and eagerly caches the conversation so it lands in the
      * list even if the stream later fails.
      */
-    fun onConversationCreated(conversationId: String, isNewConversation: Boolean) {
+    fun onConversationCreated(conversationId: String, isNewConversation: Boolean, originAccount: AccountId?) {
         // SECURITY: temp-chat data-at-rest guard. Temporary chats still navigate to a
         // Chat(id) so Back returns to the landing screen (they're a real, streaming conversation
         // for the session) — but they must never be written to Room. Two Room-write paths in this
@@ -90,7 +91,7 @@ class SendCompletionDelegate(
         // conversation list even if the stream fails later — but never for temp chats (see guard).
         if (!isTemporary) {
             stateHandle.scope.launch {
-                conversationRepository.getConversation(conversationId)
+                conversationRepository.getConversation(conversationId, originAccount)
             }
         }
     }
@@ -112,6 +113,7 @@ class SendCompletionDelegate(
         isNewConversation: Boolean,
         isHandedOffNewChat: Boolean,
         isComparison: Boolean,
+        originAccount: AccountId?,
     ) {
         val finalConversation = event.conversation
         // Belt-and-braces: if no handoff seeded the selection and the initial GET 404'd
@@ -132,7 +134,7 @@ class SendCompletionDelegate(
         val isTemporary = stateHandle.state.isTemporaryChat || finalConversation?.isTemporary == true
         if (finalConversation?.conversationId != null && !isTemporary) {
             stateHandle.scope.launch {
-                conversationRepository.saveConversation(finalConversation)
+                conversationRepository.saveConversation(finalConversation, originAccount)
             }
         }
         if (conversationId != null) {
@@ -156,7 +158,7 @@ class SendCompletionDelegate(
                     // canonical fields (refreshed anyway on the next open) while re-rendering
                     // the list with value-different instances — the completion flash.
                     val finalizedTurn = treeDelegate.finalizeChatDisplay(event)
-                    cacheTurn(finalizedTurn)
+                    cacheTurn(finalizedTurn, originAccount)
                 }
                 val shouldGenerate = shouldRequestTitleGeneration(
                     isNewConversation = isNewConversation,
@@ -166,9 +168,9 @@ class SendCompletionDelegate(
                 )
                 if (shouldGenerate) {
                     titleGenerationRequested = true
-                    generateAndSetTitle(conversationId)
+                    generateAndSetTitle(conversationId, originAccount)
                 } else {
-                    refreshConversationTitle(conversationId)
+                    refreshConversationTitle(conversationId, originAccount)
                 }
             }
         }
@@ -183,24 +185,25 @@ class SendCompletionDelegate(
      * forbids mid-stream writes), so this is what keeps it from being lost on reopen. The
      * resulting Room emission conflates away via instance-stabilization in loadConversation.
      */
-    private fun cacheTurn(turn: List<Message>) {
+    private fun cacheTurn(turn: List<Message>, originAccount: AccountId?) {
         if (turn.isEmpty()) return
         stateHandle.scope.launch {
-            runCatching { messageRepository.cacheMessages(turn) }
+            runCatching { messageRepository.cacheMessages(turn, originAccount) }
                 .onFailure { Logger.e(it) { "Failed to cache final messages for the completed turn" } }
         }
     }
 
-    private fun refreshConversationTitle(conversationId: String) {
+    private fun refreshConversationTitle(conversationId: String, originAccount: AccountId?) {
         stateHandle.scope.launch {
-            val conversation = conversationRepository.getConversation(conversationId).getOrNull() ?: return@launch
+            val conversation = conversationRepository.getConversation(conversationId, originAccount).getOrNull()
+                ?: return@launch
             stateHandle.update { copy(conversationTitle = conversation.title) }
         }
     }
 
-    private fun generateAndSetTitle(conversationId: String) {
+    private fun generateAndSetTitle(conversationId: String, originAccount: AccountId?) {
         stateHandle.scope.launch {
-            when (val result = conversationRepository.generateTitle(conversationId)) {
+            when (val result = conversationRepository.generateTitle(conversationId, originAccount)) {
                 is Result.Success -> {
                     stateHandle.update { copy(conversationTitle = result.data) }
                 }
@@ -212,7 +215,7 @@ class SendCompletionDelegate(
                     // still holds the "New Chat" placeholder, so cache-first getConversation
                     // could never observe the title, and refreshConversation's upsert also
                     // propagates it to the Room-observing conversation list.
-                    conversationRepository.refreshConversation(conversationId).getOrNull()?.let { conversation ->
+                    conversationRepository.refreshConversation(conversationId, originAccount).getOrNull()?.let { conversation ->
                         stateHandle.update { copy(conversationTitle = conversation.title) }
                     }
                 }

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/StreamingManagerDelegate.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/StreamingManagerDelegate.kt
@@ -1,6 +1,9 @@
 package com.garfiec.librechat.feature.chat.viewmodel.delegate
 
 import co.touchlab.kermit.Logger
+import com.garfiec.librechat.core.common.identity.AccountId
+import com.garfiec.librechat.core.common.identity.ActiveAccountProvider
+import com.garfiec.librechat.core.common.identity.currentAccountId
 import com.garfiec.librechat.core.common.network.ConnectivityObserver
 import com.garfiec.librechat.core.common.result.Result
 import com.garfiec.librechat.core.data.repository.ChatRepository
@@ -33,6 +36,7 @@ import kotlinx.coroutines.launch
 class StreamingManagerDelegate(
     private val stateHandle: ChatStateHandle,
     private val chatRepository: ChatRepository,
+    private val activeAccountProvider: ActiveAccountProvider,
     private val connectivityObserver: ConnectivityObserver,
     private val comparisonDelegate: ComparisonModeDelegate,
     private val subagentTraceDelegate: SubagentTraceDelegate,
@@ -55,6 +59,15 @@ class StreamingManagerDelegate(
     private var streamingBufferDirty = false
     private var wasStreaming = false
 
+    /**
+     * The account active when the current stream started (origin-capture provenance): its finalize —
+     * message cache, conversation save, gen_title — lands minutes later, possibly after the user
+     * switched accounts. Threaded to [SendCompletionDelegate] so those writes attribute to the account
+     * that initiated the stream, not the live active one. Captured at every stream start ([beginStreaming],
+     * [resumeStream]).
+     */
+    private var streamOriginAccountId: AccountId? = null
+
     /** Tracks whether the last stream failure was a network error, to enable auto-reconnect. */
     private var lastErrorWasNetwork = false
 
@@ -73,6 +86,8 @@ class StreamingManagerDelegate(
      */
     fun beginStreaming(isEdit: Boolean) {
         isEditOrRegenerate = isEdit
+        // Capture the origin account at stream start so a post-switch finalize attributes to it.
+        streamOriginAccountId = activeAccountProvider.currentAccountId()
         streamingBuffer.clear()
         streamingBufferDirty = false
         subagentTraceDelegate.reset()
@@ -344,7 +359,7 @@ class StreamingManagerDelegate(
                 copy(conversationId = event.conversationId)
             }
         }
-        completionDelegate.onConversationCreated(event.conversationId, isNewConversation())
+        completionDelegate.onConversationCreated(event.conversationId, isNewConversation(), streamOriginAccountId)
     }
 
     private fun handleFinal(event: StreamEvent.Final) {
@@ -389,6 +404,7 @@ class StreamingManagerDelegate(
             isNewConversation = isNewConversation(),
             isHandedOffNewChat = isHandedOffNewChat(),
             isComparison = isComparison,
+            originAccount = streamOriginAccountId,
         )
         // Fallback for degenerate finals: a non-comparison stream that ends with no
         // conversation id (and thus nothing to finalize) never reaches finalizeChatDisplay,
@@ -516,6 +532,9 @@ class StreamingManagerDelegate(
      * (e.g. isStreaming, error) before calling this.
      */
     private fun resumeStream(conversationId: String) {
+        // Re-capture the origin: a resumed/reconnected stream finalizes under whoever is active now
+        // (you can only resume your own conversation), so its writes attribute to that account.
+        streamOriginAccountId = activeAccountProvider.currentAccountId()
         streamingBuffer.clear()
         streamingBufferDirty = false
         startStreamingUpdater()

--- a/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/di/ChatPlatformModule.ios.kt
+++ b/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/di/ChatPlatformModule.ios.kt
@@ -44,6 +44,7 @@ actual val chatPlatformModule: Module = module {
             roleRepository = get(),
             permissionGate = get(),
             connectivityObserver = get(),
+            activeAccountProvider = get(),
             serverDataStore = get(),
             settingsDataStore = get(),
             platformDelegateFactory = get(),

--- a/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/screen/PlatformScreens.ios.kt
+++ b/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/screen/PlatformScreens.ios.kt
@@ -152,6 +152,11 @@ actual fun ChatScreen(
         onNavigateToProviderKeys = onNavigateToProviderKeys,
     )
 
+    QueuedMessageDroppedSnackbarEffect(
+        viewModel = viewModel,
+        snackbarHostState = snackbarHostState,
+    )
+
     val sendBlockMessage = uiState.sendBlockReason?.asString()
 
     ChatRoot(

--- a/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/export/ConversationExporter.kt
+++ b/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/export/ConversationExporter.kt
@@ -23,7 +23,7 @@ class ConversationExporter(
     }
 
     suspend fun exportAsJson(conversationId: String): Result<String> {
-        val conversation = when (val result = conversationRepository.getConversation(conversationId)) {
+        val conversation = when (val result = conversationRepository.getConversation(conversationId, originAccount = null)) {
             is Result.Success -> result.data
             is Result.Error -> return Result.Error(result.exception, result.message)
             is Result.Loading -> return Result.Error(message = "Unexpected loading state")
@@ -46,7 +46,7 @@ class ConversationExporter(
     }
 
     suspend fun exportAsMarkdown(conversationId: String): Result<String> {
-        val conversation = when (val result = conversationRepository.getConversation(conversationId)) {
+        val conversation = when (val result = conversationRepository.getConversation(conversationId, originAccount = null)) {
             is Result.Success -> result.data
             is Result.Error -> return Result.Error(result.exception, result.message)
             is Result.Loading -> return Result.Error(message = "Unexpected loading state")

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -20,6 +20,17 @@
     <string name="files">Files</string>
     <string name="settings">Settings</string>
 
+    <!-- Account switcher -->
+    <string name="accounts">Accounts</string>
+    <string name="add_account">Add account</string>
+    <string name="remove_account">Remove account</string>
+    <string name="remove_account_title">Remove account?</string>
+    <string name="remove_account_message">%1$s and its data will be removed from this device. The account on the server is not affected.</string>
+    <string name="remove">Remove</string>
+    <string name="cancel">Cancel</string>
+    <string name="cd_switch_account">Switch account</string>
+    <string name="cd_active_account">Active account</string>
+
     <!-- Content descriptions -->
     <string name="cd_search">Search</string>
     <string name="cd_clear_search">Clear search</string>

--- a/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/LibreChatSDK.kt
+++ b/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/LibreChatSDK.kt
@@ -2,13 +2,17 @@ package com.garfiec.librechat.shared
 
 import com.garfiec.librechat.core.network.api.AuthApi
 import com.garfiec.librechat.core.network.api.ChatApi
-import com.garfiec.librechat.core.network.api.dto.LoginResult
 import com.garfiec.librechat.core.network.client.TokenManager
 import com.garfiec.librechat.core.network.sse.SseClient
 
 /**
  * Top-level entry point that iOS uses to interact with the KMP business logic.
- * Aggregates the key APIs needed for login + SSE streaming.
+ * Aggregates the key APIs needed for SSE streaming and token access.
+ *
+ * Login is NOT exposed here: sign-in must go through `AuthRepository` (driven by the shared
+ * Compose auth UI), which establishes the active account and re-homes the staged tokens under
+ * the account-keyed slots. A bare `setTokens` without that follow-up would leave the session
+ * unresolved and clobber the active-account mirror, so no SDK login shortcut is provided.
  *
  * SSE usage: call `sseClient.connect(streamPath)` directly — the transport it
  * needs is injected into `SseClient` at construction time.
@@ -19,20 +23,4 @@ class LibreChatSDK(
     val chatApi: ChatApi,
     val sseClient: SseClient,
     val tokenManager: TokenManager,
-) {
-
-    /**
-     * Perform login and store tokens in one call.
-     * On iOS, SKIE converts this suspend fun to async throws.
-     */
-    @Throws(Exception::class)
-    suspend fun login(email: String, password: String): LoginResult {
-        val result = authApi.login(email, password)
-        val accessToken = result.response.token
-        val refreshToken = result.refreshToken
-        if (accessToken != null && refreshToken != null) {
-            tokenManager.setTokens(accessToken, refreshToken)
-        }
-        return result
-    }
-}
+)

--- a/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/AccountSwitcherSheet.kt
+++ b/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/AccountSwitcherSheet.kt
@@ -1,0 +1,291 @@
+package com.garfiec.librechat.shared.navigation
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectVerticalDragGestures
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.outlined.Delete
+import androidx.compose.material.icons.outlined.UnfoldMore
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.garfiec.librechat.core.ui.components.AvatarImage
+import com.garfiec.librechat.shared.resources.Res
+import com.garfiec.librechat.shared.resources.accounts
+import com.garfiec.librechat.shared.resources.add_account
+import com.garfiec.librechat.shared.resources.cancel
+import com.garfiec.librechat.shared.resources.cd_active_account
+import com.garfiec.librechat.shared.resources.cd_switch_account
+import com.garfiec.librechat.shared.resources.remove
+import com.garfiec.librechat.shared.resources.remove_account
+import com.garfiec.librechat.shared.resources.remove_account_message
+import com.garfiec.librechat.shared.resources.remove_account_title
+import org.jetbrains.compose.resources.stringResource
+
+/** Vertical drag past this distance (up or down) on the chip commits a round-robin switch. */
+private val SwipeSwitchThreshold = 40.dp
+
+/**
+ * The drawer-header account chip (Gmail-style): the active account's avatar + label + server host.
+ * Tapping opens the roster sheet ([AccountSwitcherSheet]). Swiping up/down round-robins to the
+ * adjacent account (like Gmail/YouTube profile swipe) via [onSwitchAdjacent] — passed +1 for a
+ * swipe up (next) and -1 for a swipe down (previous); null disables the gesture (single account).
+ * Rendered only while an account is resolved — the drawer isn't reachable from the auth flow, so
+ * [account] is normally non-null.
+ */
+@Composable
+fun AccountChip(
+    account: AccountUiModel,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    onSwitchAdjacent: ((Int) -> Unit)? = null,
+) {
+    val swipeModifier = if (onSwitchAdjacent != null) {
+        val threshold = with(LocalDensity.current) { SwipeSwitchThreshold.toPx() }
+        val currentOnSwitch by rememberUpdatedState(onSwitchAdjacent)
+        Modifier.pointerInput(Unit) {
+            var dragTotal = 0f
+            detectVerticalDragGestures(
+                onDragStart = { dragTotal = 0f },
+                onDragEnd = {
+                    // Up (negative Y) = next; down (positive Y) = previous. Wraparound is the
+                    // caller's job (it holds the account ordering).
+                    when {
+                        dragTotal <= -threshold -> currentOnSwitch(1)
+                        dragTotal >= threshold -> currentOnSwitch(-1)
+                    }
+                },
+            ) { change, dragAmount ->
+                dragTotal += dragAmount
+                change.consume()
+            }
+        }
+    } else {
+        Modifier
+    }
+    Surface(
+        onClick = onClick,
+        modifier = modifier.fillMaxWidth().padding(horizontal = 12.dp).then(swipeModifier),
+        shape = MaterialTheme.shapes.medium,
+        color = MaterialTheme.colorScheme.surfaceContainerHigh,
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            AvatarImage(
+                imageUrl = account.avatarUrl,
+                size = 32.dp,
+                fallbackText = account.displayLabel,
+                contentDescription = null,
+            )
+            Spacer(modifier = Modifier.width(10.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = account.displayLabel,
+                    style = MaterialTheme.typography.titleSmall,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Text(
+                    text = account.serverHost,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+            Icon(
+                imageVector = Icons.Outlined.UnfoldMore,
+                contentDescription = stringResource(Res.string.cd_switch_account),
+                modifier = Modifier.size(20.dp),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+/**
+ * The account id one round-robin step from the active account, for the chip's swipe gesture.
+ * Cycles a STABLE order (by [AccountUiModel.accountId]) rather than the display list's active-first
+ * order — the latter moves the target under the user's finger after every switch. [delta] is +1
+ * (next) / -1 (previous), wrapping at the ends. Returns null when there's nothing to switch to
+ * (fewer than two accounts, or no active entry).
+ */
+internal fun adjacentAccountId(accounts: List<AccountUiModel>, delta: Int): String? {
+    if (accounts.size < 2) return null
+    val ordered = accounts.sortedBy { it.accountId }
+    val activeIndex = ordered.indexOfFirst { it.isActive }
+    if (activeIndex < 0) return null
+    val size = ordered.size
+    val target = ordered[((activeIndex + delta) % size + size) % size]
+    return if (target.isActive) null else target.accountId
+}
+
+/**
+ * The roster bottom sheet: every signed-in account (active first), tap to switch, per-row remove
+ * (confirmed by [RemoveAccountDialog], hoisted by the caller), and an add-account entry.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AccountSwitcherSheet(
+    accounts: List<AccountUiModel>,
+    onSwitchAccount: (String) -> Unit,
+    onRemoveAccountRequest: (AccountUiModel) -> Unit,
+    onAddAccount: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+    ) {
+        Column(modifier = Modifier.navigationBarsPadding()) {
+            Text(
+                text = stringResource(Res.string.accounts),
+                style = MaterialTheme.typography.titleMedium,
+                modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp),
+            )
+            accounts.forEach { account ->
+                AccountRow(
+                    account = account,
+                    onClick = { if (!account.isActive) onSwitchAccount(account.accountId) },
+                    onRemoveRequest = { onRemoveAccountRequest(account) },
+                )
+            }
+            HorizontalDivider(
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
+                color = MaterialTheme.colorScheme.outlineVariant,
+            )
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable(onClick = onAddAccount)
+                    .padding(horizontal = 24.dp, vertical = 14.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Add,
+                    contentDescription = null,
+                    modifier = Modifier.size(24.dp),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(modifier = Modifier.width(16.dp))
+                Text(
+                    text = stringResource(Res.string.add_account),
+                    style = MaterialTheme.typography.bodyLarge,
+                )
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+        }
+    }
+}
+
+@Composable
+private fun AccountRow(
+    account: AccountUiModel,
+    onClick: () -> Unit,
+    onRemoveRequest: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(start = 24.dp, end = 8.dp, top = 8.dp, bottom = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        AvatarImage(
+            imageUrl = account.avatarUrl,
+            size = 36.dp,
+            fallbackText = account.displayLabel,
+            contentDescription = null,
+        )
+        Spacer(modifier = Modifier.width(16.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = account.displayLabel,
+                style = MaterialTheme.typography.bodyLarge,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Text(
+                text = account.serverHost,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+        if (account.isActive) {
+            Icon(
+                imageVector = Icons.Default.Check,
+                contentDescription = stringResource(Res.string.cd_active_account),
+                modifier = Modifier.size(20.dp),
+                tint = MaterialTheme.colorScheme.primary,
+            )
+            Spacer(modifier = Modifier.width(12.dp))
+        }
+        IconButton(onClick = onRemoveRequest) {
+            Icon(
+                imageVector = Icons.Outlined.Delete,
+                contentDescription = stringResource(Res.string.remove_account),
+                modifier = Modifier.size(20.dp),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+/** Destructive-action confirmation for removing [account] and its on-device data. */
+@Composable
+fun RemoveAccountDialog(
+    account: AccountUiModel,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(Res.string.remove_account_title)) },
+        text = { Text(stringResource(Res.string.remove_account_message, account.displayLabel)) },
+        confirmButton = {
+            TextButton(onClick = onConfirm) {
+                Text(
+                    text = stringResource(Res.string.remove),
+                    color = MaterialTheme.colorScheme.error,
+                )
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(Res.string.cancel))
+            }
+        },
+    )
+}

--- a/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/DrawerContent.kt
+++ b/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/DrawerContent.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
@@ -130,12 +131,21 @@ fun DrawerContent(
     modifier: Modifier = Modifier,
     onOpenProject: (projectId: String, projectName: String) -> Unit = { _, _ -> },
     onOpenProjectsIndex: () -> Unit = {},
+    onSwitchAccount: (String) -> Unit = {},
+    onAddAccount: () -> Unit = {},
     viewModel: NavHostViewModel = koinViewModel(),
 ) {
     val uiState by viewModel.drawerUiState.collectAsStateWithLifecycle()
     val projects by viewModel.projects.collectAsStateWithLifecycle()
     val projectsSection by viewModel.projectsSection.collectAsStateWithLifecycle()
     val projectsSectionExpanded by viewModel.projectsSectionExpanded.collectAsStateWithLifecycle()
+    val accounts by viewModel.accounts.collectAsStateWithLifecycle()
+
+    // Account switcher: the header chip opens the roster sheet; remove asks for confirmation.
+    // Switch/add callbacks come from the host (they also close the drawer); remove goes straight to
+    // the ViewModel against the tapped row's id — no captured drawer state (Nav3 stale-closure rule).
+    var showAccountSheet by remember { mutableStateOf(false) }
+    var removeAccountTarget by remember { mutableStateOf<AccountUiModel?>(null) }
 
     // Side-effects for the long-press action menu (share-link copy, export file-save, navigate to
     // a duplicated conversation, error toasts). Lives in feature/conversations so it owns the
@@ -147,6 +157,25 @@ fun DrawerContent(
 
     DrawerContent(
         uiState = uiState,
+        footerContent = {
+            accounts.firstOrNull { it.isActive }?.let { active ->
+                Spacer(modifier = Modifier.height(8.dp))
+                AccountChip(
+                    account = active,
+                    onClick = { showAccountSheet = true },
+                    // Gmail/YouTube-style: swipe the chip up/down to round-robin accounts without
+                    // opening the sheet. Switches in place via the ViewModel rather than the host's
+                    // onSwitchAccount (which also closes the drawer) — keeping the drawer open lets
+                    // the user swipe through several accounts without the jarring dismiss each time.
+                    // Disabled (null) with a single account.
+                    onSwitchAdjacent = if (accounts.size > 1) {
+                        { delta -> adjacentAccountId(accounts, delta)?.let(viewModel::switchAccount) }
+                    } else {
+                        null
+                    },
+                )
+            }
+        },
         onSearchQueryChange = viewModel::onSearchQueryChanged,
         onNewChat = onNewChat,
         onConversationClick = onConversationClick,
@@ -180,6 +209,33 @@ fun DrawerContent(
         onExportFormat = { data, format -> viewModel.exportConversation(data.conversationId, data.title, format) },
         modifier = modifier,
     )
+
+    if (showAccountSheet) {
+        AccountSwitcherSheet(
+            accounts = accounts,
+            onSwitchAccount = { accountId ->
+                showAccountSheet = false
+                onSwitchAccount(accountId)
+            },
+            onRemoveAccountRequest = { removeAccountTarget = it },
+            onAddAccount = {
+                showAccountSheet = false
+                onAddAccount()
+            },
+            onDismiss = { showAccountSheet = false },
+        )
+    }
+
+    removeAccountTarget?.let { target ->
+        RemoveAccountDialog(
+            account = target,
+            onConfirm = {
+                viewModel.removeAccount(target.accountId)
+                removeAccountTarget = null
+            },
+            onDismiss = { removeAccountTarget = null },
+        )
+    }
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -194,6 +250,9 @@ fun DrawerContent(
     onFilesClick: () -> Unit,
     onSkillsClick: () -> Unit,
     modifier: Modifier = Modifier,
+    // Slot below the footer links (Settings, Files, …) — the stateful wrapper puts the account chip
+    // here so switching accounts sits at the bottom of the drawer, near Settings.
+    footerContent: (@Composable () -> Unit)? = null,
     onToggleFavorite: (DrawerConversationDisplayData) -> Unit = {},
     onRefresh: () -> Unit = {},
     onLoadMore: () -> Unit = {},
@@ -251,6 +310,7 @@ fun DrawerContent(
             .fillMaxHeight()
             .width(300.dp)
             .statusBarsPadding()
+            .navigationBarsPadding()
             .padding(top = 16.dp),
     ) {
         Spacer(
@@ -708,6 +768,8 @@ fun DrawerContent(
             label = stringResource(Res.string.settings),
             onClick = onSettingsClick,
         )
+
+        footerContent?.invoke()
 
         Spacer(modifier = Modifier.height(8.dp))
     }

--- a/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/DrawerUiModels.kt
+++ b/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/DrawerUiModels.kt
@@ -37,6 +37,19 @@ data class DrawerProjectFolder(
 )
 
 /**
+ * One signed-in account as the drawer header chip + switcher sheet render it (multi-account,
+ * issue #179). Mapped from the persisted roster; ordered active-first, then by recency.
+ */
+@Immutable
+data class AccountUiModel(
+    val accountId: String,
+    val displayLabel: String,
+    val serverHost: String,
+    val avatarUrl: String?,
+    val isActive: Boolean,
+)
+
+/**
  * Combined UI state for the drawer sidebar.
  */
 @Immutable

--- a/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/LibreChatNavHost.kt
+++ b/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/LibreChatNavHost.kt
@@ -25,7 +25,11 @@ import androidx.compose.material3.rememberDrawerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -34,12 +38,17 @@ import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.runtime.rememberNavBackStack
 import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
 import androidx.navigation3.ui.NavDisplay
+import coil3.SingletonImageLoader
+import coil3.compose.LocalPlatformContext
+import com.garfiec.librechat.core.common.identity.AccountState
 import com.garfiec.librechat.core.logging.Diag
 import com.garfiec.librechat.core.ui.components.BannerDisplay
 import com.garfiec.librechat.core.ui.theme.AppLocale
 import com.garfiec.librechat.feature.agents.navigation.AgentMarketplace
 import com.garfiec.librechat.feature.agents.navigation.agentsEntries
+import com.garfiec.librechat.feature.auth.navigation.AddAccountServerUrl
 import com.garfiec.librechat.feature.auth.navigation.authEntries
+import com.garfiec.librechat.feature.auth.navigation.isAddAccountFlowRoute
 import com.garfiec.librechat.feature.chat.navigation.Chat
 import com.garfiec.librechat.feature.chat.navigation.NewChat
 import com.garfiec.librechat.feature.chat.navigation.chatEntries
@@ -63,10 +72,17 @@ import com.garfiec.librechat.shared.resources.dismiss
 import com.garfiec.librechat.shared.resources.dont_warn_again
 import com.garfiec.librechat.shared.resources.version_mismatch_message
 import com.garfiec.librechat.shared.resources.version_mismatch_title
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
+
+/** Sentinel for "no identity recorded yet" in the saved hygiene marker — distinct from null,
+ *  which means a recorded logged-out state. */
+private const val HYGIENE_UNRECORDED = "__unrecorded__"
 
 /**
  * Shared root composable for LibreChat navigation.
@@ -111,6 +127,64 @@ fun LibreChatNavHost(
         navHostViewModel.sessionExpired.collect {
             navigator.navigateToAuth()
         }
+    }
+
+    // A restored back stack can still hold add-account routes after process death, but the pending
+    // add session is memory-only and never survives it. Without the session the restored add-mode
+    // screens silently fall back to the LIVE server — credentials typed for the new server would be
+    // POSTed to the wrong host, and a "success" would replace the active session instead of adding.
+    // Strip the flow (and anything stacked above it) before it can render. On a plain Activity
+    // recreation the pending session is still alive, so nothing is stripped.
+    LaunchedEffect(Unit) {
+        if (!navHostViewModel.hasPendingAdd()) {
+            val firstAddRoute = backStack.indexOfFirst { it.isAddAccountFlowRoute }
+            if (firstAddRoute >= 0) {
+                while (backStack.size > firstAddRoute) backStack.removeLastOrNull()
+                if (backStack.isEmpty()) backStack.add(NewChat())
+            }
+        }
+    }
+
+    // Cancel an in-progress add-account flow once none of its routes remain on the back stack —
+    // covers back-out, the session-expiry reset, and any navigation that abandons the flow. On a
+    // successful completion the pending session is already consumed, so the cancel no-ops. Watching
+    // the stack (instead of per-screen dispose hooks) survives the flow spanning several routes.
+    LaunchedEffect(Unit) {
+        snapshotFlow { backStack.any { it.isAddAccountFlowRoute } }
+            .collect { inAddFlow ->
+                if (!inAddFlow) navHostViewModel.cancelPendingAdd()
+            }
+    }
+
+    // The active account changed underneath the UI. Drop the process-global Coil cache — it is
+    // account-blind (bare-URL keys), so the outgoing account's decoded images must not survive into
+    // the next session; the disk half only exists on Android (iOS configures no diskCache). On an
+    // account-to-account flip also reset the back stack: the outgoing account's routes point at
+    // rows the new account can't read (or, on remove, rows that no longer exist).
+    //
+    // The identity this UI last ran hygiene for is SAVED STATE, compared against the live resolved
+    // one — not a transition-flow collector. A cold collector restarted by Activity recreation or
+    // process death initializes its marker to the already-flipped account and silently swallows a
+    // flip that landed in the gap; the saved comparison catches up on whatever was missed while
+    // this composition did not exist.
+    val platformContext = LocalPlatformContext.current
+    val accountState by navHostViewModel.accountState.collectAsStateWithLifecycle()
+    var hygieneAccountId by rememberSaveable { mutableStateOf<String?>(HYGIENE_UNRECORDED) }
+    LaunchedEffect(accountState) {
+        val resolved = accountState as? AccountState.Resolved ?: return@LaunchedEffect
+        val current = resolved.id?.value
+        val previous = hygieneAccountId
+        if (previous != HYGIENE_UNRECORDED && previous != current) {
+            val imageLoader = SingletonImageLoader.get(platformContext)
+            imageLoader.memoryCache?.clear()
+            withContext(Dispatchers.IO) { imageLoader.diskCache?.clear() }
+            // Reset the stack only on an account-to-account flip; on account-to-logged-out the
+            // initiating flow (or the session-expired signal) owns navigation.
+            if (previous != null && current != null) {
+                navigator.navigateToChat()
+            }
+        }
+        hygieneAccountId = current
     }
 
     // The locale wrapper must sit BELOW the back stack: changing language recreates the rendered
@@ -234,6 +308,14 @@ fun PhoneLayout(
                     onOpenProjectsIndex = {
                         scope.launch { drawerState.close() }
                         navigator.navigate(Projects)
+                    },
+                    onSwitchAccount = { accountId ->
+                        scope.launch { drawerState.close() }
+                        navHostViewModel.switchAccount(accountId)
+                    },
+                    onAddAccount = {
+                        scope.launch { drawerState.close() }
+                        navigator.navigate(AddAccountServerUrl)
                     },
                 )
             }
@@ -361,10 +443,11 @@ fun MainNavDisplay(
             settingsEntries(
                 onNavigate = { navigator.navigate(it) },
                 onBack = { navigator.goBack() },
-                onLogout = {
-                    navHostViewModel.logout()
-                    navigator.navigateToAuth()
-                },
+                // Nav is reactive: signing out promotes the most-recent survivor and stays in the app,
+                // while the last-account teardown emits session-expired (handled above) to route to
+                // auth. Forcing navigateToAuth() here would wrongly leave the auth screen up after a
+                // successor was promoted.
+                onLogout = { navHostViewModel.logout() },
                 onNavigateToArchive = { navigator.navigate(ArchivedConversations) },
             )
             memoriesEntry(

--- a/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/NavHostViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/NavHostViewModel.kt
@@ -4,9 +4,17 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import co.touchlab.kermit.Logger
 import com.garfiec.librechat.core.common.BackendVersion
+import com.garfiec.librechat.core.common.extensions.serverHostLabel
+import com.garfiec.librechat.core.common.identity.AccountState
+import com.garfiec.librechat.core.common.identity.AccountTransition
+import com.garfiec.librechat.core.common.identity.ActiveAccountProvider
+import com.garfiec.librechat.core.common.identity.accountTransitions
 import com.garfiec.librechat.core.common.network.ConnectivityObserver
 import com.garfiec.librechat.core.common.result.Result
+import com.garfiec.librechat.core.data.datastore.AccountEntry
+import com.garfiec.librechat.core.data.datastore.AccountRoster
 import com.garfiec.librechat.core.data.datastore.SettingsDataStore
+import com.garfiec.librechat.core.data.repository.AccountSwitcher
 import com.garfiec.librechat.core.data.repository.AuthRepository
 import com.garfiec.librechat.core.data.repository.BannerRepository
 import com.garfiec.librechat.core.data.repository.ConfigRepository
@@ -26,6 +34,7 @@ import com.garfiec.librechat.core.model.permissions.Permission
 import com.garfiec.librechat.core.model.permissions.PermissionType
 import com.garfiec.librechat.core.model.permissions.canCreateSharedLinks
 import com.garfiec.librechat.core.model.permissions.hasAccessOrPermissive
+import com.garfiec.librechat.core.network.client.AccountReadyGate
 import com.garfiec.librechat.core.network.client.ServerUrlProvider
 import com.garfiec.librechat.core.network.client.TokenManager
 import com.garfiec.librechat.feature.conversations.export.ConversationExporter
@@ -62,16 +71,21 @@ class NavHostViewModel(
     private val tagRepository: TagRepository,
     private val projectRepository: ProjectRepository,
     private val tokenManager: TokenManager,
+    private val accountReadyGate: AccountReadyGate,
     private val settingsDataStore: SettingsDataStore,
     private val serverUrlProvider: ServerUrlProvider,
     private val shareRepository: ShareRepository,
     private val conversationExporter: ConversationExporter,
     private val connectivityObserver: ConnectivityObserver,
     private val endpointTokenRepository: EndpointTokenRepository,
+    private val activeAccountProvider: ActiveAccountProvider,
+    private val accountRoster: AccountRoster,
+    private val accountSwitcher: AccountSwitcher,
 ) : ViewModel() {
 
     private val bannerStateHolder = BannerStateHolder(bannerRepository, viewModelScope)
-    private val versionCheckStateHolder = VersionCheckStateHolder(configRepository, settingsDataStore, viewModelScope)
+    private val versionCheckStateHolder =
+        VersionCheckStateHolder(configRepository, settingsDataStore, serverUrlProvider, viewModelScope)
     private val conversationListStateHolder = ConversationListStateHolder(conversationRepository, viewModelScope)
 
     private val favoriteConversations: StateFlow<List<Conversation>> =
@@ -189,6 +203,33 @@ class NavHostViewModel(
     val dismissedBannerIds: StateFlow<Set<String>> = bannerStateHolder.dismissedBannerIds
 
     val sessionExpired: SharedFlow<Unit> = tokenManager.sessionExpiredFlow
+
+    // The live identity for the NavHost's account hygiene (Coil cache clear + back-stack reset on
+    // an account flip). Exposed as STATE rather than a transition flow so the UI can persist the
+    // identity it last ran hygiene for and catch up after Activity recreation or process death — a
+    // cold transition flow restarted in that gap would silently swallow a flip that landed mid-gap.
+    val accountState: StateFlow<AccountState> = activeAccountProvider.state
+
+    // The signed-in accounts for the drawer chip + switcher sheet: active entry first, the rest by
+    // recency (matching "switch to most-recently-active" on remove).
+    val accounts: StateFlow<List<AccountUiModel>> =
+        combine(accountRoster.entriesFlow(), activeAccountProvider.state) { entries, accountState ->
+            val activeId = (accountState as? AccountState.Resolved)?.id?.value
+            entries
+                .sortedWith(
+                    compareByDescending<AccountEntry> { it.accountId == activeId }
+                        .thenByDescending { it.lastActiveAt },
+                )
+                .map { entry ->
+                    AccountUiModel(
+                        accountId = entry.accountId,
+                        displayLabel = entry.displayLabel,
+                        serverHost = entry.serverUrl.serverHostLabel(),
+                        avatarUrl = entry.avatarUrl,
+                        isActive = entry.accountId == activeId,
+                    )
+                }
+        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
 
     // Seeded `null` (= "not resolved yet") and warmed up by the Eagerly-started collector. The
     // previous synchronous `firstBlocking` read blocked the Main thread Koin instantiates the VM
@@ -310,6 +351,11 @@ class NavHostViewModel(
                 // logged-in cold start can't fire requests (auth check, version/config fetch,
                 // session tasks) at an empty base URL while ServerDataStore is still resolving.
                 serverUrlProvider.awaitBaseUrl()
+                // Wait for the roster seed to reconcile the token mirror to the durable active pointer
+                // before deciding the route. The synchronous _isLoggedIn seed above reads the raw
+                // (possibly crash-diverged) mirror; without this gate a divergence would flash the
+                // wrong screen. The gate's seed also drives the server URL, so this is ordered first.
+                accountReadyGate.awaitReady()
                 val loggedIn = authRepository.isLoggedIn()
                 _isLoggedIn.value = loggedIn
                 if (loggedIn) {
@@ -343,7 +389,66 @@ class NavHostViewModel(
                 }
             }
         }
+        // The active account changed underneath this Activity-scoped VM (switch / add-completion /
+        // remove → Switched; remove-last → Ended; plain logout also lands here as Ended, where the
+        // clears below just repeat logout()'s — idempotent). Room-backed state re-filters
+        // reactively, but everything held in-memory here or in the singleton repos is account- or
+        // server-blind and must not survive the flip.
+        viewModelScope.launch {
+            activeAccountProvider.accountTransitions().collect { transition ->
+                _projects.value = emptyList()
+                _expandedProjectIds.value = emptySet()
+                _projectInlineChats.value = emptyMap()
+                _sidebarMode.value = SidebarMode.Conversations
+                _selectedSettingsCategory.value = null
+                conversationListStateHolder.reset()
+                tagRepository.clearCache()
+                endpointTokenRepository.clear()
+                // Reseed the in-memory config from the (already-flipped) server's own srv:-keyed
+                // cache — warm on switch-back — instead of clear(), which would wipe every server's
+                // disk cache.
+                configRepository.reloadForActiveServer()
+                if (transition is AccountTransition.Switched) {
+                    // The switch path never runs the login-side session machinery
+                    // (AuthRepositoryImpl fires these on sign-in; logout/re-auth via onAuthComplete)
+                    // so the incoming account's session state is fetched here.
+                    conversationListStateHolder.refreshConversations()
+                    bannerStateHolder.fetchBanners()
+                    versionCheckStateHolder.checkBackendVersion()
+                    sessionTaskRunner.runAll()
+                } else if (transition is AccountTransition.Ended) {
+                    // The last account signed out (plain logout, or remove-last): mark logged-out so
+                    // first-frame routing is correct. Nav-to-auth itself rides the session-expired
+                    // signal emitted by the teardown.
+                    _isLoggedIn.value = false
+                }
+            }
+        }
     }
+
+    /** Switch the active account (no-op for the already-active one). Post-switch refresh and the
+     *  back-stack reset ride on the [accountTransitions] collectors, not this call. */
+    fun switchAccount(accountId: String) {
+        viewModelScope.launch { accountSwitcher.switch(accountId) }
+    }
+
+    /** Remove an account and all its local data. Removing the active one switches to the
+     *  most-recently-active survivor, or routes to auth when it was the last. */
+    fun removeAccount(accountId: String) {
+        viewModelScope.launch { accountSwitcher.remove(accountId) }
+    }
+
+    /** Abandon any in-progress add-account flow; no-op when none is pending. Driven by the NavHost
+     *  when the add-flow routes leave the back stack (back-out, session expiry, completion). */
+    fun cancelPendingAdd() {
+        viewModelScope.launch { accountSwitcher.cancelAdd() }
+    }
+
+    /** True while an add-account flow is in progress. The NavHost checks this at composition: a
+     *  back stack restored after process death can still hold add-flow routes, but the pending
+     *  session is memory-only — restored add-mode screens without it would silently target the
+     *  LIVE server, so the NavHost strips them. */
+    fun hasPendingAdd(): Boolean = accountSwitcher.pendingAdd != null
 
     /**
      * Attempts the upgrade-path account restore, swallowing transient failures. Returns `true` when the
@@ -586,21 +691,13 @@ class NavHostViewModel(
     }
 
     fun logout() {
-        viewModelScope.launch {
-            authRepository.logout()
-            _isLoggedIn.value = false
-            conversationListStateHolder.reset()
-            tagRepository.clearCache()
-            configRepository.clear()
-            endpointTokenRepository.clear()
-            // Chat Projects live only in-VM (no local cache) and this Activity-scoped VM survives
-            // logout — clear them too so the next account never sees the previous account's folders
-            // or expanded inline chats before its own loadProjects() returns.
-            _projects.value = emptyList()
-            _expandedProjectIds.value = emptySet()
-            _projectInlineChats.value = emptyMap()
-            _sidebarMode.value = SidebarMode.Conversations
-            _selectedSettingsCategory.value = null
-        }
+        // Delegate to the account switcher's remove() (via the repository, which first revokes the
+        // session server-side): it promotes the most-recently-used survivor — the user stays signed in
+        // as that account — or, when this was the last account, tears down to logged-out and emits
+        // session-expired to route to auth. Either way the accountTransitions collector above resets
+        // this VM's in-memory state (conversation list, tags, projects, config, …) for both the
+        // Switched and Ended cases, so nothing is cleared imperatively here. Not forcing the auth
+        // route here is what lets the successor promotion keep the user in the app.
+        viewModelScope.launch { authRepository.logout() }
     }
 }

--- a/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/SidebarScaffold.kt
+++ b/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/SidebarScaffold.kt
@@ -26,6 +26,8 @@ fun SidebarScaffold(
     modifier: Modifier = Modifier,
     onOpenProject: (projectId: String, projectName: String) -> Unit = { _, _ -> },
     onOpenProjectsIndex: () -> Unit = {},
+    onSwitchAccount: (String) -> Unit = {},
+    onAddAccount: () -> Unit = {},
     viewModel: NavHostViewModel = koinViewModel(),
 ) {
     val sidebarMode by viewModel.sidebarMode.collectAsStateWithLifecycle()
@@ -56,6 +58,8 @@ fun SidebarScaffold(
                     onSkillsClick = onSkillsClick,
                     onOpenProject = onOpenProject,
                     onOpenProjectsIndex = onOpenProjectsIndex,
+                    onSwitchAccount = onSwitchAccount,
+                    onAddAccount = onAddAccount,
                 )
             }
             is SidebarMode.Settings -> {

--- a/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/VersionCheckStateHolder.kt
+++ b/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/VersionCheckStateHolder.kt
@@ -2,9 +2,11 @@ package com.garfiec.librechat.shared.navigation
 
 import androidx.compose.runtime.Immutable
 import co.touchlab.kermit.Logger
+import com.garfiec.librechat.core.common.identity.deriveServerId
 import com.garfiec.librechat.core.common.result.Result
 import com.garfiec.librechat.core.data.datastore.SettingsDataStore
 import com.garfiec.librechat.core.data.repository.ConfigRepository
+import com.garfiec.librechat.core.network.client.ServerUrlProvider
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -21,14 +23,23 @@ data class VersionMismatchState(
 class VersionCheckStateHolder(
     private val configRepository: ConfigRepository,
     private val settingsDataStore: SettingsDataStore,
+    private val serverUrlProvider: ServerUrlProvider,
     private val scope: CoroutineScope,
 ) {
 
     private val _versionMismatch = MutableStateFlow<VersionMismatchState?>(null)
     val versionMismatch: StateFlow<VersionMismatchState?> = _versionMismatch.asStateFlow()
 
+    // serverId the current banner describes. This holder is Activity-scoped and survives account
+    // switches, so an unreachable re-check must be able to tell a stale banner carried over from a
+    // PREVIOUS server (clear it) apart from a transient blip on the still-incompatible CURRENT server
+    // (keep it) — clearing the latter would silently hide a real incompatibility until the next
+    // successful check.
+    private var mismatchServerId: String? = null
+
     fun checkBackendVersion() {
         scope.launch {
+            val serverId = runCatching { deriveServerId(serverUrlProvider.getBaseUrl()).value }.getOrNull()
             when (val result = configRepository.checkBackendVersion()) {
                 is Result.Success -> {
                     val checkResult = result.data
@@ -40,10 +51,24 @@ class VersionCheckStateHolder(
                                 supportedVersion = checkResult.supportedVersion,
                                 backendVersion = detectedVersion,
                             )
+                            mismatchServerId = serverId
+                        } else {
+                            clearBanner()
                         }
+                    } else {
+                        // Compatible (or version undetectable): positive information about THIS server,
+                        // so clear any banner — including one left over from a previous server.
+                        clearBanner()
                     }
                 }
                 is Result.Error -> {
+                    // We couldn't reach the server, so we learned nothing about ITS compatibility. Only
+                    // drop a banner that belongs to a DIFFERENT server (stale carry-over after a switch);
+                    // keep one for the current server so a transient blip can't hide a real mismatch. A
+                    // real mismatch also re-surfaces on the next successful check.
+                    if (mismatchServerId != null && mismatchServerId != serverId) {
+                        clearBanner()
+                    }
                     Logger.w(result.exception) { "Failed to check backend version: ${result.message}" }
                 }
                 is Result.Loading -> Unit
@@ -52,16 +77,21 @@ class VersionCheckStateHolder(
     }
 
     fun dismissVersionWarning() {
-        _versionMismatch.value = null
+        clearBanner()
     }
 
     fun dismissVersionWarningPermanently() {
         val backendVersion = _versionMismatch.value?.backendVersion
-        _versionMismatch.value = null
+        clearBanner()
         if (backendVersion != null) {
             scope.launch {
                 settingsDataStore.setDismissedVersionWarning(backendVersion)
             }
         }
+    }
+
+    private fun clearBanner() {
+        _versionMismatch.value = null
+        mismatchServerId = null
     }
 }

--- a/shared/src/iosMain/kotlin/com/garfiec/librechat/shared/IosSharedModule.kt
+++ b/shared/src/iosMain/kotlin/com/garfiec/librechat/shared/IosSharedModule.kt
@@ -2,6 +2,7 @@ package com.garfiec.librechat.shared
 
 import com.garfiec.librechat.core.common.di.KoinQualifiers
 import com.garfiec.librechat.core.common.di.commonModule
+import com.garfiec.librechat.core.common.identity.ActiveAccountProvider
 import com.garfiec.librechat.core.data.di.dataModule
 import com.garfiec.librechat.core.logging.di.loggingModule
 import com.garfiec.librechat.core.network.api.AgentsApi
@@ -32,6 +33,7 @@ import com.garfiec.librechat.core.network.api.UserApi
 import com.garfiec.librechat.core.network.client.LibreChatHttpClient
 import com.garfiec.librechat.core.network.client.ServerUrlProvider
 import com.garfiec.librechat.core.network.client.ServerUrlReadyPlugin
+import com.garfiec.librechat.core.network.client.SwitchGate
 import com.garfiec.librechat.core.network.client.TokenManager
 import com.garfiec.librechat.core.network.sse.SseClient
 import com.garfiec.librechat.core.network.sse.SseHttpTransport
@@ -82,6 +84,18 @@ val iosSharedModule = module {
         }
     }
 
+    // The switch barrier. iOS builds its own client stack (Darwin engine) instead of loading
+    // networkModule, so the gate must be bound here too — the HttpClient below, the SSE transport,
+    // and dataModule's AccountSwitcher/AuthRepository all resolve it.
+    single {
+        SwitchGate(
+            activeAccountProvider = get<ActiveAccountProvider>(),
+            serverUrlProvider = get(),
+            tokenManager = get(),
+            accountReadyGate = getOrNull(),
+        )
+    }
+
     // Main HttpClient (with auth interceptor)
     single {
         LibreChatHttpClient.create(
@@ -90,6 +104,8 @@ val iosSharedModule = module {
             tokenManager = get(),
             serverUrlProvider = get(),
             redactor = get(),
+            accountReadyGate = getOrNull(),
+            switchGate = get(),
         )
     }
 


### PR DESCRIPTION
## Summary

Adds support for holding several LibreChat accounts — across different servers — signed in at once, and switching between them without re-logging-in. Builds on the `accountId` row-tenancy foundation already in `develop`, extending isolation from local storage up through the network layer. Closes #179.

## Changes

**Session engine (core)**
- Account-keyed token store: each account's tokens live under their own keyed slot, so a second sign-in never overwrites the first; switching repoints the active binding without deleting the retained account's tokens.
- `SwitchGate` barrier: every request/stream is bound to a single `(serverUrl, accountId, bearer)` snapshot captured atomically under one lock; an account switch flips URL + token key + identity atomically across all HTTP transports.
- Account roster with cold-start reconciliation; DataStore prefs scoped per-account (`acct:`) and per-server (`srv:`); origin-capture provenance so streamed writes land under the account that started them.

**Add-account & auth flow**
- Sign in an additional account/server without disturbing the active session; the add flow authenticates against the new server under an isolated request identity while the current account keeps streaming.
- Message queue drain-guard so queued follow-ups can't drain against the wrong account after a switch.

**Switcher UI & navigation**
- Account switcher sheet listing signed-in accounts, plus a drawer account chip with a swipe gesture to round-robin between accounts.
- Add another account/server or remove an existing one (with a confirmation dialog) from the switcher.
- Switching accounts stays in the app rather than routing to auth; the back stack resets to a fresh chat on an account-to-account switch, since the previous account's open conversation routes point at rows the new account can't read, and the account-blind image cache is cleared.
- Logout with multiple accounts promotes the most-recently-used survivor and stays in the app; last-account logout routes to auth.

## Account isolation (how cross-account/server leakage is prevented)

Multiple accounts share one set of HTTP client singletons rather than a client per account; isolation is enforced **per-request**, which is what keeps one account's credentials and data off another's server:

- **Atomic identity snapshot.** A barrier phase (`SwitchBarrierPlugin`, before Ktor's request-build) captures `(serverUrl, accountId, bearer)` under a single lock and pins the request to it. This closes the torn-pair race where the URL is read for one account and the bearer for another mid-switch.
- **Host-scoped bearer.** The `Authorization` header is attached only when the request host matches the snapshot's server host — so an account's token is never sent to a different account's server, nor to a presigned third-party CDN URL.
- **Account-keyed bearer.** The token is read from the snapshot account's keyed slot (not the live cache), so a concurrent sign-in staging another account's token can't bleed into a resolved request.
- **Park-during-flip.** A switch closes the gate and repoints URL + token key + identity atomically; new requests park until it completes, in-flight requests keep their original snapshot.
- **Add-account isolation.** The add-account flow runs under a coroutine-scoped pending identity and never touches the live providers, so the active account's traffic continues under its own identity while a new server authenticates.
- **Retries stay pinned.** Both the transport retry and the 401 refresh-retry re-execute the already-built request, reusing the original snapshot; a token refresh is POSTed to the snapshot's absolute server URL, so a racing switch can't redirect a refresh token to another server.
- **Long-lived streams (SSE).** A stream captures its identity once at connect (on iOS the raw NWConnection transport replicates the barrier by hand); across reconnects/resumes an origin-account guard aborts rather than re-binding a stream to a different account, preventing cross-account resume.
- **No shared client auth state.** No cookie jar is installed on any client — refresh cookies are parsed per-response into the keyed token store — so nothing carries auth across accounts at the client level.

## Testing

- Host-JVM unit tests covering the switch barrier, account-keyed token store, and SSE origin-binding (`SwitchGateTest`, `CommonTokenDataStoreAccountKeyingTest`, `SseClientOriginBindingTest`, `AuthInterceptorTest`).
- Android build gates green (`:app:assembleDebug`, `:core:data` / `:feature:chat` detekt).
- Device-tested on a Pixel 10 Pro Fold against dockerized LibreChat: fresh login, add second account on a different server, switch back and forth, per-account conversation isolation, logout survivor promotion.

## Notes

- iOS shares the Compose UI and the same session engine; verified via simulator build/link, device-archive testing deferred.
