### PR TITLE
refactor(settings): dialog-backed selectors for chat settings

### DIFF
--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/InlineArtifactPrefs.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/InlineArtifactPrefs.kt
@@ -15,4 +15,12 @@ data class InlineArtifactPrefs(
     val html: Boolean = false,
     val react: Boolean = false,
     val markdown: Boolean = false,
-)
+) {
+    val enabledCount: Int
+        get() = (if (mermaid) 1 else 0) + (if (svg) 1 else 0) + (if (html) 1 else 0) +
+            (if (react) 1 else 0) + (if (markdown) 1 else 0)
+
+    companion object {
+        const val FIELD_COUNT = 5
+    }
+}

--- a/feature/settings/src/commonMain/composeResources/values/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values/strings.xml
@@ -153,6 +153,9 @@
     <string name="cd_token_balance">Token balance: %1$s credits</string>
 
     <!-- Chat settings -->
+    <string name="chat_group_display">Display</string>
+    <string name="chat_group_behavior">Behavior</string>
+    <string name="chat_group_header_context">Header &amp; context</string>
     <string name="chat_layout">Chat layout</string>
     <string name="chat_layout_thread">Thread</string>
     <string name="chat_layout_two_sided">Two-sided chat</string>
@@ -167,13 +170,17 @@
     <string name="starred_models_off">Off</string>
     <string name="starred_models_grouped">Collapsible group at top</string>
     <string name="starred_models_top">At top, no grouping</string>
+    <string name="chat_header_title">Chat header</string>
+    <string name="chat_header_summary_format">%1$s · %2$s</string>
     <string name="chat_header_content_title">Chat header content</string>
     <string name="chat_header_content_desc">Choose what the chat top bar shows</string>
+    <string name="chat_header_content_label">Content</string>
     <string name="chat_header_content_title_option">Conversation title</string>
     <string name="chat_header_content_model">Selected model</string>
     <string name="chat_header_content_none">Nothing</string>
     <string name="chat_header_alignment_title">Chat header alignment</string>
     <string name="chat_header_alignment_desc">Choose how the chat top bar bubble is positioned</string>
+    <string name="chat_header_alignment_label">Alignment</string>
     <string name="chat_header_alignment_left">Left</string>
     <string name="chat_header_alignment_center">Center</string>
     <string name="chat_header_alignment_fill">Fill width</string>
@@ -210,6 +217,7 @@
     <string name="artifact_mode_fullscreen">Full screen</string>
     <string name="artifact_mode_fullscreen_desc">Opens as a full-screen page with more room.</string>
     <string name="artifact_inline_title">Render inline</string>
+    <string name="artifact_inline_enabled_count">%1$d of %2$d enabled</string>
     <string name="artifacts_section_desc">Render artifacts directly in the chat instead of behind a tap-to-open card. Tap an inline artifact to open the fullscreen view.</string>
     <string name="inline_artifact_mermaid">Mermaid diagrams</string>
     <string name="inline_artifact_mermaid_desc">Render Mermaid flowcharts and diagrams inline</string>

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/ArtifactSettingsSection.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/ArtifactSettingsSection.kt
@@ -1,42 +1,24 @@
 package com.garfiec.librechat.feature.settings.screen
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.selection.selectable
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.RadioButton
-import androidx.compose.material3.Switch
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
-import com.garfiec.librechat.core.data.datastore.ArtifactDisplayMode
 import com.garfiec.librechat.core.data.datastore.ArtifactDisplayPrefs
-import com.garfiec.librechat.core.data.datastore.InlineArtifactPrefs
 import com.garfiec.librechat.feature.settings.resources.*
 import com.garfiec.librechat.feature.settings.resources.Res
 import org.jetbrains.compose.resources.stringResource
 
 @Composable
 internal fun ArtifactSettingsSection(
-    prefs: InlineArtifactPrefs,
     displayPrefs: ArtifactDisplayPrefs,
-    onDisplayModeChange: (ArtifactDisplayMode) -> Unit,
-    onMermaidChange: (Boolean) -> Unit,
-    onSvgChange: (Boolean) -> Unit,
-    onHtmlChange: (Boolean) -> Unit,
-    onReactChange: (Boolean) -> Unit,
-    onMarkdownChange: (Boolean) -> Unit,
+    inlineArtifactSummary: String,
+    onOpenArtifactViewerDialog: () -> Unit,
+    onOpenRenderInlineDialog: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(modifier = modifier) {
@@ -44,137 +26,20 @@ internal fun ArtifactSettingsSection(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp, vertical = 8.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
-            Text(
-                text = stringResource(Res.string.artifact_viewer_title),
-                style = MaterialTheme.typography.bodyLarge,
+            SelectorRow(
+                title = stringResource(Res.string.artifact_viewer_title),
+                value = artifactDisplayModeLabel(displayPrefs.mode),
+                onClick = onOpenArtifactViewerDialog,
             )
-            Spacer(modifier = Modifier.height(4.dp))
-            Text(
-                text = stringResource(Res.string.artifact_viewer_desc),
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-            Spacer(modifier = Modifier.height(8.dp))
-            listOf(
-                ArtifactDisplayMode.BOTTOM_SHEET to (
-                    stringResource(Res.string.artifact_mode_bottom_sheet) to
-                        stringResource(Res.string.artifact_mode_bottom_sheet_desc)
-                ),
-                ArtifactDisplayMode.FULLSCREEN to (
-                    stringResource(Res.string.artifact_mode_fullscreen) to
-                        stringResource(Res.string.artifact_mode_fullscreen_desc)
-                ),
-            ).forEach { (mode, labelAndDesc) ->
-                val (label, description) = labelAndDesc
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .clip(RoundedCornerShape(8.dp))
-                        .selectable(
-                            selected = displayPrefs.mode == mode,
-                            onClick = { onDisplayModeChange(mode) },
-                            role = Role.RadioButton,
-                        )
-                        .padding(vertical = 8.dp, horizontal = 4.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    RadioButton(selected = displayPrefs.mode == mode, onClick = null)
-                    Spacer(modifier = Modifier.width(8.dp))
-                    Column {
-                        Text(text = label, style = MaterialTheme.typography.bodyLarge)
-                        Text(
-                            text = description,
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
-                    }
-                }
-            }
 
-            HorizontalDivider(modifier = Modifier.padding(vertical = 16.dp))
-
-            Text(
-                text = stringResource(Res.string.artifact_inline_title),
-                style = MaterialTheme.typography.bodyLarge,
-            )
-            Spacer(modifier = Modifier.height(4.dp))
-            Text(
-                text = stringResource(Res.string.artifacts_section_desc),
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-            Spacer(modifier = Modifier.height(12.dp))
-
-            ArtifactToggleRow(
-                title = stringResource(Res.string.inline_artifact_mermaid),
-                description = stringResource(Res.string.inline_artifact_mermaid_desc),
-                checked = prefs.mermaid,
-                onChange = onMermaidChange,
-            )
-            Spacer(modifier = Modifier.height(12.dp))
-
-            ArtifactToggleRow(
-                title = stringResource(Res.string.inline_artifact_svg),
-                description = stringResource(Res.string.inline_artifact_svg_desc),
-                checked = prefs.svg,
-                onChange = onSvgChange,
-            )
-            Spacer(modifier = Modifier.height(12.dp))
-
-            ArtifactToggleRow(
-                title = stringResource(Res.string.inline_artifact_markdown),
-                description = stringResource(Res.string.inline_artifact_markdown_desc),
-                checked = prefs.markdown,
-                onChange = onMarkdownChange,
-            )
-            Spacer(modifier = Modifier.height(12.dp))
-
-            ArtifactToggleRow(
-                title = stringResource(Res.string.inline_artifact_html),
-                description = stringResource(Res.string.inline_artifact_html_desc),
-                checked = prefs.html,
-                onChange = onHtmlChange,
-            )
-            Spacer(modifier = Modifier.height(12.dp))
-
-            ArtifactToggleRow(
-                title = stringResource(Res.string.inline_artifact_react),
-                description = stringResource(Res.string.inline_artifact_react_desc),
-                checked = prefs.react,
-                onChange = onReactChange,
+            SelectorRow(
+                title = stringResource(Res.string.artifact_inline_title),
+                value = inlineArtifactSummary,
+                onClick = onOpenRenderInlineDialog,
             )
         }
         HorizontalDivider(modifier = Modifier.padding(top = 8.dp))
-    }
-}
-
-@Composable
-private fun ArtifactToggleRow(
-    title: String,
-    description: String,
-    checked: Boolean,
-    onChange: (Boolean) -> Unit,
-) {
-    Row(
-        modifier = Modifier.fillMaxWidth(),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        Column(modifier = Modifier.weight(1f)) {
-            Text(
-                text = title,
-                style = MaterialTheme.typography.bodyLarge,
-            )
-            Text(
-                text = description,
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-        }
-        Spacer(modifier = Modifier.width(16.dp))
-        Switch(
-            checked = checked,
-            onCheckedChange = onChange,
-        )
     }
 }

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/ChatSettingsDialogs.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/ChatSettingsDialogs.kt
@@ -1,0 +1,368 @@
+package com.garfiec.librechat.feature.settings.screen
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.unit.dp
+import com.garfiec.librechat.core.common.ChatLayoutConstants
+import com.garfiec.librechat.core.data.datastore.ArtifactDisplayMode
+import com.garfiec.librechat.core.data.datastore.ChatFontSize
+import com.garfiec.librechat.core.data.datastore.ChatHeaderAlignment
+import com.garfiec.librechat.core.data.datastore.ChatHeaderContent
+import com.garfiec.librechat.core.data.datastore.ContextBarPlacement
+import com.garfiec.librechat.core.data.datastore.InlineArtifactPrefs
+import com.garfiec.librechat.core.data.datastore.LatexRenderer
+import com.garfiec.librechat.core.data.datastore.StarredModelsDisplay
+import com.garfiec.librechat.feature.settings.resources.*
+import com.garfiec.librechat.feature.settings.resources.Res
+import org.jetbrains.compose.resources.stringResource
+
+internal enum class ChatSettingDialog {
+    CHAT_LAYOUT,
+    FONT_SIZE,
+    LATEX_RENDERER,
+    CONTEXT_BAR,
+    STARRED_MODELS,
+    CHAT_HEADER,
+    ARTIFACT_VIEWER,
+    RENDER_INLINE,
+}
+
+// Option label resolvers, shared by the settings rows (current-value subtitle)
+// and the selection dialogs.
+
+@Composable
+internal fun chatLayoutLabel(value: String): String = when (value) {
+    ChatLayoutConstants.TWO_SIDED -> stringResource(Res.string.chat_layout_two_sided)
+    else -> stringResource(Res.string.chat_layout_thread)
+}
+
+@Composable
+internal fun fontSizeLabel(size: ChatFontSize): String = when (size) {
+    ChatFontSize.SMALL -> stringResource(Res.string.font_size_small)
+    ChatFontSize.MEDIUM -> stringResource(Res.string.font_size_medium)
+    ChatFontSize.LARGE -> stringResource(Res.string.font_size_large)
+}
+
+@Composable
+internal fun latexRendererLabel(renderer: LatexRenderer): String = when (renderer) {
+    LatexRenderer.KATEX -> stringResource(Res.string.latex_katex)
+    LatexRenderer.NATIVE -> stringResource(Res.string.latex_native)
+}
+
+@Composable
+internal fun contextBarPlacementLabel(placement: ContextBarPlacement): String = when (placement) {
+    ContextBarPlacement.HIDDEN -> stringResource(Res.string.context_bar_hidden)
+    ContextBarPlacement.ABOVE_INPUT -> stringResource(Res.string.context_bar_above_input)
+    ContextBarPlacement.OPTIONS_SHEET -> stringResource(Res.string.context_bar_options_sheet)
+    ContextBarPlacement.OVERFLOW_MENU -> stringResource(Res.string.context_bar_overflow_menu)
+}
+
+@Composable
+internal fun starredModelsDisplayLabel(display: StarredModelsDisplay): String = when (display) {
+    StarredModelsDisplay.OFF -> stringResource(Res.string.starred_models_off)
+    StarredModelsDisplay.GROUPED -> stringResource(Res.string.starred_models_grouped)
+    StarredModelsDisplay.TOP -> stringResource(Res.string.starred_models_top)
+}
+
+@Composable
+internal fun chatHeaderContentLabel(content: ChatHeaderContent): String = when (content) {
+    ChatHeaderContent.TITLE -> stringResource(Res.string.chat_header_content_title_option)
+    ChatHeaderContent.MODEL -> stringResource(Res.string.chat_header_content_model)
+    ChatHeaderContent.NONE -> stringResource(Res.string.chat_header_content_none)
+}
+
+@Composable
+internal fun chatHeaderAlignmentLabel(alignment: ChatHeaderAlignment): String = when (alignment) {
+    ChatHeaderAlignment.LEFT -> stringResource(Res.string.chat_header_alignment_left)
+    ChatHeaderAlignment.CENTER -> stringResource(Res.string.chat_header_alignment_center)
+    ChatHeaderAlignment.FILL -> stringResource(Res.string.chat_header_alignment_fill)
+}
+
+@Composable
+internal fun artifactDisplayModeLabel(mode: ArtifactDisplayMode): String = when (mode) {
+    ArtifactDisplayMode.BOTTOM_SHEET -> stringResource(Res.string.artifact_mode_bottom_sheet)
+    ArtifactDisplayMode.FULLSCREEN -> stringResource(Res.string.artifact_mode_fullscreen)
+}
+
+/**
+ * Generic single-select radio dialog with Save/Cancel, matching [ForkSettingsDialog].
+ * [optionDescription] may return null for options without a secondary line.
+ */
+@Composable
+internal fun <T> RadioSelectionDialog(
+    title: String,
+    options: List<T>,
+    selected: T,
+    onSave: (T) -> Unit,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+    description: String? = null,
+    optionDescription: @Composable (T) -> String? = { null },
+    optionLabel: @Composable (T) -> String,
+) {
+    var current by remember { mutableStateOf(selected) }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        modifier = modifier,
+        title = { Text(title) },
+        text = {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .verticalScroll(rememberScrollState()),
+            ) {
+                if (description != null) {
+                    Text(
+                        text = description,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                }
+                RadioGroup(
+                    options = options,
+                    selected = current,
+                    onSelect = { current = it },
+                    optionLabel = optionLabel,
+                    optionDescription = optionDescription,
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = { onSave(current) }) {
+                Text(stringResource(Res.string.action_save))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(Res.string.action_cancel))
+            }
+        },
+    )
+}
+
+/** Combined chat-header dialog: content (title/model/none) + bubble alignment in one place. */
+@Composable
+internal fun ChatHeaderSettingsDialog(
+    content: ChatHeaderContent,
+    alignment: ChatHeaderAlignment,
+    onSave: (ChatHeaderContent, ChatHeaderAlignment) -> Unit,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var currentContent by remember { mutableStateOf(content) }
+    var currentAlignment by remember { mutableStateOf(alignment) }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        modifier = modifier,
+        title = { Text(stringResource(Res.string.chat_header_title)) },
+        text = {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .verticalScroll(rememberScrollState()),
+            ) {
+                GroupLabel(stringResource(Res.string.chat_header_content_label))
+                RadioGroup(
+                    options = ChatHeaderContent.entries,
+                    selected = currentContent,
+                    onSelect = { currentContent = it },
+                    optionLabel = { chatHeaderContentLabel(it) },
+                )
+
+                Spacer(modifier = Modifier.height(12.dp))
+
+                GroupLabel(stringResource(Res.string.chat_header_alignment_label))
+                RadioGroup(
+                    options = ChatHeaderAlignment.entries,
+                    selected = currentAlignment,
+                    onSelect = { currentAlignment = it },
+                    optionLabel = { chatHeaderAlignmentLabel(it) },
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = { onSave(currentContent, currentAlignment) }) {
+                Text(stringResource(Res.string.action_save))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(Res.string.action_cancel))
+            }
+        },
+    )
+}
+
+/** Inline-artifact rendering toggles. Switches apply immediately; Done just closes. */
+@Composable
+internal fun RenderInlineDialog(
+    prefs: InlineArtifactPrefs,
+    onMermaidChange: (Boolean) -> Unit,
+    onSvgChange: (Boolean) -> Unit,
+    onHtmlChange: (Boolean) -> Unit,
+    onReactChange: (Boolean) -> Unit,
+    onMarkdownChange: (Boolean) -> Unit,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        modifier = modifier,
+        title = { Text(stringResource(Res.string.artifact_inline_title)) },
+        text = {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .verticalScroll(rememberScrollState()),
+            ) {
+                Text(
+                    text = stringResource(Res.string.artifacts_section_desc),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(modifier = Modifier.height(12.dp))
+
+                InlineToggleRow(
+                    title = stringResource(Res.string.inline_artifact_mermaid),
+                    description = stringResource(Res.string.inline_artifact_mermaid_desc),
+                    checked = prefs.mermaid,
+                    onChange = onMermaidChange,
+                )
+                InlineToggleRow(
+                    title = stringResource(Res.string.inline_artifact_svg),
+                    description = stringResource(Res.string.inline_artifact_svg_desc),
+                    checked = prefs.svg,
+                    onChange = onSvgChange,
+                )
+                InlineToggleRow(
+                    title = stringResource(Res.string.inline_artifact_markdown),
+                    description = stringResource(Res.string.inline_artifact_markdown_desc),
+                    checked = prefs.markdown,
+                    onChange = onMarkdownChange,
+                )
+                InlineToggleRow(
+                    title = stringResource(Res.string.inline_artifact_html),
+                    description = stringResource(Res.string.inline_artifact_html_desc),
+                    checked = prefs.html,
+                    onChange = onHtmlChange,
+                )
+                InlineToggleRow(
+                    title = stringResource(Res.string.inline_artifact_react),
+                    description = stringResource(Res.string.inline_artifact_react_desc),
+                    checked = prefs.react,
+                    onChange = onReactChange,
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(Res.string.action_done))
+            }
+        },
+    )
+}
+
+@Composable
+private fun <T> RadioGroup(
+    options: List<T>,
+    selected: T,
+    onSelect: (T) -> Unit,
+    optionLabel: @Composable (T) -> String,
+    optionDescription: @Composable (T) -> String? = { null },
+) {
+    options.forEach { option ->
+        RadioOptionRow(
+            label = optionLabel(option),
+            description = optionDescription(option),
+            selected = selected == option,
+            onClick = { onSelect(option) },
+        )
+    }
+}
+
+@Composable
+private fun RadioOptionRow(
+    label: String,
+    description: String?,
+    selected: Boolean,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(8.dp))
+            .selectable(
+                selected = selected,
+                onClick = onClick,
+                role = Role.RadioButton,
+            )
+            .padding(vertical = 8.dp, horizontal = 4.dp),
+        verticalAlignment = if (description == null) Alignment.CenterVertically else Alignment.Top,
+    ) {
+        RadioButton(selected = selected, onClick = null)
+        Spacer(modifier = Modifier.width(8.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(text = label, style = MaterialTheme.typography.bodyLarge)
+            if (description != null) {
+                Text(
+                    text = description,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun InlineToggleRow(
+    title: String,
+    description: String,
+    checked: Boolean,
+    onChange: (Boolean) -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(text = title, style = MaterialTheme.typography.bodyLarge)
+            Text(
+                text = description,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        Spacer(modifier = Modifier.width(16.dp))
+        Switch(checked = checked, onCheckedChange = onChange)
+    }
+}

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/ChatSettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/ChatSettingsScreen.kt
@@ -30,6 +30,9 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -37,6 +40,13 @@ import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.garfiec.librechat.core.common.ChatLayoutConstants
+import com.garfiec.librechat.core.data.datastore.ArtifactDisplayMode
+import com.garfiec.librechat.core.data.datastore.ChatFontSize
+import com.garfiec.librechat.core.data.datastore.ContextBarPlacement
+import com.garfiec.librechat.core.data.datastore.InlineArtifactPrefs
+import com.garfiec.librechat.core.data.datastore.LatexRenderer
+import com.garfiec.librechat.core.data.datastore.StarredModelsDisplay
 import com.garfiec.librechat.feature.settings.resources.*
 import com.garfiec.librechat.feature.settings.resources.Res
 import com.garfiec.librechat.feature.settings.viewmodel.SettingsViewModel
@@ -86,6 +96,12 @@ fun ChatSettingsContent(
     viewModel: SettingsViewModel = koinViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    var openDialog by remember { mutableStateOf<ChatSettingDialog?>(null) }
+    val dismissDialog = { openDialog = null }
+    fun <T> saveAndClose(setter: (T) -> Unit): (T) -> Unit = {
+        setter(it)
+        openDialog = null
+    }
 
     Box(modifier = modifier) {
         LazyColumn(
@@ -110,19 +126,13 @@ fun ChatSettingsContent(
                     starredModelsDisplay = uiState.starredModelsDisplay,
                     chatHeaderContent = uiState.chatHeaderContent,
                     chatHeaderAlignment = uiState.chatHeaderAlignment,
-                    onFontSizeChange = viewModel::setChatFontSize,
                     onAutoScrollChange = viewModel::setAutoScrollEnabled,
                     onShowThinkingChange = viewModel::setShowThinkingBlocks,
-                    onContextBarPlacementChange = viewModel::setContextBarPlacement,
                     onShowImageDescriptionsChange = viewModel::setShowImageDescriptions,
                     onDismissKeyboardOnSendChange = viewModel::setDismissKeyboardOnSend,
-                    onChatLayoutStyleChange = viewModel::setChatLayoutStyle,
                     onShowAvatarsChange = viewModel::setShowAvatars,
                     onShowBubblesChange = viewModel::setShowBubbles,
-                    onLatexRendererChange = viewModel::setLatexRenderer,
-                    onStarredModelsDisplayChange = viewModel::setStarredModelsDisplay,
-                    onChatHeaderContentChange = viewModel::setChatHeaderContent,
-                    onChatHeaderAlignmentChange = viewModel::setChatHeaderAlignment,
+                    onOpenDialog = { openDialog = it },
                 )
             }
 
@@ -131,15 +141,16 @@ fun ChatSettingsContent(
                 SectionHeader(stringResource(Res.string.section_artifacts))
             }
             item(key = "artifacts_settings") {
+                val prefs = uiState.inlineArtifactPrefs
                 ArtifactSettingsSection(
-                    prefs = uiState.inlineArtifactPrefs,
                     displayPrefs = uiState.artifactDisplayPrefs,
-                    onDisplayModeChange = viewModel::setArtifactDisplayMode,
-                    onMermaidChange = viewModel::setInlineArtifactMermaid,
-                    onSvgChange = viewModel::setInlineArtifactSvg,
-                    onHtmlChange = viewModel::setInlineArtifactHtml,
-                    onReactChange = viewModel::setInlineArtifactReact,
-                    onMarkdownChange = viewModel::setInlineArtifactMarkdown,
+                    inlineArtifactSummary = stringResource(
+                        Res.string.artifact_inline_enabled_count,
+                        prefs.enabledCount,
+                        InlineArtifactPrefs.FIELD_COUNT,
+                    ),
+                    onOpenArtifactViewerDialog = { openDialog = ChatSettingDialog.ARTIFACT_VIEWER },
+                    onOpenRenderInlineDialog = { openDialog = ChatSettingDialog.RENDER_INLINE },
                 )
             }
 
@@ -203,6 +214,119 @@ fun ChatSettingsContent(
 
             // Bottom spacing
             item { Spacer(modifier = Modifier.height(32.dp)) }
+        }
+
+        if (openDialog == ChatSettingDialog.CHAT_LAYOUT) {
+            RadioSelectionDialog(
+                title = stringResource(Res.string.chat_layout),
+                options = listOf(ChatLayoutConstants.THREAD, ChatLayoutConstants.TWO_SIDED),
+                selected = uiState.chatLayoutStyle,
+                onSave = saveAndClose(viewModel::setChatLayoutStyle),
+                onDismiss = dismissDialog,
+                optionLabel = { chatLayoutLabel(it) },
+                optionDescription = {
+                    if (it == ChatLayoutConstants.THREAD) {
+                        stringResource(Res.string.chat_layout_thread_desc)
+                    } else {
+                        stringResource(Res.string.chat_layout_two_sided_desc)
+                    }
+                },
+            )
+        }
+
+        if (openDialog == ChatSettingDialog.FONT_SIZE) {
+            RadioSelectionDialog(
+                title = stringResource(Res.string.font_size),
+                options = ChatFontSize.entries,
+                selected = uiState.chatFontSize,
+                onSave = saveAndClose(viewModel::setChatFontSize),
+                onDismiss = dismissDialog,
+                optionLabel = { fontSizeLabel(it) },
+            )
+        }
+
+        if (openDialog == ChatSettingDialog.LATEX_RENDERER) {
+            RadioSelectionDialog(
+                title = stringResource(Res.string.latex_renderer),
+                options = LatexRenderer.entries,
+                selected = uiState.latexRenderer,
+                onSave = saveAndClose(viewModel::setLatexRenderer),
+                onDismiss = dismissDialog,
+                optionLabel = { latexRendererLabel(it) },
+                optionDescription = {
+                    when (it) {
+                        LatexRenderer.KATEX -> stringResource(Res.string.latex_katex_desc)
+                        LatexRenderer.NATIVE -> stringResource(Res.string.latex_native_desc)
+                    }
+                },
+            )
+        }
+
+        if (openDialog == ChatSettingDialog.CONTEXT_BAR) {
+            RadioSelectionDialog(
+                title = stringResource(Res.string.context_bar_title),
+                description = stringResource(Res.string.context_bar_desc),
+                options = ContextBarPlacement.entries,
+                selected = uiState.contextBarPlacement,
+                onSave = saveAndClose(viewModel::setContextBarPlacement),
+                onDismiss = dismissDialog,
+                optionLabel = { contextBarPlacementLabel(it) },
+            )
+        }
+
+        if (openDialog == ChatSettingDialog.STARRED_MODELS) {
+            RadioSelectionDialog(
+                title = stringResource(Res.string.starred_models_title),
+                description = stringResource(Res.string.starred_models_desc),
+                options = StarredModelsDisplay.entries,
+                selected = uiState.starredModelsDisplay,
+                onSave = saveAndClose(viewModel::setStarredModelsDisplay),
+                onDismiss = dismissDialog,
+                optionLabel = { starredModelsDisplayLabel(it) },
+            )
+        }
+
+        if (openDialog == ChatSettingDialog.CHAT_HEADER) {
+            ChatHeaderSettingsDialog(
+                content = uiState.chatHeaderContent,
+                alignment = uiState.chatHeaderAlignment,
+                onSave = { content, alignment ->
+                    viewModel.setChatHeaderContent(content)
+                    viewModel.setChatHeaderAlignment(alignment)
+                    dismissDialog()
+                },
+                onDismiss = dismissDialog,
+            )
+        }
+
+        if (openDialog == ChatSettingDialog.ARTIFACT_VIEWER) {
+            RadioSelectionDialog(
+                title = stringResource(Res.string.artifact_viewer_title),
+                description = stringResource(Res.string.artifact_viewer_desc),
+                options = ArtifactDisplayMode.entries,
+                selected = uiState.artifactDisplayPrefs.mode,
+                onSave = saveAndClose(viewModel::setArtifactDisplayMode),
+                onDismiss = dismissDialog,
+                optionLabel = { artifactDisplayModeLabel(it) },
+                optionDescription = {
+                    when (it) {
+                        ArtifactDisplayMode.BOTTOM_SHEET -> stringResource(Res.string.artifact_mode_bottom_sheet_desc)
+                        ArtifactDisplayMode.FULLSCREEN -> stringResource(Res.string.artifact_mode_fullscreen_desc)
+                    }
+                },
+            )
+        }
+
+        if (openDialog == ChatSettingDialog.RENDER_INLINE) {
+            RenderInlineDialog(
+                prefs = uiState.inlineArtifactPrefs,
+                onMermaidChange = viewModel::setInlineArtifactMermaid,
+                onSvgChange = viewModel::setInlineArtifactSvg,
+                onHtmlChange = viewModel::setInlineArtifactHtml,
+                onReactChange = viewModel::setInlineArtifactReact,
+                onMarkdownChange = viewModel::setInlineArtifactMarkdown,
+                onDismiss = dismissDialog,
+            )
         }
 
         // Fork settings dialog

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/ChatSettingsSection.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/ChatSettingsSection.kt
@@ -1,26 +1,27 @@
 package com.garfiec.librechat.feature.settings.screen
 
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
-import com.garfiec.librechat.core.common.ChatLayoutConstants
 import com.garfiec.librechat.core.data.datastore.ChatFontSize
 import com.garfiec.librechat.core.data.datastore.ChatHeaderAlignment
 import com.garfiec.librechat.core.data.datastore.ChatHeaderContent
@@ -46,19 +47,13 @@ internal fun ChatSettingsSection(
     starredModelsDisplay: StarredModelsDisplay,
     chatHeaderContent: ChatHeaderContent,
     chatHeaderAlignment: ChatHeaderAlignment,
-    onFontSizeChange: (ChatFontSize) -> Unit,
     onAutoScrollChange: (Boolean) -> Unit,
     onShowThinkingChange: (Boolean) -> Unit,
-    onContextBarPlacementChange: (ContextBarPlacement) -> Unit,
     onShowImageDescriptionsChange: (Boolean) -> Unit,
     onDismissKeyboardOnSendChange: (Boolean) -> Unit,
-    onChatLayoutStyleChange: (String) -> Unit,
     onShowAvatarsChange: (Boolean) -> Unit,
     onShowBubblesChange: (Boolean) -> Unit,
-    onLatexRendererChange: (LatexRenderer) -> Unit,
-    onStarredModelsDisplayChange: (StarredModelsDisplay) -> Unit,
-    onChatHeaderContentChange: (ChatHeaderContent) -> Unit,
-    onChatHeaderAlignmentChange: (ChatHeaderAlignment) -> Unit,
+    onOpenDialog: (ChatSettingDialog) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(modifier = modifier) {
@@ -66,399 +61,180 @@ internal fun ChatSettingsSection(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp, vertical = 8.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
-            // Chat layout style selector
-            Text(
-                text = stringResource(Res.string.chat_layout),
-                style = MaterialTheme.typography.bodyLarge,
-            )
-            Spacer(modifier = Modifier.height(4.dp))
-            listOf(
-                ChatLayoutConstants.THREAD to stringResource(Res.string.chat_layout_thread),
-                ChatLayoutConstants.TWO_SIDED to stringResource(Res.string.chat_layout_two_sided),
-            ).forEach { (value, label) ->
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .clip(RoundedCornerShape(8.dp))
-                        .selectable(
-                            selected = chatLayoutStyle == value,
-                            onClick = { onChatLayoutStyleChange(value) },
-                            role = Role.RadioButton,
-                        )
-                        .padding(vertical = 8.dp, horizontal = 4.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    RadioButton(
-                        selected = chatLayoutStyle == value,
-                        onClick = null,
-                    )
-                    Spacer(modifier = Modifier.width(8.dp))
-                    Column {
-                        Text(
-                            text = label,
-                            style = MaterialTheme.typography.bodyLarge,
-                        )
-                        Text(
-                            text = if (value == ChatLayoutConstants.THREAD) {
-                                stringResource(Res.string.chat_layout_thread_desc)
-                            } else {
-                                stringResource(Res.string.chat_layout_two_sided_desc)
-                            },
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
-                    }
-                }
-            }
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                GroupLabel(stringResource(Res.string.chat_group_display))
 
-            Spacer(modifier = Modifier.height(12.dp))
+                SelectorRow(
+                    title = stringResource(Res.string.chat_layout),
+                    value = chatLayoutLabel(chatLayoutStyle),
+                    onClick = { onOpenDialog(ChatSettingDialog.CHAT_LAYOUT) },
+                )
 
-            // Show bubbles toggle
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Column(modifier = Modifier.weight(1f)) {
-                    Text(
-                        text = stringResource(Res.string.show_bubbles),
-                        style = MaterialTheme.typography.bodyLarge,
-                    )
-                    Text(
-                        text = stringResource(Res.string.show_bubbles_desc),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
-                Spacer(modifier = Modifier.width(16.dp))
-                Switch(
+                ToggleRow(
+                    title = stringResource(Res.string.show_bubbles),
+                    description = stringResource(Res.string.show_bubbles_desc),
                     checked = showBubbles,
-                    onCheckedChange = onShowBubblesChange,
+                    onChange = onShowBubblesChange,
                 )
-            }
 
-            Spacer(modifier = Modifier.height(12.dp))
-
-            // Show avatars toggle
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Column(modifier = Modifier.weight(1f)) {
-                    Text(
-                        text = stringResource(Res.string.show_avatars),
-                        style = MaterialTheme.typography.bodyLarge,
-                    )
-                    Text(
-                        text = stringResource(Res.string.show_avatars_desc),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
-                Spacer(modifier = Modifier.width(16.dp))
-                Switch(
+                ToggleRow(
+                    title = stringResource(Res.string.show_avatars),
+                    description = stringResource(Res.string.show_avatars_desc),
                     checked = showAvatars,
-                    onCheckedChange = onShowAvatarsChange,
+                    onChange = onShowAvatarsChange,
+                )
+
+                SelectorRow(
+                    title = stringResource(Res.string.font_size),
+                    value = fontSizeLabel(fontSize),
+                    onClick = { onOpenDialog(ChatSettingDialog.FONT_SIZE) },
+                )
+
+                SelectorRow(
+                    title = stringResource(Res.string.latex_renderer),
+                    value = latexRendererLabel(latexRenderer),
+                    onClick = { onOpenDialog(ChatSettingDialog.LATEX_RENDERER) },
                 )
             }
 
-            Spacer(modifier = Modifier.height(12.dp))
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                GroupLabel(stringResource(Res.string.chat_group_behavior))
 
-            // Font size selector
-            Text(
-                text = stringResource(Res.string.font_size),
-                style = MaterialTheme.typography.bodyLarge,
-            )
-            Spacer(modifier = Modifier.height(4.dp))
-            ChatFontSize.entries.forEach { size ->
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .clip(RoundedCornerShape(8.dp))
-                        .selectable(
-                            selected = fontSize == size,
-                            onClick = { onFontSizeChange(size) },
-                            role = Role.RadioButton,
-                        )
-                        .padding(vertical = 8.dp, horizontal = 4.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    RadioButton(
-                        selected = fontSize == size,
-                        onClick = null,
-                    )
-                    Spacer(modifier = Modifier.width(8.dp))
-                    Text(
-                        text = when (size) {
-                            ChatFontSize.SMALL -> stringResource(Res.string.font_size_small)
-                            ChatFontSize.MEDIUM -> stringResource(Res.string.font_size_medium)
-                            ChatFontSize.LARGE -> stringResource(Res.string.font_size_large)
-                        },
-                        style = MaterialTheme.typography.bodyLarge,
-                    )
-                }
-            }
-
-            Spacer(modifier = Modifier.height(12.dp))
-
-            // LaTeX renderer selector
-            Text(
-                text = stringResource(Res.string.latex_renderer),
-                style = MaterialTheme.typography.bodyLarge,
-            )
-            Spacer(modifier = Modifier.height(4.dp))
-            listOf(
-                LatexRenderer.KATEX to (stringResource(Res.string.latex_katex) to stringResource(Res.string.latex_katex_desc)),
-                LatexRenderer.NATIVE to (stringResource(Res.string.latex_native) to stringResource(Res.string.latex_native_desc)),
-            ).forEach { (renderer, labelAndDesc) ->
-                val (label, description) = labelAndDesc
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .clip(RoundedCornerShape(8.dp))
-                        .selectable(
-                            selected = latexRenderer == renderer,
-                            onClick = { onLatexRendererChange(renderer) },
-                            role = Role.RadioButton,
-                        )
-                        .padding(vertical = 8.dp, horizontal = 4.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    RadioButton(
-                        selected = latexRenderer == renderer,
-                        onClick = null,
-                    )
-                    Spacer(modifier = Modifier.width(8.dp))
-                    Column {
-                        Text(
-                            text = label,
-                            style = MaterialTheme.typography.bodyLarge,
-                        )
-                        Text(
-                            text = description,
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
-                    }
-                }
-            }
-
-            Spacer(modifier = Modifier.height(12.dp))
-
-            // Auto-scroll toggle
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Column(modifier = Modifier.weight(1f)) {
-                    Text(
-                        text = stringResource(Res.string.auto_scroll),
-                        style = MaterialTheme.typography.bodyLarge,
-                    )
-                    Text(
-                        text = stringResource(Res.string.auto_scroll_desc),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
-                Spacer(modifier = Modifier.width(16.dp))
-                Switch(
+                ToggleRow(
+                    title = stringResource(Res.string.auto_scroll),
+                    description = stringResource(Res.string.auto_scroll_desc),
                     checked = autoScrollEnabled,
-                    onCheckedChange = onAutoScrollChange,
+                    onChange = onAutoScrollChange,
                 )
-            }
 
-            Spacer(modifier = Modifier.height(12.dp))
-
-            // Show thinking blocks toggle
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Column(modifier = Modifier.weight(1f)) {
-                    Text(
-                        text = stringResource(Res.string.show_thinking_blocks),
-                        style = MaterialTheme.typography.bodyLarge,
-                    )
-                    Text(
-                        text = stringResource(Res.string.show_thinking_blocks_desc),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
-                Spacer(modifier = Modifier.width(16.dp))
-                Switch(
+                ToggleRow(
+                    title = stringResource(Res.string.show_thinking_blocks),
+                    description = stringResource(Res.string.show_thinking_blocks_desc),
                     checked = showThinkingBlocks,
-                    onCheckedChange = onShowThinkingChange,
+                    onChange = onShowThinkingChange,
                 )
-            }
 
-            Spacer(modifier = Modifier.height(12.dp))
-
-            // Context bar placement selector — where the v0.8.7 context-usage gauge is surfaced.
-            SettingsRadioGroup(
-                title = stringResource(Res.string.context_bar_title),
-                description = stringResource(Res.string.context_bar_desc),
-                options = ContextBarPlacement.entries,
-                selected = contextBarPlacement,
-                onSelect = onContextBarPlacementChange,
-            ) { option ->
-                when (option) {
-                    ContextBarPlacement.HIDDEN -> stringResource(Res.string.context_bar_hidden)
-                    ContextBarPlacement.ABOVE_INPUT -> stringResource(Res.string.context_bar_above_input)
-                    ContextBarPlacement.OPTIONS_SHEET -> stringResource(Res.string.context_bar_options_sheet)
-                    ContextBarPlacement.OVERFLOW_MENU -> stringResource(Res.string.context_bar_overflow_menu)
-                }
-            }
-
-            Spacer(modifier = Modifier.height(12.dp))
-
-            // Show image descriptions toggle
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Column(modifier = Modifier.weight(1f)) {
-                    Text(
-                        text = stringResource(Res.string.show_image_descriptions),
-                        style = MaterialTheme.typography.bodyLarge,
-                    )
-                    Text(
-                        text = stringResource(Res.string.show_image_descriptions_desc),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
-                Spacer(modifier = Modifier.width(16.dp))
-                Switch(
+                ToggleRow(
+                    title = stringResource(Res.string.show_image_descriptions),
+                    description = stringResource(Res.string.show_image_descriptions_desc),
                     checked = showImageDescriptions,
-                    onCheckedChange = onShowImageDescriptionsChange,
+                    onChange = onShowImageDescriptionsChange,
                 )
-            }
 
-            Spacer(modifier = Modifier.height(12.dp))
-
-            // Dismiss keyboard on send toggle
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Column(modifier = Modifier.weight(1f)) {
-                    Text(
-                        text = stringResource(Res.string.dismiss_keyboard_on_send),
-                        style = MaterialTheme.typography.bodyLarge,
-                    )
-                    Text(
-                        text = stringResource(Res.string.dismiss_keyboard_on_send_desc),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
-                Spacer(modifier = Modifier.width(16.dp))
-                Switch(
+                ToggleRow(
+                    title = stringResource(Res.string.dismiss_keyboard_on_send),
+                    description = stringResource(Res.string.dismiss_keyboard_on_send_desc),
                     checked = dismissKeyboardOnSend,
-                    onCheckedChange = onDismissKeyboardOnSendChange,
+                    onChange = onDismissKeyboardOnSendChange,
                 )
             }
 
-            Spacer(modifier = Modifier.height(12.dp))
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                GroupLabel(stringResource(Res.string.chat_group_header_context))
 
-            // Starred models display selector (mobile-only model-picker behavior)
-            SettingsRadioGroup(
-                title = stringResource(Res.string.starred_models_title),
-                description = stringResource(Res.string.starred_models_desc),
-                options = StarredModelsDisplay.entries,
-                selected = starredModelsDisplay,
-                onSelect = onStarredModelsDisplayChange,
-            ) { option ->
-                when (option) {
-                    StarredModelsDisplay.OFF -> stringResource(Res.string.starred_models_off)
-                    StarredModelsDisplay.GROUPED -> stringResource(Res.string.starred_models_grouped)
-                    StarredModelsDisplay.TOP -> stringResource(Res.string.starred_models_top)
-                }
-            }
+                SelectorRow(
+                    title = stringResource(Res.string.chat_header_title),
+                    value = stringResource(
+                        Res.string.chat_header_summary_format,
+                        chatHeaderContentLabel(chatHeaderContent),
+                        chatHeaderAlignmentLabel(chatHeaderAlignment),
+                    ),
+                    onClick = { onOpenDialog(ChatSettingDialog.CHAT_HEADER) },
+                )
 
-            Spacer(modifier = Modifier.height(12.dp))
+                SelectorRow(
+                    title = stringResource(Res.string.context_bar_title),
+                    value = contextBarPlacementLabel(contextBarPlacement),
+                    onClick = { onOpenDialog(ChatSettingDialog.CONTEXT_BAR) },
+                )
 
-            // Chat header content selector (mobile-only floating-top-bar behavior)
-            SettingsRadioGroup(
-                title = stringResource(Res.string.chat_header_content_title),
-                description = stringResource(Res.string.chat_header_content_desc),
-                options = ChatHeaderContent.entries,
-                selected = chatHeaderContent,
-                onSelect = onChatHeaderContentChange,
-            ) { option ->
-                when (option) {
-                    ChatHeaderContent.TITLE -> stringResource(Res.string.chat_header_content_title_option)
-                    ChatHeaderContent.MODEL -> stringResource(Res.string.chat_header_content_model)
-                    ChatHeaderContent.NONE -> stringResource(Res.string.chat_header_content_none)
-                }
-            }
-
-            Spacer(modifier = Modifier.height(12.dp))
-
-            // Chat header bubble alignment selector (mobile-only floating-top-bar behavior)
-            SettingsRadioGroup(
-                title = stringResource(Res.string.chat_header_alignment_title),
-                description = stringResource(Res.string.chat_header_alignment_desc),
-                options = ChatHeaderAlignment.entries,
-                selected = chatHeaderAlignment,
-                onSelect = onChatHeaderAlignmentChange,
-            ) { option ->
-                when (option) {
-                    ChatHeaderAlignment.LEFT -> stringResource(Res.string.chat_header_alignment_left)
-                    ChatHeaderAlignment.CENTER -> stringResource(Res.string.chat_header_alignment_center)
-                    ChatHeaderAlignment.FILL -> stringResource(Res.string.chat_header_alignment_fill)
-                }
+                SelectorRow(
+                    title = stringResource(Res.string.starred_models_title),
+                    value = starredModelsDisplayLabel(starredModelsDisplay),
+                    onClick = { onOpenDialog(ChatSettingDialog.STARRED_MODELS) },
+                )
             }
         }
         HorizontalDivider(modifier = Modifier.padding(top = 8.dp))
     }
 }
 
-private val RadioRowShape = RoundedCornerShape(8.dp)
-
 /**
- * A titled single-select radio group over an enum's [options]. Shared by the chat-settings
- * selectors (starred-models display, chat-header content, chat-header alignment) so the row
- * styling and selection a11y stay in one place. [optionLabel] resolves each option's display
- * string (a `@Composable` so callers can use `stringResource`).
+ * Compact clickable row for a dialog-backed setting: title with the currently
+ * selected value beneath it, chevron on the right.
  */
 @Composable
-private fun <T> SettingsRadioGroup(
+internal fun SelectorRow(
+    title: String,
+    value: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(8.dp))
+            .clickable(onClick = onClick)
+            .padding(vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.bodyLarge,
+            )
+            Text(
+                text = value,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        Icon(
+            imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+            contentDescription = null,
+            modifier = Modifier.size(20.dp),
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+internal fun GroupLabel(text: String) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.labelLarge,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+}
+
+@Composable
+private fun ToggleRow(
     title: String,
     description: String,
-    options: List<T>,
-    selected: T,
-    onSelect: (T) -> Unit,
-    modifier: Modifier = Modifier,
-    optionLabel: @Composable (T) -> String,
+    checked: Boolean,
+    onChange: (Boolean) -> Unit,
 ) {
-    Column(modifier = modifier) {
-        Text(text = title, style = MaterialTheme.typography.bodyLarge)
-        Text(
-            text = description,
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-        Spacer(modifier = Modifier.height(4.dp))
-        options.forEach { option ->
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clip(RadioRowShape)
-                    .selectable(
-                        selected = selected == option,
-                        onClick = { onSelect(option) },
-                        role = Role.RadioButton,
-                    )
-                    .padding(vertical = 8.dp, horizontal = 4.dp),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                RadioButton(selected = selected == option, onClick = null)
-                Spacer(modifier = Modifier.width(8.dp))
-                Text(text = optionLabel(option), style = MaterialTheme.typography.bodyLarge)
-            }
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.bodyLarge,
+            )
+            Text(
+                text = description,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
         }
+        Spacer(modifier = Modifier.width(16.dp))
+        Switch(
+            checked = checked,
+            onCheckedChange = onChange,
+        )
     }
 }


### PR DESCRIPTION
## Summary
Reworks Settings → Chat so single-choice options open a compact dialog (matching the existing Fork Behavior selector pattern) instead of rendering as flat inline radio groups, and reorganizes the resulting list into logical sub-groups.

## Changes
- Converted these settings to dialog-backed selectors — a compact row showing the current value, tap to open an AlertDialog with Save/Cancel: Chat layout, Font size, LaTeX renderer, Context usage placement, Starred models display, Artifact viewer display mode.
- Combined chat header content + alignment into a single dialog with two labeled sub-groups, shown as one row with a combined value summary.
- Render-inline artifact toggles moved into their own dialog (switches apply immediately, no Save step).
- Reorganized the Chat Preferences list into three labeled sub-groups — Display, Behavior, and Header & context — instead of one long flat list.
- Added `InlineArtifactPrefs.enabledCount`/`FIELD_COUNT` to back the "N of 5 enabled" summary text.

## Testing / verification
- `:feature:settings:compileDebugKotlinAndroid`, `:core:data:compileDebugKotlinAndroid`, and `detektMetadataCommonMain` (both modules) all pass.
- Installed and manually verified on a Pixel 9 Pro Fold: Chat Preferences renders as three sub-groups (Display / Behavior / Header & context) with correct current-value subtitles, and dialogs open/save/cancel correctly (spot-checked Font size).
