### PR TITLE
fix(account): keep drawer open when switching accounts from the sheet

### DIFF
--- a/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/DrawerContent.kt
+++ b/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/DrawerContent.kt
@@ -164,9 +164,9 @@ fun DrawerContent(
                     account = active,
                     onClick = { showAccountSheet = true },
                     // Gmail/YouTube-style: swipe the chip up/down to round-robin accounts without
-                    // opening the sheet. Switches in place via the ViewModel rather than the host's
-                    // onSwitchAccount (which also closes the drawer) — keeping the drawer open lets
-                    // the user swipe through several accounts without the jarring dismiss each time.
+                    // opening the sheet. Switches in place via the ViewModel so the user can swipe
+                    // through several accounts against the same open chip. The sheet path keeps the
+                    // drawer open too (the host no longer closes it on switch).
                     // Disabled (null) with a single account.
                     onSwitchAdjacent = if (accounts.size > 1) {
                         { delta -> adjacentAccountId(accounts, delta)?.let(viewModel::switchAccount) }

--- a/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/LibreChatNavHost.kt
+++ b/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/LibreChatNavHost.kt
@@ -310,7 +310,6 @@ fun PhoneLayout(
                         navigator.navigate(Projects)
                     },
                     onSwitchAccount = { accountId ->
-                        scope.launch { drawerState.close() }
                         navHostViewModel.switchAccount(accountId)
                     },
                     onAddAccount = {


### PR DESCRIPTION
## Summary
On phone, switching accounts from the account-switcher sheet dismissed the navigation drawer, unlike the chip swipe-gesture and the tablet sidebar, which switch in place. This aligns the sheet path with those so switching never closes the drawer.

## Changes
- Phone drawer's `onSwitchAccount` no longer calls `drawerState.close()` — it just switches the active account. The sheet already dismisses itself on selection, revealing the still-open drawer with the freshly reset chat behind it.

## Testing
- Deployed to a Pixel 9 Pro Fold against a running LibreChat backend; verified selecting an account from the sheet keeps the drawer open, matching the swipe gesture.
