### PR TITLE
feat(nav): sticky date headers in chat history

### DIFF
--- a/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/components/DateGroupHeader.kt
+++ b/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/components/DateGroupHeader.kt
@@ -1,22 +1,28 @@
 package com.garfiec.librechat.feature.conversations.components
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 
 @Composable
 fun DateGroupHeader(
     label: String,
     modifier: Modifier = Modifier,
+    background: Color = MaterialTheme.colorScheme.background,
 ) {
     Text(
         text = label,
         style = MaterialTheme.typography.labelMedium,
         color = MaterialTheme.colorScheme.onSurfaceVariant,
         modifier = modifier
+            .fillMaxWidth()
+            .background(background)
             .padding(horizontal = 16.dp, vertical = 8.dp)
             .padding(top = 8.dp),
     )

--- a/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/screen/ConversationListScreen.kt
+++ b/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/screen/ConversationListScreen.kt
@@ -1,5 +1,6 @@
 package com.garfiec.librechat.feature.conversations.screen
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -64,7 +65,7 @@ import org.koin.compose.viewmodel.koinViewModel
 // Hoisted: compiled once instead of per export event.
 private val ExportFileNameSanitizer = Regex("[^a-zA-Z0-9._-]")
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
 fun ConversationListScreen(
     onConversationClick: (String) -> Unit,
@@ -274,8 +275,7 @@ fun ConversationListScreen(
                             }
 
                             groupedConversations.forEach { (dateGroup, displayItems) ->
-                                // Date group header
-                                item(key = "header_$dateGroup") {
+                                stickyHeader(key = "header_$dateGroup") {
                                     DateGroupHeader(label = dateGroup)
                                 }
 

--- a/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/screen/ProjectChatsScreen.kt
+++ b/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/screen/ProjectChatsScreen.kt
@@ -1,5 +1,6 @@
 package com.garfiec.librechat.feature.conversations.screen
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -71,7 +72,7 @@ import org.koin.core.parameter.parametersOf
 
 private val ExportFileNameSanitizer = Regex("[^a-zA-Z0-9._-]")
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
 fun ProjectChatsScreen(
     projectId: String,
@@ -192,7 +193,7 @@ fun ProjectChatsScreen(
                 else -> {
                     LazyColumn(state = listState, modifier = Modifier.fillMaxSize()) {
                         uiState.groupedConversations.forEach { (dateGroup, displayItems) ->
-                            item(key = "header_$dateGroup") { DateGroupHeader(label = dateGroup) }
+                            stickyHeader(key = "header_$dateGroup") { DateGroupHeader(label = dateGroup) }
                             items(
                                 items = displayItems,
                                 key = { it.conversationId },

--- a/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/DrawerContent.kt
+++ b/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/DrawerContent.kt
@@ -238,7 +238,7 @@ fun DrawerContent(
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
 fun DrawerContent(
     uiState: DrawerUiState,
@@ -309,6 +309,7 @@ fun DrawerContent(
         modifier = modifier
             .fillMaxHeight()
             .width(300.dp)
+            .background(MaterialTheme.colorScheme.surfaceContainerLow)
             .statusBarsPadding()
             .navigationBarsPadding()
             .padding(top = 16.dp),
@@ -697,17 +698,20 @@ fun DrawerContent(
                 }
 
                 uiState.groupedConversations.forEach { (dateGroup, displayItems) ->
-                    item(key = "header_$dateGroup") {
+                    stickyHeader(key = "header_$dateGroup") {
                         Text(
                             text = dateGroup,
                             style = MaterialTheme.typography.labelSmall,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            modifier = Modifier.padding(
-                                start = 16.dp,
-                                end = 16.dp,
-                                top = 12.dp,
-                                bottom = 4.dp,
-                            ),
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .background(MaterialTheme.colorScheme.surfaceContainerLow)
+                                .padding(
+                                    start = 16.dp,
+                                    end = 16.dp,
+                                    top = 12.dp,
+                                    bottom = 4.dp,
+                                ),
                         )
                     }
 


### PR DESCRIPTION
## Summary

Date-bucket labels in the chat history list (Today, Previous 7 Days,
Previous 30 Days, month-year) now pin to the top of the list while their
section scrolls, instead of scrolling away with the content. The current
section stays visible until the next section's header pushes it up.

## Changes

- **Drawer history** (`DrawerContent.kt`): date-group headers now use
  `stickyHeader` instead of `item`. The pinned header and the drawer's root
  surface are painted `surfaceContainerLow` so scrolling rows don't bleed
  through a pinned header. This also gives the tablet/foldable sidebar (which
  has no `ModalDrawerSheet`) the same surface as the phone drawer.
- **Full-screen lists** (`ConversationListScreen`, `ProjectChatsScreen`):
  same `item` → `stickyHeader` swap for their date headers.
- **`DateGroupHeader`**: fills width and paints an opaque background so it
  reads correctly when pinned. Background is a parameter defaulting to the
  Scaffold container color, so callers on a different surface can override it.

## Testing

- Built for Android and iOS (`:feature:conversations` compiles on both;
  `:app:installDebug` deployed to a Pixel 9 Pro Fold).
- Manually verified on-device: date labels pin and get pushed up correctly
  while scrolling the drawer history, with an opaque header band.

## Notes

- Only the date-bucket headers are sticky. The Projects / Pinned / Favorites
  section headers above them are intentionally left non-sticky.
