### PR TITLE
feat(drawer): settings row beside a color-coded account avatar

### DIFF
--- a/core/ui/src/commonMain/kotlin/com/garfiec/librechat/core/ui/components/AvatarColors.kt
+++ b/core/ui/src/commonMain/kotlin/com/garfiec/librechat/core/ui/components/AvatarColors.kt
@@ -1,0 +1,42 @@
+package com.garfiec.librechat.core.ui.components
+
+import androidx.compose.ui.graphics.Color
+
+/**
+ * Curated background colors for letter-fallback avatars (accounts/users without a photo). Chosen
+ * for strong mutual contrast so different accounts are easy to tell apart at a glance, and all dark
+ * enough that white text stays legible on any of them. Deliberately fixed literals rather than
+ * theme colors so a given account keeps the same color across light/dark themes, devices, and app
+ * restarts.
+ */
+val AvatarPalette: List<Color> = listOf(
+    Color(0xFFD32F2F), // red
+    Color(0xFFC2185B), // pink
+    Color(0xFF7B1FA2), // purple
+    Color(0xFF512DA8), // deep purple
+    Color(0xFF303F9F), // indigo
+    Color(0xFF1976D2), // blue
+    Color(0xFF0288D1), // light blue
+    Color(0xFF00796B), // teal
+    Color(0xFF388E3C), // green
+    Color(0xFF689F38), // olive green
+    Color(0xFFF57C00), // orange
+    Color(0xFFE64A19), // deep orange
+    Color(0xFF5D4037), // brown
+    Color(0xFF455A64), // blue grey
+)
+
+/**
+ * Deterministically maps [seed] to a stable [AvatarPalette] entry — the same seed always yields the
+ * same color. Uses a wrapping 31-based hash computed explicitly (rather than [String.hashCode]) so
+ * the result is identical across JVM and Native. Seed with a stable per-account key (e.g. the
+ * account id), not a mutable display label.
+ */
+fun avatarColorForSeed(seed: String): Color {
+    var hash = 0
+    for (ch in seed) {
+        hash = hash * 31 + ch.code
+    }
+    val index = ((hash % AvatarPalette.size) + AvatarPalette.size) % AvatarPalette.size
+    return AvatarPalette[index]
+}

--- a/core/ui/src/commonMain/kotlin/com/garfiec/librechat/core/ui/components/AvatarImage.kt
+++ b/core/ui/src/commonMain/kotlin/com/garfiec/librechat/core/ui/components/AvatarImage.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.Dp
@@ -79,17 +80,26 @@ fun AvatarImage(
             )
         }
     } else {
+        // Letter fallback (no photo). When the caller supplies a background (e.g. a stable
+        // per-account color from avatarColorForSeed) pick black/white text by its luminance;
+        // otherwise fall back to the theme's primaryContainer pair.
+        val background = fallbackBackgroundColor ?: MaterialTheme.colorScheme.primaryContainer
+        val foreground = if (fallbackBackgroundColor != null) {
+            if (background.luminance() > 0.5f) Color.Black else Color.White
+        } else {
+            MaterialTheme.colorScheme.onPrimaryContainer
+        }
         Box(
             modifier = modifier
                 .size(size)
                 .clip(CircleShape)
-                .background(MaterialTheme.colorScheme.primaryContainer),
+                .background(background),
             contentAlignment = Alignment.Center,
         ) {
             Text(
                 text = fallbackText.take(1).uppercase(),
                 style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.onPrimaryContainer,
+                color = foreground,
             )
         }
     }

--- a/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/AccountSwitcherSheet.kt
+++ b/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/AccountSwitcherSheet.kt
@@ -11,11 +11,11 @@ import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.outlined.Delete
-import androidx.compose.material.icons.outlined.UnfoldMore
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
@@ -32,17 +32,18 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.garfiec.librechat.core.ui.components.AvatarImage
+import com.garfiec.librechat.core.ui.components.avatarColorForSeed
 import com.garfiec.librechat.shared.resources.Res
 import com.garfiec.librechat.shared.resources.accounts
 import com.garfiec.librechat.shared.resources.add_account
 import com.garfiec.librechat.shared.resources.cancel
 import com.garfiec.librechat.shared.resources.cd_active_account
-import com.garfiec.librechat.shared.resources.cd_switch_account
 import com.garfiec.librechat.shared.resources.remove
 import com.garfiec.librechat.shared.resources.remove_account
 import com.garfiec.librechat.shared.resources.remove_account_message
@@ -53,12 +54,12 @@ import org.jetbrains.compose.resources.stringResource
 private val SwipeSwitchThreshold = 40.dp
 
 /**
- * The drawer-header account chip (Gmail-style): the active account's avatar + label + server host.
- * Tapping opens the roster sheet ([AccountSwitcherSheet]). Swiping up/down round-robins to the
- * adjacent account (like Gmail/YouTube profile swipe) via [onSwitchAdjacent] — passed +1 for a
- * swipe up (next) and -1 for a swipe down (previous); null disables the gesture (single account).
- * Rendered only while an account is resolved — the drawer isn't reachable from the auth flow, so
- * [account] is normally non-null.
+ * The drawer-footer account chip (Gmail-style): just the active account's avatar, tapped to open
+ * the roster sheet ([AccountSwitcherSheet]). Swiping up/down round-robins to the adjacent account
+ * (like Gmail/YouTube profile swipe) via [onSwitchAdjacent] — passed +1 for a swipe up (next) and
+ * -1 for a swipe down (previous); null disables the gesture (single account). Rendered only while
+ * an account is resolved — the drawer isn't reachable from the auth flow, so [account] is normally
+ * non-null.
  */
 @Composable
 fun AccountChip(
@@ -92,43 +93,18 @@ fun AccountChip(
     }
     Surface(
         onClick = onClick,
-        modifier = modifier.fillMaxWidth().padding(horizontal = 12.dp).then(swipeModifier),
-        shape = MaterialTheme.shapes.medium,
-        color = MaterialTheme.colorScheme.surfaceContainerHigh,
+        modifier = modifier.then(swipeModifier),
+        shape = CircleShape,
+        color = Color.Transparent,
     ) {
-        Row(
-            modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            AvatarImage(
-                imageUrl = account.avatarUrl,
-                size = 32.dp,
-                fallbackText = account.displayLabel,
-                contentDescription = null,
-            )
-            Spacer(modifier = Modifier.width(10.dp))
-            Column(modifier = Modifier.weight(1f)) {
-                Text(
-                    text = account.displayLabel,
-                    style = MaterialTheme.typography.titleSmall,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                )
-                Text(
-                    text = account.serverHost,
-                    style = MaterialTheme.typography.labelSmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                )
-            }
-            Icon(
-                imageVector = Icons.Outlined.UnfoldMore,
-                contentDescription = stringResource(Res.string.cd_switch_account),
-                modifier = Modifier.size(20.dp),
-                tint = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-        }
+        AvatarImage(
+            imageUrl = account.avatarUrl,
+            size = 32.dp,
+            fallbackText = account.displayLabel,
+            fallbackBackgroundColor = avatarColorForSeed(account.accountId),
+            contentDescription = account.displayLabel,
+            modifier = Modifier.padding(6.dp),
+        )
     }
 }
 
@@ -225,6 +201,7 @@ private fun AccountRow(
             imageUrl = account.avatarUrl,
             size = 36.dp,
             fallbackText = account.displayLabel,
+            fallbackBackgroundColor = avatarColorForSeed(account.accountId),
             contentDescription = null,
         )
         Spacer(modifier = Modifier.width(16.dp))

--- a/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/DrawerContent.kt
+++ b/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/DrawerContent.kt
@@ -160,26 +160,38 @@ fun DrawerContent(
         footerContent = {
             accounts.firstOrNull { it.isActive }?.let { active ->
                 Spacer(modifier = Modifier.height(8.dp))
-                AccountChip(
-                    account = active,
-                    onClick = { showAccountSheet = true },
-                    // Gmail/YouTube-style: swipe the chip up/down to round-robin accounts without
-                    // opening the sheet. Switches in place via the ViewModel so the user can swipe
-                    // through several accounts against the same open chip. The sheet path keeps the
-                    // drawer open too (the host no longer closes it on switch).
-                    // Disabled (null) with a single account.
-                    onSwitchAdjacent = if (accounts.size > 1) {
-                        { delta -> adjacentAccountId(accounts, delta)?.let(viewModel::switchAccount) }
-                    } else {
-                        null
-                    },
-                )
+                // Footer row: Settings (icon + label) on the left takes the width; the account
+                // avatar (icon only, tap to switch) sits on the right.
+                Row(
+                    modifier = Modifier.fillMaxWidth().padding(end = 12.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    DrawerFooterItem(
+                        icon = Icons.Default.Settings,
+                        label = stringResource(Res.string.settings),
+                        onClick = onSettingsClick,
+                        modifier = Modifier.weight(1f),
+                    )
+                    AccountChip(
+                        account = active,
+                        onClick = { showAccountSheet = true },
+                        // Gmail/YouTube-style: swipe the avatar up/down to round-robin accounts
+                        // without opening the sheet. Switches in place via the ViewModel so the user
+                        // can swipe through several accounts against the same avatar. The sheet path
+                        // keeps the drawer open too (the host no longer closes it on switch).
+                        // Disabled (null) with a single account.
+                        onSwitchAdjacent = if (accounts.size > 1) {
+                            { delta -> adjacentAccountId(accounts, delta)?.let(viewModel::switchAccount) }
+                        } else {
+                            null
+                        },
+                    )
+                }
             }
         },
         onSearchQueryChange = viewModel::onSearchQueryChanged,
         onNewChat = onNewChat,
         onConversationClick = onConversationClick,
-        onSettingsClick = onSettingsClick,
         onAgentsClick = onAgentsClick,
         onFilesClick = onFilesClick,
         onSkillsClick = onSkillsClick,
@@ -245,13 +257,12 @@ fun DrawerContent(
     onSearchQueryChange: (String) -> Unit,
     onNewChat: () -> Unit,
     onConversationClick: (String) -> Unit,
-    onSettingsClick: () -> Unit,
     onAgentsClick: () -> Unit,
     onFilesClick: () -> Unit,
     onSkillsClick: () -> Unit,
     modifier: Modifier = Modifier,
-    // Slot below the footer links (Settings, Files, …) — the stateful wrapper puts the account chip
-    // here so switching accounts sits at the bottom of the drawer, near Settings.
+    // Slot below the footer links (Files, Agents, …) — the stateful wrapper puts the Settings row
+    // and the account avatar here, at the bottom of the drawer.
     footerContent: (@Composable () -> Unit)? = null,
     onToggleFavorite: (DrawerConversationDisplayData) -> Unit = {},
     onRefresh: () -> Unit = {},
@@ -766,11 +777,6 @@ fun DrawerContent(
             icon = Icons.Default.Folder,
             label = stringResource(Res.string.files),
             onClick = onFilesClick,
-        )
-        DrawerFooterItem(
-            icon = Icons.Default.Settings,
-            label = stringResource(Res.string.settings),
-            onClick = onSettingsClick,
         )
 
         footerContent?.invoke()


### PR DESCRIPTION
## Summary
Reorganizes the bottom of the navigation drawer so Settings and the active account sit together on one row, and gives photo-less account avatars a stable, distinguishable color instead of a single shared theme color.

## Changes
- **Drawer footer layout** — removes the full-width Settings footer link. Settings (icon + label) now occupies the left of a new footer row, with the active account's avatar on the right.
- **Account chip → avatar only** — the chip no longer shows the display name, server host, or up/down chevron; it renders just the avatar. Tap still opens the account switcher sheet, and swipe up/down to round-robin accounts is retained.
- **Per-account avatar colors** — new `AvatarPalette` (14 curated high-contrast colors) with `avatarColorForSeed()`, a deterministic JVM/Native-stable hash keyed on `accountId`. Letter-fallback avatars (no photo) now use this color instead of `primaryContainer`; `AvatarImage` picks black/white text by background luminance. Applied to both the drawer avatar and the account switcher sheet rows. Avatars with a real photo are unchanged.

## Testing
- Built and installed on a Pixel 9 Pro Fold for manual UX testing.
- Android compilation verified (`:shared`, `:core:ui`).
