### PR TITLE
feat(drawer): move Projects into a carousel sidebar mode

### DIFF
--- a/app/src/main/kotlin/com/garfiec/librechat/navigation/TabletLayout.kt
+++ b/app/src/main/kotlin/com/garfiec/librechat/navigation/TabletLayout.kt
@@ -41,6 +41,7 @@ import com.garfiec.librechat.feature.skills.navigation.SkillsList
 import com.garfiec.librechat.shared.navigation.MainNavDisplay
 import com.garfiec.librechat.shared.navigation.NavHostViewModel
 import com.garfiec.librechat.shared.navigation.Navigator
+import com.garfiec.librechat.shared.navigation.SidebarMode
 import com.garfiec.librechat.shared.navigation.SidebarScaffold
 import com.garfiec.librechat.shared.navigation.toRoute
 import kotlinx.coroutines.launch
@@ -79,6 +80,15 @@ fun TabletLayout(
     // Back press closes sidebar before navigating away
     BackHandler(enabled = isSidebarOpen) {
         navHostViewModel.setTabletSidebarOpen(false)
+    }
+
+    // Reset the sidebar to Conversations whenever it's closed, so reopening lands on recents and
+    // the Projects-mode back handler (in SidebarScaffold) can't stay armed while the sidebar is
+    // hidden off-screen and swallow back presses. Mirrors PhoneLayout's drawerState.isClosed reset.
+    LaunchedEffect(isSidebarOpen) {
+        if (!isSidebarOpen) {
+            navHostViewModel.setSidebarMode(SidebarMode.Conversations)
+        }
     }
 
     // Sync: when ViewModel state changes (e.g. hamburger button, back press), animate the

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/SettingsDataStore.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/SettingsDataStore.kt
@@ -151,11 +151,6 @@ class SettingsDataStore(
         prefs[KEY_TABLET_SIDEBAR_GESTURE_ENABLED] ?: true
     }
 
-    /** Whether the drawer's Projects folder section is expanded. Default expanded. */
-    val projectsSectionExpanded: Flow<Boolean> = dataStore.data.map { prefs ->
-        prefs[KEY_PROJECTS_SECTION_EXPANDED] ?: true
-    }
-
     val autoSendAfterStt: Flow<Boolean> = dataStore.data.map { prefs ->
         prefs[KEY_AUTO_SEND_AFTER_STT] ?: false
     }
@@ -359,12 +354,6 @@ class SettingsDataStore(
         }
     }
 
-    suspend fun setProjectsSectionExpanded(expanded: Boolean) {
-        dataStore.edit { prefs ->
-            prefs[KEY_PROJECTS_SECTION_EXPANDED] = expanded
-        }
-    }
-
     suspend fun setTabletSidebarGestureEnabled(enabled: Boolean) {
         dataStore.edit { prefs ->
             prefs[KEY_TABLET_SIDEBAR_GESTURE_ENABLED] = enabled
@@ -508,7 +497,6 @@ class SettingsDataStore(
         private val KEY_TTS_VOICE_NAME = stringPreferencesKey("tts_voice_name")
         private val KEY_TABLET_SIDEBAR_OPEN = booleanPreferencesKey("tablet_sidebar_open")
         private val KEY_TABLET_SIDEBAR_GESTURE_ENABLED = booleanPreferencesKey("tablet_sidebar_gesture_enabled")
-        private val KEY_PROJECTS_SECTION_EXPANDED = booleanPreferencesKey("projects_section_expanded")
         private val KEY_AUTO_SEND_AFTER_STT = booleanPreferencesKey("auto_send_after_stt")
         private val KEY_STT_ENGINE = stringPreferencesKey("stt_engine")
         private val KEY_STT_LANGUAGE = stringPreferencesKey("stt_language")

--- a/core/ui/src/commonMain/kotlin/com/garfiec/librechat/core/ui/components/PlatformBackHandler.kt
+++ b/core/ui/src/commonMain/kotlin/com/garfiec/librechat/core/ui/components/PlatformBackHandler.kt
@@ -1,0 +1,17 @@
+package com.garfiec.librechat.core.ui.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.backhandler.BackHandler
+
+/**
+ * KMP wrapper over Compose UI's [BackHandler]. When [enabled], intercepts the platform back gesture
+ * and invokes [onBack]. On platforms without a system back (iOS) this never fires, so callers must
+ * also offer an explicit back affordance. Lives in :core:ui because the `androidx.compose.ui.backhandler`
+ * package is only on that module's classpath, not exposed to downstream feature/shared modules.
+ */
+@OptIn(ExperimentalComposeUiApi::class)
+@Composable
+fun PlatformBackHandler(enabled: Boolean, onBack: () -> Unit) {
+    BackHandler(enabled = enabled, onBack = onBack)
+}

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -9,7 +9,6 @@
     <string name="pinned">Pinned</string>
     <string name="projects">Projects</string>
     <string name="projects_all">All projects</string>
-    <string name="project_show_all">Show all</string>
     <string name="project_unassigned">Unassigned</string>
     <string name="project_new">New project</string>
     <string name="no_conversations_found">No conversations found</string>

--- a/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/DrawerContent.kt
+++ b/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/DrawerContent.kt
@@ -1,7 +1,6 @@
 package com.garfiec.librechat.shared.navigation
 
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -32,7 +31,6 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Extension
 import androidx.compose.material.icons.filled.Folder
-import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.PushPin
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Settings
@@ -48,7 +46,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -61,7 +58,6 @@ import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
@@ -81,9 +77,6 @@ import com.garfiec.librechat.core.ui.components.EndpointIcon
 import com.garfiec.librechat.feature.conversations.components.ConversationActionDialogs
 import com.garfiec.librechat.feature.conversations.components.ConversationActionEffects
 import com.garfiec.librechat.feature.conversations.components.ConversationActionsMenu
-import com.garfiec.librechat.feature.conversations.components.ProjectActionsMenu
-import com.garfiec.librechat.feature.conversations.components.ProjectDeleteDialog
-import com.garfiec.librechat.feature.conversations.components.ProjectNameDialog
 import com.garfiec.librechat.feature.conversations.components.ProjectPicker
 import com.garfiec.librechat.feature.conversations.components.TagPicker
 import com.garfiec.librechat.feature.conversations.export.ExportFormat
@@ -99,11 +92,7 @@ import com.garfiec.librechat.shared.resources.files
 import com.garfiec.librechat.shared.resources.new_chat
 import com.garfiec.librechat.shared.resources.no_conversations_found
 import com.garfiec.librechat.shared.resources.pinned
-import com.garfiec.librechat.shared.resources.project_new
-import com.garfiec.librechat.shared.resources.project_show_all
-import com.garfiec.librechat.shared.resources.project_unassigned
 import com.garfiec.librechat.shared.resources.projects
-import com.garfiec.librechat.shared.resources.projects_all
 import com.garfiec.librechat.shared.resources.remove_bookmark
 import com.garfiec.librechat.shared.resources.search_conversations_placeholder
 import com.garfiec.librechat.shared.resources.settings
@@ -130,16 +119,13 @@ fun DrawerContent(
     onFilesClick: () -> Unit,
     onSkillsClick: () -> Unit,
     modifier: Modifier = Modifier,
-    onOpenProject: (projectId: String, projectName: String) -> Unit = { _, _ -> },
-    onOpenProjectsIndex: () -> Unit = {},
+    onOpenProjects: () -> Unit = {},
     onSwitchAccount: (String) -> Unit = {},
     onAddAccount: () -> Unit = {},
     viewModel: NavHostViewModel = koinViewModel(),
 ) {
     val uiState by viewModel.drawerUiState.collectAsStateWithLifecycle()
     val projects by viewModel.projects.collectAsStateWithLifecycle()
-    val projectsSection by viewModel.projectsSection.collectAsStateWithLifecycle()
-    val projectsSectionExpanded by viewModel.projectsSectionExpanded.collectAsStateWithLifecycle()
     val accounts by viewModel.accounts.collectAsStateWithLifecycle()
 
     // Account switcher: the header chip opens the roster sheet; remove asks for confirmation.
@@ -207,15 +193,7 @@ fun DrawerContent(
         onLoadProjects = viewModel::loadProjects,
         onMoveToProject = viewModel::moveConversationToProject,
         onCreateProjectAndAssign = viewModel::createProjectAndAssign,
-        projectsSection = projectsSection,
-        projectsSectionExpanded = projectsSectionExpanded,
-        onToggleProjectsSection = viewModel::toggleProjectsSection,
-        onToggleProjectExpansion = viewModel::toggleProjectExpanded,
-        onCreateProject = viewModel::createProject,
-        onRenameProject = viewModel::renameProject,
-        onDeleteProject = viewModel::deleteProject,
-        onOpenProject = onOpenProject,
-        onOpenProjectsIndex = onOpenProjectsIndex,
+        onOpenProjects = onOpenProjects,
         onShare = viewModel::shareConversation,
         onDuplicate = { id, title -> viewModel.duplicateConversation(id, title) },
         onUpdateTags = { data, tags -> viewModel.updateConversationTags(data.conversationId, data.tags, tags) },
@@ -276,15 +254,9 @@ fun DrawerContent(
     onLoadProjects: () -> Unit = {},
     onMoveToProject: (String, String?) -> Unit = { _, _ -> },
     onCreateProjectAndAssign: (String, String) -> Unit = { _, _ -> },
-    projectsSection: List<DrawerProjectFolder> = emptyList(),
-    projectsSectionExpanded: Boolean = true,
-    onToggleProjectsSection: () -> Unit = {},
-    onToggleProjectExpansion: (String) -> Unit = {},
-    onCreateProject: (String) -> Unit = {},
-    onRenameProject: (String, String) -> Unit = { _, _ -> },
-    onDeleteProject: (String) -> Unit = {},
-    onOpenProject: (projectId: String, projectName: String) -> Unit = { _, _ -> },
-    onOpenProjectsIndex: () -> Unit = {},
+    // Swaps the sidebar to the Projects mode ([ProjectsSidebarContent]) via SidebarScaffold, rather
+    // than navigating to the full-page index — see the Projects entry below.
+    onOpenProjects: () -> Unit = {},
     onShare: (String) -> Unit = {},
     onDuplicate: (String, String) -> Unit = { _, _ -> },
     onUpdateTags: (DrawerConversationDisplayData, List<String>) -> Unit = { _, _ -> },
@@ -301,12 +273,6 @@ fun DrawerContent(
     var tagPickerTarget by remember { mutableStateOf<DrawerConversationDisplayData?>(null) }
     var exportPickerTarget by remember { mutableStateOf<DrawerConversationDisplayData?>(null) }
     var projectPickerTarget by remember { mutableStateOf<DrawerConversationDisplayData?>(null) }
-    // Projects folder-section state (v0.8.7): which folder's overflow menu is open, and the
-    // create/rename/delete dialog targets.
-    var projectMenuOpenId by remember { mutableStateOf<String?>(null) }
-    var showCreateProjectDialog by remember { mutableStateOf(false) }
-    var renameProjectTarget by remember { mutableStateOf<DrawerProjectFolder?>(null) }
-    var deleteProjectTarget by remember { mutableStateOf<DrawerProjectFolder?>(null) }
 
     // Invisible anchor that claims initial focus so the search field below
     // doesn't auto-focus and pop the keyboard when the drawer opens. Tapping
@@ -450,11 +416,6 @@ fun DrawerContent(
         val listState = rememberLazyListState()
         val currentOnLoadMore by rememberUpdatedState(onLoadMore)
 
-        // The Projects section (index 0 when eligible) is present from the list's first frame:
-        // projectsEnabled is seeded from the cached config before the drawer opens (see
-        // ConfigRepositoryImpl.checkBackendVersion), so it isn't inserted above the scroll anchor
-        // after layout — no scroll adjustment is needed to surface it.
-
         // Single item renderer shared by the favorites section and the date groups so the
         // long-press action menu wiring isn't duplicated across both call sites. rowKey is the
         // row's LazyColumn key (unique per rendered row, unlike the conversation id).
@@ -524,129 +485,6 @@ fun DrawerContent(
                 state = listState,
                 modifier = Modifier.fillMaxSize(),
             ) {
-                // Projects folder section (v0.8.7) — expandable folders with inline chats.
-                if (uiState.projectsEnabled && uiState.searchQuery.isEmpty()) {
-                    item(key = "projects_header") {
-                        Row(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(start = 16.dp, end = 8.dp, top = 8.dp, bottom = 4.dp),
-                            verticalAlignment = Alignment.CenterVertically,
-                        ) {
-                            // Tapping the title area collapses/expands the whole section so it's
-                            // easy to get the projects out of the way and reach plain chats below.
-                            val sectionChevronRotation by animateFloatAsState(
-                                if (projectsSectionExpanded) 90f else 0f,
-                                label = "projectsSectionChevron",
-                            )
-                            Row(
-                                modifier = Modifier
-                                    .weight(1f)
-                                    .clickable(onClick = onToggleProjectsSection),
-                                verticalAlignment = Alignment.CenterVertically,
-                            ) {
-                                Icon(
-                                    imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
-                                    contentDescription = null,
-                                    modifier = Modifier.size(16.dp).rotate(sectionChevronRotation),
-                                    tint = MaterialTheme.colorScheme.primary,
-                                )
-                                Spacer(modifier = Modifier.width(4.dp))
-                                Icon(
-                                    imageVector = Icons.Default.Folder,
-                                    contentDescription = null,
-                                    modifier = Modifier.size(14.dp),
-                                    tint = MaterialTheme.colorScheme.primary,
-                                )
-                                Spacer(modifier = Modifier.width(6.dp))
-                                Text(
-                                    text = stringResource(Res.string.projects),
-                                    style = MaterialTheme.typography.labelSmall,
-                                    color = MaterialTheme.colorScheme.primary,
-                                    modifier = Modifier.semantics { heading() },
-                                )
-                            }
-                            TextButton(onClick = onOpenProjectsIndex) {
-                                Text(
-                                    text = stringResource(Res.string.projects_all),
-                                    style = MaterialTheme.typography.labelSmall,
-                                )
-                            }
-                            IconButton(onClick = { showCreateProjectDialog = true }) {
-                                Icon(
-                                    imageVector = Icons.Default.Add,
-                                    contentDescription = stringResource(Res.string.project_new),
-                                )
-                            }
-                        }
-                    }
-
-                    if (projectsSectionExpanded) {
-                    item(key = "project_unassigned") {
-                        val unassignedLabel = stringResource(Res.string.project_unassigned)
-                        DrawerProjectFolderRow(
-                            name = unassignedLabel,
-                            conversationCount = null,
-                            isExpanded = false,
-                            showChevron = false,
-                            onRowClick = { onOpenProject(ChatProject.UNASSIGNED, unassignedLabel) },
-                            menuContent = null,
-                        )
-                    }
-
-                    projectsSection.forEach { folder ->
-                        item(key = "project_${folder.id}") {
-                            DrawerProjectFolderRow(
-                                name = folder.name,
-                                conversationCount = folder.conversationCount,
-                                isExpanded = folder.isExpanded,
-                                showChevron = true,
-                                onRowClick = { onToggleProjectExpansion(folder.id) },
-                                menuContent = {
-                                    IconButton(onClick = { projectMenuOpenId = folder.id }) {
-                                        Icon(Icons.Default.MoreVert, contentDescription = null)
-                                    }
-                                    ProjectActionsMenu(
-                                        expanded = projectMenuOpenId == folder.id,
-                                        onDismiss = { projectMenuOpenId = null },
-                                        onOpen = { onOpenProject(folder.id, folder.name) },
-                                        onRename = { renameProjectTarget = folder },
-                                        onDelete = { deleteProjectTarget = folder },
-                                    )
-                                },
-                            )
-                        }
-                        if (folder.isExpanded) {
-                            items(
-                                items = folder.inlineChats,
-                                key = { "projchat_${folder.id}_${it.conversationId}" },
-                                contentType = { "conversation" },
-                            ) { data ->
-                                renderConversationItem("projchat_${folder.id}_${data.conversationId}", data)
-                            }
-                            item(key = "project_showall_${folder.id}") {
-                                Text(
-                                    text = stringResource(Res.string.project_show_all),
-                                    style = MaterialTheme.typography.labelMedium,
-                                    color = MaterialTheme.colorScheme.primary,
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                        .clickable { onOpenProject(folder.id, folder.name) }
-                                        .padding(start = 48.dp, top = 8.dp, bottom = 8.dp),
-                                )
-                            }
-                        }
-                    }
-                    } // projectsSectionExpanded
-
-                    item(key = "projects_divider") {
-                        HorizontalDivider(
-                            modifier = Modifier.padding(horizontal = 12.dp, vertical = 4.dp),
-                            color = MaterialTheme.colorScheme.outlineVariant,
-                        )
-                    }
-                }
-
                 // Pinned section (v0.8.7) — pinned conversations surfaced above favorites. This is
                 // their canonical home: when shown, they're filtered out of the date-grouped buckets
                 // (see ConversationListStateHolder.withoutPinned) so they don't appear twice. The
@@ -805,6 +643,10 @@ fun DrawerContent(
             color = MaterialTheme.colorScheme.outlineVariant,
         )
 
+        if (uiState.projectsEnabled) {
+            DrawerProjectsEntry(onClick = onOpenProjects)
+        }
+
         if (uiState.agentsEnabled) {
             DrawerFooterItem(
                 icon = Icons.Default.SmartToy,
@@ -877,95 +719,37 @@ fun DrawerContent(
             onDismiss = { projectPickerTarget = null },
         )
     }
-
-    if (showCreateProjectDialog) {
-        ProjectNameDialog(
-            title = stringResource(Res.string.project_new),
-            initialName = "",
-            onConfirm = {
-                onCreateProject(it)
-                showCreateProjectDialog = false
-            },
-            onDismiss = { showCreateProjectDialog = false },
-        )
-    }
-
-    renameProjectTarget?.let { target ->
-        ProjectNameDialog(
-            title = target.name,
-            initialName = target.name,
-            onConfirm = {
-                onRenameProject(target.id, it)
-                renameProjectTarget = null
-            },
-            onDismiss = { renameProjectTarget = null },
-        )
-    }
-
-    deleteProjectTarget?.let { target ->
-        ProjectDeleteDialog(
-            projectName = target.name,
-            onConfirm = {
-                onDeleteProject(target.id)
-                deleteProjectTarget = null
-            },
-            onDismiss = { deleteProjectTarget = null },
-        )
-    }
 }
 
+/** Drawer entry that swaps the sidebar to the Projects mode ([ProjectsSidebarContent]). */
 @Composable
-private fun DrawerProjectFolderRow(
-    name: String,
-    conversationCount: Int?,
-    isExpanded: Boolean,
-    showChevron: Boolean,
-    onRowClick: () -> Unit,
-    menuContent: (@Composable () -> Unit)?,
-) {
+private fun DrawerProjectsEntry(onClick: () -> Unit) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .clickable(onClick = onRowClick)
-            .padding(start = 16.dp, end = 8.dp, top = 10.dp, bottom = 10.dp),
+            .clickable(onClick = onClick)
+            .padding(horizontal = 16.dp, vertical = 10.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        if (showChevron) {
-            val rotation by animateFloatAsState(if (isExpanded) 90f else 0f, label = "projectChevron")
-            Icon(
-                imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
-                contentDescription = null,
-                modifier = Modifier.rotate(rotation),
-                tint = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-        } else {
-            Spacer(modifier = Modifier.width(24.dp))
-        }
-        Spacer(modifier = Modifier.width(4.dp))
         Icon(
             imageVector = Icons.Default.Folder,
             contentDescription = null,
+            modifier = Modifier.size(20.dp),
             tint = MaterialTheme.colorScheme.onSurfaceVariant,
         )
         Spacer(modifier = Modifier.width(12.dp))
         Text(
-            text = name,
+            text = stringResource(Res.string.projects),
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurface,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
             modifier = Modifier.weight(1f),
         )
-        if (conversationCount != null) {
-            Text(
-                text = conversationCount.toString(),
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-        }
-        if (menuContent != null) {
-            Box { menuContent() }
-        }
+        Icon(
+            imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+            contentDescription = null,
+            modifier = Modifier.size(20.dp),
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
     }
 }
 

--- a/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/DrawerUiModels.kt
+++ b/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/DrawerUiModels.kt
@@ -23,20 +23,6 @@ data class DrawerConversationDisplayData(
 )
 
 /**
- * A Chat Project folder row in the drawer's Projects section (v0.8.7). When
- * [isExpanded], [inlineChats] holds the first page (capped) of the project's own
- * conversations shown inline; a "Show all" affordance routes to the full list.
- */
-@Immutable
-data class DrawerProjectFolder(
-    val id: String,
-    val name: String,
-    val conversationCount: Int,
-    val isExpanded: Boolean,
-    val inlineChats: List<DrawerConversationDisplayData>,
-)
-
-/**
  * One signed-in account as the drawer header chip + switcher sheet render it (multi-account,
  * issue #179). Mapped from the persisted roster; ordered active-first, then by recency.
  */

--- a/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/NavHostViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/NavHostViewModel.kt
@@ -55,11 +55,7 @@ import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
-import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-
-/** How many of a project's chats are shown inline under an expanded drawer folder. */
-private const val INLINE_PROJECT_CHATS_CAP = 8
 
 class NavHostViewModel(
     private val authRepository: AuthRepository,
@@ -116,39 +112,10 @@ class NavHostViewModel(
             DrawerActionMenuState(tags, canShare, supportsV087, supportsV087)
         }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), DrawerActionMenuState())
 
-    // Chat Projects (v0.8.7). Loaded lazily when the move-to-project picker / folder
-    // section opens; the server is the source of truth (no local cache).
+    // Chat Projects (v0.8.7). Loaded lazily when the move-to-project picker / Projects sidebar mode
+    // ([ProjectsSidebarContent]) opens; the server is the source of truth (no local cache).
     private val _projects = MutableStateFlow<List<ChatProject>>(emptyList())
     val projects: StateFlow<List<ChatProject>> = _projects.asStateFlow()
-
-    // Drawer folder-section expand state + per-project inline chats (first page, capped).
-    private val _expandedProjectIds = MutableStateFlow<Set<String>>(emptySet())
-    private val _projectInlineChats = MutableStateFlow<Map<String, List<Conversation>>>(emptyMap())
-
-    /** Drawer Projects section: folders with their (lazily-loaded) inline chats. */
-    val projectsSection: StateFlow<List<DrawerProjectFolder>> =
-        combine(
-            _projects,
-            _expandedProjectIds,
-            _projectInlineChats,
-            configRepository.endpointConfigs,
-            conversationListStateHolder.activeConversationId,
-        ) { projects, expanded, inlineChats, endpointConfigs, activeId ->
-            projects.map { project ->
-                val isExpanded = project.id in expanded
-                DrawerProjectFolder(
-                    id = project.id,
-                    name = project.name,
-                    conversationCount = project.conversationCount,
-                    isExpanded = isExpanded,
-                    inlineChats = if (isExpanded) {
-                        inlineChats[project.id].orEmpty().map { it.toDrawerDisplayData(activeId, endpointConfigs) }
-                    } else {
-                        emptyList()
-                    },
-                )
-            }
-        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
 
     // One-shot events for the drawer action menu (share-link copied, export-ready,
     // navigate-to-duplicate, errors). Reuses the conversation-list event type. extraBufferCapacity
@@ -172,17 +139,12 @@ class NavHostViewModel(
         onMutated = {},
     )
 
-    // Shared project CRUD (same delegate ProjectsViewModel uses). onDeleted also drops this drawer's
-    // per-folder view state (expanded set + inline chats) before reloading.
+    // Shared project CRUD (same delegate ProjectsViewModel uses).
     private val projectActions = ProjectActionsDelegate(
         scope = viewModelScope,
         projectRepository = projectRepository,
         onChanged = { loadProjects() },
-        onDeleted = { projectId ->
-            _expandedProjectIds.update { it - projectId }
-            _projectInlineChats.update { it - projectId }
-            loadProjects()
-        },
+        onDeleted = { loadProjects() },
         emitError = { _events.emit(ConversationListEvent.ShowError(it)) },
     )
 
@@ -245,12 +207,6 @@ class NavHostViewModel(
         )
 
     val tabletSidebarGestureEnabled: StateFlow<Boolean> = settingsDataStore.tabletSidebarGestureEnabled
-        .stateIn(viewModelScope, SharingStarted.Eagerly, true)
-
-    // Drawer Projects section collapse state, persisted across sessions. Eagerly warmed so the
-    // section is resolved to its saved state by the time the drawer composes (no expand->collapse
-    // flash on cold start), matching tabletSidebarGestureEnabled.
-    val projectsSectionExpanded: StateFlow<Boolean> = settingsDataStore.projectsSectionExpanded
         .stateIn(viewModelScope, SharingStarted.Eagerly, true)
 
     private val _sidebarMode = MutableStateFlow<SidebarMode>(SidebarMode.Conversations)
@@ -397,8 +353,6 @@ class NavHostViewModel(
         viewModelScope.launch {
             activeAccountProvider.accountTransitions().collect { transition ->
                 _projects.value = emptyList()
-                _expandedProjectIds.value = emptySet()
-                _projectInlineChats.value = emptyMap()
                 _sidebarMode.value = SidebarMode.Conversations
                 _selectedSettingsCategory.value = null
                 conversationListStateHolder.reset()
@@ -583,51 +537,11 @@ class NavHostViewModel(
     }
 
     /**
-     * Refresh the drawer Projects section after a conversation's project assignment changes:
-     * reload the folders (their conversationCount is now stale) and re-fetch the inline chats of
-     * any expanded folder (a chat may have moved into/out of one).
+     * Refresh the Projects mode after a conversation's project assignment changes: reload the
+     * folders, whose conversationCount is now stale.
      */
     private fun onProjectAssignmentChanged() {
         loadProjects()
-        _expandedProjectIds.value.forEach { projectId ->
-            viewModelScope.launch {
-                when (
-                    val result = conversationRepository.getConversationsForProject(
-                        projectId,
-                        limit = INLINE_PROJECT_CHATS_CAP,
-                    )
-                ) {
-                    is Result.Success -> _projectInlineChats.update { it + (projectId to result.data.conversations) }
-                    is Result.Error -> Logger.w(result.exception) { "Failed to refresh project chats" }
-                    is Result.Loading -> Unit
-                }
-            }
-        }
-    }
-
-    /** Expands/collapses a project folder, lazily loading its first inline page on expand. */
-    fun toggleProjectExpanded(projectId: String) {
-        val expanded = _expandedProjectIds.value
-        if (projectId in expanded) {
-            _expandedProjectIds.value = expanded - projectId
-            return
-        }
-        _expandedProjectIds.value = expanded + projectId
-        if (_projectInlineChats.value.containsKey(projectId)) return
-        viewModelScope.launch {
-            when (val result = conversationRepository.getConversationsForProject(projectId, limit = INLINE_PROJECT_CHATS_CAP)) {
-                is Result.Success -> _projectInlineChats.update { it + (projectId to result.data.conversations) }
-                is Result.Error -> Logger.w(result.exception) { "Failed to load project chats" }
-                is Result.Loading -> Unit
-            }
-        }
-    }
-
-    /** Collapses/expands the entire drawer Projects section, persisting the new state. */
-    fun toggleProjectsSection() {
-        viewModelScope.launch {
-            settingsDataStore.setProjectsSectionExpanded(!projectsSectionExpanded.value)
-        }
     }
 
     fun createProject(name: String) = projectActions.create(name)

--- a/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/ProjectsSidebarContent.kt
+++ b/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/ProjectsSidebarContent.kt
@@ -1,0 +1,248 @@
+package com.garfiec.librechat.shared.navigation
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Folder
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.garfiec.librechat.core.model.ChatProject
+import com.garfiec.librechat.feature.conversations.components.ProjectActionsMenu
+import com.garfiec.librechat.feature.conversations.components.ProjectDeleteDialog
+import com.garfiec.librechat.feature.conversations.components.ProjectNameDialog
+import com.garfiec.librechat.shared.resources.Res
+import com.garfiec.librechat.shared.resources.cd_back_to_conversations
+import com.garfiec.librechat.shared.resources.project_new
+import com.garfiec.librechat.shared.resources.project_unassigned
+import com.garfiec.librechat.shared.resources.projects
+import com.garfiec.librechat.shared.resources.projects_all
+import org.jetbrains.compose.resources.stringResource
+import org.koin.compose.viewmodel.koinViewModel
+
+/**
+ * The Projects "mode" of the sidebar — the carousel peer of the recents [DrawerContent]. Reached by
+ * tapping the drawer's Projects entry, which swaps the recents list for this via [SidebarScaffold]'s
+ * animated transition (and animates back on system back / the back arrow here). Folders open their
+ * chats in the main content ([onOpenProject]); the full-page index ([onOpenProjectsIndex]) holds the
+ * advanced controls. Shares the [NavHostViewModel] instance with the rest of the sidebar.
+ */
+@Composable
+fun ProjectsSidebarContent(
+    onBackToConversations: () -> Unit,
+    onOpenProject: (projectId: String, projectName: String) -> Unit,
+    onOpenProjectsIndex: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: NavHostViewModel = koinViewModel(),
+) {
+    val folders by viewModel.projects.collectAsStateWithLifecycle()
+
+    // Server is the source of truth for projects (no local cache), but the list lives in the shared
+    // NavHostViewModel — load only when empty so re-entering this mode via the carousel reuses it
+    // instead of refetching. CRUD and move-to-project actions refresh it themselves.
+    LaunchedEffect(Unit) {
+        if (viewModel.projects.value.isEmpty()) viewModel.loadProjects()
+    }
+
+    // Which folder's overflow menu is open, and the create/rename/delete dialog targets. Hoisted
+    // here (single instance) so they outlive the per-row menu that requested them.
+    var menuOpenId by remember { mutableStateOf<String?>(null) }
+    var showCreateDialog by remember { mutableStateOf(false) }
+    var renameTarget by remember { mutableStateOf<ChatProject?>(null) }
+    var deleteTarget by remember { mutableStateOf<ChatProject?>(null) }
+
+    Column(
+        modifier = modifier
+            .fillMaxHeight()
+            .width(300.dp)
+            .background(MaterialTheme.colorScheme.surfaceContainerLow)
+            .statusBarsPadding()
+            .navigationBarsPadding()
+            .padding(top = 16.dp),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(start = 4.dp, end = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            IconButton(onClick = onBackToConversations) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                    contentDescription = stringResource(Res.string.cd_back_to_conversations),
+                )
+            }
+            Text(
+                text = stringResource(Res.string.projects),
+                style = MaterialTheme.typography.titleMedium,
+                modifier = Modifier
+                    .weight(1f)
+                    .semantics { heading() },
+            )
+            // Escape hatch to the full-page index for advanced controls (pagination, etc.).
+            TextButton(onClick = onOpenProjectsIndex) {
+                Text(
+                    text = stringResource(Res.string.projects_all),
+                    style = MaterialTheme.typography.labelMedium,
+                )
+            }
+            IconButton(onClick = { showCreateDialog = true }) {
+                Icon(
+                    imageVector = Icons.Default.Add,
+                    contentDescription = stringResource(Res.string.project_new),
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.padding(top = 4.dp))
+
+        LazyColumn(modifier = Modifier.fillMaxSize()) {
+            item(key = "project_unassigned") {
+                val unassignedLabel = stringResource(Res.string.project_unassigned)
+                ProjectFolderRow(
+                    name = unassignedLabel,
+                    conversationCount = null,
+                    onClick = { onOpenProject(ChatProject.UNASSIGNED, unassignedLabel) },
+                    menuContent = null,
+                )
+            }
+
+            item(key = "projects_divider") {
+                HorizontalDivider(
+                    modifier = Modifier.padding(horizontal = 12.dp, vertical = 4.dp),
+                    color = MaterialTheme.colorScheme.outlineVariant,
+                )
+            }
+
+            items(items = folders, key = { it.id }) { folder ->
+                ProjectFolderRow(
+                    name = folder.name,
+                    conversationCount = folder.conversationCount,
+                    onClick = { onOpenProject(folder.id, folder.name) },
+                    menuContent = {
+                        IconButton(onClick = { menuOpenId = folder.id }) {
+                            Icon(Icons.Default.MoreVert, contentDescription = null)
+                        }
+                        ProjectActionsMenu(
+                            expanded = menuOpenId == folder.id,
+                            onDismiss = { menuOpenId = null },
+                            onOpen = { onOpenProject(folder.id, folder.name) },
+                            onRename = { renameTarget = folder },
+                            onDelete = { deleteTarget = folder },
+                        )
+                    },
+                )
+            }
+        }
+    }
+
+    if (showCreateDialog) {
+        ProjectNameDialog(
+            title = stringResource(Res.string.project_new),
+            initialName = "",
+            onConfirm = {
+                viewModel.createProject(it)
+                showCreateDialog = false
+            },
+            onDismiss = { showCreateDialog = false },
+        )
+    }
+
+    renameTarget?.let { target ->
+        ProjectNameDialog(
+            title = target.name,
+            initialName = target.name,
+            onConfirm = {
+                viewModel.renameProject(target.id, it)
+                renameTarget = null
+            },
+            onDismiss = { renameTarget = null },
+        )
+    }
+
+    deleteTarget?.let { target ->
+        ProjectDeleteDialog(
+            projectName = target.name,
+            onConfirm = {
+                viewModel.deleteProject(target.id)
+                deleteTarget = null
+            },
+            onDismiss = { deleteTarget = null },
+        )
+    }
+}
+
+@Composable
+private fun ProjectFolderRow(
+    name: String,
+    conversationCount: Int?,
+    onClick: () -> Unit,
+    menuContent: (@Composable () -> Unit)?,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(start = 16.dp, end = 8.dp, top = 12.dp, bottom = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            imageVector = Icons.Default.Folder,
+            contentDescription = null,
+            modifier = Modifier.size(20.dp),
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Spacer(modifier = Modifier.width(12.dp))
+        Text(
+            text = name,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.weight(1f),
+        )
+        if (conversationCount != null) {
+            Text(
+                text = conversationCount.toString(),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        if (menuContent != null) {
+            Box { menuContent() }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/SidebarMode.kt
+++ b/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/SidebarMode.kt
@@ -2,6 +2,7 @@ package com.garfiec.librechat.shared.navigation
 
 sealed interface SidebarMode {
     data object Conversations : SidebarMode
+    data object Projects : SidebarMode
     data object Settings : SidebarMode
 }
 

--- a/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/SidebarScaffold.kt
+++ b/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/SidebarScaffold.kt
@@ -8,11 +8,15 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.garfiec.librechat.core.ui.components.PlatformBackHandler
 import org.koin.compose.viewmodel.koinViewModel
 
 /**
- * Sidebar scaffold that switches between Conversations and Settings modes.
- * Uses [AnimatedContent] for a smooth horizontal slide transition.
+ * Sidebar scaffold that switches between the Conversations, Projects, and Settings modes with an
+ * [AnimatedContent] horizontal slide — a carousel where the sub-modes (Projects/Settings) enter
+ * from the right and return to Conversations by sliding back. On Android the system back button
+ * pops Projects → Conversations (see [BackHandler]); on platforms without a system back (iOS) the
+ * in-mode back arrow does the same.
  */
 @Composable
 fun SidebarScaffold(
@@ -33,16 +37,25 @@ fun SidebarScaffold(
     val sidebarMode by viewModel.sidebarMode.collectAsStateWithLifecycle()
     val selectedCategory by viewModel.selectedSettingsCategory.collectAsStateWithLifecycle()
 
+    // System back pops any sub-mode (Projects/Settings) back to Conversations, as if it were on the
+    // back stack. A no-op on platforms without a system back (iOS), where the in-mode back arrow is
+    // used instead.
+    PlatformBackHandler(enabled = sidebarMode !is SidebarMode.Conversations) {
+        viewModel.setSidebarMode(SidebarMode.Conversations)
+    }
+
     AnimatedContent(
         targetState = sidebarMode,
         modifier = modifier,
         transitionSpec = {
-            if (targetState is SidebarMode.Settings) {
-                slideInHorizontally { fullWidth -> fullWidth } togetherWith
-                    slideOutHorizontally { fullWidth -> -fullWidth }
-            } else {
+            // Returning to Conversations slides back (enter from left, exit right); entering a
+            // sub-mode (Projects/Settings) slides forward (enter from right, exit left).
+            if (targetState is SidebarMode.Conversations) {
                 slideInHorizontally { fullWidth -> -fullWidth } togetherWith
                     slideOutHorizontally { fullWidth -> fullWidth }
+            } else {
+                slideInHorizontally { fullWidth -> fullWidth } togetherWith
+                    slideOutHorizontally { fullWidth -> -fullWidth }
             }
         },
         label = "SidebarModeTransition",
@@ -56,10 +69,18 @@ fun SidebarScaffold(
                     onAgentsClick = onAgentsClick,
                     onFilesClick = onFilesClick,
                     onSkillsClick = onSkillsClick,
-                    onOpenProject = onOpenProject,
-                    onOpenProjectsIndex = onOpenProjectsIndex,
+                    onOpenProjects = { viewModel.setSidebarMode(SidebarMode.Projects) },
                     onSwitchAccount = onSwitchAccount,
                     onAddAccount = onAddAccount,
+                )
+            }
+            is SidebarMode.Projects -> {
+                ProjectsSidebarContent(
+                    onBackToConversations = {
+                        viewModel.setSidebarMode(SidebarMode.Conversations)
+                    },
+                    onOpenProject = onOpenProject,
+                    onOpenProjectsIndex = onOpenProjectsIndex,
                 )
             }
             is SidebarMode.Settings -> {


### PR DESCRIPTION
## Summary
Reworks how Chat Projects are surfaced in the navigation drawer. The inline, expandable projects folder-tree that lived inside the conversation list is replaced by a single **Projects** entry in the drawer footer that swaps the sidebar to a dedicated Projects mode via a horizontal carousel slide.

## Changes
- **Projects sidebar mode** (`ProjectsSidebarContent`): a full-height sidebar pane listing the "Unassigned" filter plus each project folder with its conversation count. Tapping a folder opens its chats in the main content; an **All projects** action opens the full-page index for advanced controls (pagination, etc.). Create / rename / delete are available inline (`+` and per-row overflow menu).
- **Carousel navigation** (`SidebarScaffold`): Conversations ⇆ Projects animate as a horizontal slide. System back and an in-mode back arrow return to Conversations; the back handler is armed for any non-Conversations sub-mode.
- **`PlatformBackHandler`** (new, `:core:ui`): thin KMP wrapper over Compose UI's `BackHandler`. No-op on iOS, where the in-mode back arrow is the affordance.
- **Drawer footer entry** (`DrawerContent`): a `Projects` item above `Agents`, gated on `projectsEnabled`. Removes the old inline folder-tree, expand/collapse chevrons, and inline-chat previews.
- **Tablet layout** (`TabletLayout`): resets the sidebar to Conversations when it closes, mirroring the phone drawer, so the mode never stays on Projects while hidden off-screen.
- **Cleanup**: drops the now-dead inline expand/inline-chat state from `NavHostViewModel`, the `DrawerProjectFolder` UI model, the persisted `projects_section_expanded` preference, and the unused `project_show_all` string.

## Testing
- Manually verified on a Pixel 9 Pro Fold (phone + unfolded/tablet layouts): footer entry → carousel slide, folder open, create/rename/delete, All-projects escape hatch, in-mode arrow + system back, and the tablet close/reopen reset.
- `:shared:detektMetadataCommonMain` and `:app:assembleDebug` pass.

## Notes
- Projects have no local cache — the server is the source of truth; the list is fetched lazily on entering the mode and reused across carousel re-entries.
- The `SidebarMode.Settings` branch exists but isn't reachable yet; the generalized back handler already covers it.
