### PR TITLE
fix(ci): deflake SSE origin-binding test and fix import-order lint break

### DIFF
--- a/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/sse/SseClientOriginBindingTest.kt
+++ b/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/sse/SseClientOriginBindingTest.kt
@@ -7,10 +7,12 @@ import com.garfiec.librechat.core.model.StreamEvent
 import com.google.common.truth.Truth.assertThat
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.MockEngineConfig
 import io.ktor.client.engine.mock.respond
 import io.ktor.client.plugins.defaultRequest
 import io.ktor.client.request.url
 import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -29,11 +31,22 @@ class SseClientOriginBindingTest {
     private val accountA = AccountId("srv-1:user-a")
     private val accountB = AccountId("srv-1:user-b")
 
+    // MockEngine defaults its dispatcher to Dispatchers.IO, which runs the handler on a real thread
+    // pool outside the test scheduler. While that real thread works, runTest sees an idle queue and
+    // fast-forwards virtual time — firing SseLineParser's 120s stall watchdog before the request
+    // ever completes, which aborts the attempt with a spurious SseStreamException. Pinning the
+    // engine to Dispatchers.Unconfined keeps the whole request inline on the test scheduler, so
+    // virtual time can never advance past a request that is still in flight.
     private fun failingTransportClient(onRequest: () -> Unit): HttpClient {
-        val engine = MockEngine {
-            onRequest()
-            respond("boom", HttpStatusCode.InternalServerError)
-        }
+        val engine = MockEngine(
+            MockEngineConfig().apply {
+                dispatcher = Dispatchers.Unconfined
+                addHandler {
+                    onRequest()
+                    respond("boom", HttpStatusCode.InternalServerError)
+                }
+            },
+        )
         return HttpClient(engine) {
             defaultRequest { url("https://a.example.com") }
         }

--- a/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/AccountSwitcherSheet.kt
+++ b/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/AccountSwitcherSheet.kt
@@ -61,10 +61,10 @@ import com.garfiec.librechat.shared.resources.remove
 import com.garfiec.librechat.shared.resources.remove_account
 import com.garfiec.librechat.shared.resources.remove_account_message
 import com.garfiec.librechat.shared.resources.remove_account_title
-import kotlin.math.abs
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
+import kotlin.math.abs
 
 /** Vertical drag past this distance (up or down) on the chip commits a round-robin switch. */
 private val SwipeSwitchThreshold = 40.dp


### PR DESCRIPTION
## Summary

Fixes both currently-red CI jobs on `develop`: a deterministic Lint
failure and a flaky Test failure. Both changes are lint/test-only with no
behavioral effect (the one production file touched is a cosmetic import
reorder).

## Changes

- **Lint (`AccountSwitcherSheet.kt`)** — reorder the `kotlin.math.abs`
  import to sit after the `kotlinx`/`org.jetbrains` imports, matching the
  ktlint IDEA import-layout the detekt gate enforces. The out-of-order
  import landed via an earlier merge and fails `:app:lint` deterministically.

- **Test (`SseClientOriginBindingTest.kt`)** — pin the Ktor `MockEngine`
  to `Dispatchers.Unconfined` instead of its default `Dispatchers.IO`.
  On the default dispatcher the mock handler runs on a real thread pool
  outside the test scheduler; under `runTest`, the scheduler sees an idle
  queue and fast-forwards virtual time, firing `SseLineParser`'s 120s
  stall watchdog before the request completes and aborting the attempt
  with a spurious `SseStreamException` — which flaked the request-count
  assertion. Pinning to `Unconfined` keeps the request inline on the test
  scheduler, matching the existing precedent in
  `CommonTokenDataStoreConcurrencyTest`.

## Verification

- `./gradlew detekt detektMetadataCommonMain :app:lint --continue` — BUILD SUCCESSFUL
- `./gradlew test` — BUILD SUCCESSFUL
- Stress-ran the origin-binding test 2,500 iterations post-fix with zero failures (repro'd 2/500 pre-fix).
