### PR TITLE
feat(settings): separate sign out from account deletion

### DIFF
--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/AccountInfoSection.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/AccountInfoSection.kt
@@ -13,7 +13,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CameraAlt
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -51,27 +50,21 @@ internal fun AccountInfoSection(
             avatarUrl = user.avatar,
             onAvatarClick = onAvatarClick,
         )
-        profileLoadError != null -> Column {
-            ErrorBanner(message = profileLoadError, onRetry = onRetry)
-            HorizontalDivider(modifier = Modifier.padding(top = 8.dp))
-        }
+        profileLoadError != null -> ErrorBanner(message = profileLoadError, onRetry = onRetry)
         else -> {
             val loadingDescription = stringResource(Res.string.cd_loading_profile)
-            Column {
-                Row(
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 24.dp),
+                horizontalArrangement = Arrangement.Center,
+            ) {
+                CircularProgressIndicator(
                     modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 16.dp, vertical = 24.dp),
-                    horizontalArrangement = Arrangement.Center,
-                ) {
-                    CircularProgressIndicator(
-                        modifier = Modifier
-                            .size(24.dp)
-                            .semantics { contentDescription = loadingDescription },
-                        strokeWidth = 2.dp,
-                    )
-                }
-                HorizontalDivider(modifier = Modifier.padding(top = 8.dp))
+                        .size(24.dp)
+                        .semantics { contentDescription = loadingDescription },
+                    strokeWidth = 2.dp,
+                )
             }
         }
     }
@@ -84,64 +77,61 @@ private fun AccountInfo(
     avatarUrl: String?,
     onAvatarClick: () -> Unit,
 ) {
-    Column {
-        Row(
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Surface(
             modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 16.dp, vertical = 8.dp),
-            verticalAlignment = Alignment.CenterVertically,
+                .size(48.dp)
+                .clip(CircleShape),
+            color = MaterialTheme.colorScheme.primaryContainer,
+            onClick = onAvatarClick,
         ) {
-            Surface(
-                modifier = Modifier
-                    .size(48.dp)
-                    .clip(CircleShape),
-                color = MaterialTheme.colorScheme.primaryContainer,
-                onClick = onAvatarClick,
-            ) {
-                if (avatarUrl != null) {
-                    AsyncImage(
-                        model = avatarUrl,
-                        contentDescription = stringResource(Res.string.cd_user_avatar),
-                        modifier = Modifier.size(48.dp),
-                        contentScale = ContentScale.Crop,
-                    )
-                } else {
-                    Icon(
-                        imageVector = Icons.Default.Person,
-                        contentDescription = null,
-                        modifier = Modifier.padding(12.dp),
-                        tint = MaterialTheme.colorScheme.onPrimaryContainer,
-                    )
-                }
-            }
-            Spacer(modifier = Modifier.width(16.dp))
-            Column(modifier = Modifier.weight(1f)) {
-                if (name.isNotBlank()) {
-                    Text(
-                        text = name,
-                        style = MaterialTheme.typography.bodyLarge,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                    )
-                }
-                if (email.isNotBlank()) {
-                    Text(
-                        text = email,
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                    )
-                }
-            }
-            IconButton(onClick = onAvatarClick) {
+            if (avatarUrl != null) {
+                AsyncImage(
+                    model = avatarUrl,
+                    contentDescription = stringResource(Res.string.cd_user_avatar),
+                    modifier = Modifier.size(48.dp),
+                    contentScale = ContentScale.Crop,
+                )
+            } else {
                 Icon(
-                    imageVector = Icons.Default.CameraAlt,
-                    contentDescription = stringResource(Res.string.cd_change_avatar),
-                    modifier = Modifier.size(20.dp),
+                    imageVector = Icons.Default.Person,
+                    contentDescription = null,
+                    modifier = Modifier.padding(12.dp),
+                    tint = MaterialTheme.colorScheme.onPrimaryContainer,
                 )
             }
         }
-        HorizontalDivider(modifier = Modifier.padding(top = 8.dp))
+        Spacer(modifier = Modifier.width(16.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            if (name.isNotBlank()) {
+                Text(
+                    text = name,
+                    style = MaterialTheme.typography.bodyLarge,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+            if (email.isNotBlank()) {
+                Text(
+                    text = email,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        }
+        IconButton(onClick = onAvatarClick) {
+            Icon(
+                imageVector = Icons.Default.CameraAlt,
+                contentDescription = stringResource(Res.string.cd_change_avatar),
+                modifier = Modifier.size(20.dp),
+            )
+        }
     }
 }

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/AccountSettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/AccountSettingsScreen.kt
@@ -1,6 +1,6 @@
 package com.garfiec.librechat.feature.settings.screen
 
-import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -17,7 +17,6 @@ import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.Key
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
@@ -156,6 +155,13 @@ fun AccountSettingsContent(
                     onRetry = viewModel::retry,
                 )
             }
+            // Sign out — grouped with the profile it acts on, kept out of the Danger Zone.
+            item(key = "sign_out") {
+                SignOutButton(
+                    isDeleting = uiState.isDeletingAccount,
+                    onLogoutClick = { showLogoutDialog = true },
+                )
+            }
 
             // Balance section
             item(key = "balance_header") {
@@ -216,17 +222,17 @@ fun AccountSettingsContent(
                 }
             }
 
-            // Danger zone
-            item(key = "danger_header") {
-                SectionHeader(stringResource(Res.string.section_danger_zone))
-            }
-            item(key = "danger_actions") {
-                DangerZone(
-                    isDeleting = uiState.isDeletingAccount,
-                    allowAccountDeletion = uiState.allowAccountDeletion,
-                    onLogoutClick = { showLogoutDialog = true },
-                    onDeleteClick = { showDeleteDialog = true },
-                )
+            // Danger zone — destructive, irreversible actions only.
+            if (uiState.allowAccountDeletion) {
+                item(key = "danger_header") {
+                    SectionHeader(stringResource(Res.string.section_danger_zone))
+                }
+                item(key = "danger_actions") {
+                    DangerZone(
+                        isDeleting = uiState.isDeletingAccount,
+                        onDeleteClick = { showDeleteDialog = true },
+                    )
+                }
             }
 
             // Bottom spacing
@@ -394,38 +400,46 @@ private fun SectionHeader(title: String) {
 }
 
 @Composable
-private fun DangerZone(
+private fun SignOutButton(
     isDeleting: Boolean,
-    allowAccountDeletion: Boolean,
     onLogoutClick: () -> Unit,
-    onDeleteClick: () -> Unit,
 ) {
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 8.dp),
-        verticalArrangement = Arrangement.spacedBy(12.dp),
-    ) {
+    // Sign out closes out the profile group; the divider below it separates the
+    // whole Profile section (info + sign out) from Balance.
+    Column {
         OutlinedButton(
             onClick = onLogoutClick,
             enabled = !isDeleting,
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 8.dp),
         ) {
             Text(stringResource(Res.string.action_sign_out))
         }
-        if (allowAccountDeletion) {
-            Button(
-                onClick = onDeleteClick,
-                enabled = !isDeleting,
-                modifier = Modifier.fillMaxWidth(),
-                colors = ButtonDefaults.buttonColors(
-                    containerColor = MaterialTheme.colorScheme.error,
-                    contentColor = MaterialTheme.colorScheme.onError,
-                ),
-            ) {
-                Text(stringResource(Res.string.delete_account))
-            }
-        }
+        HorizontalDivider(modifier = Modifier.padding(top = 8.dp))
+    }
+}
+
+@Composable
+private fun DangerZone(
+    isDeleting: Boolean,
+    onDeleteClick: () -> Unit,
+) {
+    OutlinedButton(
+        onClick = onDeleteClick,
+        enabled = !isDeleting,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        colors = ButtonDefaults.outlinedButtonColors(
+            contentColor = MaterialTheme.colorScheme.error,
+        ),
+        border = BorderStroke(
+            1.dp,
+            MaterialTheme.colorScheme.error.copy(alpha = if (isDeleting) 0.12f else 1f),
+        ),
+    ) {
+        Text(stringResource(Res.string.delete_account))
     }
 }
 


### PR DESCRIPTION
## Summary
Reorganizes the Account settings screen so Sign out and Delete account are no longer adjacent look-alike buttons. Sign out is a routine action and now lives with the profile; account deletion stands alone in the Danger Zone, reducing the chance of an accidental destructive tap.

## Changes
- Move Sign out out of the Danger Zone and into the Profile section, directly under the profile info (avatar/name/email).
- Relocate the profile→Balance divider so it renders below Sign out, grouping Sign out visually with the profile it acts on.
- Danger Zone now contains Delete account only; the whole section (header + button) is gated on `allowAccountDeletion`, so no empty header shows when deletion is disallowed.
- Restyle Delete account from a filled red button to a full-width outlined error button (red text + red border); the border dims in step with the label while a deletion is in flight.

## Testing
- Manually verified on a Pixel 9 Pro Fold (loaded, and profile-load states).
