### PR TITLE
feat(chat): space overflow menu below its trigger button

### DIFF
--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ChatOverflowMenu.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ChatOverflowMenu.kt
@@ -28,6 +28,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import com.garfiec.librechat.core.data.datastore.ContextBarPlacement
 import com.garfiec.librechat.core.model.usage.ContextUsage
@@ -81,6 +82,7 @@ internal fun ChatOverflowMenu(
         expanded = expanded,
         onDismissRequest = onDismiss,
         shape = RoundedCornerShape(16.dp),
+        offset = DpOffset(x = 0.dp, y = 8.dp),
     ) {
         if (conversationId != null) {
             DropdownMenuItem(


### PR DESCRIPTION
## Summary
The chat top bar's overflow (⋮) menu opened flush against its trigger button, with no visual gap between them. This adds a small vertical offset so the menu drops slightly below the button.

## Changes
- Add an 8dp downward `offset` to the `ChatOverflowMenu` `DropdownMenu` so it no longer visually touches the overflow button.

## Testing
- Manually verified on a Pixel 9 Pro Fold.
