### PR TITLE
feat(drawer): inset, rounded ripple for sidebar rows

### DIFF
--- a/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/DrawerContent.kt
+++ b/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/DrawerContent.kt
@@ -66,6 +66,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
@@ -116,6 +117,12 @@ import org.koin.compose.viewmodel.koinViewModel
 // Pre-computed shapes to avoid creating new ones per item per frame
 private val ItemShape = RoundedCornerShape(8.dp)
 private val ActiveIndicatorShape = RoundedCornerShape(2.dp)
+
+// Pulls a tappable drawer row in from the edges and clips its ripple to [ItemShape], so every row
+// reads as the same inset, rounded button instead of a full-bleed rectangular highlight. Apply
+// before .clickable so the indication is bounded by the rounded shape.
+private fun Modifier.drawerRowShape(): Modifier =
+    padding(horizontal = 4.dp, vertical = 1.dp).clip(ItemShape)
 
 // Gap between the conversation row's bottom edge and the long-press menu's top edge.
 private val MenuVerticalGap = 4.dp
@@ -739,8 +746,9 @@ private fun DrawerProjectsEntry(onClick: () -> Unit) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
+            .drawerRowShape()
             .clickable(onClick = onClick)
-            .padding(horizontal = 16.dp, vertical = 10.dp),
+            .padding(horizontal = 12.dp, vertical = 10.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Icon(
@@ -808,6 +816,7 @@ private fun DrawerConversationItem(
                 .padding(horizontal = 4.dp, vertical = 1.dp)
                 .fillMaxWidth()
                 .background(backgroundColor, ItemShape)
+                .clip(ItemShape)
                 .combinedClickable(
                     role = Role.Button,
                     onClick = onClick,
@@ -935,6 +944,7 @@ private fun SectionHeader(
         Modifier
             .fillMaxWidth()
             .heightIn(min = 48.dp)
+            .drawerRowShape()
             .clickable(
                 role = Role.Button,
                 onClickLabel = stringResource(
@@ -942,7 +952,7 @@ private fun SectionHeader(
                 ),
                 onClick = onToggle,
             )
-            .padding(horizontal = 16.dp)
+            .padding(horizontal = 12.dp)
     } else {
         Modifier
             .fillMaxWidth()
@@ -989,8 +999,9 @@ private fun ShowMoreLessRow(
     Row(
         modifier = Modifier
             .fillMaxWidth()
+            .drawerRowShape()
             .clickable(role = Role.Button, onClick = onClick)
-            .padding(start = 16.dp, end = 16.dp, top = 4.dp, bottom = 4.dp),
+            .padding(start = 12.dp, end = 12.dp, top = 4.dp, bottom = 4.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Text(
@@ -1011,8 +1022,9 @@ private fun DrawerFooterItem(
     Row(
         modifier = modifier
             .fillMaxWidth()
+            .drawerRowShape()
             .clickable(onClick = onClick)
-            .padding(horizontal = 16.dp, vertical = 10.dp),
+            .padding(horizontal = 12.dp, vertical = 10.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Icon(


### PR DESCRIPTION
## Summary
Unifies the touch-feedback ripple across the navigation drawer's tappable rows. Previously some rows (footer links, section headers, show-more) rippled full-width with square corners while conversation rows rippled square-cornered inside a rounded background. Now every row shows the same inset, rounded ripple.

## Changes
- Add a `drawerRowShape()` modifier helper that insets a row from the drawer edges and clips its ripple to the shared 8dp `ItemShape`.
- Apply it to the footer links (Projects, Agents, Skills, Files, Settings), the collapsible section headers (Favorites/Pinned), and the "Show more/less" row — replacing their full-width `clickable`.
- Clip the conversation rows' ripple to `ItemShape` so it follows the existing rounded background instead of painting square corners.
- On the rows adopting the helper, shift inner horizontal padding 16dp→12dp to offset the new 4dp outer inset, keeping content at the same 16dp indent.

## Testing
- Built and installed on a Pixel 9 Pro Fold; opened the drawer and confirmed the ripple on favorites, history rows, section headers, footer links, and show-more is inset and rounded, with content alignment unchanged.
