### PR TITLE
feat(drawer): sticky header for the favorites section

### DIFF
--- a/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/DrawerContent.kt
+++ b/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/DrawerContent.kt
@@ -548,13 +548,19 @@ fun DrawerContent(
                 // [FavoritesPreviewCount] show until "Show more" reveals the rest.
                 if (uiState.bookmarksEnabled && uiState.favoriteConversations.isNotEmpty() && uiState.searchQuery.isEmpty()) {
                     val favorites = uiState.favoriteConversations
-                    item(key = "favorites_header") {
-                        SectionHeader(
-                            icon = Icons.Default.Star,
-                            title = stringResource(Res.string.favorites),
-                            collapsed = favoritesCollapsed,
-                            onToggle = { favoritesCollapsed = !favoritesCollapsed },
-                        )
+                    stickyHeader(key = "favorites_header") {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .background(MaterialTheme.colorScheme.surfaceContainerLow),
+                        ) {
+                            SectionHeader(
+                                icon = Icons.Default.Star,
+                                title = stringResource(Res.string.favorites),
+                                collapsed = favoritesCollapsed,
+                                onToggle = { favoritesCollapsed = !favoritesCollapsed },
+                            )
+                        }
                     }
 
                     // The whole body (preview rows + show-more + divider) lives in one item so it can


### PR DESCRIPTION
## Summary
Makes the drawer's **Favorites** section header sticky, matching the existing behavior of the date-group ("history") headers. As you scroll the conversation list, the Favorites title now pins to the top while its rows scroll underneath, until the first date-group header pushes it up.

## Changes
- Convert the favorites header from a plain `item` to a `stickyHeader`.
- Wrap the header in a full-width, opaque (`surfaceContainerLow`) background so the favorite rows sliding beneath the inset, rounded header button don't show through.

## Testing
- Built and deployed to a Pixel 9 Pro Fold; opened the drawer and scrolled to confirm the Favorites header pins and hands off to the first date header as expected.

## Notes
- Scope is Favorites only. The **Pinned** section header remains non-sticky.
