### PR TITLE
feat(chat): inset rounded ripple for options and model sheet rows

### DIFF
--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ChatToolsBottomSheet.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ChatToolsBottomSheet.kt
@@ -112,7 +112,6 @@ fun ChatToolsBottomSheet(
             modifier = Modifier
                 .fillMaxWidth()
                 .navigationBarsPadding()
-                .padding(horizontal = 16.dp)
                 .padding(bottom = 16.dp),
         ) {
             // Top section: Camera, Photos, Files, Server cards — hidden when the selected
@@ -120,7 +119,9 @@ fun ChatToolsBottomSheet(
             // attaches an already-uploaded file by reference (no re-upload).
             if (gates.fileUploadEnabled) {
                 Row(
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp),
                     horizontalArrangement = Arrangement.spacedBy(12.dp),
                 ) {
                     AttachmentOptionCard(
@@ -162,7 +163,7 @@ fun ChatToolsBottomSheet(
                 }
 
                 Spacer(modifier = Modifier.height(12.dp))
-                HorizontalDivider()
+                HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
                 Spacer(modifier = Modifier.height(8.dp))
             }
 
@@ -177,7 +178,9 @@ fun ChatToolsBottomSheet(
                 ContextUsageExpandableGauge(
                     usage = sheetContextUsage,
                     tokenUsage = tokenUsage,
-                    modifier = Modifier.padding(bottom = 8.dp),
+                    modifier = Modifier
+                        .padding(horizontal = 16.dp)
+                        .padding(bottom = 8.dp),
                 )
             }
 
@@ -186,11 +189,12 @@ fun ChatToolsBottomSheet(
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
+                        .sheetRowRipple()
                         .clickable {
                             onOpenModelSelector()
                             onDismiss()
                         }
-                        .padding(vertical = 12.dp),
+                        .padding(horizontal = 12.dp, vertical = 12.dp),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     Icon(
@@ -226,11 +230,12 @@ fun ChatToolsBottomSheet(
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
+                        .sheetRowRipple()
                         .clickable {
                             onOpenModelParameters()
                             onDismiss()
                         }
-                        .padding(vertical = 12.dp),
+                        .padding(horizontal = 12.dp, vertical = 12.dp),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     Icon(
@@ -259,7 +264,7 @@ fun ChatToolsBottomSheet(
                 }
             }
 
-            HorizontalDivider()
+            HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
             Spacer(modifier = Modifier.height(8.dp))
 
             // Tool toggle items — ephemeral tools are hidden for the agents endpoint
@@ -294,8 +299,9 @@ fun ChatToolsBottomSheet(
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
+                        .sheetRowRipple()
                         .clickable { showMcpServers = !showMcpServers }
-                        .padding(vertical = 12.dp),
+                        .padding(horizontal = 12.dp, vertical = 12.dp),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     Icon(
@@ -360,8 +366,9 @@ private fun ToolToggleRow(
     Row(
         modifier = Modifier
             .fillMaxWidth()
+            .sheetRowRipple()
             .clickable(onClick = onToggle)
-            .padding(vertical = 12.dp)
+            .padding(horizontal = 12.dp, vertical = 12.dp)
             .semantics {
                 contentDescription = if (isEnabled) {
                     "$title enabled"
@@ -454,8 +461,9 @@ private fun McpServerToggleRow(
     Row(
         modifier = Modifier
             .fillMaxWidth()
+            .sheetRowRipple()
             .clickable(onClick = onToggle)
-            .padding(vertical = 8.dp),
+            .padding(horizontal = 12.dp, vertical = 8.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         // Connection status indicator

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ModelSelectorSheet.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ModelSelectorSheet.kt
@@ -242,9 +242,7 @@ fun ModelSelectorSheet(
             Spacer(modifier = Modifier.height(12.dp))
 
             LazyColumn(
-                modifier = Modifier
-                    .weight(1f)
-                    .padding(horizontal = 16.dp),
+                modifier = Modifier.weight(1f),
             ) {
                 // Optional "Starred" section at the very top (mobile-only). Starred items
                 // are duplicated here — they still render in their own groups below.
@@ -306,7 +304,7 @@ fun ModelSelectorSheet(
                     }
                     if (starredDisplay == StarredModelsDisplay.TOP) {
                         item(key = "starred_divider") {
-                            HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+                            HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp))
                         }
                     }
                 }
@@ -417,8 +415,14 @@ private fun EndpointGroupHeader(
             // `clickable(enabled = false)` still consumes touch events and
             // announces "disabled" to TalkBack/VoiceOver. Only the inner
             // SetApiKeyChip remains interactive in that branch.
-            .then(if (needsKey) Modifier else Modifier.clickable(onClick = onToggle))
-            .padding(vertical = 8.dp),
+            .then(
+                if (needsKey) {
+                    Modifier.padding(horizontal = 4.dp)
+                } else {
+                    Modifier.sheetRowRipple().clickable(onClick = onToggle)
+                },
+            )
+            .padding(horizontal = 12.dp, vertical = 8.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         // Disabled icon + label use Material's standard 0.38 disabled alpha. The
@@ -509,8 +513,9 @@ private fun LazyItemScope.ModelListItem(
     Row(
         modifier = Modifier
             .fillMaxWidth()
+            .sheetRowRipple()
             .clickable(onClick = onClick)
-            .padding(vertical = verticalPadding, horizontal = 8.dp)
+            .padding(vertical = verticalPadding, horizontal = 12.dp)
             .animateItem(),
         verticalAlignment = Alignment.CenterVertically,
     ) {
@@ -555,8 +560,9 @@ private fun LazyItemScope.AgentListItem(
     Row(
         modifier = Modifier
             .fillMaxWidth()
+            .sheetRowRipple()
             .clickable(onClick = onClick)
-            .padding(vertical = verticalPadding, horizontal = 8.dp)
+            .padding(vertical = verticalPadding, horizontal = 12.dp)
             .animateItem(),
         verticalAlignment = Alignment.CenterVertically,
     ) {

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/SheetRowRipple.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/SheetRowRipple.kt
@@ -1,0 +1,15 @@
+package com.garfiec.librechat.feature.chat.components
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.dp
+
+private val SheetRowShape = RoundedCornerShape(8.dp)
+
+// Insets a tappable bottom-sheet row and clips its ripple to [SheetRowShape], so the highlight
+// reads as an inset rounded button instead of a full-bleed rectangle. Apply before .clickable so
+// the indication is bounded by the rounded shape.
+internal fun Modifier.sheetRowRipple(): Modifier =
+    padding(horizontal = 4.dp).clip(SheetRowShape)


### PR DESCRIPTION
## Summary
Tappable rows in the chat options bottom sheet and the model-selector bottom sheet used a full-bleed rectangular ripple that spanned the whole sheet width. This gives them the same inset, rounded highlight already used by the navigation drawer rows, so a press reads as a floating rounded button rather than an edge-to-edge rectangle.

## Changes
- Add a `Modifier.sheetRowRipple()` helper that insets a row 4dp horizontally and clips its ripple to an 8dp rounded shape (applied before `.clickable`).
- **ChatToolsBottomSheet** — apply it to the Model, Model Parameters, MCP, ephemeral tool-toggle (web search / URL context / code interpreter / file search), and MCP-server rows. Move the sheet's horizontal inset off the outer `Column` and onto the non-row elements (attachment cards, dividers, context gauge) so the rows keep their original content alignment while the ripple gains its inset.
- **ModelSelectorSheet** — apply it to the model rows, agent rows, and the collapsible endpoint group headers; the disabled ("Set API Key") header keeps a matching inset without the ripple. Move the list's horizontal inset off the `LazyColumn` onto the rows and starred divider.

## Testing
- Built and deployed to a Pixel 9 Pro Fold; verified in both sheets that each tappable row shows an inset rounded highlight, content stays aligned at its original position, and row heights are unchanged.
