### PR TITLE
fix(auth): keep session on transient token-refresh failures

### DIFF
--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/datastore/AccountRegistryTest.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/datastore/AccountRegistryTest.kt
@@ -10,6 +10,7 @@ import com.garfiec.librechat.core.common.identity.AccountState.Resolved
 import com.garfiec.librechat.core.common.identity.InMemoryActiveAccountProvider
 import com.garfiec.librechat.core.common.identity.deriveAccountId
 import com.garfiec.librechat.core.common.identity.deriveServerId
+import com.garfiec.librechat.core.network.client.RefreshResult
 import com.garfiec.librechat.core.network.client.TokenManager
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.CoroutineScope
@@ -142,14 +143,14 @@ class AccountRegistryTest {
         override val isAuthenticated: Boolean = false
         override suspend fun getAccessToken(): String? = null
         override suspend fun setTokens(accessToken: String, refreshToken: String) {}
-        override suspend fun refreshAccessToken(): Boolean = false
+        override suspend fun refreshAccessToken(): RefreshResult = RefreshResult.HardExpired
         override suspend fun clearTokens() {}
         override suspend fun getAccessTokenFor(accountId: String): String? = null
         override suspend fun getStagedAccessToken(): String? = null
         override suspend fun clearStagedTokens() {}
         override suspend fun selectAccount(accountId: String) { selected = accountId }
         override suspend fun removeAccount(accountId: String) {}
-        override suspend fun refreshAccessTokenFor(accountId: String, baseUrl: String): Boolean = false
+        override suspend fun refreshAccessTokenFor(accountId: String, baseUrl: String): RefreshResult = RefreshResult.HardExpired
         override suspend fun onAccountResolved(accountId: String) {}
         override suspend fun onAccountCleared() { cleared = true }
         override fun emitSessionExpired(expiredAccountId: String?) {}

--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/datastore/CommonTokenDataStoreAccountKeyingTest.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/datastore/CommonTokenDataStoreAccountKeyingTest.kt
@@ -1,5 +1,6 @@
 package com.garfiec.librechat.core.data.datastore
 
+import com.garfiec.librechat.core.network.client.RefreshResult
 import com.google.common.truth.Truth.assertThat
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
@@ -411,7 +412,7 @@ class CommonTokenDataStoreAccountKeyingTest {
 
         val ok = store.refreshAccessToken()
 
-        assertThat(ok).isTrue()
+        assertThat(ok).isEqualTo(RefreshResult.Refreshed)
         assertThat(store.store[accessKey("acctA")]).isEqualTo("A-access-refreshed")
         assertThat(store.getAccessToken()).isEqualTo("A-access-refreshed")
     }
@@ -451,7 +452,7 @@ class CommonTokenDataStoreAccountKeyingTest {
 
         val ok = store.refreshAccessTokenFor("acctB", "https://b.example.com")
 
-        assertThat(ok).isTrue()
+        assertThat(ok).isEqualTo(RefreshResult.Refreshed)
         assertThat(requestedUrl).startsWith("https://b.example.com/api/auth/refresh")
         assertThat(store.store[accessKey("acctB")]).isEqualTo("B-access-refreshed")
         // acctB is not the active account, so the cached bearer (A's) is untouched.

--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/datastore/CommonTokenDataStoreConcurrencyTest.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/datastore/CommonTokenDataStoreConcurrencyTest.kt
@@ -1,5 +1,6 @@
 package com.garfiec.librechat.core.data.datastore
 
+import com.garfiec.librechat.core.network.client.RefreshResult
 import com.google.common.truth.Truth.assertThat
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
@@ -25,6 +26,7 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.yield
 import org.junit.Test
+import java.io.IOException
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class CommonTokenDataStoreConcurrencyTest {
@@ -136,9 +138,10 @@ class CommonTokenDataStoreConcurrencyTest {
             release.complete(Unit)
             advanceUntilIdle()
 
-            // The refresh detects the epoch bump from clearTokens and discards its result (returns
-            // false), so it can never resurrect the cleared session. Final state: logged out.
-            assertThat(refreshJob.await()).isFalse()
+            // The refresh detects the epoch bump from clearTokens and discards its result (a
+            // Transient outcome — a teardown owns the routing, so it never re-emits session-expired),
+            // so it can never resurrect the cleared session. Final state: logged out.
+            assertThat(refreshJob.await()).isEqualTo(RefreshResult.Transient)
             assertThat(store.persistedAccess()).isNull()
             assertThat(store.persistedRefresh()).isNull()
             assertThat(store.removeCount).isEqualTo(1)
@@ -190,7 +193,7 @@ class CommonTokenDataStoreConcurrencyTest {
 
             val result = store.refreshAccessToken()
 
-            assertThat(result).isTrue()
+            assertThat(result).isEqualTo(RefreshResult.Refreshed)
             assertThat(store.writeLog).hasSize(1)
             assertThat(store.writeLog.single().first).isEqualTo("fresh-access")
             assertThat(store.persistedAccess()).isEqualTo("fresh-access")
@@ -212,9 +215,230 @@ class CommonTokenDataStoreConcurrencyTest {
             assertThat(store.removeCount).isEqualTo(1)
 
             // Without a refresh token in storage the refresh should short-circuit
-            // false without touching the network — and without deadlocking on a
+            // HardExpired without touching the network — and without deadlocking on a
             // mutex that clearTokens already released.
             val result = store.refreshAccessToken()
-            assertThat(result).isFalse()
+            assertThat(result).isEqualTo(RefreshResult.HardExpired)
+        }
+
+    @Test
+    fun `a persistent refresh 401 retries the full budget then classifies HardExpired`() =
+        runTest(UnconfinedTestDispatcher()) {
+            var requestCount = 0
+            val engine = mockEngine {
+                requestCount++
+                // text/html 401, exactly like the backend's "Refresh token expired or not found".
+                respond(
+                    content = "Refresh token expired or not found for this user",
+                    status = HttpStatusCode.Unauthorized,
+                    headers = headersOf("Content-Type", "text/html"),
+                )
+            }
+            val store = FakeTokenDataStore(mockRefreshClient(engine))
+
+            val result = store.refreshAccessToken()
+
+            assertThat(result).isEqualTo(RefreshResult.HardExpired)
+            assertThat(requestCount).isEqualTo(3)
+            // A hard-expired refresh does NOT clear the stored tokens: a relaunch may still recover,
+            // and the session-expired routing (not this store) owns navigation to re-auth.
+            assertThat(store.persistedRefresh()).isEqualTo("initial-refresh")
+        }
+
+    @Test
+    fun `a refresh 401 that clears on a retry recovers without logging out`() =
+        runTest(UnconfinedTestDispatcher()) {
+            // The exact "occasional logout" scenario: a transient server session-lookup miss returns
+            // 401, then the very next attempt with the same token succeeds. Retrying absorbs it.
+            var requestCount = 0
+            val engine = mockEngine {
+                requestCount++
+                if (requestCount == 1) {
+                    respond("transient miss", HttpStatusCode.Unauthorized, headersOf("Content-Type", "text/html"))
+                } else {
+                    respond(
+                        content = """{"token":"recovered-access"}""",
+                        status = HttpStatusCode.OK,
+                        headers = jsonHeaders,
+                    )
+                }
+            }
+            val store = FakeTokenDataStore(mockRefreshClient(engine))
+
+            val result = store.refreshAccessToken()
+
+            assertThat(result).isEqualTo(RefreshResult.Refreshed)
+            assertThat(requestCount).isEqualTo(2)
+            assertThat(store.persistedAccess()).isEqualTo("recovered-access")
+        }
+
+    @Test
+    fun `a persistent 5xx retries the full budget then classifies Transient`() =
+        runTest(UnconfinedTestDispatcher()) {
+            var requestCount = 0
+            val engine = mockEngine {
+                requestCount++
+                respond("boom", HttpStatusCode.InternalServerError, headersOf("Content-Type", "text/html"))
+            }
+            val store = FakeTokenDataStore(mockRefreshClient(engine))
+
+            val result = store.refreshAccessToken()
+
+            // A server 5xx is recoverable — keep the session (no logout) and leave tokens intact.
+            assertThat(result).isEqualTo(RefreshResult.Transient)
+            assertThat(requestCount).isEqualTo(3)
+            assertThat(store.persistedRefresh()).isEqualTo("initial-refresh")
+        }
+
+    @Test
+    fun `a 2xx with an unparseable body is transient, not a spurious refresh`() =
+        runTest(UnconfinedTestDispatcher()) {
+            // A proxy interstitial: HTTP 200 but an HTML body. The body-deserialization failure is
+            // recoverable, not a dead session, so it is classified transient and retried.
+            var requestCount = 0
+            val engine = mockEngine {
+                requestCount++
+                respond("<html>login</html>", HttpStatusCode.OK, headersOf("Content-Type", "text/html"))
+            }
+            val store = FakeTokenDataStore(mockRefreshClient(engine))
+
+            val result = store.refreshAccessToken()
+
+            assertThat(result).isEqualTo(RefreshResult.Transient)
+            assertThat(requestCount).isEqualTo(3)
+            assertThat(store.persistedAccess()).isEqualTo("initial-access")
+        }
+
+    @Test
+    fun `a hard rejection on any attempt classifies HardExpired even if the last attempt is transient`() =
+        runTest(UnconfinedTestDispatcher()) {
+            // A genuinely-dead session that 401s, then hits a 5xx blip on the final attempt, must still
+            // route to re-auth — not be masked as Transient by the last attempt.
+            var requestCount = 0
+            val engine = mockEngine {
+                requestCount++
+                if (requestCount < 3) {
+                    respond("expired", HttpStatusCode.Unauthorized, headersOf("Content-Type", "text/html"))
+                } else {
+                    respond("boom", HttpStatusCode.InternalServerError, headersOf("Content-Type", "text/html"))
+                }
+            }
+            val store = FakeTokenDataStore(mockRefreshClient(engine))
+
+            val result = store.refreshAccessToken()
+
+            assertThat(result).isEqualTo(RefreshResult.HardExpired)
+            assertThat(requestCount).isEqualTo(3)
+        }
+
+    @Test
+    fun `a transport failure is terminal-Transient and does not retry under the flight lock`() =
+        runTest(UnconfinedTestDispatcher()) {
+            // A hung/unreachable server (POST throws) must NOT re-POST twice more while holding the
+            // per-account flight lock — one attempt, then keep the session.
+            var requestCount = 0
+            val engine = mockEngine {
+                requestCount++
+                throw IOException("connection reset")
+            }
+            val store = FakeTokenDataStore(mockRefreshClient(engine))
+
+            val result = store.refreshAccessToken()
+
+            assertThat(result).isEqualTo(RefreshResult.Transient)
+            assertThat(requestCount).isEqualTo(1)
+            assertThat(store.persistedRefresh()).isEqualTo("initial-refresh")
+        }
+
+    @Test
+    fun `a transport failure after a 401 still classifies HardExpired`() =
+        runTest(UnconfinedTestDispatcher()) {
+            // A confirmed-dead session (401) followed by the server going unreachable must still route
+            // to re-auth, not be downgraded to Transient by the transport error.
+            var requestCount = 0
+            val engine = mockEngine {
+                requestCount++
+                if (requestCount == 1) {
+                    respond("expired", HttpStatusCode.Unauthorized, headersOf("Content-Type", "text/html"))
+                } else {
+                    throw IOException("connection reset")
+                }
+            }
+            val store = FakeTokenDataStore(mockRefreshClient(engine))
+
+            val result = store.refreshAccessToken()
+
+            assertThat(result).isEqualTo(RefreshResult.HardExpired)
+            assertThat(requestCount).isEqualTo(2)
+        }
+
+    @Test
+    fun `a 429 with a Retry-After beyond the cap stops instead of hammering`() =
+        runTest(UnconfinedTestDispatcher()) {
+            var requestCount = 0
+            val engine = mockEngine {
+                requestCount++
+                respond(
+                    content = "slow down",
+                    status = HttpStatusCode.TooManyRequests,
+                    headers = headersOf("Retry-After", "60"),
+                )
+            }
+            val store = FakeTokenDataStore(mockRefreshClient(engine))
+
+            val result = store.refreshAccessToken()
+
+            // Retry-After (60s) exceeds our max backoff, so we back off fully by not re-POSTing.
+            assertThat(result).isEqualTo(RefreshResult.Transient)
+            assertThat(requestCount).isEqualTo(1)
+        }
+
+    @Test
+    fun `a 429 is retried and recovers on the next attempt`() =
+        runTest(UnconfinedTestDispatcher()) {
+            var requestCount = 0
+            val engine = mockEngine {
+                requestCount++
+                if (requestCount == 1) {
+                    respond(
+                        content = "slow down",
+                        status = HttpStatusCode.TooManyRequests,
+                        headers = headersOf("Retry-After", "1"),
+                    )
+                } else {
+                    respond("""{"token":"post-429-access"}""", HttpStatusCode.OK, headers = jsonHeaders)
+                }
+            }
+            val store = FakeTokenDataStore(mockRefreshClient(engine))
+
+            val result = store.refreshAccessToken()
+
+            assertThat(result).isEqualTo(RefreshResult.Refreshed)
+            assertThat(requestCount).isEqualTo(2)
+            assertThat(store.persistedAccess()).isEqualTo("post-429-access")
+        }
+
+    @Test
+    fun `a successful refresh persists the rotated refresh token from Set-Cookie`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val engine = mockEngine {
+                respond(
+                    content = """{"token":"rotated-access"}""",
+                    status = HttpStatusCode.OK,
+                    headers = headersOf(
+                        "Content-Type" to listOf(ContentType.Application.Json.toString()),
+                        "Set-Cookie" to listOf("refreshToken=rotated-refresh; HttpOnly; Path=/"),
+                    ),
+                )
+            }
+            val store = FakeTokenDataStore(mockRefreshClient(engine))
+
+            val result = store.refreshAccessToken()
+
+            assertThat(result).isEqualTo(RefreshResult.Refreshed)
+            assertThat(store.persistedAccess()).isEqualTo("rotated-access")
+            // The backend rotates on every refresh; the new token must replace the old one on disk so
+            // the next refresh doesn't send a now-dead token.
+            assertThat(store.persistedRefresh()).isEqualTo("rotated-refresh")
         }
 }

--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/repository/AccountSwitcherTestHarness.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/repository/AccountSwitcherTestHarness.kt
@@ -8,6 +8,7 @@ import com.garfiec.librechat.core.common.identity.InMemoryActiveAccountProvider
 import com.garfiec.librechat.core.data.datastore.AccountRoster
 import com.garfiec.librechat.core.data.datastore.AccountScopedPrefsPurger
 import com.garfiec.librechat.core.data.datastore.ServerDataStore
+import com.garfiec.librechat.core.network.client.RefreshResult
 import com.garfiec.librechat.core.network.client.SwitchGate
 import com.garfiec.librechat.core.network.client.TokenManager
 import io.mockk.mockk
@@ -33,7 +34,7 @@ internal class RecordingTokenManager : TokenManager {
     override suspend fun setTokens(accessToken: String, refreshToken: String) {
         stagedAccess = accessToken
     }
-    override suspend fun refreshAccessToken(): Boolean = false
+    override suspend fun refreshAccessToken(): RefreshResult = RefreshResult.HardExpired
     override suspend fun clearTokens() {}
     override suspend fun getAccessTokenFor(accountId: String): String? = null
     override suspend fun getStagedAccessToken(): String? = stagedAccess
@@ -46,7 +47,7 @@ internal class RecordingTokenManager : TokenManager {
     override suspend fun removeAccount(accountId: String) {
         removedAccounts += accountId
     }
-    override suspend fun refreshAccessTokenFor(accountId: String, baseUrl: String): Boolean = false
+    override suspend fun refreshAccessTokenFor(accountId: String, baseUrl: String): RefreshResult = RefreshResult.HardExpired
     override suspend fun onAccountResolved(accountId: String) {
         resolvedAccount = accountId
         stagedAccess = null

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/CommonTokenDataStore.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/CommonTokenDataStore.kt
@@ -6,21 +6,24 @@ import com.garfiec.librechat.core.logging.Diag
 import com.garfiec.librechat.core.logging.LogOrigin
 import com.garfiec.librechat.core.model.response.RefreshResponse
 import com.garfiec.librechat.core.network.client.CookieHelper
+import com.garfiec.librechat.core.network.client.RefreshResult
 import com.garfiec.librechat.core.network.client.SecureTokenStorage
 import com.garfiec.librechat.core.network.client.TokenManager
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
-import io.ktor.client.plugins.ClientRequestException
 import io.ktor.client.request.header
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.client.statement.HttpResponse
+import io.ktor.http.HttpHeaders
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlin.concurrent.Volatile
+import kotlin.random.Random
 
 /**
  * Account-keyed secure token store. Tokens are namespaced by account
@@ -266,76 +269,211 @@ abstract class CommonTokenDataStore(
         }
     }
 
-    override suspend fun refreshAccessToken(): Boolean =
+    override suspend fun refreshAccessToken(): RefreshResult =
         // The live active account, against the live base URL (the refresh client's defaultRequest).
         performRefresh(accountKey = activeAccountKey, absoluteRefreshUrl = null)
 
-    override suspend fun refreshAccessTokenFor(accountId: String, baseUrl: String): Boolean =
+    override suspend fun refreshAccessTokenFor(accountId: String, baseUrl: String): RefreshResult =
         // URL-pinned: post to an absolute URL so a concurrent server switch can't redirect this
         // account's refresh token to another server.
         performRefresh(accountKey = accountId, absoluteRefreshUrl = "${baseUrl.trimTrailingSlash()}$REFRESH_PATH")
 
-    private suspend fun performRefresh(accountKey: String?, absoluteRefreshUrl: String?): Boolean =
+    /**
+     * Refresh [accountKey]'s tokens with a bounded retry loop, classifying the outcome so a caller can
+     * tell a hard-expired session (route to re-auth) from a transient failure (keep the session).
+     *
+     * The whole loop runs under the per-account flight lock: same-account refreshes stay single-flight
+     * across every retry+backoff, so a queued 401 waits and then reads the freshly-rotated token
+     * instead of re-POSTing a spent one. [stateMutex] is still taken only for the brief epoch read and
+     * the commit — never across a POST or a backoff delay — so a switch/logout never stalls behind a
+     * slow or retrying refresh.
+     *
+     * A refresh 401 is **not** treated as immediately terminal: the backend returns the same `401`
+     * ("Refresh token expired or not found") for a transiently-missed session (replica lag / lookup
+     * hiccup) as for a genuinely-expired one, and the app relaunch that "fixes" such a logout proves
+     * the token was fine — so an auth rejection is retried with backoff. The budget is classified
+     * [HardExpired] if **any** attempt saw an auth rejection (a dead session must route to re-auth even
+     * if a later attempt hit a transient blip); a purely transient run (5xx / rate-limit) stays
+     * [Transient] so the session is kept. A transport failure (server unreachable) is terminal-Transient
+     * rather than retried, so the flight lock is not held across repeated full request timeouts.
+     */
+    private suspend fun performRefresh(accountKey: String?, absoluteRefreshUrl: String?): RefreshResult =
         flightFor(accountKey).withLock {
-            // Capture the slot's epoch BEFORE the stored-token read, so any teardown of THIS slot that
-            // races the POST below is detected (and its result discarded) with no lock held across the
-            // network call. Under stateMutex only for the map read — released before the POST.
-            val epochAtStart = stateMutex.withLock { epochOf(accountKey) }
-            val storedRefreshToken = readValue(refreshKey(accountKey))
-            if (storedRefreshToken.isNullOrBlank()) {
-                Diag.w(
-                    "Auth",
-                    origin = LogOrigin.CLIENT,
-                    attrs = mapOf("event" to "session_expired", "reason" to "no_refresh_token"),
-                ) { "No refresh token available" }
-                return@withLock false
-            }
+            // Any auth rejection ⇒ a genuinely dead session ⇒ route to re-auth, even if a later attempt
+            // hit a transient blip; a purely transient run (5xx / rate-limit / transport) keeps the
+            // session. This fold is the terminal classification for every non-Success exit of the loop.
+            var sawHardRejection = false
+            fun settle(): RefreshResult =
+                if (sawHardRejection) RefreshResult.HardExpired else RefreshResult.Transient
+            repeat(MAX_REFRESH_ATTEMPTS) { attempt ->
+                // Capture the slot's epoch BEFORE the stored-token read, so any teardown of THIS slot
+                // that races the POST below is detected (and its result discarded) with no lock held
+                // across the network call. Re-read each attempt: a teardown or a sibling that landed
+                // between retries must be seen.
+                val epochAtStart = stateMutex.withLock { epochOf(accountKey) }
+                val storedRefreshToken = readValue(refreshKey(accountKey))
+                if (storedRefreshToken.isNullOrBlank()) {
+                    // Attempt 0 with no token = no session at all → hard. A LATER attempt losing the
+                    // token means a teardown (logout/removal) landed mid-loop and already owns the
+                    // routing → Transient, so we don't double-emit session-expired over it.
+                    return@withLock if (attempt == 0) {
+                        Diag.w(
+                            "Auth",
+                            origin = LogOrigin.CLIENT,
+                            attrs = mapOf("event" to "session_expired", "reason" to "no_refresh_token"),
+                        ) { "No refresh token available" }
+                        RefreshResult.HardExpired
+                    } else {
+                        RefreshResult.Transient
+                    }
+                }
 
-            try {
-                val httpResponse: HttpResponse = refreshClient.value
-                    .post(absoluteRefreshUrl ?: REFRESH_PATH) {
-                        header("Cookie", "refreshToken=$storedRefreshToken")
-                        setBody(mapOf("refreshToken" to storedRefreshToken))
+                val delayMillis: Long =
+                    when (val outcome = attemptRefresh(accountKey, epochAtStart, storedRefreshToken, absoluteRefreshUrl)) {
+                        RefreshAttempt.Success -> return@withLock RefreshResult.Refreshed
+                        // A teardown/re-authentication owns the routing for this slot; never double-emit
+                        // a session-expired from here and never re-persist over it.
+                        RefreshAttempt.Discarded -> return@withLock RefreshResult.Transient
+                        RefreshAttempt.KeystoreCleared -> return@withLock RefreshResult.HardExpired
+                        // Server unreachable: retrying now only holds the flight lock across another full
+                        // request timeout; stop. A session already confirmed dead by a prior 401 still
+                        // routes to re-auth; otherwise keep the session (a later request/relaunch recovers).
+                        RefreshAttempt.TransportError -> return@withLock settle()
+                        RefreshAttempt.AuthRejected -> {
+                            sawHardRejection = true
+                            retryBackoffMillis(attempt)
+                        }
+                        RefreshAttempt.Retryable -> retryBackoffMillis(attempt)
+                        is RefreshAttempt.RateLimited -> {
+                            val wait = outcome.retryAfterMillis
+                            // Honor the server's Retry-After when we can wait it out under the flight
+                            // lock; if it exceeds our cap, stop retrying (keep the session) rather than
+                            // re-POSTing while still rate-limited.
+                            if (wait != null && wait > REFRESH_RETRY_MAX_DELAY_MS) {
+                                return@withLock RefreshResult.Transient
+                            }
+                            wait ?: retryBackoffMillis(attempt)
+                        }
                     }
 
-                val body: RefreshResponse = httpResponse.body()
-                val newRefreshToken = CookieHelper.extractRefreshToken(httpResponse.headers)
-                    ?: storedRefreshToken
+                if (attempt < MAX_REFRESH_ATTEMPTS - 1) delay(delayMillis)
+            }
+            // Budget exhausted with no terminal outcome; classify by whether any attempt was rejected.
+            settle()
+        }
 
-                commitRefresh(accountKey, epochAtStart, body.token, newRefreshToken)
-            } catch (e: ClientRequestException) {
-                Diag.w(
-                    "Auth",
-                    origin = LogOrigin.SERVER,
-                    throwable = e,
-                    attrs = mapOf(
-                        "event" to "refresh_failed",
-                        "status" to e.response.status.value.toString(),
-                    ),
-                ) { "Auth error during token refresh" }
-                invalidateRefresh(accountKey, epochAtStart)
-                false
-            } catch (e: Exception) {
-                if (isKeystoreException(e)) {
-                    Diag.e(
-                        "Auth",
-                        origin = LogOrigin.CLIENT,
-                        throwable = e,
-                        attrs = mapOf("event" to "keystore_corruption"),
-                    ) { "Keystore corruption—clearing tokens" }
-                    onKeystoreCorruption()
-                    invalidateRefresh(accountKey, epochAtStart)
-                } else {
+    /** One refresh POST + classification. Caller owns the flight lock and the retry/backoff loop. */
+    private suspend fun attemptRefresh(
+        accountKey: String?,
+        epochAtStart: Int,
+        storedRefreshToken: String,
+        absoluteRefreshUrl: String?,
+    ): RefreshAttempt =
+        try {
+            val httpResponse: HttpResponse = refreshClient.value
+                .post(absoluteRefreshUrl ?: REFRESH_PATH) {
+                    header("Cookie", "refreshToken=$storedRefreshToken")
+                    setBody(mapOf("refreshToken" to storedRefreshToken))
+                }
+            // The refresh client has no response validator, so a non-2xx returns here instead of
+            // throwing — inspect the status directly rather than relying on a deserialization failure.
+            val status = httpResponse.status.value
+            when {
+                status in 200..299 -> handleSuccess(accountKey, epochAtStart, httpResponse, storedRefreshToken)
+                status == 401 || status == 403 -> {
                     Diag.w(
                         "Auth",
-                        origin = LogOrigin.NETWORK,
-                        throwable = e,
-                        attrs = mapOf("event" to "refresh_failed"),
-                    ) { "Error during token refresh" }
+                        origin = LogOrigin.SERVER,
+                        attrs = mapOf("event" to "refresh_rejected", "status" to status.toString()),
+                    ) { "Auth rejected during token refresh" }
+                    RefreshAttempt.AuthRejected
                 }
-                false
+                status == 429 -> {
+                    val retryAfter = parseRetryAfterMillis(httpResponse)
+                    Diag.w(
+                        "Auth",
+                        origin = LogOrigin.SERVER,
+                        attrs = mapOf("event" to "refresh_rate_limited", "status" to "429"),
+                    ) { "Refresh rate-limited" }
+                    RefreshAttempt.RateLimited(retryAfter)
+                }
+                else -> {
+                    Diag.w(
+                        "Auth",
+                        origin = LogOrigin.SERVER,
+                        attrs = mapOf("event" to "refresh_transient", "status" to status.toString()),
+                    ) { "Transient server error during token refresh" }
+                    RefreshAttempt.Retryable
+                }
+            }
+        } catch (e: Exception) {
+            if (isKeystoreException(e)) {
+                Diag.e(
+                    "Auth",
+                    origin = LogOrigin.CLIENT,
+                    throwable = e,
+                    attrs = mapOf("event" to "keystore_corruption"),
+                ) { "Keystore corruption—clearing tokens" }
+                onKeystoreCorruption()
+                invalidateRefresh(accountKey, epochAtStart)
+                RefreshAttempt.KeystoreCleared
+            } else {
+                // Transport failure (timeout / connection reset / DNS): the server is unreachable, so
+                // immediately re-POSTing under the flight lock won't help. Keep the session (don't log
+                // out) and let a later request / relaunch recover.
+                Diag.w(
+                    "Auth",
+                    origin = LogOrigin.NETWORK,
+                    throwable = e,
+                    attrs = mapOf("event" to "refresh_transport_error"),
+                ) { "Network error during token refresh" }
+                RefreshAttempt.TransportError
             }
         }
+
+    /** Parse a `Retry-After` header (delta-seconds form only) into millis; null when absent/unparseable. */
+    private fun parseRetryAfterMillis(httpResponse: HttpResponse): Long? =
+        httpResponse.headers[HttpHeaders.RetryAfter]?.trim()?.toLongOrNull()?.let { it * 1000 }
+
+    /** Parse + commit a 2xx refresh. A malformed body or a discarded commit is not a hard failure. */
+    private suspend fun handleSuccess(
+        accountKey: String?,
+        epochAtStart: Int,
+        httpResponse: HttpResponse,
+        storedRefreshToken: String,
+    ): RefreshAttempt {
+        val body: RefreshResponse = try {
+            httpResponse.body()
+        } catch (e: Exception) {
+            // A 2xx whose body isn't the expected JSON (e.g. an HTML interstitial from a proxy).
+            // Recoverable, not a dead session.
+            Diag.w(
+                "Auth",
+                origin = LogOrigin.SERVER,
+                throwable = e,
+                attrs = mapOf("event" to "refresh_malformed"),
+            ) { "Refresh response body not parseable" }
+            return RefreshAttempt.Retryable
+        }
+        // The backend rotates the refresh token on every successful refresh and returns the new one
+        // via Set-Cookie; persist it. A 2xx without a rotated cookie means the server didn't rotate
+        // (reuse path) — the stored token stays valid, so retain it rather than dropping the slot.
+        val rotated = CookieHelper.extractRefreshToken(httpResponse.headers)
+        if (rotated == null) {
+            Diag.d("Auth", origin = LogOrigin.SERVER) { "Refresh 2xx without rotated cookie; retaining stored token" }
+        }
+        return if (commitRefresh(accountKey, epochAtStart, body.token, rotated ?: storedRefreshToken)) {
+            RefreshAttempt.Success
+        } else {
+            RefreshAttempt.Discarded
+        }
+    }
+
+    /** Equal-jitter exponential backoff between refresh retries, capped (half fixed + half random). */
+    private fun retryBackoffMillis(attempt: Int): Long {
+        val exp = (REFRESH_RETRY_BASE_DELAY_MS shl attempt).coerceAtMost(REFRESH_RETRY_MAX_DELAY_MS)
+        return exp / 2 + Random.nextLong(exp / 2 + 1)
+    }
 
     /** Persist a successful refresh — unless a teardown changed the epoch while the POST was in flight. */
     private suspend fun commitRefresh(
@@ -394,6 +532,30 @@ abstract class CommonTokenDataStore(
 
     protected open fun isKeystoreException(e: Exception): Boolean = false
 
+    /** Classification of a single refresh POST, consumed by [performRefresh]'s retry loop. */
+    private sealed interface RefreshAttempt {
+        /** 2xx parsed + committed. Terminal → [RefreshResult.Refreshed]. */
+        data object Success : RefreshAttempt
+
+        /** A teardown/re-auth of this slot landed mid-POST; the commit was dropped. Terminal → Transient. */
+        data object Discarded : RefreshAttempt
+
+        /** Keystore corruption cleared the slot. Terminal → HardExpired. */
+        data object KeystoreCleared : RefreshAttempt
+
+        /** 401/403 — the session was rejected. Retried (may be a transient server false-negative). */
+        data object AuthRejected : RefreshAttempt
+
+        /** A received 5xx / malformed-2xx response. Retried with local backoff. */
+        data object Retryable : RefreshAttempt
+
+        /** 429 with the server's requested delay (ms), when present. Retried honoring it. */
+        data class RateLimited(val retryAfterMillis: Long?) : RefreshAttempt
+
+        /** Transport failure (server unreachable). Terminal → Transient, so we don't retry under the lock. */
+        data object TransportError : RefreshAttempt
+    }
+
     companion object {
         const val KEY_ACCESS_TOKEN = "access_token"
         const val KEY_REFRESH_TOKEN = "refresh_token"
@@ -402,5 +564,10 @@ abstract class CommonTokenDataStore(
 
         /** [flights] key for the bare (null-account) refresh path. */
         private const val BARE_FLIGHT_KEY = ""
+
+        /** Total refresh attempts (initial + retries) before a persistent failure is classified. */
+        private const val MAX_REFRESH_ATTEMPTS = 3
+        private const val REFRESH_RETRY_BASE_DELAY_MS = 300L
+        private const val REFRESH_RETRY_MAX_DELAY_MS = 2_000L
     }
 }

--- a/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/client/AuthInterceptorTest.kt
+++ b/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/client/AuthInterceptorTest.kt
@@ -24,7 +24,7 @@ class AuthInterceptorTest {
 
     private class FakeTokenManager(
         private var accessToken: String? = "initial-token",
-        private var refreshSucceeds: Boolean = true,
+        private var refreshOutcome: RefreshResult = RefreshResult.Refreshed,
         private var refreshedToken: String = "refreshed-token",
     ) : TokenManager {
         var refreshCallCount = 0
@@ -39,14 +39,10 @@ class AuthInterceptorTest {
             this.accessToken = accessToken
         }
 
-        override suspend fun refreshAccessToken(): Boolean {
+        override suspend fun refreshAccessToken(): RefreshResult {
             refreshCallCount++
-            return if (refreshSucceeds) {
-                accessToken = refreshedToken
-                true
-            } else {
-                false
-            }
+            if (refreshOutcome == RefreshResult.Refreshed) accessToken = refreshedToken
+            return refreshOutcome
         }
 
         override suspend fun clearTokens() {
@@ -65,7 +61,7 @@ class AuthInterceptorTest {
             accessToken = null
         }
 
-        override suspend fun refreshAccessTokenFor(accountId: String, baseUrl: String): Boolean =
+        override suspend fun refreshAccessTokenFor(accountId: String, baseUrl: String): RefreshResult =
             refreshAccessToken()
 
         override suspend fun onAccountResolved(accountId: String) = Unit
@@ -145,7 +141,7 @@ class AuthInterceptorTest {
     fun `refreshes token on 401 and retries`() = runTest {
         val tokenManager = FakeTokenManager(
             accessToken = "expired-token",
-            refreshSucceeds = true,
+            refreshOutcome = RefreshResult.Refreshed,
             refreshedToken = "new-token",
         )
         var requestCount = 0
@@ -174,7 +170,7 @@ class AuthInterceptorTest {
     fun `emits session expired when refresh fails`() = runTest {
         val tokenManager = FakeTokenManager(
             accessToken = "expired-token",
-            refreshSucceeds = false,
+            refreshOutcome = RefreshResult.HardExpired,
         )
 
         val engine = MockEngine {
@@ -189,10 +185,30 @@ class AuthInterceptorTest {
     }
 
     @Test
+    fun `transient refresh failure does not emit session expired`() = runTest {
+        // A recoverable refresh failure (network/5xx/malformed/server false-negative) must NOT log the
+        // user out — the request fails but the session is kept so a later attempt can recover.
+        val tokenManager = FakeTokenManager(
+            accessToken = "expired-token",
+            refreshOutcome = RefreshResult.Transient,
+        )
+
+        val engine = MockEngine {
+            respond("Unauthorized", HttpStatusCode.Unauthorized)
+        }
+        val client = createClient(tokenManager, engine)
+
+        val response = client.get("https://example.com/api/data")
+        assertThat(response.status).isEqualTo(HttpStatusCode.Unauthorized)
+        assertThat(tokenManager.refreshCallCount).isEqualTo(1)
+        assertThat(tokenManager.sessionExpiredCount).isEqualTo(0)
+    }
+
+    @Test
     fun `returns 401 when refreshed token is also expired`() = runTest {
         val tokenManager = FakeTokenManager(
             accessToken = "expired-token",
-            refreshSucceeds = true,
+            refreshOutcome = RefreshResult.Refreshed,
             refreshedToken = "still-expired",
         )
 
@@ -284,7 +300,7 @@ class AuthInterceptorTest {
 
     @Test
     fun `does not refresh-and-retry token to a foreign host on 401`() = runTest {
-        val tokenManager = FakeTokenManager(accessToken = "my-token", refreshSucceeds = true)
+        val tokenManager = FakeTokenManager(accessToken = "my-token", refreshOutcome = RefreshResult.Refreshed)
         var requestCount = 0
 
         val engine = MockEngine {
@@ -308,7 +324,7 @@ class AuthInterceptorTest {
     fun `empty base url falls back to attach-always and exercises 401 retry`() = runTest {
         val tokenManager = FakeTokenManager(
             accessToken = "expired-token",
-            refreshSucceeds = true,
+            refreshOutcome = RefreshResult.Refreshed,
             refreshedToken = "new-token",
         )
         var requestCount = 0
@@ -355,7 +371,7 @@ class AuthInterceptorTest {
     fun `pending-identity request carries the staged bearer and its 401 passes through untouched`() = runTest {
         // Add-account flow: the pending snapshot routes URL + bearer; a 401 must neither refresh any
         // account nor emit the global session-expired signal (which would tear down the live account).
-        val tokenManager = FakeTokenManager(accessToken = "live-a-token", refreshSucceeds = true)
+        val tokenManager = FakeTokenManager(accessToken = "live-a-token", refreshOutcome = RefreshResult.Refreshed)
         var requestCount = 0
         var capturedAuth: String? = null
         var capturedHost: String? = null
@@ -394,7 +410,7 @@ class AuthInterceptorTest {
         // The store decides whether a scoped expiry still matters (it suppresses non-active
         // accounts); the plugin's contract is to pass the snapshot's account along, never a blanket
         // global signal.
-        val tokenManager = FakeTokenManager(accessToken = "a-token", refreshSucceeds = false)
+        val tokenManager = FakeTokenManager(accessToken = "a-token", refreshOutcome = RefreshResult.HardExpired)
         val engine = MockEngine { respond("Unauthorized", HttpStatusCode.Unauthorized) }
         val gate = SwitchGate(
             activeAccountProvider = InMemoryActiveAccountProvider(AccountState.Resolved(AccountId("acct-a"))),

--- a/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/client/SwitchGateTest.kt
+++ b/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/client/SwitchGateTest.kt
@@ -30,14 +30,14 @@ class SwitchGateTest {
         override val isAuthenticated: Boolean get() = liveToken != null
         override suspend fun getAccessToken(): String? = liveToken
         override suspend fun setTokens(accessToken: String, refreshToken: String) = Unit
-        override suspend fun refreshAccessToken(): Boolean = false
+        override suspend fun refreshAccessToken(): RefreshResult = RefreshResult.HardExpired
         override suspend fun clearTokens() = Unit
         override suspend fun getAccessTokenFor(accountId: String): String? = keyed[accountId]
         override suspend fun getStagedAccessToken(): String? = null
         override suspend fun clearStagedTokens() = Unit
         override suspend fun selectAccount(accountId: String) = Unit
         override suspend fun removeAccount(accountId: String) = Unit
-        override suspend fun refreshAccessTokenFor(accountId: String, baseUrl: String): Boolean = false
+        override suspend fun refreshAccessTokenFor(accountId: String, baseUrl: String): RefreshResult = RefreshResult.HardExpired
         override suspend fun onAccountResolved(accountId: String) = Unit
         override suspend fun onAccountCleared() = Unit
         override fun emitSessionExpired(expiredAccountId: String?) = Unit

--- a/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/AuthInterceptorPlugin.kt
+++ b/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/AuthInterceptorPlugin.kt
@@ -129,20 +129,29 @@ class AuthInterceptorPlugin private constructor(
                 }
 
                 Logger.d("Auth") { "401 received, attempting token refresh" }
-                val newToken = plugin.tokenManager.refreshBearerFor(snapshot)
-                if (newToken == null) {
-                    Logger.w("Auth") { "Token refresh failed - session expired" }
-                    plugin.tokenManager.emitSessionExpired(snapshot?.accountId)
-                    return@intercept originalCall
+                when (val refresh = plugin.tokenManager.refreshBearerFor(snapshot)) {
+                    is BearerResult.Refreshed -> {
+                        request.headers {
+                            remove(HttpHeaders.Authorization)
+                            append(HttpHeaders.Authorization, "Bearer ${refresh.token}")
+                        }
+                        request.attributes.put(RetryFlag, true)
+                        execute(request)
+                    }
+                    BearerResult.Expired -> {
+                        // Hard failure: the session is gone. Route the (snapshot's) account to re-auth.
+                        Logger.w("Auth") { "Token refresh failed - session expired" }
+                        plugin.tokenManager.emitSessionExpired(snapshot?.accountId)
+                        originalCall
+                    }
+                    BearerResult.Transient -> {
+                        // Recoverable failure (network/5xx/malformed/server false-negative). Do NOT
+                        // emit session-expired — fail just this request and keep the user signed in so
+                        // a later request (or relaunch) recovers instead of a spurious logout.
+                        Logger.w("Auth") { "Token refresh transient failure - keeping session" }
+                        originalCall
+                    }
                 }
-
-                request.headers {
-                    remove(HttpHeaders.Authorization)
-                    append(HttpHeaders.Authorization, "Bearer $newToken")
-                }
-                request.attributes.put(RetryFlag, true)
-
-                execute(request)
             }
         }
     }

--- a/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/RequestIdentityAuth.kt
+++ b/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/RequestIdentityAuth.kt
@@ -1,22 +1,45 @@
 package com.garfiec.librechat.core.network.client
 
 /**
+ * Result of a shared 401-recovery attempt. [Refreshed] carries the new bearer to retry the request
+ * with; [Expired] is a hard failure that must route the account to re-auth; [Transient] means the
+ * refresh failed in a recoverable way (network/5xx/malformed/a server false-negative) and the caller
+ * must fail just this request **without** tearing down the session — a later request or an app
+ * relaunch can still recover.
+ */
+sealed interface BearerResult {
+    data class Refreshed(val token: String) : BearerResult
+    data object Expired : BearerResult
+    data object Transient : BearerResult
+}
+
+/**
  * The one 401-recovery path shared by every transport (Ktor [AuthInterceptorPlugin] and the iOS raw
  * SSE transport): refresh the account the request was snapshotted for — keyed and URL-pinned to the
  * snapshot, so a switch that raced the request refreshes the right account against the right server,
- * never the live one — and return the refreshed bearer. Without a snapshot (refresh client / tests)
- * falls back to the live active account, preserving legacy behavior.
+ * never the live one. Without a snapshot (refresh client / tests) falls back to the live active
+ * account, preserving legacy behavior.
  *
- * Returns null when the refresh failed or the refreshed slot came back empty (a logout/removal raced
- * the refresh); callers treat null as session-expired for `identity?.accountId`.
+ * Maps the refresh [RefreshResult] to a [BearerResult]: only a genuine [RefreshResult.HardExpired]
+ * (or a refreshed-but-empty slot, meaning a logout/removal raced the refresh) becomes [Expired] and
+ * logs the user out; a [RefreshResult.Transient] becomes [Transient] and keeps the session.
  */
-suspend fun TokenManager.refreshBearerFor(identity: RequestIdentity?): String? {
+suspend fun TokenManager.refreshBearerFor(identity: RequestIdentity?): BearerResult {
     val account = identity?.accountId
-    val refreshed = if (account != null) {
+    val result = if (account != null) {
         refreshAccessTokenFor(account, identity.baseUrl)
     } else {
         refreshAccessToken()
     }
-    if (!refreshed) return null
-    return if (account != null) getAccessTokenFor(account) else getAccessToken()
+    return when (result) {
+        RefreshResult.Refreshed -> {
+            val token = if (account != null) getAccessTokenFor(account) else getAccessToken()
+            // The refresh succeeded but the slot read back empty — a teardown (logout/removal) raced
+            // between the commit and this read. That teardown owns the routing, so treat it as
+            // Transient here rather than emitting a second session-expired over it.
+            if (token != null) BearerResult.Refreshed(token) else BearerResult.Transient
+        }
+        RefreshResult.HardExpired -> BearerResult.Expired
+        RefreshResult.Transient -> BearerResult.Transient
+    }
 }

--- a/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/TokenManager.kt
+++ b/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/TokenManager.kt
@@ -2,12 +2,23 @@ package com.garfiec.librechat.core.network.client
 
 import kotlinx.coroutines.flow.SharedFlow
 
+/**
+ * Outcome of a token refresh, so a caller can tell a **hard** failure (the session is genuinely gone
+ * — route to re-auth) from a **transient** one (network blip, 5xx, a malformed response, or a server
+ * session-lookup false-negative) that must NOT log the user out. The refresh implementation retries
+ * transient failures — and a first-seen auth rejection, since the backend returns the same `401` for a
+ * transiently-missed session as for a truly-expired one — with backoff before settling on
+ * [HardExpired]. A [Transient] result leaves the stored tokens intact so a later attempt (or an app
+ * relaunch) can still recover.
+ */
+enum class RefreshResult { Refreshed, HardExpired, Transient }
+
 interface TokenManager {
     /** Non-suspend check — returns true when an access token is cached in memory. */
     val isAuthenticated: Boolean
     suspend fun getAccessToken(): String?
     suspend fun setTokens(accessToken: String, refreshToken: String)
-    suspend fun refreshAccessToken(): Boolean
+    suspend fun refreshAccessToken(): RefreshResult
 
     /**
      * Full teardown of the active session — keyed tokens, any bare staging keys, and the persisted
@@ -63,7 +74,7 @@ interface TokenManager {
      * account. Distinct from [refreshAccessToken], which refreshes the live active account against the
      * live base URL.
      */
-    suspend fun refreshAccessTokenFor(accountId: String, baseUrl: String): Boolean
+    suspend fun refreshAccessTokenFor(accountId: String, baseUrl: String): RefreshResult
 
     /**
      * Bind token storage to [accountId] once identity resolves (login, cold-start restore, upgrade).

--- a/core/network/src/iosMain/kotlin/com/garfiec/librechat/core/network/sse/SseHttpTransport.ios.kt
+++ b/core/network/src/iosMain/kotlin/com/garfiec/librechat/core/network/sse/SseHttpTransport.ios.kt
@@ -1,6 +1,7 @@
 package com.garfiec.librechat.core.network.sse
 
 import co.touchlab.kermit.Logger
+import com.garfiec.librechat.core.network.client.BearerResult
 import com.garfiec.librechat.core.network.client.LibreChatHttpClient
 import com.garfiec.librechat.core.network.client.SwitchGate
 import com.garfiec.librechat.core.network.client.TokenManager
@@ -118,14 +119,23 @@ actual class SseHttpTransport(
                     // Refresh the snapshot's account (keyed + URL-pinned), never the live active one;
                     // an expiry is likewise scoped to the snapshot's account, so a switched-away
                     // stream's dead credentials can't tear down the live account's session.
-                    val refreshedToken = tokenManager.refreshBearerFor(snapshot)
-                    if (refreshedToken == null) {
-                        Logger.w("SSE-iOS") { "token refresh failed — session expired" }
-                        tokenManager.emitSessionExpired(snapshot.accountId)
-                        throw e
+                    when (val refresh = tokenManager.refreshBearerFor(snapshot)) {
+                        is BearerResult.Refreshed -> {
+                            token = refresh.token
+                            // loop to retry with new token
+                        }
+                        BearerResult.Expired -> {
+                            Logger.w("SSE-iOS") { "token refresh failed — session expired" }
+                            tokenManager.emitSessionExpired(snapshot.accountId)
+                            throw e
+                        }
+                        BearerResult.Transient -> {
+                            // Recoverable refresh failure — surface the stream error without tearing
+                            // down the session; a fresh stream attempt can recover.
+                            Logger.w("SSE-iOS") { "token refresh transient — not logging out" }
+                            throw e
+                        }
                     }
-                    token = refreshedToken
-                    // loop to retry with new token
                 } else {
                     throw e
                 }


### PR DESCRIPTION
## Summary
Token refresh now distinguishes a genuinely expired session from a transient refresh failure (network blip, 5xx, malformed body, rate-limit, or a backend session-lookup false-negative). Only a genuine expiry routes the app to re-auth; transient failures keep the user signed in and let a later request or an app relaunch recover. This fixes the occasional spurious logout to the login screen that a restart would "heal".

## Changes
- **Three-way refresh outcome.** `refreshAccessToken`/`refreshAccessTokenFor` return a `RefreshResult` (`Refreshed` / `HardExpired` / `Transient`) instead of a boolean. The refresh client has no response validator, so a non-2xx returns normally and is classified by HTTP status rather than inferred from a deserialization failure.
- **Bounded retry with backoff.** Up to 3 attempts with jittered (equal-jitter) exponential backoff, run under the existing per-account single-flight lock so a queued same-account 401 waits and reads the rotated token instead of re-POSTing a spent one.
- **401/403 is retried, not immediately terminal.** The backend returns the same 401 for a transiently-missed session as for a truly-expired one; the run is classified `HardExpired` only if any attempt saw an auth rejection, otherwise `Transient`.
- **429 honors `Retry-After`** (delta-seconds) when it fits under the retry cap; a longer delay stops retrying and keeps the session rather than hammering. Transport failures (server unreachable) are terminal without further retries, so the flight lock is not held across repeated request timeouts.
- **Shared transport seam.** Both the Android Ktor `AuthInterceptorPlugin` and the iOS raw-SSE `SseHttpTransport` map the outcome through a `BearerResult`: `Refreshed` retries with the new bearer, `Expired` emits session-expired, `Transient` fails just that request without logging out.

## Testing
- Unit tests: core/data and core/network suites pass, with added coverage for the classification matrix (persistent 401 → HardExpired, 401-recovers-on-retry, 5xx → Transient, unparseable 2xx → Transient, Set-Cookie rotation persisted, transport-after-401 → HardExpired, 429 `Retry-After` beyond cap stops).
- Android `:app:assembleDebug` and iOS `:core:network:compileKotlinIosSimulatorArm64` compile; detekt passes.
- Deployed to a Pixel 9 Pro Fold for manual testing.

## Notes
On a hard expiry the app routes to re-auth but no longer clears the account's stored tokens — an auth-rejected refresh previously dropped the token slot; now the tokens, rows, and roster entry are retained, so a relaunch or re-auth recovers without data loss. Keystore corruption still clears the slot.
