### PR TITLE
feat(chat): jump in-chat search to the focused occurrence

### DIFF
--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -125,7 +125,7 @@ coroutines:
 Compose:
   CompositionLocalAllowlist:
     active: true
-    allowedCompositionLocals: LocalChatMediaViewer,LocalImmediateMarkdown,LocalInlineArtifactPrefs,LocalMermaidRenderCache,LocalOpenArtifact,LocalParsedMarkdownCache,LocalSubagentProgress
+    allowedCompositionLocals: LocalChatMediaViewer,LocalImmediateMarkdown,LocalInlineArtifactPrefs,LocalMermaidRenderCache,LocalOpenArtifact,LocalParsedMarkdownCache,LocalSearchFocusNonce,LocalSubagentProgress
 
 # detekt-koin rule overrides (defaults ship in plugin jar; buildUponDefaultConfig = true)
 koin-rules:

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/components/ContentPartRenderer.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/components/ContentPartRenderer.kt
@@ -2,6 +2,7 @@ package com.garfiec.librechat.feature.chat.components
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.layout.LayoutCoordinates
 import com.garfiec.librechat.core.model.Attachment
 import com.garfiec.librechat.core.model.content.MessageContentPart
@@ -17,7 +18,7 @@ actual fun ContentPartRenderer(
     showImageDescriptions: Boolean,
     searchQuery: String?,
     searchFocusedOccurrence: Int,
-    onFocusedOccurrencePosition: ((LayoutCoordinates) -> Unit)?,
+    onFocusedOccurrencePosition: ((LayoutCoordinates, Rect) -> Unit)?,
 ) {
     ContentPartDispatcher(
         part = part,

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/components/MarkdownContent.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/components/MarkdownContent.kt
@@ -40,12 +40,14 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.layout.LayoutCoordinates
-import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontStyle
@@ -93,7 +95,7 @@ actual fun MarkdownContent(
     useKatex: Boolean,
     searchQuery: String?,
     searchFocusedOccurrence: Int,
-    onFocusedOccurrencePosition: ((LayoutCoordinates) -> Unit)?,
+    onFocusedOccurrencePosition: ((LayoutCoordinates, Rect) -> Unit)?,
     immediate: Boolean,
     streaming: Boolean,
 ) {
@@ -107,10 +109,24 @@ actual fun MarkdownContent(
                 contentDescription = text
             },
     ) {
-        // Track occurrence offset across segments for focused highlighting
-        var occurrenceOffset = 0
+        // Per-segment occurrence base offsets, advanced via countSegmentOccurrences so they stay
+        // identical to the ViewModel-side numbering in SearchMatchEnumeration (mermaid blocks
+        // contribute nothing). Computed once per (segments, query), not every recomposition.
+        val segmentOffsets = remember(segments, searchQuery) {
+            IntArray(segments.size).also { offsets ->
+                if (!searchQuery.isNullOrBlank()) {
+                    var acc = 0
+                    segments.forEachIndexed { i, segment ->
+                        offsets[i] = acc
+                        acc += countSegmentOccurrences(segment, searchQuery)
+                    }
+                }
+            }
+        }
 
         segments.forEachIndexed { index, segment ->
+            val focusedInSegment = if (isSearchActive) searchFocusedOccurrence - segmentOffsets[index] else -1
+
             when (segment) {
                 is MarkdownSegment.CodeBlock -> {
                     if (index > 0) Spacer(modifier = Modifier.height(8.dp))
@@ -124,11 +140,10 @@ actual fun MarkdownContent(
                             code = segment.code,
                             language = segment.language,
                             modifier = Modifier.padding(vertical = 4.dp),
+                            searchQuery = if (isSearchActive) searchQuery else null,
+                            searchFocusedOccurrence = focusedInSegment,
+                            onFocusedMatchPosition = onFocusedOccurrencePosition,
                         )
-                    }
-                    // Code blocks can also contain matches; count them for offset tracking
-                    if (isSearchActive) {
-                        occurrenceOffset += countOccurrences(segment.code, searchQuery!!)
                     }
                     if (index < segments.lastIndex) Spacer(modifier = Modifier.height(8.dp))
                 }
@@ -143,22 +158,23 @@ actual fun MarkdownContent(
                 }
                 is MarkdownSegment.InlineLatexText -> {
                     Column {
+                        // Rebase again per Text run within the segment.
+                        var inlineOffset = 0
                         segment.segments.forEach { inlineSegment ->
                             when (inlineSegment) {
                                 is InlineSegment.Text -> {
                                     if (inlineSegment.text.isNotBlank()) {
                                         if (isSearchActive) {
-                                            val segmentOccurrences = countOccurrences(inlineSegment.text, searchQuery!!)
-                                            val focusedInSegment = searchFocusedOccurrence - occurrenceOffset
-                                            val hasFocus = focusedInSegment in 0 until segmentOccurrences
+                                            val runOccurrences = countOccurrences(inlineSegment.text, searchQuery)
+                                            val focusedInRun = focusedInSegment - inlineOffset
                                             HighlightedTextSegment(
                                                 content = inlineSegment.text,
                                                 searchQuery = searchQuery,
-                                                focusedOccurrence = focusedInSegment,
+                                                focusedOccurrence = focusedInRun,
                                                 fontSizeMultiplier = fontSizeMultiplier,
-                                                onPositioned = if (hasFocus) onFocusedOccurrencePosition else null,
+                                                onFocusedMatchPosition = onFocusedOccurrencePosition,
                                             )
-                                            occurrenceOffset += segmentOccurrences
+                                            inlineOffset += runOccurrences
                                         } else {
                                             MarkdownTextSegment(
                                                 content = inlineSegment.text,
@@ -187,26 +203,21 @@ actual fun MarkdownContent(
                         rows = segment.rows,
                         fontSizeMultiplier = fontSizeMultiplier,
                         modifier = Modifier.padding(vertical = 4.dp),
+                        searchQuery = if (isSearchActive) searchQuery else null,
+                        searchFocusedOccurrence = focusedInSegment,
+                        onFocusedMatchPosition = onFocusedOccurrencePosition,
                     )
-                    if (isSearchActive) {
-                        val tableText = (segment.headers + segment.rows.flatten()).joinToString(" ")
-                        occurrenceOffset += countOccurrences(tableText, searchQuery!!)
-                    }
                     if (index < segments.lastIndex) Spacer(modifier = Modifier.height(8.dp))
                 }
                 is MarkdownSegment.TextBlock -> {
                     if (isSearchActive) {
-                        val segmentOccurrences = countOccurrences(segment.text, searchQuery!!)
-                        val focusedInSegment = searchFocusedOccurrence - occurrenceOffset
-                        val hasFocus = focusedInSegment in 0 until segmentOccurrences
                         HighlightedTextSegment(
                             content = segment.text,
                             searchQuery = searchQuery,
                             focusedOccurrence = focusedInSegment,
                             fontSizeMultiplier = fontSizeMultiplier,
-                            onPositioned = if (hasFocus) onFocusedOccurrencePosition else null,
+                            onFocusedMatchPosition = onFocusedOccurrencePosition,
                         )
-                        occurrenceOffset += segmentOccurrences
                     } else {
                         val hasCitations = remember(segment.text) {
                             segment.text.contains(CITATION_DETECT_REGEX)
@@ -229,56 +240,6 @@ actual fun MarkdownContent(
             }
         }
     }
-}
-
-/**
- * Renders a text segment with search highlight spans. When [onPositioned] is non-null
- * (meaning this segment contains the focused search occurrence), attaches an
- * [onGloballyPositioned] modifier so the parent can fine-tune scroll position.
- */
-@Composable
-private fun HighlightedTextSegment(
-    content: String,
-    searchQuery: String,
-    modifier: Modifier = Modifier,
-    focusedOccurrence: Int = -1,
-    fontSizeMultiplier: Float = 1.0f,
-    onPositioned: ((LayoutCoordinates) -> Unit)? = null,
-) {
-    val bodyStyle = MaterialTheme.typography.bodyLarge
-    val scaledStyle = bodyStyle.scaleFontSize(fontSizeMultiplier)
-    val isDarkTheme = isSystemInDarkTheme()
-    val highlighted = remember(content, searchQuery, focusedOccurrence, isDarkTheme) {
-        buildHighlightedString(content, searchQuery, focusedOccurrence, isDarkTheme)
-    }
-
-    val positionedModifier = if (onPositioned != null) {
-        Modifier.onGloballyPositioned { coordinates ->
-            onPositioned(coordinates)
-        }
-    } else {
-        Modifier
-    }
-
-    Text(
-        text = highlighted,
-        style = scaledStyle,
-        color = MaterialTheme.colorScheme.onSurface,
-        modifier = modifier
-            .fillMaxWidth()
-            .then(positionedModifier),
-    )
-}
-
-/**
- * Scales both fontSize and lineHeight of a TextStyle by the given multiplier.
- * Uses explicit .sp conversion to avoid TextUnit.Unspecified edge cases.
- */
-internal fun TextStyle.scaleFontSize(multiplier: Float): TextStyle {
-    if (multiplier == 1.0f) return this
-    val scaledFontSize = if (fontSize.isSpecified) (fontSize.value * multiplier).sp else fontSize
-    val scaledLineHeight = if (lineHeight.isSpecified) (lineHeight.value * multiplier).sp else lineHeight
-    return copy(fontSize = scaledFontSize, lineHeight = scaledLineHeight)
 }
 
 /**
@@ -349,6 +310,9 @@ private fun MarkdownTableWithFullscreen(
     rows: List<List<String>>,
     modifier: Modifier,
     fontSizeMultiplier: Float = 1.0f,
+    searchQuery: String? = null,
+    searchFocusedOccurrence: Int = -1,
+    onFocusedMatchPosition: ((LayoutCoordinates, Rect) -> Unit)? = null,
 ) {
     var showFullscreen by remember { mutableStateOf(false) }
 
@@ -358,6 +322,9 @@ private fun MarkdownTableWithFullscreen(
             alignments = alignments,
             rows = rows,
             fontSizeMultiplier = fontSizeMultiplier,
+            searchQuery = searchQuery,
+            searchFocusedOccurrence = searchFocusedOccurrence,
+            onFocusedMatchPosition = onFocusedMatchPosition,
         )
 
         IconButton(
@@ -460,7 +427,11 @@ private fun MarkdownTable(
     rows: List<List<String>>,
     modifier: Modifier = Modifier,
     fontSizeMultiplier: Float = 1.0f,
+    searchQuery: String? = null,
+    searchFocusedOccurrence: Int = -1,
+    onFocusedMatchPosition: ((LayoutCoordinates, Rect) -> Unit)? = null,
 ) {
+    val isSearchActive = !searchQuery.isNullOrBlank()
     val textColor = MaterialTheme.colorScheme.onSurface
     val headerBackground = MaterialTheme.colorScheme.surfaceContainerHigh
     val dividerColor = MaterialTheme.colorScheme.outlineVariant
@@ -502,6 +473,27 @@ private fun MarkdownTable(
             .clip(MaterialTheme.shapes.small),
     ) {
         Column {
+            // Per-cell occurrence base offsets, headers-first then rows row-major — the same order
+            // as SearchMatchEnumeration's tableCellTexts. Computed once per (headers, rows, query).
+            val (headerOffsets, rowOffsets) = remember(headers, rows, searchQuery) {
+                val hOffsets = IntArray(headers.size)
+                val rOffsets = rows.map { IntArray(it.size) }
+                if (!searchQuery.isNullOrBlank()) {
+                    var acc = 0
+                    headers.forEachIndexed { i, header ->
+                        hOffsets[i] = acc
+                        acc += countOccurrences(header, searchQuery)
+                    }
+                    rows.forEachIndexed { r, row ->
+                        row.forEachIndexed { c, cell ->
+                            rOffsets[r][c] = acc
+                            acc += countOccurrences(cell, searchQuery)
+                        }
+                    }
+                }
+                hOffsets to rOffsets
+            }
+
             // Header row
             Row(
                 modifier = Modifier
@@ -523,6 +515,9 @@ private fun MarkdownTable(
                         cellWidth = columnWidths[colIndex],
                         paddingH = cellPaddingH,
                         paddingV = cellPaddingV,
+                        searchQuery = searchQuery,
+                        searchFocusedOccurrence = if (isSearchActive) searchFocusedOccurrence - headerOffsets[colIndex] else -1,
+                        onFocusedMatchPosition = onFocusedMatchPosition,
                     )
                 }
             }
@@ -549,6 +544,9 @@ private fun MarkdownTable(
                             cellWidth = columnWidths.getOrElse(colIndex) { columnWidths.last() },
                             paddingH = cellPaddingH,
                             paddingV = cellPaddingV,
+                            searchQuery = searchQuery,
+                            searchFocusedOccurrence = if (isSearchActive) searchFocusedOccurrence - rowOffsets[rowIndex][colIndex] else -1,
+                            onFocusedMatchPosition = onFocusedMatchPosition,
                         )
                     }
                 }
@@ -574,12 +572,28 @@ private fun TableCell(
     paddingH: Dp,
     paddingV: Dp,
     modifier: Modifier = Modifier,
+    searchQuery: String? = null,
+    searchFocusedOccurrence: Int = -1,
+    onFocusedMatchPosition: ((LayoutCoordinates, Rect) -> Unit)? = null,
 ) {
     val textAlign = when (alignment) {
         TableCellAlignment.LEFT -> TextAlign.Start
         TableCellAlignment.CENTER -> TextAlign.Center
         TableCellAlignment.RIGHT -> TextAlign.End
     }
+
+    val isDarkTheme = isSystemInDarkTheme()
+    val display = remember(text, searchQuery, searchFocusedOccurrence, isDarkTheme) {
+        if (searchQuery.isNullOrBlank()) {
+            AnnotatedString(text)
+        } else {
+            buildHighlightedString(text, searchQuery, searchFocusedOccurrence, isDarkTheme)
+        }
+    }
+    val focusedRange = remember(text, searchQuery, searchFocusedOccurrence) {
+        if (searchQuery.isNullOrBlank()) null else findOccurrenceRange(text, searchQuery, searchFocusedOccurrence)
+    }
+    var layoutResult by remember { mutableStateOf<TextLayoutResult?>(null) }
 
     Box(
         modifier = modifier
@@ -592,12 +606,18 @@ private fun TableCell(
         },
     ) {
         Text(
-            text = text,
+            text = display,
             style = style,
             color = color,
             textAlign = textAlign,
-            maxLines = 10,
+            // Only the cell holding the focused match needs full layout so its wrapped-line rect
+            // reports accurately (getBoundingBox clamps to laid-out lines). Every other cell — even
+            // while search is open — keeps the 10-line clamp so opening search doesn't balloon whole
+            // tables. focusedRange is non-null exactly for the focused cell.
+            maxLines = if (focusedRange != null) Int.MAX_VALUE else 10,
             overflow = TextOverflow.Ellipsis,
+            onTextLayout = { layoutResult = it },
+            modifier = Modifier.reportFocusedMatchPosition(layoutResult, focusedRange, onFocusedMatchPosition),
         )
     }
 }

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/components/MessageBubble.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/components/MessageBubble.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.compositeOver
+import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.layout.LayoutCoordinates
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -70,7 +71,7 @@ actual fun MessageBubble(
     isSearchMatch: Boolean,
     isCurrentSearchMatch: Boolean,
     searchFocusedOccurrence: Int,
-    onFocusedOccurrencePosition: ((LayoutCoordinates) -> Unit)?,
+    onFocusedOccurrencePosition: ((LayoutCoordinates, Rect) -> Unit)?,
     useKatex: Boolean,
     chatLayoutStyle: String,
     showAvatars: Boolean,
@@ -192,7 +193,7 @@ private fun ThreadMessageBubble(
     isSearchMatch: Boolean,
     isCurrentSearchMatch: Boolean,
     searchFocusedOccurrence: Int,
-    onFocusedOccurrencePosition: ((LayoutCoordinates) -> Unit)?,
+    onFocusedOccurrencePosition: ((LayoutCoordinates, Rect) -> Unit)?,
     showAvatars: Boolean,
     showBubbles: Boolean,
 ) {
@@ -395,7 +396,7 @@ private fun TwoSidedMessageBubble(
     isSearchMatch: Boolean,
     isCurrentSearchMatch: Boolean,
     searchFocusedOccurrence: Int,
-    onFocusedOccurrencePosition: ((LayoutCoordinates) -> Unit)?,
+    onFocusedOccurrencePosition: ((LayoutCoordinates, Rect) -> Unit)?,
     showAvatars: Boolean,
     showBubbles: Boolean,
 ) {

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatContent.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatContent.kt
@@ -196,7 +196,7 @@ private fun ChatMessageListPane(
         searchQuery = if (uiState.isSearchOpen) uiState.searchQuery else null,
         searchMatchIndices = uiState.searchMatchIndices,
         currentSearchMatchIndex = uiState.currentSearchMatchIndex,
-        searchScrollToIndex = uiState.searchScrollToIndex,
+        searchFocusRequest = uiState.searchFocusRequest,
         onSearchScrollHandle = viewModel::onSearchScrollHandled,
         bottomContentPadding = bottomContentPadding,
         topContentPadding = topContentPadding,

--- a/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/components/SearchMatchEnumerationTest.kt
+++ b/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/components/SearchMatchEnumerationTest.kt
@@ -1,0 +1,185 @@
+package com.garfiec.librechat.feature.chat.components
+
+import com.garfiec.librechat.core.model.ContentType
+import com.garfiec.librechat.core.model.Message
+import com.garfiec.librechat.core.model.content.MessageContentPart
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Consistency contract for the shared render-order occurrence enumeration
+ * (SearchMatchEnumeration). Both the ViewModel (InConversationSearchDelegate)
+ * and the renderers count via these helpers; any drift focuses the wrong match,
+ * so these tests pin the counting rules the render walk must follow.
+ */
+class SearchMatchEnumerationTest {
+
+    private fun message(text: String = "", parts: List<MessageContentPart>? = null) = Message(
+        messageId = "m1",
+        conversationId = "c1",
+        text = text,
+        content = parts,
+    )
+
+    private fun textPart(text: String) = MessageContentPart(type = ContentType.TEXT, text = text)
+    private fun thinkPart(think: String) = MessageContentPart(type = ContentType.THINK, think = think)
+
+    // --- plain text / fallback (no parts) ---
+
+    @Test
+    fun `no-parts message counts occurrences in message text`() {
+        val msg = message(text = "foo bar foo baz foo")
+        assertThat(countMessageOccurrences(msg, "foo")).isEqualTo(3)
+    }
+
+    @Test
+    fun `counting is case-insensitive`() {
+        val msg = message(text = "Foo FOO foo fOo")
+        assertThat(countMessageOccurrences(msg, "foo")).isEqualTo(4)
+    }
+
+    @Test
+    fun `blank query yields zero`() {
+        assertThat(countMessageOccurrences(message(text = "anything"), "")).isEqualTo(0)
+    }
+
+    // --- code blocks ---
+
+    @Test
+    fun `code fence language tag is not counted`() {
+        // "python" appears only as the fence's language tag, never in the code body.
+        val msg = message(text = "```python\nprint('hello')\n```")
+        assertThat(countMessageOccurrences(msg, "python")).isEqualTo(0)
+    }
+
+    @Test
+    fun `matches inside code body are counted`() {
+        val msg = message(text = "```kotlin\nval x = x + x\n```")
+        assertThat(countMessageOccurrences(msg, "x")).isEqualTo(3)
+    }
+
+    @Test
+    fun `mermaid code block occurrences are not counted`() {
+        // Mermaid renders as a WebView diagram with no text layout; occurrences there
+        // are not navigable, so the enumerator must skip them to stay consistent.
+        val msg = message(text = "```mermaid\ngraph TD; graph --> node\n```")
+        assertThat(countMessageOccurrences(msg, "graph")).isEqualTo(0)
+    }
+
+    // --- tables (per-cell) ---
+
+    @Test
+    fun `table matches are counted per cell across headers and rows`() {
+        val table = """
+            | Name | Value |
+            |------|-------|
+            | foo  | foo   |
+            | bar  | foo   |
+        """.trimIndent()
+        // headers: "Name","Value" (0) + rows: foo,foo,bar,foo (3 foos)
+        assertThat(countMessageOccurrences(message(text = table), "foo")).isEqualTo(3)
+    }
+
+    @Test
+    fun `table cell texts are ordered headers-first then rows row-major`() {
+        val table = """
+            | A | B |
+            |---|---|
+            | c | d |
+            | e | f |
+        """.trimIndent()
+        val segment = parseMarkdownSegments(table)
+            .filterIsInstance<MarkdownSegment.Table>()
+            .single()
+        assertThat(tableCellTexts(segment)).containsExactly("A", "B", "c", "d", "e", "f").inOrder()
+    }
+
+    // --- multi-part text + think ---
+
+    @Test
+    fun `occurrences sum across text and think parts in order`() {
+        val msg = message(
+            parts = listOf(
+                textPart("alpha beta"),
+                thinkPart("beta beta"),
+                textPart("beta"),
+            ),
+        )
+        // text: 1, think: 2, text: 1
+        assertThat(countMessageOccurrences(msg, "beta")).isEqualTo(4)
+    }
+
+    @Test
+    fun `non-searchable part types contribute nothing`() {
+        val msg = message(
+            parts = listOf(
+                textPart("match"),
+                MessageContentPart(type = ContentType.TOOL_CALL, text = "match match"),
+                MessageContentPart(type = ContentType.ERROR, text = "match"),
+            ),
+        )
+        assertThat(countMessageOccurrences(msg, "match")).isEqualTo(1)
+    }
+
+    @Test
+    fun `parts present takes precedence over message text fallback`() {
+        // When content parts exist, message.text must NOT be double-counted.
+        val msg = message(text = "ghost ghost", parts = listOf(textPart("ghost")))
+        assertThat(countMessageOccurrences(msg, "ghost")).isEqualTo(1)
+    }
+
+    // --- findOccurrenceRange ---
+
+    @Test
+    fun `findOccurrenceRange returns nth match range case-insensitively`() {
+        val text = "Foo foo FOO"
+        assertThat(findOccurrenceRange(text, "foo", 0)).isEqualTo(0 until 3)
+        assertThat(findOccurrenceRange(text, "foo", 1)).isEqualTo(4 until 7)
+        assertThat(findOccurrenceRange(text, "foo", 2)).isEqualTo(8 until 11)
+    }
+
+    @Test
+    fun `findOccurrenceRange out of range is null`() {
+        assertThat(findOccurrenceRange("foo foo", "foo", 2)).isNull()
+        assertThat(findOccurrenceRange("foo", "foo", -1)).isNull()
+    }
+
+    @Test
+    fun `findOccurrenceRange stays aligned after a character whose lowercase changes length`() {
+        // U+0130 (Turkish 'İ') lowercases to two chars ("i" + combining dot). Indexing a
+        // lowercased copy would shift this range by one; matching the original string keeps it exact.
+        val text = "İ foo" // 'İ' at 0, space at 1, "foo" at 2..4
+        assertThat(findOccurrenceRange(text, "foo", 0)).isEqualTo(2 until 5)
+    }
+
+    @Test
+    fun `highlight span anchors to original offsets after a length-changing lowercase`() {
+        val text = "İ foo"
+        val span = buildHighlightedString(text, "foo").spanStyles.single()
+        assertThat(span.start).isEqualTo(2)
+        assertThat(span.end).isEqualTo(5)
+    }
+
+    // --- render-side rebasing contract ---
+
+    @Test
+    fun `per-part offset rebasing partitions every global occurrence into exactly one part`() {
+        // Reproduces the walk in MessageContentAndActions: each part resolves the focused
+        // occurrence as (global - runningOffset). Every message-wide occurrence index must land
+        // in exactly one part (no gaps, no overlaps) or prev/next focuses the wrong part.
+        val parts = listOf(textPart("beta beta"), thinkPart("beta"), textPart("x beta beta"))
+        val counts = parts.map { countPartOccurrences(it, "beta") }
+        val total = countMessageOccurrences(message(parts = parts), "beta")
+        assertThat(total).isEqualTo(counts.sum())
+
+        for (global in 0 until total) {
+            var offset = 0
+            val owners = parts.indices.filter { i ->
+                val local = global - offset
+                offset += counts[i]
+                local in 0 until counts[i]
+            }
+            assertThat(owners).hasSize(1)
+        }
+    }
+}

--- a/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/InConversationSearchDelegateTest.kt
+++ b/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/InConversationSearchDelegateTest.kt
@@ -1,0 +1,169 @@
+package com.garfiec.librechat.feature.chat.viewmodel.delegate
+
+import com.garfiec.librechat.core.model.ContentType
+import com.garfiec.librechat.core.model.Message
+import com.garfiec.librechat.core.model.content.MessageContentPart
+import com.garfiec.librechat.feature.chat.util.MessageNode
+import com.garfiec.librechat.feature.chat.viewmodel.ChatStateHandle
+import com.garfiec.librechat.feature.chat.viewmodel.ChatUiState
+import com.garfiec.librechat.feature.chat.viewmodel.SearchMatch
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.TestScope
+import org.junit.Test
+
+/**
+ * Behavior tests for [InConversationSearchDelegate]: it flattens matches via the shared
+ * render-order enumeration and emits a [com.garfiec.librechat.feature.chat.viewmodel.SearchFocusRequest]
+ * carrying the occurrence index the renderer will resolve. Each request must carry a fresh
+ * monotonic id so consecutive navigations (even to the same match) re-fire the scroll effect.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class InConversationSearchDelegateTest {
+
+    private val stateFlow = MutableStateFlow(ChatUiState())
+    private val stateHandle = ChatStateHandle(stateFlow, TestScope())
+    private val delegate = InConversationSearchDelegate(stateHandle)
+
+    private val state get() = stateFlow.value
+
+    private fun node(text: String) = MessageNode(
+        message = Message(messageId = "m", conversationId = "c", text = text),
+        children = emptyList(),
+        siblingIndex = 0,
+        siblingCount = 1,
+    )
+
+    private fun seed(vararg texts: String) {
+        stateFlow.value = ChatUiState(displayMessages = texts.map { node(it) })
+    }
+
+    /** A parallel (Compare-Models) message: a primary-agent part plus an added-agent (`____1`) part. */
+    private fun parallelNode(primaryText: String, secondaryText: String) = MessageNode(
+        message = Message(
+            messageId = "m",
+            conversationId = "c",
+            content = listOf(
+                MessageContentPart(type = ContentType.TEXT, text = primaryText, agentId = "agent_primary"),
+                MessageContentPart(type = ContentType.TEXT, text = secondaryText, agentId = "agent_primary____1"),
+            ),
+        ),
+        children = emptyList(),
+        siblingIndex = 0,
+        siblingCount = 1,
+    )
+
+    @Test
+    fun `parallel turn counts only the primary agent's occurrences`() {
+        // The single/primary list renders only the primary-agent parts (collapseParallelToPrimary),
+        // so the secondary "foo foo" must NOT inflate the match list or shift occurrence indices.
+        stateFlow.value = ChatUiState(displayMessages = listOf(parallelNode("foo", "foo foo")))
+        delegate.onSearchQueryChanged("foo")
+
+        assertThat(state.searchMatchIndices).containsExactly(
+            SearchMatch(messageIndex = 0, occurrenceInMessage = 0),
+        )
+    }
+
+    @Test
+    fun `query change flattens per-occurrence matches across messages`() {
+        seed("foo foo", "bar", "foo")
+        delegate.onSearchQueryChanged("foo")
+
+        assertThat(state.searchMatchIndices).containsExactly(
+            SearchMatch(messageIndex = 0, occurrenceInMessage = 0),
+            SearchMatch(messageIndex = 0, occurrenceInMessage = 1),
+            SearchMatch(messageIndex = 2, occurrenceInMessage = 0),
+        ).inOrder()
+    }
+
+    @Test
+    fun `query change focuses the first match`() {
+        seed("foo foo", "foo")
+        delegate.onSearchQueryChanged("foo")
+
+        assertThat(requireNotNull(state.searchFocusRequest).messageIndex).isEqualTo(0)
+        assertThat(state.currentSearchMatchIndex).isEqualTo(0)
+        assertThat(state.searchMatchIndices[state.currentSearchMatchIndex])
+            .isEqualTo(SearchMatch(messageIndex = 0, occurrenceInMessage = 0))
+    }
+
+    @Test
+    fun `next advances focus to the next occurrence in the same message`() {
+        seed("foo foo foo")
+        delegate.onSearchQueryChanged("foo")
+        delegate.nextSearchMatch()
+
+        assertThat(requireNotNull(state.searchFocusRequest).messageIndex).isEqualTo(0)
+        assertThat(state.searchMatchIndices[state.currentSearchMatchIndex])
+            .isEqualTo(SearchMatch(messageIndex = 0, occurrenceInMessage = 1))
+    }
+
+    @Test
+    fun `next wraps around past the last match`() {
+        seed("foo", "foo")
+        delegate.onSearchQueryChanged("foo")
+        delegate.nextSearchMatch() // -> index 1
+        delegate.nextSearchMatch() // wraps -> index 0
+
+        assertThat(state.currentSearchMatchIndex).isEqualTo(0)
+        assertThat(state.searchFocusRequest?.messageIndex).isEqualTo(0)
+    }
+
+    @Test
+    fun `previous wraps from first to last`() {
+        seed("foo", "bar foo")
+        delegate.onSearchQueryChanged("foo")
+        delegate.previousSearchMatch()
+
+        assertThat(state.currentSearchMatchIndex).isEqualTo(1)
+        assertThat(state.searchFocusRequest?.messageIndex).isEqualTo(1)
+    }
+
+    @Test
+    fun `each navigation carries a fresh request id even for the same match`() {
+        seed("only")
+        delegate.onSearchQueryChanged("only")
+        val first = requireNotNull(state.searchFocusRequest).requestId
+
+        // Single match: next wraps to the same match, but the id must still change so
+        // the LaunchedEffect re-fires and re-scrolls.
+        delegate.nextSearchMatch()
+        val second = requireNotNull(state.searchFocusRequest).requestId
+
+        assertThat(second).isNotEqualTo(first)
+    }
+
+    @Test
+    fun `scroll handled clears the focus request`() {
+        seed("foo")
+        delegate.onSearchQueryChanged("foo")
+        assertThat(state.searchFocusRequest).isNotNull()
+
+        delegate.onSearchScrollHandled()
+        assertThat(state.searchFocusRequest).isNull()
+    }
+
+    @Test
+    fun `blank query clears matches and focus`() {
+        seed("foo")
+        delegate.onSearchQueryChanged("foo")
+        delegate.onSearchQueryChanged("")
+
+        assertThat(state.searchMatchIndices).isEmpty()
+        assertThat(state.searchFocusRequest).isNull()
+    }
+
+    @Test
+    fun `close resets search state`() {
+        seed("foo")
+        delegate.onSearchQueryChanged("foo")
+        delegate.closeSearch()
+
+        assertThat(state.isSearchOpen).isFalse()
+        assertThat(state.searchQuery).isEmpty()
+        assertThat(state.searchMatchIndices).isEmpty()
+        assertThat(state.searchFocusRequest).isNull()
+    }
+}

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/CodeBlock.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/CodeBlock.kt
@@ -6,6 +6,7 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
 import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -31,11 +32,14 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.LayoutCoordinates
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontStyle
@@ -53,6 +57,12 @@ fun CodeBlock(
     code: String,
     language: String?,
     modifier: Modifier = Modifier,
+    // In-conversation search: overlays yellow/orange match spans on the syntax
+    // highlighting; when this block owns the focused occurrence, reports its
+    // rect (in the code Text's coordinates) for precise scroll positioning.
+    searchQuery: String? = null,
+    searchFocusedOccurrence: Int = -1,
+    onFocusedMatchPosition: ((LayoutCoordinates, Rect) -> Unit)? = null,
 ) {
     var showCopied by remember { mutableStateOf(false) }
 
@@ -130,9 +140,23 @@ fun CodeBlock(
                 .horizontalScroll(rememberScrollState())
                 .padding(12.dp),
         ) {
-            val highlightedCode = remember(code, language) {
-                highlightSyntax(code, language?.lowercase())
+            val isDarkTheme = isSystemInDarkTheme()
+            val highlightedCode = remember(code, language, searchQuery, searchFocusedOccurrence, isDarkTheme) {
+                val syntax = highlightSyntax(code, language?.lowercase())
+                if (searchQuery.isNullOrBlank()) {
+                    syntax
+                } else {
+                    addSearchSpans(syntax, searchQuery, searchFocusedOccurrence, isDarkTheme)
+                }
             }
+            val focusedRange = remember(code, searchQuery, searchFocusedOccurrence) {
+                if (searchQuery.isNullOrBlank()) {
+                    null
+                } else {
+                    findOccurrenceRange(code, searchQuery, searchFocusedOccurrence)
+                }
+            }
+            var layoutResult by remember { mutableStateOf<TextLayoutResult?>(null) }
             Text(
                 text = highlightedCode,
                 style = MaterialTheme.typography.bodyMedium.copy(
@@ -140,6 +164,8 @@ fun CodeBlock(
                     fontSize = 13.sp,
                     lineHeight = 20.sp,
                 ),
+                onTextLayout = { layoutResult = it },
+                modifier = Modifier.reportFocusedMatchPosition(layoutResult, focusedRange, onFocusedMatchPosition),
             )
         }
     }

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/CollapsibleContentParts.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/CollapsibleContentParts.kt
@@ -24,6 +24,8 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -31,6 +33,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.LayoutCoordinates
 import androidx.compose.ui.semantics.Role
@@ -42,6 +45,15 @@ import com.garfiec.librechat.feature.chat.resources.*
 import com.garfiec.librechat.feature.chat.resources.Res
 import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.stringResource
+
+/**
+ * Monotonic id of the current in-conversation-search focus request (see `SearchFocusRequest`),
+ * provided by `MessageList` only around the current-match bubble (0L elsewhere, so unrelated
+ * bubbles never recompose on navigation). A collapsible block that holds the focused match keys
+ * its auto-expand on this so re-navigating to the *same* occurrence — even after the user manually
+ * collapsed it — re-opens the card; the plain occurrence index alone wouldn't change on a re-focus.
+ */
+internal val LocalSearchFocusNonce = compositionLocalOf { 0L }
 
 // ─── CollapsibleDisclosureCard ──────────────────────────────────────
 
@@ -60,9 +72,18 @@ private fun CollapsibleDisclosureCard(
     expandActionContentDescription: StringResource,
     collapseActionContentDescription: StringResource,
     modifier: Modifier = Modifier,
+    // Flips the card open when it becomes true (find-in-page expands folded regions);
+    // the user can still collapse it manually afterwards.
+    autoExpand: Boolean = false,
+    // Re-arms the auto-expand each time it changes, so navigating to a *different* focused match
+    // inside the same block re-opens it even if the user manually collapsed it after the last jump.
+    autoExpandKey: Any? = null,
     body: @Composable () -> Unit,
 ) {
     var isExpanded by remember { mutableStateOf(false) }
+    LaunchedEffect(autoExpand, autoExpandKey) {
+        if (autoExpand) isExpanded = true
+    }
     val toggleContentDescription =
         stringResource(if (isExpanded) collapseActionContentDescription else expandActionContentDescription)
 
@@ -124,8 +145,14 @@ internal fun ThinkingContentPart(
     useKatex: Boolean = false,
     searchQuery: String? = null,
     searchFocusedOccurrence: Int = -1,
-    onFocusedOccurrencePosition: ((LayoutCoordinates) -> Unit)? = null,
+    onFocusedOccurrencePosition: ((LayoutCoordinates, Rect) -> Unit)? = null,
 ) {
+    // The focused occurrence index is already rebased to this part; when it falls
+    // inside the thinking text, pop the card open so the match can be scrolled to.
+    val containsFocusedMatch = remember(thinkingText, searchQuery, searchFocusedOccurrence) {
+        searchFocusedOccurrence >= 0 && !searchQuery.isNullOrBlank() &&
+            searchFocusedOccurrence < countMarkdownOccurrences(thinkingText, searchQuery)
+    }
     CollapsibleDisclosureCard(
         leadingIcon = Icons.Default.Psychology,
         leadingIconContentDescription = stringResource(Res.string.cd_thinking_indicator),
@@ -133,6 +160,12 @@ internal fun ThinkingContentPart(
         expandActionContentDescription = Res.string.cd_expand_thinking,
         collapseActionContentDescription = Res.string.cd_collapse_thinking,
         modifier = modifier,
+        autoExpand = containsFocusedMatch,
+        // Re-arm on every navigation: LocalSearchFocusNonce changes per focus request, so both
+        // moving to a different occurrence in this block AND returning to the same one (after a
+        // manual collapse) re-open the card — the rebased occurrence index alone wouldn't change
+        // on a re-focus of the same match.
+        autoExpandKey = LocalSearchFocusNonce.current,
     ) {
         MarkdownContent(
             thinkingText,

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/MessageContentAndActions.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/MessageContentAndActions.kt
@@ -27,8 +27,10 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.layout.LayoutCoordinates
 import androidx.compose.ui.unit.dp
 import com.garfiec.librechat.core.model.Message
@@ -179,7 +181,7 @@ internal fun MessageContentAndActions(
     isSearchMatch: Boolean,
     isCurrentSearchMatch: Boolean,
     searchFocusedOccurrence: Int,
-    onFocusedOccurrencePosition: ((LayoutCoordinates) -> Unit)?,
+    onFocusedOccurrencePosition: ((LayoutCoordinates, Rect) -> Unit)?,
     showActions: Boolean,
     siblingIndex: Int,
     siblingCount: Int,
@@ -239,7 +241,24 @@ internal fun MessageContentAndActions(
 
             val contentParts = message.content
             if (!contentParts.isNullOrEmpty()) {
-                contentParts.forEach { part ->
+                // Occurrence indices are message-wide (SearchMatchEnumeration): rebase them
+                // per part so each part resolves the focused occurrence within itself. The focused
+                // message contains the query by definition, so the fast-path bail never triggers —
+                // compute each part's starting offset once (not on every recomposition, which would
+                // re-parse every part's markdown each animateScrollBy frame).
+                val partOffsets = remember(contentParts, searchQuery, isCurrentSearchMatch) {
+                    val offsets = IntArray(contentParts.size)
+                    if (isCurrentSearchMatch && !searchQuery.isNullOrBlank()) {
+                        var acc = 0
+                        contentParts.forEachIndexed { i, part ->
+                            offsets[i] = acc
+                            acc += countPartOccurrences(part, searchQuery)
+                        }
+                    }
+                    offsets
+                }
+                contentParts.forEachIndexed { index, part ->
+                    val focusedInPart = if (isCurrentSearchMatch) searchFocusedOccurrence - partOffsets[index] else -1
                     ContentPartRenderer(
                         part = part,
                         baseUrl = baseUrl,
@@ -248,7 +267,7 @@ internal fun MessageContentAndActions(
                         attachments = message.attachments.orEmpty(),
                         showImageDescriptions = showImageDescriptions,
                         searchQuery = if (isSearchMatch) searchQuery else null,
-                        searchFocusedOccurrence = if (isCurrentSearchMatch) searchFocusedOccurrence else -1,
+                        searchFocusedOccurrence = focusedInPart,
                         onFocusedOccurrencePosition = if (isCurrentSearchMatch) onFocusedOccurrencePosition else null,
                         modifier = Modifier.padding(vertical = 2.dp),
                     )

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/MessageList.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/MessageList.kt
@@ -1,6 +1,8 @@
 package com.garfiec.librechat.feature.chat.components
 
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.spring
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.gestures.animateScrollBy
@@ -35,9 +37,12 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.layout.boundsInRoot
+import androidx.compose.ui.layout.LayoutCoordinates
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -50,10 +55,14 @@ import com.garfiec.librechat.feature.chat.resources.*
 import com.garfiec.librechat.feature.chat.resources.Res
 import com.garfiec.librechat.feature.chat.util.MessageNode
 import com.garfiec.librechat.feature.chat.viewmodel.ActiveToolCall
+import com.garfiec.librechat.feature.chat.viewmodel.SearchFocusRequest
 import com.garfiec.librechat.feature.chat.viewmodel.SearchMatch
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
 import org.jetbrains.compose.resources.stringResource
+import kotlin.math.abs
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -95,7 +104,7 @@ fun MessageList(
     searchQuery: String? = null,
     searchMatchIndices: List<SearchMatch> = emptyList(),
     currentSearchMatchIndex: Int = 0,
-    searchScrollToIndex: Int? = null,
+    searchFocusRequest: SearchFocusRequest? = null,
     onSearchScrollHandle: () -> Unit = {},
     // Scrollable bottom inset that keeps the latest content clear of the overlaid input bar. The
     // caller measures the actual bar height (which grows as queued ghost rows stack above the
@@ -191,22 +200,58 @@ fun MessageList(
     // or any other display-list change — only streaming and initial load.
     // ─────────────────────────────────────────────────────────────────
 
-    // Track whether we need a fine-tune scroll after the item scroll completes.
-    // When the focused occurrence's HighlightedTextSegment reports its layout position,
-    // we compare it against the viewport and animateScrollBy the delta if needed.
-    var pendingFineTuneScroll by remember { mutableStateOf(false) }
+    // ── Search focus scroll ───────────────────────────────────────────
+    // Two-phase, race-free jump to the focused search occurrence:
+    //   Phase 1: scrollToItem composes the target message (a LazyColumn item
+    //            composes fully even when taller than the viewport), like a
+    //            browser's instant find-in-page jump.
+    //   Phase 2: the focused segment reports its live LayoutCoordinates plus
+    //            the match's rect within it on every position pass (keyed
+    //            state, never a consumable flag — reports for a stale target
+    //            are simply ignored). Once a report matching the CURRENT
+    //            request exists, one animateScrollBy places the match on the
+    //            browser-style anchor line (~1/3 down the usable viewport).
+    var listCoordinates by remember { mutableStateOf<LayoutCoordinates?>(null) }
+    var focusedMatchReport by remember { mutableStateOf<FocusedSearchMatchReport?>(null) }
     val currentOnSearchScrollHandled by rememberUpdatedState(onSearchScrollHandle)
 
-    // Scroll to search match when navigating prev/next
-    LaunchedEffect(searchScrollToIndex) {
-        val index = searchScrollToIndex
-        if (index != null && index in displayMessages.indices) {
-            pendingFineTuneScroll = true
-            listState.animateScrollToItem(index)
-            // After scroll completes, the focused segment will report its position
-            // via onGloballyPositioned, and the fine-tune scroll will happen there.
-            currentOnSearchScrollHandled()
+    // Drop the held LayoutCoordinates once search closes.
+    LaunchedEffect(searchQuery) {
+        if (searchQuery == null) focusedMatchReport = null
+    }
+
+    LaunchedEffect(searchFocusRequest) {
+        val request = searchFocusRequest ?: return@LaunchedEffect
+        if (request.messageIndex !in displayMessages.indices) return@LaunchedEffect
+
+        val viewportHeight = listState.layoutInfo.viewportSize.height.toFloat()
+        val anchorLine = topContentPaddingPx + (viewportHeight - topContentPaddingPx) / 3f
+
+        // Only jump when the target message isn't laid out yet; a far jump is expected to be
+        // instant. When it's already composed (next/prev within the same or a visible message),
+        // skip the jump so phase 2 animates straight to the match with no teleport-then-reverse.
+        val alreadyLaidOut = listState.layoutInfo.visibleItemsInfo.any { it.index == request.messageIndex }
+        if (!alreadyLaidOut) {
+            listState.scrollToItem(request.messageIndex, scrollOffset = -anchorLine.toInt())
         }
+
+        val report = withTimeoutOrNull(SEARCH_FOCUS_REPORT_TIMEOUT_MS) {
+            snapshotFlow { focusedMatchReport }
+                .first { it != null && it.matches(request) && it.coordinates.isAttached }
+        }
+
+        val listCoords = listCoordinates
+        if (report != null && listCoords != null && listCoords.isAttached && report.coordinates.isAttached) {
+            val matchTop = listCoords.localPositionOf(
+                report.coordinates,
+                Offset(0f, report.matchRect.top),
+            ).y
+            val delta = matchTop - anchorLine
+            if (abs(delta) > 1f) {
+                listState.animateScrollBy(delta, SearchFocusScrollSpec)
+            }
+        }
+        currentOnSearchScrollHandled()
     }
 
     // Determine the currently focused SearchMatch
@@ -341,6 +386,7 @@ fun MessageList(
         LazyColumn(
             modifier = Modifier
                 .fillMaxSize()
+                .onGloballyPositioned { listCoordinates = it }
                 .pointerInput(Unit) {
                     awaitPointerEventScope {
                         while (true) {
@@ -375,16 +421,16 @@ fun MessageList(
 
                 val isMatch = index in searchMatchMessageIndexSet
                 val isCurrent = currentSearchMatch != null && index == currentSearchMatch.messageIndex
-                // Determine which occurrence in this message is focused
-                val focusedOccurrenceInMessage = if (isCurrent) {
-                    currentSearchMatch?.occurrenceInMessage ?: -1
-                } else {
-                    -1
-                }
+                // Which occurrence within this message is focused (-1 when this isn't the current match).
+                val focusedOccurrenceInMessage = if (isCurrent) currentSearchMatch.occurrenceInMessage else -1
 
                 // Last message parses markdown synchronously; see [LocalImmediateMarkdown].
+                // Publish the focus-request nonce only around the current match so a collapsible
+                // block re-arms its auto-expand on every navigation (even back to the same match);
+                // non-current bubbles see 0L and don't recompose on navigation.
                 CompositionLocalProvider(
                     LocalImmediateMarkdown provides (index == displayMessages.lastIndex),
+                    LocalSearchFocusNonce provides if (isCurrent) searchFocusRequest?.requestId ?: 0L else 0L,
                 ) {
                 MessageBubble(
                     message = node.message,
@@ -436,29 +482,16 @@ fun MessageList(
                     isSearchMatch = isMatch,
                     isCurrentSearchMatch = isCurrent,
                     searchFocusedOccurrence = focusedOccurrenceInMessage,
-                    onFocusedOccurrencePosition = if (isCurrent) {
-                        { coordinates ->
-                            if (!pendingFineTuneScroll) return@MessageBubble
-                            pendingFineTuneScroll = false
-
-                            val layoutInfo = listState.layoutInfo
-                            val viewportTop = layoutInfo.viewportStartOffset.toFloat()
-                            val viewportBottom = layoutInfo.viewportEndOffset.toFloat()
-
-                            val segmentBounds = coordinates.boundsInRoot()
-                            val padding = 80f // Extra padding so the highlight isn't flush against edges
-                            // Push the focused match clear of the floating top bar, which overlays
-                            // the list's top edge (the list is full-bleed beneath it).
-                            val topInset = padding + topContentPaddingPx
-
-                            coroutineScope.launch {
-                                if (segmentBounds.top < viewportTop + topInset) {
-                                    // Segment is above or too close to the top of the viewport
-                                    listState.animateScrollBy(segmentBounds.top - viewportTop - topInset)
-                                } else if (segmentBounds.bottom > viewportBottom - padding) {
-                                    // Segment is below or too close to the bottom of the viewport
-                                    listState.animateScrollBy(segmentBounds.bottom - viewportBottom + padding)
-                                }
+                    onFocusedOccurrencePosition = if (isCurrent && searchQuery != null) {
+                        { coordinates, matchRect ->
+                            // Only record while a jump is pending; the focused node keeps reporting
+                            // on every later scroll pass, and consuming those would churn state.
+                            if (searchFocusRequest != null) {
+                                focusedMatchReport = FocusedSearchMatchReport(
+                                    requestId = searchFocusRequest.requestId,
+                                    coordinates = coordinates,
+                                    matchRect = matchRect,
+                                )
                             }
                         }
                     } else {
@@ -557,4 +590,27 @@ fun MessageList(
             }
         }
     }
+}
+
+/** How long phase 2 waits for the focused occurrence to report before settling for the message top. */
+private const val SEARCH_FOCUS_REPORT_TIMEOUT_MS = 500L
+
+private val SearchFocusScrollSpec = spring<Float>(
+    dampingRatio = Spring.DampingRatioNoBouncy,
+    stiffness = Spring.StiffnessMediumLow,
+)
+
+/**
+ * Latest reported position of the focused search occurrence: the reporting text node's
+ * [coordinates] (a live handle — queries return current geometry) and the match's
+ * bounding [matchRect] within that node. Tagged with the [requestId] that was live when it was
+ * emitted, so the scroll effect only ever acts on a report for the exact request it is serving
+ * (and never mistakes a stale report from a prior wrap-around jump for the current one).
+ */
+private class FocusedSearchMatchReport(
+    val requestId: Long,
+    val coordinates: LayoutCoordinates,
+    val matchRect: Rect,
+) {
+    fun matches(request: SearchFocusRequest): Boolean = requestId == request.requestId
 }

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/PlatformChatComponents.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/PlatformChatComponents.kt
@@ -2,6 +2,7 @@ package com.garfiec.librechat.feature.chat.components
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.layout.LayoutCoordinates
 import com.garfiec.librechat.core.common.ChatLayoutConstants
 import com.garfiec.librechat.core.model.Attachment
@@ -42,7 +43,7 @@ expect fun MessageBubble(
     isSearchMatch: Boolean = false,
     isCurrentSearchMatch: Boolean = false,
     searchFocusedOccurrence: Int = -1,
-    onFocusedOccurrencePosition: ((LayoutCoordinates) -> Unit)? = null,
+    onFocusedOccurrencePosition: ((LayoutCoordinates, Rect) -> Unit)? = null,
     useKatex: Boolean = false,
     chatLayoutStyle: String = ChatLayoutConstants.THREAD,
     showAvatars: Boolean = true,
@@ -61,7 +62,7 @@ expect fun ContentPartRenderer(
     showImageDescriptions: Boolean = true,
     searchQuery: String? = null,
     searchFocusedOccurrence: Int = -1,
-    onFocusedOccurrencePosition: ((LayoutCoordinates) -> Unit)? = null,
+    onFocusedOccurrencePosition: ((LayoutCoordinates, Rect) -> Unit)? = null,
 )
 
 /** Platform-specific markdown content rendering. */
@@ -73,7 +74,7 @@ expect fun MarkdownContent(
     useKatex: Boolean = false,
     searchQuery: String? = null,
     searchFocusedOccurrence: Int = -1,
-    onFocusedOccurrencePosition: ((LayoutCoordinates) -> Unit)? = null,
+    onFocusedOccurrencePosition: ((LayoutCoordinates, Rect) -> Unit)? = null,
     immediate: Boolean = false,
     streaming: Boolean = false,
 )

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/SearchHighlight.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/SearchHighlight.kt
@@ -1,11 +1,27 @@
 package com.garfiec.librechat.feature.chat.components
 
 import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.LayoutCoordinates
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.isSpecified
+import androidx.compose.ui.unit.sp
+import kotlin.math.max
+import kotlin.math.min
 
 // --- Light mode highlight colors ---
 private val SearchHighlightYellowLight = Color(0xFFFFEB3B)
@@ -55,40 +71,145 @@ fun buildHighlightedString(
     query: String,
     focusedOccurrence: Int = -1,
     isDarkTheme: Boolean = false,
+): AnnotatedString = addSearchSpans(AnnotatedString(text), query, focusedOccurrence, isDarkTheme)
+
+/**
+ * Overlays search-highlight background spans onto an existing [AnnotatedString],
+ * preserving its current spans (e.g. code-block syntax coloring). Same yellow/orange
+ * semantics as [buildHighlightedString].
+ */
+fun addSearchSpans(
+    base: AnnotatedString,
+    query: String,
+    focusedOccurrence: Int = -1,
+    isDarkTheme: Boolean = false,
 ): AnnotatedString {
-    if (query.isBlank()) return AnnotatedString(text)
+    if (query.isBlank()) return base
 
     val highlightColor = searchHighlightYellow(isDarkTheme)
     val focusedColor = searchHighlightOrange(isDarkTheme)
 
-    return buildAnnotatedString {
-        append(text)
+    val builder = AnnotatedString.Builder(base)
+    var startIndex = 0
+    var occurrence = 0
 
-        val lowerText = text.lowercase()
-        val lowerQuery = query.lowercase()
-        var startIndex = 0
-        var occurrence = 0
+    // Match case-insensitively against the original string (not a lowercased copy): some
+    // characters change length when lowercased (e.g. Turkish 'İ' → "i̇"), which would shift
+    // every subsequent index and mis-place spans/rects. `indexOf(ignoreCase)` compares
+    // char-by-char and returns original-string offsets, so `foundIndex + query.length` stays valid.
+    while (true) {
+        val foundIndex = base.text.indexOf(query, startIndex, ignoreCase = true)
+        if (foundIndex < 0) break
 
-        while (true) {
-            val foundIndex = lowerText.indexOf(lowerQuery, startIndex)
-            if (foundIndex < 0) break
-
-            val bgColor = if (occurrence == focusedOccurrence) {
-                focusedColor
-            } else {
-                highlightColor
-            }
-
-            addStyle(
-                SpanStyle(background = bgColor),
-                start = foundIndex,
-                end = foundIndex + query.length,
-            )
-
-            occurrence++
-            startIndex = foundIndex + query.length
+        val bgColor = if (occurrence == focusedOccurrence) {
+            focusedColor
+        } else {
+            highlightColor
         }
+
+        builder.addStyle(
+            SpanStyle(background = bgColor),
+            start = foundIndex,
+            end = foundIndex + query.length,
+        )
+
+        occurrence++
+        startIndex = foundIndex + query.length
     }
+    return builder.toAnnotatedString()
+}
+
+/**
+ * Renders a text run with search-highlight spans during active in-conversation search.
+ * Used by both platforms' MarkdownContent in place of the markdown renderer (plain text
+ * keeps occurrence offsets and [TextLayoutResult] character rects tractable).
+ *
+ * When [onFocusedMatchPosition] is non-null and [focusedOccurrence] falls inside this
+ * run, every layout/position pass reports the segment's [LayoutCoordinates] plus the
+ * focused match's bounding [Rect] *within* the segment (from [TextLayoutResult]), letting
+ * the message list scroll precisely to the match rather than to the whole segment.
+ */
+@Composable
+internal fun HighlightedTextSegment(
+    content: String,
+    searchQuery: String,
+    modifier: Modifier = Modifier,
+    focusedOccurrence: Int = -1,
+    fontSizeMultiplier: Float = 1.0f,
+    onFocusedMatchPosition: ((LayoutCoordinates, Rect) -> Unit)? = null,
+) {
+    val bodyStyle = MaterialTheme.typography.bodyLarge
+    val scaledStyle = bodyStyle.scaleFontSize(fontSizeMultiplier)
+    val isDarkTheme = isSystemInDarkTheme()
+    val highlighted = remember(content, searchQuery, focusedOccurrence, isDarkTheme) {
+        buildHighlightedString(content, searchQuery, focusedOccurrence, isDarkTheme)
+    }
+    val focusedRange = remember(content, searchQuery, focusedOccurrence) {
+        findOccurrenceRange(content, searchQuery, focusedOccurrence)
+    }
+
+    var layoutResult by remember { mutableStateOf<TextLayoutResult?>(null) }
+
+    Text(
+        text = highlighted,
+        style = scaledStyle,
+        color = MaterialTheme.colorScheme.onSurface,
+        onTextLayout = { layoutResult = it },
+        modifier = modifier
+            .fillMaxWidth()
+            .reportFocusedMatchPosition(layoutResult, focusedRange, onFocusedMatchPosition),
+    )
+}
+
+/**
+ * Reports the focused search match's position for scroll targeting. When both
+ * [onFocusedMatchPosition] and [focusedRange] are non-null, every layout/position pass reports
+ * the reporting node's [LayoutCoordinates] plus the match's bounding [Rect] within it (computed
+ * from [layout] via [matchBoundingRect]); a no-op otherwise. Shared by every search-highlightable
+ * [Text] (plain segments, code blocks, table cells) so the wiring lives in exactly one place.
+ */
+internal fun Modifier.reportFocusedMatchPosition(
+    layout: TextLayoutResult?,
+    focusedRange: IntRange?,
+    onFocusedMatchPosition: ((LayoutCoordinates, Rect) -> Unit)?,
+): Modifier = if (onFocusedMatchPosition != null && focusedRange != null) {
+    onGloballyPositioned { coordinates ->
+        val laidOut = layout ?: return@onGloballyPositioned
+        onFocusedMatchPosition(coordinates, matchBoundingRect(laidOut, focusedRange))
+    }
+} else {
+    this
+}
+
+/**
+ * Bounding rect of [range] within a laid-out text, in the text node's local coordinates.
+ * For matches that wrap lines, spans from the first character's top to the last
+ * character's bottom (the full-width union is irrelevant for vertical scrolling).
+ */
+internal fun matchBoundingRect(layout: TextLayoutResult, range: IntRange): Rect {
+    val lastOffset = layout.layoutInput.text.length - 1
+    if (lastOffset < 0) return Rect.Zero
+    val start = range.first.coerceIn(0, lastOffset)
+    val end = range.last.coerceIn(start, lastOffset)
+    val startBox = layout.getBoundingBox(start)
+    val endBox = layout.getBoundingBox(end)
+    return Rect(
+        left = min(startBox.left, endBox.left),
+        top = min(startBox.top, endBox.top),
+        right = max(startBox.right, endBox.right),
+        bottom = max(startBox.bottom, endBox.bottom),
+    )
+}
+
+/**
+ * Scales both fontSize and lineHeight of a TextStyle by the given multiplier.
+ * Uses explicit .sp conversion to avoid TextUnit.Unspecified edge cases.
+ */
+internal fun TextStyle.scaleFontSize(multiplier: Float): TextStyle {
+    if (multiplier == 1.0f) return this
+    val scaledFontSize = if (fontSize.isSpecified) (fontSize.value * multiplier).sp else fontSize
+    val scaledLineHeight = if (lineHeight.isSpecified) (lineHeight.value * multiplier).sp else lineHeight
+    return copy(fontSize = scaledFontSize, lineHeight = scaledLineHeight)
 }
 
 /**
@@ -96,12 +217,10 @@ fun buildHighlightedString(
  */
 fun countOccurrences(text: String, query: String): Int {
     if (query.isBlank() || text.isBlank()) return 0
-    val lowerText = text.lowercase()
-    val lowerQuery = query.lowercase()
     var count = 0
     var startIndex = 0
     while (true) {
-        val foundIndex = lowerText.indexOf(lowerQuery, startIndex)
+        val foundIndex = text.indexOf(query, startIndex, ignoreCase = true)
         if (foundIndex < 0) break
         count++
         startIndex = foundIndex + query.length

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/SearchMatchEnumeration.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/SearchMatchEnumeration.kt
@@ -1,0 +1,104 @@
+package com.garfiec.librechat.feature.chat.components
+
+import com.garfiec.librechat.core.model.ContentType
+import com.garfiec.librechat.core.model.Message
+import com.garfiec.librechat.core.model.content.MessageContentPart
+import com.garfiec.librechat.feature.chat.components.artifact.ArtifactSegment
+import com.garfiec.librechat.feature.chat.components.artifact.detectArtifacts
+
+// Shared search-occurrence enumeration used by BOTH the ViewModel side
+// (InConversationSearchDelegate, to build the flat match list) and the renderer side
+// (MessageContentAndActions / MarkdownContent, to resolve which on-screen unit owns the
+// focused occurrence). A message's occurrences are numbered by walking it in exact render
+// order; any divergence between the two sides makes prev/next focus the wrong occurrence,
+// so renderers must consume offsets via these same functions.
+//
+// Render-order contract (mirrors MessageContentAndActions → ContentPartDispatcher):
+//  1. Content parts in list order; only TEXT/TEXT_DELTA (part.text) and THINK (part.think)
+//     render searchable text. Messages without parts render message.text via
+//     MarkdownContent directly (no artifact split).
+//  2. TEXT parts split on artifact directives first (TextContentPart); only the plain
+//     Text segments are enumerated — inline-artifact content is highlighted but not
+//     navigable (whether it renders inline at all depends on a UI preference the
+//     ViewModel cannot see).
+//  3. Within a text run, parseMarkdownSegments order. LatexBlock and mermaid CodeBlocks
+//     render as native/WebView content with no text layout, so they contribute nothing.
+//     Table occurrences are counted per cell (headers left-to-right, then rows
+//     row-major) because highlight spans cannot cross cell boundaries.
+
+/** Occurrences contributed by one parsed [MarkdownSegment], in its render order. */
+internal fun countSegmentOccurrences(segment: MarkdownSegment, query: String): Int = when (segment) {
+    is MarkdownSegment.TextBlock -> countOccurrences(segment.text, query)
+    is MarkdownSegment.CodeBlock ->
+        if (segment.language?.lowercase() == "mermaid") 0 else countOccurrences(segment.code, query)
+    is MarkdownSegment.LatexBlock -> 0
+    is MarkdownSegment.InlineLatexText -> segment.segments.sumOf { inline ->
+        when (inline) {
+            is InlineSegment.Text -> countOccurrences(inline.text, query)
+            is InlineSegment.Latex -> 0
+        }
+    }
+    is MarkdownSegment.Table -> tableCellTexts(segment).sumOf { countOccurrences(it, query) }
+}
+
+/** Table cell texts in highlight order: headers left-to-right, then rows row-major. */
+internal fun tableCellTexts(segment: MarkdownSegment.Table): List<String> =
+    segment.headers + segment.rows.flatten()
+
+/** Occurrences in one markdown text run (a whole part, or one artifact Text segment). */
+internal fun countMarkdownOccurrences(text: String, query: String): Int {
+    // Fast-path bail before the (relatively expensive) parse: every counted match is a substring
+    // of [text], so if the query isn't present at all the message contributes nothing. This keeps
+    // per-keystroke search enumeration cheap for the many messages that don't match.
+    if (text.isBlank() || query.isBlank() || !text.contains(query, ignoreCase = true)) return 0
+    return parseMarkdownSegments(text).sumOf { countSegmentOccurrences(it, query) }
+}
+
+/** Occurrences in a TEXT part's body, honoring the artifact split (see contract above). */
+internal fun countTextPartOccurrences(text: String, query: String): Int {
+    // Same fast-path bail: skip detectArtifacts + parsing when the query can't be here.
+    if (text.isBlank() || query.isBlank() || !text.contains(query, ignoreCase = true)) return 0
+    return detectArtifacts(text).sumOf { segment ->
+        when (segment) {
+            is ArtifactSegment.Text -> countMarkdownOccurrences(segment.text, query)
+            is ArtifactSegment.ArtifactReference -> 0
+        }
+    }
+}
+
+/** Occurrences contributed by one content part, in its render order. */
+internal fun countPartOccurrences(part: MessageContentPart, query: String): Int = when (part.type) {
+    ContentType.TEXT, ContentType.TEXT_DELTA -> countTextPartOccurrences(part.text.orEmpty(), query)
+    ContentType.THINK -> countMarkdownOccurrences(part.think.orEmpty(), query)
+    else -> 0
+}
+
+/** Total searchable occurrences in a message, numbering the render walk 0-based. */
+internal fun countMessageOccurrences(message: Message, query: String): Int {
+    val parts = message.content
+    return if (!parts.isNullOrEmpty()) {
+        parts.sumOf { countPartOccurrences(it, query) }
+    } else {
+        countMarkdownOccurrences(message.text, query)
+    }
+}
+
+/**
+ * Character range of the [occurrence]-th (0-based) case-insensitive match of [query]
+ * in [text], or null when out of range. Must walk matches exactly like
+ * [buildHighlightedString] so the orange span and the reported rect agree.
+ */
+internal fun findOccurrenceRange(text: String, query: String, occurrence: Int): IntRange? {
+    if (occurrence < 0 || query.isBlank() || text.isEmpty()) return null
+    // Match against the original string (see [addSearchSpans]): a lowercased copy can change
+    // length and shift the returned range off the actual characters.
+    var startIndex = 0
+    var index = 0
+    while (true) {
+        val foundIndex = text.indexOf(query, startIndex, ignoreCase = true)
+        if (foundIndex < 0) return null
+        if (index == occurrence) return foundIndex until foundIndex + query.length
+        index++
+        startIndex = foundIndex + query.length
+    }
+}

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/SharedContentParts.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/SharedContentParts.kt
@@ -13,6 +13,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.layout.LayoutCoordinates
 import androidx.compose.ui.unit.dp
 import com.garfiec.librechat.core.model.Attachment
@@ -46,7 +47,7 @@ internal fun ContentPartDispatcher(
     showImageDescriptions: Boolean = true,
     searchQuery: String? = null,
     searchFocusedOccurrence: Int = -1,
-    onFocusedOccurrencePosition: ((LayoutCoordinates) -> Unit)? = null,
+    onFocusedOccurrencePosition: ((LayoutCoordinates, Rect) -> Unit)? = null,
     // When false, a `subagent` tool_call renders flat instead of as a trace card.
     // Set false while rendering a subagent's own nested parts (depth-1 guard).
     allowSubagentCard: Boolean = true,

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/TextArtifactContentPart.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/TextArtifactContentPart.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.layout.LayoutCoordinates
 import androidx.compose.ui.unit.dp
 import com.garfiec.librechat.core.ui.theme.isSurfaceDark
@@ -38,7 +39,7 @@ internal fun TextContentPart(
     useKatex: Boolean = false,
     searchQuery: String? = null,
     searchFocusedOccurrence: Int = -1,
-    onFocusedOccurrencePosition: ((LayoutCoordinates) -> Unit)? = null,
+    onFocusedOccurrencePosition: ((LayoutCoordinates, Rect) -> Unit)? = null,
 ) {
     if (text.isBlank()) return
 
@@ -59,8 +60,24 @@ internal fun TextContentPart(
         val versionMap = remember(segments) { groupArtifactVersions(segments) }
         val inlinePrefs = LocalInlineArtifactPrefs.current
         val openArtifact = LocalOpenArtifact.current
+        // Per-Text-segment occurrence base offsets (artifact content contributes none — see the
+        // SearchMatchEnumeration render-order contract). Computed once per (segments, query): the
+        // per-segment countMarkdownOccurrences re-parses markdown, so keeping it off recomposition matters.
+        val textOffsets = remember(segments, searchQuery) {
+            IntArray(segments.size).also { offsets ->
+                if (!searchQuery.isNullOrBlank()) {
+                    var acc = 0
+                    segments.forEachIndexed { i, segment ->
+                        offsets[i] = acc
+                        if (segment is ArtifactSegment.Text) {
+                            acc += countMarkdownOccurrences(segment.text, searchQuery)
+                        }
+                    }
+                }
+            }
+        }
         Column(modifier = modifier) {
-            segments.forEach { segment ->
+            segments.forEachIndexed { index, segment ->
                 when (segment) {
                     is ArtifactSegment.Text -> {
                         MarkdownContent(
@@ -69,7 +86,7 @@ internal fun TextContentPart(
                             fontSizeMultiplier,
                             useKatex,
                             searchQuery,
-                            searchFocusedOccurrence,
+                            searchFocusedOccurrence - textOffsets[index],
                             onFocusedOccurrencePosition,
                         )
                     }
@@ -92,8 +109,6 @@ internal fun TextContentPart(
                                     modifier = Modifier.fillMaxWidth(),
                                     fontSizeMultiplier = fontSizeMultiplier,
                                     searchQuery = searchQuery,
-                                    searchFocusedOccurrence = searchFocusedOccurrence,
-                                    onFocusedOccurrencePosition = onFocusedOccurrencePosition,
                                 )
                                 InlineArtifactStrategy.IntrinsicSvg -> InlineSvgArtifact(
                                     artifact = segment.artifact,

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/InlineMarkdownArtifact.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/InlineMarkdownArtifact.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.layout.LayoutCoordinates
 import androidx.compose.ui.unit.dp
 import com.garfiec.librechat.feature.chat.components.MarkdownContent
 
@@ -15,6 +14,11 @@ import com.garfiec.librechat.feature.chat.components.MarkdownContent
  * LaTeX, so we reuse it. This sidesteps async height measurement entirely:
  * Compose knows the layout at measure time, so `LazyColumn` does not scroll-
  * jump when these artifacts re-enter the viewport.
+ *
+ * Search matches inside artifact content are highlighted but NOT navigable
+ * (no focused occurrence / position reporting): whether an artifact renders
+ * inline depends on a UI preference the search enumeration cannot see, so
+ * artifact content is excluded from occurrence counting (SearchMatchEnumeration).
  */
 @Composable
 fun InlineMarkdownArtifact(
@@ -23,8 +27,6 @@ fun InlineMarkdownArtifact(
     modifier: Modifier = Modifier,
     fontSizeMultiplier: Float = 1.0f,
     searchQuery: String? = null,
-    searchFocusedOccurrence: Int = -1,
-    onFocusedOccurrencePosition: ((LayoutCoordinates) -> Unit)? = null,
 ) {
     ArtifactCardSurface(onTap = onTap, modifier = modifier) {
         MarkdownContent(
@@ -35,8 +37,6 @@ fun InlineMarkdownArtifact(
             fontSizeMultiplier = fontSizeMultiplier,
             useKatex = false,
             searchQuery = searchQuery,
-            searchFocusedOccurrence = searchFocusedOccurrence,
-            onFocusedOccurrencePosition = onFocusedOccurrencePosition,
             // Synchronous parsing: the m3 Markdown composable parses async by
             // default, so each text segment's height arrives over multiple
             // frames and the LazyColumn scroll-jumps when the artifact item

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/screen/ComparisonPanes.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/screen/ComparisonPanes.kt
@@ -153,7 +153,7 @@ internal fun ComparisonPanes(
             searchQuery = if (uiState.isSearchOpen) uiState.searchQuery else null,
             searchMatchIndices = uiState.searchMatchIndices,
             currentSearchMatchIndex = uiState.currentSearchMatchIndex,
-            searchScrollToIndex = uiState.searchScrollToIndex,
+            searchFocusRequest = uiState.searchFocusRequest,
             onSearchScrollHandle = viewModel::onSearchScrollHandled,
             bottomContentPadding = bottomContentPadding,
             // The comparison container is already padded clear of the floating bar.

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatUiState.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatUiState.kt
@@ -88,6 +88,17 @@ data class SearchMatch(
     val occurrenceInMessage: Int,
 )
 
+/**
+ * A request to scroll the message list to one specific search occurrence. [messageIndex] is the
+ * scroll target; [requestId] is a monotonic id that both makes repeat jumps to the same occurrence
+ * distinct (so the list's LaunchedEffect re-fires) and identifies the position report to act on.
+ */
+@Immutable
+data class SearchFocusRequest(
+    val messageIndex: Int,
+    val requestId: Long,
+)
+
 @Immutable
 data class RetryInfo(
     val attempt: Int,
@@ -309,8 +320,8 @@ data class ChatUiState(
     val searchQuery: String = "",
     val searchMatchIndices: List<SearchMatch> = emptyList(),
     val currentSearchMatchIndex: Int = 0,
-    /** The displayMessages index to scroll to when search match changes. Consumed by MessageList. */
-    val searchScrollToIndex: Int? = null,
+    /** The search occurrence to scroll to when the focused match changes. Consumed by MessageList. */
+    val searchFocusRequest: SearchFocusRequest? = null,
     // Tool toolbar state
     val enabledTools: Set<String> = emptySet(),
     // MCP server state

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/InConversationSearchDelegate.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/InConversationSearchDelegate.kt
@@ -1,11 +1,17 @@
 package com.garfiec.librechat.feature.chat.viewmodel.delegate
 
+import com.garfiec.librechat.feature.chat.components.countMessageOccurrences
+import com.garfiec.librechat.feature.chat.util.collapseParallelToPrimary
 import com.garfiec.librechat.feature.chat.viewmodel.ChatStateHandle
+import com.garfiec.librechat.feature.chat.viewmodel.SearchFocusRequest
 import com.garfiec.librechat.feature.chat.viewmodel.SearchMatch
 
 class InConversationSearchDelegate(
     private val stateHandle: ChatStateHandle,
 ) {
+
+    /** Monotonic id so consecutive requests are never equal (see [SearchFocusRequest]). */
+    private var nextFocusRequestId = 0L
 
     fun openSearch() {
         stateHandle.update {
@@ -14,7 +20,7 @@ class InConversationSearchDelegate(
                 searchQuery = "",
                 searchMatchIndices = emptyList(),
                 currentSearchMatchIndex = 0,
-                searchScrollToIndex = null,
+                searchFocusRequest = null,
             )
         }
     }
@@ -26,7 +32,7 @@ class InConversationSearchDelegate(
                 searchQuery = "",
                 searchMatchIndices = emptyList(),
                 currentSearchMatchIndex = 0,
-                searchScrollToIndex = null,
+                searchFocusRequest = null,
             )
         }
     }
@@ -39,33 +45,25 @@ class InConversationSearchDelegate(
                     searchQuery = query,
                     searchMatchIndices = emptyList(),
                     currentSearchMatchIndex = 0,
-                    searchScrollToIndex = null,
+                    searchFocusRequest = null,
                 )
             }
             return
         }
 
-        val lowerQuery = query.lowercase()
+        // Occurrences are numbered by the shared render-order walk so the renderer
+        // resolves the exact same occurrence the delegate counted (SearchMatchEnumeration).
+        // Enumerate over the SAME parts the list renders: a parallel (Compare-Models) turn
+        // renders only its primary-agent parts — collapseParallelToPrimary in the single list
+        // and partsForPane(secondary=false) in the primary comparison pane — so counting the raw
+        // message would over-count the secondary agent's occurrences and desync the focus index
+        // (dead next/prev stops, wrong-occurrence highlight). The collapse maps 1:1, so
+        // messageIndex still aligns with displayMessages.
+        val renderedMessages = collapseParallelToPrimary(state.displayMessages)
         val allMatches = mutableListOf<SearchMatch>()
-
-        state.displayMessages.forEachIndexed { index, node ->
-            val message = node.message
-            val contentParts = message.content
-            val text = if (!contentParts.isNullOrEmpty()) {
-                contentParts.mapNotNull { part -> part.text ?: part.think }.joinToString("")
-            } else {
-                message.text
-            }
-            // Count occurrences in this message
-            val lowerText = text.lowercase()
-            var startIndex = 0
-            var occurrenceInMessage = 0
-            while (true) {
-                val foundIndex = lowerText.indexOf(lowerQuery, startIndex)
-                if (foundIndex < 0) break
-                allMatches.add(SearchMatch(messageIndex = index, occurrenceInMessage = occurrenceInMessage))
-                occurrenceInMessage++
-                startIndex = foundIndex + query.length
+        renderedMessages.forEachIndexed { index, node ->
+            repeat(countMessageOccurrences(node.message, query)) { occurrence ->
+                allMatches.add(SearchMatch(messageIndex = index, occurrenceInMessage = occurrence))
             }
         }
 
@@ -74,7 +72,7 @@ class InConversationSearchDelegate(
                 searchQuery = query,
                 searchMatchIndices = allMatches,
                 currentSearchMatchIndex = 0,
-                searchScrollToIndex = allMatches.firstOrNull()?.messageIndex,
+                searchFocusRequest = allMatches.firstOrNull()?.let { focusRequestFor(it) },
             )
         }
     }
@@ -86,7 +84,7 @@ class InConversationSearchDelegate(
         stateHandle.update {
             copy(
                 currentSearchMatchIndex = nextIndex,
-                searchScrollToIndex = searchMatchIndices[nextIndex].messageIndex,
+                searchFocusRequest = focusRequestFor(searchMatchIndices[nextIndex]),
             )
         }
     }
@@ -102,12 +100,17 @@ class InConversationSearchDelegate(
         stateHandle.update {
             copy(
                 currentSearchMatchIndex = prevIndex,
-                searchScrollToIndex = searchMatchIndices[prevIndex].messageIndex,
+                searchFocusRequest = focusRequestFor(searchMatchIndices[prevIndex]),
             )
         }
     }
 
     fun onSearchScrollHandled() {
-        stateHandle.update { copy(searchScrollToIndex = null) }
+        stateHandle.update { copy(searchFocusRequest = null) }
     }
+
+    private fun focusRequestFor(match: SearchMatch) = SearchFocusRequest(
+        messageIndex = match.messageIndex,
+        requestId = nextFocusRequestId++,
+    )
 }

--- a/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/components/PlatformChatComponents.ios.kt
+++ b/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/components/PlatformChatComponents.ios.kt
@@ -3,6 +3,7 @@ package com.garfiec.librechat.feature.chat.components
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -44,8 +45,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.compositeOver
+import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.layout.LayoutCoordinates
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontStyle
@@ -114,7 +118,7 @@ actual fun MessageBubble(
     isSearchMatch: Boolean,
     isCurrentSearchMatch: Boolean,
     searchFocusedOccurrence: Int,
-    onFocusedOccurrencePosition: ((LayoutCoordinates) -> Unit)?,
+    onFocusedOccurrencePosition: ((LayoutCoordinates, Rect) -> Unit)?,
     useKatex: Boolean,
     chatLayoutStyle: String,
     showAvatars: Boolean,
@@ -157,7 +161,7 @@ private fun ThreadBubble(
     resolvedEndpoint: String?, tintEndpointIcon: Boolean,
     showImageDescriptions: Boolean, showActionsInitially: Boolean, searchQuery: String?,
     isSearchMatch: Boolean, isCurrentSearchMatch: Boolean, searchFocusedOccurrence: Int,
-    onFocusedOccurrencePosition: ((LayoutCoordinates) -> Unit)?, showAvatars: Boolean, showBubbles: Boolean,
+    onFocusedOccurrencePosition: ((LayoutCoordinates, Rect) -> Unit)?, showAvatars: Boolean, showBubbles: Boolean,
 ) {
     val isUser = message.isCreatedByUser
     var showActions by remember(message.messageId) { mutableStateOf(showActionsInitially) }
@@ -250,7 +254,7 @@ private fun TwoSidedBubble(
     resolvedEndpoint: String?, tintEndpointIcon: Boolean,
     showImageDescriptions: Boolean, showActionsInitially: Boolean, searchQuery: String?,
     isSearchMatch: Boolean, isCurrentSearchMatch: Boolean, searchFocusedOccurrence: Int,
-    onFocusedOccurrencePosition: ((LayoutCoordinates) -> Unit)?, showAvatars: Boolean, showBubbles: Boolean,
+    onFocusedOccurrencePosition: ((LayoutCoordinates, Rect) -> Unit)?, showAvatars: Boolean, showBubbles: Boolean,
 ) {
     val isUser = message.isCreatedByUser
     var showActions by remember(message.messageId) { mutableStateOf(showActionsInitially) }
@@ -355,7 +359,7 @@ actual fun ContentPartRenderer(
     part: MessageContentPart, modifier: Modifier, baseUrl: String, fontSizeMultiplier: Float,
     useKatex: Boolean, attachments: List<Attachment>,
     showImageDescriptions: Boolean, searchQuery: String?, searchFocusedOccurrence: Int,
-    onFocusedOccurrencePosition: ((LayoutCoordinates) -> Unit)?,
+    onFocusedOccurrencePosition: ((LayoutCoordinates, Rect) -> Unit)?,
 ) {
     ContentPartDispatcher(
         part = part,
@@ -377,7 +381,7 @@ actual fun ContentPartRenderer(
 actual fun MarkdownContent(
     text: String, modifier: Modifier, fontSizeMultiplier: Float, useKatex: Boolean,
     searchQuery: String?, searchFocusedOccurrence: Int,
-    onFocusedOccurrencePosition: ((LayoutCoordinates) -> Unit)?,
+    onFocusedOccurrencePosition: ((LayoutCoordinates, Rect) -> Unit)?,
     immediate: Boolean,
     streaming: Boolean,
 ) {
@@ -404,8 +408,27 @@ actual fun MarkdownContent(
         ordered = bl.scale(fontSizeMultiplier), bullet = bl.scale(fontSizeMultiplier), list = bl.scale(fontSizeMultiplier),
     )
 
+    val isSearchActive = !searchQuery.isNullOrBlank()
+
     Column(modifier = modifier.fillMaxWidth()) {
+        // Per-segment occurrence base offsets, advanced via countSegmentOccurrences to stay
+        // identical to SearchMatchEnumeration's numbering (mirrors androidMain). Computed once
+        // per (segments, query), not every recomposition.
+        val segmentOffsets = remember(segments, searchQuery) {
+            IntArray(segments.size).also { offsets ->
+                if (!searchQuery.isNullOrBlank()) {
+                    var acc = 0
+                    segments.forEachIndexed { i, segment ->
+                        offsets[i] = acc
+                        acc += countSegmentOccurrences(segment, searchQuery)
+                    }
+                }
+            }
+        }
+
         segments.forEachIndexed { index, segment ->
+            val focusedInSegment = if (isSearchActive) searchFocusedOccurrence - segmentOffsets[index] else -1
+
             when (segment) {
                 is MarkdownSegment.CodeBlock -> {
                     if (index > 0) Spacer(modifier = Modifier.height(8.dp))
@@ -419,6 +442,9 @@ actual fun MarkdownContent(
                             code = segment.code,
                             language = segment.language,
                             modifier = Modifier.padding(vertical = 4.dp),
+                            searchQuery = if (isSearchActive) searchQuery else null,
+                            searchFocusedOccurrence = focusedInSegment,
+                            onFocusedMatchPosition = onFocusedOccurrencePosition,
                         )
                     }
                     if (index < segments.lastIndex) Spacer(modifier = Modifier.height(8.dp))
@@ -434,19 +460,34 @@ actual fun MarkdownContent(
                 }
                 is MarkdownSegment.InlineLatexText -> {
                     Column {
+                        // Rebase again per Text run within the segment.
+                        var inlineOffset = 0
                         segment.segments.forEach { inlineSegment ->
                             when (inlineSegment) {
                                 is InlineSegment.Text -> {
                                     if (inlineSegment.text.isNotBlank()) {
-                                        key(fontSizeMultiplier) {
-                                            CachedMarkdown(
+                                        if (isSearchActive) {
+                                            val runOccurrences = countOccurrences(inlineSegment.text, searchQuery)
+                                            val focusedInRun = focusedInSegment - inlineOffset
+                                            HighlightedTextSegment(
                                                 content = inlineSegment.text,
-                                                colors = colors,
-                                                typography = typography,
-                                                modifier = Modifier.fillMaxWidth(),
-                                                immediate = immediate,
-                                                streaming = streaming,
+                                                searchQuery = searchQuery,
+                                                focusedOccurrence = focusedInRun,
+                                                fontSizeMultiplier = fontSizeMultiplier,
+                                                onFocusedMatchPosition = onFocusedOccurrencePosition,
                                             )
+                                            inlineOffset += runOccurrences
+                                        } else {
+                                            key(fontSizeMultiplier) {
+                                                CachedMarkdown(
+                                                    content = inlineSegment.text,
+                                                    colors = colors,
+                                                    typography = typography,
+                                                    modifier = Modifier.fillMaxWidth(),
+                                                    immediate = immediate,
+                                                    streaming = streaming,
+                                                )
+                                            }
                                         }
                                     }
                                 }
@@ -468,19 +509,32 @@ actual fun MarkdownContent(
                         rows = segment.rows,
                         fontSizeMultiplier = fontSizeMultiplier,
                         modifier = Modifier.padding(vertical = 4.dp),
+                        searchQuery = if (isSearchActive) searchQuery else null,
+                        searchFocusedOccurrence = focusedInSegment,
+                        onFocusedMatchPosition = onFocusedOccurrencePosition,
                     )
                     if (index < segments.lastIndex) Spacer(modifier = Modifier.height(8.dp))
                 }
                 is MarkdownSegment.TextBlock -> {
-                    key(fontSizeMultiplier, index) {
-                        CachedMarkdown(
+                    if (isSearchActive) {
+                        HighlightedTextSegment(
                             content = segment.text,
-                            colors = colors,
-                            typography = typography,
-                            modifier = Modifier.fillMaxWidth(),
-                            immediate = immediate,
-                            streaming = streaming,
+                            searchQuery = searchQuery,
+                            focusedOccurrence = focusedInSegment,
+                            fontSizeMultiplier = fontSizeMultiplier,
+                            onFocusedMatchPosition = onFocusedOccurrencePosition,
                         )
+                    } else {
+                        key(fontSizeMultiplier, index) {
+                            CachedMarkdown(
+                                content = segment.text,
+                                colors = colors,
+                                typography = typography,
+                                modifier = Modifier.fillMaxWidth(),
+                                immediate = immediate,
+                                streaming = streaming,
+                            )
+                        }
                     }
                 }
             }
@@ -497,6 +551,9 @@ private fun IosMarkdownTableWithFullscreen(
     rows: List<List<String>>,
     modifier: Modifier = Modifier,
     fontSizeMultiplier: Float = 1.0f,
+    searchQuery: String? = null,
+    searchFocusedOccurrence: Int = -1,
+    onFocusedMatchPosition: ((LayoutCoordinates, Rect) -> Unit)? = null,
 ) {
     var showFullscreen by remember { mutableStateOf(false) }
 
@@ -506,6 +563,9 @@ private fun IosMarkdownTableWithFullscreen(
             alignments = alignments,
             rows = rows,
             fontSizeMultiplier = fontSizeMultiplier,
+            searchQuery = searchQuery,
+            searchFocusedOccurrence = searchFocusedOccurrence,
+            onFocusedMatchPosition = onFocusedMatchPosition,
         )
 
         IconButton(
@@ -596,7 +656,11 @@ private fun IosMarkdownTable(
     rows: List<List<String>>,
     modifier: Modifier = Modifier,
     fontSizeMultiplier: Float = 1.0f,
+    searchQuery: String? = null,
+    searchFocusedOccurrence: Int = -1,
+    onFocusedMatchPosition: ((LayoutCoordinates, Rect) -> Unit)? = null,
 ) {
+    val isSearchActive = !searchQuery.isNullOrBlank()
     val textColor = MaterialTheme.colorScheme.onSurface
     val headerBackground = MaterialTheme.colorScheme.surfaceContainerHigh
     val dividerColor = MaterialTheme.colorScheme.outlineVariant
@@ -625,10 +689,36 @@ private fun IosMarkdownTable(
         modifier = modifier.fillMaxWidth().horizontalScroll(rememberScrollState()).clip(MaterialTheme.shapes.small),
     ) {
         Column {
+            // Per-cell occurrence base offsets, headers-first then rows row-major — the same order
+            // as SearchMatchEnumeration's tableCellTexts. Computed once per (headers, rows, query).
+            val (headerOffsets, rowOffsets) = remember(headers, rows, searchQuery) {
+                val hOffsets = IntArray(headers.size)
+                val rOffsets = rows.map { IntArray(it.size) }
+                if (!searchQuery.isNullOrBlank()) {
+                    var acc = 0
+                    headers.forEachIndexed { i, header ->
+                        hOffsets[i] = acc
+                        acc += countOccurrences(header, searchQuery)
+                    }
+                    rows.forEachIndexed { r, row ->
+                        row.forEachIndexed { c, cell ->
+                            rOffsets[r][c] = acc
+                            acc += countOccurrences(cell, searchQuery)
+                        }
+                    }
+                }
+                hOffsets to rOffsets
+            }
             Row(modifier = Modifier.height(IntrinsicSize.Min).background(headerBackground)) {
                 headers.forEachIndexed { colIndex, header ->
                     if (colIndex > 0) VerticalDivider(color = dividerColor, modifier = Modifier.fillMaxHeight())
-                    TableCell(header, headerStyle, textColor, alignments.getOrElse(colIndex) { TableCellAlignment.LEFT }, columnWidths[colIndex], cellPaddingH, cellPaddingV)
+                    TableCell(
+                        header, headerStyle, textColor, alignments.getOrElse(colIndex) { TableCellAlignment.LEFT },
+                        columnWidths[colIndex], cellPaddingH, cellPaddingV,
+                        searchQuery = searchQuery,
+                        searchFocusedOccurrence = if (isSearchActive) searchFocusedOccurrence - headerOffsets[colIndex] else -1,
+                        onFocusedMatchPosition = onFocusedMatchPosition,
+                    )
                 }
             }
             HorizontalDivider(color = dividerColor, thickness = 1.dp)
@@ -636,7 +726,13 @@ private fun IosMarkdownTable(
                 Row(modifier = Modifier.height(IntrinsicSize.Min)) {
                     row.forEachIndexed { colIndex, cell ->
                         if (colIndex > 0) VerticalDivider(color = dividerColor, modifier = Modifier.fillMaxHeight())
-                        TableCell(cell, bodyStyle, textColor, alignments.getOrElse(colIndex) { TableCellAlignment.LEFT }, columnWidths.getOrElse(colIndex) { columnWidths.last() }, cellPaddingH, cellPaddingV)
+                        TableCell(
+                            cell, bodyStyle, textColor, alignments.getOrElse(colIndex) { TableCellAlignment.LEFT },
+                            columnWidths.getOrElse(colIndex) { columnWidths.last() }, cellPaddingH, cellPaddingV,
+                            searchQuery = searchQuery,
+                            searchFocusedOccurrence = if (isSearchActive) searchFocusedOccurrence - rowOffsets[rowIndex][colIndex] else -1,
+                            onFocusedMatchPosition = onFocusedMatchPosition,
+                        )
                     }
                 }
                 if (rowIndex < rows.lastIndex) HorizontalDivider(color = dividerColor, thickness = Dp.Hairline)
@@ -649,7 +745,23 @@ private fun IosMarkdownTable(
 private fun TableCell(
     text: String, style: TextStyle, color: Color,
     alignment: TableCellAlignment, cellWidth: Dp, paddingH: Dp, paddingV: Dp, modifier: Modifier = Modifier,
+    searchQuery: String? = null,
+    searchFocusedOccurrence: Int = -1,
+    onFocusedMatchPosition: ((LayoutCoordinates, Rect) -> Unit)? = null,
 ) {
+    val isDarkTheme = isSystemInDarkTheme()
+    val display = remember(text, searchQuery, searchFocusedOccurrence, isDarkTheme) {
+        if (searchQuery.isNullOrBlank()) {
+            AnnotatedString(text)
+        } else {
+            buildHighlightedString(text, searchQuery, searchFocusedOccurrence, isDarkTheme)
+        }
+    }
+    val focusedRange = remember(text, searchQuery, searchFocusedOccurrence) {
+        if (searchQuery.isNullOrBlank()) null else findOccurrenceRange(text, searchQuery, searchFocusedOccurrence)
+    }
+    var layoutResult by remember { mutableStateOf<TextLayoutResult?>(null) }
+
     Box(
         modifier = modifier.width(cellWidth).padding(horizontal = paddingH, vertical = paddingV),
         contentAlignment = when (alignment) {
@@ -659,12 +771,19 @@ private fun TableCell(
         },
     ) {
         Text(
-            text = text, style = style, color = color, maxLines = 10, overflow = TextOverflow.Ellipsis,
+            text = display, style = style, color = color,
+            // Only the focused cell needs full layout so its wrapped-line rect reports accurately;
+            // every other cell keeps the 10-line clamp even while search is open, so opening search
+            // doesn't balloon whole tables. focusedRange is non-null exactly for the focused cell.
+            maxLines = if (focusedRange != null) Int.MAX_VALUE else 10,
+            overflow = TextOverflow.Ellipsis,
             textAlign = when (alignment) {
                 TableCellAlignment.LEFT -> TextAlign.Start
                 TableCellAlignment.CENTER -> TextAlign.Center
                 TableCellAlignment.RIGHT -> TextAlign.End
             },
+            onTextLayout = { layoutResult = it },
+            modifier = Modifier.reportFocusedMatchPosition(layoutResult, focusedRange, onFocusedMatchPosition),
         )
     }
 }

--- a/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/screen/PlatformScreens.ios.kt
+++ b/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/screen/PlatformScreens.ios.kt
@@ -292,7 +292,7 @@ actual fun ChatScreen(
                         searchQuery = if (uiState.isSearchOpen) uiState.searchQuery else null,
                         searchMatchIndices = uiState.searchMatchIndices,
                         currentSearchMatchIndex = uiState.currentSearchMatchIndex,
-                        searchScrollToIndex = uiState.searchScrollToIndex,
+                        searchFocusRequest = uiState.searchFocusRequest,
                         onSearchScrollHandle = viewModel::onSearchScrollHandled,
                         bottomContentPadding = bottomContentPadding,
                         topContentPadding = topContentPadding,


### PR DESCRIPTION
## Summary
In-conversation search navigated at message granularity, so the focused match
inside a long message could land off-screen. This makes prev/next jump to the
exact occurrence and place it at a predictable viewport position, with accurate
counts and highlighting across every searchable content type.

## Changes
- **Shared occurrence enumeration** — a render-order enumerator numbers matches
  once and is consumed by both the search delegate and the renderers, so counts
  and focus stay aligned across plain text, code blocks, tables (per cell),
  inline-latex runs, and thinking blocks. Parallel (Compare-Models) turns count
  only the primary agent's parts, matching what the single list renders.
- **Two-phase scroll** — compose the target message, await a match-level
  position report, then settle the match on a ~1/3-viewport anchor line. The
  initial jump is skipped when the target is already laid out, so nearby
  next/prev animate in place instead of teleporting; the settle uses a
  `StiffnessMediumLow` spring.
- **Match-level highlighting & position reporting** — the focused occurrence is
  highlighted distinctly and reports its bounding rect; table cells expand past
  their line clamp only for the focused cell; thinking blocks auto-expand when
  they hold the focused match.
- **Case-insensitive matching without index drift** on characters whose
  lowercase changes length.
- **Efficiency** — per-navigation occurrence offsets are memoized at the part,
  segment, cell, and artifact levels; position reports are recorded only while a
  jump is pending.

## Testing
- Unit tests: enumeration rules (code-fence/mermaid exclusion, per-cell table
  order, case-insensitivity, length-changing-lowercase offset alignment,
  per-part rebasing) and delegate behavior (flatten, next/prev/wrap, parallel
  turn counting).
- Android compile + detekt (commonMain gate) + chat unit tests pass; iOS chat
  module compiles.
- Device-tested on a Pixel 9 Pro Fold.

## Notes
- LaTeX, Mermaid, and other WebView-rendered content isn't text-layout
  accessible, so occurrences there are intentionally not counted or navigable.
  Inline artifact content is likewise excluded, since whether it renders inline
  depends on a UI preference the enumerator can't see. Both stay consistent
  between the enumerator and the renderers.
