### PR TITLE
feat(ui): persist Files sort and view mode, and drawer tab selection

### DIFF
--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/SettingsDataStore.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/SettingsDataStore.kt
@@ -179,6 +179,31 @@ class SettingsDataStore(
         prefs[KEY_CHAT_LAYOUT_STYLE] ?: "thread"
     }
 
+    // Unlike the typed enum prefs above (StarredModelsDisplay, ContextBarPlacement, …), these are
+    // exposed as raw String and mapped in the caller: their enums (FileSortField/FileViewMode in
+    // :feature:files, DrawerTab in :shared) are UI-domain types that can't be imported down into
+    // :core:data. Keep the enum<->string mapping in the ViewModel — don't "harmonize" by moving them.
+
+    /** Files screen list/grid toggle, stored as the FileViewMode storage string; null until first set. */
+    val filesViewMode: Flow<String?> = dataStore.data.map { prefs ->
+        prefs[KEY_FILES_VIEW_MODE]
+    }
+
+    /** Files screen sort field, stored as the FileSortField storage string; null until first set. */
+    val filesSortField: Flow<String?> = dataStore.data.map { prefs ->
+        prefs[KEY_FILES_SORT_FIELD]
+    }
+
+    /** Files screen sort order, stored as the FileSortOrder storage string; null until first set. */
+    val filesSortOrder: Flow<String?> = dataStore.data.map { prefs ->
+        prefs[KEY_FILES_SORT_ORDER]
+    }
+
+    /** Drawer "Library" toggle, stored as the DrawerTab storage string; null until first set. */
+    val drawerLibraryTab: Flow<String?> = dataStore.data.map { prefs ->
+        prefs[KEY_DRAWER_LIBRARY_TAB]
+    }
+
     val showAvatars: Flow<Boolean> = dataStore.data.map { prefs ->
         prefs[KEY_SHOW_AVATARS] ?: true
     }
@@ -402,6 +427,25 @@ class SettingsDataStore(
         }
     }
 
+    suspend fun setFilesViewMode(mode: String) {
+        dataStore.edit { prefs ->
+            prefs[KEY_FILES_VIEW_MODE] = mode
+        }
+    }
+
+    suspend fun setFilesSort(field: String, order: String) {
+        dataStore.edit { prefs ->
+            prefs[KEY_FILES_SORT_FIELD] = field
+            prefs[KEY_FILES_SORT_ORDER] = order
+        }
+    }
+
+    suspend fun setDrawerLibraryTab(tab: String) {
+        dataStore.edit { prefs ->
+            prefs[KEY_DRAWER_LIBRARY_TAB] = tab
+        }
+    }
+
     suspend fun setShowAvatars(show: Boolean) {
         dataStore.edit { prefs ->
             prefs[KEY_SHOW_AVATARS] = show
@@ -504,6 +548,10 @@ class SettingsDataStore(
         private val KEY_TTS_VOICE = stringPreferencesKey("tts_voice")
         private val KEY_TTS_CACHING = booleanPreferencesKey("tts_caching")
         private val KEY_CHAT_LAYOUT_STYLE = stringPreferencesKey("chat_layout_style")
+        private val KEY_FILES_VIEW_MODE = stringPreferencesKey("files_view_mode")
+        private val KEY_FILES_SORT_FIELD = stringPreferencesKey("files_sort_field")
+        private val KEY_FILES_SORT_ORDER = stringPreferencesKey("files_sort_order")
+        private val KEY_DRAWER_LIBRARY_TAB = stringPreferencesKey("drawer_library_tab")
         private val KEY_SHOW_AVATARS = booleanPreferencesKey("show_avatars")
         private val KEY_SHOW_BUBBLES = booleanPreferencesKey("show_bubbles")
         private val KEY_INLINE_ARTIFACT_MERMAID = booleanPreferencesKey("inline_artifact_mermaid")

--- a/feature/files/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/files/di/FilesModuleVerificationTest.kt
+++ b/feature/files/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/files/di/FilesModuleVerificationTest.kt
@@ -3,6 +3,7 @@ package com.garfiec.librechat.feature.files.di
 import android.app.Application
 import android.content.Context
 import com.garfiec.librechat.core.data.datastore.ServerDataStore
+import com.garfiec.librechat.core.data.datastore.SettingsDataStore
 import com.garfiec.librechat.core.data.repository.FileRepository
 import com.garfiec.librechat.feature.files.platform.FileReader
 import kotlinx.coroutines.CoroutineDispatcher
@@ -18,6 +19,7 @@ class FilesModuleVerificationTest {
                 Application::class,
                 FileRepository::class,
                 ServerDataStore::class,
+                SettingsDataStore::class,
                 FileReader::class,
                 CoroutineDispatcher::class,
             ),

--- a/feature/files/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/files/viewmodel/FilesViewModelTest.kt
+++ b/feature/files/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/files/viewmodel/FilesViewModelTest.kt
@@ -2,6 +2,7 @@ package com.garfiec.librechat.feature.files.viewmodel
 
 import com.garfiec.librechat.core.common.result.Result
 import com.garfiec.librechat.core.data.datastore.ServerDataStore
+import com.garfiec.librechat.core.data.datastore.SettingsDataStore
 import com.garfiec.librechat.core.data.repository.FileRepository
 import com.garfiec.librechat.core.model.FileObject
 import com.garfiec.librechat.feature.files.platform.FileReader
@@ -12,6 +13,7 @@ import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
@@ -29,6 +31,12 @@ class FilesViewModelTest {
     private val fileRepository = mockk<FileRepository>(relaxed = true)
     private val fileReader = mockk<FileReader>(relaxed = true)
     private val serverDataStore = mockk<ServerDataStore>(relaxed = true)
+    private val settingsDataStore = mockk<SettingsDataStore>(relaxed = true)
+
+    // In-memory backing for the persisted sort/view-mode so setters round-trip through the flows.
+    private val filesViewModeFlow = MutableStateFlow<String?>(null)
+    private val filesSortFieldFlow = MutableStateFlow<String?>(null)
+    private val filesSortOrderFlow = MutableStateFlow<String?>(null)
 
     private lateinit var viewModel: FilesViewModel
 
@@ -64,6 +72,14 @@ class FilesViewModelTest {
         Dispatchers.setMain(testDispatcher)
         coEvery { fileRepository.getFiles() } returns Result.Success(testFiles)
         every { serverDataStore.getBaseUrl() } returns "https://chat.example.com"
+        every { settingsDataStore.filesViewMode } returns filesViewModeFlow
+        every { settingsDataStore.filesSortField } returns filesSortFieldFlow
+        every { settingsDataStore.filesSortOrder } returns filesSortOrderFlow
+        coEvery { settingsDataStore.setFilesViewMode(any()) } answers { filesViewModeFlow.value = firstArg() }
+        coEvery { settingsDataStore.setFilesSort(any(), any()) } answers {
+            filesSortFieldFlow.value = firstArg()
+            filesSortOrderFlow.value = secondArg()
+        }
     }
 
     @After
@@ -75,6 +91,7 @@ class FilesViewModelTest {
         fileRepository = fileRepository,
         fileReader = fileReader,
         serverDataStore = serverDataStore,
+        settingsDataStore = settingsDataStore,
         ioDispatcher = testDispatcher,
     )
 
@@ -320,6 +337,27 @@ class FilesViewModelTest {
     }
 
     @Test
+    fun `toggleViewMode persists the new mode`() = runTest {
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.toggleViewMode()
+        advanceUntilIdle()
+
+        coVerify { settingsDataStore.setFilesViewMode(FileViewMode.GRID.toStorageString()) }
+    }
+
+    @Test
+    fun `persisted view mode hydrates initial state`() = runTest {
+        filesViewModeFlow.value = FileViewMode.GRID.toStorageString()
+
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        assertThat(viewModel.uiState.value.viewMode).isEqualTo(FileViewMode.GRID)
+    }
+
+    @Test
     fun `setSort updates sort field and order`() = runTest {
         viewModel = createViewModel()
         advanceUntilIdle()
@@ -330,6 +368,49 @@ class FilesViewModelTest {
         val state = viewModel.uiState.value
         assertThat(state.sortField).isEqualTo(FileSortField.NAME)
         assertThat(state.sortOrder).isEqualTo(FileSortOrder.ASCENDING)
+    }
+
+    @Test
+    fun `setSort persists the field and order`() = runTest {
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.setSort(FileSortField.NAME, FileSortOrder.ASCENDING)
+        advanceUntilIdle()
+
+        coVerify {
+            settingsDataStore.setFilesSort(
+                FileSortField.NAME.toStorageString(),
+                FileSortOrder.ASCENDING.toStorageString(),
+            )
+        }
+    }
+
+    @Test
+    fun `persisted sort hydrates initial state`() = runTest {
+        filesSortFieldFlow.value = FileSortField.NAME.toStorageString()
+        filesSortOrderFlow.value = FileSortOrder.ASCENDING.toStorageString()
+
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertThat(state.sortField).isEqualTo(FileSortField.NAME)
+        assertThat(state.sortOrder).isEqualTo(FileSortOrder.ASCENDING)
+    }
+
+    @Test
+    fun `filter is not persisted across sessions`() = runTest {
+        viewModel = createViewModel()
+        advanceUntilIdle()
+        viewModel.setFilter(FileTypeFilter.IMAGES)
+        advanceUntilIdle()
+        assertThat(viewModel.uiState.value.selectedFilter).isEqualTo(FileTypeFilter.IMAGES)
+
+        // A fresh ViewModel (new app session) starts back at ALL — the filter was never persisted.
+        val next = createViewModel()
+        advanceUntilIdle()
+        assertThat(next.uiState.value.selectedFilter).isEqualTo(FileTypeFilter.ALL)
     }
 
     @Test

--- a/feature/files/src/commonMain/kotlin/com/garfiec/librechat/feature/files/di/FilesModule.kt
+++ b/feature/files/src/commonMain/kotlin/com/garfiec/librechat/feature/files/di/FilesModule.kt
@@ -15,6 +15,7 @@ val filesModule = module {
             fileRepository = get(),
             fileReader = get(),
             serverDataStore = get(),
+            settingsDataStore = get(),
             ioDispatcher = get(KoinQualifiers.IO),
         )
     }

--- a/feature/files/src/commonMain/kotlin/com/garfiec/librechat/feature/files/viewmodel/FilesViewModel.kt
+++ b/feature/files/src/commonMain/kotlin/com/garfiec/librechat/feature/files/viewmodel/FilesViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.viewModelScope
 import co.touchlab.kermit.Logger
 import com.garfiec.librechat.core.common.result.Result
 import com.garfiec.librechat.core.data.datastore.ServerDataStore
+import com.garfiec.librechat.core.data.datastore.SettingsDataStore
 import com.garfiec.librechat.core.data.repository.FileRepository
 import com.garfiec.librechat.core.model.FileObject
 import com.garfiec.librechat.core.model.request.DeleteFileEntry
@@ -22,6 +23,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -36,21 +38,61 @@ enum class FileTypeFilter(val label: String) {
     VIDEO("Video"),
 }
 
+// Stored strings are decoupled from the constant names so renaming a constant can't orphan a saved
+// preference (matches StarredModelsDisplay/ContextBarPlacement/etc. in :core:data).
 enum class FileSortField(val label: String) {
     NAME("Name"),
     DATE("Date"),
     SIZE("Size"),
-    TYPE("Type"),
+    TYPE("Type");
+
+    companion object {
+        fun fromString(value: String?): FileSortField = when (value) {
+            "name" -> NAME
+            "size" -> SIZE
+            "type" -> TYPE
+            else -> DATE
+        }
+    }
+
+    fun toStorageString(): String = when (this) {
+        NAME -> "name"
+        DATE -> "date"
+        SIZE -> "size"
+        TYPE -> "type"
+    }
 }
 
 enum class FileSortOrder {
     ASCENDING,
-    DESCENDING,
+    DESCENDING;
+
+    companion object {
+        fun fromString(value: String?): FileSortOrder =
+            if (value == "ascending") ASCENDING else DESCENDING
+    }
+
+    fun toStorageString(): String = when (this) {
+        ASCENDING -> "ascending"
+        DESCENDING -> "descending"
+    }
 }
 
 enum class FileViewMode {
     LIST,
-    GRID,
+    GRID;
+
+    companion object {
+        fun fromString(value: String?): FileViewMode = when (value) {
+            "grid" -> GRID
+            else -> LIST
+        }
+    }
+
+    fun toStorageString(): String = when (this) {
+        LIST -> "list"
+        GRID -> "grid"
+    }
 }
 
 @Immutable
@@ -78,13 +120,21 @@ class FilesViewModel(
     private val fileRepository: FileRepository,
     private val fileReader: FileReader,
     private val serverDataStore: ServerDataStore,
+    private val settingsDataStore: SettingsDataStore,
     private val ioDispatcher: CoroutineDispatcher,
 ) : ViewModel() {
 
     private val _files = MutableStateFlow<List<FileObject>>(emptyList())
+
+    // Type filter is session-local (resets to All on relaunch, by design).
     private val _selectedFilter = MutableStateFlow(FileTypeFilter.ALL)
-    private val _sortField = MutableStateFlow(FileSortField.DATE)
-    private val _sortOrder = MutableStateFlow(FileSortOrder.DESCENDING)
+
+    // Sort and view mode are optimistic local state (the UI source of truth) written through to
+    // DataStore and hydrated from it once in init. They start null ("not yet hydrated"): the default
+    // is shown for the brief window until the persisted value loads, and the seed uses
+    // update { it ?: ... } so a change made in that window wins over the incoming persisted value.
+    private val _sort = MutableStateFlow<SortSpec?>(null)
+    private val _viewMode = MutableStateFlow<FileViewMode?>(null)
 
     private val _transientState = MutableStateFlow(TransientState())
 
@@ -99,24 +149,25 @@ class FilesViewModel(
     private val displayList: Flow<DisplayList> = combine(
         _files,
         _selectedFilter,
-        _sortField,
-        _sortOrder,
-    ) { files, filter, sortField, sortOrder ->
+        _sort,
+    ) { files, filter, sortOrNull ->
+        val sort = sortOrNull ?: DefaultSort
         val filtered = filterFiles(files, filter)
-        val sorted = sortFiles(filtered, sortField, sortOrder)
+        val sorted = sortFiles(filtered, sort.field, sort.order)
         DisplayList(
             files = sorted.map { file -> displayDataCache.getOrPut(file.fileId) { file.toDisplayData() } },
             hasFiles = files.isNotEmpty(),
             filter = filter,
-            sortField = sortField,
-            sortOrder = sortOrder,
+            sortField = sort.field,
+            sortOrder = sort.order,
         )
     }
 
     val uiState: StateFlow<FilesUiState> = combine(
         displayList,
         _transientState,
-    ) { list, transient ->
+        _viewMode,
+    ) { list, transient, mode ->
         FilesUiState(
             displayFiles = list.files,
             isLoading = transient.isLoading,
@@ -134,7 +185,7 @@ class FilesViewModel(
             previewFile = transient.previewFile,
             mediaPreview = transient.mediaPreview,
             hasFiles = list.hasFiles,
-            viewMode = transient.viewMode,
+            viewMode = mode ?: FileViewMode.LIST,
         )
     }.stateIn(
         scope = viewModelScope,
@@ -143,6 +194,15 @@ class FilesViewModel(
     )
 
     init {
+        viewModelScope.launch {
+            val field = FileSortField.fromString(settingsDataStore.filesSortField.first())
+            val order = FileSortOrder.fromString(settingsDataStore.filesSortOrder.first())
+            _sort.update { it ?: SortSpec(field, order) }
+        }
+        viewModelScope.launch {
+            val mode = FileViewMode.fromString(settingsDataStore.filesViewMode.first())
+            _viewMode.update { it ?: mode }
+        }
         loadFiles()
     }
 
@@ -305,18 +365,21 @@ class FilesViewModel(
     }
 
     fun setSort(field: FileSortField, order: FileSortOrder) {
-        _sortField.value = field
-        _sortOrder.value = order
+        _sort.value = SortSpec(field, order)
+        viewModelScope.launch {
+            settingsDataStore.setFilesSort(field.toStorageString(), order.toStorageString())
+        }
     }
 
     fun toggleViewMode() {
-        updateTransient {
-            copy(
-                viewMode = when (viewMode) {
-                    FileViewMode.LIST -> FileViewMode.GRID
-                    FileViewMode.GRID -> FileViewMode.LIST
-                },
-            )
+        // Read-then-set is synchronous here (no async gap), so back-to-back taps can't lose a toggle.
+        val next = when (_viewMode.value ?: FileViewMode.LIST) {
+            FileViewMode.LIST -> FileViewMode.GRID
+            FileViewMode.GRID -> FileViewMode.LIST
+        }
+        _viewMode.value = next
+        viewModelScope.launch {
+            settingsDataStore.setFilesViewMode(next.toStorageString())
         }
     }
 
@@ -578,6 +641,11 @@ private data class DisplayList(
     val sortOrder: FileSortOrder,
 )
 
+/** Sort field + order as one unit so a sort change is a single atomic emission. */
+private data class SortSpec(val field: FileSortField, val order: FileSortOrder)
+
+private val DefaultSort = SortSpec(FileSortField.DATE, FileSortOrder.DESCENDING)
+
 private data class TransientState(
     val isLoading: Boolean = false,
     val isRefreshing: Boolean = false,
@@ -590,5 +658,4 @@ private data class TransientState(
     val selectedFileIds: Set<String> = emptySet(),
     val previewFile: FilePreviewDisplayData? = null,
     val mediaPreview: MediaPreviewState? = null,
-    val viewMode: FileViewMode = FileViewMode.LIST,
 )

--- a/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/DrawerContent.kt
+++ b/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/DrawerContent.kt
@@ -151,9 +151,6 @@ private val MenuVerticalGap = 4.dp
 // Favorites shown before the "Show more" toggle reveals the rest.
 private const val FavoritesPreviewCount = 5
 
-// The drawer body's two segmented-toggle modes: the recents history vs. the project folders.
-private enum class DrawerTab { Chats, Projects }
-
 /**
  * Stateful DrawerContent that collects its own state from the ViewModel.
  */
@@ -175,6 +172,7 @@ fun DrawerContent(
     val projects by viewModel.projects.collectAsStateWithLifecycle()
     val inlineProjectChats by viewModel.inlineProjectChats.collectAsStateWithLifecycle()
     val accounts by viewModel.accounts.collectAsStateWithLifecycle()
+    val libraryTab by viewModel.drawerLibraryTab.collectAsStateWithLifecycle()
 
     // Account switcher: the header chip opens the roster sheet; remove asks for confirmation.
     // Switch/add callbacks come from the host (they also close the drawer); remove goes straight to
@@ -242,6 +240,8 @@ fun DrawerContent(
         onMoveToProject = viewModel::moveConversationToProject,
         onCreateProjectAndAssign = viewModel::createProjectAndAssign,
         onOpenProjectsIndex = onOpenProjectsIndex,
+        selectedTab = libraryTab ?: DrawerTab.Chats,
+        onSelectTab = viewModel::setDrawerLibraryTab,
         inlineProjectChats = inlineProjectChats,
         onToggleProject = viewModel::toggleProjectExpanded,
         onCreateProject = viewModel::createProject,
@@ -310,6 +310,9 @@ fun DrawerContent(
     // Projects tab (segmented toggle above the list): the folder list + inline chat accordion, plus
     // an escape hatch to the full-page projects index for advanced controls.
     onOpenProjectsIndex: () -> Unit = {},
+    // Persisted Chats/Projects toggle selection (controlled by the caller).
+    selectedTab: DrawerTab = DrawerTab.Chats,
+    onSelectTab: (DrawerTab) -> Unit = {},
     inlineProjectChats: InlineProjectChatsState = InlineProjectChatsState(),
     onToggleProject: (String) -> Unit = {},
     onCreateProject: (String) -> Unit = {},
@@ -331,10 +334,6 @@ fun DrawerContent(
     var tagPickerTarget by remember { mutableStateOf<DrawerConversationDisplayData?>(null) }
     var exportPickerTarget by remember { mutableStateOf<DrawerConversationDisplayData?>(null) }
     var projectPickerTarget by remember { mutableStateOf<DrawerConversationDisplayData?>(null) }
-
-    // Which mode the segmented toggle above the list selects (folder browsing lives in
-    // [DrawerProjectsList], which owns its own menu/dialog state).
-    var selectedTab by rememberSaveable { mutableStateOf(DrawerTab.Chats) }
 
     // Favorites section view state: whether the whole section is collapsed, and (when expanded)
     // whether it shows all favorites or just the top [FavoritesPreviewCount]. Saveable so the
@@ -510,7 +509,7 @@ fun DrawerContent(
                 )
                 DrawerTabToggle(
                     selectedTab = selectedTab,
-                    onSelect = { selectedTab = it },
+                    onSelect = onSelectTab,
                 )
             }
             // Keep the folder counts fresh whenever the user opens the Projects tab.

--- a/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/DrawerTab.kt
+++ b/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/DrawerTab.kt
@@ -1,0 +1,24 @@
+package com.garfiec.librechat.shared.navigation
+
+/**
+ * The drawer "Library" section's two modes: the recents history vs. the project folders. Persisted
+ * so the choice survives app restarts. Stored strings are decoupled from the constant names so
+ * renaming a constant can't orphan a saved preference, and a future third tab is an added case here
+ * rather than a storage-schema change.
+ */
+enum class DrawerTab {
+    Chats,
+    Projects;
+
+    companion object {
+        fun fromString(value: String?): DrawerTab = when (value) {
+            "projects" -> Projects
+            else -> Chats
+        }
+    }
+
+    fun toStorageString(): String = when (this) {
+        Chats -> "chats"
+        Projects -> "projects"
+    }
+}

--- a/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/NavHostViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/NavHostViewModel.kt
@@ -52,9 +52,11 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 class NavHostViewModel(
@@ -231,6 +233,18 @@ class NavHostViewModel(
     val tabletSidebarGestureEnabled: StateFlow<Boolean> = settingsDataStore.tabletSidebarGestureEnabled
         .stateIn(viewModelScope, SharingStarted.Eagerly, true)
 
+    // Drawer "Library" tab is optimistic local state (instant toggle) with DataStore as a write-behind
+    // cache: hydrated once in init and written on change. Null = not yet hydrated; the drawer shows
+    // Chats for the brief window until the persisted value loads, and the seed's update { it ?: ... }
+    // lets a tap in that window win over the incoming persisted value.
+    private val _drawerLibraryTab = MutableStateFlow<DrawerTab?>(null)
+    val drawerLibraryTab: StateFlow<DrawerTab?> = _drawerLibraryTab.asStateFlow()
+
+    fun setDrawerLibraryTab(tab: DrawerTab) {
+        _drawerLibraryTab.value = tab
+        viewModelScope.launch { settingsDataStore.setDrawerLibraryTab(tab.toStorageString()) }
+    }
+
     private val _sidebarMode = MutableStateFlow<SidebarMode>(SidebarMode.Conversations)
     val sidebarMode: StateFlow<SidebarMode> = _sidebarMode.asStateFlow()
 
@@ -323,6 +337,10 @@ class NavHostViewModel(
     )
 
     init {
+        viewModelScope.launch {
+            val persisted = DrawerTab.fromString(settingsDataStore.drawerLibraryTab.first())
+            _drawerLibraryTab.update { it ?: persisted }
+        }
         viewModelScope.launch {
             try {
                 // Wait for the server URL's async warm-up before any startup network work, so a


### PR DESCRIPTION
## Summary
The Files screen (list/grid view and sort) and the drawer's Chats/Projects toggle reset to defaults on every app restart. This remembers those selections so they persist across restarts.

## Changes
- **Files screen** — the list/grid view mode and the sort (Name/Date/Size/Type, ascending/descending) are now remembered. They're held as optimistic local state so changes apply instantly, and written through to DataStore; the screen hydrates from the saved values on load. The type filter (All/Images/…) stays session-local and resets to All on relaunch.
- **Drawer** — the Chats/Projects segmented toggle is now remembered. Previously it survived only configuration changes (`rememberSaveable`), not app restarts. The selection is modeled as a `DrawerTab` enum persisted via DataStore.
- **Storage** — new preferences in `SettingsDataStore`, stored as stable strings decoupled from the enum constant names (matching the existing persisted-enum convention) so renaming a constant can't orphan a saved preference.

## Testing
- Files ViewModel unit tests cover persistence and hydration of sort and view mode (stateful DataStore mock), that the filter stays session-local across ViewModel recreation, and the existing filter/selection/sort behavior.
- Android compile + detekt (commonMain gate) + files unit tests pass.
- Device-tested on a Pixel 9 Pro Fold.

## Notes
- These are device-level UI preferences (global, not account-scoped).
