### PR TITLE
fix(chat): expand tool-card ripple to the full card bounds

### DIFF
--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/LogContentCard.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/LogContentCard.kt
@@ -63,11 +63,12 @@ fun LogContentCard(
         ),
         shape = RoundedCornerShape(8.dp),
     ) {
-        Column(modifier = Modifier.padding(12.dp)) {
+        Column {
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
                     .clickable { isExpanded = !isExpanded }
+                    .padding(12.dp)
                     .semantics {
                         role = Role.Button
                         contentDescription = if (isExpanded) {
@@ -104,7 +105,7 @@ fun LogContentCard(
                 enter = expandVertically(),
                 exit = shrinkVertically(),
             ) {
-                Column {
+                Column(modifier = Modifier.padding(start = 12.dp, end = 12.dp, bottom = 12.dp)) {
                     Spacer(modifier = Modifier.height(8.dp))
                     Text(
                         text = log.content,

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/StreamingToolCallCard.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/StreamingToolCallCard.kt
@@ -71,7 +71,7 @@ fun StreamingToolCallCard(
         ),
         shape = RoundedCornerShape(8.dp),
     ) {
-        Column(modifier = Modifier.padding(12.dp)) {
+        Column {
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -81,7 +81,8 @@ fun StreamingToolCallCard(
                         } else {
                             Modifier
                         },
-                    ),
+                    )
+                    .padding(12.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 Icon(
@@ -129,7 +130,7 @@ fun StreamingToolCallCard(
                 enter = expandVertically(),
                 exit = shrinkVertically(),
             ) {
-                Column {
+                Column(modifier = Modifier.padding(start = 12.dp, end = 12.dp, bottom = 12.dp)) {
                     Spacer(modifier = Modifier.height(8.dp))
                     Text(
                         text = stringResource(Res.string.tool_call_output),

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/SubagentTraceCard.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/SubagentTraceCard.kt
@@ -88,12 +88,13 @@ internal fun SubagentTraceCard(
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerHigh),
         shape = RoundedCornerShape(8.dp),
     ) {
-        Column(modifier = Modifier.padding(12.dp)) {
+        Column {
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
                     .heightIn(min = 32.dp)
                     .clickable { isExpanded = !isExpanded }
+                    .padding(12.dp)
                     .semantics {
                         role = Role.Button
                         contentDescription = toggleCd
@@ -129,7 +130,7 @@ internal fun SubagentTraceCard(
             }
 
             AnimatedVisibility(visible = isExpanded, enter = expandVertically(), exit = shrinkVertically()) {
-                Column {
+                Column(modifier = Modifier.padding(start = 12.dp, end = 12.dp, bottom = 12.dp)) {
                     parts.forEach { part ->
                         Spacer(modifier = Modifier.padding(top = 6.dp))
                         ContentPartDispatcher(

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ToolCallContentPart.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ToolCallContentPart.kt
@@ -140,13 +140,14 @@ internal fun GenericToolCallCard(
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerHigh),
         shape = RoundedCornerShape(8.dp),
     ) {
-        Column(modifier = Modifier.padding(12.dp)) {
+        Column {
             val toolCallCd =
                 stringResource(if (isExpanded) Res.string.cd_collapse_tool_call else Res.string.cd_expand_tool_call, toolName)
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
                     .clickable { isExpanded = !isExpanded }
+                    .padding(12.dp)
                     .semantics {
                         role = Role.Button
                         contentDescription = toolCallCd
@@ -174,7 +175,7 @@ internal fun GenericToolCallCard(
             }
 
             AnimatedVisibility(visible = isExpanded, enter = expandVertically(), exit = shrinkVertically()) {
-                Column {
+                Column(modifier = Modifier.padding(start = 12.dp, end = 12.dp, bottom = 12.dp)) {
                     if (!args.isNullOrBlank()) {
                         Spacer(modifier = Modifier.height(8.dp))
                         Text(


### PR DESCRIPTION
## Summary
The tap ripple on collapsible tool-use cards was inset from the card edges and didn't follow the rounded corners, because the clickable header sat inside a padded `Column`. This moves the padding onto the clickable row itself so the ripple fills the full card width and is clipped to the card's rounded corners — matching the existing `CollapsibleDisclosureCard` pattern.

## Changes
- Move the `12.dp` padding off the outer `Column` and onto each clickable header `Row`, so the ripple spans the full card and hugs the `8.dp` rounded corners.
- Give the expanded content its own `start/end/bottom` padding to preserve the previous inset.
- Applied to the generic tool card, streaming tool card, log card, and subagent trace card.

## Testing
- Built and deployed to a physical device; verified the ripple now covers the whole card and follows the rounded corners across the affected card types.
