### PR TITLE
fix(chat): drop the copy-button label in code blocks

### DIFF
--- a/feature/chat/src/commonMain/composeResources/values-ar/strings.xml
+++ b/feature/chat/src/commonMain/composeResources/values-ar/strings.xml
@@ -92,8 +92,6 @@
     <!-- Content descriptions - Code -->
     <string name="cd_copy_code">نسخ الكود</string>
     <string name="cd_copied">تم النسخ</string>
-    <string name="action_copy_code">نسخ</string>
-    <string name="action_copied">تم النسخ!</string>
     <string name="cd_code_execution_result">نتيجة تنفيذ الكود</string>
     <string name="cd_exit_code_success">رمز الخروج 0 (نجاح)</string>
     <string name="cd_exit_code_failure">رمز الخروج %1$d (فشل)</string>

--- a/feature/chat/src/commonMain/composeResources/values-de/strings.xml
+++ b/feature/chat/src/commonMain/composeResources/values-de/strings.xml
@@ -92,8 +92,6 @@
     <!-- Content descriptions - Code -->
     <string name="cd_copy_code">Code kopieren</string>
     <string name="cd_copied">Kopiert</string>
-    <string name="action_copy_code">Kopieren</string>
-    <string name="action_copied">Kopiert!</string>
     <string name="cd_code_execution_result">Ergebnis der Code-Ausführung</string>
     <string name="cd_exit_code_success">Exit-Code 0 (Erfolg)</string>
     <string name="cd_exit_code_failure">Exit-Code %1$d (Fehler)</string>

--- a/feature/chat/src/commonMain/composeResources/values-es/strings.xml
+++ b/feature/chat/src/commonMain/composeResources/values-es/strings.xml
@@ -92,8 +92,6 @@
     <!-- Content descriptions - Code -->
     <string name="cd_copy_code">Copiar código</string>
     <string name="cd_copied">Copiado</string>
-    <string name="action_copy_code">Copiar</string>
-    <string name="action_copied">¡Copiado!</string>
     <string name="cd_code_execution_result">Resultado de la ejecución de código</string>
     <string name="cd_exit_code_success">Código de salida 0 (correcto)</string>
     <string name="cd_exit_code_failure">Código de salida %1$d (error)</string>

--- a/feature/chat/src/commonMain/composeResources/values-fr/strings.xml
+++ b/feature/chat/src/commonMain/composeResources/values-fr/strings.xml
@@ -92,8 +92,6 @@
     <!-- Content descriptions - Code -->
     <string name="cd_copy_code">Copier le code</string>
     <string name="cd_copied">Copié</string>
-    <string name="action_copy_code">Copier</string>
-    <string name="action_copied">Copié !</string>
     <string name="cd_code_execution_result">Résultat de l\'exécution du code</string>
     <string name="cd_exit_code_success">Code de sortie 0 (succès)</string>
     <string name="cd_exit_code_failure">Code de sortie %1$d (échec)</string>

--- a/feature/chat/src/commonMain/composeResources/values-ja/strings.xml
+++ b/feature/chat/src/commonMain/composeResources/values-ja/strings.xml
@@ -92,8 +92,6 @@
     <!-- Content descriptions - Code -->
     <string name="cd_copy_code">コードをコピー</string>
     <string name="cd_copied">コピー済み</string>
-    <string name="action_copy_code">コピー</string>
-    <string name="action_copied">コピーしました！</string>
     <string name="cd_code_execution_result">コードの実行結果</string>
     <string name="cd_exit_code_success">終了コード 0（成功）</string>
     <string name="cd_exit_code_failure">終了コード %1$d（失敗）</string>

--- a/feature/chat/src/commonMain/composeResources/values-ko/strings.xml
+++ b/feature/chat/src/commonMain/composeResources/values-ko/strings.xml
@@ -92,8 +92,6 @@
     <!-- Content descriptions - Code -->
     <string name="cd_copy_code">코드 복사</string>
     <string name="cd_copied">복사됨</string>
-    <string name="action_copy_code">복사</string>
-    <string name="action_copied">복사됨!</string>
     <string name="cd_code_execution_result">코드 실행 결과</string>
     <string name="cd_exit_code_success">종료 코드 0 (성공)</string>
     <string name="cd_exit_code_failure">종료 코드 %1$d (실패)</string>

--- a/feature/chat/src/commonMain/composeResources/values-pt/strings.xml
+++ b/feature/chat/src/commonMain/composeResources/values-pt/strings.xml
@@ -92,8 +92,6 @@
     <!-- Content descriptions - Code -->
     <string name="cd_copy_code">Copiar código</string>
     <string name="cd_copied">Copiado</string>
-    <string name="action_copy_code">Copiar</string>
-    <string name="action_copied">Copiado!</string>
     <string name="cd_code_execution_result">Resultado da execução do código</string>
     <string name="cd_exit_code_success">Código de saída 0 (sucesso)</string>
     <string name="cd_exit_code_failure">Código de saída %1$d (falha)</string>

--- a/feature/chat/src/commonMain/composeResources/values-ru/strings.xml
+++ b/feature/chat/src/commonMain/composeResources/values-ru/strings.xml
@@ -92,8 +92,6 @@
     <!-- Content descriptions - Code -->
     <string name="cd_copy_code">Скопировать код</string>
     <string name="cd_copied">Скопировано</string>
-    <string name="action_copy_code">Копировать</string>
-    <string name="action_copied">Скопировано!</string>
     <string name="cd_code_execution_result">Результат выполнения кода</string>
     <string name="cd_exit_code_success">Код выхода 0 (успех)</string>
     <string name="cd_exit_code_failure">Код выхода %1$d (ошибка)</string>

--- a/feature/chat/src/commonMain/composeResources/values-zh/strings.xml
+++ b/feature/chat/src/commonMain/composeResources/values-zh/strings.xml
@@ -92,8 +92,6 @@
     <!-- Content descriptions - Code -->
     <string name="cd_copy_code">复制代码</string>
     <string name="cd_copied">已复制</string>
-    <string name="action_copy_code">复制</string>
-    <string name="action_copied">已复制！</string>
     <string name="cd_code_execution_result">代码执行结果</string>
     <string name="cd_exit_code_success">退出码 0（成功）</string>
     <string name="cd_exit_code_failure">退出码 %1$d（失败）</string>

--- a/feature/chat/src/commonMain/composeResources/values/strings.xml
+++ b/feature/chat/src/commonMain/composeResources/values/strings.xml
@@ -100,8 +100,6 @@
     <!-- Content descriptions - Code -->
     <string name="cd_copy_code">Copy code</string>
     <string name="cd_copied">Copied</string>
-    <string name="action_copy_code">Copy</string>
-    <string name="action_copied">Copied!</string>
     <string name="cd_code_execution_result">Code execution result</string>
     <string name="cd_exit_code_success">Exit code 0 (success)</string>
     <string name="cd_exit_code_failure">Exit code %1$d (failure)</string>

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/CodeBlock.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/CodeBlock.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -108,27 +107,15 @@ fun CodeBlock(
                     transitionSpec = { fadeIn() togetherWith fadeOut() },
                     label = "copy_button",
                 ) { copied ->
-                    Row(verticalAlignment = Alignment.CenterVertically) {
-                        Icon(
-                            imageVector = if (copied) Icons.Default.Check else Icons.Default.ContentCopy,
-                            contentDescription = stringResource(if (copied) Res.string.cd_copied else Res.string.cd_copy_code),
-                            tint = if (copied) {
-                                MaterialTheme.colorScheme.primary
-                            } else {
-                                MaterialTheme.colorScheme.onSurfaceVariant
-                            },
-                        )
-                        Spacer(modifier = Modifier.width(4.dp))
-                        Text(
-                            text = stringResource(if (copied) Res.string.action_copied else Res.string.action_copy_code),
-                            style = MaterialTheme.typography.labelSmall,
-                            color = if (copied) {
-                                MaterialTheme.colorScheme.primary
-                            } else {
-                                MaterialTheme.colorScheme.onSurfaceVariant
-                            },
-                        )
-                    }
+                    Icon(
+                        imageVector = if (copied) Icons.Default.Check else Icons.Default.ContentCopy,
+                        contentDescription = stringResource(if (copied) Res.string.cd_copied else Res.string.cd_copy_code),
+                        tint = if (copied) {
+                            MaterialTheme.colorScheme.primary
+                        } else {
+                            MaterialTheme.colorScheme.onSurfaceVariant
+                        },
+                    )
                 }
             }
         }


### PR DESCRIPTION
## Summary
The copy button in the code-block header paired its icon with a "Copy"/"Copied!" text label. In narrow chat bubbles that label was clipped to near-invisibility and added nothing beside the already-clear icon. This removes the label, leaving just the copy icon (which still animates to a checkmark on copy).

## Changes
- `CodeBlock.kt`: replace the icon-plus-label `Row` in the copy `IconButton` with the icon alone; drop the now-unused `width` import.
- Remove the now-orphaned `action_copy_code` / `action_copied` strings from all 10 locale files. The `cd_copy_code` / `cd_copied` content descriptions are retained on the icon for accessibility.

## Testing
- Compiled (`:feature:chat:compileDebugKotlin`) and detekt (`:feature:chat:detektMetadataCommonMain`) clean.
- Installed on a Pixel 9 Pro Fold and verified code blocks render with an icon-only copy button.
