### PR TITLE
feat(chat): render tool-call file attachments with native PDF preview

### DIFF
--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -125,7 +125,7 @@ coroutines:
 Compose:
   CompositionLocalAllowlist:
     active: true
-    allowedCompositionLocals: LocalChatMediaViewer,LocalImmediateMarkdown,LocalInlineArtifactPrefs,LocalMermaidRenderCache,LocalOpenArtifact,LocalParsedMarkdownCache,LocalSearchFocusNonce,LocalSubagentProgress
+    allowedCompositionLocals: LocalAttachmentDownloader,LocalChatMediaViewer,LocalImmediateMarkdown,LocalInlineArtifactPrefs,LocalMermaidRenderCache,LocalOpenArtifact,LocalOpenPdf,LocalParsedMarkdownCache,LocalSearchFocusNonce,LocalSubagentProgress
 
 # detekt-koin rule overrides (defaults ship in plugin jar; buildUponDefaultConfig = true)
 koin-rules:

--- a/core/common/src/commonMain/kotlin/com/garfiec/librechat/core/common/Constants.kt
+++ b/core/common/src/commonMain/kotlin/com/garfiec/librechat/core/common/Constants.kt
@@ -16,6 +16,26 @@ object ToolConstants {
     const val PROGRAMMATIC_TOOLS = "programmatic_tools"
     const val DEFERRED_TOOLS = "deferred_tools"
 
+    /** Server-side retrieval tool (`retrieval` / RAG). Rendered as a generic tool card on
+     *  mobile — its structured sources live in the attachment's file_search payload, which
+     *  the mobile Attachment model does not yet carry. */
+    const val RETRIEVAL = "retrieval"
+
+    /** Sandbox "bash tool" — runs a shell command whose `code` arg is the command line.
+     *  Routed to the code-execution card (matches upstream `BashCall`, `commandField="code"`). */
+    const val BASH_TOOL = "bash_tool"
+
+    /** Programmatic tool calling: the agent emits Python (`run_tools_with_code`) or bash
+     *  (`run_tools_with_bash`) that orchestrates other tools. Both surface a `code` arg and
+     *  render as the code-execution card, like upstream ExecuteCode/BashCall. */
+    const val PROGRAMMATIC_TOOL_CALLING = "run_tools_with_code"
+    const val BASH_PROGRAMMATIC_TOOL_CALLING = "run_tools_with_bash"
+
+    /** Prefix of the agent-handoff tool a supervisor emits to transfer control to a named
+     *  child agent (`lc_transfer_to_<agent>`). Rendered as an agent-handoff row (upstream
+     *  `AgentHandoff`). */
+    const val LC_TRANSFER_TO_PREFIX = "lc_transfer_to_"
+
     /** The `subagent` tool a parent agent invokes to delegate to a child agent
      *  (v0.8.6). Matches upstream `Constants.SUBAGENT`; used to correlate live
      *  `on_subagent_update` traces to their parent tool_call and to render the

--- a/core/ui/src/iosMain/kotlin/com/garfiec/librechat/core/ui/media/MediaActions.ios.kt
+++ b/core/ui/src/iosMain/kotlin/com/garfiec/librechat/core/ui/media/MediaActions.ios.kt
@@ -32,7 +32,7 @@ actual fun rememberShareImage(): (url: String) -> Unit = { url -> shareUrl(url) 
 actual fun rememberShareFile(): (bytes: ByteArray, filename: String, mime: String?) -> Unit {
     val scope = rememberCoroutineScope()
     return remember(scope) {
-        { bytes, filename, _ -> scope.launch { shareFile(bytes, filename) } }
+        { bytes, filename, mime -> scope.launch { shareFile(bytes, filename, mime) } }
     }
 }
 
@@ -51,8 +51,8 @@ private fun shareUrl(url: String) {
 // The NSData copy and disk write are sized by the file, so they run off the main thread; only the
 // UIKit presentation hops back to main.
 @OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
-private suspend fun shareFile(bytes: ByteArray, filename: String) {
-    val tempPath = NSTemporaryDirectory() + sanitizeFilename(filename)
+private suspend fun shareFile(bytes: ByteArray, filename: String, mime: String?) {
+    val tempPath = NSTemporaryDirectory() + ensureExtension(sanitizeFilename(filename), mime)
     val wrote = withContext(Dispatchers.Default) {
         bytes.toNSData().writeToFile(tempPath, atomically = true)
     }
@@ -71,8 +71,29 @@ private suspend fun shareFile(bytes: ByteArray, filename: String) {
 private fun sanitizeFilename(filename: String): String =
     filename.substringAfterLast('/').substringAfterLast('\\').ifBlank { "file" }
 
+/**
+ * Ensures the temp filename carries an extension so the iOS share sheet / receiving apps can infer
+ * the type (a PDF whose display name lacks `.pdf` otherwise shares as an unrecognized blob). If the
+ * name already has an extension it's left alone; otherwise one is derived from the MIME subtype
+ * (`application/pdf` → `pdf`).
+ */
+private fun ensureExtension(filename: String, mime: String?): String {
+    if (filename.contains('.')) return filename
+    val ext = mime?.substringAfterLast('/', "")
+        ?.substringBefore(';')
+        ?.substringBefore('+')
+        ?.takeIf { it.isNotBlank() && it.all { c -> c.isLetterOrDigit() } }
+        ?: return filename
+    return "$filename.$ext"
+}
+
+/**
+ * Copies this [ByteArray] into an [NSData]. The `isEmpty()` guard is load-bearing:
+ * `pinned.addressOf(0)` on an empty array is an out-of-bounds access. Shared so callers that hand
+ * bytes to UIKit/PDFKit APIs don't each re-implement (and each risk dropping) the empty guard.
+ */
 @OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
-private fun ByteArray.toNSData(): NSData {
+fun ByteArray.toNSData(): NSData {
     if (isEmpty()) return NSData()
     return usePinned { pinned ->
         NSData.create(bytes = pinned.addressOf(0), length = size.toULong())

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/components/PdfViewer.android.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/components/PdfViewer.android.kt
@@ -1,0 +1,311 @@
+package com.garfiec.librechat.feature.chat.components
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.Color
+import android.graphics.pdf.PdfRenderer
+import android.os.ParcelFileDescriptor
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.calculatePan
+import androidx.compose.foundation.gestures.calculateZoom
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asAndroidBitmap
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.input.pointer.positionChanged
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
+import co.touchlab.kermit.Logger
+import com.garfiec.librechat.feature.chat.resources.Res
+import com.garfiec.librechat.feature.chat.resources.pdf_page_failed
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import org.jetbrains.compose.resources.stringResource
+import java.io.File
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicIntegerArray
+
+/** Placeholder aspect (≈ A4 portrait, 1/√2) used before a page's real dimensions are known. */
+private const val DEFAULT_PAGE_ASPECT = 0.7071f
+
+/**
+ * Hard caps on a rendered page bitmap's dimensions in pixels. A page fit to a large-screen width
+ * (unfolded foldable, tablet) or a pathological aspect could otherwise demand hundreds of MB across
+ * the visible window and OOM. We downscale by a single factor so *both* dimensions stay under their
+ * cap while the aspect is preserved, and let [ContentScale.FillWidth] upscale the smaller bitmap.
+ */
+private const val MAX_PAGE_BITMAP_WIDTH_PX = 2048
+private const val MAX_PAGE_BITMAP_HEIGHT_PX = 8192
+
+/** Per-page render outcome. [Loading] and [Failed] are distinguished so a failed page can show an
+ *  inline indicator instead of a silent blank gap. */
+private sealed interface PageRender {
+    data object Loading : PageRender
+    data object Failed : PageRender
+    data class Ready(val bitmap: ImageBitmap) : PageRender
+}
+
+/**
+ * Android PDF surface backed by [android.graphics.pdf.PdfRenderer]. The bytes are staged to a
+ * cache file (PdfRenderer needs a seekable [ParcelFileDescriptor]), then each page is rendered to a
+ * bitmap on demand as it scrolls into view — off-screen pages are disposed by the [LazyColumn], so
+ * memory tracks the visible window rather than the whole document.
+ *
+ * Pinch-zoom is per page and gated to multi-touch (see the second `pointerInput`) so a one-finger
+ * drag still scrolls the list.
+ */
+@Composable
+actual fun PdfViewer(bytes: ByteArray, onRenderError: () -> Unit, modifier: Modifier) {
+    val context = LocalContext.current
+    val currentOnRenderError by rememberUpdatedState(onRenderError)
+
+    // The producer owns the holder's lifecycle: it publishes the instance it created and closes that
+    // same instance via awaitDispose. (A DisposableEffect keyed on the delegated holder would read
+    // the *live* value at dispose time and close the just-created holder on the null→holder swap.)
+    // NonCancellable so a create() that finishes after the composition scrolled away is still
+    // published-or-closed rather than leaking its fd/renderer.
+    val holder by produceState<PdfDocumentHolder?>(null, bytes) {
+        val fresh = withContext(Dispatchers.IO + NonCancellable) {
+            PdfDocumentHolder.create(context, bytes)
+        }
+        value = fresh
+        if (fresh == null) currentOnRenderError()
+        awaitDispose { fresh?.close() }
+    }
+
+    val doc = holder ?: return
+    LazyColumn(modifier = modifier.fillMaxSize()) {
+        items(count = doc.pageCount, key = { it }, contentType = { "pdf_page" }) { index ->
+            PdfPage(doc = doc, index = index)
+        }
+    }
+}
+
+/**
+ * One page, fit to width, with per-page pinch-zoom + pan. The zoom gesture is gated to multi-touch
+ * (see the second `pointerInput`) so a one-finger drag is left unconsumed and the enclosing
+ * [LazyColumn] scrolls; two fingers zoom/pan the page. Double-tap resets. Pan is clamped so the page
+ * can't be dragged off its own bounds.
+ */
+@Composable
+private fun PdfPage(doc: PdfDocumentHolder, index: Int) {
+    var scale by remember { mutableFloatStateOf(1f) }
+    var offsetX by remember { mutableFloatStateOf(0f) }
+    var offsetY by remember { mutableFloatStateOf(0f) }
+    var size by remember { mutableStateOf(IntSize.Zero) }
+
+    val widthPx = size.width
+    val render by produceState<PageRender>(PageRender.Loading, doc, index, widthPx) {
+        value = PageRender.Loading
+        if (widthPx > 0) {
+            value = doc.renderPage(index, widthPx)?.let { PageRender.Ready(it) } ?: PageRender.Failed
+        }
+    }
+    val bitmap = (render as? PageRender.Ready)?.bitmap
+
+    // Recycle the page bitmap's native memory when the page leaves composition (scrolls out of the
+    // LazyColumn window); GC alone lets ARGB_8888 buffers pile up while the collector catches up.
+    // rememberUpdatedState so the effect frees whichever bitmap is current at dispose time.
+    val bitmapToRecycle by rememberUpdatedState(bitmap)
+    DisposableEffect(Unit) {
+        onDispose { bitmapToRecycle?.asAndroidBitmap()?.recycle() }
+    }
+
+    // Once the bitmap is in, size the box to its true aspect (drives relayout); until then use the
+    // stored/placeholder ratio. Sanitize so Modifier.aspectRatio never sees 0 / NaN / ∞.
+    val aspect = bitmap
+        ?.let { it.width.toFloat() / it.height.toFloat() }
+        ?.takeIf { it.isFinite() && it > 0f }
+        ?: doc.aspectRatio(index)
+
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .aspectRatio(aspect)
+            .onSizeChanged { size = it }
+            .graphicsLayer {
+                scaleX = scale
+                scaleY = scale
+                translationX = offsetX
+                translationY = offsetY
+            }
+            .pointerInput(Unit) {
+                detectTapGestures(onDoubleTap = {
+                    scale = 1f
+                    offsetX = 0f
+                    offsetY = 0f
+                })
+            }
+            .pointerInput(Unit) {
+                awaitEachGesture {
+                    awaitFirstDown(requireUnconsumed = false, pass = PointerEventPass.Initial)
+                    do {
+                        val event = awaitPointerEvent(PointerEventPass.Initial)
+                        if (event.changes.size >= 2) {
+                            scale = (scale * event.calculateZoom()).coerceIn(1f, 5f)
+                            if (scale > 1f) {
+                                val pan = event.calculatePan()
+                                val maxX = (size.width * (scale - 1f)) / 2f
+                                val maxY = (size.height * (scale - 1f)) / 2f
+                                offsetX = (offsetX + pan.x).coerceIn(-maxX, maxX)
+                                offsetY = (offsetY + pan.y).coerceIn(-maxY, maxY)
+                            } else {
+                                offsetX = 0f
+                                offsetY = 0f
+                            }
+                            // Consume only the multi-touch gesture so single-finger scroll passes through.
+                            event.changes.forEach { if (it.positionChanged()) it.consume() }
+                        }
+                    } while (event.changes.any { it.pressed })
+                }
+            },
+        contentAlignment = Alignment.Center,
+    ) {
+        when (val r = render) {
+            is PageRender.Ready -> Image(
+                bitmap = r.bitmap,
+                contentDescription = null,
+                modifier = Modifier.fillMaxSize(),
+                contentScale = ContentScale.FillWidth,
+            )
+            is PageRender.Failed -> Text(
+                text = stringResource(Res.string.pdf_page_failed),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(16.dp),
+            )
+            is PageRender.Loading -> Unit // blank until the first render lands
+        }
+    }
+}
+
+/**
+ * Owns the [PdfRenderer] and its backing fd. [renderPage] is serialized by a [Mutex] because
+ * PdfRenderer allows only one open page at a time and the LazyColumn may render several pages
+ * concurrently as they scroll in.
+ */
+private class PdfDocumentHolder private constructor(
+    private val fd: ParcelFileDescriptor,
+    private val renderer: PdfRenderer,
+    val pageCount: Int,
+) {
+    private val mutex = Mutex()
+
+    @Volatile private var closed = false
+    private val tornDown = AtomicBoolean(false)
+
+    // Holder-owned teardown scope (cancelled once teardown completes) rather than a fresh anonymous
+    // CoroutineScope per close() with no lifecycle owner.
+    private val ioScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    // Real per-page width/height ratios, filled lazily by renderPage. Float bits in an
+    // AtomicIntegerArray so the render-thread write is visible to the main-thread aspectRatio() read
+    // (a plain FloatArray gives no cross-thread visibility guarantee). 0 bits == unset.
+    private val aspectRatios = AtomicIntegerArray(pageCount)
+
+    /** width / height, for placeholder sizing before the bitmap renders (real value once rendered). */
+    fun aspectRatio(index: Int): Float {
+        if (index < 0 || index >= pageCount) return DEFAULT_PAGE_ASPECT
+        return Float.fromBits(aspectRatios.get(index)).takeIf { it.isFinite() && it > 0f }
+            ?: DEFAULT_PAGE_ASPECT
+    }
+
+    suspend fun renderPage(index: Int, widthPx: Int): ImageBitmap? = withContext(Dispatchers.IO) {
+        runCatching {
+            mutex.withLock {
+                if (closed) return@withLock null
+                renderer.openPage(index).use { page ->
+                    if (page.width <= 0 || page.height <= 0) return@use null
+                    aspectRatios.set(index, (page.width.toFloat() / page.height).toRawBits())
+
+                    // Fit to width, then downscale by one factor so neither dimension exceeds its cap
+                    // (aspect preserved). FillWidth upscales the smaller bitmap back to the container.
+                    val fitHeight = widthPx.toFloat() * page.height / page.width
+                    val downscale = minOf(
+                        1f,
+                        MAX_PAGE_BITMAP_WIDTH_PX / widthPx.toFloat(),
+                        MAX_PAGE_BITMAP_HEIGHT_PX / fitHeight,
+                    )
+                    val renderWidth = (widthPx * downscale).toInt().coerceAtLeast(1)
+                    val renderHeight = (fitHeight * downscale).toInt().coerceAtLeast(1)
+
+                    val bmp = Bitmap.createBitmap(renderWidth, renderHeight, Bitmap.Config.ARGB_8888)
+                    // PDF pages are transparent where unpainted; fill white so text is legible on dark themes.
+                    bmp.eraseColor(Color.WHITE)
+                    page.render(bmp, null, null, PdfRenderer.Page.RENDER_MODE_FOR_DISPLAY)
+                    bmp.asImageBitmap()
+                }
+            }
+        }.getOrNull()
+    }
+
+    fun close() {
+        // Idempotent: guard so a double-dispose doesn't launch teardown twice.
+        if (!tornDown.compareAndSet(false, true)) return
+        // Flag first so in-flight renders bail; do the actual teardown under the lock so we never
+        // close the renderer out from under a page.render() that's mid-flight.
+        closed = true
+        ioScope.launch {
+            mutex.withLock {
+                runCatching { renderer.close() }
+                runCatching { fd.close() }
+            }
+        }.invokeOnCompletion { ioScope.cancel() }
+    }
+
+    companion object {
+        fun create(context: Context, bytes: ByteArray): PdfDocumentHolder? {
+            val dir = File(context.cacheDir, "pdf_preview").apply { mkdirs() }
+            val file = File.createTempFile("preview_", ".pdf", dir)
+            var opened: ParcelFileDescriptor? = null
+            return runCatching {
+                file.writeBytes(bytes)
+                val fd = ParcelFileDescriptor.open(file, ParcelFileDescriptor.MODE_READ_ONLY)
+                opened = fd
+                // Unlink now: the fd keeps the data readable, and the on-disk entry is gone even if the
+                // process is killed with the preview open — no orphaned cache files.
+                file.delete()
+                val renderer = PdfRenderer(fd)
+                PdfDocumentHolder(fd, renderer, renderer.pageCount)
+            }.onFailure { e ->
+                Logger.e(e) { "PdfDocumentHolder.create failed" }
+                runCatching { opened?.close() }
+                runCatching { file.delete() }
+            }.getOrNull()
+        }
+    }
+}

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatScreen.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatScreen.kt
@@ -123,6 +123,7 @@ actual fun ChatScreen(
         mediaPreview = uiState.mediaPreview,
         onOpenMedia = viewModel::openMedia,
         onCloseMedia = viewModel::closeMedia,
+        onDownloadAttachment = viewModel::downloadFileBytes,
     ) {
     Scaffold(
         modifier = modifier

--- a/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/components/ToolCallAttachmentsTest.kt
+++ b/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/components/ToolCallAttachmentsTest.kt
@@ -1,0 +1,214 @@
+package com.garfiec.librechat.feature.chat.components
+
+import com.garfiec.librechat.core.model.Attachment
+import com.garfiec.librechat.feature.chat.components.artifact.ArtifactType
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class ToolCallAttachmentsTest {
+
+    // ─── partitionToolCallAttachments ──────────────────────────────
+
+    @Test
+    fun `filters to the given tool call id`() {
+        val attachments = listOf(
+            Attachment(fileId = "a", filename = "a.pdf", type = "application/pdf", toolCallId = "call_1"),
+            Attachment(fileId = "b", filename = "b.pdf", type = "application/pdf", toolCallId = "call_2"),
+        )
+
+        val result = partitionToolCallAttachments(attachments, "call_1")
+
+        assertThat(result).hasSize(1)
+        assertThat(result.single().attachment.fileId).isEqualTo("a")
+    }
+
+    @Test
+    fun `null tool call id yields nothing`() {
+        val attachments = listOf(
+            Attachment(fileId = "a", filename = "a.pdf", type = "application/pdf", toolCallId = "call_1"),
+        )
+        assertThat(partitionToolCallAttachments(attachments, null)).isEmpty()
+    }
+
+    @Test
+    fun `skips pseudo attachment types`() {
+        val attachments = listOf(
+            Attachment(fileId = "w", type = "web_search", toolCallId = "c"),
+            Attachment(fileId = "f", type = "file_search", toolCallId = "c"),
+            Attachment(fileId = "m", type = "memory", toolCallId = "c"),
+            Attachment(fileId = "u", type = "ui_resources", toolCallId = "c"),
+        )
+        assertThat(partitionToolCallAttachments(attachments, "c")).isEmpty()
+    }
+
+    @Test
+    fun `skips office preview attachments`() {
+        val attachments = listOf(
+            Attachment(
+                fileId = "d",
+                filename = "report.docx",
+                type = ArtifactType.DEFAULT_OFFICE_PREVIEW_MIME,
+                toolCallId = "c",
+            ),
+        )
+        assertThat(partitionToolCallAttachments(attachments, "c")).isEmpty()
+    }
+
+    @Test
+    fun `skips sandbox placeholder leaves`() {
+        val attachments = listOf(
+            Attachment(fileId = "p", filename = "_.dirkeep-88b30b", toolCallId = "c"),
+            Attachment(fileId = "q", filename = "_.gitkeep-abc123", toolCallId = "c"),
+        )
+        assertThat(partitionToolCallAttachments(attachments, "c")).isEmpty()
+    }
+
+    @Test
+    fun `dedups by file id keeping first`() {
+        val attachments = listOf(
+            Attachment(fileId = "same", filename = "x.pdf", type = "application/pdf", toolCallId = "c"),
+            Attachment(fileId = "same", filename = "x-copy.pdf", type = "application/pdf", toolCallId = "c"),
+        )
+        val result = partitionToolCallAttachments(attachments, "c")
+        assertThat(result).hasSize(1)
+        assertThat(result.single().attachment.filename).isEqualTo("x.pdf")
+    }
+
+    @Test
+    fun `classifies image artifact pdf and file buckets`() {
+        val attachments = listOf(
+            Attachment(fileId = "img", filename = "plot.png", type = "image/png", toolCallId = "c"),
+            Attachment(fileId = "py", filename = "make.py", type = "text/x-python", text = "print(1)", toolCallId = "c"),
+            Attachment(fileId = "pdf", filename = "receipt.pdf", type = "application/pdf", toolCallId = "c"),
+            Attachment(fileId = "csv", filename = "data.csv", type = "text/csv", toolCallId = "c"),
+        )
+
+        val result = partitionToolCallAttachments(attachments, "c")
+
+        assertThat(result.filterIsInstance<ToolAttachment.Image>().map { it.attachment.fileId })
+            .containsExactly("img")
+        assertThat(result.filterIsInstance<ToolAttachment.ArtifactContent>().map { it.attachment.fileId })
+            .containsExactly("py")
+        assertThat(result.filterIsInstance<ToolAttachment.Pdf>().map { it.attachment.fileId })
+            .containsExactly("pdf")
+        assertThat(result.filterIsInstance<ToolAttachment.File>().map { it.attachment.fileId })
+            .containsExactly("csv")
+    }
+
+    @Test
+    fun `pdf by extension without mime is a pdf bucket`() {
+        val attachments = listOf(
+            Attachment(fileId = "p", filename = "invoice.PDF", type = null, toolCallId = "c"),
+        )
+        val result = partitionToolCallAttachments(attachments, "c")
+        assertThat(result.single()).isInstanceOf(ToolAttachment.Pdf::class.java)
+    }
+
+    @Test
+    fun `pdf without a file id falls back to a download chip`() {
+        // No fileId → nothing to download for the native preview, so it stays a file chip.
+        val attachments = listOf(
+            Attachment(fileId = null, filename = "receipt.pdf", type = "application/pdf", toolCallId = "c"),
+        )
+        val result = partitionToolCallAttachments(attachments, "c")
+        assertThat(result.single()).isInstanceOf(ToolAttachment.File::class.java)
+    }
+
+    @Test
+    fun `code file with no extracted text falls back to file chip`() {
+        val attachments = listOf(
+            Attachment(fileId = "py", filename = "make.py", type = "text/x-python", text = null, toolCallId = "c"),
+        )
+        val result = partitionToolCallAttachments(attachments, "c")
+        assertThat(result.single()).isInstanceOf(ToolAttachment.File::class.java)
+    }
+
+    // ─── looksLikePdf ──────────────────────────────────────────────
+
+    @Test
+    fun `looksLikePdf accepts a standard header`() {
+        assertThat(looksLikePdf("%PDF-1.7\n%âãÏÓ".encodeToByteArray())).isTrue()
+    }
+
+    @Test
+    fun `looksLikePdf finds a header after leading whitespace within the first kilobyte`() {
+        val bytes = ByteArray(600) { ' '.code.toByte() } + "%PDF-1.5".encodeToByteArray()
+        assertThat(looksLikePdf(bytes)).isTrue()
+    }
+
+    @Test
+    fun `looksLikePdf ignores a header past the first kilobyte`() {
+        val bytes = ByteArray(2000) { ' '.code.toByte() } + "%PDF-1.5".encodeToByteArray()
+        assertThat(looksLikePdf(bytes)).isFalse()
+    }
+
+    @Test
+    fun `looksLikePdf rejects an html error body`() {
+        assertThat(looksLikePdf("<!DOCTYPE html><html><body>Not Found</body></html>".encodeToByteArray()))
+            .isFalse()
+    }
+
+    @Test
+    fun `looksLikePdf rejects empty bytes`() {
+        assertThat(looksLikePdf(ByteArray(0))).isFalse()
+    }
+
+    // ─── displayFilename ───────────────────────────────────────────
+
+    @Test
+    fun `displayFilename restores sanitized dotfile with extension`() {
+        assertThat(displayFilename("_.config-abcdef.txt")).isEqualTo(".config.txt")
+    }
+
+    @Test
+    fun `displayFilename restores sanitized dotfile without extension`() {
+        assertThat(displayFilename("_.dirkeep-88b30b")).isEqualTo(".dirkeep")
+    }
+
+    @Test
+    fun `displayFilename passes ordinary names through`() {
+        assertThat(displayFilename("report-deadbe.csv")).isEqualTo("report-deadbe.csv")
+        assertThat(displayFilename("dummy_receipt.pdf")).isEqualTo("dummy_receipt.pdf")
+    }
+
+    // ─── attachmentToArtifact ──────────────────────────────────────
+
+    @Test
+    fun `python file maps to fenced markdown artifact`() {
+        val artifact = attachmentToArtifact(
+            Attachment(fileId = "py", filename = "make_receipt.py", text = "print('hi')"),
+        )
+        assertThat(artifact).isNotNull()
+        assertThat(artifact!!.type).isEqualTo("text/markdown")
+        assertThat(artifact.content).isEqualTo("```py\nprint('hi')\n```")
+        assertThat(artifact.title).isEqualTo("make_receipt.py")
+    }
+
+    @Test
+    fun `html file maps to html artifact`() {
+        val artifact = attachmentToArtifact(
+            Attachment(fileId = "h", filename = "page.html", text = "<h1>hi</h1>"),
+        )
+        assertThat(artifact?.type).isEqualTo("text/html")
+        assertThat(artifact?.content).isEqualTo("<h1>hi</h1>")
+    }
+
+    @Test
+    fun `mermaid file maps to mermaid artifact`() {
+        val artifact = attachmentToArtifact(
+            Attachment(fileId = "m", filename = "diagram.mmd", text = "graph TD; A-->B"),
+        )
+        assertThat(artifact?.type).isEqualTo("application/vnd.mermaid")
+    }
+
+    @Test
+    fun `blank text yields no artifact`() {
+        assertThat(attachmentToArtifact(Attachment(filename = "x.md", text = "  "))).isNull()
+        assertThat(attachmentToArtifact(Attachment(filename = "x.html", text = null))).isNull()
+    }
+
+    @Test
+    fun `unknown extension yields no artifact`() {
+        assertThat(attachmentToArtifact(Attachment(filename = "receipt.pdf", text = "%PDF"))).isNull()
+    }
+}

--- a/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/components/ToolCallRoutingTest.kt
+++ b/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/components/ToolCallRoutingTest.kt
@@ -1,0 +1,35 @@
+package com.garfiec.librechat.feature.chat.components
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class ToolCallRoutingTest {
+
+    @Test
+    fun `code interpreter and execute names route to code card`() {
+        assertThat(isCodeExecutionToolCall("code_interpreter")).isTrue()
+        assertThat(isCodeExecutionToolCall("execute_code")).isTrue()
+    }
+
+    @Test
+    fun `bash and programmatic tool names route to code card`() {
+        assertThat(isCodeExecutionToolCall("bash_tool")).isTrue()
+        assertThat(isCodeExecutionToolCall("run_tools_with_bash")).isTrue()
+        assertThat(isCodeExecutionToolCall("run_tools_with_code")).isTrue()
+    }
+
+    @Test
+    fun `bash names are recognized as bash tool calls`() {
+        assertThat(isBashToolCall("bash_tool")).isTrue()
+        assertThat(isBashToolCall("run_tools_with_bash")).isTrue()
+        assertThat(isBashToolCall("run_tools_with_code")).isFalse()
+        assertThat(isBashToolCall("code_interpreter")).isFalse()
+    }
+
+    @Test
+    fun `non-code tools do not route to code card`() {
+        assertThat(isCodeExecutionToolCall("web_search")).isFalse()
+        assertThat(isCodeExecutionToolCall("file_search")).isFalse()
+        assertThat(isCodeExecutionToolCall("lc_transfer_to_agent")).isFalse()
+    }
+}

--- a/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/MergeStreamedAttachmentsTest.kt
+++ b/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/MergeStreamedAttachmentsTest.kt
@@ -1,0 +1,66 @@
+package com.garfiec.librechat.feature.chat.viewmodel.delegate
+
+import com.garfiec.librechat.core.model.Attachment
+import com.garfiec.librechat.core.model.Message
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class MergeStreamedAttachmentsTest {
+
+    private fun message(vararg attachments: Attachment) =
+        Message(
+            messageId = "m1",
+            conversationId = "c1",
+            attachments = if (attachments.isEmpty()) null else attachments.toList(),
+        )
+
+    @Test
+    fun `attachments already present are left untouched`() {
+        val msg = message(Attachment(fileId = "f1", filename = "a.pdf"))
+        val streamed = listOf(Attachment(fileId = "f1", filename = "a.pdf"))
+
+        val result = mergeStreamedAttachments(msg, streamed)
+
+        assertThat(result).isSameInstanceAs(msg)
+        assertThat(result.attachments).hasSize(1)
+    }
+
+    @Test
+    fun `missing streamed attachment is merged in`() {
+        val msg = message()
+        val streamed = listOf(Attachment(fileId = "f1", filename = "a.pdf", toolCallId = "call_1"))
+
+        val result = mergeStreamedAttachments(msg, streamed)
+
+        assertThat(result.attachments).hasSize(1)
+        assertThat(result.attachments!!.single().fileId).isEqualTo("f1")
+    }
+
+    @Test
+    fun `only the gap is filled, server copy is kept`() {
+        val msg = message(Attachment(fileId = "f1", filename = "server.pdf"))
+        val streamed = listOf(
+            Attachment(fileId = "f1", filename = "streamed.pdf"),
+            Attachment(fileId = "f2", filename = "new.png"),
+        )
+
+        val result = mergeStreamedAttachments(msg, streamed)
+
+        assertThat(result.attachments!!.map { it.fileId }).containsExactly("f1", "f2").inOrder()
+        // Server's copy of f1 (server.pdf) is preserved, not overwritten by the streamed one.
+        assertThat(result.attachments!!.first { it.fileId == "f1" }.filename).isEqualTo("server.pdf")
+    }
+
+    @Test
+    fun `empty streamed list is a no-op`() {
+        val msg = message(Attachment(fileId = "f1"))
+        assertThat(mergeStreamedAttachments(msg, emptyList())).isSameInstanceAs(msg)
+    }
+
+    @Test
+    fun `streamed attachments without file id are skipped`() {
+        val msg = message()
+        val streamed = listOf(Attachment(fileId = null, filename = "nameless.bin"))
+        assertThat(mergeStreamedAttachments(msg, streamed)).isSameInstanceAs(msg)
+    }
+}

--- a/feature/chat/src/commonMain/composeResources/values/strings.xml
+++ b/feature/chat/src/commonMain/composeResources/values/strings.xml
@@ -259,6 +259,16 @@
     <!-- Message files -->
     <string name="file_fallback">File</string>
 
+    <!-- Tool-call generated-file attachments -->
+    <string name="attachment_fallback">Attachment</string>
+    <string name="cd_download_attachment">Download %1$s</string>
+    <string name="pdf_document">PDF Document</string>
+    <string name="pdf_load_failed">Couldn\'t load PDF</string>
+    <string name="pdf_page_failed">Couldn\'t render this page</string>
+    <string name="cd_share_pdf">Share PDF</string>
+    <string name="cd_open_pdf">Open PDF</string>
+    <string name="retry">Retry</string>
+
     <!-- Model selector sheet -->
     <string name="cd_selected">Selected</string>
     <string name="cd_public_agent">Public agent</string>

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ChatRoot.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ChatRoot.kt
@@ -2,6 +2,12 @@ package com.garfiec.librechat.feature.chat.components
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.listSaver
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import com.garfiec.librechat.core.data.datastore.InlineArtifactPrefs
 import com.garfiec.librechat.core.ui.media.MediaActionBar
 import com.garfiec.librechat.core.ui.media.MediaPreviewState
@@ -33,14 +39,23 @@ fun ChatRoot(
     mediaPreview: MediaPreviewState?,
     onOpenMedia: (url: String) -> Unit,
     onCloseMedia: () -> Unit,
+    onDownloadAttachment: suspend (fileId: String) -> ByteArray?,
     content: @Composable () -> Unit,
 ) {
+    // Hosted here (not in the VM) so the tapped PDF card can scroll off-screen without dismissing
+    // the viewer. rememberSaveable so the open preview survives configuration changes (rotation);
+    // the opener just records the request and the overlay re-downloads + renders below.
+    var pdfRequest by rememberSaveable(stateSaver = PdfRequestSaver) { mutableStateOf<PdfRequest?>(null) }
+    val openPdf = remember { { fileId: String, filename: String -> pdfRequest = PdfRequest(fileId, filename) } }
+
     CompositionLocalProvider(
         LocalInlineArtifactPrefs provides inlineArtifactPrefs,
         LocalMermaidRenderCache provides mermaidRenderCache,
         LocalParsedMarkdownCache provides parsedMarkdownCache,
         LocalSubagentProgress provides subagentProgress,
         LocalChatMediaViewer provides onOpenMedia,
+        LocalAttachmentDownloader provides onDownloadAttachment,
+        LocalOpenPdf provides openPdf,
     ) {
         content()
 
@@ -72,5 +87,23 @@ fun ChatRoot(
                 },
             )
         }
+
+        pdfRequest?.let { req ->
+            PdfPreviewOverlay(
+                fileId = req.fileId,
+                filename = req.filename,
+                onDownload = onDownloadAttachment,
+                onDismiss = { pdfRequest = null },
+            )
+        }
     }
 }
+
+/** The file the PDF preview overlay should open. */
+private data class PdfRequest(val fileId: String, val filename: String)
+
+/** Saves [PdfRequest] across configuration changes as a `[fileId, filename]` pair (empty = null). */
+private val PdfRequestSaver = listSaver<PdfRequest?, String>(
+    save = { req -> req?.let { listOf(it.fileId, it.filename) } ?: emptyList() },
+    restore = { list -> list.takeIf { it.size == 2 }?.let { PdfRequest(it[0], it[1]) } },
+)

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/LocalAttachmentDownloader.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/LocalAttachmentDownloader.kt
@@ -1,0 +1,16 @@
+package com.garfiec.librechat.feature.chat.components
+
+import androidx.compose.runtime.staticCompositionLocalOf
+
+/**
+ * Composition-scoped, authenticated file downloader for tool-call attachments. Provided once at
+ * the chat screen root (backed by `ChatViewModel.downloadFileBytes`), so a file chip deep in the
+ * message list can fetch a generated file's bytes on tap without threading a lambda through
+ * MessageList → MessageBubble → ContentPartRenderer → ToolCallDispatcher.
+ *
+ * Returns the file's bytes, or `null` on failure / when no host is in scope (previews, tests).
+ * Mirrors the [LocalChatMediaViewer] precedent.
+ */
+val LocalAttachmentDownloader = staticCompositionLocalOf<suspend (fileId: String) -> ByteArray?> {
+    { null }
+}

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/LocalOpenPdf.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/LocalOpenPdf.kt
@@ -1,0 +1,17 @@
+package com.garfiec.librechat.feature.chat.components
+
+import androidx.compose.runtime.staticCompositionLocalOf
+import co.touchlab.kermit.Logger
+
+/**
+ * Opener for the full-screen PDF preview, provided by [ChatRoot]. A tool-call PDF attachment card
+ * deep in the message list fires this with the file's id + display name; ChatRoot downloads the
+ * bytes (via [LocalAttachmentDownloader]) and hosts the native [PdfViewer] overlay at the screen
+ * root, so it survives the tapped card scrolling off-screen.
+ *
+ * Default is a logging no-op (not a silent swallow) so a missing provider surfaces in logs.
+ * Mirrors [LocalChatMediaViewer].
+ */
+val LocalOpenPdf = staticCompositionLocalOf<(fileId: String, filename: String) -> Unit> {
+    { fileId, _ -> Logger.w { "LocalOpenPdf not provided; ignoring PDF open for $fileId" } }
+}

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/MessageFiles.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/MessageFiles.kt
@@ -108,7 +108,7 @@ fun MessageFiles(
  * Inline image preview that can be tapped to open fullscreen.
  */
 @Composable
-private fun MessageImagePreview(
+internal fun MessageImagePreview(
     imageUrl: String,
     altText: String,
     modifier: Modifier = Modifier,
@@ -166,26 +166,39 @@ private fun MessageImagePreview(
 
 /**
  * A chip that shows a non-image file with an icon and filename.
+ *
+ * When [onClick] is non-null the chip is tappable (e.g. to download + share a generated file);
+ * [isLoading] swaps the leading icon for a spinner while that action is in flight.
  */
 @Composable
-private fun FileChip(
+internal fun FileChip(
     filename: String,
     type: String?,
     modifier: Modifier = Modifier,
+    isLoading: Boolean = false,
+    onClick: (() -> Unit)? = null,
 ) {
     Row(
         modifier = modifier
             .clip(RoundedCornerShape(8.dp))
             .background(MaterialTheme.colorScheme.surfaceContainerHigh)
+            .then(if (onClick != null) Modifier.clickable(onClick = onClick) else Modifier)
             .padding(horizontal = 10.dp, vertical = 8.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        Icon(
-            imageVector = fileTypeIcon(type),
-            contentDescription = null,
-            modifier = Modifier.size(18.dp),
-            tint = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
+        if (isLoading) {
+            CircularProgressIndicator(
+                modifier = Modifier.size(18.dp),
+                strokeWidth = 2.dp,
+            )
+        } else {
+            Icon(
+                imageVector = fileTypeIcon(type),
+                contentDescription = null,
+                modifier = Modifier.size(18.dp),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
         Spacer(modifier = Modifier.width(6.dp))
         Text(
             text = filename,

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/PdfPreviewOverlay.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/PdfPreviewOverlay.kt
@@ -1,0 +1,181 @@
+package com.garfiec.librechat.feature.chat.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Share
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.garfiec.librechat.core.ui.components.PlatformBackHandler
+import com.garfiec.librechat.core.ui.media.rememberShareFile
+import com.garfiec.librechat.feature.chat.resources.Res
+import com.garfiec.librechat.feature.chat.resources.cd_close
+import com.garfiec.librechat.feature.chat.resources.cd_share_pdf
+import com.garfiec.librechat.feature.chat.resources.pdf_load_failed
+import com.garfiec.librechat.feature.chat.resources.retry
+import org.jetbrains.compose.resources.stringResource
+
+private sealed interface PdfLoadState {
+    data object Loading : PdfLoadState
+
+    /** Download produced no bytes (network/auth failure) — retryable. */
+    data object DownloadFailed : PdfLoadState
+
+    // Not data classes: ByteArray has no structural equals, and these are only ever compared by
+    // reference (the produceState value swap), never by content.
+
+    /** Bytes downloaded but they don't look like a PDF (e.g. an HTML error body). Not previewable,
+     *  but the bytes are still shareable — re-downloading won't change them, so no retry. */
+    class Unrenderable(val bytes: ByteArray) : PdfLoadState
+
+    /** Bytes downloaded and look like a PDF — handed to the native viewer. */
+    class Loaded(val bytes: ByteArray) : PdfLoadState
+}
+
+/**
+ * Full-screen PDF preview rendered at the chat screen root (by [ChatRoot]). Downloads the file's
+ * bytes via [onDownload], checks they actually look like a PDF, then hands them to the platform-native
+ * [PdfViewer]. A slim top bar carries close + share; system back dismisses on Android, and the
+ * explicit close covers iOS (which has no system back). Mirrors the media-viewer overlay pattern.
+ *
+ * Share stays available whenever bytes were downloaded — even if they aren't previewable or the
+ * native engine rejects them — so a file that can't be rendered can still be exported (the escape
+ * hatch the plain download chip used to provide). Retry only re-downloads; failures that re-downloading
+ * can't fix (non-PDF bytes, an unrenderable PDF) don't offer it, to avoid a no-progress loop.
+ */
+@Composable
+internal fun PdfPreviewOverlay(
+    fileId: String,
+    filename: String,
+    onDownload: suspend (fileId: String) -> ByteArray?,
+    onDismiss: () -> Unit,
+) {
+    PlatformBackHandler(enabled = true, onBack = onDismiss)
+
+    // Bumping `attempt` re-runs the download (Retry) and resets the per-attempt render-failed flag.
+    var attempt by remember(fileId) { mutableIntStateOf(0) }
+    var renderFailed by remember(fileId, attempt) { mutableStateOf(false) }
+
+    // rememberUpdatedState so the download effect keys only on (fileId, attempt), not the (stable) lambda.
+    val currentDownload by rememberUpdatedState(onDownload)
+    val loadState by produceState<PdfLoadState>(PdfLoadState.Loading, fileId, attempt) {
+        value = PdfLoadState.Loading
+        val bytes = currentDownload(fileId)
+        value = when {
+            bytes == null -> PdfLoadState.DownloadFailed
+            !looksLikePdf(bytes) -> PdfLoadState.Unrenderable(bytes)
+            else -> PdfLoadState.Loaded(bytes)
+        }
+    }
+    val shareFile = rememberShareFile()
+
+    // Bytes are shareable whenever the download produced them, even if the native engine later
+    // failed to render them or they aren't a PDF — the user can still get the file out to another app.
+    val shareBytes = when (val state = loadState) {
+        is PdfLoadState.Loaded -> state.bytes
+        is PdfLoadState.Unrenderable -> state.bytes
+        else -> null
+    }
+
+    Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.surface) {
+        Column(modifier = Modifier.fillMaxSize().statusBarsPadding()) {
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(start = 4.dp, end = 4.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                IconButton(onClick = onDismiss) {
+                    Icon(
+                        imageVector = Icons.Default.Close,
+                        contentDescription = stringResource(Res.string.cd_close),
+                        tint = MaterialTheme.colorScheme.onSurface,
+                    )
+                }
+                Text(
+                    text = filename,
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f),
+                )
+                IconButton(
+                    onClick = { shareBytes?.let { shareFile(it, filename, "application/pdf") } },
+                    enabled = shareBytes != null,
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Share,
+                        contentDescription = stringResource(Res.string.cd_share_pdf),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+
+            Box(
+                modifier = Modifier.fillMaxSize().navigationBarsPadding(),
+                contentAlignment = Alignment.Center,
+            ) {
+                when (val state = loadState) {
+                    is PdfLoadState.Loading -> CircularProgressIndicator()
+                    // Only a failed download is worth retrying; re-downloading won't fix bad bytes.
+                    is PdfLoadState.DownloadFailed -> PdfErrorContent(onRetry = { attempt++ })
+                    is PdfLoadState.Unrenderable -> PdfErrorContent(onRetry = null)
+                    is PdfLoadState.Loaded ->
+                        if (renderFailed) {
+                            PdfErrorContent(onRetry = null)
+                        } else {
+                            PdfViewer(
+                                bytes = state.bytes,
+                                onRenderError = { renderFailed = true },
+                                modifier = Modifier.fillMaxSize(),
+                            )
+                        }
+                }
+            }
+        }
+    }
+}
+
+/** Error text, plus a Retry button when [onRetry] is non-null (retry re-downloads). */
+@Composable
+private fun PdfErrorContent(onRetry: (() -> Unit)?) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Text(
+            text = stringResource(Res.string.pdf_load_failed),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        if (onRetry != null) {
+            TextButton(onClick = onRetry) {
+                Text(stringResource(Res.string.retry))
+            }
+        }
+    }
+}

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/PdfViewer.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/PdfViewer.kt
@@ -1,0 +1,20 @@
+package com.garfiec.librechat.feature.chat.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+/**
+ * Renders a PDF (given its raw [bytes]) as a scrollable, zoomable page view using the platform's
+ * native PDF engine — Android [android.graphics.pdf.PdfRenderer] rendering each page to a bitmap,
+ * iOS PDFKit `PDFView` via `UIKitView`. No third-party dependency and no network: the bytes are
+ * already in hand (downloaded through [LocalAttachmentDownloader]).
+ *
+ * Hosted full-screen by [PdfPreviewOverlay]; the shared shell (top bar, download/loading states)
+ * lives there, this is just the page surface.
+ *
+ * [onRenderError] fires when the native engine can't open the bytes (corrupt/encrypted PDF, or a
+ * non-PDF body that slipped past the magic-byte check) so the overlay can surface an error instead
+ * of a permanently blank surface.
+ */
+@Composable
+expect fun PdfViewer(bytes: ByteArray, onRenderError: () -> Unit, modifier: Modifier = Modifier)

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/StreamingToolCallCard.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/StreamingToolCallCard.kt
@@ -64,87 +64,98 @@ fun StreamingToolCallCard(
     var isExpanded by remember { mutableStateOf(false) }
     val canExpand = toolCall.isComplete && !toolCall.output.isNullOrBlank()
 
-    Card(
-        modifier = modifier.fillMaxWidth(),
-        colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
-        ),
-        shape = RoundedCornerShape(8.dp),
-    ) {
-        Column {
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .then(
-                        if (canExpand) {
-                            Modifier.clickable { isExpanded = !isExpanded }
-                        } else {
-                            Modifier
-                        },
-                    )
-                    .padding(12.dp),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Icon(
-                    imageVector = Icons.Default.Build,
-                    contentDescription = null,
-                    modifier = Modifier.size(16.dp),
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-                Spacer(modifier = Modifier.width(8.dp))
-                Text(
-                    text = toolCall.name,
-                    style = MaterialTheme.typography.titleSmall,
-                    color = MaterialTheme.colorScheme.onSurface,
-                    modifier = Modifier.weight(1f),
-                )
-
-                if (toolCall.isComplete) {
+    Column(modifier = modifier.fillMaxWidth()) {
+        Card(
+            modifier = Modifier.fillMaxWidth(),
+            colors = CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+            ),
+            shape = RoundedCornerShape(8.dp),
+        ) {
+            Column {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .then(
+                            if (canExpand) {
+                                Modifier.clickable { isExpanded = !isExpanded }
+                            } else {
+                                Modifier
+                            },
+                        )
+                        .padding(12.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
                     Icon(
-                        imageVector = Icons.Default.Check,
-                        contentDescription = stringResource(Res.string.cd_tool_complete),
-                        modifier = Modifier.size(16.dp),
-                        tint = MaterialTheme.colorScheme.primary,
-                    )
-                } else {
-                    CircularProgressIndicator(
-                        modifier = Modifier.size(16.dp),
-                        strokeWidth = 2.dp,
-                        color = MaterialTheme.colorScheme.primary,
-                    )
-                }
-
-                if (canExpand) {
-                    Spacer(modifier = Modifier.width(4.dp))
-                    Icon(
-                        imageVector = if (isExpanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
-                        contentDescription = if (isExpanded) "Collapse" else "Expand",
+                        imageVector = Icons.Default.Build,
+                        contentDescription = null,
                         modifier = Modifier.size(16.dp),
                         tint = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
-                }
-            }
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(
+                        text = toolCall.name,
+                        style = MaterialTheme.typography.titleSmall,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        modifier = Modifier.weight(1f),
+                    )
 
-            AnimatedVisibility(
-                visible = isExpanded && canExpand,
-                enter = expandVertically(),
-                exit = shrinkVertically(),
-            ) {
-                Column(modifier = Modifier.padding(start = 12.dp, end = 12.dp, bottom = 12.dp)) {
-                    Spacer(modifier = Modifier.height(8.dp))
-                    Text(
-                        text = stringResource(Res.string.tool_call_output),
-                        style = MaterialTheme.typography.labelSmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                    Spacer(modifier = Modifier.height(4.dp))
-                    Text(
-                        text = toolCall.output.orEmpty(),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
+                    if (toolCall.isComplete) {
+                        Icon(
+                            imageVector = Icons.Default.Check,
+                            contentDescription = stringResource(Res.string.cd_tool_complete),
+                            modifier = Modifier.size(16.dp),
+                            tint = MaterialTheme.colorScheme.primary,
+                        )
+                    } else {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(16.dp),
+                            strokeWidth = 2.dp,
+                            color = MaterialTheme.colorScheme.primary,
+                        )
+                    }
+
+                    if (canExpand) {
+                        Spacer(modifier = Modifier.width(4.dp))
+                        Icon(
+                            imageVector = if (isExpanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
+                            contentDescription = if (isExpanded) "Collapse" else "Expand",
+                            modifier = Modifier.size(16.dp),
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+
+                AnimatedVisibility(
+                    visible = isExpanded && canExpand,
+                    enter = expandVertically(),
+                    exit = shrinkVertically(),
+                ) {
+                    Column(modifier = Modifier.padding(start = 12.dp, end = 12.dp, bottom = 12.dp)) {
+                        Spacer(modifier = Modifier.height(8.dp))
+                        Text(
+                            text = stringResource(Res.string.tool_call_output),
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                        Spacer(modifier = Modifier.height(4.dp))
+                        Text(
+                            text = toolCall.output.orEmpty(),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
                 }
             }
         }
+
+        // Files this tool call has generated so far (e.g. a code-interpreter PDF/PNG), routed by
+        // toolCallId. Office-preview docs are rendered separately (streaming_office_previews).
+        ToolCallAttachments(
+            attachments = streamingAttachments,
+            toolCallId = toolCall.id,
+            baseUrl = baseUrl,
+            modifier = Modifier.padding(top = 8.dp),
+        )
     }
 }

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ToolCallAttachments.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ToolCallAttachments.kt
@@ -1,0 +1,373 @@
+package com.garfiec.librechat.feature.chat.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.OpenInNew
+import androidx.compose.material.icons.filled.Description
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.garfiec.librechat.core.model.Attachment
+import com.garfiec.librechat.core.ui.media.rememberShareFile
+import com.garfiec.librechat.feature.chat.components.artifact.Artifact
+import com.garfiec.librechat.feature.chat.components.artifact.ArtifactButton
+import com.garfiec.librechat.feature.chat.components.artifact.ArtifactType
+import com.garfiec.librechat.feature.chat.components.artifact.LocalOpenArtifact
+import com.garfiec.librechat.feature.chat.resources.Res
+import com.garfiec.librechat.feature.chat.resources.attachment_fallback
+import com.garfiec.librechat.feature.chat.resources.cd_open_pdf
+import com.garfiec.librechat.feature.chat.resources.pdf_document
+import com.garfiec.librechat.feature.chat.util.resolveAttachmentUrl
+import kotlinx.coroutines.launch
+import org.jetbrains.compose.resources.stringResource
+
+// ─── ToolCallAttachments ────────────────────────────────────────────
+//
+// Renders the files a tool call generated (code-interpreter output, etc.) below its card,
+// matching the web client which passes each tool call's attachments to every tool component.
+// The data already arrives via SSE `attachment` events / persisted `message.attachments`; this
+// is the render layer.
+
+/**
+ * The three ways a generated file is surfaced, after filtering to one tool call and skipping
+ * the non-file pseudo-attachments. Order within a partition is the attachments' arrival order.
+ */
+internal sealed interface ToolAttachment {
+    val attachment: Attachment
+
+    /** Bitmap output (e.g. a matplotlib PNG) — inline preview, tap for fullscreen. */
+    data class Image(override val attachment: Attachment) : ToolAttachment
+
+    /** Text-bearing source/doc the server extracted (`.py`, `.md`, `.html`, `.mmd`, …) —
+     *  opens readably in the artifacts panel. */
+    data class ArtifactContent(override val attachment: Attachment, val artifact: Artifact) : ToolAttachment
+
+    /** A PDF (with a downloadable fileId) — a card that opens the native full-screen preview. */
+    data class Pdf(override val attachment: Attachment) : ToolAttachment
+
+    /** Anything else (CSV, binary) — a download chip that shares the bytes on tap. */
+    data class File(override val attachment: Attachment) : ToolAttachment
+}
+
+/**
+ * Attachment `type` values that are NOT files — they carry structured payloads (search sources,
+ * memory artifacts, MCP UI resources) that mobile renders from tool *output* elsewhere. They must
+ * never render as a file chip. Mirrors upstream `TAttachmentMetadata` (schemas.ts).
+ */
+private val PSEUDO_ATTACHMENT_TYPES = setOf("web_search", "file_search", "memory", "ui_resources")
+
+/** Sandbox placeholder leaves the backend injects to keep empty dirs; never shown. Upstream
+ *  `SANDBOX_PLACEHOLDER_LEAVES` (attachmentTypes.ts). */
+private val SANDBOX_PLACEHOLDER = Regex("""^_\.(?:dirkeep|gitkeep)-[0-9a-f]{6}$""", RegexOption.IGNORE_CASE)
+
+/** Sanitized-dotfile name the sandbox produces (`_.config-abcdef.txt`); shown as `.config.txt`.
+ *  Upstream `SANITIZED_DOTFILE_PATTERN`. */
+private val SANITIZED_DOTFILE = Regex("""^_\.(.+?)-[0-9a-f]{6}(\.[^.]+)?$""", RegexOption.IGNORE_CASE)
+
+/** Extensions rendered as syntax-highlighted code (fenced markdown) in the artifacts panel. */
+private val CODE_EXTENSIONS = setOf(
+    "py", "js", "jsx", "ts", "tsx", "kt", "kts", "java", "c", "cc", "cpp", "h", "hpp",
+    "cs", "go", "rs", "rb", "php", "swift", "sh", "bash", "sql", "json", "yaml", "yml",
+    "xml", "css", "scss", "r", "pl", "lua", "dart", "scala", "groovy", "gradle", "toml", "ini",
+)
+
+/**
+ * Splits a message's [attachments] to the given [toolCallId] into renderable buckets, skipping
+ * pseudo-types, office-preview docs (rendered by `OfficePreviewAttachments`), and sandbox
+ * placeholders. Deduped by `fileId ?: filename`. Pure — unit-tested.
+ */
+internal fun partitionToolCallAttachments(
+    attachments: List<Attachment>,
+    toolCallId: String?,
+): List<ToolAttachment> {
+    if (toolCallId == null) return emptyList()
+    val seen = HashSet<String>()
+    return attachments.asSequence()
+        .filter { it.toolCallId == toolCallId }
+        .filter { it.type !in PSEUDO_ATTACHMENT_TYPES }
+        .filter { !ArtifactType.isOfficePreviewMime(it.type) }
+        .filter { att ->
+            val name = attachmentName(att)
+            name == null || !SANDBOX_PLACEHOLDER.matches(name)
+        }
+        .filter { att ->
+            val key = att.fileId ?: attachmentName(att) ?: return@filter false
+            seen.add(key)
+        }
+        .map { att ->
+            when {
+                att.type?.startsWith("image/") == true -> ToolAttachment.Image(att)
+                // A PDF needs its downloadable fileId to preview; without one it stays a file chip.
+                isPdf(att) && att.fileId != null -> ToolAttachment.Pdf(att)
+                else -> attachmentToArtifact(att)?.let { ToolAttachment.ArtifactContent(att, it) }
+                    ?: ToolAttachment.File(att)
+            }
+        }
+        .toList()
+}
+
+private fun isPdf(attachment: Attachment): Boolean =
+    attachment.type == "application/pdf" ||
+        attachmentName(attachment)?.endsWith(".pdf", ignoreCase = true) == true
+
+/** How far into the bytes to scan for the PDF header; some servers prepend a BOM or whitespace. */
+private const val PDF_HEADER_SCAN_LIMIT = 1024
+
+/** The PDF magic number, `%PDF-`. */
+private val PDF_MAGIC = byteArrayOf(0x25, 0x50, 0x44, 0x46, 0x2D)
+
+/**
+ * True if [bytes] contains the PDF header (`%PDF-`) within the first [PDF_HEADER_SCAN_LIMIT] bytes.
+ * Guards the native parsers against non-PDF bodies that arrive with a 200 status (e.g. an HTML error
+ * page), which would otherwise blank the Android surface or crash iOS's failable initializer.
+ * Pure — unit-tested.
+ */
+internal fun looksLikePdf(bytes: ByteArray): Boolean {
+    if (bytes.size < PDF_MAGIC.size) return false
+    val lastStart = minOf(bytes.size, PDF_HEADER_SCAN_LIMIT) - PDF_MAGIC.size
+    for (start in 0..lastStart) {
+        var matched = true
+        for (j in PDF_MAGIC.indices) {
+            if (bytes[start + j] != PDF_MAGIC[j]) {
+                matched = false
+                break
+            }
+        }
+        if (matched) return true
+    }
+    return false
+}
+
+private fun attachmentName(attachment: Attachment): String? =
+    attachment.filename ?: attachment.filepath?.substringAfterLast('/')
+
+/**
+ * Cleans a sandbox-sanitized filename for display: `_.config-abcdef.txt` → `.config.txt`,
+ * `_.dirkeep-88b30b` → `.dirkeep`. Ordinary names (incl. `report-deadbe.csv`) pass through.
+ * Upstream `getDisplayFileName`. Pure — unit-tested.
+ */
+internal fun displayFilename(name: String): String {
+    val match = SANITIZED_DOTFILE.matchEntire(name) ?: return name
+    return ".${match.groupValues[1]}${match.groupValues[2]}"
+}
+
+/**
+ * Mobile equivalent of upstream `fileToArtifact`: maps a text-bearing attachment to an [Artifact]
+ * the existing `ArtifactPanel` can render, or `null` to fall back to a download chip. Content is the
+ * server-extracted `attachment.text`; a blank/absent text can't be rendered (mobile has no deferred
+ * preview polling), so it falls back. Code files are wrapped in a fenced block so the markdown
+ * artifact renderer highlights them. Pure — unit-tested.
+ */
+internal fun attachmentToArtifact(attachment: Attachment): Artifact? {
+    val text = attachment.text
+    if (text.isNullOrBlank()) return null
+    val name = attachmentName(attachment) ?: return null
+    val ext = name.substringAfterLast('.', "").lowercase()
+    if (ext.isEmpty()) return null
+
+    val type: String
+    val content: String
+    val language: String?
+    when {
+        ext == "html" || ext == "htm" -> {
+            type = "text/html"; content = text; language = "html"
+        }
+        ext == "md" || ext == "mdx" || ext == "markdown" -> {
+            type = "text/markdown"; content = text; language = "markdown"
+        }
+        ext == "mmd" || ext == "mermaid" -> {
+            type = "application/vnd.mermaid"; content = text; language = "mermaid"
+        }
+        ext == "txt" -> {
+            type = "text/plain"; content = text; language = null
+        }
+        ext in CODE_EXTENSIONS -> {
+            type = "text/markdown"; content = "```$ext\n$text\n```"; language = ext
+        }
+        else -> return null
+    }
+    return Artifact(
+        identifier = attachment.fileId ?: name,
+        type = type,
+        title = displayFilename(name),
+        language = language,
+        content = content,
+    )
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+internal fun ToolCallAttachments(
+    attachments: List<Attachment>,
+    toolCallId: String?,
+    baseUrl: String,
+    modifier: Modifier = Modifier,
+) {
+    val items = remember(attachments, toolCallId) {
+        partitionToolCallAttachments(attachments, toolCallId)
+    }
+    if (items.isEmpty()) return
+
+    val openArtifact = LocalOpenArtifact.current
+    val openPdf = LocalOpenPdf.current
+    val fallbackName = stringResource(Res.string.attachment_fallback)
+    val images = items.filterIsInstance<ToolAttachment.Image>()
+    val artifacts = items.filterIsInstance<ToolAttachment.ArtifactContent>()
+    val pdfs = items.filterIsInstance<ToolAttachment.Pdf>()
+    val files = items.filterIsInstance<ToolAttachment.File>()
+
+    Column(modifier = modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        images.forEach { item ->
+            val url = resolveAttachmentUrl(item.attachment, baseUrl)
+            if (url != null) {
+                MessageImagePreview(
+                    imageUrl = url,
+                    altText = item.attachment.filename?.let { displayFilename(it) } ?: fallbackName,
+                )
+            }
+        }
+
+        artifacts.forEach { item ->
+            ArtifactButton(
+                artifact = item.artifact,
+                onClick = { openArtifact?.invoke(item.artifact, listOf(item.artifact)) },
+            )
+        }
+
+        pdfs.forEach { item ->
+            val fileId = item.attachment.fileId ?: return@forEach
+            val name = attachmentName(item.attachment)?.let { displayFilename(it) } ?: fallbackName
+            PdfAttachmentCard(
+                title = name,
+                onClick = { openPdf(fileId, name) },
+            )
+        }
+
+        if (files.isNotEmpty()) {
+            FlowRow(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                files.forEach { item ->
+                    AttachmentDownloadChip(attachment = item.attachment)
+                }
+            }
+        }
+    }
+}
+
+/** Cached per core/ui Compose perf rule 13 (don't allocate `RoundedCornerShape` per composition). */
+private val PDF_CARD_SHAPE = RoundedCornerShape(12.dp)
+
+/**
+ * A card for a generated PDF, styled like [ArtifactButton] (icon + title + "PDF Document" subtitle
+ * + open affordance). Tapping opens the native full-screen preview via [LocalOpenPdf] — the
+ * download-on-open + rendering happen there, mirroring how the web client opens PDFs in a viewer
+ * rather than forcing a download.
+ */
+@Composable
+private fun PdfAttachmentCard(title: String, onClick: () -> Unit) {
+    Card(
+        onClick = onClick,
+        modifier = Modifier.fillMaxWidth(),
+        shape = PDF_CARD_SHAPE,
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.secondaryContainer,
+        ),
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                imageVector = Icons.Default.Description,
+                contentDescription = null,
+                modifier = Modifier.size(20.dp),
+                tint = MaterialTheme.colorScheme.onSecondaryContainer,
+            )
+            Spacer(modifier = Modifier.width(12.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.onSecondaryContainer,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Text(
+                    text = stringResource(Res.string.pdf_document),
+                    style = MaterialTheme.typography.bodySmall,
+                    // Opaque theme role rather than copy(alpha=…) per core/ui Compose perf rule 15.
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                )
+            }
+            Spacer(modifier = Modifier.width(8.dp))
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.OpenInNew,
+                contentDescription = stringResource(Res.string.cd_open_pdf),
+                modifier = Modifier.size(16.dp),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+/**
+ * A file chip that downloads (authenticated) the attachment's bytes on tap and hands them to the
+ * platform share sheet, showing a spinner while in flight. Reuses [FileChip]; the download goes
+ * through [LocalAttachmentDownloader].
+ */
+@Composable
+private fun AttachmentDownloadChip(attachment: Attachment) {
+    val downloader = LocalAttachmentDownloader.current
+    val shareFile = rememberShareFile()
+    val scope = rememberCoroutineScope()
+    var isDownloading by remember(attachment.fileId, attachment.filepath) { mutableStateOf(false) }
+
+    val rawName = attachmentName(attachment)
+    val displayName = rawName?.let { displayFilename(it) }
+    val fileId = attachment.fileId
+
+    FileChip(
+        filename = displayName ?: stringResource(Res.string.attachment_fallback),
+        type = attachment.type,
+        isLoading = isDownloading,
+        onClick = if (fileId != null && !isDownloading) {
+            {
+                scope.launch {
+                    isDownloading = true
+                    val bytes = downloader(fileId)
+                    isDownloading = false
+                    if (bytes != null) {
+                        shareFile(bytes, displayName ?: fileId, attachment.type)
+                    }
+                }
+            }
+        } else {
+            null
+        },
+    )
+}

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ToolCallContentPart.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ToolCallContentPart.kt
@@ -60,7 +60,8 @@ internal fun ToolCallDispatcher(
     // Subagent tool_call → collapsible trace card (v0.8.6). Live progress comes
     // from LocalSubagentProgress (keyed by the parent tool_call id); persisted
     // `subagentContent` (reload) takes precedence inside the card. Depth-1:
-    // nested parts pass allowSubagentCard=false so this never recurses.
+    // nested parts pass allowSubagentCard=false so this never recurses. Nested parts
+    // render their own attachments, so this branch keeps its pass-through return.
     if (allowSubagentCard && toolNameLower == ToolConstants.SUBAGENT) {
         val toolCallId = toolCall?.id
         val liveTrace = toolCallId?.let { LocalSubagentProgress.current[it] }
@@ -75,51 +76,83 @@ internal fun ToolCallDispatcher(
         return
     }
 
-    when {
-        toolNameLower.contains("search") -> {
-            val results = remember(output) { parseWebSearchResults(output) }
-            if (results.isNotEmpty()) {
-                WebSearchResultList(results = results, modifier = modifier)
-            } else {
-                GenericToolCallCard(toolName, toolCall?.function?.arguments, output, modifier)
+    val isImageGen = isImageGenToolCall(toolNameLower)
+
+    // The card, then (for every non-image-gen tool) the files this tool call generated. Web passes
+    // each tool call's attachments to every tool component; ToolCallAttachments skips the non-file
+    // pseudo-types. Image-gen already consumes its attachment as the generated image.
+    Column(modifier = modifier) {
+        val cardModifier = Modifier.fillMaxWidth()
+        when {
+            toolNameLower.startsWith(ToolConstants.LC_TRANSFER_TO_PREFIX) -> {
+                val target = toolName.substring(ToolConstants.LC_TRANSFER_TO_PREFIX.length).ifBlank { toolName }
+                AgentHandoffCard(
+                    handoff = AgentHandoff(fromAgent = null, toAgent = target, reason = null),
+                    modifier = cardModifier,
+                )
+            }
+            // file_search / retrieval carry their sources in an attachment payload the mobile model
+            // doesn't parse yet — route to the generic card, not the web-search list.
+            toolNameLower != ToolConstants.FILE_SEARCH &&
+                toolNameLower != ToolConstants.RETRIEVAL &&
+                toolNameLower.contains("search") -> {
+                val results = remember(output) { parseWebSearchResults(output) }
+                if (results.isNotEmpty()) {
+                    WebSearchResultList(results = results, modifier = cardModifier)
+                } else {
+                    GenericToolCallCard(toolName, toolCall?.function?.arguments, output, cardModifier)
+                }
+            }
+            isCodeExecutionToolCall(toolNameLower) -> {
+                val result = remember(toolCall, toolNameLower) {
+                    parseCodeExecution(toolCall)?.let { r ->
+                        if (r.language == null && isBashToolCall(toolNameLower)) r.copy(language = "bash") else r
+                    }
+                }
+                if (result != null) {
+                    CodeExecutionCard(result = result, modifier = cardModifier)
+                } else {
+                    GenericToolCallCard(toolName, toolCall?.function?.arguments, output, cardModifier)
+                }
+            }
+            toolNameLower.contains("memory") -> {
+                val artifact = remember(output) { parseMemoryArtifact(output) }
+                if (artifact != null) {
+                    MemoryArtifactCard(artifact = artifact, modifier = cardModifier)
+                } else {
+                    GenericToolCallCard(toolName, toolCall?.function?.arguments, output, cardModifier)
+                }
+            }
+            toolNameLower.contains("mcp") -> {
+                val resources = remember(output) { parseMcpResources(output) }
+                if (resources.isNotEmpty()) {
+                    McpResourceCarousel(resources = resources, modifier = cardModifier)
+                } else {
+                    GenericToolCallCard(toolName, toolCall?.function?.arguments, output, cardModifier)
+                }
+            }
+            isImageGen -> {
+                val imageResult = remember(toolCall, baseUrl, attachments) {
+                    parseImageGenResult(toolCall, baseUrl, attachments)
+                }
+                ImageGenCard(result = imageResult, showDescription = showImageDescriptions, modifier = cardModifier)
+            }
+            toolNameLower.contains("log") -> {
+                val logContent = remember(toolCall) { parseLogContent(toolCall) }
+                LogContentCard(log = logContent, modifier = cardModifier)
+            }
+            else -> {
+                GenericToolCallCard(toolName, toolCall?.function?.arguments, output, cardModifier)
             }
         }
-        toolNameLower.contains(ToolConstants.CODE_INTERPRETER) || toolNameLower.contains("execute") -> {
-            val result = remember(toolCall) { parseCodeExecution(toolCall) }
-            if (result != null) {
-                CodeExecutionCard(result = result, modifier = modifier)
-            } else {
-                GenericToolCallCard(toolName, toolCall?.function?.arguments, output, modifier)
-            }
-        }
-        toolNameLower.contains("memory") -> {
-            val artifact = remember(output) { parseMemoryArtifact(output) }
-            if (artifact != null) {
-                MemoryArtifactCard(artifact = artifact, modifier = modifier)
-            } else {
-                GenericToolCallCard(toolName, toolCall?.function?.arguments, output, modifier)
-            }
-        }
-        toolNameLower.contains("mcp") -> {
-            val resources = remember(output) { parseMcpResources(output) }
-            if (resources.isNotEmpty()) {
-                McpResourceCarousel(resources = resources, modifier = modifier)
-            } else {
-                GenericToolCallCard(toolName, toolCall?.function?.arguments, output, modifier)
-            }
-        }
-        isImageGenToolCall(toolNameLower) -> {
-            val imageResult = remember(toolCall, baseUrl, attachments) {
-                parseImageGenResult(toolCall, baseUrl, attachments)
-            }
-            ImageGenCard(result = imageResult, showDescription = showImageDescriptions, modifier = modifier)
-        }
-        toolNameLower.contains("log") -> {
-            val logContent = remember(toolCall) { parseLogContent(toolCall) }
-            LogContentCard(log = logContent, modifier = modifier)
-        }
-        else -> {
-            GenericToolCallCard(toolName, toolCall?.function?.arguments, output, modifier)
+
+        if (!isImageGen) {
+            ToolCallAttachments(
+                attachments = attachments,
+                toolCallId = toolCall?.id,
+                baseUrl = baseUrl,
+                modifier = Modifier.padding(top = 8.dp),
+            )
         }
     }
 }

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ToolCallParsing.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ToolCallParsing.kt
@@ -1,6 +1,7 @@
 package com.garfiec.librechat.feature.chat.components
 
 import co.touchlab.kermit.Logger
+import com.garfiec.librechat.core.common.ToolConstants
 import com.garfiec.librechat.core.model.Attachment
 import com.garfiec.librechat.core.model.content.AgentToolCall
 import com.garfiec.librechat.feature.chat.util.resolveAttachmentUrl
@@ -37,6 +38,27 @@ private val IMAGE_GEN_CONTAINS = listOf(
 internal fun isImageGenToolCall(toolNameLower: String): Boolean {
     if (toolNameLower in IMAGE_GEN_EXACT_NAMES) return true
     return IMAGE_GEN_CONTAINS.any { toolNameLower.contains(it) }
+}
+
+/** Bash-flavored code tool calls, whose `code` arg is a shell command (web `BashCall`). */
+private val BASH_TOOL_NAMES = setOf(
+    ToolConstants.BASH_TOOL,
+    ToolConstants.BASH_PROGRAMMATIC_TOOL_CALLING,
+)
+
+internal fun isBashToolCall(toolNameLower: String): Boolean = toolNameLower in BASH_TOOL_NAMES
+
+/**
+ * True for tool calls that render as the code-execution card: the code interpreter, `execute_code`,
+ * the bash tool, and programmatic tool-calling (Python/bash). Matches upstream ExecuteCode/BashCall
+ * routing. `run_tools_with_code`/`run_tools_with_bash` don't contain "execute", so they're matched
+ * by exact name.
+ */
+internal fun isCodeExecutionToolCall(toolNameLower: String): Boolean {
+    if (toolNameLower.contains(ToolConstants.CODE_INTERPRETER) || toolNameLower.contains("execute")) {
+        return true
+    }
+    return toolNameLower == ToolConstants.PROGRAMMATIC_TOOL_CALLING || toolNameLower in BASH_TOOL_NAMES
 }
 
 // --- Parsing helpers ---

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModel.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModel.kt
@@ -1511,6 +1511,7 @@ class ChatViewModel(
             when (val result = userRepository.getUser()) {
                 is Result.Success -> {
                     val user = result.data
+                    cachedUserId = user.id
                     _uiState.update {
                         it.copy(
                             userName = user.name ?: user.username,
@@ -1523,6 +1524,28 @@ class ChatViewModel(
                 }
                 is Result.Loading -> { /* no-op */ }
             }
+        }
+    }
+
+    // Cached so tapping several generated-file chips doesn't re-fetch the user each time.
+    private var cachedUserId: String? = null
+
+    /**
+     * Downloads a generated tool-call file's bytes (authenticated) for the file-chip share action;
+     * null on failure. Backs [com.garfiec.librechat.feature.chat.components.LocalAttachmentDownloader].
+     * Mirrors `ConversationMediaViewModel.downloadFileBytes`.
+     */
+    suspend fun downloadFileBytes(fileId: String): ByteArray? {
+        val userId = cachedUserId
+            ?: (userRepository.getUser() as? Result.Success)?.data?.id?.also { cachedUserId = it }
+            ?: return null
+        return when (val result = fileRepository.downloadFile(userId, fileId)) {
+            is Result.Success -> result.data
+            is Result.Error -> {
+                Logger.e(result.exception) { "Failed to download file $fileId: ${result.message}" }
+                null
+            }
+            is Result.Loading -> null
         }
     }
 

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/MessageTreeDelegate.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/MessageTreeDelegate.kt
@@ -1,9 +1,9 @@
 package com.garfiec.librechat.feature.chat.viewmodel.delegate
 
+import com.garfiec.librechat.core.model.Attachment
 import com.garfiec.librechat.core.model.Message
 import com.garfiec.librechat.core.model.StreamEvent
 import com.garfiec.librechat.feature.chat.util.buildActiveMessagePath
-import com.garfiec.librechat.feature.chat.util.finalMessages
 import com.garfiec.librechat.feature.chat.util.mergeFinalMessagesInMemory
 import com.garfiec.librechat.feature.chat.util.resolvedResponseMessage
 import com.garfiec.librechat.feature.chat.viewmodel.ChatScreenState
@@ -99,7 +99,13 @@ class MessageTreeDelegate(
      * ignore the return value.
      */
     fun finalizeChatDisplay(event: StreamEvent.Final): List<Message> {
-        val finalMessages = event.finalMessages()
+        // Defensive: upstream 0.8.7 sets responseMessage.attachments before saving, but the app
+        // supports a backend version range. If the Final payload omitted a file that streamed in
+        // via `attachment` SSE events, fold it back in (by fileId) so it survives the reload — the
+        // streamed list is about to be cleared in the update below. Cheap insurance.
+        val streamedAttachments = stateHandle.state.streamingAttachments
+        val response = event.resolvedResponseMessage()?.let { mergeStreamedAttachments(it, streamedAttachments) }
+        val finalMessages = listOfNotNull(event.requestMessage, response)
         // Retiring the streaming bubble (clearing the streaming fields) and swapping in the
         // finalized message MUST be ONE update: with a Main.immediate StateFlow every write is
         // observed, so two updates leave a frame where the bubble is gone but the reply isn't
@@ -127,11 +133,25 @@ class MessageTreeDelegate(
             )
         }
         if (finalMessages.isEmpty()) return emptyList()
-        val response = event.resolvedResponseMessage()
         val request = event.requestMessage
             ?: response?.parentMessageId?.let { parentId ->
                 stateHandle.state.messages.firstOrNull { it.messageId == parentId }
             }
         return listOfNotNull(request, response)
     }
+}
+
+/**
+ * Upserts [streamed] attachments into [message] by `fileId`, keeping the server's copy on
+ * conflict. Only fills gaps — when the Final payload already carried every streamed file, the
+ * message is returned unchanged. Attachments with no fileId are skipped (can't be deduped, and
+ * generated files always carry one).
+ */
+internal fun mergeStreamedAttachments(message: Message, streamed: List<Attachment>): Message {
+    if (streamed.isEmpty()) return message
+    val existing = message.attachments.orEmpty()
+    val existingIds = existing.mapNotNull { it.fileId }.toHashSet()
+    val toAdd = streamed.filter { it.fileId != null && it.fileId !in existingIds }
+    if (toAdd.isEmpty()) return message
+    return message.copy(attachments = existing + toAdd)
 }

--- a/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/components/PdfViewer.ios.kt
+++ b/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/components/PdfViewer.ios.kt
@@ -1,0 +1,54 @@
+package com.garfiec.librechat.feature.chat.components
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.viewinterop.UIKitView
+import com.garfiec.librechat.core.ui.media.toNSData
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.PDFKit.PDFDocument
+import platform.PDFKit.PDFView
+
+/**
+ * iOS PDF surface — a PDFKit `PDFView`, which handles continuous scroll, pinch-zoom, and text
+ * selection natively. The shared shell (top bar, download/loading states) lives in
+ * [PdfPreviewOverlay]; this is just the page surface.
+ */
+@OptIn(ExperimentalForeignApi::class)
+@Composable
+actual fun PdfViewer(bytes: ByteArray, onRenderError: () -> Unit, modifier: Modifier) {
+    // PDFDocument(data:) is a failable initializer; Kotlin/Native maps that nil to an NPE at the call
+    // site (truncated bytes, an HTTP-200 HTML error body, etc.). Catch it and report render failure.
+    // A password-protected PDF returns a *non-nil but locked* document (and PDFView would render
+    // nothing), and a structurally-empty one has no pages — treat both as render failures too, so the
+    // overlay shows its error state instead of a permanently blank surface.
+    val document = remember(bytes) {
+        runCatching { PDFDocument(bytes.toNSData()) }.getOrNull()
+            ?.takeIf { !it.isLocked() && it.pageCount() > 0uL }
+    }
+    val currentOnRenderError by rememberUpdatedState(onRenderError)
+    LaunchedEffect(document) {
+        if (document == null) currentOnRenderError()
+    }
+    if (document == null) return
+
+    UIKitView(
+        modifier = modifier.fillMaxSize(),
+        factory = {
+            PDFView().apply {
+                // Continuous vertical scroll with pinch-zoom; autoScales fits pages to width.
+                setAutoScales(true)
+                setDocument(document)
+            }
+        },
+        update = { view ->
+            if (view.document != document) {
+                view.setDocument(document)
+            }
+        },
+    )
+}

--- a/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/screen/PlatformScreens.ios.kt
+++ b/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/screen/PlatformScreens.ios.kt
@@ -170,6 +170,7 @@ actual fun ChatScreen(
         mediaPreview = uiState.mediaPreview,
         onOpenMedia = viewModel::openMedia,
         onCloseMedia = viewModel::closeMedia,
+        onDownloadAttachment = viewModel::downloadFileBytes,
     ) {
     Scaffold(
         modifier = modifier.imePadding(),


### PR DESCRIPTION
## Summary
Renders the files a tool call generates (code-interpreter output, etc.) beneath its tool card, matching the web client which passes each tool call's attachments to every tool component. Generated PDFs open in a new native full-screen preview. The attachment data already arrives via SSE `attachment` events / persisted `message.attachments`; this is the render layer.

## Changes
- **Tool-call attachments** (`ToolCallAttachments`): images render inline; text-bearing sources (`.py`/`.md`/`.html`/`.mmd`, etc.) open in the artifacts panel; PDFs show a card that opens the native preview; other files become download-and-share chips. Skips pseudo-types (`web_search`/`file_search`/`memory`/`ui_resources`), office-preview docs, and sandbox placeholder leaves; dedups by `fileId ?: filename`.
- **Native PDF preview** (`PdfPreviewOverlay` + expect/actual `PdfViewer`): Android renders pages on demand via `PdfRenderer` in a `LazyColumn` with per-page pinch-zoom; iOS uses PDFKit `PDFView`. A magic-byte check guards the native parsers against non-PDF bodies; downloaded bytes stay shareable even when a file can't be rendered; the preview survives configuration changes. Opened through the `LocalOpenPdf` CompositionLocal, hosted by `ChatRoot`.
- **Authenticated downloads**: `LocalAttachmentDownloader` CompositionLocal backed by `ChatViewModel.downloadFileBytes` for chip downloads and preview bytes.
- **iOS share**: the shared `rememberShareFile` now threads the file's MIME type through and appends a matching extension when the display name lacks one (affects all files shared on iOS, not just PDFs); `toNSData` is made public for reuse.
- **Tool-name routing/parsing**: `bash_tool`/`run_tools_with_bash`/`run_tools_with_code` route to the code card; `lc_transfer_to_*` to an agent-handoff row; `file_search`/`retrieval` excluded from web-search parsing.
- **Defensive finalize merge**: folds streamed attachments into the final response message by `fileId` when a backend omits them.

## Testing
- Unit tests: attachment partitioning/classification, `looksLikePdf`, tool-name routing, streamed-attachment merge.
- `detekt` (commonMain / feature:chat / core:ui), Android `assembleDebug`, and iOS Kotlin compile all pass.
- Installed and launched on a Pixel 9 Pro Fold.

## Notes
Deferred follow-ups: hoist `PdfViewer` + overlay shell into `core/ui` (shared with `feature/files`), a `fileId`-keyed byte cache, and consolidating the several independent `isPdf` checks.
