### PR TITLE
feat(artifacts): pin generated artifacts to the Android home screen

### DIFF
--- a/app/CLAUDE.md
+++ b/app/CLAUDE.md
@@ -38,9 +38,17 @@ Conversations are integrated into the drawer body. Agents, Files, and Settings a
 
 ## Deep Linking
 
-- Scheme: `librechat://conversation/{conversationId}`
-- Handled in `MainActivity.handleDeepLink()` and forwarded to this module's `LibreChatNavHost`
-- `onNewIntent` handles deep links when app is already running
+- Scheme `librechat://`. Hosts: `conversation/{id}`, `artifact/{uuid}`, `oauth` (cookie-consumed; see below).
+- **Single source of truth**: `DeepLinks.resolve()` in `:shared/commonMain` maps a URI to a
+  `DeepLinkResolution` (`Route(target, requiresAuth)` / `Consumed` / `None`). Add a new deep link by
+  adding one branch there — do NOT reintroduce a per-host allowlist here.
+- `MainActivity.handleDeepLink()` calls the resolver to accept/drop the intent (via the Android
+  `Uri → DeepLinkUri` adapter in `DeepLinkUriAdapter.kt`), then forwards to this module's
+  `LibreChatNavHost`, which resolves again to place the target on the back stack.
+- `requiresAuth` links (conversation) redirect to login when logged out; non-auth links (device-scoped
+  artifact) open logged-out. `oauth` is `Consumed` — its token returns via cookie read by the login
+  screen (`checkOAuthResult`), so the link only brings the app forward.
+- `onNewIntent` handles deep links when the app is already running.
 
 ## Connectivity
 

--- a/app/src/main/kotlin/com/garfiec/librechat/MainActivity.kt
+++ b/app/src/main/kotlin/com/garfiec/librechat/MainActivity.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.core.net.toUri
 import androidx.core.view.WindowCompat
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import co.touchlab.kermit.Logger
@@ -47,7 +48,12 @@ import com.garfiec.librechat.core.ui.theme.LibreChatTheme
 import com.garfiec.librechat.feature.chat.ShareIntentConsumer
 import com.garfiec.librechat.feature.chat.SharedContent
 import com.garfiec.librechat.navigation.LibreChatNavHost
+import com.garfiec.librechat.navigation.toDeepLinkUri
+import com.garfiec.librechat.shared.navigation.DeepLinkResolution
+import com.garfiec.librechat.shared.navigation.DeepLinks
 import org.koin.android.ext.android.inject
+
+private const val KEY_PENDING_DEEP_LINK = "pending_deep_link"
 
 class MainActivity : ComponentActivity() {
 
@@ -70,7 +76,17 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
 
-        handleIntent(intent)
+        // Only process the launch intent on a genuinely fresh start. On recreation (rotation,
+        // theme/locale change, restore) it is still sticky; re-processing would re-fire the deep link
+        // and yank the user back to it. Instead restore any not-yet-consumed link (see onSaveInstanceState):
+        // if the nav host hadn't composed to consume it before a recreation — e.g. a config change during
+        // the theme/locale warm-up gate below — it would otherwise be lost, since deepLinkUri isn't saved
+        // state and the back stack has nothing to restore yet. A consumed link was already nulled.
+        if (savedInstanceState == null) {
+            handleIntent(intent)
+        } else {
+            deepLinkUri = savedInstanceState.getString(KEY_PENDING_DEEP_LINK)?.toUri()
+        }
         setContent {
             val windowSizeClass = calculateWindowSizeClass(this)
             val isConnected by connectivityObserver.isConnected.collectAsStateWithLifecycle(initialValue = true)
@@ -160,8 +176,17 @@ class MainActivity : ComponentActivity() {
         }
     }
 
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        // Preserve a link that hasn't been placed on the back stack yet, so a recreation during the
+        // warm-up gate doesn't drop it (restored in onCreate). A consumed link is already null.
+        deepLinkUri?.let { outState.putString(KEY_PENDING_DEEP_LINK, it.toString()) }
+    }
+
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
+        // Keep getIntent() pointing at the latest intent so a later recreation doesn't re-read a stale one.
+        setIntent(intent)
         handleIntent(intent)
     }
 
@@ -177,20 +202,15 @@ class MainActivity : ComponentActivity() {
 
     private fun handleDeepLink(intent: Intent) {
         intent.data?.let { uri ->
-            if (uri.scheme == "librechat" && uri.host in KNOWN_DEEP_LINK_HOSTS) {
+            if (uri.scheme != DeepLinks.SCHEME) return@let
+            // Same resolver the nav host uses — the accept decision and the routing decision can't
+            // drift because they're one source of truth. Anything it doesn't route is dropped here.
+            if (DeepLinks.resolve(uri.toDeepLinkUri()) is DeepLinkResolution.None) {
+                Logger.w { "Ignoring unhandled deep link: $uri" }
+            } else {
                 deepLinkUri = uri
-            } else if (uri.scheme == "librechat") {
-                Logger.w { "Ignoring deep link with unknown host: ${uri.host}" }
             }
         }
-    }
-
-    companion object {
-        /** Hosts accepted by the librechat:// deep link scheme. */
-        private val KNOWN_DEEP_LINK_HOSTS = setOf("conversation", "oauth")
-
-        /** MongoDB ObjectID: exactly 24 lowercase hex characters. */
-        val CONVERSATION_ID_REGEX = Regex("^[a-f0-9]{24}$")
     }
 
     private fun handleShareIntent(intent: Intent) {

--- a/app/src/main/kotlin/com/garfiec/librechat/navigation/DeepLinkUriAdapter.kt
+++ b/app/src/main/kotlin/com/garfiec/librechat/navigation/DeepLinkUriAdapter.kt
@@ -1,0 +1,18 @@
+package com.garfiec.librechat.navigation
+
+import android.net.Uri
+import com.garfiec.librechat.shared.navigation.DeepLinkUri
+
+/** Adapts an Android [Uri] to the platform-neutral [DeepLinkUri] the shared resolver consumes. */
+fun Uri.toDeepLinkUri(): DeepLinkUri = DeepLinkUri(
+    host = host,
+    pathSegments = pathSegments.orEmpty(),
+    // The query accessors throw UnsupportedOperationException on an opaque ("librechat:foo", no "//")
+    // URI, which the scheme-only intent filter still delivers. Such URIs carry no routable host, so
+    // give them an empty query rather than crashing; the resolver drops them as None.
+    query = if (isHierarchical) {
+        queryParameterNames.orEmpty().associateWith { getQueryParameter(it).orEmpty() }
+    } else {
+        emptyMap()
+    },
+)

--- a/app/src/main/kotlin/com/garfiec/librechat/navigation/LibreChatNavHost.kt
+++ b/app/src/main/kotlin/com/garfiec/librechat/navigation/LibreChatNavHost.kt
@@ -6,12 +6,14 @@ import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import co.touchlab.kermit.Logger
-import com.garfiec.librechat.MainActivity
 import com.garfiec.librechat.feature.chat.navigation.Chat
 import com.garfiec.librechat.feature.chat.navigation.NewChat
+import com.garfiec.librechat.shared.navigation.DeepLinkResolution
+import com.garfiec.librechat.shared.navigation.DeepLinks
 import com.garfiec.librechat.shared.navigation.PhoneLayout
 import com.garfiec.librechat.shared.navigation.LibreChatNavHost as SharedLibreChatNavHost
 
@@ -28,22 +30,45 @@ fun LibreChatNavHost(
     shareNavigationTrigger: Int = 0,
     appLocaleTag: String? = null,
 ) {
-    SharedLibreChatNavHost(modifier = modifier, appLocaleTag = appLocaleTag) { navigator, navHostViewModel, mod ->
+    // Resolve the pending link once (both the auth-suppression flag and the handler below use it).
+    val resolution = remember(deepLinkUri) { deepLinkUri?.let { DeepLinks.resolve(it.toDeepLinkUri()) } }
+
+    SharedLibreChatNavHost(
+        modifier = modifier,
+        appLocaleTag = appLocaleTag,
+        // Cold-start deep links are set before setContent, so this is true on the first composition
+        // when a link is pending that is *valid without auth* — the shared host then skips its initial
+        // auth redirect and lets the handler below own the stack (so a logged-out target isn't wiped by
+        // an auth clear). Auth-required and non-routable links must NOT suppress it: the former should
+        // land on login, the latter would strand a logged-out user on an un-authed screen.
+        hasPendingDeepLink = resolution is DeepLinkResolution.Route && !resolution.requiresAuth,
+    ) { navigator, navHostViewModel, mod ->
         // Handle deep links
         val currentOnDeepLinkConsume by rememberUpdatedState(onDeepLinkConsume)
         LaunchedEffect(deepLinkUri) {
-            deepLinkUri?.let { uri ->
-                if (uri.scheme == "librechat" && uri.host == "conversation") {
-                    uri.lastPathSegment?.let { conversationId ->
-                        if (MainActivity.CONVERSATION_ID_REGEX.matches(conversationId)) {
-                            navigator.navigateToChat(conversationId)
-                        } else {
-                            Logger.w { "Ignoring deep link with invalid conversation ID: $conversationId" }
-                        }
+            val uri = deepLinkUri ?: return@LaunchedEffect
+            when (resolution) {
+                is DeepLinkResolution.Route -> {
+                    val target = resolution.target
+                    val loggedIn = navHostViewModel.isLoggedIn.value
+                    when {
+                        // Auth-required target while logged out → login. (Resuming to the target
+                        // after login is a follow-up; this at least never lands on a broken screen.)
+                        resolution.requiresAuth && !loggedIn -> navigator.navigateToAuth()
+                        // Open-logged-out target (device-scoped artifact) sits atop an auth base so
+                        // backing out lands on login; rebuilds the stack so repeat taps can't pile up.
+                        !loggedIn -> navigator.navigateToDeepLinkLoggedOut(target)
+                        // Switching chats replaces the current chat entry so back returns to NewChat.
+                        target is Chat -> target.conversationId?.let { navigator.navigateToChat(it) }
+                        // Otherwise push, de-duping a repeat tap of the same target.
+                        navigator.currentRoute != target -> navigator.navigate(target)
                     }
                 }
-                currentOnDeepLinkConsume()
+                // OAuth redirect: the login screen consumes the refresh-token cookie; nothing to route.
+                DeepLinkResolution.Consumed, null -> Unit
+                DeepLinkResolution.None -> Logger.w { "Ignoring non-routable deep link: $uri" }
             }
+            currentOnDeepLinkConsume()
         }
 
         // Handle share intent

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -125,7 +125,7 @@ coroutines:
 Compose:
   CompositionLocalAllowlist:
     active: true
-    allowedCompositionLocals: LocalAttachmentDownloader,LocalChatMediaViewer,LocalImmediateMarkdown,LocalInlineArtifactPrefs,LocalMermaidRenderCache,LocalOpenArtifact,LocalOpenPdf,LocalParsedMarkdownCache,LocalSearchFocusNonce,LocalSubagentProgress
+    allowedCompositionLocals: LocalAddArtifactToHomeScreen,LocalAttachmentDownloader,LocalChatMediaViewer,LocalImmediateMarkdown,LocalInlineArtifactPrefs,LocalMermaidRenderCache,LocalOpenArtifact,LocalOpenPdf,LocalParsedMarkdownCache,LocalSearchFocusNonce,LocalSubagentProgress
 
 # detekt-koin rule overrides (defaults ship in plugin jar; buildUponDefaultConfig = true)
 koin-rules:

--- a/core/data/schemas/com.garfiec.librechat.core.data.db.LibreChatDatabase/7.json
+++ b/core/data/schemas/com.garfiec.librechat.core.data.db.LibreChatDatabase/7.json
@@ -1,0 +1,616 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 7,
+    "identityHash": "bd42ed825f973043addd329db2e25aa7",
+    "entities": [
+      {
+        "tableName": "conversations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`conversationId` TEXT NOT NULL, `title` TEXT NOT NULL, `user` TEXT NOT NULL, `endpoint` TEXT, `endpointType` TEXT, `model` TEXT, `agentId` TEXT, `isArchived` INTEGER NOT NULL, `pinned` INTEGER NOT NULL DEFAULT 0, `chatProjectId` TEXT, `tags` TEXT NOT NULL, `iconURL` TEXT, `greeting` TEXT, `modelParams` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, `accountId` TEXT, PRIMARY KEY(`conversationId`))",
+        "fields": [
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "user",
+            "columnName": "user",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endpoint",
+            "columnName": "endpoint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "endpointType",
+            "columnName": "endpointType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "model",
+            "columnName": "model",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "agentId",
+            "columnName": "agentId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isArchived",
+            "columnName": "isArchived",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pinned",
+            "columnName": "pinned",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "chatProjectId",
+            "columnName": "chatProjectId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "tags",
+            "columnName": "tags",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "iconURL",
+            "columnName": "iconURL",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "greeting",
+            "columnName": "greeting",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "modelParams",
+            "columnName": "modelParams",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "conversationId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_conversations_isArchived_updatedAt",
+            "unique": false,
+            "columnNames": [
+              "isArchived",
+              "updatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_conversations_isArchived_updatedAt` ON `${TABLE_NAME}` (`isArchived`, `updatedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`messageId` TEXT NOT NULL, `conversationId` TEXT NOT NULL, `parentMessageId` TEXT, `sender` TEXT, `text` TEXT, `content` TEXT, `isCreatedByUser` INTEGER NOT NULL, `model` TEXT, `endpoint` TEXT, `iconURL` TEXT, `unfinished` INTEGER NOT NULL, `error` INTEGER NOT NULL, `finishReason` TEXT, `tokenCount` INTEGER, `feedback` TEXT, `files` TEXT, `attachments` TEXT, `metadata` TEXT, `quotes` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `accountId` TEXT, PRIMARY KEY(`messageId`))",
+        "fields": [
+          {
+            "fieldPath": "messageId",
+            "columnName": "messageId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "parentMessageId",
+            "columnName": "parentMessageId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sender",
+            "columnName": "sender",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isCreatedByUser",
+            "columnName": "isCreatedByUser",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "model",
+            "columnName": "model",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "endpoint",
+            "columnName": "endpoint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "iconURL",
+            "columnName": "iconURL",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "unfinished",
+            "columnName": "unfinished",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "error",
+            "columnName": "error",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "finishReason",
+            "columnName": "finishReason",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "tokenCount",
+            "columnName": "tokenCount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "feedback",
+            "columnName": "feedback",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "files",
+            "columnName": "files",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "attachments",
+            "columnName": "attachments",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "metadata",
+            "columnName": "metadata",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "quotes",
+            "columnName": "quotes",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "messageId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_messages_conversationId",
+            "unique": false,
+            "columnNames": [
+              "conversationId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_messages_conversationId` ON `${TABLE_NAME}` (`conversationId`)"
+          },
+          {
+            "name": "index_messages_parentMessageId",
+            "unique": false,
+            "columnNames": [
+              "parentMessageId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_messages_parentMessageId` ON `${TABLE_NAME}` (`parentMessageId`)"
+          },
+          {
+            "name": "index_messages_conversationId_createdAt",
+            "unique": false,
+            "columnNames": [
+              "conversationId",
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_messages_conversationId_createdAt` ON `${TABLE_NAME}` (`conversationId`, `createdAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "agents",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT, `description` TEXT, `avatar` TEXT, `provider` TEXT NOT NULL, `model` TEXT NOT NULL, `category` TEXT, `authorName` TEXT, `isPromoted` INTEGER NOT NULL, `conversationStarters` TEXT, `tools` TEXT, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "avatar",
+            "columnName": "avatar",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "provider",
+            "columnName": "provider",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "model",
+            "columnName": "model",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "authorName",
+            "columnName": "authorName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isPromoted",
+            "columnName": "isPromoted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationStarters",
+            "columnName": "conversationStarters",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "tools",
+            "columnName": "tools",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "presets",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`presetId` TEXT NOT NULL, `title` TEXT NOT NULL, `endpoint` TEXT, `model` TEXT, `isDefault` INTEGER NOT NULL, `order` INTEGER, `params` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`presetId`))",
+        "fields": [
+          {
+            "fieldPath": "presetId",
+            "columnName": "presetId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endpoint",
+            "columnName": "endpoint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "model",
+            "columnName": "model",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isDefault",
+            "columnName": "isDefault",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "order",
+            "columnName": "order",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "params",
+            "columnName": "params",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "presetId"
+          ]
+        }
+      },
+      {
+        "tableName": "conversation_tags",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `tag` TEXT NOT NULL, `user` TEXT NOT NULL, `description` TEXT, `count` INTEGER NOT NULL, `position` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `accountId` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tag",
+            "columnName": "tag",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "user",
+            "columnName": "user",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "count",
+            "columnName": "count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_conversation_tags_tag_user",
+            "unique": true,
+            "columnNames": [
+              "tag",
+              "user"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_conversation_tags_tag_user` ON `${TABLE_NAME}` (`tag`, `user`)"
+          }
+        ]
+      },
+      {
+        "tableName": "drafts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`conversation_id` TEXT NOT NULL, `text` TEXT NOT NULL, `updated_at` INTEGER NOT NULL, `accountId` TEXT, PRIMARY KEY(`conversation_id`))",
+        "fields": [
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversation_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "conversation_id"
+          ]
+        }
+      },
+      {
+        "tableName": "artifact_shortcuts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `shortcut_label` TEXT NOT NULL, `emoji` TEXT, `identifier` TEXT NOT NULL, `type` TEXT NOT NULL, `title` TEXT NOT NULL, `language` TEXT, `content` TEXT NOT NULL, `version` INTEGER NOT NULL, `created_at` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shortcutLabel",
+            "columnName": "shortcut_label",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "emoji",
+            "columnName": "emoji",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "identifier",
+            "columnName": "identifier",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "language",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "version",
+            "columnName": "version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'bd42ed825f973043addd329db2e25aa7')"
+    ]
+  }
+}

--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/repository/ArtifactShortcutRepositoryImplTest.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/repository/ArtifactShortcutRepositoryImplTest.kt
@@ -1,0 +1,91 @@
+package com.garfiec.librechat.core.data.repository
+
+import com.garfiec.librechat.core.data.db.dao.ArtifactShortcutDao
+import com.garfiec.librechat.core.data.db.entity.ArtifactShortcutEntity
+import com.garfiec.librechat.core.model.ArtifactShortcut
+import com.google.common.truth.Truth.assertThat
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+/** Verifies the entity ↔ core-model mapping on both the write (save) and read (get/observeAll) sides. */
+@OptIn(ExperimentalCoroutinesApi::class)
+class ArtifactShortcutRepositoryImplTest {
+
+    private val model = ArtifactShortcut(
+        id = "11111111-2222-3333-4444-555555555555",
+        label = "My Chart",
+        emoji = "📊",
+        identifier = "chart-1",
+        type = "application/vnd.mermaid",
+        title = "Sales Chart",
+        language = null,
+        content = "graph TD; A-->B",
+        version = 2,
+        createdAt = 1_700_000_000_000L,
+    )
+
+    @Test
+    fun save_mapsModelToEntity() = runTest {
+        val dao = mockk<ArtifactShortcutDao>(relaxed = true)
+        val captured = slot<ArtifactShortcutEntity>()
+        coEvery { dao.upsert(capture(captured)) } returns Unit
+        val repo = ArtifactShortcutRepositoryImpl(dao, StandardTestDispatcher(testScheduler))
+
+        repo.save(model)
+        testScheduler.advanceUntilIdle()
+
+        val entity = captured.captured
+        assertThat(entity.id).isEqualTo(model.id)
+        assertThat(entity.shortcutLabel).isEqualTo("My Chart")
+        assertThat(entity.emoji).isEqualTo("📊")
+        assertThat(entity.identifier).isEqualTo("chart-1")
+        assertThat(entity.type).isEqualTo("application/vnd.mermaid")
+        assertThat(entity.language).isNull()
+        assertThat(entity.version).isEqualTo(2)
+        assertThat(entity.createdAt).isEqualTo(1_700_000_000_000L)
+    }
+
+    @Test
+    fun get_mapsEntityToModel() = runTest {
+        val dao = mockk<ArtifactShortcutDao>()
+        coEvery { dao.getById(model.id) } returns model.toEntity()
+        val repo = ArtifactShortcutRepositoryImpl(dao, StandardTestDispatcher(testScheduler))
+
+        val result = repo.get(model.id)
+        testScheduler.advanceUntilIdle()
+
+        assertThat(result).isEqualTo(model)
+    }
+
+    @Test
+    fun observeAll_mapsEachEntity() = runTest {
+        val dao = mockk<ArtifactShortcutDao>()
+        every { dao.observeAll() } returns flowOf(listOf(model.toEntity()))
+        val repo = ArtifactShortcutRepositoryImpl(dao, StandardTestDispatcher(testScheduler))
+
+        val result = repo.observeAll().first()
+
+        assertThat(result).containsExactly(model)
+    }
+}
+
+private fun ArtifactShortcut.toEntity() = ArtifactShortcutEntity(
+    id = id,
+    shortcutLabel = label,
+    emoji = emoji,
+    identifier = identifier,
+    type = type,
+    title = title,
+    language = language,
+    content = content,
+    version = version,
+    createdAt = createdAt,
+)

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/db/LibreChatDatabase.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/db/LibreChatDatabase.kt
@@ -9,12 +9,14 @@ import androidx.room.TypeConverters
 import com.garfiec.librechat.core.data.db.converter.Converters
 import com.garfiec.librechat.core.data.db.dao.AccountClaimDao
 import com.garfiec.librechat.core.data.db.dao.AgentDao
+import com.garfiec.librechat.core.data.db.dao.ArtifactShortcutDao
 import com.garfiec.librechat.core.data.db.dao.ConversationDao
 import com.garfiec.librechat.core.data.db.dao.ConversationTagDao
 import com.garfiec.librechat.core.data.db.dao.DraftDao
 import com.garfiec.librechat.core.data.db.dao.MessageDao
 import com.garfiec.librechat.core.data.db.dao.PresetDao
 import com.garfiec.librechat.core.data.db.entity.AgentEntity
+import com.garfiec.librechat.core.data.db.entity.ArtifactShortcutEntity
 import com.garfiec.librechat.core.data.db.entity.ConversationEntity
 import com.garfiec.librechat.core.data.db.entity.ConversationTagEntity
 import com.garfiec.librechat.core.data.db.entity.DraftEntity
@@ -29,8 +31,9 @@ import com.garfiec.librechat.core.data.db.entity.PresetEntity
         PresetEntity::class,
         ConversationTagEntity::class,
         DraftEntity::class,
+        ArtifactShortcutEntity::class,
     ],
-    version = 6,
+    version = 7,
     exportSchema = true,
     autoMigrations = [
         AutoMigration(from = 1, to = 2),
@@ -42,6 +45,8 @@ import com.garfiec.librechat.core.data.db.entity.PresetEntity
         // (referenced-text excerpts). Bundled into a single hop because none shipped as a released
         // DB version — there is no in-the-wild v6 to migrate through.
         AutoMigration(from = 5, to = 6),
+        // 6 -> 7 adds the device-scoped artifact_shortcuts table (home-screen artifact snapshots).
+        AutoMigration(from = 6, to = 7),
     ],
 )
 @TypeConverters(Converters::class)
@@ -54,6 +59,7 @@ abstract class LibreChatDatabase : RoomDatabase() {
     abstract fun conversationTagDao(): ConversationTagDao
     abstract fun draftDao(): DraftDao
     abstract fun accountClaimDao(): AccountClaimDao
+    abstract fun artifactShortcutDao(): ArtifactShortcutDao
 }
 
 // Room KSP auto-generates the actual implementations for each platform

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/db/dao/ArtifactShortcutDao.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/db/dao/ArtifactShortcutDao.kt
@@ -1,0 +1,23 @@
+package com.garfiec.librechat.core.data.db.dao
+
+import androidx.room.Dao
+import androidx.room.Query
+import androidx.room.Upsert
+import com.garfiec.librechat.core.data.db.entity.ArtifactShortcutEntity
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface ArtifactShortcutDao {
+
+    @Upsert
+    suspend fun upsert(shortcut: ArtifactShortcutEntity)
+
+    @Query("SELECT * FROM artifact_shortcuts WHERE id = :id")
+    suspend fun getById(id: String): ArtifactShortcutEntity?
+
+    @Query("SELECT * FROM artifact_shortcuts ORDER BY created_at DESC")
+    fun observeAll(): Flow<List<ArtifactShortcutEntity>>
+
+    @Query("DELETE FROM artifact_shortcuts WHERE id = :id")
+    suspend fun deleteById(id: String)
+}

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/db/entity/ArtifactShortcutEntity.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/db/entity/ArtifactShortcutEntity.kt
@@ -1,0 +1,35 @@
+package com.garfiec.librechat.core.data.db.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+/**
+ * A pinned-artifact snapshot. Deliberately has NO accountId column: a home-screen launcher icon must
+ * keep opening after logout / account-switch, so this table is device-scoped and is intentionally
+ * excluded from AccountDataPurger's per-account teardown.
+ */
+@Entity(tableName = "artifact_shortcuts")
+data class ArtifactShortcutEntity(
+    @PrimaryKey
+    @ColumnInfo(name = "id")
+    val id: String,
+    @ColumnInfo(name = "shortcut_label")
+    val shortcutLabel: String,
+    @ColumnInfo(name = "emoji")
+    val emoji: String?,
+    @ColumnInfo(name = "identifier")
+    val identifier: String,
+    @ColumnInfo(name = "type")
+    val type: String,
+    @ColumnInfo(name = "title")
+    val title: String,
+    @ColumnInfo(name = "language")
+    val language: String?,
+    @ColumnInfo(name = "content")
+    val content: String,
+    @ColumnInfo(name = "version")
+    val version: Int,
+    @ColumnInfo(name = "created_at")
+    val createdAt: Long,
+)

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/di/DataModule.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/di/DataModule.kt
@@ -23,6 +23,8 @@ import com.garfiec.librechat.core.data.repository.AgentToolsRepository
 import com.garfiec.librechat.core.data.repository.AgentToolsRepositoryImpl
 import com.garfiec.librechat.core.data.repository.ApiKeyRepository
 import com.garfiec.librechat.core.data.repository.ApiKeyRepositoryImpl
+import com.garfiec.librechat.core.data.repository.ArtifactShortcutRepository
+import com.garfiec.librechat.core.data.repository.ArtifactShortcutRepositoryImpl
 import com.garfiec.librechat.core.data.repository.AuthRepository
 import com.garfiec.librechat.core.data.repository.AuthRepositoryImpl
 import com.garfiec.librechat.core.data.repository.BalanceRepository
@@ -104,6 +106,7 @@ val dataModule = module {
     single { get<LibreChatDatabase>().conversationTagDao() }
     single { get<LibreChatDatabase>().draftDao() }
     single { get<LibreChatDatabase>().accountClaimDao() }
+    single { get<LibreChatDatabase>().artifactShortcutDao() }
 
     // --- Account identity (row-tenancy) ---
 
@@ -276,6 +279,13 @@ val dataModule = module {
         DraftRepositoryImpl(
             draftDao = get(),
             activeAccountProvider = get(),
+            ioDispatcher = get(KoinQualifiers.IO),
+        )
+    }
+
+    single<ArtifactShortcutRepository> {
+        ArtifactShortcutRepositoryImpl(
+            dao = get(),
             ioDispatcher = get(KoinQualifiers.IO),
         )
     }

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/ArtifactShortcutRepository.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/ArtifactShortcutRepository.kt
@@ -1,0 +1,11 @@
+package com.garfiec.librechat.core.data.repository
+
+import com.garfiec.librechat.core.model.ArtifactShortcut
+import kotlinx.coroutines.flow.Flow
+
+interface ArtifactShortcutRepository {
+    suspend fun save(shortcut: ArtifactShortcut)
+    suspend fun get(id: String): ArtifactShortcut?
+    fun observeAll(): Flow<List<ArtifactShortcut>>
+    suspend fun delete(id: String)
+}

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/ArtifactShortcutRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/ArtifactShortcutRepositoryImpl.kt
@@ -1,0 +1,57 @@
+package com.garfiec.librechat.core.data.repository
+
+import com.garfiec.librechat.core.data.db.dao.ArtifactShortcutDao
+import com.garfiec.librechat.core.data.db.entity.ArtifactShortcutEntity
+import com.garfiec.librechat.core.model.ArtifactShortcut
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.withContext
+
+class ArtifactShortcutRepositoryImpl(
+    private val dao: ArtifactShortcutDao,
+    private val ioDispatcher: CoroutineDispatcher,
+) : ArtifactShortcutRepository {
+
+    override suspend fun save(shortcut: ArtifactShortcut) = withContext(ioDispatcher) {
+        dao.upsert(shortcut.toEntity())
+    }
+
+    override suspend fun get(id: String): ArtifactShortcut? = withContext(ioDispatcher) {
+        dao.getById(id)?.toModel()
+    }
+
+    override fun observeAll(): Flow<List<ArtifactShortcut>> =
+        dao.observeAll().map { entities -> entities.map { it.toModel() } }.flowOn(ioDispatcher)
+
+    override suspend fun delete(id: String) = withContext(ioDispatcher) {
+        dao.deleteById(id)
+    }
+}
+
+private fun ArtifactShortcutEntity.toModel() = ArtifactShortcut(
+    id = id,
+    label = shortcutLabel,
+    emoji = emoji,
+    identifier = identifier,
+    type = type,
+    title = title,
+    language = language,
+    content = content,
+    version = version,
+    createdAt = createdAt,
+)
+
+private fun ArtifactShortcut.toEntity() = ArtifactShortcutEntity(
+    id = id,
+    shortcutLabel = label,
+    emoji = emoji,
+    identifier = identifier,
+    type = type,
+    title = title,
+    language = language,
+    content = content,
+    version = version,
+    createdAt = createdAt,
+)

--- a/core/model/src/commonMain/kotlin/com/garfiec/librechat/core/model/ArtifactShortcut.kt
+++ b/core/model/src/commonMain/kotlin/com/garfiec/librechat/core/model/ArtifactShortcut.kt
@@ -1,0 +1,28 @@
+package com.garfiec.librechat.core.model
+
+import kotlinx.serialization.Serializable
+
+/**
+ * A snapshot of a generated artifact that the user pinned to the device home screen (Android).
+ *
+ * Self-contained by design: the artifact's content is copied in full at pin time, so the shortcut
+ * survives the source conversation being edited or deleted and opens while logged out. Device-scoped,
+ * not account-scoped — a launcher icon must outlive logout/account-switch, so there is no owning
+ * account here (see [com.garfiec.librechat.core.model] siblings, which are account-scoped).
+ *
+ * [id] is the snapshot's stable identifier: the primary key, the pinned shortcut id, and the
+ * `librechat://artifact/{id}` deep-link path segment.
+ */
+@Serializable
+data class ArtifactShortcut(
+    val id: String,
+    val label: String,
+    val emoji: String?,
+    val identifier: String,
+    val type: String,
+    val title: String,
+    val language: String?,
+    val content: String,
+    val version: Int,
+    val createdAt: Long,
+)

--- a/core/model/src/commonMain/kotlin/com/garfiec/librechat/core/model/ArtifactTypeDisplay.kt
+++ b/core/model/src/commonMain/kotlin/com/garfiec/librechat/core/model/ArtifactTypeDisplay.kt
@@ -1,0 +1,45 @@
+package com.garfiec.librechat.core.model
+
+private const val OFFICE_PREVIEW_MIME_PREFIX = "application/vnd.librechat."
+private const val OFFICE_PREVIEW_MIME_SUFFIX = "-preview"
+
+/**
+ * Type-string → representative emoji for a pinned artifact. Single-sourced here so the launcher icon
+ * (:feature:chat) and the management-screen row (:feature:settings) can't drift apart for the same
+ * snapshot. Mirrors the substring ladder in :feature:chat `ArtifactType.from`, including the
+ * office-doc preview buckets that ship as HTML.
+ */
+fun artifactTypeGlyph(type: String): String = when {
+    type.contains("mermaid") -> "📊"
+    type.contains("react") -> "⚛️"
+    type.contains("svg") -> "🖼️"
+    type.contains("markdown") || type == "text/md" -> "📝"
+    type.contains("html") -> "🌐"
+    type.startsWith(OFFICE_PREVIEW_MIME_PREFIX) && type.endsWith(OFFICE_PREVIEW_MIME_SUFFIX) -> "🌐"
+    type == "text/plain" -> "📄"
+    else -> "💻"
+}
+
+/**
+ * Type-string → human label, single-sourced alongside [artifactTypeGlyph] so the two never disagree
+ * (e.g. an office-preview artifact shows the 🌐 glyph and the "HTML Page" label, not "Code"). Same
+ * branch order as the glyph ladder and :feature:chat `ArtifactType.from`.
+ */
+fun artifactTypeLabel(type: String): String = when {
+    type.contains("mermaid") -> "Mermaid Diagram"
+    type.contains("react") -> "React Component"
+    type.contains("svg") -> "SVG Image"
+    type.contains("markdown") || type == "text/md" -> "Markdown Document"
+    type.contains("html") -> "HTML Page"
+    type.startsWith(OFFICE_PREVIEW_MIME_PREFIX) && type.endsWith(OFFICE_PREVIEW_MIME_SUFFIX) -> "HTML Page"
+    type == "text/plain" -> "Plain Text"
+    else -> "Code"
+}
+
+/** Glyph shown for a pinned shortcut: the user's emoji when set, otherwise the type default. */
+val ArtifactShortcut.displayGlyph: String
+    get() = emoji?.takeIf { it.isNotBlank() } ?: artifactTypeGlyph(type)
+
+/** Label shown for a pinned shortcut: the user's label when set, otherwise the artifact title. */
+val ArtifactShortcut.displayLabel: String
+    get() = label.ifBlank { title }

--- a/feature/chat/build.gradle.kts
+++ b/feature/chat/build.gradle.kts
@@ -21,6 +21,7 @@ kotlin {
         }
         androidMain.dependencies {
             implementation(libs.koin.android)
+            implementation(libs.androidx.core.ktx)
             implementation(libs.media3.exoplayer)
             implementation(libs.media3.ui)
             implementation(libs.media3.datasource)

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/ArtifactPanel.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/ArtifactPanel.kt
@@ -28,8 +28,12 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import co.touchlab.kermit.Logger
+import com.garfiec.librechat.core.data.repository.ArtifactShortcutRepository
 import kotlinx.coroutines.launch
 import androidx.compose.runtime.rememberCoroutineScope
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+import org.koin.compose.koinInject
 
 /**
  * Android preview surface — a `WebView` hosting the artifact's rendered HTML.
@@ -150,6 +154,29 @@ actual fun rememberShareArtifact(): (Artifact) -> Unit {
     return remember(context) {
         { artifact ->
             scope.launch { ArtifactDownloadHelper.share(context = context, artifact = artifact) }
+        }
+    }
+}
+
+@OptIn(ExperimentalUuidApi::class)
+@Composable
+actual fun rememberAddArtifactToHomeScreen(): ((artifact: Artifact, label: String, emoji: String?) -> Unit)? {
+    val context = LocalContext.current
+    val repository = koinInject<ArtifactShortcutRepository>()
+    val scope = rememberCoroutineScope()
+    return remember(context, repository) {
+        { artifact, label, emoji ->
+            val shortcut = buildArtifactShortcut(
+                id = Uuid.random().toString(),
+                label = label,
+                emoji = emoji,
+                artifact = artifact,
+            )
+            // The snapshot is persisted from the launcher's pin-confirmation callback (see
+            // requestPinArtifactShortcut), so declining the system prompt leaves no orphan row.
+            scope.launch {
+                requestPinArtifactShortcut(context, shortcut) { repository.save(it) }
+            }
         }
     }
 }

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/ArtifactShortcutHelper.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/ArtifactShortcutHelper.kt
@@ -1,0 +1,172 @@
+package com.garfiec.librechat.feature.chat.components.artifact
+
+import android.app.PendingIntent
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import androidx.core.content.ContextCompat
+import androidx.core.content.pm.ShortcutInfoCompat
+import androidx.core.content.pm.ShortcutManagerCompat
+import androidx.core.graphics.drawable.IconCompat
+import androidx.core.net.toUri
+import com.garfiec.librechat.core.model.ArtifactShortcut
+import com.garfiec.librechat.core.model.displayGlyph
+import com.garfiec.librechat.core.model.displayLabel
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.time.Clock
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+/** Fully-qualified launcher activity — referenced by string because :app isn't visible from here. */
+private const val MAIN_ACTIVITY = "com.garfiec.librechat.MainActivity"
+
+/** Adaptive-icon canvas edge in px; sized for xxhdpi so the launcher downscales rather than upscales. */
+private const val ICON_SIZE_PX = 324
+
+private const val ACTION_PIN_CONFIRMED = "com.garfiec.librechat.artifact.PIN_CONFIRMED"
+private const val EXTRA_SHORTCUT_ID = "artifact_shortcut_id"
+
+/** A snapshot dispatched to the pin prompt, plus how to persist it once the launcher confirms. */
+private class PendingPin(val shortcut: ArtifactShortcut, val save: suspend (ArtifactShortcut) -> Unit)
+
+/**
+ * Snapshots dispatched to the system pin prompt but not yet confirmed, keyed by shortcut id. A row is
+ * persisted (via its paired [PendingPin.save]) only when the launcher's success callback fires — so
+ * declining the prompt (which fires no callback) writes no orphan row. Because a decline is silent,
+ * its entry can't be removed on confirmation; a timeout ([PIN_CONFIRM_TIMEOUT_MS]) evicts it so an
+ * unconfirmed snapshot doesn't retain the artifact content for the life of the process.
+ */
+private val pendingPins = ConcurrentHashMap<String, PendingPin>()
+
+/** App-lifetime scope so a confirmation arriving after the originating screen is gone still persists. */
+private val pinScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+
+private val pinReceiverRegistered = AtomicBoolean(false)
+
+/** Monotonic request code so each in-flight pin gets a distinct PendingIntent (see [requestPinArtifactShortcut]). */
+private val pinRequestCode = AtomicInteger(0)
+
+/** A pin prompt is answered in seconds; evict an unconfirmed snapshot well after that so a silent decline can't leak it. */
+private const val PIN_CONFIRM_TIMEOUT_MS = 5 * 60 * 1000L
+
+/** Registers (once) the receiver for our own pin-confirmation broadcast on the application context. */
+private fun ensurePinReceiver(appContext: Context) {
+    if (!pinReceiverRegistered.compareAndSet(false, true)) return
+    val receiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context, intent: Intent) {
+            val id = intent.getStringExtra(EXTRA_SHORTCUT_ID) ?: return
+            val pending = pendingPins.remove(id) ?: return
+            pinScope.launch { pending.save(pending.shortcut) }
+        }
+    }
+    ContextCompat.registerReceiver(
+        appContext,
+        receiver,
+        IntentFilter(ACTION_PIN_CONFIRMED),
+        ContextCompat.RECEIVER_NOT_EXPORTED,
+    )
+}
+
+/**
+ * Requests the system pin-shortcut prompt for an already-built [ArtifactShortcut] snapshot, persisting
+ * it via [save] only if the launcher actually places the icon (a success callback). Declining the
+ * prompt writes nothing, so no orphan snapshot is left behind. Returns `false` (without prompting) when
+ * the launcher can't pin at all. The bitmap render runs off the main thread.
+ */
+suspend fun requestPinArtifactShortcut(
+    context: Context,
+    shortcut: ArtifactShortcut,
+    save: suspend (ArtifactShortcut) -> Unit,
+): Boolean {
+    if (!ShortcutManagerCompat.isRequestPinShortcutSupported(context)) return false
+    val appContext = context.applicationContext
+    ensurePinReceiver(appContext)
+
+    val intent = Intent(Intent.ACTION_VIEW, "librechat://artifact/${shortcut.id}".toUri())
+        // Explicit component so the launcher routes straight to us regardless of other VIEW handlers.
+        .setClassName(context.packageName, MAIN_ACTIVITY)
+
+    val icon = withContext(Dispatchers.Default) { renderIcon(shortcut) }
+    val info = ShortcutInfoCompat.Builder(context, shortcut.id)
+        .setShortLabel(shortcut.displayLabel)
+        .setIcon(IconCompat.createWithAdaptiveBitmap(icon))
+        .setIntent(intent)
+        .build()
+
+    pendingPins[shortcut.id] = PendingPin(shortcut, save)
+    // Fresh request code per pin: the callback intents are filterEquals-equal (same action, differing
+    // only by extras), so a shared code would let FLAG_UPDATE_CURRENT merge two in-flight pins and
+    // clobber the earlier one's id extra. A distinct code keeps each PendingIntent separate.
+    val callback = PendingIntent.getBroadcast(
+        appContext,
+        pinRequestCode.getAndIncrement(),
+        Intent(ACTION_PIN_CONFIRMED)
+            .setPackage(appContext.packageName)
+            .putExtra(EXTRA_SHORTCUT_ID, shortcut.id),
+        PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+    )
+    val dispatched = ShortcutManagerCompat.requestPinShortcut(context, info, callback.intentSender)
+    if (dispatched) {
+        // A declined prompt fires no callback, so evict the unconfirmed snapshot rather than leak it.
+        pinScope.launch {
+            delay(PIN_CONFIRM_TIMEOUT_MS)
+            pendingPins.remove(shortcut.id)
+        }
+    } else {
+        pendingPins.remove(shortcut.id)
+    }
+    return dispatched
+}
+
+/** Snapshots the artifact primitives plus the user-chosen label/emoji into a storable model. */
+fun buildArtifactShortcut(
+    id: String,
+    label: String,
+    emoji: String?,
+    artifact: Artifact,
+): ArtifactShortcut = ArtifactShortcut(
+    id = id,
+    label = label,
+    emoji = emoji,
+    identifier = artifact.identifier,
+    type = artifact.type,
+    title = artifact.title,
+    language = artifact.language,
+    content = artifact.content,
+    version = artifact.version,
+    createdAt = Clock.System.now().toEpochMilliseconds(),
+)
+
+/**
+ * Renders the launcher icon at runtime (the repo ships no per-artifact drawables): a solid full-bleed
+ * background with a centered glyph — the user's emoji when set, otherwise a type-representative emoji.
+ * Full-bleed so the launcher's adaptive mask can crop to any shape.
+ */
+private fun renderIcon(shortcut: ArtifactShortcut): Bitmap {
+    val glyph = shortcut.displayGlyph
+    val bitmap = Bitmap.createBitmap(ICON_SIZE_PX, ICON_SIZE_PX, Bitmap.Config.ARGB_8888)
+    val canvas = Canvas(bitmap)
+    canvas.drawColor(ARTIFACT_ICON_BACKGROUND_ARGB.toInt())
+
+    val textPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        color = Color.WHITE
+        textAlign = Paint.Align.CENTER
+        // Kept within the adaptive safe zone (~66/108 of the canvas) so the mask never clips the glyph.
+        textSize = ICON_SIZE_PX * 0.42f
+    }
+    // Vertically center on the text's own metrics, not the baseline.
+    val centerY = ICON_SIZE_PX / 2f - (textPaint.descent() + textPaint.ascent()) / 2f
+    canvas.drawText(glyph, ICON_SIZE_PX / 2f, centerY, textPaint)
+    return bitmap
+}

--- a/feature/chat/src/commonMain/composeResources/values/strings.xml
+++ b/feature/chat/src/commonMain/composeResources/values/strings.xml
@@ -313,6 +313,17 @@
     <!-- Artifacts -->
     <string name="cd_open_artifact">Open artifact</string>
     <string name="cd_share_artifact">Share artifact</string>
+    <string name="cd_add_artifact_to_home_screen">Add to Home screen</string>
+    <string name="add_to_home_screen_dialog_title">Add to Home screen</string>
+    <string name="add_to_home_screen_dialog_name_label">Name</string>
+    <string name="add_to_home_screen_dialog_emoji_label">Emoji</string>
+    <string name="add_to_home_screen_icon_label">Icon</string>
+    <string name="add_to_home_screen_icon_auto">Auto</string>
+    <string name="add_to_home_screen_icon_custom">Custom</string>
+    <string name="cd_icon_preview">Icon preview</string>
+    <string name="artifact_shortcut_unavailable">This artifact is no longer available.</string>
+    <string name="add_to_home_screen_confirm">Add</string>
+    <string name="artifact_shortcut_back">Back</string>
     <string name="cd_previous_version">Previous version</string>
     <string name="cd_next_version">Next version</string>
     <string name="artifact_version">v%1$d/%2$d</string>

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/TextArtifactContentPart.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/TextArtifactContentPart.kt
@@ -19,6 +19,7 @@ import com.garfiec.librechat.feature.chat.components.artifact.InlineArtifactView
 import com.garfiec.librechat.feature.chat.components.artifact.InlineMarkdownArtifact
 import com.garfiec.librechat.feature.chat.components.artifact.InlineSvgArtifact
 import com.garfiec.librechat.feature.chat.components.artifact.InlineSvgSurface
+import com.garfiec.librechat.feature.chat.components.artifact.LocalAddArtifactToHomeScreen
 import com.garfiec.librechat.feature.chat.components.artifact.LocalInlineArtifactPrefs
 import com.garfiec.librechat.feature.chat.components.artifact.LocalMermaidRenderCache
 import com.garfiec.librechat.feature.chat.components.artifact.LocalOpenArtifact
@@ -60,6 +61,7 @@ internal fun TextContentPart(
         val versionMap = remember(segments) { groupArtifactVersions(segments) }
         val inlinePrefs = LocalInlineArtifactPrefs.current
         val openArtifact = LocalOpenArtifact.current
+        val addToHomeScreen = LocalAddArtifactToHomeScreen.current
         // Per-Text-segment occurrence base offsets (artifact content contributes none — see the
         // SearchMatchEnumeration render-order contract). Computed once per (segments, query): the
         // per-segment countMarkdownOccurrences re-parses markdown, so keeping it off recomposition matters.
@@ -126,6 +128,7 @@ internal fun TextContentPart(
                                 artifact = segment.artifact,
                                 onClick = { openArtifact?.invoke(segment.artifact, versions) },
                                 versionCount = versions.size,
+                                onAddToHomeScreen = addToHomeScreen?.let { add -> { add(segment.artifact) } },
                             )
                         }
                         Spacer(modifier = Modifier.height(8.dp))

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/AddArtifactToHomeScreen.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/AddArtifactToHomeScreen.kt
@@ -1,0 +1,313 @@
+package com.garfiec.librechat.feature.chat.components.artifact
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.unit.dp
+import com.garfiec.librechat.core.model.artifactTypeGlyph
+import com.garfiec.librechat.feature.chat.resources.Res
+import com.garfiec.librechat.feature.chat.resources.add_to_home_screen_confirm
+import com.garfiec.librechat.feature.chat.resources.add_to_home_screen_dialog_emoji_label
+import com.garfiec.librechat.feature.chat.resources.add_to_home_screen_dialog_name_label
+import com.garfiec.librechat.feature.chat.resources.add_to_home_screen_dialog_title
+import com.garfiec.librechat.feature.chat.resources.add_to_home_screen_icon_auto
+import com.garfiec.librechat.feature.chat.resources.add_to_home_screen_icon_custom
+import com.garfiec.librechat.feature.chat.resources.add_to_home_screen_icon_label
+import com.garfiec.librechat.feature.chat.resources.cancel
+import com.garfiec.librechat.feature.chat.resources.cd_icon_preview
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * Screen-scoped launcher that opens the "Add to Home screen" flow for a tapped artifact. Provided once
+ * per navigation entry that owns the pin action (via [ProvideAddArtifactToHomeScreen]); call sites deep
+ * in the message list (the artifact card, the viewer toolbar) just invoke it. `null` when no provider
+ * is in scope — on iOS (no platform API) and in the shortcut viewer itself (a pinned artifact can't be
+ * re-pinned from its own screen), so those call sites hide the affordance.
+ */
+val LocalAddArtifactToHomeScreen =
+    staticCompositionLocalOf<((Artifact) -> Unit)?> { null }
+
+/** Launcher-icon background as 0xAARRGGBB — the single source for both the Compose preview here and the androidMain bitmap fill in `ArtifactShortcutHelper.renderIcon`. */
+internal const val ARTIFACT_ICON_BACKGROUND_ARGB = 0xFF6750A4L
+
+private val ArtifactIconBackground = Color(ARTIFACT_ICON_BACKGROUND_ARGB)
+
+/** Tap-to-pick glyphs for the icon, chosen to render across launcher emoji fonts. The type-default and a custom entry sit alongside. */
+private val CURATED_ICON_EMOJI = listOf(
+    "📝", "📄", "🌐", "📊", "📈", "⚛️", "🖼️", "💻",
+    "🎨", "🧠", "💡", "🚀", "⭐", "🔖", "🎯", "🧩",
+)
+
+/** The icon the user is composing: the type default, a tapped curated glyph, or a typed custom one. */
+private sealed interface IconChoice {
+    data object Auto : IconChoice
+    data class Curated(val emoji: String) : IconChoice
+    data class Custom(val emoji: String) : IconChoice
+}
+
+/**
+ * Wires [LocalAddArtifactToHomeScreen] to the platform pin action ([rememberAddArtifactToHomeScreen])
+ * and hosts the confirmation dialog at the screen root, so it survives the tapped list item scrolling
+ * off. On platforms without a pin action the local stays `null` (the default) and callers no-op.
+ */
+@Composable
+fun ProvideAddArtifactToHomeScreen(content: @Composable () -> Unit) {
+    val addAction = rememberAddArtifactToHomeScreen()
+    var pending by remember { mutableStateOf<Artifact?>(null) }
+    // Null on platforms without a pin action → the local keeps its null default and callers no-op.
+    // Remembered so its identity is stable: it feeds a staticCompositionLocalOf, so a fresh instance
+    // each recomposition (e.g. every pending toggle) would force-recompose the whole message list.
+    val opener: ((Artifact) -> Unit)? = remember(addAction) {
+        addAction?.let { { artifact: Artifact -> pending = artifact } }
+    }
+
+    CompositionLocalProvider(LocalAddArtifactToHomeScreen provides opener) {
+        content()
+    }
+
+    val action = addAction
+    val artifact = pending
+    if (action != null && artifact != null) {
+        AddArtifactToHomeScreenDialog(
+            initialName = artifact.title,
+            artifactType = artifact.type,
+            onConfirm = { name, emoji ->
+                action(artifact, name, emoji)
+                pending = null
+            },
+            onDismiss = { pending = null },
+        )
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun AddArtifactToHomeScreenDialog(
+    initialName: String,
+    artifactType: String,
+    onConfirm: (name: String, emoji: String?) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var name by remember { mutableStateOf(initialName) }
+    var choice by remember { mutableStateOf<IconChoice>(IconChoice.Auto) }
+
+    val defaultGlyph = artifactTypeGlyph(artifactType)
+    // The emoji that will actually be pinned: null falls back to the type glyph in renderIcon.
+    val chosenEmoji: String? = when (val c = choice) {
+        IconChoice.Auto -> null
+        is IconChoice.Curated -> c.emoji
+        is IconChoice.Custom -> c.emoji.trim().ifBlank { null }
+    }
+    val previewGlyph = chosenEmoji ?: defaultGlyph
+    // A half-entered custom emoji is not a valid pick — force a typed glyph or a switch back to Auto,
+    // rather than silently pinning the type default the user didn't ask for.
+    val customPending = (choice as? IconChoice.Custom)?.emoji?.isBlank() == true
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(Res.string.add_to_home_screen_dialog_title)) },
+        text = {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .imePadding()
+                    .verticalScroll(rememberScrollState()),
+            ) {
+                IconPreview(
+                    glyph = previewGlyph,
+                    modifier = Modifier.align(Alignment.CenterHorizontally),
+                )
+                Spacer(Modifier.height(16.dp))
+
+                OutlinedTextField(
+                    value = name,
+                    onValueChange = { name = it },
+                    singleLine = true,
+                    label = { Text(stringResource(Res.string.add_to_home_screen_dialog_name_label)) },
+                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Spacer(Modifier.height(16.dp))
+
+                Text(
+                    text = stringResource(Res.string.add_to_home_screen_icon_label),
+                    style = MaterialTheme.typography.labelLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(Modifier.height(8.dp))
+                FlowRow(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    IconChip(
+                        glyph = defaultGlyph,
+                        selected = choice is IconChoice.Auto,
+                        contentDescription = stringResource(Res.string.add_to_home_screen_icon_auto),
+                        onClick = { choice = IconChoice.Auto },
+                    )
+                    CURATED_ICON_EMOJI.forEach { emoji ->
+                        IconChip(
+                            glyph = emoji,
+                            selected = (choice as? IconChoice.Curated)?.emoji == emoji,
+                            onClick = { choice = IconChoice.Curated(emoji) },
+                        )
+                    }
+                    IconChip(
+                        glyph = (choice as? IconChoice.Custom)?.emoji?.ifBlank { null } ?: "+",
+                        selected = choice is IconChoice.Custom,
+                        contentDescription = stringResource(Res.string.add_to_home_screen_icon_custom),
+                        onClick = { choice = IconChoice.Custom((choice as? IconChoice.Custom)?.emoji.orEmpty()) },
+                    )
+                }
+
+                (choice as? IconChoice.Custom)?.let { custom ->
+                    Spacer(Modifier.height(12.dp))
+                    OutlinedTextField(
+                        // A single grapheme, so a short fixed width is enough.
+                        value = custom.emoji,
+                        onValueChange = { choice = IconChoice.Custom(firstGrapheme(it)) },
+                        singleLine = true,
+                        label = { Text(stringResource(Res.string.add_to_home_screen_dialog_emoji_label)) },
+                        modifier = Modifier.width(120.dp),
+                    )
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(
+                enabled = name.isNotBlank() && !customPending,
+                onClick = { onConfirm(name.trim(), chosenEmoji) },
+            ) { Text(stringResource(Res.string.add_to_home_screen_confirm)) }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text(stringResource(Res.string.cancel)) }
+        },
+    )
+}
+
+/** Circular preview of the launcher icon (solid fill + centered glyph), mirroring `renderIcon`. */
+@Composable
+private fun IconPreview(glyph: String, modifier: Modifier = Modifier) {
+    val description = stringResource(Res.string.cd_icon_preview)
+    Box(
+        modifier = modifier
+            .size(64.dp)
+            .background(ArtifactIconBackground, CircleShape)
+            .semantics { contentDescription = description },
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(text = glyph, style = MaterialTheme.typography.headlineMedium, color = Color.White)
+    }
+}
+
+/** A single tappable glyph in the icon grid, ringed when selected (mirrors the accent-color swatch style). */
+@Composable
+private fun IconChip(
+    glyph: String,
+    selected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    contentDescription: String? = null,
+) {
+    val semanticsModifier = if (contentDescription != null) {
+        Modifier.semantics { this.contentDescription = contentDescription }
+    } else {
+        Modifier
+    }
+    Box(
+        modifier = modifier
+            .size(44.dp)
+            .clip(CircleShape)
+            .background(MaterialTheme.colorScheme.surfaceVariant)
+            .border(
+                width = if (selected) 3.dp else 1.dp,
+                color = if (selected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.outline,
+                shape = CircleShape,
+            )
+            .clickable(onClick = onClick)
+            .then(semanticsModifier),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(text = glyph, style = MaterialTheme.typography.titleLarge)
+    }
+}
+
+/**
+ * Keeps only the first emoji grapheme cluster so the field holds a single glyph without corrupting the
+ * common multi-code-unit emoji a naive "first code point" cut would break: variation-selector emoji
+ * (❤️), skin-tone modifiers (👍🏽), flags and subdivision flags (🇺🇸), and ZWJ sequences (👨‍👩‍👧).
+ */
+private fun firstGrapheme(input: String): String {
+    if (input.isEmpty()) return input
+    val (first, firstEnd) = codePointAt(input, 0)
+    if (first < 0) return "" // lone/partial surrogate — would render as a replacement box
+    // A flag is a pair of regional-indicator symbols.
+    if (first in 0x1F1E6..0x1F1FF) {
+        if (firstEnd < input.length) {
+            val (next, nextEnd) = codePointAt(input, firstEnd)
+            if (next in 0x1F1E6..0x1F1FF) return input.substring(0, nextEnd)
+        }
+        return input.substring(0, firstEnd)
+    }
+    var end = firstEnd
+    while (end < input.length) {
+        val (cp, cpEnd) = codePointAt(input, end)
+        val extends = cp == 0x200D || // ZWJ
+            cp in 0xFE00..0xFE0F || // variation selectors
+            cp in 0x1F3FB..0x1F3FF || // skin-tone modifiers
+            cp == 0x20E3 || // enclosing keycap
+            cp in 0x0300..0x036F || // combining marks
+            cp in 0xE0020..0xE007F // tag chars (subdivision flags)
+        if (!extends) break
+        end = cpEnd
+        // A ZWJ joins the following emoji into the same cluster — pull it in too.
+        if (cp == 0x200D && end < input.length) end = codePointAt(input, end).second
+    }
+    return input.substring(0, end)
+}
+
+/** Reads the code point starting at [index], returning it with the index just past it; -1 for a lone surrogate. */
+private fun codePointAt(s: String, index: Int): Pair<Int, Int> {
+    val c = s[index]
+    if (c.isHighSurrogate() && index + 1 < s.length && s[index + 1].isLowSurrogate()) {
+        val cp = 0x10000 + ((c.code - 0xD800) shl 10) + (s[index + 1].code - 0xDC00)
+        return cp to index + 2
+    }
+    if (c.isHighSurrogate() || c.isLowSurrogate()) return -1 to index + 1
+    return c.code to index + 1
+}

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/ArtifactButton.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/ArtifactButton.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.AddToHomeScreen
 import androidx.compose.material.icons.automirrored.filled.Article
 import androidx.compose.material.icons.automirrored.filled.OpenInNew
 import androidx.compose.material.icons.filled.AccountTree
@@ -22,6 +23,7 @@ import androidx.compose.material.icons.filled.Widgets
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -31,6 +33,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.garfiec.librechat.core.model.artifactTypeLabel
 import com.garfiec.librechat.feature.chat.resources.*
 import com.garfiec.librechat.feature.chat.resources.Res
 import org.jetbrains.compose.resources.stringResource
@@ -41,6 +44,7 @@ fun ArtifactButton(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     versionCount: Int = 1,
+    onAddToHomeScreen: (() -> Unit)? = null,
 ) {
     Card(
         onClick = onClick,
@@ -72,7 +76,7 @@ fun ArtifactButton(
                     overflow = TextOverflow.Ellipsis,
                 )
                 Text(
-                    text = artifactTypeSubtitle(artifact.type),
+                    text = artifactTypeLabel(artifact.type),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.7f),
                     maxLines = 1,
@@ -96,6 +100,16 @@ fun ArtifactButton(
                     )
                 }
             }
+            if (onAddToHomeScreen != null) {
+                IconButton(onClick = onAddToHomeScreen, modifier = Modifier.size(32.dp)) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.AddToHomeScreen,
+                        contentDescription = stringResource(Res.string.cd_add_artifact_to_home_screen),
+                        modifier = Modifier.size(18.dp),
+                        tint = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.7f),
+                    )
+                }
+            }
             Spacer(modifier = Modifier.width(8.dp))
             Icon(
                 imageVector = Icons.AutoMirrored.Filled.OpenInNew,
@@ -115,15 +129,4 @@ private fun artifactTypeIcon(type: String): ImageVector =
         ArtifactType.SVG -> Icons.Default.Image
         ArtifactType.MARKDOWN -> Icons.AutoMirrored.Filled.Article
         ArtifactType.PLAIN, ArtifactType.CODE -> Icons.Default.Code
-    }
-
-private fun artifactTypeSubtitle(type: String): String =
-    when (ArtifactType.from(type)) {
-        ArtifactType.MERMAID -> "Mermaid Diagram"
-        ArtifactType.REACT -> "React Component"
-        ArtifactType.SVG -> "SVG Image"
-        ArtifactType.MARKDOWN -> "Markdown Document"
-        ArtifactType.HTML -> "HTML Page"
-        ArtifactType.PLAIN -> "Plain Text"
-        ArtifactType.CODE -> "Code"
     }

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/PlatformArtifactPanel.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/PlatformArtifactPanel.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.AddToHomeScreen
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Code
 import androidx.compose.material.icons.filled.Fullscreen
@@ -46,6 +47,7 @@ import com.garfiec.librechat.feature.chat.components.CodeBlock
 import com.garfiec.librechat.feature.chat.resources.Res
 import com.garfiec.librechat.feature.chat.resources.artifact_view_preview
 import com.garfiec.librechat.feature.chat.resources.artifact_view_source
+import com.garfiec.librechat.feature.chat.resources.cd_add_artifact_to_home_screen
 import com.garfiec.librechat.feature.chat.resources.cd_close
 import com.garfiec.librechat.feature.chat.resources.cd_fullscreen
 import com.garfiec.librechat.feature.chat.resources.cd_share_artifact
@@ -70,6 +72,15 @@ expect fun ArtifactPreviewSurface(
  */
 @Composable
 expect fun rememberShareArtifact(): (Artifact) -> Unit
+
+/**
+ * Returns an action that pins [Artifact] to the device home screen as a launcher shortcut, or `null`
+ * on platforms that can't place home-screen icons (iOS). The action snapshots the artifact into local
+ * storage and requests the pin; [label]/[emoji] come from the confirmation dialog. Distributed to call
+ * sites (viewer toolbar, inline card) via [LocalAddArtifactToHomeScreen] — invoked once here.
+ */
+@Composable
+expect fun rememberAddArtifactToHomeScreen(): ((artifact: Artifact, label: String, emoji: String?) -> Unit)?
 
 private enum class ArtifactTab { CODE, PREVIEW }
 
@@ -154,6 +165,9 @@ internal fun ArtifactViewer(
 
     val isDarkTheme = isSurfaceDark()
     val shareArtifact = rememberShareArtifact()
+    // Null unless a home-screen-pin provider is in scope (Android chat/media entries). The shortcut
+    // viewer itself doesn't provide it, so a pinned artifact can't be re-pinned from its own screen.
+    val addToHomeScreen = LocalAddArtifactToHomeScreen.current
 
     ArtifactViewerBody(
         artifact = currentArtifact,
@@ -170,6 +184,7 @@ internal fun ArtifactViewer(
         onExpand = { onExpand?.invoke(currentArtifact) },
         onClose = onClose,
         onShare = { shareArtifact(currentArtifact) },
+        onAddToHomeScreen = addToHomeScreen?.let { add -> { add(currentArtifact) } },
         modifier = modifier,
     )
 }
@@ -190,6 +205,7 @@ private fun ArtifactViewerBody(
     onExpand: () -> Unit,
     onClose: () -> Unit,
     onShare: () -> Unit,
+    onAddToHomeScreen: (() -> Unit)?,
     modifier: Modifier = Modifier,
 ) {
     Column(modifier = modifier.fillMaxWidth()) {
@@ -232,6 +248,7 @@ private fun ArtifactViewerBody(
                 canExpand = canExpand,
                 onExpand = onExpand,
                 onShare = onShare,
+                onAddToHomeScreen = onAddToHomeScreen,
             )
         }
 
@@ -277,6 +294,7 @@ private fun RowScope.ArtifactActionButtons(
     canExpand: Boolean,
     onExpand: () -> Unit,
     onShare: () -> Unit,
+    onAddToHomeScreen: (() -> Unit)?,
 ) {
     val tint = MaterialTheme.colorScheme.onSurfaceVariant
     // Source/preview toggle for previewable artifacts.
@@ -288,6 +306,15 @@ private fun RowScope.ArtifactActionButtons(
                 contentDescription = stringResource(
                     if (toCode) Res.string.artifact_view_source else Res.string.artifact_view_preview,
                 ),
+                tint = tint,
+            )
+        }
+    }
+    if (onAddToHomeScreen != null) {
+        IconButton(onClick = onAddToHomeScreen) {
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.AddToHomeScreen,
+                contentDescription = stringResource(Res.string.cd_add_artifact_to_home_screen),
                 tint = tint,
             )
         }

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/navigation/ChatNavigation.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/navigation/ChatNavigation.kt
@@ -16,9 +16,11 @@ import com.garfiec.librechat.feature.chat.components.artifact.Artifact
 import com.garfiec.librechat.feature.chat.components.artifact.ArtifactPanel
 import com.garfiec.librechat.feature.chat.components.artifact.ArtifactViewerHandoff
 import com.garfiec.librechat.feature.chat.components.artifact.LocalOpenArtifact
+import com.garfiec.librechat.feature.chat.components.artifact.ProvideAddArtifactToHomeScreen
 import com.garfiec.librechat.feature.chat.prompts.PromptEditorScreen
 import com.garfiec.librechat.feature.chat.prompts.PromptsLibraryScreen
 import com.garfiec.librechat.feature.chat.screen.ArtifactFullscreenScreen
+import com.garfiec.librechat.feature.chat.screen.ArtifactShortcutViewerScreen
 import com.garfiec.librechat.feature.chat.screen.ChatScreen
 import com.garfiec.librechat.feature.chat.screen.ConversationMediaScreen
 import com.garfiec.librechat.feature.chat.screen.NewChatScreen
@@ -55,6 +57,13 @@ import org.koin.compose.koinInject
  * (potentially large) content is handed off in-memory via [ArtifactViewerHandoff].
  */
 @Serializable data class ArtifactFullscreen(val identifier: String, val version: Int) : ChatRoute
+
+/**
+ * Viewer for a home-screen-pinned artifact, opened by tapping its launcher icon
+ * (`librechat://artifact/{snapshotId}`). Unlike [ArtifactFullscreen] it loads a self-contained Room
+ * snapshot by [snapshotId], so it survives cold start / process death and works while logged out.
+ */
+@Serializable data class ArtifactShortcutViewer(val snapshotId: String) : ChatRoute
 
 fun EntryProviderScope<NavKey>.chatEntries(
     onNavigate: (NavKey) -> Unit,
@@ -111,9 +120,19 @@ fun EntryProviderScope<NavKey>.chatEntries(
         }
     }
     entry<ArtifactFullscreen> { key ->
-        ArtifactFullscreenScreen(
-            identifier = key.identifier,
-            version = key.version,
+        // Provider present so the fullscreen viewer's toolbar can pin the artifact too.
+        ProvideAddArtifactToHomeScreen {
+            ArtifactFullscreenScreen(
+                identifier = key.identifier,
+                version = key.version,
+                onBack = onBack,
+            )
+        }
+    }
+    entry<ArtifactShortcutViewer> { key ->
+        // No pin provider here: a launcher-opened artifact can't be re-pinned from its own screen.
+        ArtifactShortcutViewerScreen(
+            snapshotId = key.snapshotId,
             onBack = onBack,
         )
     }
@@ -171,17 +190,21 @@ private fun ProvideOpenArtifact(
         }
     }
 
-    CompositionLocalProvider(LocalOpenArtifact provides openArtifact) {
-        content()
-    }
+    // Wrap both the content and the screen-root sheet so the pin action reaches inline cards and the
+    // bottom-sheet viewer alike (no-op on platforms without a pin action).
+    ProvideAddArtifactToHomeScreen {
+        CompositionLocalProvider(LocalOpenArtifact provides openArtifact) {
+            content()
+        }
 
-    sheetRequest?.let { req ->
-        ArtifactPanel(
-            artifact = req.artifact,
-            versions = req.versions,
-            onDismiss = { sheetRequest = null },
-            onExpandFullscreen = openFullscreen,
-        )
+        sheetRequest?.let { req ->
+            ArtifactPanel(
+                artifact = req.artifact,
+                versions = req.versions,
+                onDismiss = { sheetRequest = null },
+                onExpandFullscreen = openFullscreen,
+            )
+        }
     }
 }
 
@@ -193,5 +216,6 @@ val chatSerializersModule = SerializersModule {
         subclass(PromptEditor::class, PromptEditor.serializer())
         subclass(ConversationMedia::class, ConversationMedia.serializer())
         subclass(ArtifactFullscreen::class, ArtifactFullscreen.serializer())
+        subclass(ArtifactShortcutViewer::class, ArtifactShortcutViewer.serializer())
     }
 }

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/screen/ArtifactShortcutViewerScreen.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/screen/ArtifactShortcutViewerScreen.kt
@@ -1,0 +1,105 @@
+package com.garfiec.librechat.feature.chat.screen
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.garfiec.librechat.core.data.repository.ArtifactShortcutRepository
+import com.garfiec.librechat.core.model.ArtifactShortcut
+import com.garfiec.librechat.core.ui.components.EmptyState
+import com.garfiec.librechat.core.ui.components.LoadingIndicator
+import com.garfiec.librechat.feature.chat.components.artifact.Artifact
+import com.garfiec.librechat.feature.chat.components.artifact.ArtifactViewer
+import com.garfiec.librechat.feature.chat.resources.Res
+import com.garfiec.librechat.feature.chat.resources.artifact_shortcut_back
+import com.garfiec.librechat.feature.chat.resources.artifact_shortcut_unavailable
+import org.jetbrains.compose.resources.stringResource
+import org.koin.compose.koinInject
+
+private sealed interface ShortcutLoad {
+    data object Loading : ShortcutLoad
+
+    // versions is the single-element list ArtifactViewer wants, built once here rather than per frame.
+    data class Loaded(val artifact: Artifact, val versions: List<Artifact>) : ShortcutLoad
+    data object NotFound : ShortcutLoad
+}
+
+/**
+ * Full-screen viewer for a home-screen-pinned artifact. Loads the self-contained Room snapshot by
+ * [snapshotId] (so it works on cold start / logged out) and renders it through the shared
+ * [ArtifactViewer]. A missing snapshot (the user deleted it from the management screen while a launcher
+ * icon lingered) shows an "unavailable" message rather than a blank screen.
+ */
+@Composable
+fun ArtifactShortcutViewerScreen(
+    snapshotId: String,
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val repository = koinInject<ArtifactShortcutRepository>()
+    var state by remember(snapshotId) { mutableStateOf<ShortcutLoad>(ShortcutLoad.Loading) }
+
+    LaunchedEffect(snapshotId) {
+        val snapshot = repository.get(snapshotId)
+        state = if (snapshot == null) {
+            ShortcutLoad.NotFound
+        } else {
+            val artifact = snapshot.toArtifact()
+            ShortcutLoad.Loaded(artifact, listOf(artifact))
+        }
+    }
+
+    Surface(
+        modifier = modifier.fillMaxSize(),
+        color = MaterialTheme.colorScheme.surface,
+    ) {
+        when (val current = state) {
+            ShortcutLoad.Loading -> LoadingIndicator(modifier = Modifier.fillMaxSize())
+
+            is ShortcutLoad.Loaded -> ArtifactViewer(
+                artifact = current.artifact,
+                versions = current.versions,
+                isFullscreen = true,
+                onClose = onBack,
+                onExpand = null,
+                modifier = Modifier.fillMaxSize().statusBarsPadding().navigationBarsPadding(),
+            )
+
+            ShortcutLoad.NotFound -> Column(
+                modifier = Modifier.fillMaxSize().padding(24.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                EmptyState(
+                    title = stringResource(Res.string.artifact_shortcut_unavailable),
+                    modifier = Modifier.weight(1f),
+                )
+                TextButton(onClick = onBack) {
+                    Text(stringResource(Res.string.artifact_shortcut_back))
+                }
+            }
+        }
+    }
+}
+
+private fun ArtifactShortcut.toArtifact() = Artifact(
+    identifier = identifier,
+    type = type,
+    title = title,
+    language = language,
+    content = content,
+    version = version,
+)

--- a/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/PlatformArtifactPanel.ios.kt
+++ b/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/PlatformArtifactPanel.ios.kt
@@ -75,3 +75,7 @@ actual fun rememberShareArtifact(): (Artifact) -> Unit = remember {
         )
     }
 }
+
+// iOS has no API to place a home-screen launcher icon, so the affordance is unavailable.
+@Composable
+actual fun rememberAddArtifactToHomeScreen(): ((artifact: Artifact, label: String, emoji: String?) -> Unit)? = null

--- a/feature/settings/build.gradle.kts
+++ b/feature/settings/build.gradle.kts
@@ -17,6 +17,7 @@ kotlin {
         }
         androidMain.dependencies {
             implementation(libs.koin.android)
+            implementation(libs.androidx.core.ktx)
         }
         getByName("androidUnitTest").dependencies {
             implementation(libs.koin.test)

--- a/feature/settings/src/androidMain/kotlin/com/garfiec/librechat/feature/settings/screen/HomeScreenShortcut.android.kt
+++ b/feature/settings/src/androidMain/kotlin/com/garfiec/librechat/feature/settings/screen/HomeScreenShortcut.android.kt
@@ -1,0 +1,16 @@
+package com.garfiec.librechat.feature.settings.screen
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
+import androidx.core.content.pm.ShortcutManagerCompat
+
+@Composable
+actual fun rememberDisableHomeScreenShortcut(): (id: String, message: String) -> Unit {
+    val context = LocalContext.current
+    return remember(context) {
+        { id, message ->
+            ShortcutManagerCompat.disableShortcuts(context, listOf(id), message)
+        }
+    }
+}

--- a/feature/settings/src/commonMain/composeResources/values/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values/strings.xml
@@ -518,4 +518,10 @@
     <string name="role_skills_share">Share skills</string>
     <string name="role_skills_share_public">Share skills publicly</string>
     <string name="role_skills_save">Save</string>
+
+    <!-- Home-screen artifact shortcuts -->
+    <string name="artifact_shortcuts_title">Home-screen shortcuts</string>
+    <string name="artifact_shortcuts_empty">No artifacts pinned to the home screen yet.</string>
+    <string name="artifact_shortcuts_disabled_message">This artifact shortcut was removed.</string>
+    <string name="cd_artifact_shortcut_delete">Delete shortcut</string>
 </resources>

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/navigation/ArtifactShortcutsNavigation.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/navigation/ArtifactShortcutsNavigation.kt
@@ -1,0 +1,18 @@
+package com.garfiec.librechat.feature.settings.navigation
+
+import androidx.navigation3.runtime.EntryProviderScope
+import androidx.navigation3.runtime.NavKey
+import com.garfiec.librechat.feature.settings.screen.ArtifactShortcutsScreen
+import kotlinx.serialization.Serializable
+
+@Serializable data object ArtifactShortcuts : SettingsRoute
+
+fun EntryProviderScope<NavKey>.artifactShortcutsEntry(
+    onBack: () -> Unit,
+) {
+    entry<ArtifactShortcuts> {
+        ArtifactShortcutsScreen(
+            onNavigateBack = onBack,
+        )
+    }
+}

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/navigation/SettingsNavigation.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/navigation/SettingsNavigation.kt
@@ -65,6 +65,7 @@ fun EntryProviderScope<NavKey>.settingsEntries(
             onLogout = onLogout,
             onNavigateToArchive = onNavigateToArchive,
             onNavigateToSharedLinks = { onNavigate(SharedLinks) },
+            onNavigateToArtifactShortcuts = { onNavigate(ArtifactShortcuts) },
             onNavigateToPresets = { onNavigate(PresetManager) },
             onNavigateToApiKeys = { onNavigate(ApiKeys) },
             onNavigateToFavorites = { onNavigate(Favorites) },
@@ -98,6 +99,7 @@ fun EntryProviderScope<NavKey>.settingsEntries(
             onNavigateBack = onBack,
             onNavigateToArchive = onNavigateToArchive,
             onNavigateToSharedLinks = { onNavigate(SharedLinks) },
+            onNavigateToArtifactShortcuts = { onNavigate(ArtifactShortcuts) },
         )
     }
     entry<SharedLinks> {
@@ -137,6 +139,7 @@ fun EntryProviderScope<NavKey>.settingsEntries(
     }
     favoritesEntry(onBack = onBack)
     roleSkillsAdminEntry(onBack = onBack)
+    artifactShortcutsEntry(onBack = onBack)
 }
 
 val settingsSerializersModule = SerializersModule {
@@ -154,5 +157,6 @@ val settingsSerializersModule = SerializersModule {
         subclass(McpServers::class, McpServers.serializer())
         subclass(Favorites::class, Favorites.serializer())
         subclass(RoleSkillsAdmin::class, RoleSkillsAdmin.serializer())
+        subclass(ArtifactShortcuts::class, ArtifactShortcuts.serializer())
     }
 }

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/ArtifactShortcutsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/ArtifactShortcutsScreen.kt
@@ -1,0 +1,153 @@
+package com.garfiec.librechat.feature.settings.screen
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.garfiec.librechat.core.data.repository.ArtifactShortcutRepository
+import com.garfiec.librechat.core.model.ArtifactShortcut
+import com.garfiec.librechat.core.model.artifactTypeLabel
+import com.garfiec.librechat.core.model.displayGlyph
+import com.garfiec.librechat.core.model.displayLabel
+import com.garfiec.librechat.core.ui.components.EmptyState
+import com.garfiec.librechat.feature.settings.resources.Res
+import com.garfiec.librechat.feature.settings.resources.artifact_shortcuts_disabled_message
+import com.garfiec.librechat.feature.settings.resources.artifact_shortcuts_empty
+import com.garfiec.librechat.feature.settings.resources.artifact_shortcuts_title
+import com.garfiec.librechat.feature.settings.resources.cd_artifact_shortcut_delete
+import com.garfiec.librechat.feature.settings.resources.cd_back
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.jetbrains.compose.resources.stringResource
+import org.koin.compose.koinInject
+
+/**
+ * Lists the artifacts the user pinned to the home screen and lets them remove one. Delete removes the
+ * local snapshot and disables the launcher shortcut; since Android can't remove an already-placed icon,
+ * a lingering icon becomes inert (tapping it shows the disabled message). The list reflects the app's
+ * snapshots, not the launcher's exact set.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ArtifactShortcutsScreen(
+    onNavigateBack: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val repository = koinInject<ArtifactShortcutRepository>()
+    val shortcuts by repository.observeAll().collectAsStateWithLifecycle(emptyList())
+    val disableShortcut = rememberDisableHomeScreenShortcut()
+    val disabledMessage = stringResource(Res.string.artifact_shortcuts_disabled_message)
+    val scope = rememberCoroutineScope()
+
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(Res.string.artifact_shortcuts_title)) },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(Res.string.cd_back),
+                        )
+                    }
+                },
+            )
+        },
+    ) { innerPadding ->
+        if (shortcuts.isEmpty()) {
+            EmptyState(
+                title = stringResource(Res.string.artifact_shortcuts_empty),
+                modifier = Modifier.fillMaxSize().padding(innerPadding).padding(24.dp),
+            )
+        } else {
+            LazyColumn(modifier = Modifier.fillMaxSize().padding(innerPadding)) {
+                items(shortcuts, key = { it.id }) { shortcut ->
+                    ArtifactShortcutRow(
+                        shortcut = shortcut,
+                        onDelete = {
+                            // Disable the launcher icon first (best-effort), then drop the snapshot —
+                            // both off the main thread (disableShortcut is a launcher binder IPC).
+                            scope.launch {
+                                withContext(Dispatchers.Default) { disableShortcut(shortcut.id, disabledMessage) }
+                                repository.delete(shortcut.id)
+                            }
+                        },
+                    )
+                    HorizontalDivider()
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ArtifactShortcutRow(
+    shortcut: ArtifactShortcut,
+    onDelete: () -> Unit,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Box(
+            modifier = Modifier.size(40.dp),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                text = shortcut.displayGlyph,
+                fontSize = 22.sp,
+            )
+        }
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = shortcut.displayLabel,
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Text(
+                text = artifactTypeLabel(shortcut.type),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+            )
+        }
+        IconButton(onClick = onDelete) {
+            Icon(
+                imageVector = Icons.Default.Delete,
+                contentDescription = stringResource(Res.string.cd_artifact_shortcut_delete),
+                tint = MaterialTheme.colorScheme.error,
+            )
+        }
+    }
+}

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/DataSettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/DataSettingsScreen.kt
@@ -52,6 +52,7 @@ fun DataSettingsScreen(
     onNavigateBack: () -> Unit,
     onNavigateToArchive: () -> Unit,
     onNavigateToSharedLinks: () -> Unit,
+    onNavigateToArtifactShortcuts: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val snackbarHostState = remember { SnackbarHostState() }
@@ -76,6 +77,7 @@ fun DataSettingsScreen(
         DataSettingsContent(
             onNavigateToArchive = onNavigateToArchive,
             onNavigateToSharedLinks = onNavigateToSharedLinks,
+            onNavigateToArtifactShortcuts = onNavigateToArtifactShortcuts,
             snackbarHostState = snackbarHostState,
             modifier = Modifier
                 .fillMaxSize()
@@ -92,6 +94,7 @@ fun DataSettingsScreen(
 fun DataSettingsContent(
     onNavigateToArchive: () -> Unit,
     onNavigateToSharedLinks: () -> Unit,
+    onNavigateToArtifactShortcuts: () -> Unit,
     modifier: Modifier = Modifier,
     snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
     viewModel: SettingsViewModel = koinViewModel(),
@@ -181,6 +184,7 @@ fun DataSettingsContent(
             item(key = "data_extra_actions") {
                 DataExtraActions(
                     onSharedLinksClick = onNavigateToSharedLinks,
+                    onArtifactShortcutsClick = onNavigateToArtifactShortcuts,
                     onClearCacheClick = { showClearCacheDialog = true },
                     isCacheClearing = uiState.isCacheClearing,
                     onRevokeKeysClick = { showRevokeKeysDialog = true },
@@ -314,6 +318,7 @@ private fun SectionHeader(title: String) {
 @Composable
 private fun DataExtraActions(
     onSharedLinksClick: () -> Unit,
+    onArtifactShortcutsClick: () -> Unit,
     onClearCacheClick: () -> Unit,
     isCacheClearing: Boolean,
     onRevokeKeysClick: () -> Unit,
@@ -337,6 +342,25 @@ private fun DataExtraActions(
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     Text(stringResource(Res.string.shared_links))
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                        contentDescription = null,
+                        modifier = Modifier.size(18.dp),
+                    )
+                }
+            }
+
+            // Home-screen artifact shortcuts
+            OutlinedButton(
+                onClick = onArtifactShortcutsClick,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(stringResource(Res.string.artifact_shortcuts_title))
                     Icon(
                         imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
                         contentDescription = null,

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/HomeScreenShortcut.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/HomeScreenShortcut.kt
@@ -1,0 +1,11 @@
+package com.garfiec.librechat.feature.settings.screen
+
+import androidx.compose.runtime.Composable
+
+/**
+ * Returns an action that disables a pinned home-screen shortcut by id. Android has no API to remove an
+ * already-placed launcher icon, so disabling is the most we can do: a lingering icon becomes inert and
+ * tapping it shows [message]. No-op on platforms without pinned shortcuts (iOS).
+ */
+@Composable
+expect fun rememberDisableHomeScreenShortcut(): (id: String, message: String) -> Unit

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/TabbedSettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/TabbedSettingsScreen.kt
@@ -41,6 +41,7 @@ fun TabbedSettingsScreen(
     onLogout: () -> Unit,
     onNavigateToArchive: () -> Unit,
     onNavigateToSharedLinks: () -> Unit,
+    onNavigateToArtifactShortcuts: () -> Unit,
     onNavigateToPresets: () -> Unit,
     onNavigateToApiKeys: () -> Unit,
     onNavigateToFavorites: () -> Unit,
@@ -120,6 +121,7 @@ fun TabbedSettingsScreen(
                 3 -> DataSettingsContent(
                     onNavigateToArchive = onNavigateToArchive,
                     onNavigateToSharedLinks = onNavigateToSharedLinks,
+                    onNavigateToArtifactShortcuts = onNavigateToArtifactShortcuts,
                     snackbarHostState = snackbarHostState,
                     modifier = Modifier.fillMaxSize(),
                 )

--- a/feature/settings/src/iosMain/kotlin/com/garfiec/librechat/feature/settings/screen/HomeScreenShortcut.ios.kt
+++ b/feature/settings/src/iosMain/kotlin/com/garfiec/librechat/feature/settings/screen/HomeScreenShortcut.ios.kt
@@ -1,0 +1,7 @@
+package com.garfiec.librechat.feature.settings.screen
+
+import androidx.compose.runtime.Composable
+
+// iOS has no pinned home-screen shortcuts, so there is nothing to disable.
+@Composable
+actual fun rememberDisableHomeScreenShortcut(): (id: String, message: String) -> Unit = { _, _ -> }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ compose-bom = "2026.06.00"
 compose-multiplatform = "1.11.0-beta03"
 material3 = "1.3.1"
 activity-compose = "1.13.0"
+androidx-core = "1.18.0"
 lifecycle = "2.10.0"
 lifecycle-kmp = "2.10.0"
 navigation3-kmp = "1.1.1"
@@ -97,6 +98,8 @@ compose-foundation = { group = "androidx.compose.foundation", name = "foundation
 
 # Activity / Navigation
 activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activity-compose" }
+# AndroidX core (ShortcutManagerCompat / IconCompat for home-screen artifact shortcuts)
+androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "androidx-core" }
 # Lifecycle
 lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "lifecycle" }
 lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycle" }

--- a/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/DeepLinks.kt
+++ b/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/DeepLinks.kt
@@ -1,0 +1,84 @@
+package com.garfiec.librechat.shared.navigation
+
+import androidx.navigation3.runtime.NavKey
+import com.garfiec.librechat.feature.chat.navigation.ArtifactShortcutViewer
+import com.garfiec.librechat.feature.chat.navigation.Chat
+
+/**
+ * Platform-neutral view of an incoming `librechat://` URI, so [DeepLinks.resolve] — the routing
+ * decision — lives in common and can be reused per platform. Android builds this from
+ * `android.net.Uri` (see `DeepLinkUriAdapter`); an iOS intake (from `NSURLComponents`) would build
+ * the same shape and reuse [DeepLinks.resolve] — not yet wired. Only field extraction is per-platform.
+ */
+data class DeepLinkUri(
+    val host: String?,
+    val pathSegments: List<String>,
+    val query: Map<String, String>,
+)
+
+/**
+ * The outcome of resolving a deep link. A sealed result (not a bare `NavKey?`) so the three
+ * genuinely different link kinds are each expressible: navigate, accept-but-don't-navigate, ignore.
+ */
+sealed interface DeepLinkResolution {
+    /**
+     * Navigate to [target]. [requiresAuth] links redirect to login when logged out (a conversation
+     * or a model-preselect chat is useless without a session); non-auth links open even logged out
+     * (a device-scoped artifact snapshot renders from local Room).
+     */
+    data class Route(val target: NavKey, val requiresAuth: Boolean) : DeepLinkResolution
+
+    /**
+     * Accepted — the app should come to the foreground — but there is nothing to place on the back
+     * stack: the payload is consumed by an in-progress flow. The OAuth redirect is the case; its
+     * refresh token rides back in a cookie read by the login screen (`checkOAuthResult`), so the
+     * link only needs to return focus to the app.
+     */
+    data object Consumed : DeepLinkResolution
+
+    /** Not a link this app routes: wrong host, or a malformed / failed-validation id. */
+    data object None : DeepLinkResolution
+}
+
+/**
+ * Single source of truth for `librechat://` deep-link routing. Every host is declared here exactly
+ * once; both platform intake (the accept / bring-to-front decision) and the nav host (back-stack
+ * placement) call [resolve], so there is no second allowlist to drift out of sync.
+ *
+ * To add a deep-linked feature, add one [resolve] branch. Path ids validate through a [Regex];
+ * query-param links read [DeepLinkUri.query]. Treat all extracted values as untrusted input — match
+ * them against a strict pattern (ids) or pass them as opaque strings (never interpret as commands).
+ */
+object DeepLinks {
+    const val SCHEME = "librechat"
+
+    /**
+     * Both a LibreChat conversationId and an artifact-shortcut snapshot id are UUIDs — the server
+     * generates conversationId via uuidv4() (validated server-side with isUUID), and the snapshot id
+     * is Uuid.random(). Validate strictly so a malformed segment resolves to [DeepLinkResolution.None]
+     * rather than routing to a dead screen. (Not a Mongo ObjectID — that would reject every real id.)
+     */
+    private val UUID_PATTERN = Regex(
+        "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+    )
+
+    fun resolve(uri: DeepLinkUri): DeepLinkResolution = when (uri.host) {
+        "conversation" -> uri.pathSegments.firstOrNull()
+            ?.takeIf { UUID_PATTERN.matches(it) }
+            ?.let { DeepLinkResolution.Route(Chat(it), requiresAuth = true) }
+            ?: DeepLinkResolution.None
+
+        "artifact" -> uri.pathSegments.firstOrNull()
+            ?.takeIf { UUID_PATTERN.matches(it) }
+            ?.let { DeepLinkResolution.Route(ArtifactShortcutViewer(it), requiresAuth = false) }
+            ?: DeepLinkResolution.None
+
+        // OAuth redirect (librechat://oauth): token comes back via cookie, not the URI — see [Consumed].
+        // A model-shortcut host would slot in here as a query-param Route, e.g.:
+        //   "model" -> uri.query["model"]?.let {
+        //       Route(NewChat(endpoint = uri.query["endpoint"], model = it), requiresAuth = true) } ?: None
+        "oauth" -> DeepLinkResolution.Consumed
+
+        else -> DeepLinkResolution.None
+    }
+}

--- a/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/LibreChatNavHost.kt
+++ b/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/LibreChatNavHost.kt
@@ -96,6 +96,7 @@ private const val HYGIENE_UNRECORDED = "__unrecorded__"
 fun LibreChatNavHost(
     modifier: Modifier = Modifier,
     appLocaleTag: String? = null,
+    hasPendingDeepLink: Boolean = false,
     navHostViewModel: NavHostViewModel = koinViewModel(),
     content: (@Composable (Navigator, NavHostViewModel, Modifier) -> Unit)? = null,
 ) {
@@ -105,10 +106,19 @@ fun LibreChatNavHost(
     val backStack = rememberNavBackStack(navigationSavedStateConfig, NewChat())
     val navigator = Navigator(backStack)
 
-    // Redirect to auth if not logged in (on first composition only).
+    // Redirect to auth if not logged in — once per saved-state lifecycle, NOT on every recreation.
+    // LaunchedEffect(Unit) restarts on each Activity recreation (config change / process-death restore,
+    // see the hygiene note below), but by then the back stack is already restored — possibly to a
+    // logged-out-viewable deep-link target (an artifact viewer atop the auth base). Re-firing would
+    // clear() that away, so a rememberSaveable latch makes this run only on a genuinely fresh start.
+    // Also skipped while a deep link is pending: the deep-link handler owns the initial stack then.
+    var initialAuthRedirectDone by rememberSaveable { mutableStateOf(false) }
     LaunchedEffect(Unit) {
-        if (!navHostViewModel.isLoggedIn.value) {
-            navigator.navigateToAuth()
+        if (!initialAuthRedirectDone) {
+            initialAuthRedirectDone = true
+            if (!navHostViewModel.isLoggedIn.value && !hasPendingDeepLink) {
+                navigator.navigateToAuth()
+            }
         }
     }
 
@@ -256,6 +266,7 @@ fun PhoneLayout(
 ) {
     val drawerState = rememberDrawerState(DrawerValue.Closed)
     val scope = rememberCoroutineScope()
+    val isLoggedIn by navHostViewModel.isLoggedIn.collectAsStateWithLifecycle()
     val banners by navHostViewModel.banners.collectAsStateWithLifecycle()
     val dismissedBannerIds by navHostViewModel.dismissedBannerIds.collectAsStateWithLifecycle()
 
@@ -268,7 +279,11 @@ fun PhoneLayout(
 
     ModalNavigationDrawer(
         drawerState = drawerState,
-        gesturesEnabled = !navigator.isInAuthFlow,
+        // The drawer is an authenticated surface (conversations, account, settings). Require a session,
+        // not just "not in the auth flow" — a logged-out deep link (e.g. an artifact viewer atop the
+        // auth base) leaves a non-auth route on top, and without this its edge-swipe would open the
+        // drawer over a session-less state.
+        gesturesEnabled = isLoggedIn && !navigator.isInAuthFlow,
         drawerContent = {
             ModalDrawerSheet(drawerState = drawerState) {
                 SidebarScaffold(

--- a/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/Navigator.kt
+++ b/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/Navigator.kt
@@ -73,6 +73,18 @@ class Navigator(val backStack: NavBackStack<NavKey>) {
         backStack.add(ServerUrl)
     }
 
+    /**
+     * Cold-start deep link handled while logged out: show [route] atop an auth base, so the target
+     * (e.g. a device-scoped artifact shortcut, viewable logged out) is reached deterministically and
+     * backing out of it lands on login rather than a half-initialized logged-out screen. The shared
+     * host's initial auth redirect is skipped when a deep link is pending, so this owns that setup.
+     */
+    fun navigateToDeepLinkLoggedOut(route: NavKey) {
+        backStack.clear()
+        backStack.add(ServerUrl)
+        backStack.add(route)
+    }
+
     /** Clear back stack and navigate to chat (auth complete). */
     fun navigateToChat() {
         backStack.clear()

--- a/shared/src/commonTest/kotlin/com/garfiec/librechat/shared/navigation/DeepLinksTest.kt
+++ b/shared/src/commonTest/kotlin/com/garfiec/librechat/shared/navigation/DeepLinksTest.kt
@@ -1,0 +1,65 @@
+package com.garfiec.librechat.shared.navigation
+
+import com.garfiec.librechat.feature.chat.navigation.ArtifactShortcutViewer
+import com.garfiec.librechat.feature.chat.navigation.Chat
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+class DeepLinksTest {
+
+    private fun uri(host: String, path: String? = null, query: Map<String, String> = emptyMap()) =
+        DeepLinkUri(host = host, pathSegments = listOfNotNull(path), query = query)
+
+    @Test
+    fun conversationValidUuid_routesToChatRequiringAuth() {
+        // conversationId is a server-generated uuidv4, not a Mongo ObjectID.
+        val id = "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d"
+        val resolution = DeepLinks.resolve(uri("conversation", id))
+        val route = assertIs<DeepLinkResolution.Route>(resolution)
+        assertTrue(route.requiresAuth)
+        assertEquals(id, assertIs<Chat>(route.target).conversationId)
+    }
+
+    @Test
+    fun conversationMalformedId_isNotRouted() {
+        assertEquals(DeepLinkResolution.None, DeepLinks.resolve(uri("conversation", "not-a-uuid")))
+        // A 24-hex Mongo ObjectID is NOT a conversationId — must be rejected (regression lock).
+        assertEquals(DeepLinkResolution.None, DeepLinks.resolve(uri("conversation", "0123456789abcdef01234567")))
+        assertEquals(DeepLinkResolution.None, DeepLinks.resolve(uri("conversation")))
+    }
+
+    @Test
+    fun artifactValidUuid_routesToViewerOpenLoggedOut() {
+        val id = "3f2504e0-4f89-41d3-9a0c-0305e82c3301"
+        val resolution = DeepLinks.resolve(uri("artifact", id))
+        val route = assertIs<DeepLinkResolution.Route>(resolution)
+        assertTrue(!route.requiresAuth) // device-scoped snapshot renders without a session
+        assertEquals(id, assertIs<ArtifactShortcutViewer>(route.target).snapshotId)
+    }
+
+    @Test
+    fun artifactMalformedId_isNotRouted() {
+        assertEquals(DeepLinkResolution.None, DeepLinks.resolve(uri("artifact", "12345")))
+    }
+
+    @Test
+    fun oauth_isConsumedNotNavigated() {
+        assertEquals(DeepLinkResolution.Consumed, DeepLinks.resolve(uri("oauth", query = mapOf("code" to "x"))))
+    }
+
+    @Test
+    fun unknownHost_isNotRouted() {
+        assertEquals(DeepLinkResolution.None, DeepLinks.resolve(uri("wat", "whatever")))
+    }
+
+    @Test
+    fun nullHost_isNotRouted() {
+        // The shape an opaque "librechat:foo" URI adapts to (host null, no segments, empty query).
+        assertEquals(
+            DeepLinkResolution.None,
+            DeepLinks.resolve(DeepLinkUri(host = null, pathSegments = emptyList(), query = emptyMap())),
+        )
+    }
+}


### PR DESCRIPTION
## Summary
Adds an Android-only "Add to Home screen" action for generated chat artifacts. Pinning takes a self-contained snapshot and places a launcher icon that deep-links straight into a full-screen viewer — reachable on cold start and while logged out, and unaffected by the source conversation being edited or deleted. A Settings screen lists and removes pinned shortcuts.

## Changes
- **Data (`:core:model`, `:core:data`)** — new `ArtifactShortcut` model and a device-scoped `artifact_shortcuts` Room table (schema v6→v7 auto-migration). Deliberately device-scoped (no account id), so a launcher icon outlives logout/account-switch.
- **Pin action (`:feature:chat`)** — affordance on the inline artifact card and the artifact viewer toolbar (peek and fullscreen), opening a name + optional-emoji dialog. The icon is a runtime-rendered adaptive bitmap (emoji or type glyph). The snapshot is persisted only once the launcher confirms the pin.
- **Deep-link routing (`:shared`)** — all `librechat://` links resolve through a single shared `DeepLinks.resolve` seam in commonMain that returns a typed result (route / consumed / ignored). Platform intake (Android `Uri`) only adapts into that resolver, so the accept decision and the nav decision share one source of truth instead of a second host allowlist; conversation and OAuth links route through the same seam.
- **Viewer + deep link (`:feature:chat`, `:app`, `:shared`)** — `librechat://artifact/{id}` opens a full-screen viewer backed by the local snapshot; a missing snapshot shows an "unavailable" state. Logged-out taps open the artifact atop an auth base, and only routable deep links defer the logged-out auth redirect.
- **Management (`:feature:settings`)** — a "Home-screen shortcuts" screen under Settings → Data lists shortcuts and deletes them (drops the snapshot and disables the launcher icon).
- **iOS** — no platform API to place a home-screen icon, so the affordance is absent (expect/actual returns null / no-op); shared code still compiles for iOS.
- **Dependency** — adds `androidx.core:core-ktx` (for `ShortcutManagerCompat` / `IconCompat`).

## Testing
- Unit tests for the repository entity↔model mapping (`:core:data`) and the deep-link resolver (`:shared`).
- Compile, detekt (commonMain), and unit-test gates green across the touched modules.
- The current reviewed revision is installed and running on a Pixel 9 Pro Fold; on-device verification of the pin flow, cold-start launch, logged-out open, and fold/rotate handling is in progress.

## Notes / known limitations
- Not offline: CDN-backed types (HTML/React/Mermaid/Markdown) still need network to render — the promise is "works logged out / survives conversation deletion," not offline.
- Android can't remove an already-placed launcher icon; deleting disables it, so a lingering icon becomes inert.
- On non-standard launchers that place a pin without firing a success callback, the snapshot isn't saved and the icon opens to "unavailable."
