### PR TITLE
feat(chat): most-used-model home-screen shortcuts and iOS quick actions

### DIFF
--- a/app/src/main/kotlin/com/garfiec/librechat/MainActivity.kt
+++ b/app/src/main/kotlin/com/garfiec/librechat/MainActivity.kt
@@ -38,7 +38,10 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
 import androidx.core.view.WindowCompat
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import co.touchlab.kermit.Logger
 import com.garfiec.librechat.core.common.network.ConnectivityObserver
 import com.garfiec.librechat.core.data.datastore.SettingsDataStore
@@ -51,6 +54,9 @@ import com.garfiec.librechat.navigation.LibreChatNavHost
 import com.garfiec.librechat.navigation.toDeepLinkUri
 import com.garfiec.librechat.shared.navigation.DeepLinkResolution
 import com.garfiec.librechat.shared.navigation.DeepLinks
+import com.garfiec.librechat.shortcuts.ModelShortcuts
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.launch
 import org.koin.android.ext.android.inject
 
 private const val KEY_PENDING_DEEP_LINK = "pending_deep_link"
@@ -87,6 +93,21 @@ class MainActivity : ComponentActivity() {
         } else {
             deepLinkUri = savedInstanceState.getString(KEY_PENDING_DEEP_LINK)?.toUri()
         }
+
+        // Keep home-screen model shortcuts in sync with the account's most-used models. The flow
+        // emits an empty list once the account resolves logged-out, which clears the shortcuts.
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                settingsDataStore.topUsedModels(ModelShortcuts.maxCount)
+                    // The backing flow re-emits on every settings write; only republish when the
+                    // ranked list actually changes to avoid redundant main-thread setDynamicShortcuts IPC.
+                    .distinctUntilChanged()
+                    .collect { models ->
+                        ModelShortcuts.publish(this@MainActivity, models)
+                    }
+            }
+        }
+
         setContent {
             val windowSizeClass = calculateWindowSizeClass(this)
             val isConnected by connectivityObserver.isConnected.collectAsStateWithLifecycle(initialValue = true)

--- a/app/src/main/kotlin/com/garfiec/librechat/navigation/LibreChatNavHost.kt
+++ b/app/src/main/kotlin/com/garfiec/librechat/navigation/LibreChatNavHost.kt
@@ -60,6 +60,10 @@ fun LibreChatNavHost(
                         !loggedIn -> navigator.navigateToDeepLinkLoggedOut(target)
                         // Switching chats replaces the current chat entry so back returns to NewChat.
                         target is Chat -> target.conversationId?.let { navigator.navigateToChat(it) }
+                        // Model shortcut: NewChat carries an endpoint/model payload. Go through top-level
+                        // nav so it replaces a bare landing NewChat (dedup-by-value) and re-seeds even
+                        // when already on the landing.
+                        target is NewChat -> navigator.navigateToTopLevel(target)
                         // Otherwise push, de-duping a repeat tap of the same target.
                         navigator.currentRoute != target -> navigator.navigate(target)
                     }

--- a/app/src/main/kotlin/com/garfiec/librechat/shortcuts/ModelShortcuts.kt
+++ b/app/src/main/kotlin/com/garfiec/librechat/shortcuts/ModelShortcuts.kt
@@ -1,0 +1,48 @@
+package com.garfiec.librechat.shortcuts
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import androidx.core.content.pm.ShortcutInfoCompat
+import androidx.core.content.pm.ShortcutManagerCompat
+import androidx.core.graphics.drawable.IconCompat
+import com.garfiec.librechat.MainActivity
+import com.garfiec.librechat.R
+import com.garfiec.librechat.core.model.ModelRef
+
+/**
+ * Publishes the user's most-used models as dynamic home-screen app shortcuts (long-press the app
+ * icon). Each shortcut deep-links to `librechat://model?endpoint=…&model=…`, which opens a new chat
+ * pre-selected on that model. Driven by [com.garfiec.librechat.core.data.datastore.SettingsDataStore.topUsedModels];
+ * [publish] fully replaces the set, so an empty list (logged out) clears them.
+ */
+object ModelShortcuts {
+
+    /** Launchers surface at most ~4 static+dynamic shortcuts; keep within the platform max. */
+    val maxCount: Int
+        get() = MAX_SHORTCUTS
+
+    fun publish(context: Context, models: List<ModelRef>) {
+        val capped = models.take(ShortcutManagerCompat.getMaxShortcutCountPerActivity(context).coerceAtMost(MAX_SHORTCUTS))
+        val shortcuts = capped.mapIndexed { index, ref ->
+            val uri = Uri.parse(
+                "librechat://model?endpoint=${Uri.encode(ref.endpoint)}&model=${Uri.encode(ref.model)}",
+            )
+            val intent = Intent(Intent.ACTION_VIEW, uri, context, MainActivity::class.java)
+            ShortcutInfoCompat.Builder(context, shortcutId(ref))
+                .setShortLabel(ref.model)
+                .setLongLabel(ref.model)
+                .setRank(index)
+                .setIcon(IconCompat.createWithResource(context, R.mipmap.ic_launcher))
+                .setIntent(intent)
+                .build()
+        }
+        // Replaces the whole dynamic set; an empty list clears every model shortcut.
+        ShortcutManagerCompat.setDynamicShortcuts(context, shortcuts)
+    }
+
+    // Stable per-model id so the same model keeps its shortcut identity across republishes.
+    private fun shortcutId(ref: ModelRef) = "model:${ref.endpoint}:${ref.model}"
+
+    private const val MAX_SHORTCUTS = 4
+}

--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/datastore/DataStoreRoundTripTest.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/datastore/DataStoreRoundTripTest.kt
@@ -6,6 +6,7 @@ import androidx.datastore.preferences.core.Preferences
 import com.garfiec.librechat.core.common.identity.AccountId
 import com.garfiec.librechat.core.common.identity.ActiveAccountProvider
 import com.garfiec.librechat.core.common.identity.InMemoryActiveAccountProvider
+import com.garfiec.librechat.core.model.ModelRef
 import com.garfiec.librechat.core.network.client.ServerUrlProvider
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.CoroutineScope
@@ -209,6 +210,102 @@ class DataStoreRoundTripTest {
         assertThat(emissions.last()).isEqualTo("gpt-4o")
 
         job.cancel()
+    }
+
+    // --- SettingsDataStore: model usage ranking (home-screen shortcuts) ---
+
+    @Test
+    fun settingsDataStore_modelUsage_ranksByCountDescending() = runTest(testDispatcher) {
+        val ds = createDataStore("settings-usage-rank")
+        val store = settingsStore(ds)
+
+        repeat(3) { store.incrementModelUsage("openAI", "gpt-4o") }
+        store.incrementModelUsage("anthropic", "claude-3.5-sonnet")
+        repeat(2) { store.incrementModelUsage("openAI", "gpt-4o-mini") }
+
+        assertThat(store.topUsedModels(10).first())
+            .containsExactly(
+                ModelRef("openAI", "gpt-4o"),
+                ModelRef("openAI", "gpt-4o-mini"),
+                ModelRef("anthropic", "claude-3.5-sonnet"),
+            )
+            .inOrder()
+    }
+
+    @Test
+    fun settingsDataStore_modelUsage_tieBrokenByRecency() = runTest(testDispatcher) {
+        val ds = createDataStore("settings-usage-tie")
+        val store = settingsStore(ds)
+
+        store.incrementModelUsage("openAI", "gpt-4o")
+        store.incrementModelUsage("anthropic", "claude-3.5-sonnet")
+
+        // Equal counts → the more recently used ranks first.
+        assertThat(store.topUsedModels(10).first())
+            .containsExactly(
+                ModelRef("anthropic", "claude-3.5-sonnet"),
+                ModelRef("openAI", "gpt-4o"),
+            )
+            .inOrder()
+    }
+
+    @Test
+    fun settingsDataStore_modelUsage_respectsLimit() = runTest(testDispatcher) {
+        val ds = createDataStore("settings-usage-limit")
+        val store = settingsStore(ds)
+
+        repeat(3) { store.incrementModelUsage("openAI", "gpt-4o") }
+        repeat(2) { store.incrementModelUsage("openAI", "gpt-4o-mini") }
+        store.incrementModelUsage("anthropic", "claude-3.5-sonnet")
+
+        assertThat(store.topUsedModels(2).first())
+            .containsExactly(
+                ModelRef("openAI", "gpt-4o"),
+                ModelRef("openAI", "gpt-4o-mini"),
+            )
+            .inOrder()
+    }
+
+    @Test
+    fun settingsDataStore_modelUsage_customEndpointWithSpaceRoundTrips() = runTest(testDispatcher) {
+        val ds = createDataStore("settings-usage-space")
+        val store = settingsStore(ds)
+
+        // The composite storage key must survive endpoints/models containing spaces.
+        store.incrementModelUsage("My Custom Endpoint", "some model v1")
+
+        assertThat(store.topUsedModels(5).first())
+            .containsExactly(ModelRef("My Custom Endpoint", "some model v1"))
+    }
+
+    @Test
+    fun settingsDataStore_modelUsage_blankInputsIgnored() = runTest(testDispatcher) {
+        val ds = createDataStore("settings-usage-blank")
+        val store = settingsStore(ds)
+
+        store.incrementModelUsage("", "gpt-4o")
+        store.incrementModelUsage("openAI", "")
+
+        assertThat(store.topUsedModels(5).first()).isEmpty()
+    }
+
+    @Test
+    fun settingsDataStore_modelUsage_recordedWhileWarming_landsOnResolve() = runTest(testDispatcher) {
+        val ds = createDataStore("settings-usage-warming")
+        val provider = InMemoryActiveAccountProvider() // starts Warming (mirrors a fresh post-login send)
+        val store = SettingsDataStore(ds, provider, CoroutineScope(testDispatcher), testDispatcher)
+
+        // The very first send can fire before the account has re-homed. The write must await
+        // resolution rather than snapshot a null id and silently drop the usage tick.
+        val recorded = launch { store.incrementModelUsage("anthropic", "claude-sonnet-5") }
+        advanceUntilIdle()
+        assertThat(recorded.isActive).isTrue() // still awaiting resolution, not dropped
+
+        provider.set(AccountId("srv:acctY"))
+        recorded.join() // resolution unblocks the awaited write; join past the DataStore commit
+
+        assertThat(store.topUsedModels(5).first())
+            .containsExactly(ModelRef("anthropic", "claude-sonnet-5"))
     }
 
     @Test

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/SettingsDataStore.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/SettingsDataStore.kt
@@ -9,10 +9,12 @@ import androidx.datastore.preferences.core.stringPreferencesKey
 import com.garfiec.librechat.core.common.identity.AccountState
 import com.garfiec.librechat.core.common.identity.ActiveAccountProvider
 import com.garfiec.librechat.core.common.identity.currentAccountId
+import com.garfiec.librechat.core.model.ModelRef
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -23,6 +25,11 @@ import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 import kotlin.concurrent.Volatile
 
 class SettingsDataStore(
@@ -122,6 +129,24 @@ class SettingsDataStore(
     val lastUsedEndpoint: Flow<String?> = scopedString(::endpointKey)
 
     val lastUsedModel: Flow<String?> = scopedString(::modelKey)
+
+    /**
+     * The account's most-used endpoint/model pairs, ranked by send count (recency breaks ties),
+     * capped to [limit]. Backs the home-screen app shortcuts / quick actions. Emits nothing while
+     * the account is Warming (so a one-shot consumer waits for the real value) and an empty list
+     * once resolved-but-logged-out, so a shortcut publisher clears its entries on sign-out.
+     */
+    @OptIn(ExperimentalCoroutinesApi::class)
+    fun topUsedModels(limit: Int): Flow<List<ModelRef>> =
+        activeAccountProvider.state.flatMapLatest { state ->
+            when (state) {
+                AccountState.Warming -> emptyFlow()
+                is AccountState.Resolved ->
+                    state.id?.let { id ->
+                        dataStore.data.map { prefs -> rankUsage(prefs[usageKey(id.value)], limit) }
+                    } ?: flowOf(emptyList())
+            }
+        }
 
     val dismissKeyboardOnSend: Flow<Boolean> = dataStore.data.map { prefs ->
         prefs[KEY_DISMISS_KEYBOARD_ON_SEND] ?: true
@@ -349,6 +374,73 @@ class SettingsDataStore(
 
     private fun modelKey(accountId: String) = accountScopedKey(accountId, LAST_USED_MODEL)
 
+    private fun usageKey(accountId: String) = accountScopedKey(accountId, MODEL_USAGE)
+
+    /**
+     * Records one "used" tick for [endpoint]/[model] — called once per message sent, the true
+     * usage signal (a passively auto-restored model that's never chatted with must not climb the
+     * ranking). Read-modify-write of the account-scoped counts map; a monotonically increasing
+     * [UsageEntry.seq] provides the recency tie-break and bounds map growth via [MAX_USAGE_ENTRIES].
+     */
+    suspend fun incrementModelUsage(endpoint: String, model: String) {
+        if (endpoint.isBlank() || model.isBlank()) return
+        // Await account resolution instead of snapshotting it: the first send right after a fresh
+        // login can fire before the active account has re-homed (the bearer is already staged, so the
+        // chat POST succeeds), and a snapshot read would hit null and drop that usage silently. Only
+        // reached from the send path, which implies a logged-in account, so this resolves promptly.
+        val accountId = activeAccountProvider.awaitResolvedAccount().value
+        val key = usageKey(accountId)
+        // The mutation is a durable write; keep it off the caller's cancellation so a ViewModel
+        // teardown mid-edit (e.g. the new-chat → Chat(id) handoff) can't drop the recorded tick.
+        withContext(NonCancellable) {
+            dataStore.edit { prefs ->
+                val current = decodeUsage(prefs[key])
+                val nextSeq = (current.values.maxOfOrNull { it.seq } ?: 0L) + 1
+                val composite = usageCompositeKey(endpoint, model)
+                val incremented = current[composite]?.let { it.copy(count = it.count + 1, seq = nextSeq) }
+                    ?: UsageEntry(count = 1, seq = nextSeq)
+                val merged = current + (composite to incremented)
+                // Keep the map bounded: retain the strongest entries by the same (count, recency) order
+                // the ranking uses, so a long tail of one-off models can't grow the pref without limit.
+                val trimmed = if (merged.size > MAX_USAGE_ENTRIES) {
+                    merged.entries
+                        .sortedWith(compareByDescending<Map.Entry<String, UsageEntry>> { it.value.count }
+                            .thenByDescending { it.value.seq })
+                        .take(MAX_USAGE_ENTRIES)
+                        .associate { it.toPair() }
+                } else {
+                    merged
+                }
+                prefs[key] = usageJson.encodeToString(trimmed)
+            }
+        }
+    }
+
+    private fun usageCompositeKey(endpoint: String, model: String) =
+        "$endpoint$USAGE_KEY_SEPARATOR$model"
+
+    /** Tolerant decode — a malformed/absent blob yields an empty map, never a crash. */
+    private fun decodeUsage(raw: String?): Map<String, UsageEntry> =
+        raw?.let { runCatching { usageJson.decodeFromString<Map<String, UsageEntry>>(it) }.getOrNull() }
+            ?: emptyMap()
+
+    /** Decode + rank by (count desc, recency desc), take [limit], split composite keys to [ModelRef]. */
+    private fun rankUsage(raw: String?, limit: Int): List<ModelRef> =
+        decodeUsage(raw).entries
+            .sortedWith(
+                compareByDescending<Map.Entry<String, UsageEntry>> { it.value.count }
+                    .thenByDescending { it.value.seq },
+            )
+            .take(limit)
+            .mapNotNull { (composite, _) ->
+                val sep = composite.indexOf(USAGE_KEY_SEPARATOR)
+                if (sep <= 0 || sep >= composite.lastIndex) {
+                    null
+                } else {
+                    ModelRef(composite.substring(0, sep), composite.substring(sep + 1))
+                }
+            }
+
     suspend fun setTtsSource(source: String) {
         dataStore.edit { prefs ->
             prefs[KEY_TTS_SOURCE] = source
@@ -534,6 +626,9 @@ class SettingsDataStore(
         private val KEY_SELECTED_VOICE_ID = stringPreferencesKey("selected_voice_id")
         private const val LAST_USED_ENDPOINT = "last_used_endpoint"
         private const val LAST_USED_MODEL = "last_used_model"
+        private const val MODEL_USAGE = "model_usage"
+        private const val MAX_USAGE_ENTRIES = 50
+        private const val USAGE_KEY_SEPARATOR = '\u0000'
         private val KEY_DISMISS_KEYBOARD_ON_SEND = booleanPreferencesKey("dismiss_keyboard_on_send")
         private val KEY_TTS_SOURCE = stringPreferencesKey("tts_source")
         private val KEY_TTS_SPEECH_RATE = floatPreferencesKey("tts_speech_rate")
@@ -565,3 +660,9 @@ class SettingsDataStore(
         private val KEY_ENABLED_TOOLS = stringPreferencesKey("enabled_tools")
     }
 }
+
+/** Per-model usage record: total send [count], plus a monotonic [seq] for the recency tie-break. */
+@Serializable
+private data class UsageEntry(val count: Int, val seq: Long)
+
+private val usageJson = Json { ignoreUnknownKeys = true }

--- a/core/model/src/commonMain/kotlin/com/garfiec/librechat/core/model/ModelRef.kt
+++ b/core/model/src/commonMain/kotlin/com/garfiec/librechat/core/model/ModelRef.kt
@@ -1,0 +1,13 @@
+package com.garfiec.librechat.core.model
+
+import kotlinx.serialization.Serializable
+
+/**
+ * A concrete endpoint + model pair the user can start a chat on. Used by the most-used-models
+ * ranking that backs the home-screen app shortcuts (Android) / quick actions (iOS).
+ */
+@Serializable
+data class ModelRef(
+    val endpoint: String,
+    val model: String,
+)

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/di/ChatPlatformModule.android.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/di/ChatPlatformModule.android.kt
@@ -28,6 +28,9 @@ actual val chatPlatformModule: Module = module {
             initialAgentId = params.values.getOrNull(1) as String?,
             // [2] isTemporary route flag (temp-chat data-at-rest guard); absent on non-temp callers.
             initialIsTemporary = params.values.getOrNull(2) as? Boolean ?: false,
+            // [3] initialEndpoint, [4] initialModel — model-shortcut pre-select; absent otherwise.
+            initialEndpoint = params.values.getOrNull(3) as String?,
+            initialModel = params.values.getOrNull(4) as String?,
             agentRepository = get(),
             chatRepository = get(),
             messageRepository = get(),

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatScreen.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatScreen.kt
@@ -46,6 +46,8 @@ actual fun ChatScreen(
     conversationId: String?,
     isTemporaryRoute: Boolean,
     initialAgentId: String?,
+    initialEndpoint: String?,
+    initialModel: String?,
     onConversationStart: ((conversationId: String, isTemporary: Boolean) -> Unit)?,
     onNavigateToConversation: ((String) -> Unit)?,
     onOpenDrawer: (() -> Unit)?,
@@ -56,7 +58,9 @@ actual fun ChatScreen(
     onNavigateToProviderKeys: (endpointName: String?) -> Unit,
 ) {
     val viewModel: ChatViewModel =
-        koinViewModel { parametersOf(conversationId, initialAgentId, isTemporaryRoute) }
+        koinViewModel {
+            parametersOf(conversationId, initialAgentId, isTemporaryRoute, initialEndpoint, initialModel)
+        }
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val attachedFiles by viewModel.attachedFiles.collectAsStateWithLifecycle()
     val shareLinkUrl by viewModel.shareLinkUrl.collectAsStateWithLifecycle()

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/NewChatScreen.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/NewChatScreen.kt
@@ -14,6 +14,8 @@ actual fun NewChatScreen(
     onConversationStart: (conversationId: String, isTemporary: Boolean) -> Unit,
     modifier: Modifier,
     initialAgentId: String?,
+    initialEndpoint: String?,
+    initialModel: String?,
     onOpenDrawer: (() -> Unit)?,
     onNavigateToPromptsLibrary: (() -> Unit)?,
     onAttachFromServer: () -> Unit,
@@ -22,6 +24,8 @@ actual fun NewChatScreen(
     ChatScreen(
         modifier = modifier,
         initialAgentId = initialAgentId,
+        initialEndpoint = initialEndpoint,
+        initialModel = initialModel,
         onConversationStart = onConversationStart,
         onOpenDrawer = onOpenDrawer,
         onNavigateToPromptsLibrary = onNavigateToPromptsLibrary,

--- a/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/ModelSelectionDelegateTest.kt
+++ b/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/ModelSelectionDelegateTest.kt
@@ -70,7 +70,12 @@ class ModelSelectionDelegateTest {
     private fun newHandle(scope: CoroutineScope, state: ChatUiState = ChatUiState()) =
         ChatStateHandle(stateFlow = MutableStateFlow(state), scope = scope)
 
-    private fun newDelegate(handle: ChatStateHandle, initialAgentId: String? = null) = ModelSelectionDelegate(
+    private fun newDelegate(
+        handle: ChatStateHandle,
+        initialAgentId: String? = null,
+        initialEndpoint: String? = null,
+        initialModel: String? = null,
+    ) = ModelSelectionDelegate(
         stateHandle = handle,
         configRepository = configRepository,
         agentRepository = agentRepository,
@@ -78,6 +83,8 @@ class ModelSelectionDelegateTest {
         settingsDataStore = settingsDataStore,
         permissionGate = permissionGate,
         initialAgentId = initialAgentId,
+        initialEndpoint = initialEndpoint,
+        initialModel = initialModel,
     )
 
     private fun allowAgents() {
@@ -434,6 +441,33 @@ class ModelSelectionDelegateTest {
     }
 
     // ── Group C: seedInitialSelection precedence + race determinism ──────────
+
+    @Test
+    fun seedModelOverrideWinsOverLastUsed() = runTest {
+        // A home-screen model shortcut passes an explicit (endpoint, model) that must win over a
+        // stored last-used, mirroring the agent override's tier-0 precedence.
+        val scope = TestScope(StandardTestDispatcher(testScheduler))
+        val handle = newHandle(scope)
+        val delegate = newDelegate(handle, initialEndpoint = "openAI", initialModel = "gpt-4o")
+        lastUsedEndpoint.value = "anthropic"
+        lastUsedModel.value = "claude-3.5-sonnet"
+        availableModels.value = mapOf(
+            "openAI" to listOf("gpt-4o"),
+            "anthropic" to listOf("claude-3.5-sonnet"),
+        )
+
+        delegate.seedInitialSelection(isNewConversation = true)
+        advanceUntilIdle()
+
+        assertThat(handle.state.selectedEndpoint).isEqualTo("openAI")
+        assertThat(handle.state.selectedModel).isEqualTo("gpt-4o")
+
+        // A later agents-loaded emission must not clobber the explicitly-launched model.
+        delegate.agentsLoaded.value = true
+        advanceUntilIdle()
+        assertThat(handle.state.selectedEndpoint).isEqualTo("openAI")
+        assertThat(handle.state.selectedModel).isEqualTo("gpt-4o")
+    }
 
     @Test
     fun seedLastUsedValidSeededWhenModelsArriveFirst() = runTest {

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/di/ChatModule.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/di/ChatModule.kt
@@ -2,6 +2,7 @@ package com.garfiec.librechat.feature.chat.di
 
 import com.garfiec.librechat.core.common.di.KoinQualifiers
 import com.garfiec.librechat.feature.chat.components.artifact.ArtifactViewerHandoff
+import com.garfiec.librechat.feature.chat.navigation.ModelShortcutBus
 import com.garfiec.librechat.feature.chat.prompts.PromptEditorViewModel
 import com.garfiec.librechat.feature.chat.prompts.PromptsViewModel
 import com.garfiec.librechat.feature.chat.viewmodel.ConversationMediaViewModel
@@ -17,6 +18,7 @@ val chatModule = module {
     single { NewChatSelectionHandoff() }
     single { ServerFileSelectionHandoff() }
     single { ArtifactViewerHandoff() }
+    single { ModelShortcutBus() }
     viewModelOf(::PromptsViewModel)
     // Koin's constructor-DSL (`viewModelOf`) wires every argument via `get()` and cannot read
     // values passed through `parametersOf`. This VM receives its `initialGroupId` from the

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/navigation/ChatNavigation.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/navigation/ChatNavigation.kt
@@ -34,8 +34,15 @@ import org.koin.compose.koinInject
 
 /** [agentId] (when non-null) is the agent to pre-select for the new chat — set when
  *  starting a chat from an agent's detail/marketplace card so the new chat opens on
- *  that agent rather than falling back to last-used/first-agent/first-model. */
-@Serializable data class NewChat(val agentId: String? = null) : ChatRoute
+ *  that agent rather than falling back to last-used/first-agent/first-model.
+ *  [endpoint]/[model] pre-select a concrete model instead (home-screen model shortcut /
+ *  quick action); they ride on the route so a payload-carrying NewChat replaces a bare
+ *  landing NewChat (dedup-by-value) and re-seeds even when already on the landing. */
+@Serializable data class NewChat(
+    val agentId: String? = null,
+    val endpoint: String? = null,
+    val model: String? = null,
+) : ChatRoute
 
 /**
  * [isTemporary] marks a conversation the user started as a temporary chat. It rides on the
@@ -83,6 +90,8 @@ fun EntryProviderScope<NavKey>.chatEntries(
     entry<NewChat> { key ->
         NewChatScreen(
             initialAgentId = key.agentId,
+            initialEndpoint = key.endpoint,
+            initialModel = key.model,
             onConversationStart = { conversationId, isTemporary ->
                 onNavigateToChat(conversationId, isTemporary)
             },

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/navigation/ModelShortcutBus.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/navigation/ModelShortcutBus.kt
@@ -1,0 +1,27 @@
+package com.garfiec.librechat.feature.chat.navigation
+
+import com.garfiec.librechat.core.model.ModelRef
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * Single-slot hand-off for a home-screen model shortcut / quick-action tap into the shared
+ * navigation host. iOS has no deep-link path, so the Swift quick-action handler pushes the tapped
+ * (endpoint, model) here (via `IosKoinAccessor.requestModelShortcut`); the shared `LibreChatNavHost`
+ * observes [pending] and opens a `NewChat` pre-selected on that model, then [consume]s it. Android
+ * routes the same intent through its `librechat://model` deep link instead, so it never sets this bus.
+ */
+class ModelShortcutBus {
+    private val _pending = MutableStateFlow<ModelRef?>(null)
+    val pending: StateFlow<ModelRef?> = _pending.asStateFlow()
+
+    fun request(endpoint: String, model: String) {
+        if (endpoint.isBlank() || model.isBlank()) return
+        _pending.value = ModelRef(endpoint, model)
+    }
+
+    fun consume() {
+        _pending.value = null
+    }
+}

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/screen/PlatformScreens.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/screen/PlatformScreens.kt
@@ -12,6 +12,10 @@ expect fun ChatScreen(
      *  VM temp-aware so it never persists the server-hidden conversation. See Chat.isTemporary. */
     isTemporaryRoute: Boolean = false,
     initialAgentId: String? = null,
+    /** Explicit (endpoint, model) to pre-select on a new chat — set when launched from a
+     *  home-screen model shortcut / quick action. Mutually exclusive with [initialAgentId]. */
+    initialEndpoint: String? = null,
+    initialModel: String? = null,
     onConversationStart: ((conversationId: String, isTemporary: Boolean) -> Unit)? = null,
     onNavigateToConversation: ((String) -> Unit)? = null,
     onOpenDrawer: (() -> Unit)? = null,
@@ -32,12 +36,15 @@ expect fun ChatScreen(
 )
 
 /** Platform-specific new chat screen. [initialAgentId], when non-null, pre-selects
- *  that agent for the new chat (set when starting from an agent detail/card). */
+ *  that agent for the new chat (set when starting from an agent detail/card).
+ *  [initialEndpoint]/[initialModel] pre-select a concrete model (home-screen shortcut). */
 @Composable
 expect fun NewChatScreen(
     onConversationStart: (conversationId: String, isTemporary: Boolean) -> Unit,
     modifier: Modifier = Modifier,
     initialAgentId: String? = null,
+    initialEndpoint: String? = null,
+    initialModel: String? = null,
     onOpenDrawer: (() -> Unit)? = null,
     onNavigateToPromptsLibrary: (() -> Unit)? = null,
     onAttachFromServer: () -> Unit = {},

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModel.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModel.kt
@@ -99,6 +99,10 @@ import kotlin.uuid.Uuid
 class ChatViewModel(
     initialConversationId: String? = null,
     initialAgentId: String? = null,
+    /** Explicit (endpoint, model) to pre-select on a new chat — set when launched from a home-screen
+     *  model shortcut / quick action. Null for normal new chats. Mutually exclusive with an agent. */
+    initialEndpoint: String? = null,
+    initialModel: String? = null,
     /** True when this Chat(id) entry is a temporary chat. Rides on the Chat route so it
      *  survives process death: a restored entry re-initializes temp-aware and never persists the
      *  server-hidden conversation to Room. SECURITY: temp-chat data-at-rest guard — see init. */
@@ -175,6 +179,8 @@ class ChatViewModel(
         settingsDataStore = settingsDataStore,
         permissionGate = permissionGate,
         initialAgentId = initialAgentId,
+        initialEndpoint = initialEndpoint,
+        initialModel = initialModel,
     )
     private val keyStatusDelegate = EndpointKeyStatusDelegate(
         stateHandle = stateHandle,
@@ -1140,6 +1146,14 @@ class ChatViewModel(
         if ((messageText.isBlank() && !hasFiles) || _uiState.value.isStreaming) return
         // Guard passed: safe to clear the composer for a live send without risking message loss.
         if (clearComposerOnSend) clearComposer()
+
+        // Count one "used" tick for the picked model — the real usage signal for the most-used
+        // ranking behind home-screen shortcuts. Fires on every dispatched send (live or a drained
+        // queue item, since both land here). Agents are excluded: their selection is an opaque
+        // agentId, which would surface as an unreadable shortcut label.
+        if (spec.endpoint != EndpointConstants.AGENTS && !spec.model.isNullOrBlank()) {
+            viewModelScope.launch { settingsDataStore.incrementModelUsage(spec.endpoint, spec.model) }
+        }
 
         val conversationId = _uiState.value.conversationId
         val lastMessageId = _uiState.value.displayMessages.lastOrNull()?.message?.messageId

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/ModelSelectionDelegate.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/ModelSelectionDelegate.kt
@@ -38,6 +38,8 @@ class ModelSelectionDelegate(
     private val settingsDataStore: SettingsDataStore,
     private val permissionGate: PermissionGate,
     initialAgentId: String? = null,
+    initialEndpoint: String? = null,
+    initialModel: String? = null,
 ) {
 
     /**
@@ -49,6 +51,20 @@ class ModelSelectionDelegate(
      * clobber-guard in [refilterModels] never sees it).
      */
     private var pendingAgentOverride: String? = initialAgentId?.takeIf { it.isNotBlank() }
+
+    /**
+     * Tier-0 explicit (endpoint, model) passed from the start-chat navigation — set when a chat is
+     * launched from a home-screen model shortcut / quick action. Same one-shot, authoritative
+     * semantics as [pendingAgentOverride] (they're mutually exclusive: a route carries an agent id
+     * OR a concrete model). Trusted directly rather than validated, mirroring the agent override —
+     * a shortcut points at a recently-used model, so it's applied even if the config hasn't loaded.
+     */
+    private var pendingModelOverride: Pair<String, String>? =
+        if (!initialEndpoint.isNullOrBlank() && !initialModel.isNullOrBlank()) {
+            initialEndpoint to initialModel
+        } else {
+            null
+        }
 
     /**
      * Cached last-used endpoint/model from DataStore, kept in sync by
@@ -337,6 +353,38 @@ class ModelSelectionDelegate(
         )
     }
 
+    /**
+     * Tier-0 seeding: applies an explicit agent or concrete (endpoint, model) passed from the
+     * start-chat navigation — an agent detail/card, or a home-screen model shortcut / quick action.
+     * Authoritative and one-shot: cleared after applying so later seeder emissions don't re-pin it,
+     * and trusted directly (no validation) since it was just chosen. Returns true when an override
+     * was applied so [applySeed] can stop.
+     *
+     * CRITICAL: also pins [lastAppliedLastUsed] to the CURRENT last-used so the re-sync in [applySeed]
+     * (`lastUsed != lastAppliedLastUsed`) does NOT fire on the next emission (e.g. when the agents
+     * list finishes loading) and clobber the override back to a last-used value. A genuinely NEW
+     * last-used picked later still differs from this pinned value, so the re-sync still follows it.
+     */
+    private fun applyPendingOverride(lastUsed: Pair<String, String>?): Boolean {
+        pendingAgentOverride?.let { agentId ->
+            pendingAgentOverride = null
+            lastAppliedLastUsed = lastUsed
+            // Hold this explicit agent across the transient empty-agents window until the populated
+            // list arrives (see [holdAgentForPopulate]); without it the next (agentsLoaded=true,
+            // agents=[]) emission would score the agent INVALID/PENDING and clobber it to a config model.
+            holdAgentForPopulate = true
+            applySelection(EndpointConstants.AGENTS, agentId, reason = "tier0-agentOverride")
+            return true
+        }
+        pendingModelOverride?.let { (endpoint, model) ->
+            pendingModelOverride = null
+            lastAppliedLastUsed = lastUsed
+            applySelection(endpoint, model, reason = "tier0-modelOverride")
+            return true
+        }
+        return false
+    }
+
     private fun applySeed(input: SeedInputs) {
         val filtered = filterModelsByEndpoint(input.rawModels, input.endpointConfigs)
         val state = stateHandle.state
@@ -347,29 +395,10 @@ class ModelSelectionDelegate(
             null
         }
 
-        // Tier 0: an explicit agent passed from the start-chat navigation wins over
-        // everything (last-used / first-agent / first-model). Authoritative + one-shot:
-        // apply the agents endpoint + this agent id directly (the agent was just
-        // selected/created, so trust the id even if the agents list hasn't loaded it
-        // yet — the chat sends the right agent_id and the label resolves once it does).
-        // Cleared after applying so subsequent seeder emissions don't re-pin it.
-        // CRITICAL: also pin [lastAppliedLastUsed] to the CURRENT last-used so the
-        // last-used re-sync below (`lastUsed != lastAppliedLastUsed`) does NOT fire on
-        // the next emission (e.g. when the agents list finishes loading) and clobber
-        // the agent back to a non-agent last-used model. A genuinely NEW last-used
-        // picked later still differs from this pinned value, so the re-sync correctly
-        // follows an explicit later choice.
-        pendingAgentOverride?.let { agentId ->
-            pendingAgentOverride = null
-            lastAppliedLastUsed = lastUsed
-            // Hold this explicit agent across the transient empty-agents window until the
-            // populated list arrives (see [holdAgentForPopulate]); without it the next
-            // (agentsLoaded=true, agents=[]) emission would score the agent INVALID/PENDING
-            // and clobber it to a config model.
-            holdAgentForPopulate = true
-            applySelection(EndpointConstants.AGENTS, agentId, reason = "tier0-agentOverride")
-            return
-        }
+        // Tier 0: an explicit agent or concrete model passed from the start-chat navigation wins
+        // over everything (last-used / first-agent / first-model). One-shot — see [applyPendingOverride].
+        if (applyPendingOverride(lastUsed)) return
+
         val lastUsedSelectability = lastUsed?.let {
             selectability(it.first, it.second, filtered, input.endpointConfigs, input.agents, input.agentsLoaded)
         }

--- a/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/di/ChatPlatformModule.ios.kt
+++ b/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/di/ChatPlatformModule.ios.kt
@@ -26,6 +26,9 @@ actual val chatPlatformModule: Module = module {
             initialAgentId = params.values.getOrNull(1) as String?,
             // [2] isTemporary route flag (temp-chat data-at-rest guard); absent on non-temp callers.
             initialIsTemporary = params.values.getOrNull(2) as? Boolean ?: false,
+            // [3] initialEndpoint, [4] initialModel — model-shortcut pre-select; absent otherwise.
+            initialEndpoint = params.values.getOrNull(3) as String?,
+            initialModel = params.values.getOrNull(4) as String?,
             agentRepository = get(),
             chatRepository = get(),
             messageRepository = get(),

--- a/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/screen/PlatformScreens.ios.kt
+++ b/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/screen/PlatformScreens.ios.kt
@@ -73,6 +73,8 @@ actual fun ChatScreen(
     conversationId: String?,
     isTemporaryRoute: Boolean,
     initialAgentId: String?,
+    initialEndpoint: String?,
+    initialModel: String?,
     onConversationStart: ((conversationId: String, isTemporary: Boolean) -> Unit)?,
     onNavigateToConversation: ((String) -> Unit)?,
     onOpenDrawer: (() -> Unit)?,
@@ -83,7 +85,9 @@ actual fun ChatScreen(
     onNavigateToProviderKeys: (endpointName: String?) -> Unit,
 ) {
     val viewModel: ChatViewModel =
-        koinViewModel { parametersOf(conversationId, initialAgentId, isTemporaryRoute) }
+        koinViewModel {
+            parametersOf(conversationId, initialAgentId, isTemporaryRoute, initialEndpoint, initialModel)
+        }
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val attachedFiles by viewModel.attachedFiles.collectAsStateWithLifecycle()
     val prefs by viewModel.chatPreferences.collectAsStateWithLifecycle()
@@ -588,6 +592,8 @@ actual fun NewChatScreen(
     onConversationStart: (conversationId: String, isTemporary: Boolean) -> Unit,
     modifier: Modifier,
     initialAgentId: String?,
+    initialEndpoint: String?,
+    initialModel: String?,
     onOpenDrawer: (() -> Unit)?,
     onNavigateToPromptsLibrary: (() -> Unit)?,
     onAttachFromServer: () -> Unit,
@@ -596,6 +602,8 @@ actual fun NewChatScreen(
     ChatScreen(
         modifier = modifier,
         initialAgentId = initialAgentId,
+        initialEndpoint = initialEndpoint,
+        initialModel = initialModel,
         onConversationStart = onConversationStart,
         onOpenDrawer = onOpenDrawer,
         onNavigateToPromptsLibrary = onNavigateToPromptsLibrary,

--- a/iosApp/iosApp/iOSApp.swift
+++ b/iosApp/iosApp/iOSApp.swift
@@ -1,8 +1,14 @@
 import SwiftUI
+import UIKit
 import Shared
 
 @main
 struct iOSApp: App {
+
+    // A UIKit app delegate is needed so we can supply a scene delegate that receives Home-Screen
+    // quick-action taps (SwiftUI's App lifecycle doesn't surface UIApplicationShortcutItem directly).
+    @UIApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
+    @Environment(\.scenePhase) private var scenePhase
 
     init() {
         // Initialize Koin DI — must happen before any KMP code is used
@@ -14,5 +20,90 @@ struct iOSApp: App {
             LibreChatComposeView()
                 .ignoresSafeArea()
         }
+        .onChange(of: scenePhase) { phase in
+            // Refresh the most-used-model quick actions as the app leaves the foreground, so a
+            // long-press on the app icon reflects the latest usage.
+            if phase == .background {
+                ModelQuickActions.refresh()
+            }
+        }
+    }
+}
+
+/// Supplies a scene delegate; that's the object iOS delivers quick-action taps to.
+final class AppDelegate: NSObject, UIApplicationDelegate {
+    func application(
+        _ application: UIApplication,
+        configurationForConnecting connectingSceneSession: UISceneSession,
+        options: UIScene.ConnectionOptions
+    ) -> UISceneConfiguration {
+        let configuration = UISceneConfiguration(name: nil, sessionRole: connectingSceneSession.role)
+        configuration.delegateClass = SceneDelegate.self
+        return configuration
+    }
+}
+
+/// Handles Home-Screen quick actions both at cold launch (`willConnectTo`) and while running
+/// (`performActionFor`). It only observes scene events — it never creates a window, so SwiftUI's
+/// `WindowGroup` still owns the UI.
+final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+    func scene(
+        _ scene: UIScene,
+        willConnectTo session: UISceneSession,
+        options connectionOptions: UIScene.ConnectionOptions
+    ) {
+        if let shortcutItem = connectionOptions.shortcutItem {
+            ModelQuickActions.handle(shortcutItem)
+        }
+    }
+
+    func windowScene(
+        _ windowScene: UIWindowScene,
+        performActionFor shortcutItem: UIApplicationShortcutItem,
+        completionHandler: @escaping (Bool) -> Void
+    ) {
+        completionHandler(ModelQuickActions.handle(shortcutItem))
+    }
+}
+
+/// Bridges the KMP most-used-models ranking to iOS Home-Screen quick actions.
+enum ModelQuickActions {
+
+    /// Single shortcut type; the concrete model rides in `userInfo` so one handler covers all.
+    private static let itemType = "com.garfiec.librechat.model"
+
+    /// Rebuilds `UIApplication.shortcutItems` from the account's most-used models. An empty list
+    /// (logged out / no usage yet) clears them.
+    static func refresh() {
+        Task {
+            guard let models = try? await IosKoinAccessor.shared.currentTopModels(limit: 4) else { return }
+            let items = models.map { ref in
+                UIApplicationShortcutItem(
+                    type: itemType,
+                    localizedTitle: ref.model,
+                    localizedSubtitle: nil,
+                    icon: UIApplicationShortcutIcon(type: .message),
+                    userInfo: [
+                        "endpoint": ref.endpoint as NSString,
+                        "model": ref.model as NSString,
+                    ]
+                )
+            }
+            await MainActor.run {
+                UIApplication.shared.shortcutItems = items
+            }
+        }
+    }
+
+    /// Routes a tapped quick action into the shared navigation host. Returns whether it was ours.
+    @discardableResult
+    static func handle(_ shortcutItem: UIApplicationShortcutItem) -> Bool {
+        guard shortcutItem.type == itemType,
+              let endpoint = shortcutItem.userInfo?["endpoint"] as? String,
+              let model = shortcutItem.userInfo?["model"] as? String else {
+            return false
+        }
+        try? IosKoinAccessor.shared.requestModelShortcut(endpoint: endpoint, model: model)
+        return true
     }
 }

--- a/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/DeepLinks.kt
+++ b/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/DeepLinks.kt
@@ -3,6 +3,7 @@ package com.garfiec.librechat.shared.navigation
 import androidx.navigation3.runtime.NavKey
 import com.garfiec.librechat.feature.chat.navigation.ArtifactShortcutViewer
 import com.garfiec.librechat.feature.chat.navigation.Chat
+import com.garfiec.librechat.feature.chat.navigation.NewChat
 
 /**
  * Platform-neutral view of an incoming `librechat://` URI, so [DeepLinks.resolve] — the routing
@@ -73,10 +74,20 @@ object DeepLinks {
             ?.let { DeepLinkResolution.Route(ArtifactShortcutViewer(it), requiresAuth = false) }
             ?: DeepLinkResolution.None
 
+        // Home-screen model shortcut (librechat://model?endpoint=<endpoint>&model=<model>): the payload
+        // rides on the NewChat route so it replaces a bare landing NewChat (dedup-by-value) and re-seeds
+        // even when already on the landing. Auth-required — a model preselect is useless without a session.
+        "model" -> {
+            val endpoint = uri.query["endpoint"]
+            val model = uri.query["model"]
+            if (!endpoint.isNullOrBlank() && !model.isNullOrBlank()) {
+                DeepLinkResolution.Route(NewChat(endpoint = endpoint, model = model), requiresAuth = true)
+            } else {
+                DeepLinkResolution.None
+            }
+        }
+
         // OAuth redirect (librechat://oauth): token comes back via cookie, not the URI — see [Consumed].
-        // A model-shortcut host would slot in here as a query-param Route, e.g.:
-        //   "model" -> uri.query["model"]?.let {
-        //       Route(NewChat(endpoint = uri.query["endpoint"], model = it), requiresAuth = true) } ?: None
         "oauth" -> DeepLinkResolution.Consumed
 
         else -> DeepLinkResolution.None

--- a/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/LibreChatNavHost.kt
+++ b/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/LibreChatNavHost.kt
@@ -50,6 +50,7 @@ import com.garfiec.librechat.feature.auth.navigation.AddAccountServerUrl
 import com.garfiec.librechat.feature.auth.navigation.authEntries
 import com.garfiec.librechat.feature.auth.navigation.isAddAccountFlowRoute
 import com.garfiec.librechat.feature.chat.navigation.Chat
+import com.garfiec.librechat.feature.chat.navigation.ModelShortcutBus
 import com.garfiec.librechat.feature.chat.navigation.NewChat
 import com.garfiec.librechat.feature.chat.navigation.chatEntries
 import com.garfiec.librechat.feature.chat.viewmodel.ServerFileSelectionHandoff
@@ -120,6 +121,18 @@ fun LibreChatNavHost(
                 navigator.navigateToAuth()
             }
         }
+    }
+
+    // iOS home-screen quick action: the Swift handler pushes the tapped (endpoint, model) onto the
+    // bus; open a NewChat pre-selected on it. Deferred until logged in so a cold launch from a quick
+    // action lands the model once auth resolves. Android sets this bus never — it deep-links instead.
+    val modelShortcutBus = koinInject<ModelShortcutBus>()
+    val pendingModelShortcut by modelShortcutBus.pending.collectAsStateWithLifecycle()
+    LaunchedEffect(pendingModelShortcut, isLoggedIn) {
+        val ref = pendingModelShortcut ?: return@LaunchedEffect
+        if (!isLoggedIn) return@LaunchedEffect
+        navigator.navigateToTopLevel(NewChat(endpoint = ref.endpoint, model = ref.model))
+        modelShortcutBus.consume()
     }
 
     // Track active conversation from nav back stack

--- a/shared/src/iosMain/kotlin/com/garfiec/librechat/shared/IosKoinAccessor.kt
+++ b/shared/src/iosMain/kotlin/com/garfiec/librechat/shared/IosKoinAccessor.kt
@@ -1,9 +1,13 @@
 package com.garfiec.librechat.shared
 
 import com.garfiec.librechat.core.data.datastore.ServerDataStore
+import com.garfiec.librechat.core.data.datastore.SettingsDataStore
 import com.garfiec.librechat.core.data.repository.AuthRepository
 import com.garfiec.librechat.core.data.repository.ConfigRepository
 import com.garfiec.librechat.core.data.repository.FileRepository
+import com.garfiec.librechat.core.model.ModelRef
+import com.garfiec.librechat.feature.chat.navigation.ModelShortcutBus
+import kotlinx.coroutines.flow.first
 import org.koin.core.Koin
 
 /**
@@ -33,4 +37,19 @@ object IosKoinAccessor {
 
     @Throws(Exception::class)
     fun getConfigRepository(): ConfigRepository = koin.get()
+
+    /**
+     * Snapshot of the account's most-used models, for the Swift layer to publish as home-screen
+     * quick actions (typically read when the app backgrounds). Suspends until the account resolves
+     * (the flow emits nothing while warming), which is already the case by background time.
+     */
+    @Throws(Exception::class)
+    suspend fun currentTopModels(limit: Int): List<ModelRef> =
+        koin.get<SettingsDataStore>().topUsedModels(limit).first()
+
+    /** Routes a tapped quick action into the shared navigation host — opens a new chat on the model. */
+    @Throws(Exception::class)
+    fun requestModelShortcut(endpoint: String, model: String) {
+        koin.get<ModelShortcutBus>().request(endpoint, model)
+    }
 }


### PR DESCRIPTION
## Summary
Surfaces each account's most-used models as OS-level launch shortcuts — Android dynamic app shortcuts and iOS home-screen quick actions — that open a new chat with that endpoint/model preselected. Lets users jump straight into a chat with a frequently-used model without navigating the picker.

## Changes
- **Usage tracking** — `SettingsDataStore` gains an account-scoped model-usage map (bounded to 50 entries) with `incrementModelUsage()` and `topUsedModels(limit)`, ranked by send count with recency breaking ties. Usage is recorded once per dispatched send; agents are excluded (their opaque `agentId` has no readable label).
- **Android** — `MainActivity` publishes up to 4 dynamic shortcuts via `ShortcutManagerCompat`, kept in sync with the ranked list (republished only on change). Each shortcut fires a `librechat://model?endpoint=&model=` deep link.
- **iOS** — `AppDelegate`/`SceneDelegate` expose `UIApplicationShortcutItems`; taps route through a `ModelShortcutBus` observed by the shared nav host, which opens the preselected new chat once logged in.
- **Deep-link routing** — the `model` host is declared in the shared `DeepLinks.resolve()` seam as an auth-required `Route(NewChat(endpoint, model))`, consistent with the single-source-of-truth resolver (no per-host allowlist).
- **Preselect** — endpoint/model ride on the `NewChat` route and apply as a one-shot tier-0 override in `ModelSelectionDelegate`, so a payload-carrying `NewChat` re-seeds even when already on a bare landing screen.
- `ModelRef` added to `core/model` (`@Serializable`).

## Testing
- Android: device-tested on the Fold; new unit tests for usage ranking (including the warming→resolve account-timing case) and the model-override path.
- Unit tests pass; `:app` + `:shared` metadata compile clean.
- iOS: compiles (Gradle framework link) but **not yet device-tested** — quick-actions layer unverified on-device.

## Notes
- iOS on-device verification of the quick-actions layer is a follow-up before merge.
- iOS quick actions refresh when the app moves to the background; Android republishes reactively whenever the ranking changes.
