### PR TITLE
fix(chat): auto-retry agents on reconnect and auto-dismiss the error snackbar

### DIFF
--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatScreenEffects.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatScreenEffects.kt
@@ -2,6 +2,7 @@ package com.garfiec.librechat.feature.chat.screen
 
 import android.content.ClipData
 import android.content.ClipboardManager
+import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -52,6 +53,7 @@ internal fun ChatScreenEffects(
             snackbarHostState.showSnackbar(
                 message = error,
                 actionLabel = "Dismiss",
+                duration = SnackbarDuration.Long,
             )
             viewModel.dismissError()
         }

--- a/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/ModelSelectionDelegateTest.kt
+++ b/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/ModelSelectionDelegateTest.kt
@@ -1,6 +1,7 @@
 package com.garfiec.librechat.feature.chat.viewmodel.delegate
 
 import com.garfiec.librechat.core.common.EndpointConstants
+import com.garfiec.librechat.core.common.network.ConnectivityObserver
 import com.garfiec.librechat.core.common.result.Result
 import com.garfiec.librechat.core.data.datastore.SettingsDataStore
 import com.garfiec.librechat.core.data.repository.AgentRepository
@@ -67,6 +68,14 @@ class ModelSelectionDelegateTest {
     }
     private val permissionGate = mockk<PermissionGate>(relaxed = true)
 
+    // Fake connectivity: tests drive offline→online transitions via [isConnected].value.
+    // Starts connected so the observer's initial current-state emission is never a
+    // transition (mirrors the real observer, which emits the current state on collect).
+    private val isConnected = MutableStateFlow(true)
+    private val connectivityObserver = mockk<ConnectivityObserver>(relaxed = true).also {
+        every { it.isConnected } returns isConnected
+    }
+
     private fun newHandle(scope: CoroutineScope, state: ChatUiState = ChatUiState()) =
         ChatStateHandle(stateFlow = MutableStateFlow(state), scope = scope)
 
@@ -82,6 +91,7 @@ class ModelSelectionDelegateTest {
         mcpRepository = mcpRepository,
         settingsDataStore = settingsDataStore,
         permissionGate = permissionGate,
+        connectivityObserver = connectivityObserver,
         initialAgentId = initialAgentId,
         initialEndpoint = initialEndpoint,
         initialModel = initialModel,
@@ -435,6 +445,77 @@ class ModelSelectionDelegateTest {
         delegate.loadAgents(isNewConversation = false)
         advanceUntilIdle()
         delegate.retryAgentsIfFailed(isNewConversation = false)
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { agentRepository.getAgents() }
+    }
+
+    @Test
+    fun agentsLoadFailedRetriesOnConnectivityRegained() = runTest {
+        // The cold-start-failure fix: a failed load auto-retries on an offline→online
+        // transition, so the user doesn't have to open the selector to recover.
+        val scope = TestScope(StandardTestDispatcher(testScheduler))
+        val handle = newHandle(scope)
+        val delegate = newDelegate(handle)
+        allowAgents()
+        isConnected.value = true
+        coEvery { agentRepository.getAgents() } returns Result.Error(RuntimeException("boom"))
+
+        delegate.loadAgents(isNewConversation = false)
+        advanceUntilIdle()
+        assertThat(handle.state.agents).isEmpty()
+
+        // Network drops then recovers; the offline→online transition re-fetches.
+        coEvery { agentRepository.getAgents() } returns Result.Success(listOf(Agent(id = "agent_1")))
+        isConnected.value = false
+        advanceUntilIdle()
+        isConnected.value = true
+        advanceUntilIdle()
+
+        assertThat(handle.state.agents).hasSize(1)
+        assertThat(handle.state.error).isNull()
+        coVerify(exactly = 2) { agentRepository.getAgents() }
+    }
+
+    @Test
+    fun agentsLoadFailedDoesNotRetryWhileStayingConnected() = runTest {
+        // Transition-detection guard: a failure while already online (server unreachable /
+        // DNS broken) must NOT retry without an offline→online transition — otherwise a
+        // persistently-connected-but-failing device would spin a tight retry loop.
+        val scope = TestScope(StandardTestDispatcher(testScheduler))
+        val handle = newHandle(scope)
+        val delegate = newDelegate(handle)
+        allowAgents()
+        isConnected.value = true
+        coEvery { agentRepository.getAgents() } returns Result.Error(RuntimeException("boom"))
+
+        delegate.loadAgents(isNewConversation = false)
+        advanceUntilIdle()
+
+        // Stays connected the whole time — no transition, so no auto-retry.
+        isConnected.value = true
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { agentRepository.getAgents() }
+    }
+
+    @Test
+    fun successfulLoadDoesNotRetryOnLaterReconnect() = runTest {
+        // A successful load must not leave a reconnect observer running — a later
+        // offline→online transition must not trigger a needless re-fetch.
+        val scope = TestScope(StandardTestDispatcher(testScheduler))
+        val handle = newHandle(scope)
+        val delegate = newDelegate(handle)
+        allowAgents()
+        isConnected.value = true
+        coEvery { agentRepository.getAgents() } returns Result.Success(listOf(Agent(id = "agent_1")))
+
+        delegate.loadAgents(isNewConversation = false)
+        advanceUntilIdle()
+
+        isConnected.value = false
+        advanceUntilIdle()
+        isConnected.value = true
         advanceUntilIdle()
 
         coVerify(exactly = 1) { agentRepository.getAgents() }

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModel.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModel.kt
@@ -178,6 +178,7 @@ class ChatViewModel(
         mcpRepository = mcpRepository,
         settingsDataStore = settingsDataStore,
         permissionGate = permissionGate,
+        connectivityObserver = connectivityObserver,
         initialAgentId = initialAgentId,
         initialEndpoint = initialEndpoint,
         initialModel = initialModel,

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/ModelSelectionDelegate.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/ModelSelectionDelegate.kt
@@ -3,6 +3,7 @@ package com.garfiec.librechat.feature.chat.viewmodel.delegate
 import co.touchlab.kermit.Logger
 import com.garfiec.librechat.core.common.EndpointConstants
 import com.garfiec.librechat.core.common.ToolConstants
+import com.garfiec.librechat.core.common.network.ConnectivityObserver
 import com.garfiec.librechat.core.common.result.Result
 import com.garfiec.librechat.core.data.datastore.SettingsDataStore
 import com.garfiec.librechat.core.data.repository.AgentRepository
@@ -37,6 +38,7 @@ class ModelSelectionDelegate(
     private val mcpRepository: McpRepository,
     private val settingsDataStore: SettingsDataStore,
     private val permissionGate: PermissionGate,
+    private val connectivityObserver: ConnectivityObserver,
     initialAgentId: String? = null,
     initialEndpoint: String? = null,
     initialModel: String? = null,
@@ -157,6 +159,14 @@ class ModelSelectionDelegate(
      * launching a duplicate concurrent fetch while one is still running.
      */
     private var agentsLoadJob: Job? = null
+
+    /**
+     * The connectivity observer that retries the agent fetch when the device comes
+     * back online after a failed load. Started from [loadAgents]'s error branch and
+     * cancelled on success; self-cancels once a reconnect retry fires. See
+     * [scheduleAgentsRetryOnReconnect].
+     */
+    private var connectivityRetryJob: Job? = null
 
     /**
      * The last-used (endpoint, model) pair this delegate last applied as the
@@ -621,6 +631,11 @@ class ModelSelectionDelegate(
             }
             when (val result = agentRepository.getAgents()) {
                 is Result.Success -> {
+                    // A selector-open recovery (or a plain success) makes any pending
+                    // reconnect observer moot — cancel it so it can't fire a duplicate
+                    // retry after we already have the list.
+                    connectivityRetryJob?.cancel()
+                    connectivityRetryJob = null
                     // Set agentsLoaded BEFORE publishing the agent list so the
                     // seeder emission carrying the agents already sees the flag —
                     // otherwise tier 2 could fall through to a config model in the
@@ -645,6 +660,7 @@ class ModelSelectionDelegate(
                     agentsLoadFailed = true
                     stateHandle.update { copy(error = AGENTS_LOAD_ERROR) }
                     agentsLoaded.value = true
+                    scheduleAgentsRetryOnReconnect(isNewConversation)
                 }
                 is Result.Loading -> return@launch
             }
@@ -667,6 +683,38 @@ class ModelSelectionDelegate(
     fun retryAgentsIfFailed(isNewConversation: Boolean) {
         if (agentsLoadFailed && agentsLoadJob?.isActive != true) {
             loadAgents(isNewConversation)
+        }
+    }
+
+    /**
+     * Observes connectivity after a failed load and re-fetches agents on the first
+     * offline→online transition, so a cold-start failure (network/DNS not up yet)
+     * recovers on its own instead of waiting for the user to open the model selector.
+     *
+     * Transition-detection (not "retry whenever connected") is deliberate: it fires
+     * once per reconnect rather than looping while online-but-server-unreachable.
+     * [wasConnected] starts null so the observer's initial current-state emission is
+     * never mistaken for a transition. The observer self-cancels after firing; if the
+     * retry fails again it re-enters [loadAgents]'s error branch and re-schedules a
+     * fresh one.
+     *
+     * Known limit: the Android observer keys on NET_CAPABILITY_INTERNET, so a
+     * "connected but DNS broken" failure produces no offline→online transition — the
+     * selector-open [retryAgentsIfFailed] still covers that case.
+     */
+    private fun scheduleAgentsRetryOnReconnect(isNewConversation: Boolean) {
+        connectivityRetryJob?.cancel()
+        connectivityRetryJob = stateHandle.scope.launch {
+            var wasConnected: Boolean? = null
+            connectivityObserver.isConnected.collect { connected ->
+                val recovered = wasConnected == false && connected
+                wasConnected = connected
+                if (recovered) {
+                    retryAgentsIfFailed(isNewConversation)
+                    connectivityRetryJob?.cancel()
+                    connectivityRetryJob = null
+                }
+            }
         }
     }
 

--- a/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/screen/PlatformScreens.ios.kt
+++ b/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/screen/PlatformScreens.ios.kt
@@ -20,6 +20,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
@@ -148,6 +149,7 @@ actual fun ChatScreen(
             snackbarHostState.showSnackbar(
                 message = error,
                 actionLabel = "Dismiss",
+                duration = SnackbarDuration.Long,
             )
             viewModel.dismissError()
         }


### PR DESCRIPTION
## Summary

Fixes two rough edges in the cold-start "Could not load available agents" path. When the app launches before connectivity is up, the agents fetch fails; until now recovery required opening the model selector, and the error banner sat on screen forever. Now the fetch auto-retries when the device regains connectivity, and the error snackbar times out.

## Changes

- **Auto-retry agents on reconnect** (`ModelSelectionDelegate`): after a failed load, observe connectivity and re-fetch agents on the first offline→online transition, then cancel the observer. A plain/selector-open success also cancels any pending observer so it can't fire a duplicate retry. Transition detection (rather than "retry whenever connected") fires once per reconnect instead of looping while the device is online but the server is unreachable.
- **Error snackbar auto-dismiss**: the chat error snackbar now uses `SnackbarDuration.Long` (~10s) on both Android and iOS, keeping the "Dismiss" action but no longer relying on the Material3 `Indefinite` default that applies whenever an `actionLabel` is passed.

## Testing

- `./gradlew :feature:chat:testDebugUnitTest` — passing, including three new `ModelSelectionDelegateTest` cases covering retry-on-reconnect, no-retry while staying connected, and no-retry after a successful load.

## Notes

- The Android connectivity observer keys on `NET_CAPABILITY_INTERNET`, so a "connected but DNS broken" failure produces no offline→online transition; the existing selector-open retry still covers that case.
