### PR TITLE
fix(data): recover from token-store and DataStore corruption instead of crashing

### DIFF
--- a/core/data/CLAUDE.md
+++ b/core/data/CLAUDE.md
@@ -53,7 +53,12 @@ Interactive sign-in (`setTokens`) **stages** the pair under the bare keys and dr
 `onAccountResolved` re-homes it into the account's keyed slot. This makes a re-login while another
 account is active unable to corrupt/leak into that account's slot.
 
-Wrap `EncryptedSharedPreferences` in try/catch -- some OEM devices have broken Keystore implementations. On `KeyStoreException`, clear tokens and force re-login.
+Wrap `EncryptedSharedPreferences` access in try/catch -- some OEM devices have broken Keystore
+implementations. `TokenDataStore` recovers in place rather than crashing: a single undecryptable entry
+is dropped (other retained accounts stay logged in), a broken keyset is wiped and rebuilt with a fresh
+master key, and if even a rebuild can't produce a working store it degrades to an in-memory session for
+the process. Construction never throws into `startKoin`. The next request then 401s and routes to
+re-login through the normal expired-session flow.
 
 ### DataModule Bindings
 

--- a/core/data/src/androidMain/kotlin/com/garfiec/librechat/core/data/datastore/EncryptedPrefsFactory.kt
+++ b/core/data/src/androidMain/kotlin/com/garfiec/librechat/core/data/datastore/EncryptedPrefsFactory.kt
@@ -1,0 +1,41 @@
+package com.garfiec.librechat.core.data.datastore
+
+import co.touchlab.kermit.Logger
+
+/**
+ * Build a value that depends on the Android keystore / `EncryptedSharedPreferences`, recovering from a
+ * corrupt keystore or keyset instead of letting the exception escape `startKoin` into an
+ * unrecoverable crash loop.
+ *
+ * [create] is attempted; on any [Exception] (a broken OEM keystore, or a keyset that no longer
+ * decrypts after a backup-restore / OS update — these surface as `GeneralSecurityException`,
+ * `IOException` or `ProviderException`, all [Exception] subtypes) the corrupt state is wiped via
+ * [wipe] and [create] is retried once. A second failure returns `null`, signalling the caller to fall
+ * back to a non-persistent store rather than crash.
+ *
+ * Catches [Exception], not [Throwable]: an `OutOfMemoryError` / `LinkageError` is a genuine failure
+ * that must not be swallowed. A [wipe] that itself throws is logged and ignored so it can never mask
+ * the retry.
+ *
+ * Extracted as a free function so the recovery logic is unit-testable with plain fakes — Robolectric
+ * can't run a real `EncryptedSharedPreferences`.
+ */
+internal fun <T : Any> createWithRecovery(create: () -> T, wipe: () -> Unit): T? =
+    try {
+        create()
+    } catch (e: Exception) {
+        Logger.e(e) { "Encrypted store creation failed — wiping corrupt keystore state and retrying" }
+        try {
+            wipe()
+        } catch (wipeError: Exception) {
+            Logger.e(wipeError) { "Wipe of corrupt encrypted store failed; retrying creation anyway" }
+        }
+        try {
+            create()
+        } catch (retryError: Exception) {
+            Logger.e(retryError) {
+                "Encrypted store creation failed after wipe — falling back to in-memory session store"
+            }
+            null
+        }
+    }

--- a/core/data/src/androidMain/kotlin/com/garfiec/librechat/core/data/datastore/TokenDataStore.kt
+++ b/core/data/src/androidMain/kotlin/com/garfiec/librechat/core/data/datastore/TokenDataStore.kt
@@ -4,54 +4,175 @@ import android.content.Context
 import android.content.SharedPreferences
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
+import co.touchlab.kermit.Logger
 import io.ktor.client.HttpClient
+import java.security.GeneralSecurityException
+import java.security.KeyStore
 import java.security.KeyStoreException
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.concurrent.Volatile
 
 class TokenDataStore(
     context: Context,
     refreshClient: Lazy<HttpClient>,
 ) : CommonTokenDataStore(refreshClient) {
 
-    private val masterKey: MasterKey = MasterKey.Builder(context)
-        .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
-        .build()
+    private val appContext: Context = context.applicationContext
 
-    private val prefs: SharedPreferences = EncryptedSharedPreferences.create(
-        context,
-        PREFS_NAME,
-        masterKey,
-        EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
-        EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
-    )
+    /**
+     * The encrypted store, or `null` once the device keystore is so broken that even a wipe + rebuild
+     * can't produce a working one. A `null` routes every override onto [memoryFallback] — the session
+     * lives only in memory until process death, then the user re-logs in — instead of crashing during
+     * `startKoin`. Keystore/keyset corruption (backup-restore, OS update, broken OEM keystore) would
+     * otherwise throw here and, via the eager `AccountRegistry` single, take down every launch.
+     *
+     * Reassigned at runtime (never back to a store known-broken) when a write rebuilds the keyset or
+     * drops to memory mode; `@Volatile` so the unlocked hot-path reads (`isAuthenticated`,
+     * `getAccessToken`) observe the swap.
+     */
+    @Volatile
+    private var prefs: SharedPreferences? = createEncryptedPrefsWithRecovery()
+
+    /**
+     * Session-only backing used when [prefs] is `null` (the keystore never recovered). Reads/writes go
+     * here instead; nothing survives process death, so the user re-authenticates each launch — a
+     * degraded but usable app rather than a crash loop.
+     */
+    private val memoryFallback = ConcurrentHashMap<String, String>()
 
     init {
         initializeTokenCache()
     }
 
-    override fun readValue(key: String): String? = prefs.getString(key, null)
-
-    override fun writeValue(key: String, value: String) {
-        prefs.edit().putString(key, value).apply()
+    override fun readValue(key: String): String? {
+        val store = prefs ?: return memoryFallback[key]
+        return try {
+            store.getString(key, null)
+        } catch (e: GeneralSecurityException) {
+            // Keyset-level failure (broken master key / keyset — KeyStoreException is a subtype): every
+            // entry is now undecryptable, so piecemeal-dropping just this key would leave the rest
+            // throwing until some later write happens to rebuild. Rebuild the keyset here (fresh, empty
+            // store) so subsequent reads and writes work again — mirroring the write path. The tokens are
+            // unrecoverable either way; the user re-logs in.
+            Logger.e(e) { "Token read hit a broken keyset — rebuilding the encrypted store" }
+            rebuildStore()
+            null
+        } catch (e: SecurityException) {
+            // One entry's ciphertext won't decrypt while the keyset itself is intact (writes still
+            // succeed). Drop ONLY this entry so it stops throwing, and leave every other slot alone: a
+            // whole-store rebuild here would log every retained account out over a single bad value.
+            Logger.e(e) { "Token read failed to decrypt one entry — dropping it and returning empty" }
+            runCatching { store.edit().remove(key).apply() }
+            null
+        }
     }
 
-    override fun writeValues(values: Map<String, String>) {
-        val editor = prefs.edit()
-        values.forEach { (key, value) -> editor.putString(key, value) }
-        editor.apply()
-    }
+    override fun writeValue(key: String, value: String) =
+        write(toMemory = { memoryFallback[key] = value }) { editor -> editor.putString(key, value) }
 
-    override fun removeValue(key: String) {
-        prefs.edit().remove(key).apply()
-    }
+    override fun writeValues(values: Map<String, String>) =
+        write(toMemory = { memoryFallback.putAll(values) }) { editor ->
+            values.forEach { (key, value) -> editor.putString(key, value) }
+        }
+
+    override fun removeValue(key: String) =
+        write(toMemory = { memoryFallback.remove(key) }) { editor -> editor.remove(key) }
 
     override fun onKeystoreCorruption() {
-        // The encrypted store is unreadable; wipe it wholesale so a fresh master key can back new writes.
-        prefs.edit().clear().apply()
+        // Called by the base refresh path when a keystore exception escaped a POST. The keyset is
+        // unusable, so rebuild it (fresh master key + keyset) rather than clear entries against a
+        // broken key; per-slot cleanup is the caller's job (invalidateRefresh). A rebuild that can't
+        // produce a working store leaves [prefs] null (memory mode) — either way, best-effort and
+        // never re-throwing.
+        rebuildStore()
+        memoryFallback.clear()
     }
 
+    // The base classifies the refresh POST path with this narrow predicate (KeyStoreException only) on
+    // purpose: a bare SecurityException escaping a POST can be a TLS fault that must NOT be treated as
+    // a keystore logout. Storage ops use the broader [isCorruption] instead, and recover in place, so
+    // decrypt/encrypt failures never reach this classifier.
     override fun isKeystoreException(e: Exception): Boolean = e is KeyStoreException
+
+    /**
+     * Apply an editor mutation, recovering from a corrupt keystore instead of crashing. An escaping
+     * keystore throw matters because `setTokens`/`commitRefresh` run inside `safeApiCall`, which only
+     * catches network/serialization types — the throw would otherwise reach the ViewModel scope. An
+     * encrypt failure means the shared value key is unusable, so rebuild the store once (fresh keyset)
+     * and retry; if the rebuild can't produce a working store, switch to [memoryFallback] for the rest
+     * of the process. Either way the write lands somewhere — durable or in memory — so a caller like
+     * `commitRefresh` never reports a persisted token it silently dropped. Non-keystore exceptions are
+     * real bugs and re-thrown.
+     */
+    private inline fun write(toMemory: () -> Unit, mutate: (SharedPreferences.Editor) -> Unit) {
+        val store = prefs
+        if (store == null) {
+            toMemory()
+            return
+        }
+        try {
+            store.edit().also(mutate).apply()
+        } catch (e: Exception) {
+            if (!isCorruption(e)) throw e
+            Logger.e(e) { "Token write failed on a corrupt keystore — rebuilding the encrypted store" }
+            val rebuilt = rebuildStore()
+            if (rebuilt == null) {
+                toMemory()
+                return
+            }
+            try {
+                rebuilt.edit().also(mutate).apply()
+            } catch (retry: Exception) {
+                if (!isCorruption(retry)) throw retry
+                Logger.e(retry) { "Token write still failing after rebuild — using in-memory fallback" }
+                prefs = null
+                toMemory()
+            }
+        }
+    }
+
+    // EncryptedSharedPreferences throws SecurityException ("Could not decrypt value…") on a bad entry
+    // and GeneralSecurityException / KeyStoreException (a subtype) on a broken keyset.
+    private fun isCorruption(e: Exception): Boolean = e is SecurityException || e is GeneralSecurityException
+
+    /** Wipe the corrupt keystore state and recreate the store, publishing the result to [prefs]. */
+    private fun rebuildStore(): SharedPreferences? = createEncryptedPrefsWithRecovery().also { prefs = it }
+
+    private fun createEncryptedPrefsWithRecovery(): SharedPreferences? = createWithRecovery(
+        create = { createEncryptedPrefs(appContext) },
+        wipe = { wipeEncryptedPrefs(appContext) },
+    )
+
+    private fun createEncryptedPrefs(context: Context): SharedPreferences {
+        val masterKey = MasterKey.Builder(context)
+            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+            .build()
+        return EncryptedSharedPreferences.create(
+            context,
+            PREFS_NAME,
+            masterKey,
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
+        )
+    }
+
+    private fun wipeEncryptedPrefs(context: Context) {
+        // security-crypto keeps the Tink keysets INSIDE this same prefs file, so deleting it drops the
+        // corrupt keysets along with the data. Also delete the master key entry so a corrupt /
+        // inaccessible master key is regenerated on the retry. Best-effort on the keystore step — the
+        // prefs deletion has already happened, so the retry can still succeed even if this throws.
+        context.deleteSharedPreferences(PREFS_NAME)
+        try {
+            val keyStore = KeyStore.getInstance(ANDROID_KEYSTORE)
+            keyStore.load(null)
+            keyStore.deleteEntry(MasterKey.DEFAULT_MASTER_KEY_ALIAS)
+        } catch (e: Exception) {
+            Logger.e(e) { "Failed to delete master key entry during token store recovery" }
+        }
+    }
 
     companion object {
         private const val PREFS_NAME = "librechat_tokens"
+        private const val ANDROID_KEYSTORE = "AndroidKeyStore"
     }
 }

--- a/core/data/src/androidMain/kotlin/com/garfiec/librechat/core/data/di/DataPlatformModule.android.kt
+++ b/core/data/src/androidMain/kotlin/com/garfiec/librechat/core/data/di/DataPlatformModule.android.kt
@@ -24,6 +24,7 @@ import org.koin.dsl.module
 
 private val Context.settingsDataStore: DataStore<Preferences> by preferencesDataStore(
     name = DATASTORE_FILE_NAME,
+    corruptionHandler = settingsCorruptionHandler(),
 )
 
 actual val dataPlatformModule: Module = module {

--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/datastore/DataStoreCorruptionRecoveryTest.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/datastore/DataStoreCorruptionRecoveryTest.kt
@@ -1,0 +1,47 @@
+package com.garfiec.librechat.core.data.datastore
+
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import com.garfiec.librechat.core.data.di.settingsCorruptionHandler
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+/**
+ * Locks the shared [settingsCorruptionHandler] wired into both platform DI modules
+ * (`DataPlatformModule.android.kt` / `.ios.kt`): a corrupt settings file must heal to empty
+ * preferences instead of throwing `CorruptionException` on every read forever.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class DataStoreCorruptionRecoveryTest {
+
+    @get:Rule
+    val tmpFolder = TemporaryFolder()
+
+    private val key = stringPreferencesKey("k")
+
+    @Test
+    fun corruptFile_healsToEmpty_thenRoundTrips() = runTest {
+        val file = File(tmpFolder.root, "corrupt.preferences_pb")
+        // Non-empty garbage: the preferences serializer fails to parse it as a protobuf and raises
+        // CorruptionException (an empty file, by contrast, is a valid empty store — not corrupt).
+        file.writeBytes("not a valid preferences proto".encodeToByteArray())
+
+        val store = PreferenceDataStoreFactory.create(
+            corruptionHandler = settingsCorruptionHandler(),
+        ) { file }
+
+        // Without the handler this first read throws; instead it heals the file to empty prefs.
+        assertThat(store.data.first()[key]).isNull()
+
+        // And the healed store is fully writable + readable afterwards.
+        store.edit { it[key] = "value" }
+        assertThat(store.data.first()[key]).isEqualTo("value")
+    }
+}

--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/datastore/EncryptedPrefsRecoveryTest.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/datastore/EncryptedPrefsRecoveryTest.kt
@@ -1,0 +1,59 @@
+package com.garfiec.librechat.core.data.datastore
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import java.security.GeneralSecurityException
+
+class EncryptedPrefsRecoveryTest {
+
+    @Test
+    fun success_passesThrough_withoutWiping() {
+        var wipeCount = 0
+        val result = createWithRecovery(create = { "ok" }, wipe = { wipeCount++ })
+        assertThat(result).isEqualTo("ok")
+        assertThat(wipeCount).isEqualTo(0)
+    }
+
+    @Test
+    fun firstAttemptThrows_wipesThenReturnsRetryValue() {
+        var attempts = 0
+        var wipeCount = 0
+        val result = createWithRecovery(
+            create = {
+                attempts++
+                if (attempts == 1) throw GeneralSecurityException("boom") else "recovered"
+            },
+            wipe = { wipeCount++ },
+        )
+        assertThat(result).isEqualTo("recovered")
+        assertThat(attempts).isEqualTo(2)
+        assertThat(wipeCount).isEqualTo(1)
+    }
+
+    @Test
+    fun bothAttemptsThrow_returnsNull_afterExactlyOneWipe() {
+        var attempts = 0
+        var wipeCount = 0
+        val result = createWithRecovery<String>(
+            create = { attempts++; throw SecurityException("still broken") },
+            wipe = { wipeCount++ },
+        )
+        assertThat(result).isNull()
+        assertThat(attempts).isEqualTo(2)
+        assertThat(wipeCount).isEqualTo(1)
+    }
+
+    @Test
+    fun wipeItselfThrowing_doesNotMaskRetry() {
+        var attempts = 0
+        val result = createWithRecovery(
+            create = {
+                attempts++
+                if (attempts == 1) throw SecurityException("boom") else "recovered"
+            },
+            wipe = { throw IllegalStateException("wipe failed") },
+        )
+        assertThat(result).isEqualTo("recovered")
+        assertThat(attempts).isEqualTo(2)
+    }
+}

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/di/DataStorePath.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/di/DataStorePath.kt
@@ -1,6 +1,25 @@
 package com.garfiec.librechat.core.data.di
 
+import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.emptyPreferences
+import co.touchlab.kermit.Logger
+
 /**
  * The base name used for the DataStore preferences file on all platforms.
  */
 internal const val DATASTORE_FILE_NAME = "librechat_settings"
+
+/**
+ * Shared corruption handler for the settings DataStore. A corrupt preferences file (interrupted write,
+ * backup-restore) would otherwise throw `CorruptionException` on every read/edit forever — permanently
+ * bricking a startup that reads it eagerly. Heal by replacing with empty prefs: the user re-onboards /
+ * re-logs in (nothing recoverable is lost; a corrupt file is unreadable anyway; on iOS the server URL
+ * restores from the keychain fallback in `ServerDataStore`). One definition so both platforms' DI
+ * modules can't drift apart.
+ */
+internal fun settingsCorruptionHandler(): ReplaceFileCorruptionHandler<Preferences> =
+    ReplaceFileCorruptionHandler { e ->
+        Logger.e(e) { "Settings DataStore corrupted — replacing with empty preferences" }
+        emptyPreferences()
+    }

--- a/core/data/src/iosMain/kotlin/com/garfiec/librechat/core/data/di/DataPlatformModule.ios.kt
+++ b/core/data/src/iosMain/kotlin/com/garfiec/librechat/core/data/di/DataPlatformModule.ios.kt
@@ -55,6 +55,7 @@ actual val dataPlatformModule: Module = module {
         ensureDirectoryExists(datastoreDir)
         val path = "$datastoreDir/$DATASTORE_FILE_NAME.preferences_pb"
         PreferenceDataStoreFactory.createWithPath(
+            corruptionHandler = settingsCorruptionHandler(),
             produceFile = { path.toPath() },
         )
     }


### PR DESCRIPTION
## Summary

The eager `AccountRegistry` singleton constructs the token store inside
`startKoin`, so a corrupt Android keystore/keyset or a corrupt settings DataStore
file turned app launch into an unrecoverable crash loop — only clearing app data
recovered it. This makes both stores heal in place instead of crashing: a corrupt
settings file resets to empty (logged-out, re-onboard), and a corrupt token store
recovers its keyset or, worst case, degrades to a working in-memory session for
the process.

## Changes

- **Settings DataStore (both platforms):** a shared `ReplaceFileCorruptionHandler`
  (`settingsCorruptionHandler`, commonMain) heals a corrupt preferences file to
  empty prefs, so it stops throwing `CorruptionException` on every read. Wired
  into the Android and iOS DI modules.
- **Token-store construction (Android):** routed through a `createWithRecovery`
  seam — on a keystore/keyset failure it wipes the corrupt state (prefs file +
  master key), retries once, and if that still fails falls back to a session-only
  in-memory store rather than throwing into `startKoin`.
- **Runtime token storage ops (Android):** recover in place. A read that hits one
  undecryptable entry drops only that entry (other retained accounts stay logged
  in); a read that hits a broken keyset rebuilds it. A write that can't encrypt
  rebuilds the keyset and retries, or degrades to the in-memory fallback — so a
  refresh commit never reports a token it silently failed to persist. The
  refresh-path keystore hook (`onKeystoreCorruption`) likewise rebuilds the keyset
  rather than wiping every entry.
- iOS token storage is keychain-based and has no construction throw path, so it
  needs no change.

## Testing

- `:core:data:testDebugUnitTest`, `:core:data:detekt`, `:app:assembleDebug`, and
  the iOS framework link (`:shared:linkDebugFrameworkIosSimulatorArm64`) all pass.
- New unit tests cover the recovery seam (`EncryptedPrefsRecoveryTest`) and the
  DataStore corruption handler (`DataStoreCorruptionRecoveryTest`).
- On-device smoke test (corrupt the store on a debug install → app opens
  logged-out instead of crash-looping) is still pending.
