### PR TITLE
refactor(chat): split ChatUiState into slices with per-delegate write handles

### DIFF
--- a/feature/chat/CLAUDE.md
+++ b/feature/chat/CLAUDE.md
@@ -1,5 +1,31 @@
 # feature:chat
 
+## State Architecture (ChatUiState slices + narrowed handles)
+`ChatUiState` is decomposed into **16 `@Immutable` sub-state slices** (15 new files under
+`viewmodel/state/`, plus the pre-existing `comparisonState`), plus two top-level fields: `error`
+(a shared transient-banner channel) and `mediaPreview`. The slices: `conversation`, `content`
+(message tree + all streaming fields),
+`editing`, `composer`, `selection` (endpoint/model/tools/params), `queue`, `search`,
+`presetPrompts`, `voice`, `favorites`, `subagents`, `comparisonState`, `gates`, `account`,
+`actions`, `prefs`.
+
+- **Compat accessors.** `ChatUiState` keeps flat `val field get() = slice.field` accessors for
+  every former field, so the ~250 UI read sites and test assertions read `uiState.isStreaming`
+  etc. unchanged. UI still reads flat; only writes changed.
+- **Narrowed write handles.** Delegates never receive the root `ChatStateHandle`. Each gets a
+  per-delegate handle from `DelegateHandles.kt` (e.g. `StreamingHandle`, `QueueHandle`) whose
+  `update { … }` block exposes only the slices that delegate may mutate (compile-time enforced
+  via a `*Writes` class). `error` is writable from every handle (shared channel); use
+  `setError(msg)` or assign `error` inside an `update`. Reads stay global via `handle.state`.
+  `ChatViewModel` alone holds the root `ChatStateHandle` for its orchestration transactions.
+- **Atomic-transaction invariant.** The completion-flash finalize, begin-stream, reset-with-
+  carryover, `applyComposer`, and `switchBranch` each write within a single slice (or a single
+  writer block), so they remain **one** `StateFlow` emission — do not split them across multiple
+  `update`/`copy` calls. Message-tree + streaming fields deliberately live in ONE slice
+  (`MessagesState`) because all five couple them.
+- Adding a field: put it on the owning slice, add a flat compat accessor on `ChatUiState`, and
+  add the slice to the writer of whichever delegate(s) own it.
+
 ## Screen States
 `ChatScreenState` enum: `LANDING` | `LOADING` | `ACTIVE`
 - **Landing**: no conversation selected, shows greeting + model icon + optional conversation starters

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/AndroidDelegateFactory.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/AndroidDelegateFactory.kt
@@ -4,7 +4,9 @@ import android.content.Context
 import com.garfiec.librechat.core.data.datastore.SettingsDataStore
 import com.garfiec.librechat.core.data.repository.FileRepository
 import com.garfiec.librechat.core.data.repository.SpeechRepository
-import com.garfiec.librechat.feature.chat.viewmodel.ChatStateHandle
+import com.garfiec.librechat.feature.chat.viewmodel.ErrorOnlyHandle
+import com.garfiec.librechat.feature.chat.viewmodel.TtsHandle
+import com.garfiec.librechat.feature.chat.viewmodel.VoiceHandle
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.stateIn
@@ -17,10 +19,10 @@ class AndroidDelegateFactory(
     private val ioDispatcher: CoroutineDispatcher,
 ) : PlatformDelegateFactory {
 
-    override fun createFileHandler(stateHandle: ChatStateHandle): PlatformFileHandler {
+    override fun createFileHandler(handle: ErrorOnlyHandle): PlatformFileHandler {
         return AndroidFileHandler(
             FileAttachmentDelegate(
-                stateHandle = stateHandle,
+                handle = handle,
                 appContext = appContext,
                 fileRepository = fileRepository,
                 ioDispatcher = ioDispatcher,
@@ -29,16 +31,16 @@ class AndroidDelegateFactory(
     }
 
     override fun createVoiceInput(
-        stateHandle: ChatStateHandle,
+        handle: VoiceHandle,
         onTranscriptionComplete: () -> Unit,
     ): PlatformVoiceInput {
         return AndroidVoiceInput(
             VoiceInputDelegate(
-                stateHandle = stateHandle,
+                handle = handle,
                 appContext = appContext,
                 speechRepository = speechRepository,
                 autoSendAfterStt = settingsDataStore.autoSendAfterStt
-                    .stateIn(stateHandle.scope, SharingStarted.Eagerly, false),
+                    .stateIn(handle.scope, SharingStarted.Eagerly, false),
                 ioDispatcher = ioDispatcher,
                 onTranscriptionComplete = onTranscriptionComplete,
             ),
@@ -46,12 +48,12 @@ class AndroidDelegateFactory(
     }
 
     override fun createTts(
-        stateHandle: ChatStateHandle,
+        handle: TtsHandle,
         getMessageText: (String) -> String,
     ): PlatformTts {
         return AndroidTts(
             TextToSpeechDelegate(
-                stateHandle = stateHandle,
+                handle = handle,
                 appContext = appContext,
                 speechRepository = speechRepository,
                 settingsDataStore = settingsDataStore,

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/FileAttachmentDelegate.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/FileAttachmentDelegate.kt
@@ -13,7 +13,7 @@ import com.garfiec.librechat.feature.chat.util.fixFilenameExtension
 import com.garfiec.librechat.feature.chat.util.guessMimeType
 import com.garfiec.librechat.feature.chat.util.reEncodeImageIfNeeded
 import com.garfiec.librechat.feature.chat.util.resolveFileName
-import com.garfiec.librechat.feature.chat.viewmodel.ChatStateHandle
+import com.garfiec.librechat.feature.chat.viewmodel.ErrorOnlyHandle
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Job
@@ -26,7 +26,7 @@ import kotlinx.coroutines.launch
 import java.util.UUID
 
 class FileAttachmentDelegate(
-    private val stateHandle: ChatStateHandle,
+    private val handle: ErrorOnlyHandle,
     private val appContext: Context,
     private val fileRepository: FileRepository,
     private val ioDispatcher: CoroutineDispatcher,
@@ -69,14 +69,14 @@ class FileAttachmentDelegate(
 
         _attachedFiles.update { currentList -> currentList + pendingFile }
 
-        stateHandle.scope.launch(ioDispatcher) {
+        handle.scope.launch(ioDispatcher) {
             try {
                 // Read file bytes
                 val bytes = contentResolver.openInputStream(uri)?.use { it.readBytes() }
                 if (bytes == null) {
                     Logger.e { "uploadFile: could not read bytes from URI: $uri" }
                     markUploadFailed(uri)
-                    stateHandle.update { copy(error = "Failed to upload $filename: Could not read file") }
+                    handle.setError("Failed to upload $filename: Could not read file")
                     return@launch
                 }
 
@@ -155,7 +155,7 @@ class FileAttachmentDelegate(
                 val fileId = UUID.randomUUID().toString()
 
                 // Upload to server with context about current endpoint/model
-                val state = stateHandle.state
+                val state = handle.state
                 val isAgent = state.selectedEndpoint == EndpointConstants.AGENTS
                 Logger.d { "uploadFile: sending to server -- fileId=$fileId, endpoint=${state.selectedEndpoint}, model=${state.selectedModel}, isAgent=$isAgent, mimeType=$mimeType, filename=$uploadFilename" }
                 val result = fileRepository.uploadFile(
@@ -206,9 +206,7 @@ class FileAttachmentDelegate(
                                 }
                             }
                         }
-                        stateHandle.update {
-                            copy(error = "Failed to upload $filename: ${result.message ?: "Unknown error"}")
-                        }
+                        handle.setError("Failed to upload $filename: ${result.message ?: "Unknown error"}")
                     }
                     is Result.Loading -> {
                         Logger.w { "uploadFile: unexpected Result.Loading received for $filename" }
@@ -221,7 +219,7 @@ class FileAttachmentDelegate(
             } catch (e: Exception) {
                 Logger.e(e) { "uploadFile: unexpected exception for $filename" }
                 markUploadFailed(uri)
-                stateHandle.update { copy(error = "Failed to upload $filename: ${e.message}") }
+                handle.setError("Failed to upload $filename: ${e.message}")
             }
         }
     }

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/TextToSpeechDelegate.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/TextToSpeechDelegate.kt
@@ -8,7 +8,7 @@ import android.speech.tts.UtteranceProgressListener
 import com.garfiec.librechat.core.common.result.Result
 import com.garfiec.librechat.core.data.datastore.SettingsDataStore
 import com.garfiec.librechat.core.data.repository.SpeechRepository
-import com.garfiec.librechat.feature.chat.viewmodel.ChatStateHandle
+import com.garfiec.librechat.feature.chat.viewmodel.TtsHandle
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.first
@@ -17,7 +17,7 @@ import kotlinx.coroutines.withContext
 import java.io.File
 
 class TextToSpeechDelegate(
-    private val stateHandle: ChatStateHandle,
+    private val handle: TtsHandle,
     private val appContext: Context,
     private val speechRepository: SpeechRepository,
     private val settingsDataStore: SettingsDataStore,
@@ -41,26 +41,22 @@ class TextToSpeechDelegate(
                 ttsEngine?.setOnUtteranceProgressListener(object : UtteranceProgressListener() {
                     override fun onStart(utteranceId: String?) = Unit
                     override fun onDone(utteranceId: String?) {
-                        stateHandle.update { copy(currentlyReadingMessageId = null) }
+                        handle.update { voice = voice.copy(currentlyReadingMessageId = null) }
                     }
 
                     @Deprecated("Deprecated in Java")
                     override fun onError(utteranceId: String?) {
-                        stateHandle.update {
-                            copy(
-                                currentlyReadingMessageId = null,
-                                error = "Text-to-speech playback error",
-                            )
+                        handle.update {
+                            voice = voice.copy(currentlyReadingMessageId = null)
+                            error = "Text-to-speech playback error"
                         }
                     }
                 })
                 onReady()
             } else {
-                stateHandle.update {
-                    copy(
-                        currentlyReadingMessageId = null,
-                        error = "Text-to-speech engine not available on this device",
-                    )
+                handle.update {
+                    voice = voice.copy(currentlyReadingMessageId = null)
+                    error = "Text-to-speech engine not available on this device"
                 }
             }
         }
@@ -68,7 +64,7 @@ class TextToSpeechDelegate(
 
     fun readAloud(messageId: String) {
         // If already reading this message, stop
-        if (stateHandle.state.currentlyReadingMessageId == messageId) {
+        if (handle.state.currentlyReadingMessageId == messageId) {
             stopReading()
             return
         }
@@ -79,9 +75,9 @@ class TextToSpeechDelegate(
         val text = getMessageText(messageId)
         if (text.isBlank()) return
 
-        stateHandle.update { copy(currentlyReadingMessageId = messageId) }
+        handle.update { voice = voice.copy(currentlyReadingMessageId = messageId) }
 
-        stateHandle.scope.launch {
+        handle.scope.launch {
             val source = settingsDataStore.ttsSource.first()
             if (source == "server") {
                 readAloudViaServer(text)
@@ -134,21 +130,19 @@ class TextToSpeechDelegate(
                             // delete are blocking, so hand them to ioDispatcher.
                             setOnCompletionListener { mp ->
                                 serverTtsPlayer = null
-                                stateHandle.update { copy(currentlyReadingMessageId = null) }
-                                stateHandle.scope.launch(ioDispatcher) {
+                                handle.update { voice = voice.copy(currentlyReadingMessageId = null) }
+                                handle.scope.launch(ioDispatcher) {
                                     mp.release()
                                     tempFile.delete()
                                 }
                             }
                             setOnErrorListener { mp, _, _ ->
                                 serverTtsPlayer = null
-                                stateHandle.update {
-                                    copy(
-                                        currentlyReadingMessageId = null,
-                                        error = "Server TTS playback failed",
-                                    )
+                                handle.update {
+                                    voice = voice.copy(currentlyReadingMessageId = null)
+                                    error = "Server TTS playback failed"
                                 }
-                                stateHandle.scope.launch(ioDispatcher) {
+                                handle.scope.launch(ioDispatcher) {
                                     mp.release()
                                     tempFile.delete()
                                 }
@@ -161,20 +155,16 @@ class TextToSpeechDelegate(
                 } catch (e: CancellationException) {
                     throw e
                 } catch (e: Exception) {
-                    stateHandle.update {
-                        copy(
-                            currentlyReadingMessageId = null,
-                            error = "Server TTS playback failed: ${e.message}",
-                        )
+                    handle.update {
+                        voice = voice.copy(currentlyReadingMessageId = null)
+                        error = "Server TTS playback failed: ${e.message}"
                     }
                 }
             }
             is Result.Error -> {
-                stateHandle.update {
-                    copy(
-                        currentlyReadingMessageId = null,
-                        error = result.message ?: "Server TTS request failed",
-                    )
+                handle.update {
+                    voice = voice.copy(currentlyReadingMessageId = null)
+                    error = result.message ?: "Server TTS request failed"
                 }
             }
             is Result.Loading -> { /* no-op */ }
@@ -188,7 +178,7 @@ class TextToSpeechDelegate(
             it.release()
         }
         serverTtsPlayer = null
-        stateHandle.update { copy(currentlyReadingMessageId = null) }
+        handle.update { voice = voice.copy(currentlyReadingMessageId = null) }
     }
 
     /**
@@ -201,14 +191,14 @@ class TextToSpeechDelegate(
      */
     fun maybeAutoReadResponse(responseText: String) {
         // Don't auto-read if the user has already started typing
-        if (stateHandle.state.inputText.isNotBlank()) return
+        if (handle.state.inputText.isNotBlank()) return
 
-        stateHandle.scope.launch {
+        handle.scope.launch {
             val autoRead = settingsDataStore.autoReadEnabled.first()
             if (!autoRead) return@launch
 
             val syntheticId = "auto_read_${System.currentTimeMillis()}"
-            stateHandle.update { copy(currentlyReadingMessageId = syntheticId) }
+            handle.update { voice = voice.copy(currentlyReadingMessageId = syntheticId) }
 
             val source = settingsDataStore.ttsSource.first()
             if (source == "server") {

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/VoiceInputDelegate.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/VoiceInputDelegate.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import com.garfiec.librechat.core.common.result.Result
 import com.garfiec.librechat.core.data.repository.SpeechRepository
 import com.garfiec.librechat.feature.chat.audio.VoiceRecorder
-import com.garfiec.librechat.feature.chat.viewmodel.ChatStateHandle
+import com.garfiec.librechat.feature.chat.viewmodel.VoiceHandle
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
@@ -13,7 +13,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 
 class VoiceInputDelegate(
-    private val stateHandle: ChatStateHandle,
+    private val handle: VoiceHandle,
     private val appContext: Context,
     private val speechRepository: SpeechRepository,
     private val autoSendAfterStt: StateFlow<Boolean>,
@@ -28,13 +28,13 @@ class VoiceInputDelegate(
     private var startJob: Job? = null
 
     fun startRecording() {
-        if (stateHandle.state.isRecording) return
+        if (handle.state.isRecording) return
         // Set state + assign the recorder synchronously on Main so the isRecording guard above
         // and stopRecording()/cancelRecording() see a consistent recorder during start()'s warm-up.
         val recorder = VoiceRecorder(appContext, ioDispatcher)
         voiceRecorder = recorder
-        stateHandle.update { copy(isRecording = true) }
-        startJob = stateHandle.scope.launch {
+        handle.update { voice = voice.copy(isRecording = true) }
+        startJob = handle.scope.launch {
             try {
                 recorder.start()
             } catch (e: CancellationException) {
@@ -42,8 +42,9 @@ class VoiceInputDelegate(
             } catch (e: Exception) {
                 if (voiceRecorder === recorder) {
                     voiceRecorder = null
-                    stateHandle.update {
-                        copy(isRecording = false, error = "Could not start recording: ${e.message}")
+                    handle.update {
+                        voice = voice.copy(isRecording = false)
+                        error = "Could not start recording: ${e.message}"
                     }
                 }
             }
@@ -54,39 +55,38 @@ class VoiceInputDelegate(
         val recorder = voiceRecorder ?: return
         val mimeType = recorder.mimeType
         voiceRecorder = null
-        stateHandle.update { copy(isRecording = false, isTranscribing = true) }
+        handle.update { voice = voice.copy(isRecording = false, isTranscribing = true) }
 
-        stateHandle.scope.launch {
+        handle.scope.launch {
             // Ensure start() finished before we stop the recorder.
             startJob?.join()
             val audioData = recorder.stop()
             if (audioData == null || audioData.isEmpty()) {
-                stateHandle.update { copy(isTranscribing = false, error = "Recording was empty") }
+                handle.update {
+                    voice = voice.copy(isTranscribing = false)
+                    error = "Recording was empty"
+                }
                 return@launch
             }
 
             when (val result = speechRepository.transcribeAudio(audioData, mimeType)) {
                 is Result.Success -> {
                     val transcribedText = result.data.text
-                    val currentInput = stateHandle.state.inputText
+                    val currentInput = handle.state.inputText
                     val separator = if (currentInput.isNotBlank() && !currentInput.endsWith(" ")) " " else ""
-                    stateHandle.update {
-                        copy(
-                            inputText = currentInput + separator + transcribedText,
-                            isTranscribing = false,
-                        )
+                    handle.update {
+                        composer = composer.copy(inputText = currentInput + separator + transcribedText)
+                        voice = voice.copy(isTranscribing = false)
                     }
                     // Auto-send if enabled and transcribed text is non-empty and not already streaming
-                    if (autoSendAfterStt.value && transcribedText.isNotBlank() && !stateHandle.state.isStreaming) {
+                    if (autoSendAfterStt.value && transcribedText.isNotBlank() && !handle.state.isStreaming) {
                         onTranscriptionComplete()
                     }
                 }
                 is Result.Error -> {
-                    stateHandle.update {
-                        copy(
-                            isTranscribing = false,
-                            error = result.message ?: "Transcription failed",
-                        )
+                    handle.update {
+                        voice = voice.copy(isTranscribing = false)
+                        error = result.message ?: "Transcription failed"
                     }
                 }
                 is Result.Loading -> { /* no-op */ }
@@ -97,10 +97,10 @@ class VoiceInputDelegate(
     fun cancelRecording() {
         val recorder = voiceRecorder ?: return
         voiceRecorder = null
-        stateHandle.update { copy(isRecording = false) }
+        handle.update { voice = voice.copy(isRecording = false) }
         // Join start() first so cancel() can't race the in-flight warm-up; cancel() then runs
         // MediaRecorder.stop()/release() off the Main thread.
-        stateHandle.scope.launch {
+        handle.scope.launch {
             startJob?.join()
             recorder.cancel()
         }
@@ -112,26 +112,26 @@ class VoiceInputDelegate(
      */
     fun onDeviceSpeechResult(transcribedText: String) {
         if (transcribedText.isBlank()) return
-        val currentInput = stateHandle.state.inputText
+        val currentInput = handle.state.inputText
         val separator = if (currentInput.isNotBlank() && !currentInput.endsWith(" ")) " " else ""
-        stateHandle.update {
-            copy(inputText = currentInput + separator + transcribedText)
+        handle.update {
+            composer = composer.copy(inputText = currentInput + separator + transcribedText)
         }
         // Auto-send if enabled and not already streaming
-        if (autoSendAfterStt.value && !stateHandle.state.isStreaming) {
+        if (autoSendAfterStt.value && !handle.state.isStreaming) {
             onTranscriptionComplete()
         }
     }
 
     fun loadSpeechConfig() {
-        stateHandle.scope.launch {
+        handle.scope.launch {
             when (val result = speechRepository.getSpeechConfig()) {
                 is Result.Success -> {
-                    stateHandle.update { copy(serverSttEnabled = result.data.sttExternal) }
+                    handle.update { voice = voice.copy(serverSttEnabled = result.data.sttExternal) }
                 }
                 is Result.Error -> {
                     // If we can't fetch the config, assume server STT is not available
-                    stateHandle.update { copy(serverSttEnabled = false) }
+                    handle.update { voice = voice.copy(serverSttEnabled = false) }
                 }
                 is Result.Loading -> { /* no-op */ }
             }
@@ -141,7 +141,7 @@ class VoiceInputDelegate(
     fun release() {
         val recorder = voiceRecorder ?: return
         voiceRecorder = null
-        // Called from onCleared(), at which point stateHandle.scope is already cancelled — a
+        // Called from onCleared(), at which point handle.scope is already cancelled — a
         // launch on it would never run and the recorder/mic would leak. Run the cleanup on a
         // detached IO scope so the blocking MediaRecorder.stop()/release() still happens off the
         // Main thread and is guaranteed to complete (cancel() uses NonCancellable internally).

--- a/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatUiStateSendReadyTest.kt
+++ b/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatUiStateSendReadyTest.kt
@@ -19,10 +19,12 @@ class ChatUiStateSendReadyTest {
     @Test
     fun `not ready when availableModels is empty`() {
         val state = ChatUiState(
-            selectedEndpoint = anthropic,
-            selectedModel = haiku,
-            agentsEnabled = true,
-            availableModels = emptyMap(),
+            selection = ModelSelectionState(
+                selectedEndpoint = anthropic,
+                selectedModel = haiku,
+                availableModels = emptyMap(),
+            ),
+            gates = FeatureGatesState(agentsEnabled = true),
         )
         assertThat(state.isSendReady).isFalse()
     }
@@ -30,10 +32,12 @@ class ChatUiStateSendReadyTest {
     @Test
     fun `ready when non-agents endpoint selected and models available`() {
         val state = ChatUiState(
-            selectedEndpoint = anthropic,
-            selectedModel = haiku,
-            agentsEnabled = true,
-            availableModels = mapOf(anthropic to listOf(haiku)),
+            selection = ModelSelectionState(
+                selectedEndpoint = anthropic,
+                selectedModel = haiku,
+                availableModels = mapOf(anthropic to listOf(haiku)),
+            ),
+            gates = FeatureGatesState(agentsEnabled = true),
         )
         assertThat(state.isSendReady).isTrue()
     }
@@ -44,9 +48,11 @@ class ChatUiStateSendReadyTest {
         // selection, but role has loaded and denied AGENTS.USE. A send right now
         // would hit /api/agents/chat/agents and 403.
         val state = ChatUiState(
-            selectedEndpoint = EndpointConstants.AGENTS,
-            agentsEnabled = false,
-            availableModels = mapOf(anthropic to listOf(haiku)),
+            selection = ModelSelectionState(
+                selectedEndpoint = EndpointConstants.AGENTS,
+                availableModels = mapOf(anthropic to listOf(haiku)),
+            ),
+            gates = FeatureGatesState(agentsEnabled = false),
         )
         assertThat(state.isSendReady).isFalse()
     }
@@ -54,12 +60,14 @@ class ChatUiStateSendReadyTest {
     @Test
     fun `ready when agents endpoint selected and AGENTS USE granted`() {
         val state = ChatUiState(
-            selectedEndpoint = EndpointConstants.AGENTS,
-            agentsEnabled = true,
-            availableModels = mapOf(
-                EndpointConstants.AGENTS to listOf("someAgentId"),
-                anthropic to listOf(haiku),
+            selection = ModelSelectionState(
+                selectedEndpoint = EndpointConstants.AGENTS,
+                availableModels = mapOf(
+                    EndpointConstants.AGENTS to listOf("someAgentId"),
+                    anthropic to listOf(haiku),
+                ),
             ),
+            gates = FeatureGatesState(agentsEnabled = true),
         )
         assertThat(state.isSendReady).isTrue()
     }
@@ -69,9 +77,11 @@ class ChatUiStateSendReadyTest {
         // Edge: server exposes only the agents endpoint in availableModels, role denies.
         // No viable send path — stays not-ready. runWhenSendReady will time out and toast.
         val state = ChatUiState(
-            selectedEndpoint = EndpointConstants.AGENTS,
-            agentsEnabled = false,
-            availableModels = mapOf(EndpointConstants.AGENTS to listOf("someAgentId")),
+            selection = ModelSelectionState(
+                selectedEndpoint = EndpointConstants.AGENTS,
+                availableModels = mapOf(EndpointConstants.AGENTS to listOf("someAgentId")),
+            ),
+            gates = FeatureGatesState(agentsEnabled = false),
         )
         assertThat(state.isSendReady).isFalse()
     }
@@ -82,13 +92,15 @@ class ChatUiStateSendReadyTest {
         // endpoint isn't a known-denied one. An empty model list on the current endpoint
         // is the user's concern (pick a model), not the race guard's.
         val state = ChatUiState(
-            selectedEndpoint = anthropic,
-            selectedModel = null,
-            agentsEnabled = true,
-            availableModels = mapOf(
-                EndpointConstants.AGENTS to listOf("someAgentId"),
-                anthropic to emptyList(),
+            selection = ModelSelectionState(
+                selectedEndpoint = anthropic,
+                selectedModel = null,
+                availableModels = mapOf(
+                    EndpointConstants.AGENTS to listOf("someAgentId"),
+                    anthropic to emptyList(),
+                ),
             ),
+            gates = FeatureGatesState(agentsEnabled = true),
         )
         assertThat(state.isSendReady).isTrue()
     }

--- a/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/ComparisonModeDelegateTest.kt
+++ b/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/ComparisonModeDelegateTest.kt
@@ -6,7 +6,9 @@ import com.garfiec.librechat.core.model.Message
 import com.garfiec.librechat.core.model.content.MessageContentPart
 import com.garfiec.librechat.feature.chat.viewmodel.ChatScreenState
 import com.garfiec.librechat.feature.chat.viewmodel.ChatStateHandle
+import com.garfiec.librechat.feature.chat.viewmodel.ComparisonHandle
 import com.garfiec.librechat.feature.chat.viewmodel.ChatUiState
+import com.garfiec.librechat.feature.chat.viewmodel.MessagesState
 import com.google.common.truth.Truth.assertThat
 import io.mockk.mockk
 import kotlinx.coroutines.CoroutineScope
@@ -20,7 +22,7 @@ class ComparisonModeDelegateTest {
         val flow = MutableStateFlow(state)
         val handle = ChatStateHandle(flow, CoroutineScope(Dispatchers.Unconfined))
         val delegate = ComparisonModeDelegate(
-            stateHandle = handle,
+            handle = ComparisonHandle(handle),
             messageRepository = mockk<MessageRepository>(relaxed = true),
             reloadConversation = {},
         )
@@ -68,7 +70,7 @@ class ComparisonModeDelegateTest {
 
     @Test
     fun `rehydrate switches a landing screen to active`() {
-        val (delegate, flow) = delegateWith(ChatUiState(screenState = ChatScreenState.LANDING))
+        val (delegate, flow) = delegateWith(ChatUiState(content = MessagesState(screenState = ChatScreenState.LANDING)))
 
         delegate.rehydrateFromMessage(parallelMessage("agent_secondary____1"))
 

--- a/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/EndpointKeyStatusDelegateTest.kt
+++ b/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/EndpointKeyStatusDelegateTest.kt
@@ -7,6 +7,7 @@ import com.garfiec.librechat.core.model.endpoint.KeyInvalidation
 import com.garfiec.librechat.core.model.endpoint.KeyState
 import com.garfiec.librechat.core.model.endpoint.fromWire
 import com.garfiec.librechat.feature.chat.viewmodel.ChatStateHandle
+import com.garfiec.librechat.feature.chat.viewmodel.EndpointKeyHandle
 import com.garfiec.librechat.feature.chat.viewmodel.ChatUiState
 import com.google.common.truth.Truth.assertThat
 import io.mockk.coEvery
@@ -61,7 +62,7 @@ class EndpointKeyStatusDelegateTest {
     fun unsetWhenGetKeyExpiryReturnsNull() = runTest {
         val scope = TestScope(StandardTestDispatcher(testScheduler))
         val handle = newHandle(scope)
-        val delegate = EndpointKeyStatusDelegate(handle, keyRepository)
+        val delegate = EndpointKeyStatusDelegate(EndpointKeyHandle(handle), keyRepository)
         coEvery { keyRepository.fetchKeyState(any()) } returns Result.Success(KeyState.Unset)
 
         delegate.recomputeFor(mapOf("openAI" to EndpointConfig(userProvide = true)))
@@ -74,7 +75,7 @@ class EndpointKeyStatusDelegateTest {
     fun setWithFutureIsoTimestamp() = runTest {
         val scope = TestScope(StandardTestDispatcher(testScheduler))
         val handle = newHandle(scope)
-        val delegate = EndpointKeyStatusDelegate(handle, keyRepository)
+        val delegate = EndpointKeyStatusDelegate(EndpointKeyHandle(handle), keyRepository)
         val future = (Clock.System.now() + 1.days).toString()
         coEvery { keyRepository.fetchKeyState("openAI") } returns
             Result.Success(KeyState.fromWire(future, Clock.System.now()).state)
@@ -93,7 +94,7 @@ class EndpointKeyStatusDelegateTest {
     fun expiredWhenIsoTimestampInPast() = runTest {
         val scope = TestScope(StandardTestDispatcher(testScheduler))
         val handle = newHandle(scope)
-        val delegate = EndpointKeyStatusDelegate(handle, keyRepository)
+        val delegate = EndpointKeyStatusDelegate(EndpointKeyHandle(handle), keyRepository)
         val past = (Clock.System.now() - 1.days).toString()
         coEvery { keyRepository.fetchKeyState("openAI") } returns
             Result.Success(KeyState.fromWire(past, Clock.System.now()).state)
@@ -108,7 +109,7 @@ class EndpointKeyStatusDelegateTest {
     fun setNeverExpiresWhenWireValueIsNeverLiteral() = runTest {
         val scope = TestScope(StandardTestDispatcher(testScheduler))
         val handle = newHandle(scope)
-        val delegate = EndpointKeyStatusDelegate(handle, keyRepository)
+        val delegate = EndpointKeyStatusDelegate(EndpointKeyHandle(handle), keyRepository)
         coEvery { keyRepository.fetchKeyState("openAI") } returns
             Result.Success(KeyState.Set(expiresAt = null, neverExpires = true, wire = "never"))
 
@@ -126,7 +127,7 @@ class EndpointKeyStatusDelegateTest {
     fun userProvideUrlOnlyEndpointStillTrackedAsNeedsKey() = runTest {
         val scope = TestScope(StandardTestDispatcher(testScheduler))
         val handle = newHandle(scope)
-        val delegate = EndpointKeyStatusDelegate(handle, keyRepository)
+        val delegate = EndpointKeyStatusDelegate(EndpointKeyHandle(handle), keyRepository)
         coEvery { keyRepository.fetchKeyState(any()) } returns Result.Success(KeyState.Unset)
 
         delegate.recomputeFor(
@@ -141,7 +142,7 @@ class EndpointKeyStatusDelegateTest {
     fun builtInEndpointsAbsentFromResultMap() = runTest {
         val scope = TestScope(StandardTestDispatcher(testScheduler))
         val handle = newHandle(scope)
-        val delegate = EndpointKeyStatusDelegate(handle, keyRepository)
+        val delegate = EndpointKeyStatusDelegate(EndpointKeyHandle(handle), keyRepository)
         coEvery { keyRepository.fetchKeyState(any()) } returns Result.Success(KeyState.Unset)
 
         delegate.recomputeFor(
@@ -159,7 +160,7 @@ class EndpointKeyStatusDelegateTest {
     fun azureEndpointResolvesToAzureOpenAiKeyName() = runTest {
         val scope = TestScope(StandardTestDispatcher(testScheduler))
         val handle = newHandle(scope)
-        val delegate = EndpointKeyStatusDelegate(handle, keyRepository)
+        val delegate = EndpointKeyStatusDelegate(EndpointKeyHandle(handle), keyRepository)
         coEvery { keyRepository.fetchKeyState("azureOpenAI") } returns Result.Success(KeyState.Unset)
 
         delegate.recomputeFor(
@@ -175,7 +176,7 @@ class EndpointKeyStatusDelegateTest {
     fun networkErrorOnFirstLoadFallsBackToUnset() = runTest {
         val scope = TestScope(StandardTestDispatcher(testScheduler))
         val handle = newHandle(scope)
-        val delegate = EndpointKeyStatusDelegate(handle, keyRepository)
+        val delegate = EndpointKeyStatusDelegate(EndpointKeyHandle(handle), keyRepository)
         coEvery { keyRepository.fetchKeyState(any()) } returns
             Result.Error(RuntimeException("server unavailable"))
 
@@ -196,7 +197,7 @@ class EndpointKeyStatusDelegateTest {
         // last-known value rather than demoting it to Unset/CTA.
         val scope = TestScope(StandardTestDispatcher(testScheduler))
         val handle = newHandle(scope)
-        val delegate = EndpointKeyStatusDelegate(handle, keyRepository)
+        val delegate = EndpointKeyStatusDelegate(EndpointKeyHandle(handle), keyRepository)
 
         val future = (Clock.System.now() + 1.days).toString()
         val resolvedSet = KeyState.Set(
@@ -225,7 +226,7 @@ class EndpointKeyStatusDelegateTest {
     fun loadingStatePushedOptimisticallyBeforeFanOut() = runTest {
         val scope = TestScope(StandardTestDispatcher(testScheduler))
         val handle = newHandle(scope)
-        val delegate = EndpointKeyStatusDelegate(handle, keyRepository)
+        val delegate = EndpointKeyStatusDelegate(EndpointKeyHandle(handle), keyRepository)
 
         // Stub never returns until we explicitly advance the scheduler so we can
         // observe the optimistic Loading state mid-fan-out.
@@ -248,7 +249,7 @@ class EndpointKeyStatusDelegateTest {
     fun emptyConfigsClearsExistingStates() = runTest {
         val scope = TestScope(StandardTestDispatcher(testScheduler))
         val handle = newHandle(scope)
-        val delegate = EndpointKeyStatusDelegate(handle, keyRepository)
+        val delegate = EndpointKeyStatusDelegate(EndpointKeyHandle(handle), keyRepository)
         coEvery { keyRepository.fetchKeyState(any()) } returns Result.Success(KeyState.Unset)
 
         delegate.recomputeFor(mapOf("openAI" to EndpointConfig(userProvide = true)))
@@ -263,7 +264,7 @@ class EndpointKeyStatusDelegateTest {
     fun keyInvalidationByNameTriggersRecompute() = runTest {
         val scope = TestScope(StandardTestDispatcher(testScheduler))
         val handle = newHandle(scope)
-        val delegate = EndpointKeyStatusDelegate(handle, keyRepository)
+        val delegate = EndpointKeyStatusDelegate(EndpointKeyHandle(handle), keyRepository)
         coEvery { keyRepository.fetchKeyState(any()) } returns Result.Success(KeyState.Unset)
 
         delegate.recomputeFor(mapOf("openAI" to EndpointConfig(userProvide = true)))
@@ -279,7 +280,7 @@ class EndpointKeyStatusDelegateTest {
     fun keyInvalidationForUnrelatedEndpointDoesNotTriggerRecompute() = runTest {
         val scope = TestScope(StandardTestDispatcher(testScheduler))
         val handle = newHandle(scope)
-        val delegate = EndpointKeyStatusDelegate(handle, keyRepository)
+        val delegate = EndpointKeyStatusDelegate(EndpointKeyHandle(handle), keyRepository)
         coEvery { keyRepository.fetchKeyState(any()) } returns Result.Success(KeyState.Unset)
 
         delegate.recomputeFor(mapOf("openAI" to EndpointConfig(userProvide = true)))
@@ -296,7 +297,7 @@ class EndpointKeyStatusDelegateTest {
     fun keyInvalidationAllAlwaysRefreshes() = runTest {
         val scope = TestScope(StandardTestDispatcher(testScheduler))
         val handle = newHandle(scope)
-        val delegate = EndpointKeyStatusDelegate(handle, keyRepository)
+        val delegate = EndpointKeyStatusDelegate(EndpointKeyHandle(handle), keyRepository)
         coEvery { keyRepository.fetchKeyState(any()) } returns Result.Success(KeyState.Unset)
 
         delegate.recomputeFor(mapOf("openAI" to EndpointConfig(userProvide = true)))
@@ -314,7 +315,7 @@ class EndpointKeyStatusDelegateTest {
         // it had entries, and must skip the state write entirely if already empty.
         val scope = TestScope(StandardTestDispatcher(testScheduler))
         val handle = newHandle(scope)
-        val delegate = EndpointKeyStatusDelegate(handle, keyRepository)
+        val delegate = EndpointKeyStatusDelegate(EndpointKeyHandle(handle), keyRepository)
         coEvery { keyRepository.fetchKeyState(any()) } returns Result.Success(KeyState.Unset)
 
         // Seed with a non-empty map.
@@ -336,7 +337,7 @@ class EndpointKeyStatusDelegateTest {
         // Otherwise the user's just-saved key would not be reflected snappily.
         val scope = TestScope(StandardTestDispatcher(testScheduler))
         val handle = newHandle(scope)
-        val delegate = EndpointKeyStatusDelegate(handle, keyRepository)
+        val delegate = EndpointKeyStatusDelegate(EndpointKeyHandle(handle), keyRepository)
 
         // First call: suspend indefinitely so the fan-out is in-flight when the
         // invalidation arrives.
@@ -376,7 +377,7 @@ class EndpointKeyStatusDelegateTest {
         // Loading; resolved Set/Expired/Unset values are preserved.
         val scope = TestScope(StandardTestDispatcher(testScheduler))
         val handle = newHandle(scope)
-        val delegate = EndpointKeyStatusDelegate(handle, keyRepository)
+        val delegate = EndpointKeyStatusDelegate(EndpointKeyHandle(handle), keyRepository)
 
         val future = (Clock.System.now() + 1.days).toString()
         coEvery { keyRepository.fetchKeyState("openAI") } returns

--- a/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/FileAttachmentDelegateTest.kt
+++ b/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/FileAttachmentDelegateTest.kt
@@ -1,7 +1,7 @@
 package com.garfiec.librechat.feature.chat.viewmodel.delegate
 
 import com.garfiec.librechat.feature.chat.components.AttachedFile
-import com.garfiec.librechat.feature.chat.viewmodel.ChatStateHandle
+import com.garfiec.librechat.feature.chat.viewmodel.ErrorOnlyHandle
 import com.google.common.truth.Truth.assertThat
 import io.mockk.mockk
 import kotlinx.coroutines.Dispatchers
@@ -10,7 +10,7 @@ import org.junit.Test
 class FileAttachmentDelegateTest {
 
     private fun createDelegate() = FileAttachmentDelegate(
-        stateHandle = mockk<ChatStateHandle>(relaxed = true),
+        handle = mockk<ErrorOnlyHandle>(relaxed = true),
         appContext = mockk(relaxed = true),
         fileRepository = mockk(relaxed = true),
         ioDispatcher = Dispatchers.Unconfined,

--- a/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/InConversationSearchDelegateTest.kt
+++ b/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/InConversationSearchDelegateTest.kt
@@ -5,7 +5,9 @@ import com.garfiec.librechat.core.model.Message
 import com.garfiec.librechat.core.model.content.MessageContentPart
 import com.garfiec.librechat.feature.chat.util.MessageNode
 import com.garfiec.librechat.feature.chat.viewmodel.ChatStateHandle
+import com.garfiec.librechat.feature.chat.viewmodel.SearchHandle
 import com.garfiec.librechat.feature.chat.viewmodel.ChatUiState
+import com.garfiec.librechat.feature.chat.viewmodel.MessagesState
 import com.garfiec.librechat.feature.chat.viewmodel.SearchMatch
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -24,7 +26,7 @@ class InConversationSearchDelegateTest {
 
     private val stateFlow = MutableStateFlow(ChatUiState())
     private val stateHandle = ChatStateHandle(stateFlow, TestScope())
-    private val delegate = InConversationSearchDelegate(stateHandle)
+    private val delegate = InConversationSearchDelegate(SearchHandle(stateHandle))
 
     private val state get() = stateFlow.value
 
@@ -36,7 +38,7 @@ class InConversationSearchDelegateTest {
     )
 
     private fun seed(vararg texts: String) {
-        stateFlow.value = ChatUiState(displayMessages = texts.map { node(it) })
+        stateFlow.value = ChatUiState(content = MessagesState(displayMessages = texts.map { node(it) }))
     }
 
     /** A parallel (Compare-Models) message: a primary-agent part plus an added-agent (`____1`) part. */
@@ -58,7 +60,7 @@ class InConversationSearchDelegateTest {
     fun `parallel turn counts only the primary agent's occurrences`() {
         // The single/primary list renders only the primary-agent parts (collapseParallelToPrimary),
         // so the secondary "foo foo" must NOT inflate the match list or shift occurrence indices.
-        stateFlow.value = ChatUiState(displayMessages = listOf(parallelNode("foo", "foo foo")))
+        stateFlow.value = ChatUiState(content = MessagesState(displayMessages = listOf(parallelNode("foo", "foo foo"))))
         delegate.onSearchQueryChanged("foo")
 
         assertThat(state.searchMatchIndices).containsExactly(

--- a/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/MessageQueueDelegateTest.kt
+++ b/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/MessageQueueDelegateTest.kt
@@ -5,6 +5,7 @@ import com.garfiec.librechat.core.common.identity.AccountState
 import com.garfiec.librechat.core.common.identity.InMemoryActiveAccountProvider
 import com.garfiec.librechat.core.data.endpoint.EndpointDispatch
 import com.garfiec.librechat.feature.chat.viewmodel.ChatStateHandle
+import com.garfiec.librechat.feature.chat.viewmodel.QueueHandle
 import com.garfiec.librechat.feature.chat.viewmodel.ChatUiState
 import com.garfiec.librechat.feature.chat.viewmodel.ComposerSnapshot
 import com.garfiec.librechat.feature.chat.viewmodel.QueuedEditSession
@@ -32,7 +33,7 @@ class MessageQueueDelegateTest {
     private val droppedCounts = mutableListOf<Int>()
     private val activeAccount = InMemoryActiveAccountProvider(AccountState.Resolved(AccountId("srv:user-1")))
     private val delegate = MessageQueueDelegate(
-        stateHandle = stateHandle,
+        handle = QueueHandle(stateHandle),
         activeAccountProvider = activeAccount,
         sendWithSpec = { spec, awaitSettle ->
             sent.add(spec)
@@ -56,10 +57,12 @@ class MessageQueueDelegateTest {
     /** Puts the delegate's state into queued-edit mode (an item pulled out into the composer). */
     private fun enterEditMode(original: QueuedMessage = spec("edited")) {
         stateFlow.value = stateFlow.value.copy(
-            editingQueuedItem = QueuedEditSession(
-                original = original,
-                originalIndex = 0,
-                stashed = ComposerSnapshot(text = "", endpoint = "openAI", model = null),
+            composer = stateFlow.value.composer.copy(
+                editingQueuedItem = QueuedEditSession(
+                    original = original,
+                    originalIndex = 0,
+                    stashed = ComposerSnapshot(text = "", endpoint = "openAI", model = null),
+                ),
             ),
         )
     }
@@ -264,7 +267,9 @@ class MessageQueueDelegateTest {
     fun `drained spec retains its queue-time config after state changes`() {
         delegate.enqueue(spec("a", model = "gpt-4"))
         // Mutate live state after queueing — must not retro-edit the queued snapshot.
-        stateFlow.value = stateFlow.value.copy(selectedModel = "claude", selectedEndpoint = "anthropic")
+        stateFlow.value = stateFlow.value.copy(
+            selection = stateFlow.value.selection.copy(selectedModel = "claude", selectedEndpoint = "anthropic"),
+        )
 
         delegate.drainNext()
 
@@ -320,7 +325,7 @@ class MessageQueueDelegateTest {
         val warmingSent = mutableListOf<QueuedMessage>()
         val warmingDropped = mutableListOf<Int>()
         val warmingDelegate = MessageQueueDelegate(
-            stateHandle = stateHandle,
+            handle = QueueHandle(stateHandle),
             activeAccountProvider = warming,
             sendWithSpec = { spec, _ -> warmingSent.add(spec) },
             onQueuedDropped = { warmingDropped.add(it) },

--- a/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/MessageTreeDelegateTest.kt
+++ b/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/MessageTreeDelegateTest.kt
@@ -5,7 +5,9 @@ import com.garfiec.librechat.core.model.StreamEvent
 import com.garfiec.librechat.feature.chat.util.buildActiveMessagePath
 import com.garfiec.librechat.feature.chat.viewmodel.ChatScreenState
 import com.garfiec.librechat.feature.chat.viewmodel.ChatStateHandle
+import com.garfiec.librechat.feature.chat.viewmodel.MessageTreeHandle
 import com.garfiec.librechat.feature.chat.viewmodel.ChatUiState
+import com.garfiec.librechat.feature.chat.viewmodel.MessagesState
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -36,7 +38,7 @@ class MessageTreeDelegateTest {
     private fun delegateWith(state: ChatUiState): Pair<MessageTreeDelegate, MutableStateFlow<ChatUiState>> {
         val flow = MutableStateFlow(state)
         val handle = ChatStateHandle(flow, CoroutineScope(Dispatchers.Unconfined))
-        return MessageTreeDelegate(handle) to flow
+        return MessageTreeDelegate(MessageTreeHandle(handle)) to flow
     }
 
     @Test
@@ -44,9 +46,11 @@ class MessageTreeDelegateTest {
         val optimistic = message("u1", text = "hi", isUser = true)
         val (delegate, flow) = delegateWith(
             ChatUiState(
-                messages = listOf(optimistic),
-                displayMessages = buildActiveMessagePath(listOf(optimistic)),
-                isStreaming = true,
+                content = MessagesState(
+                    messages = listOf(optimistic),
+                    displayMessages = buildActiveMessagePath(listOf(optimistic)),
+                    isStreaming = true,
+                ),
             ),
         )
 
@@ -71,8 +75,10 @@ class MessageTreeDelegateTest {
         val optimistic = message("u2", parentId = "a1", isUser = true)
         val (delegate, flow) = delegateWith(
             ChatUiState(
-                messages = listOf(priorUser, priorAi, optimistic),
-                isStreaming = true,
+                content = MessagesState(
+                    messages = listOf(priorUser, priorAi, optimistic),
+                    isStreaming = true,
+                ),
             ),
         )
 
@@ -94,7 +100,7 @@ class MessageTreeDelegateTest {
     fun `finalizeChatDisplay with no final messages is a no-op`() {
         val optimistic = message("u1", isUser = true)
         val (delegate, flow) = delegateWith(
-            ChatUiState(messages = listOf(optimistic), isStreaming = true),
+            ChatUiState(content = MessagesState(messages = listOf(optimistic), isStreaming = true)),
         )
 
         delegate.finalizeChatDisplay(StreamEvent.Final())

--- a/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/ModelSelectionDelegateTest.kt
+++ b/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/ModelSelectionDelegateTest.kt
@@ -12,7 +12,10 @@ import com.garfiec.librechat.core.model.Agent
 import com.garfiec.librechat.core.model.EndpointConfig
 import com.garfiec.librechat.core.model.permissions.UserRolePermissions
 import com.garfiec.librechat.feature.chat.viewmodel.ChatStateHandle
+import com.garfiec.librechat.feature.chat.viewmodel.ModelSelectionHandle
 import com.garfiec.librechat.feature.chat.viewmodel.ChatUiState
+import com.garfiec.librechat.feature.chat.viewmodel.ConversationMetaState
+import com.garfiec.librechat.feature.chat.viewmodel.ModelSelectionState
 import com.google.common.truth.Truth.assertThat
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -76,8 +79,26 @@ class ModelSelectionDelegateTest {
         every { it.isConnected } returns isConnected
     }
 
-    private fun newHandle(scope: CoroutineScope, state: ChatUiState = ChatUiState()) =
+    private fun newHandle(scope: CoroutineScope, state: ChatUiState = uiState()) =
         ChatStateHandle(stateFlow = MutableStateFlow(state), scope = scope)
+
+    /** Builds a [ChatUiState] from the flat selection fields these tests set, wrapping them into
+     *  the [ModelSelectionState] slice. */
+    private fun uiState(
+        conversationId: String? = null,
+        selectedEndpoint: String = EndpointConstants.AGENTS,
+        selectedModel: String? = null,
+        agents: List<Agent> = emptyList(),
+        error: String? = null,
+    ) = ChatUiState(
+        conversation = ConversationMetaState(conversationId = conversationId),
+        error = error,
+        selection = ModelSelectionState(
+            selectedEndpoint = selectedEndpoint,
+            selectedModel = selectedModel,
+            agents = agents,
+        ),
+    )
 
     private fun newDelegate(
         handle: ChatStateHandle,
@@ -85,7 +106,7 @@ class ModelSelectionDelegateTest {
         initialEndpoint: String? = null,
         initialModel: String? = null,
     ) = ModelSelectionDelegate(
-        stateHandle = handle,
+        handle = ModelSelectionHandle(handle),
         configRepository = configRepository,
         agentRepository = agentRepository,
         mcpRepository = mcpRepository,
@@ -116,7 +137,7 @@ class ModelSelectionDelegateTest {
         val scope = TestScope(StandardTestDispatcher(testScheduler))
         val handle = newHandle(
             scope,
-            ChatUiState(conversationId = "c1", selectedEndpoint = "openAI", selectedModel = "gpt-4o"),
+            uiState(conversationId = "c1", selectedEndpoint = "openAI", selectedModel = "gpt-4o"),
         )
         val delegate = newDelegate(handle)
         delegate.conversationModelLoaded = true
@@ -135,7 +156,7 @@ class ModelSelectionDelegateTest {
         val scope = TestScope(StandardTestDispatcher(testScheduler))
         val handle = newHandle(
             scope,
-            ChatUiState(conversationId = "c1", selectedEndpoint = "openAI", selectedModel = "ghost"),
+            uiState(conversationId = "c1", selectedEndpoint = "openAI", selectedModel = "ghost"),
         )
         val delegate = newDelegate(handle)
         delegate.conversationModelLoaded = true
@@ -155,7 +176,7 @@ class ModelSelectionDelegateTest {
         val scope = TestScope(StandardTestDispatcher(testScheduler))
         val handle = newHandle(
             scope,
-            ChatUiState(conversationId = "c1", selectedEndpoint = "openAI", selectedModel = "ghost"),
+            uiState(conversationId = "c1", selectedEndpoint = "openAI", selectedModel = "ghost"),
         )
         val delegate = newDelegate(handle)
         delegate.conversationModelLoaded = true
@@ -175,7 +196,7 @@ class ModelSelectionDelegateTest {
         val scope = TestScope(StandardTestDispatcher(testScheduler))
         val handle = newHandle(
             scope,
-            ChatUiState(conversationId = "c1", selectedEndpoint = EndpointConstants.AGENTS, selectedModel = "gpt-4o"),
+            uiState(conversationId = "c1", selectedEndpoint = EndpointConstants.AGENTS, selectedModel = "gpt-4o"),
         )
         val delegate = newDelegate(handle)
         delegate.conversationModelLoaded = true
@@ -199,7 +220,7 @@ class ModelSelectionDelegateTest {
         val scope = TestScope(StandardTestDispatcher(testScheduler))
         val handle = newHandle(
             scope,
-            ChatUiState(conversationId = "c1", selectedEndpoint = EndpointConstants.AGENTS, selectedModel = "agent_abc"),
+            uiState(conversationId = "c1", selectedEndpoint = EndpointConstants.AGENTS, selectedModel = "agent_abc"),
         )
         val delegate = newDelegate(handle)
         delegate.conversationModelLoaded = true
@@ -217,7 +238,7 @@ class ModelSelectionDelegateTest {
         val scope = TestScope(StandardTestDispatcher(testScheduler))
         val handle = newHandle(
             scope,
-            ChatUiState(conversationId = "c1", selectedEndpoint = "openAI", selectedModel = null),
+            uiState(conversationId = "c1", selectedEndpoint = "openAI", selectedModel = null),
         )
         val delegate = newDelegate(handle)
         delegate.conversationModelLoaded = false
@@ -244,7 +265,7 @@ class ModelSelectionDelegateTest {
         val scope = TestScope(StandardTestDispatcher(testScheduler))
         val handle = newHandle(
             scope,
-            ChatUiState(conversationId = "c1", selectedEndpoint = "openAI", selectedModel = "ghost"),
+            uiState(conversationId = "c1", selectedEndpoint = "openAI", selectedModel = "ghost"),
         )
         val delegate = newDelegate(handle)
         delegate.conversationModelLoaded = true
@@ -262,7 +283,7 @@ class ModelSelectionDelegateTest {
         val scope = TestScope(StandardTestDispatcher(testScheduler))
         val handle = newHandle(
             scope,
-            ChatUiState(conversationId = "c1", selectedEndpoint = "openAI", selectedModel = "ghost"),
+            uiState(conversationId = "c1", selectedEndpoint = "openAI", selectedModel = "ghost"),
         )
         val delegate = newDelegate(handle)
         delegate.conversationModelLoaded = true
@@ -280,7 +301,7 @@ class ModelSelectionDelegateTest {
         // For new chats, refilter is validation-only: it never seeds/fallbacks —
         // seedInitialSelection owns the selection. An invalid selection is left as-is.
         val scope = TestScope(StandardTestDispatcher(testScheduler))
-        val handle = newHandle(scope, ChatUiState(selectedEndpoint = "openAI", selectedModel = "ghost"))
+        val handle = newHandle(scope, uiState(selectedEndpoint = "openAI", selectedModel = "ghost"))
         val delegate = newDelegate(handle)
         delegate.conversationModelLoaded = true // even so, new-chat path must not fallback
         delegate.cachedLastUsedEndpoint = "anthropic"
@@ -404,7 +425,7 @@ class ModelSelectionDelegateTest {
         // The error slot is shared with other delegates — a successful agent load must
         // clear only its own failure banner, never someone else's message.
         val scope = TestScope(StandardTestDispatcher(testScheduler))
-        val handle = newHandle(scope, ChatUiState(error = "Failed to rename conversation"))
+        val handle = newHandle(scope, uiState(error = "Failed to rename conversation"))
         val delegate = newDelegate(handle)
         allowAgents()
         coEvery { agentRepository.getAgents() } returns Result.Success(listOf(Agent(id = "agent_1")))
@@ -564,7 +585,7 @@ class ModelSelectionDelegateTest {
 
         // Models present, agents arrive later — last-used must win and stay.
         delegate.agentsLoaded.value = true
-        handle.update { copy(agents = listOf(Agent(id = "agent_1"))) }
+        handle.update { copy(selection = selection.copy(agents = listOf(Agent(id = "agent_1")))) }
         advanceUntilIdle()
 
         assertThat(handle.state.selectedEndpoint).isEqualTo("openAI")
@@ -587,7 +608,7 @@ class ModelSelectionDelegateTest {
 
         // Agents arrive first, models still pending → must NOT pick the first agent.
         delegate.agentsLoaded.value = true
-        handle.update { copy(agents = listOf(Agent(id = "agent_1"))) }
+        handle.update { copy(selection = selection.copy(agents = listOf(Agent(id = "agent_1")))) }
         advanceUntilIdle()
         assertThat(handle.state.selectedModel).isNull()
 
@@ -612,7 +633,7 @@ class ModelSelectionDelegateTest {
         assertThat(handle.state.selectedModel).isNull()
 
         delegate.agentsLoaded.value = true
-        handle.update { copy(agents = listOf(Agent(id = "agent_1"))) }
+        handle.update { copy(selection = selection.copy(agents = listOf(Agent(id = "agent_1")))) }
         advanceUntilIdle()
 
         assertThat(handle.state.selectedEndpoint).isEqualTo(EndpointConstants.AGENTS)
@@ -643,7 +664,7 @@ class ModelSelectionDelegateTest {
         lastUsedEndpoint.value = "openAI"
         lastUsedModel.value = "gpt-OLD" // no longer offered
         availableModels.value = mapOf("openAI" to listOf("gpt-4o"))
-        handle.update { copy(agents = listOf(Agent(id = "agent_1"))) }
+        handle.update { copy(selection = selection.copy(agents = listOf(Agent(id = "agent_1")))) }
 
         delegate.seedInitialSelection(isNewConversation = true)
         advanceUntilIdle()
@@ -693,7 +714,7 @@ class ModelSelectionDelegateTest {
         assertThat(handle.state.selectedModel).isEqualTo("gpt-4o")
 
         // Conversation starts with its own model.
-        handle.update { copy(conversationId = "conv_new", selectedEndpoint = "anthropic", selectedModel = "claude-3") }
+        handle.update { copy(conversation = conversation.copy(conversationId = "conv_new"), selection = selection.copy(selectedEndpoint = "anthropic", selectedModel = "claude-3")) }
         advanceUntilIdle()
 
         // Last-used changes afterwards → must NOT override the started conversation.
@@ -724,7 +745,7 @@ class ModelSelectionDelegateTest {
     @Test
     fun seedNoOpForExistingConversation() = runTest {
         val scope = TestScope(StandardTestDispatcher(testScheduler))
-        val handle = newHandle(scope, ChatUiState(conversationId = "c1", selectedModel = "claude-3", selectedEndpoint = "anthropic"))
+        val handle = newHandle(scope, uiState(conversationId = "c1", selectedModel = "claude-3", selectedEndpoint = "anthropic"))
         val delegate = newDelegate(handle)
         delegate.agentsLoaded.value = true
         lastUsedEndpoint.value = "openAI"
@@ -786,7 +807,7 @@ class ModelSelectionDelegateTest {
         // (INVALID), not still-loading (PENDING), so the seeder corrects a stale
         // selection instead of pinning a non-functional one forever.
         val scope = TestScope(StandardTestDispatcher(testScheduler))
-        val handle = newHandle(scope, ChatUiState(selectedEndpoint = "openAI", selectedModel = "gpt-4o"))
+        val handle = newHandle(scope, uiState(selectedEndpoint = "openAI", selectedModel = "gpt-4o"))
         val delegate = newDelegate(handle)
         delegate.agentsLoaded.value = true
         endpointConfigs.value = mapOf("anthropic" to EndpointConfig())
@@ -808,7 +829,7 @@ class ModelSelectionDelegateTest {
         val scope = TestScope(StandardTestDispatcher(testScheduler))
         val handle = newHandle(
             scope,
-            ChatUiState(conversationId = "c1", selectedEndpoint = "anthropic", selectedModel = "claude-3"),
+            uiState(conversationId = "c1", selectedEndpoint = "anthropic", selectedModel = "claude-3"),
         )
         val delegate = newDelegate(handle)
         delegate.agentsLoaded.value = true
@@ -880,7 +901,7 @@ class ModelSelectionDelegateTest {
 
         // SECOND emission: agents list loads (post-create refetch surfaces the agent).
         delegate.agentsLoaded.value = true
-        handle.update { copy(agents = listOf(Agent(id = "agent_X"))) }
+        handle.update { copy(selection = selection.copy(agents = listOf(Agent(id = "agent_X")))) }
         advanceUntilIdle()
 
         // The override must STILL hold — not clobbered back to last-used gpt-4o.
@@ -931,14 +952,14 @@ class ModelSelectionDelegateTest {
 
         // TRANSIENT empty-list emission: agentsLoaded flips true with an EMPTY agents list.
         delegate.agentsLoaded.value = true
-        handle.update { copy(agents = emptyList()) }
+        handle.update { copy(selection = selection.copy(agents = emptyList())) }
         advanceUntilIdle()
         // Must STILL be the agent (today's bug flipped it to openAI/gpt-4o via Tier-3/last-used).
         assertThat(handle.state.selectedEndpoint).isEqualTo(EndpointConstants.AGENTS)
         assertThat(handle.state.selectedModel).isEqualTo("agent_X")
 
         // Real list arrives (contains the agent) → selection holds.
-        handle.update { copy(agents = listOf(Agent(id = "agent_X"), Agent(id = "agent_Y"))) }
+        handle.update { copy(selection = selection.copy(agents = listOf(Agent(id = "agent_X"), Agent(id = "agent_Y")))) }
         advanceUntilIdle()
         assertThat(handle.state.selectedEndpoint).isEqualTo(EndpointConstants.AGENTS)
         assertThat(handle.state.selectedModel).isEqualTo("agent_X")
@@ -955,7 +976,7 @@ class ModelSelectionDelegateTest {
         // whose last-used resolved to agents before the account's agents were all removed).
         val handle = newHandle(
             scope,
-            ChatUiState(selectedEndpoint = EndpointConstants.AGENTS, selectedModel = "agent_stale"),
+            uiState(selectedEndpoint = EndpointConstants.AGENTS, selectedModel = "agent_stale"),
         )
         val delegate = newDelegate(handle) // NO initialAgentId → no hold
         lastUsedEndpoint.value = EndpointConstants.AGENTS
@@ -967,7 +988,7 @@ class ModelSelectionDelegateTest {
 
         // Agents finish loading and the list is genuinely empty.
         delegate.agentsLoaded.value = true
-        handle.update { copy(agents = emptyList()) }
+        handle.update { copy(selection = selection.copy(agents = emptyList())) }
         advanceUntilIdle()
 
         // Must NOT be stranded on the (nonexistent) agent — resolve to a config model.
@@ -983,7 +1004,7 @@ class ModelSelectionDelegateTest {
     @Test
     fun applyResolvedConversationModelSetsSelectionAndFlagsAndRefilterDoesNotClobber() = runTest {
         val scope = TestScope(StandardTestDispatcher(testScheduler))
-        val handle = newHandle(scope, ChatUiState(conversationId = "c1"))
+        val handle = newHandle(scope, uiState(conversationId = "c1"))
         val delegate = newDelegate(handle)
 
         delegate.applyResolvedConversationModel("anthropic", "claude-3")
@@ -1011,7 +1032,7 @@ class ModelSelectionDelegateTest {
         val scope = TestScope(StandardTestDispatcher(testScheduler))
         val handle = newHandle(
             scope,
-            ChatUiState(
+            uiState(
                 conversationId = "c1",
                 selectedEndpoint = "openAI",
                 selectedModel = "ghost",
@@ -1037,7 +1058,7 @@ class ModelSelectionDelegateTest {
         val scope = TestScope(StandardTestDispatcher(testScheduler))
         val handle = newHandle(
             scope,
-            ChatUiState(
+            uiState(
                 conversationId = "c1",
                 selectedEndpoint = "openAI",
                 selectedModel = "ghost",
@@ -1065,7 +1086,7 @@ class ModelSelectionDelegateTest {
         val scope = TestScope(StandardTestDispatcher(testScheduler))
         val handle = newHandle(
             scope,
-            ChatUiState(conversationId = "c1", selectedEndpoint = "openAI", selectedModel = "ghost"),
+            uiState(conversationId = "c1", selectedEndpoint = "openAI", selectedModel = "ghost"),
         )
         val delegate = newDelegate(handle)
         delegate.conversationModelLoaded = true

--- a/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/OfficePreviewDelegateTest.kt
+++ b/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/OfficePreviewDelegateTest.kt
@@ -3,6 +3,7 @@ package com.garfiec.librechat.feature.chat.viewmodel.delegate
 import com.garfiec.librechat.core.data.repository.FileRepository
 import com.garfiec.librechat.core.model.Attachment
 import com.garfiec.librechat.feature.chat.viewmodel.ChatStateHandle
+import com.garfiec.librechat.feature.chat.viewmodel.OfficePreviewHandle
 import com.garfiec.librechat.feature.chat.viewmodel.ChatUiState
 import com.google.common.truth.Truth.assertThat
 import io.mockk.mockk
@@ -22,7 +23,7 @@ class OfficePreviewDelegateTest {
     private fun delegate(): OfficePreviewDelegate {
         val flow = MutableStateFlow(ChatUiState())
         val handle = ChatStateHandle(flow, CoroutineScope(TestScope().coroutineContext))
-        return OfficePreviewDelegate(handle, mockk<FileRepository>())
+        return OfficePreviewDelegate(OfficePreviewHandle(handle), mockk<FileRepository>())
     }
 
     private val docMime = "application/vnd.librechat.docx-preview"

--- a/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/SubagentTraceDelegateTest.kt
+++ b/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/SubagentTraceDelegateTest.kt
@@ -4,7 +4,9 @@ import com.garfiec.librechat.core.model.ContentType
 import com.garfiec.librechat.core.model.StreamEvent
 import com.garfiec.librechat.feature.chat.viewmodel.ActiveToolCall
 import com.garfiec.librechat.feature.chat.viewmodel.ChatStateHandle
+import com.garfiec.librechat.feature.chat.viewmodel.SubagentHandle
 import com.garfiec.librechat.feature.chat.viewmodel.ChatUiState
+import com.garfiec.librechat.feature.chat.viewmodel.MessagesState
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -26,7 +28,7 @@ class SubagentTraceDelegateTest {
     ): Pair<SubagentTraceDelegate, MutableStateFlow<ChatUiState>> {
         val flow = MutableStateFlow(initial)
         val handle = ChatStateHandle(flow, CoroutineScope(TestScope().coroutineContext))
-        return SubagentTraceDelegate(handle, json) to flow
+        return SubagentTraceDelegate(SubagentHandle(handle), json) to flow
     }
 
     private fun messageDelta(
@@ -63,9 +65,11 @@ class SubagentTraceDelegateTest {
     fun `falls back to oldest unclaimed subagent tool_call when parentToolCallId absent`() {
         val (delegate, flow) = fixture(
             ChatUiState(
-                activeToolCalls = listOf(
-                    ActiveToolCall(id = "call_old", name = "subagent"),
-                    ActiveToolCall(id = "call_new", name = "subagent"),
+                content = MessagesState(
+                    activeToolCalls = listOf(
+                        ActiveToolCall(id = "call_old", name = "subagent"),
+                        ActiveToolCall(id = "call_new", name = "subagent"),
+                    ),
                 ),
             ),
         )
@@ -82,7 +86,7 @@ class SubagentTraceDelegateTest {
     @Test
     fun `same run reuses the claimed tool_call across envelopes`() {
         val (delegate, flow) = fixture(
-            ChatUiState(activeToolCalls = listOf(ActiveToolCall(id = "call_x", name = "subagent"))),
+            ChatUiState(content = MessagesState(activeToolCalls = listOf(ActiveToolCall(id = "call_x", name = "subagent")))),
         )
         delegate.onUpdate(messageDelta(null, "run_1", "a"))
         delegate.onUpdate(messageDelta(null, "run_1", "b"))
@@ -144,7 +148,7 @@ class SubagentTraceDelegateTest {
     @Test
     fun `reset clears state and correlation buffers across runs`() {
         val (delegate, flow) = fixture(
-            ChatUiState(activeToolCalls = listOf(ActiveToolCall(id = "call_x", name = "subagent"))),
+            ChatUiState(content = MessagesState(activeToolCalls = listOf(ActiveToolCall(id = "call_x", name = "subagent")))),
         )
         delegate.onUpdate(messageDelta(null, "run_1", "first"))
         assertThat(flow.value.subagentProgress).isNotEmpty()

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatRequestBuilder.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatRequestBuilder.kt
@@ -11,13 +11,13 @@ import kotlinx.serialization.json.JsonObject
  * regenerate, continue): the endpoint dispatch for the active selection and the optional
  * [EphemeralAgent] derived from the current ephemeral tool/MCP selections.
  *
- * Pure reads over [ChatStateHandle.state] — no coroutines, no repositories — so it can be
+ * Pure reads over the current [ChatUiState] — no coroutines, no repositories — so it can be
  * unit-tested directly. Extracted so both `ChatViewModel`'s send path and
  * [com.garfiec.librechat.feature.chat.viewmodel.delegate.MessageEditingDelegate] share one
  * implementation instead of duplicating it.
  */
 class ChatRequestBuilder(
-    private val stateHandle: ChatStateHandle,
+    private val stateProvider: () -> ChatUiState,
 ) {
 
     /**
@@ -26,7 +26,7 @@ class ChatRequestBuilder(
      * secondary) must call [resolveEndpointDispatch] directly with that endpoint name.
      */
     fun currentDispatch(): EndpointDispatch {
-        val state = stateHandle.state
+        val state = stateProvider()
         return resolveEndpointDispatch(
             endpointName = state.selectedEndpoint,
             endpointConfigs = state.endpointConfigs,
@@ -39,7 +39,7 @@ class ChatRequestBuilder(
      * enabled tools). Returns null when there is nothing to send.
      */
     fun buildEphemeralAgent(): EphemeralAgent? {
-        val state = stateHandle.state
+        val state = stateProvider()
         // A saved agent uses its own configured tools; the backend ignores client-supplied
         // ephemeral tools for agent runs. Mirror web's `showEphemeralBadges` (ChatForm.tsx)
         // and never serialize leftover UI selections on the agents endpoint.
@@ -67,7 +67,7 @@ class ChatRequestBuilder(
      * selects the correct parameter set.
      */
     fun buildModelParams(): JsonObject? {
-        val state = stateHandle.state
+        val state = stateProvider()
         val isAgent = state.selectedEndpoint == EndpointConstants.AGENTS
         val provider = if (isAgent) {
             state.agents.firstOrNull { it.id == state.selectedModel }?.provider

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatUiState.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatUiState.kt
@@ -1,438 +1,50 @@
 package com.garfiec.librechat.feature.chat.viewmodel
 
 import androidx.compose.runtime.Immutable
-import com.garfiec.librechat.core.common.ChatLayoutConstants
 import com.garfiec.librechat.core.common.EndpointConstants
 import com.garfiec.librechat.core.common.ToolConstants
 import com.garfiec.librechat.core.data.datastore.ChatFontSize
 import com.garfiec.librechat.core.data.datastore.ChatHeaderAlignment
 import com.garfiec.librechat.core.data.datastore.ChatHeaderContent
 import com.garfiec.librechat.core.data.datastore.ContextBarPlacement
-import com.garfiec.librechat.core.data.datastore.InlineArtifactPrefs
-import com.garfiec.librechat.core.data.datastore.LatexRenderer
 import com.garfiec.librechat.core.data.datastore.StarredModelsDisplay
-import com.garfiec.librechat.core.data.endpoint.EndpointDispatch
 import com.garfiec.librechat.core.model.Agent
 import com.garfiec.librechat.core.model.Attachment
 import com.garfiec.librechat.core.model.EndpointConfig
 import com.garfiec.librechat.core.model.Message
-import com.garfiec.librechat.core.model.SubagentPhase
-import com.garfiec.librechat.core.model.content.MessageContentPart
 import com.garfiec.librechat.core.model.endpoint.KeyState
-import com.garfiec.librechat.core.model.request.EphemeralAgent
 import com.garfiec.librechat.core.model.response.FileUploadConfig
 import com.garfiec.librechat.core.model.usage.ContextUsage
 import com.garfiec.librechat.core.model.usage.TokenUsage
 import com.garfiec.librechat.core.ui.components.ModelParameters
 import com.garfiec.librechat.core.ui.media.MediaPreviewState
-import com.garfiec.librechat.feature.chat.components.AttachedFile
 import com.garfiec.librechat.feature.chat.model.McpServerDisplayData
 import com.garfiec.librechat.feature.chat.model.PresetDisplayData
 import com.garfiec.librechat.feature.chat.model.PromptMentionDisplayData
 import com.garfiec.librechat.feature.chat.util.MessageNode
-import kotlinx.serialization.json.JsonObject
-
-enum class ChatScreenState { LANDING, LOADING, ACTIVE }
-
-/**
- * Reasons why a send attempt was blocked. Resolved to a user-facing string in the Compose
- * layer via `stringResource`, so the ViewModel stays free of hard-coded English UI copy.
- */
-sealed interface SendBlockReason {
-    data object SelectAgent : SendBlockReason
-    data object SelectModel : SendBlockReason
-    data object AgentsUnavailable : SendBlockReason
-    data object AgentNotAvailable : SendBlockReason
-    data object ModelNotAvailable : SendBlockReason
-    data object ModelLoadFailed : SendBlockReason
-}
-
-/**
- * Consolidated chat-related user preferences from [SettingsDataStore].
- * Exposed as a single [StateFlow] to reduce the number of individual subscriptions
- * in the UI layer.
- */
-@Immutable
-data class ChatPreferences(
-    val showImageDescriptions: Boolean = false,
-    val dismissKeyboardOnSend: Boolean = false,
-    val chatLayoutStyle: String = ChatLayoutConstants.THREAD,
-    val showAvatars: Boolean = true,
-    val showBubbles: Boolean = false,
-    val latexRenderer: LatexRenderer = LatexRenderer.KATEX,
-    val autoSendAfterStt: Boolean = false,
-    val sttEngine: String = "",
-    val sttLanguage: String = "",
-    val inlineArtifactPrefs: InlineArtifactPrefs = InlineArtifactPrefs(),
-)
-
-/**
- * The chat floating top bar's mobile-only display preferences, bundled into a single
- * flow so [ChatViewModel]'s `uiState` combine stays within Kotlin's 5-arg typed limit.
- */
-@Immutable
-data class ChatHeaderPrefs(
-    val content: ChatHeaderContent = ChatHeaderContent.TITLE,
-    val alignment: ChatHeaderAlignment = ChatHeaderAlignment.LEFT,
-    val contextBarPlacement: ContextBarPlacement = ContextBarPlacement.OPTIONS_SHEET,
-)
-
-/**
- * Represents a single occurrence of a search query match.
- * @param messageIndex Index into [ChatUiState.displayMessages] containing this occurrence.
- * @param occurrenceInMessage 0-based index of this occurrence within the message text.
- */
-@Immutable
-data class SearchMatch(
-    val messageIndex: Int,
-    val occurrenceInMessage: Int,
-)
-
-/**
- * A request to scroll the message list to one specific search occurrence. [messageIndex] is the
- * scroll target; [requestId] is a monotonic id that both makes repeat jumps to the same occurrence
- * distinct (so the list's LaunchedEffect re-fires) and identifies the position report to act on.
- */
-@Immutable
-data class SearchFocusRequest(
-    val messageIndex: Int,
-    val requestId: Long,
-)
-
-@Immutable
-data class RetryInfo(
-    val attempt: Int,
-    val maxAttempts: Int,
-)
-
-@Immutable
-data class ActiveToolCall(
-    val id: String,
-    val name: String,
-    val isComplete: Boolean = false,
-    val output: String? = null,
-    /** Raw tool-call arguments JSON from [StreamEvent.ToolCallStart]. Holds the
-     *  image prompt/quality for image-gen tools so a placeholder can render mid-stream. */
-    val input: String? = null,
-)
-
-/**
- * A follow-up message the user queued while a response was streaming, waiting to be
- * auto-sent (FIFO) once the current reply completes. Rendered as a dimmed "ghost" bubble
- * after the streaming bubble — it is NOT part of the message tree.
- *
- * Captures a full snapshot of the send config **at queue time** (model/endpoint/tools/
- * webSearch/attachments + the resolved [dispatch]/[ephemeralAgent]), so a mid-stream model
- * switch never retro-edits an already-queued item. The live-lineage fields
- * (conversationId / parentMessageId / userMessageId) are deliberately NOT snapshotted — they
- * are recomputed from the current tree when the item actually fires.
- *
- * [attachments] holds the already-uploaded [AttachedFile]s (not bare FileReferences) so editing
- * a queued item restores its composer chips — including the local-uri image thumbnail — intact.
- */
-@Immutable
-data class QueuedMessage(
-    /** Stable local id for list keying, edit, and reorder. Not a server message id. */
-    val localId: String,
-    val text: String,
-    val attachments: List<AttachedFile> = emptyList(),
-    val endpoint: String,
-    val model: String?,
-    val agentId: String?,
-    val enabledTools: Set<String> = emptySet(),
-    /** Selected ephemeral MCP servers — snapshotted so editing the item restores its tool state. */
-    val mcpServerNames: Set<String> = emptySet(),
-    /** Full composer parameters (web search, reasoning effort, etc.) — restored to the composer on edit. */
-    val modelParameters: ModelParameters = ModelParameters.DEFAULT,
-    /**
-     * Non-default model params (provider-keyed) serialized for the wire, snapshotted at enqueue time
-     * so a queued send carries the params it was composed with. Null when nothing was customized.
-     */
-    val modelParamsPayload: JsonObject? = null,
-    val ephemeralAgent: EphemeralAgent? = null,
-    val dispatch: EndpointDispatch,
-    val isTemporary: Boolean = false,
-    /**
-     * The active account when this item was queued. A drain guard drops any item whose account no
-     * longer matches the active one (the user switched accounts since queueing), so a follow-up
-     * composed under account A can never be POSTed to account B's server under B's bearer. Null for
-     * items composed before multi-account (or in tests) — treated as "matches any", never dropped.
-     */
-    val accountId: String? = null,
-)
-
-/**
- * Snapshot of the editable composer surface (the "new message" draft) stashed when entering
- * queued-edit mode and restored on commit/cancel, so editing a queued item never clobbers what
- * the user was already composing.
- *
- * These fields mirror [QueuedMessage]'s source-config fields (model/endpoint/tools/mcp/params) and
- * are captured/applied by `ChatViewModel.captureComposer`/`applyComposer`/`toComposerSnapshot` — a
- * new composer setting must be threaded through all of them (no compiler enforcement).
- */
-@Immutable
-data class ComposerSnapshot(
-    val text: String,
-    val attachments: List<AttachedFile> = emptyList(),
-    val endpoint: String,
-    val model: String?,
-    val enabledTools: Set<String> = emptySet(),
-    val mcpServerNames: Set<String> = emptySet(),
-    val modelParameters: ModelParameters = ModelParameters.DEFAULT,
-)
-
-/**
- * Active queued-edit session: the composer is loaded with [original]'s content + config for
- * editing, while [stashed] holds the new-message draft to restore afterward and [originalIndex]
- * is the FIFO slot to put the (possibly edited) item back into on commit/cancel.
- */
-@Immutable
-data class QueuedEditSession(
-    val original: QueuedMessage,
-    val originalIndex: Int,
-    val stashed: ComposerSnapshot,
-)
-
-/** Loads a queued item's content + config onto the composer surface when entering edit mode. */
-fun QueuedMessage.toComposerSnapshot(): ComposerSnapshot = ComposerSnapshot(
-    text = text,
-    attachments = attachments,
-    endpoint = endpoint,
-    model = model,
-    enabledTools = enabledTools,
-    mcpServerNames = mcpServerNames,
-    modelParameters = modelParameters,
-)
-
-/**
- * Live progress of a single child agent's run (v0.8.6 subagents), accumulated
- * from `on_subagent_update` SSE envelopes and keyed in
- * [ChatUiState.subagentProgress] by the parent `subagent` tool_call id.
- *
- * [parts] are the child's flat content (reasoning / tool calls / text) folded in
- * arrival order — the same shapes a normal message renders, so the trace card
- * reuses the existing content-part renderers (depth 1; a subagent never nests
- * another subagent card). On reload this live trace is superseded by the
- * authoritative persisted `AgentToolCall.subagentContent`.
- */
-@Immutable
-data class SubagentTrace(
-    val parentToolCallId: String,
-    val subagentRunId: String? = null,
-    val subagentType: String? = null,
-    /** Latest phase label for the live ticker (e.g. the agent's display name). */
-    val label: String? = null,
-    /** Latest lifecycle/content phase reported by the server. */
-    val phase: String = SubagentPhase.START,
-    val parts: List<MessageContentPart> = emptyList(),
-    /** True once the server reports a terminal phase (`stop`/`error`). */
-    val isComplete: Boolean = false,
-)
-
-/**
- * Feature gates that flow into the composer ([ChatInput] → [ChatToolsBottomSheet]),
- * bundled so they thread as one value across Android and iOS. Each defaults to true
- * (shown) so a default-constructed bundle is fully permissive. Built by
- * [ChatUiState.chatInputGates]; see [ChatUiState.modelSelectEnabled] /
- * [ChatUiState.parametersEnabled] / [ChatUiState.showEphemeralTools] /
- * [ChatUiState.fileUploadEnabled] for the individual gating rules.
- */
-@Immutable
-data class ChatInputGates(
-    val modelSelectEnabled: Boolean = true,
-    val parametersEnabled: Boolean = true,
-    val showEphemeralTools: Boolean = true,
-    val fileUploadEnabled: Boolean = true,
-)
 
 @Immutable
 data class ChatUiState(
-    val screenState: ChatScreenState = ChatScreenState.LANDING,
-    val messages: List<Message> = emptyList(),
-    val displayMessages: List<MessageNode> = emptyList(),
-    /**
-     * A just-sent optimistic user message handed off from the NewChat landing VM, kept on screen
-     * until the server persists its own copy. For a resumed new chat the server saves the request
-     * message only when the reply finishes (see `agents/request.js`), so `getMessages` returns no
-     * user message mid-stream; without this seed the user's own message would vanish for the whole
-     * stream. `loadConversation` reconciles it away by id once the server's copy arrives. Null in
-     * every other case. See [NewChatSelectionHandoff].
-     */
-    val pendingResumeUserMessage: Message? = null,
-    val activeBranches: Map<String, Int> = emptyMap(),
-    val inputText: String = "",
-    val isStreaming: Boolean = false,
-    val streamingContent: String = "",
-    val activeToolCalls: List<ActiveToolCall> = emptyList(),
-    /** Live subagent traces (v0.8.6) keyed by the parent `subagent` tool_call id.
-     *  Folded from `on_subagent_update` SSE events while streaming; reset on each
-     *  new run and conversation switch alongside [activeToolCalls]. On reload the
-     *  persisted `AgentToolCall.subagentContent` is authoritative instead. */
-    val subagentProgress: Map<String, SubagentTrace> = emptyMap(),
-    /** Attachments received during SSE streaming (e.g., tool-generated images).
-     *  Cleared when streaming ends. Used to provide attachment context while the
-     *  final message (with full attachments) has not yet been persisted to Room. */
-    val streamingAttachments: List<Attachment> = emptyList(),
-    /** Follow-up messages queued while a reply streams, drained FIFO on each successful
-     *  completion. Rendered as ghost bubbles after the streaming bubble; never part of the
-     *  message tree. In-memory only (dropped on conversation switch / process death). */
-    val messageQueue: List<QueuedMessage> = emptyList(),
-    /** True after Stop/stream-error with a non-empty queue: draining is held until the user
-     *  explicitly taps "Send queued". A successful Final drains automatically instead. */
-    val isQueuePaused: Boolean = false,
-    /** Non-null while a queued item is being edited in the composer (queued-edit mode). Holds the
-     *  stashed new-message draft + the item's slot so both are restored on commit/cancel. */
-    val editingQueuedItem: QueuedEditSession? = null,
-    val selectedModel: String? = null,
-    val selectedEndpoint: String = EndpointConstants.AGENTS,
-    val endpointConfigs: Map<String, EndpointConfig> = emptyMap(),
-    /**
-     * Per-endpoint user-provided-key state for endpoints with `userProvide=true`
-     * (or `userProvideURL=true`). Drives the model selector's greyed-out group +
-     * "Set API Key" CTA. Endpoints absent from this map are implicitly "doesn't
-     * need a key" (built-ins) — [ModelSelectorSheet] fail-opens on `null` and
-     * on [KeyState.Loading] so the cold-start window doesn't flash to greyed.
-     */
-    val endpointKeyStates: Map<String, KeyState> = emptyMap(),
-    val availableModels: Map<String, List<String>> = emptyMap(),
-    val agents: List<Agent> = emptyList(),
-    val conversationId: String? = null,
+    // ── Extracted sub-state slices. Flat compat accessors below delegate to these so the
+    //    ~250 UI read sites keep compiling; delegates write only their own slice. ──
+    val queue: QueueState = QueueState(),
+    val search: ChatSearchState = ChatSearchState(),
+    val favorites: FavoritesState = FavoritesState(),
+    val subagents: SubagentState = SubagentState(),
+    val actions: ConversationActionsState = ConversationActionsState(),
+    val editing: MessageEditingState = MessageEditingState(),
+    val composer: ComposerState = ComposerState(),
+    val presetPrompts: PresetPromptState = PresetPromptState(),
+    val voice: VoiceState = VoiceState(),
+    val gates: FeatureGatesState = FeatureGatesState(),
+    val account: AccountConfigState = AccountConfigState(),
+    val prefs: ChatPrefsState = ChatPrefsState(),
+    val selection: ModelSelectionState = ModelSelectionState(),
+    val content: MessagesState = MessagesState(),
+    val conversation: ConversationMetaState = ConversationMetaState(),
     val error: String? = null,
-    /** Set when a send was blocked for a selection/readiness reason. Resolved to a
-     *  user-facing string in the Compose layer. Null means no send-block to show. */
-    val sendBlockReason: SendBlockReason? = null,
-    val presets: List<PresetDisplayData> = emptyList(),
-    val availablePrompts: List<PromptMentionDisplayData> = emptyList(),
-    val editingMessageId: String? = null,
-    val editingText: String = "",
-    val modelParameters: ModelParameters = ModelParameters.DEFAULT,
-    val showModelParameters: Boolean = false,
-    val isRecording: Boolean = false,
-    val isTranscribing: Boolean = false,
-    /** Whether the server has STT configured. When false, use device speech recognition. */
-    val serverSttEnabled: Boolean = false,
-    // TTS state
-    val currentlyReadingMessageId: String? = null,
-    // Temporary chat state
-    val isTemporaryChat: Boolean = false,
-    // In-conversation search state
-    val isSearchOpen: Boolean = false,
-    val searchQuery: String = "",
-    val searchMatchIndices: List<SearchMatch> = emptyList(),
-    val currentSearchMatchIndex: Int = 0,
-    /** The search occurrence to scroll to when the focused match changes. Consumed by MessageList. */
-    val searchFocusRequest: SearchFocusRequest? = null,
-    // Tool toolbar state
-    val enabledTools: Set<String> = emptySet(),
-    // MCP server state
-    val mcpServers: List<McpServerDisplayData> = emptyList(),
-    val selectedMcpServerNames: Set<String> = emptySet(),
-    // SSE reconnection retry state (null when not retrying)
-    val retryInfo: RetryInfo? = null,
-    // Pull-to-refresh state
-    val isRefreshingMessages: Boolean = false,
-    // Merged from separate StateFlows
-    val serverUrl: String = "",
-    val chatFontSize: ChatFontSize = ChatFontSize.MEDIUM,
-    /**
-     * Mobile-only preference for how pinned models/agents are surfaced in
-     * [ModelSelectorSheet]: off (float within group), grouped (collapsible top
-     * section), or top (flat top list). Read from [SettingsDataStore].
-     */
-    val starredModelsDisplay: StarredModelsDisplay = StarredModelsDisplay.OFF,
-    /**
-     * Mobile-only preferences for the chat floating top bar: what its bubble shows
-     * ([chatHeaderContent]) and how the bubble is positioned ([chatHeaderAlignment]).
-     * Read from [SettingsDataStore].
-     */
-    val chatHeaderContent: ChatHeaderContent = ChatHeaderContent.TITLE,
-    val chatHeaderAlignment: ChatHeaderAlignment = ChatHeaderAlignment.LEFT,
-    val forkedConversationId: String? = null,
-    val showForkOptionsForMessageId: String? = null,
-    val isForkInProgress: Boolean = false,
-    // User profile info for message avatars
-    val userName: String? = null,
-    val userAvatarUrl: String? = null,
-    // Conversation actions state
-    val conversationTitle: String? = null,
-    val sharedLinksEnabled: Boolean = false,
-    val showRenameDialog: Boolean = false,
-    val showDeleteConfirmation: Boolean = false,
-    val duplicatedConversationId: String? = null,
-    /** Set at StreamEvent.Created when a new conversation's conversationId becomes available.
-     *  The UI navigates to Chat(id) and then clears this via [ChatViewModel.onPendingNavigationHandled],
-     *  which also resets this ViewModel to a clean landing state. */
-    val pendingNavigationConversationId: String? = null,
-    /** Single source of truth for whether the model-selector sheet is open. Preflight
-     *  failures and readiness timeouts flip this to true so the user sees the sheet with
-     *  a send-block banner. Manual taps on the model chip also set it true via
-     *  [ChatViewModel.openModelSheet]. UI dismissal routes through [ChatViewModel.dismissModelSheet]. */
-    val showModelSheet: Boolean = false,
     // Model comparison state
     val comparisonState: ComparisonState = ComparisonState(),
-    // Feature gates — effective value is `interface.* flag AND role permission`,
-    // matching the web client. Default permissive (true); narrowed once both the
-    // RoleRepository and the server's interface config emit. Fails open when an
-    // interface flag is absent (older backends that don't send it).
-    val promptsEnabled: Boolean = true,
-    val promptsCreateEnabled: Boolean = true,
-    val agentsEnabled: Boolean = true,
-    val agentsCreateEnabled: Boolean = true,
-    val mcpServersEnabled: Boolean = true,
-    val multiConvoEnabled: Boolean = true,
-    val temporaryChatEnabled: Boolean = true,
-    val webSearchEnabled: Boolean = true,
-    val runCodeEnabled: Boolean = true,
-    val fileSearchEnabled: Boolean = true,
-    val bookmarksEnabled: Boolean = true,
-    /**
-     * Interface-only gates (no corresponding role permission on web). Driven solely by
-     * the server's `interface.*` config: presets on `interface.presets && interface.modelSelect`,
-     * model select on `interface.modelSelect`, parameters on `interface.parameters`.
-     * See web `Chat/Header.tsx` and `Chat/Input/HeaderOptions.tsx`.
-     */
-    val presetsEnabled: Boolean = true,
-    val modelSelectEnabled: Boolean = true,
-    val parametersEnabled: Boolean = true,
-    /** `interface.defaultPinnedTools` (v0.8.7): tool keys the server pins to the prompt bar.
-     *  Raw, as sent; mapped/filtered to renderable chips by [pinnedToolChips]. */
-    val pinnedTools: List<String> = emptyList(),
-    /**
-     * Context-usage gauge gate (v0.8.7). [contextUsageEnabled] = `interface.contextUsage`
-     * AND backend ≥ 0.8.7. Fails closed on older/unknown servers (the gauge has no data source there).
-     */
-    val contextUsageEnabled: Boolean = false,
-    /** Latest context-window usage snapshot for the gauge, from the `on_context_usage` SSE
-     *  event or the context-projection endpoint. Null until the first snapshot arrives. */
-    val contextUsage: ContextUsage? = null,
-    /** Latest per-call provider token usage (`on_token_usage` SSE), feeding the context
-     *  sheet's Input/Output rows. Null until a stream reports usage. */
-    val tokenUsage: TokenUsage? = null,
-    /** User preference (Settings → Chat) for where the context gauge is surfaced (above the
-     *  composer, in the "+" sheet, in the overflow menu, or hidden). Default
-     *  [ContextBarPlacement.OPTIONS_SHEET]; independent of [contextUsageEnabled] (the server/version gate). */
-    val contextBarPlacement: ContextBarPlacement = ContextBarPlacement.OPTIONS_SHEET,
-    /**
-     * User-pinned agent IDs (v0.8.5 favorites). Pinned agents sort to the top
-     * of the "My Agents" group in [ModelSelectorSheet] and get a filled star.
-     */
-    val favoriteAgentIds: Set<String> = emptySet(),
-    /**
-     * User-pinned model keys. Each key is `"$endpoint::$model"` — compare with
-     * `FavoritesDelegate.favoriteModelKey(endpoint, model)`.
-     */
-    val favoriteModelKeys: Set<String> = emptySet(),
-    /**
-     * Whether the detected backend is v0.8.5+ and therefore accepts the `xhigh`
-     * and `max` values in the reasoning-effort and effort dropdowns. False on
-     * older or unknown servers (per VERSION_GATES.md guideline #2). See VERSION_GATES.md.
-     */
-    val extendedEffortSupported: Boolean = false,
-    /**
-     * Server upload config (`GET /api/files/config`).
-     * Null before fetch or on fetch failure; treated as no constraint (controls fail open).
-     */
-    val fileUploadConfig: FileUploadConfig? = null,
     /**
      * Open-state for the full-screen zoomable media viewer (null = closed). Computed once on
      * tap by [ChatViewModel.openMedia] from a state snapshot, so the branch-media walk never
@@ -440,6 +52,92 @@ data class ChatUiState(
      */
     val mediaPreview: MediaPreviewState? = null,
 ) {
+    // ── Flat compat accessors: preserve the pre-slice read API (`uiState.field`) for UI + tests.
+    //    Each delegates to its owning slice; writes go through the slice, not these. ──
+    val messageQueue: List<QueuedMessage> get() = queue.messageQueue
+    val isQueuePaused: Boolean get() = queue.isQueuePaused
+    val isSearchOpen: Boolean get() = search.isSearchOpen
+    val searchQuery: String get() = search.searchQuery
+    val searchMatchIndices: List<SearchMatch> get() = search.searchMatchIndices
+    val currentSearchMatchIndex: Int get() = search.currentSearchMatchIndex
+    val searchFocusRequest: SearchFocusRequest? get() = search.searchFocusRequest
+    val favoriteAgentIds: Set<String> get() = favorites.favoriteAgentIds
+    val favoriteModelKeys: Set<String> get() = favorites.favoriteModelKeys
+    val subagentProgress: Map<String, SubagentTrace> get() = subagents.subagentProgress
+    val showRenameDialog: Boolean get() = actions.showRenameDialog
+    val showDeleteConfirmation: Boolean get() = actions.showDeleteConfirmation
+    val duplicatedConversationId: String? get() = actions.duplicatedConversationId
+    val showForkOptionsForMessageId: String? get() = actions.showForkOptionsForMessageId
+    val isForkInProgress: Boolean get() = actions.isForkInProgress
+    val forkedConversationId: String? get() = actions.forkedConversationId
+    val editingMessageId: String? get() = editing.editingMessageId
+    val editingText: String get() = editing.editingText
+    val selectedModel: String? get() = selection.selectedModel
+    val selectedEndpoint: String get() = selection.selectedEndpoint
+    val endpointConfigs: Map<String, EndpointConfig> get() = selection.endpointConfigs
+    val endpointKeyStates: Map<String, KeyState> get() = selection.endpointKeyStates
+    val availableModels: Map<String, List<String>> get() = selection.availableModels
+    val agents: List<Agent> get() = selection.agents
+    val modelParameters: ModelParameters get() = selection.modelParameters
+    val showModelParameters: Boolean get() = selection.showModelParameters
+    val showModelSheet: Boolean get() = selection.showModelSheet
+    val enabledTools: Set<String> get() = selection.enabledTools
+    val mcpServers: List<McpServerDisplayData> get() = selection.mcpServers
+    val selectedMcpServerNames: Set<String> get() = selection.selectedMcpServerNames
+    val extendedEffortSupported: Boolean get() = selection.extendedEffortSupported
+    val inputText: String get() = composer.inputText
+    val sendBlockReason: SendBlockReason? get() = composer.sendBlockReason
+    val editingQueuedItem: QueuedEditSession? get() = composer.editingQueuedItem
+    val presets: List<PresetDisplayData> get() = presetPrompts.presets
+    val availablePrompts: List<PromptMentionDisplayData> get() = presetPrompts.availablePrompts
+    val isRecording: Boolean get() = voice.isRecording
+    val isTranscribing: Boolean get() = voice.isTranscribing
+    val serverSttEnabled: Boolean get() = voice.serverSttEnabled
+    val currentlyReadingMessageId: String? get() = voice.currentlyReadingMessageId
+    val userName: String? get() = account.userName
+    val userAvatarUrl: String? get() = account.userAvatarUrl
+    val fileUploadConfig: FileUploadConfig? get() = account.fileUploadConfig
+    val serverUrl: String get() = prefs.serverUrl
+    val chatFontSize: ChatFontSize get() = prefs.chatFontSize
+    val starredModelsDisplay: StarredModelsDisplay get() = prefs.starredModelsDisplay
+    val chatHeaderContent: ChatHeaderContent get() = prefs.chatHeaderContent
+    val chatHeaderAlignment: ChatHeaderAlignment get() = prefs.chatHeaderAlignment
+    val contextBarPlacement: ContextBarPlacement get() = prefs.contextBarPlacement
+    val promptsEnabled: Boolean get() = gates.promptsEnabled
+    val promptsCreateEnabled: Boolean get() = gates.promptsCreateEnabled
+    val agentsEnabled: Boolean get() = gates.agentsEnabled
+    val agentsCreateEnabled: Boolean get() = gates.agentsCreateEnabled
+    val mcpServersEnabled: Boolean get() = gates.mcpServersEnabled
+    val multiConvoEnabled: Boolean get() = gates.multiConvoEnabled
+    val temporaryChatEnabled: Boolean get() = gates.temporaryChatEnabled
+    val webSearchEnabled: Boolean get() = gates.webSearchEnabled
+    val runCodeEnabled: Boolean get() = gates.runCodeEnabled
+    val fileSearchEnabled: Boolean get() = gates.fileSearchEnabled
+    val bookmarksEnabled: Boolean get() = gates.bookmarksEnabled
+    val presetsEnabled: Boolean get() = gates.presetsEnabled
+    val modelSelectEnabled: Boolean get() = gates.modelSelectEnabled
+    val parametersEnabled: Boolean get() = gates.parametersEnabled
+    val pinnedTools: List<String> get() = gates.pinnedTools
+    val contextUsageEnabled: Boolean get() = gates.contextUsageEnabled
+    val screenState: ChatScreenState get() = content.screenState
+    val messages: List<Message> get() = content.messages
+    val displayMessages: List<MessageNode> get() = content.displayMessages
+    val pendingResumeUserMessage: Message? get() = content.pendingResumeUserMessage
+    val activeBranches: Map<String, Int> get() = content.activeBranches
+    val isStreaming: Boolean get() = content.isStreaming
+    val streamingContent: String get() = content.streamingContent
+    val activeToolCalls: List<ActiveToolCall> get() = content.activeToolCalls
+    val streamingAttachments: List<Attachment> get() = content.streamingAttachments
+    val retryInfo: RetryInfo? get() = content.retryInfo
+    val isRefreshingMessages: Boolean get() = content.isRefreshingMessages
+    val contextUsage: ContextUsage? get() = content.contextUsage
+    val tokenUsage: TokenUsage? get() = content.tokenUsage
+    val conversationId: String? get() = conversation.conversationId
+    val conversationTitle: String? get() = conversation.conversationTitle
+    val isTemporaryChat: Boolean get() = conversation.isTemporaryChat
+    val sharedLinksEnabled: Boolean get() = conversation.sharedLinksEnabled
+    val pendingNavigationConversationId: String? get() = conversation.pendingNavigationConversationId
+
     /**
      * Whether the chat attach controls (Camera / Photos / Files) should be offered for
      * the current endpoint. Mirrors web's AttachFileChat gate:

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModel.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModel.kt
@@ -152,27 +152,27 @@ class ChatViewModel(
     // re-entry render directly from the cached AST. See CachedMarkdown.
     val parsedMarkdownCache: ParsedMarkdownCache = ParsedMarkdownCache()
 
-    // --- Platform delegates (created via factory so they get the ViewModel's stateHandle) ---
-    private val fileDelegate = platformDelegateFactory.createFileHandler(stateHandle)
-    private val ttsDelegate = platformDelegateFactory.createTts(stateHandle, ::getMessageText)
-    private val voiceDelegate = platformDelegateFactory.createVoiceInput(stateHandle, ::sendMessage)
+    // --- Platform delegates (created via factory so they get a narrowed handle over stateHandle) ---
+    private val fileDelegate = platformDelegateFactory.createFileHandler(ErrorOnlyHandle(stateHandle))
+    private val ttsDelegate = platformDelegateFactory.createTts(TtsHandle(stateHandle), ::getMessageText)
+    private val voiceDelegate = platformDelegateFactory.createVoiceInput(VoiceHandle(stateHandle), ::sendMessage)
     private val shareConsumer = platformDelegateFactory.createShareConsumer()
 
-    // --- Delegates ---
-    private val requestBuilder = ChatRequestBuilder(stateHandle)
-    private val treeDelegate = MessageTreeDelegate(stateHandle)
+    // --- Delegates (each gets a narrowed handle that can write only its own slices) ---
+    private val requestBuilder = ChatRequestBuilder { _uiState.value }
+    private val treeDelegate = MessageTreeDelegate(MessageTreeHandle(stateHandle))
     private val comparisonDelegate = ComparisonModeDelegate(
-        stateHandle = stateHandle,
+        handle = ComparisonHandle(stateHandle),
         messageRepository = messageRepository,
         reloadConversation = ::loadConversation,
     )
-    private val searchDelegate = InConversationSearchDelegate(stateHandle)
+    private val searchDelegate = InConversationSearchDelegate(SearchHandle(stateHandle))
     private val conversationActionsDelegate =
-        ConversationActionsDelegate(stateHandle, conversationRepository, shareRepository)
-    private val presetPromptDelegate = PresetPromptDelegate(stateHandle, presetRepository, promptRepository)
-    private val favoritesDelegate = FavoritesDelegate(stateHandle, favoritesRepository)
+        ConversationActionsDelegate(ConversationActionsHandle(stateHandle), conversationRepository, shareRepository)
+    private val presetPromptDelegate = PresetPromptDelegate(PresetPromptHandle(stateHandle), presetRepository, promptRepository)
+    private val favoritesDelegate = FavoritesDelegate(FavoritesHandle(stateHandle), favoritesRepository)
     private val modelDelegate = ModelSelectionDelegate(
-        stateHandle = stateHandle,
+        handle = ModelSelectionHandle(stateHandle),
         configRepository = configRepository,
         agentRepository = agentRepository,
         mcpRepository = mcpRepository,
@@ -184,13 +184,13 @@ class ChatViewModel(
         initialModel = initialModel,
     )
     private val keyStatusDelegate = EndpointKeyStatusDelegate(
-        stateHandle = stateHandle,
+        handle = EndpointKeyHandle(stateHandle),
         keyRepository = keyRepository,
     )
-    private val subagentTraceDelegate = SubagentTraceDelegate(stateHandle, json)
-    private val officePreviewDelegate = OfficePreviewDelegate(stateHandle, fileRepository)
+    private val subagentTraceDelegate = SubagentTraceDelegate(SubagentHandle(stateHandle), json)
+    private val officePreviewDelegate = OfficePreviewDelegate(OfficePreviewHandle(stateHandle), fileRepository)
     private val completionDelegate = SendCompletionDelegate(
-        stateHandle = stateHandle,
+        handle = SendCompletionHandle(stateHandle),
         conversationRepository = conversationRepository,
         messageRepository = messageRepository,
         draftRepository = draftRepository,
@@ -207,7 +207,7 @@ class ChatViewModel(
     val queuedMessagesDropped: Flow<Int> = _queuedMessagesDropped.receiveAsFlow()
 
     private val queueDelegate = MessageQueueDelegate(
-        stateHandle = stateHandle,
+        handle = QueueHandle(stateHandle),
         // Drained items send with their snapshotted config but LIVE lineage. We first wait for
         // the previous reply to settle into the tree (the Final-triggered Room reload is async),
         // so the optimistic insert chains onto the freshly-finalized assistant message rather
@@ -300,12 +300,14 @@ class ChatViewModel(
         chatHeaderPrefs,
     ) { state, url, fontSize, starredDisplay, headerPrefs ->
         state.copy(
-            serverUrl = url,
-            chatFontSize = fontSize,
-            starredModelsDisplay = starredDisplay,
-            chatHeaderContent = headerPrefs.content,
-            chatHeaderAlignment = headerPrefs.alignment,
-            contextBarPlacement = headerPrefs.contextBarPlacement,
+            prefs = ChatPrefsState(
+                serverUrl = url,
+                chatFontSize = fontSize,
+                starredModelsDisplay = starredDisplay,
+                chatHeaderContent = headerPrefs.content,
+                chatHeaderAlignment = headerPrefs.alignment,
+                contextBarPlacement = headerPrefs.contextBarPlacement,
+            ),
         )
     }.stateIn(viewModelScope, SharingStarted.Eagerly, ChatUiState())
 
@@ -316,7 +318,7 @@ class ChatViewModel(
     private var roomObserverJob: Job? = null
 
     private val streamingManager = StreamingManagerDelegate(
-        stateHandle = stateHandle,
+        handle = StreamingHandle(stateHandle),
         chatRepository = chatRepository,
         activeAccountProvider = activeAccountProvider,
         connectivityObserver = connectivityObserver,
@@ -332,7 +334,7 @@ class ChatViewModel(
     )
 
     private val editingDelegate = MessageEditingDelegate(
-        stateHandle = stateHandle,
+        handle = MessageEditingHandle(stateHandle),
         chatRepository = chatRepository,
         messageRepository = messageRepository,
         treeDelegate = treeDelegate,
@@ -387,17 +389,21 @@ class ChatViewModel(
         if (conversationId != null) {
             _uiState.update {
                 it.copy(
-                    conversationId = conversationId,
                     // SECURITY: do not remove — temp-chat data-at-rest guard. Seeded from the Chat
                     // route (durable across process death), so a restored temp Chat(id) stays
                     // temp-aware from the first frame: this short-circuits loadConversation and
                     // loadConversationModel below, both of which would otherwise upsert the
                     // server-hidden conversation to Room, and makes follow-up sends temporary.
-                    isTemporaryChat = initialIsTemporary,
+                    conversation = it.conversation.copy(
+                        conversationId = conversationId,
+                        isTemporaryChat = initialIsTemporary,
+                    ),
                     // A temp chat restored across process death has no in-memory handoff to seed its
                     // messages (they're gone with the session), and its Room read is guarded off — so
                     // land on an empty ACTIVE chat rather than a LOADING spinner that never resolves.
-                    screenState = if (initialIsTemporary) ChatScreenState.ACTIVE else ChatScreenState.LOADING,
+                    content = it.content.copy(
+                        screenState = if (initialIsTemporary) ChatScreenState.ACTIVE else ChatScreenState.LOADING,
+                    ),
                 )
             }
             // If we arrived here straight from the NewChat landing (the common case for a
@@ -424,12 +430,14 @@ class ChatViewModel(
                 _uiState.update {
                     val seeded = listOf(optimistic)
                     it.copy(
-                        messages = seeded,
-                        displayMessages = buildActiveMessagePath(seeded, it.activeBranches),
-                        pendingResumeUserMessage = optimistic,
-                        // Show the message immediately instead of the LOADING spinner set above —
-                        // we already have content to render while the stream resumes.
-                        screenState = ChatScreenState.ACTIVE,
+                        content = it.content.copy(
+                            messages = seeded,
+                            displayMessages = buildActiveMessagePath(seeded, it.activeBranches),
+                            pendingResumeUserMessage = optimistic,
+                            // Show the message immediately instead of the LOADING spinner set above —
+                            // we already have content to render while the stream resumes.
+                            screenState = ChatScreenState.ACTIVE,
+                        ),
                     )
                 }
             }
@@ -479,7 +487,7 @@ class ChatViewModel(
 
         viewModelScope.launch {
             configRepository.endpointConfigs.collect { configs ->
-                _uiState.update { it.copy(endpointConfigs = configs) }
+                _uiState.update { it.copy(selection = it.selection.copy(endpointConfigs = configs)) }
                 modelDelegate.refilterModels(isNewConversation)
                 keyStatusDelegate.recomputeFor(configs)
                 // If code interpreter is no longer available, remove it from enabled tools
@@ -487,7 +495,7 @@ class ChatViewModel(
                 if (agentsCapabilities.isNotEmpty() && ToolConstants.EXECUTE_CODE !in agentsCapabilities) {
                     _uiState.update {
                         if (ToolConstants.CODE_INTERPRETER in it.enabledTools) {
-                            it.copy(enabledTools = it.enabledTools - ToolConstants.CODE_INTERPRETER)
+                            it.copy(selection = it.selection.copy(enabledTools = it.enabledTools - ToolConstants.CODE_INTERPRETER))
                         } else {
                             it
                         }
@@ -510,7 +518,7 @@ class ChatViewModel(
             configRepository.detectedBackendVersion.collect { version ->
                 val supported = version != null &&
                     BackendVersion.isCompatibleOrNewer(version, "0.8.5")
-                _uiState.update { it.copy(extendedEffortSupported = supported) }
+                _uiState.update { it.copy(selection = it.selection.copy(extendedEffortSupported = supported)) }
             }
         }
 
@@ -538,8 +546,10 @@ class ChatViewModel(
             if (mcpServers.isNotEmpty() || tools.isNotEmpty()) {
                 _uiState.update {
                     it.copy(
-                        selectedMcpServerNames = mcpServers,
-                        enabledTools = tools,
+                        selection = it.selection.copy(
+                            selectedMcpServerNames = mcpServers,
+                            enabledTools = tools,
+                        ),
                     )
                 }
             }
@@ -598,7 +608,7 @@ class ChatViewModel(
                 _uiState.update {
                     it.copy(
                         error = "Could not load messages",
-                        screenState = ChatScreenState.ACTIVE,
+                        content = it.content.copy(screenState = ChatScreenState.ACTIVE),
                     )
                 }
             }
@@ -640,12 +650,14 @@ class ChatViewModel(
                 .collect { (messages, displayMessages, retainedPending) ->
                     _uiState.update {
                         it.copy(
-                            messages = messages,
-                            displayMessages = displayMessages,
-                            screenState = ChatScreenState.ACTIVE,
-                            // Null once the server echoes its own copy (or there was never a seed) →
-                            // a later server-side delete can then still remove the row.
-                            pendingResumeUserMessage = retainedPending,
+                            content = it.content.copy(
+                                messages = messages,
+                                displayMessages = displayMessages,
+                                screenState = ChatScreenState.ACTIVE,
+                                // Null once the server echoes its own copy (or there was never a seed) →
+                                // a later server-side delete can then still remove the row.
+                                pendingResumeUserMessage = retainedPending,
+                            ),
                         )
                     }
                     // Restore comparison mode when reopening a Compare Models conversation: the
@@ -695,7 +707,7 @@ class ChatViewModel(
                     // the live SSE owns the gauge then, and clearing would kill the moving readout.
                     val prev = previousProjectionKey
                     if (prev != null && !prev.sameWindowAs(key) && !_uiState.value.isStreaming) {
-                        _uiState.update { it.copy(contextUsage = null) }
+                        _uiState.update { it.copy(content = it.content.copy(contextUsage = null)) }
                     }
                     previousProjectionKey = key
                     refreshContextProjection()
@@ -803,7 +815,7 @@ class ChatViewModel(
         // Only seed when the server actually returned a snapshot — never overwrite or blank an
         // existing gauge. On null/error, leave the gauge as-is; the next turn's SSE refreshes it.
         val usage = (result as? Result.Success)?.data ?: return
-        _uiState.update { it.copy(contextUsage = usage) }
+        _uiState.update { it.copy(content = it.content.copy(contextUsage = usage)) }
     }
 
     /**
@@ -818,7 +830,7 @@ class ChatViewModel(
             val draft = draftRepository.awaitDraft(draftKey)
             if (!draft.isNullOrBlank()) {
                 _uiState.update {
-                    if (it.inputText.isBlank()) it.copy(inputText = draft) else it
+                    if (it.inputText.isBlank()) it.copy(composer = it.composer.copy(inputText = draft)) else it
                 }
             }
         }
@@ -838,7 +850,7 @@ class ChatViewModel(
             val result = conversationRepository.getConversation(conversationId, originAccount = null)
             val conversation = result.getOrNull()
             if (conversation != null) {
-                _uiState.update { it.copy(conversationTitle = conversation.title) }
+                _uiState.update { it.copy(conversation = it.conversation.copy(conversationTitle = conversation.title)) }
                 val applied = modelDelegate.applyConversationModel(conversation)
                 Diag.d(
                     tag = "ModelSel",
@@ -869,7 +881,7 @@ class ChatViewModel(
         treeDelegate.switchBranch(parentMessageId, siblingIndex)
 
     fun onInputChanged(text: String) {
-        _uiState.update { it.copy(inputText = text) }
+        _uiState.update { it.copy(composer = it.composer.copy(inputText = text)) }
         // While editing a queued item the composer holds that item, not the persisted draft —
         // don't overwrite the on-disk new-message draft (it's restored on commit/cancel).
         if (_uiState.value.isEditingQueued) return
@@ -884,7 +896,7 @@ class ChatViewModel(
         Logger.d { "consumeShareIntent: text=${shareData.text != null}, files=${shareData.fileRefs.size}" }
 
         if (!shareData.text.isNullOrBlank()) {
-            _uiState.update { it.copy(inputText = shareData.text) }
+            _uiState.update { it.copy(composer = it.composer.copy(inputText = shareData.text)) }
         }
 
         if (shareData.fileRefs.isNotEmpty()) {
@@ -966,10 +978,12 @@ class ChatViewModel(
         applyComposer(taken.value.toComposerSnapshot())
         _uiState.update {
             it.copy(
-                editingQueuedItem = QueuedEditSession(
-                    original = taken.value,
-                    originalIndex = taken.index,
-                    stashed = stashed,
+                composer = it.composer.copy(
+                    editingQueuedItem = QueuedEditSession(
+                        original = taken.value,
+                        originalIndex = taken.index,
+                        stashed = stashed,
+                    ),
                 ),
             )
         }
@@ -1005,7 +1019,7 @@ class ChatViewModel(
 
     private fun finishQueuedEdit(session: QueuedEditSession) {
         applyComposer(session.stashed)
-        _uiState.update { it.copy(editingQueuedItem = null) }
+        _uiState.update { it.copy(composer = it.composer.copy(editingQueuedItem = null)) }
         // Draining was frozen during the edit; resume it now if the queue is idle (a reply may
         // have finished while editing).
         tryResumeDrain()
@@ -1047,12 +1061,14 @@ class ChatViewModel(
         fileDelegate.restoreAttachedFiles(snapshot.attachments)
         _uiState.update {
             it.copy(
-                inputText = snapshot.text,
-                selectedEndpoint = snapshot.endpoint,
-                selectedModel = snapshot.model,
-                enabledTools = snapshot.enabledTools,
-                selectedMcpServerNames = snapshot.mcpServerNames,
-                modelParameters = snapshot.modelParameters,
+                composer = it.composer.copy(inputText = snapshot.text),
+                selection = it.selection.copy(
+                    selectedEndpoint = snapshot.endpoint,
+                    selectedModel = snapshot.model,
+                    enabledTools = snapshot.enabledTools,
+                    selectedMcpServerNames = snapshot.mcpServerNames,
+                    modelParameters = snapshot.modelParameters,
+                ),
             )
         }
     }
@@ -1123,7 +1139,7 @@ class ChatViewModel(
     /** Clears the input, its persisted draft, and any attached files. */
     private fun clearComposer() {
         val draftKey = _uiState.value.conversationId ?: NEW_CHAT_DRAFT_KEY
-        _uiState.update { it.copy(inputText = "") }
+        _uiState.update { it.copy(composer = it.composer.copy(inputText = "")) }
         viewModelScope.launch { draftRepository.deleteDraft(draftKey) }
         fileDelegate.clearAttachedFiles()
     }
@@ -1175,14 +1191,16 @@ class ChatViewModel(
             val updatedMessages = it.messages + optimisticMessage
             val updatedDisplay = buildActiveMessagePath(updatedMessages, it.activeBranches, optimisticMessage.messageId)
             it.copy(
-                isStreaming = true,
-                streamingContent = "",
-                activeToolCalls = emptyList(),
-                streamingAttachments = emptyList(),
-                screenState = if (isNewChat) ChatScreenState.LANDING else ChatScreenState.ACTIVE,
+                content = it.content.copy(
+                    isStreaming = true,
+                    streamingContent = "",
+                    activeToolCalls = emptyList(),
+                    streamingAttachments = emptyList(),
+                    screenState = if (isNewChat) ChatScreenState.LANDING else ChatScreenState.ACTIVE,
+                    messages = updatedMessages,
+                    displayMessages = updatedDisplay,
+                ),
                 error = null,
-                messages = updatedMessages,
-                displayMessages = updatedDisplay,
             )
         }
         streamingManager.beginStreaming(isEdit = false)
@@ -1230,7 +1248,7 @@ class ChatViewModel(
                 if (cid != null && roomObserverJob?.isActive != true) {
                     loadConversation(cid)
                 } else if (cid == null) {
-                    _uiState.update { it.copy(isStreaming = false) }
+                    _uiState.update { it.copy(content = it.content.copy(isStreaming = false)) }
                 }
             }
         }
@@ -1296,20 +1314,23 @@ class ChatViewModel(
         roomObserverJob = null
         _uiState.update { current ->
             ChatUiState(
-                selectedEndpoint = current.selectedEndpoint,
-                selectedModel = current.selectedModel,
-                availableModels = current.availableModels,
-                endpointConfigs = current.endpointConfigs,
-                agents = current.agents,
-                presets = current.presets,
-                availablePrompts = current.availablePrompts,
-                mcpServers = current.mcpServers,
-                selectedMcpServerNames = current.selectedMcpServerNames,
-                enabledTools = current.enabledTools,
-                serverSttEnabled = current.serverSttEnabled,
-                userName = current.userName,
-                userAvatarUrl = current.userAvatarUrl,
-                sharedLinksEnabled = current.sharedLinksEnabled,
+                selection = ModelSelectionState(
+                    selectedEndpoint = current.selectedEndpoint,
+                    selectedModel = current.selectedModel,
+                    availableModels = current.availableModels,
+                    endpointConfigs = current.endpointConfigs,
+                    agents = current.agents,
+                    mcpServers = current.mcpServers,
+                    selectedMcpServerNames = current.selectedMcpServerNames,
+                    enabledTools = current.enabledTools,
+                ),
+                presetPrompts = current.presetPrompts,
+                voice = VoiceState(serverSttEnabled = current.serverSttEnabled),
+                account = AccountConfigState(
+                    userName = current.userName,
+                    userAvatarUrl = current.userAvatarUrl,
+                ),
+                conversation = ConversationMetaState(sharedLinksEnabled = current.sharedLinksEnabled),
             )
         }
     }
@@ -1324,11 +1345,11 @@ class ChatViewModel(
         // to Room. Skip — there's nothing to refresh for a temporary chat.
         if (_uiState.value.isTemporaryChat) return
         if (_uiState.value.isRefreshingMessages) return
-        _uiState.update { it.copy(isRefreshingMessages = true) }
+        _uiState.update { it.copy(content = it.content.copy(isRefreshingMessages = true)) }
         viewModelScope.launch {
             messageRepository.refreshMessages(conversationId)
             loadConversation(conversationId)
-            _uiState.update { it.copy(isRefreshingMessages = false) }
+            _uiState.update { it.copy(content = it.content.copy(isRefreshingMessages = false)) }
         }
     }
 
@@ -1343,7 +1364,7 @@ class ChatViewModel(
             ) { config, role ->
                 role.canCreateSharedLinks(config?.sharedLinksEnabled ?: false)
             }.distinctUntilChanged().collect { canShare ->
-                _uiState.update { it.copy(sharedLinksEnabled = canShare) }
+                _uiState.update { it.copy(conversation = it.conversation.copy(sharedLinksEnabled = canShare)) }
             }
         }
         // Feature gates. The effective rule mirrors web: `interface.* flag AND role permission`.
@@ -1373,26 +1394,28 @@ class ChatViewModel(
                     role.hasAccessOrPermissive(type, action) && (iface?.let(flag) ?: true)
                 _uiState.update {
                     it.copy(
-                        promptsEnabled = role.hasAccessOrPermissive(PermissionType.PROMPTS, Permission.USE),
-                        promptsCreateEnabled = role.hasAccessOrPermissive(PermissionType.PROMPTS, Permission.CREATE),
-                        agentsEnabled = role.hasAccessOrPermissive(PermissionType.AGENTS, Permission.USE),
-                        agentsCreateEnabled = role.hasAccessOrPermissive(PermissionType.AGENTS, Permission.CREATE),
-                        mcpServersEnabled = role.hasAccessOrPermissive(PermissionType.MCP_SERVERS, Permission.USE),
-                        multiConvoEnabled = gate(PermissionType.MULTI_CONVO, Permission.USE) { it.multiConvo },
-                        temporaryChatEnabled = gate(PermissionType.TEMPORARY_CHAT, Permission.USE) { it.temporaryChat },
-                        webSearchEnabled = gate(PermissionType.WEB_SEARCH, Permission.USE) { it.webSearch },
-                        runCodeEnabled = gate(PermissionType.RUN_CODE, Permission.USE) { it.runCode },
-                        fileSearchEnabled = gate(PermissionType.FILE_SEARCH, Permission.USE) { it.fileSearch },
-                        bookmarksEnabled = gate(PermissionType.BOOKMARKS, Permission.USE) { it.bookmarks },
-                        // Interface-only gates (no role permission counterpart on web).
-                        modelSelectEnabled = iface?.modelSelect ?: true,
-                        parametersEnabled = iface?.parameters ?: true,
-                        // Web gates the presets menu on `presets && modelSelect` (Header.tsx).
-                        presetsEnabled = (iface?.presets ?: true) && (iface?.modelSelect ?: true),
-                        // Context-usage gauge (v0.8.7): interface flag AND backend support.
-                        contextUsageEnabled = contextGaugeSupported && (iface?.contextUsage ?: true),
-                        // Pinned tools (v0.8.7): raw interface list; mapped/filtered by pinnedToolChips.
-                        pinnedTools = iface?.defaultPinnedTools ?: emptyList(),
+                        gates = it.gates.copy(
+                            promptsEnabled = role.hasAccessOrPermissive(PermissionType.PROMPTS, Permission.USE),
+                            promptsCreateEnabled = role.hasAccessOrPermissive(PermissionType.PROMPTS, Permission.CREATE),
+                            agentsEnabled = role.hasAccessOrPermissive(PermissionType.AGENTS, Permission.USE),
+                            agentsCreateEnabled = role.hasAccessOrPermissive(PermissionType.AGENTS, Permission.CREATE),
+                            mcpServersEnabled = role.hasAccessOrPermissive(PermissionType.MCP_SERVERS, Permission.USE),
+                            multiConvoEnabled = gate(PermissionType.MULTI_CONVO, Permission.USE) { it.multiConvo },
+                            temporaryChatEnabled = gate(PermissionType.TEMPORARY_CHAT, Permission.USE) { it.temporaryChat },
+                            webSearchEnabled = gate(PermissionType.WEB_SEARCH, Permission.USE) { it.webSearch },
+                            runCodeEnabled = gate(PermissionType.RUN_CODE, Permission.USE) { it.runCode },
+                            fileSearchEnabled = gate(PermissionType.FILE_SEARCH, Permission.USE) { it.fileSearch },
+                            bookmarksEnabled = gate(PermissionType.BOOKMARKS, Permission.USE) { it.bookmarks },
+                            // Interface-only gates (no role permission counterpart on web).
+                            modelSelectEnabled = iface?.modelSelect ?: true,
+                            parametersEnabled = iface?.parameters ?: true,
+                            // Web gates the presets menu on `presets && modelSelect` (Header.tsx).
+                            presetsEnabled = (iface?.presets ?: true) && (iface?.modelSelect ?: true),
+                            // Context-usage gauge (v0.8.7): interface flag AND backend support.
+                            contextUsageEnabled = contextGaugeSupported && (iface?.contextUsage ?: true),
+                            // Pinned tools (v0.8.7): raw interface list; mapped/filtered by pinnedToolChips.
+                            pinnedTools = iface?.defaultPinnedTools ?: emptyList(),
+                        ),
                     )
                 }
             }
@@ -1407,7 +1430,7 @@ class ChatViewModel(
     private fun loadFileConfig() {
         viewModelScope.launch {
             fileRepository.getFileConfig().getOrNull()?.let { config ->
-                _uiState.update { it.copy(fileUploadConfig = config) }
+                _uiState.update { it.copy(account = it.account.copy(fileUploadConfig = config)) }
             }
         }
     }
@@ -1510,15 +1533,15 @@ class ChatViewModel(
         favoritesDelegate.refresh()
         _uiState.update {
             it.copy(
-                sendBlockReason = reason ?: it.sendBlockReason,
-                showModelSheet = true,
+                composer = it.composer.copy(sendBlockReason = reason ?: it.sendBlockReason),
+                selection = it.selection.copy(showModelSheet = true),
             )
         }
     }
 
     /** Dismisses the model-selector sheet. Called on sheet dismiss and model selection. */
     fun dismissModelSheet() {
-        _uiState.update { it.copy(showModelSheet = false) }
+        _uiState.update { it.copy(selection = it.selection.copy(showModelSheet = false)) }
     }
 
     private fun loadUserProfile() {
@@ -1529,8 +1552,10 @@ class ChatViewModel(
                     cachedUserId = user.id
                     _uiState.update {
                         it.copy(
-                            userName = user.name ?: user.username,
-                            userAvatarUrl = user.avatar,
+                            account = it.account.copy(
+                                userName = user.name ?: user.username,
+                                userAvatarUrl = user.avatar,
+                            ),
                         )
                     }
                 }
@@ -1569,7 +1594,7 @@ class ChatViewModel(
     }
 
     fun dismissSendBlockReason() {
-        _uiState.update { it.copy(sendBlockReason = null) }
+        _uiState.update { it.copy(composer = it.composer.copy(sendBlockReason = null)) }
     }
 
     /**

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/DelegateHandles.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/DelegateHandles.kt
@@ -1,0 +1,256 @@
+package com.garfiec.librechat.feature.chat.viewmodel
+
+import com.garfiec.librechat.core.model.endpoint.KeyState
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Per-delegate narrowed write handles over the shared [ChatStateHandle].
+ *
+ * Each delegate receives a handle that can mutate only the [ChatUiState] slices it owns
+ * (enforced at compile time by the corresponding `*Writes` class exposing only those slices
+ * as vars), plus the shared `error` channel. Reads stay global via [DelegateHandle.state]; a
+ * delegate may legitimately read any slice. Writes go through each handle's `update`, whose block
+ * receives a mutable writer and is applied as a single [ChatStateHandle.update] — so a multi-field
+ * change is one StateFlow emission, preserving the atomic-transaction invariants (completion
+ * flash, etc.).
+ *
+ * The root [ChatStateHandle] is held only by [ChatViewModel] for its orchestration
+ * transactions; delegates never receive it. See feature/chat/CLAUDE.md.
+ *
+ * `error` is intentionally writable from every handle — it is a shared, transient banner
+ * channel, not a per-delegate slice. Set it inside an `update` block alongside a slice write,
+ * or via [DelegateHandle.setError] on its own.
+ */
+
+/**
+ * Shared read/error surface for every delegate handle. Holds the global read view ([state]),
+ * the delegate's [scope], and the shared-channel [setError]. Subclasses add only their typed
+ * `update` (and, where needed, extra read views like [ModelSelectionHandle.stateFlow]) — the
+ * per-delegate write narrowing lives entirely in each `*Writes` class.
+ */
+abstract class DelegateHandle(protected val root: ChatStateHandle) {
+    val state: ChatUiState get() = root.state
+    val scope: CoroutineScope get() = root.scope
+    fun setError(message: String?) = root.update { copy(error = message) }
+}
+
+// ── StreamingManagerDelegate ──────────────────────────────────────────────
+class StreamingWrites internal constructor(state: ChatUiState) {
+    var content: MessagesState = state.content
+    var conversation: ConversationMetaState = state.conversation
+    var error: String? = state.error
+    internal fun applyTo(s: ChatUiState) = s.copy(content = content, conversation = conversation, error = error)
+}
+
+class StreamingHandle(root: ChatStateHandle) : DelegateHandle(root) {
+    fun update(block: StreamingWrites.() -> Unit) =
+        root.update { StreamingWrites(this).apply(block).applyTo(this) }
+}
+
+// ── MessageTreeDelegate ───────────────────────────────────────────────────
+class MessageTreeWrites internal constructor(state: ChatUiState) {
+    var content: MessagesState = state.content
+    var conversation: ConversationMetaState = state.conversation
+    var error: String? = state.error
+    internal fun applyTo(s: ChatUiState) = s.copy(content = content, conversation = conversation, error = error)
+}
+
+class MessageTreeHandle(root: ChatStateHandle) : DelegateHandle(root) {
+    fun update(block: MessageTreeWrites.() -> Unit) =
+        root.update { MessageTreeWrites(this).apply(block).applyTo(this) }
+}
+
+// ── MessageEditingDelegate ────────────────────────────────────────────────
+class MessageEditingWrites internal constructor(state: ChatUiState) {
+    var editing: MessageEditingState = state.editing
+    var content: MessagesState = state.content
+    var error: String? = state.error
+    internal fun applyTo(s: ChatUiState) = s.copy(editing = editing, content = content, error = error)
+}
+
+class MessageEditingHandle(root: ChatStateHandle) : DelegateHandle(root) {
+    fun update(block: MessageEditingWrites.() -> Unit) =
+        root.update { MessageEditingWrites(this).apply(block).applyTo(this) }
+}
+
+// ── ComparisonModeDelegate ────────────────────────────────────────────────
+class ComparisonWrites internal constructor(state: ChatUiState) {
+    var comparisonState: ComparisonState = state.comparisonState
+    var content: MessagesState = state.content
+    var conversation: ConversationMetaState = state.conversation
+    var error: String? = state.error
+    internal fun applyTo(s: ChatUiState) = s.copy(
+        comparisonState = comparisonState,
+        content = content,
+        conversation = conversation,
+        error = error,
+    )
+}
+
+class ComparisonHandle(root: ChatStateHandle) : DelegateHandle(root) {
+    fun update(block: ComparisonWrites.() -> Unit) =
+        root.update { ComparisonWrites(this).apply(block).applyTo(this) }
+}
+
+// ── ModelSelectionDelegate ────────────────────────────────────────────────
+class ModelSelectionWrites internal constructor(state: ChatUiState) {
+    var selection: ModelSelectionState = state.selection
+    var error: String? = state.error
+    internal fun applyTo(s: ChatUiState) = s.copy(selection = selection, error = error)
+}
+
+class ModelSelectionHandle(root: ChatStateHandle) : DelegateHandle(root) {
+    /** Read-only observation of the full state (the seeder combines over agents/conversationId). */
+    val stateFlow: StateFlow<ChatUiState> get() = root.stateFlow
+    fun update(block: ModelSelectionWrites.() -> Unit) =
+        root.update { ModelSelectionWrites(this).apply(block).applyTo(this) }
+}
+
+// ── EndpointKeyStatusDelegate ─────────────────────────────────────────────
+// Narrower than ModelSelectionHandle on purpose: this delegate owns only the
+// per-endpoint key-state map, so it may not touch the rest of the selection slice.
+class EndpointKeyWrites internal constructor(state: ChatUiState) {
+    var endpointKeyStates: Map<String, KeyState> = state.selection.endpointKeyStates
+    var error: String? = state.error
+    internal fun applyTo(s: ChatUiState) =
+        s.copy(selection = s.selection.copy(endpointKeyStates = endpointKeyStates), error = error)
+}
+
+class EndpointKeyHandle(root: ChatStateHandle) : DelegateHandle(root) {
+    fun update(block: EndpointKeyWrites.() -> Unit) =
+        root.update { EndpointKeyWrites(this).apply(block).applyTo(this) }
+}
+
+// ── PresetPromptDelegate ──────────────────────────────────────────────────
+class PresetPromptWrites internal constructor(state: ChatUiState) {
+    var presetPrompts: PresetPromptState = state.presetPrompts
+    var selection: ModelSelectionState = state.selection
+    var composer: ComposerState = state.composer
+    var error: String? = state.error
+    internal fun applyTo(s: ChatUiState) = s.copy(
+        presetPrompts = presetPrompts,
+        selection = selection,
+        composer = composer,
+        error = error,
+    )
+}
+
+class PresetPromptHandle(root: ChatStateHandle) : DelegateHandle(root) {
+    fun update(block: PresetPromptWrites.() -> Unit) =
+        root.update { PresetPromptWrites(this).apply(block).applyTo(this) }
+}
+
+// ── ConversationActionsDelegate ───────────────────────────────────────────
+class ConversationActionsWrites internal constructor(state: ChatUiState) {
+    var actions: ConversationActionsState = state.actions
+    var conversation: ConversationMetaState = state.conversation
+    var error: String? = state.error
+    internal fun applyTo(s: ChatUiState) = s.copy(actions = actions, conversation = conversation, error = error)
+}
+
+class ConversationActionsHandle(root: ChatStateHandle) : DelegateHandle(root) {
+    fun update(block: ConversationActionsWrites.() -> Unit) =
+        root.update { ConversationActionsWrites(this).apply(block).applyTo(this) }
+}
+
+// ── SendCompletionDelegate ────────────────────────────────────────────────
+class SendCompletionWrites internal constructor(state: ChatUiState) {
+    var conversation: ConversationMetaState = state.conversation
+    var error: String? = state.error
+    internal fun applyTo(s: ChatUiState) = s.copy(conversation = conversation, error = error)
+}
+
+class SendCompletionHandle(root: ChatStateHandle) : DelegateHandle(root) {
+    fun update(block: SendCompletionWrites.() -> Unit) =
+        root.update { SendCompletionWrites(this).apply(block).applyTo(this) }
+}
+
+// ── MessageQueueDelegate ──────────────────────────────────────────────────
+class QueueWrites internal constructor(state: ChatUiState) {
+    var queue: QueueState = state.queue
+    var error: String? = state.error
+    internal fun applyTo(s: ChatUiState) = s.copy(queue = queue, error = error)
+}
+
+class QueueHandle(root: ChatStateHandle) : DelegateHandle(root) {
+    fun update(block: QueueWrites.() -> Unit) =
+        root.update { QueueWrites(this).apply(block).applyTo(this) }
+}
+
+// ── InConversationSearchDelegate ──────────────────────────────────────────
+class SearchWrites internal constructor(state: ChatUiState) {
+    var search: ChatSearchState = state.search
+    var error: String? = state.error
+    internal fun applyTo(s: ChatUiState) = s.copy(search = search, error = error)
+}
+
+class SearchHandle(root: ChatStateHandle) : DelegateHandle(root) {
+    fun update(block: SearchWrites.() -> Unit) =
+        root.update { SearchWrites(this).apply(block).applyTo(this) }
+}
+
+// ── FavoritesDelegate ─────────────────────────────────────────────────────
+class FavoritesWrites internal constructor(state: ChatUiState) {
+    var favorites: FavoritesState = state.favorites
+    var error: String? = state.error
+    internal fun applyTo(s: ChatUiState) = s.copy(favorites = favorites, error = error)
+}
+
+class FavoritesHandle(root: ChatStateHandle) : DelegateHandle(root) {
+    fun update(block: FavoritesWrites.() -> Unit) =
+        root.update { FavoritesWrites(this).apply(block).applyTo(this) }
+}
+
+// ── SubagentTraceDelegate ─────────────────────────────────────────────────
+class SubagentWrites internal constructor(state: ChatUiState) {
+    var subagents: SubagentState = state.subagents
+    var error: String? = state.error
+    internal fun applyTo(s: ChatUiState) = s.copy(subagents = subagents, error = error)
+}
+
+class SubagentHandle(root: ChatStateHandle) : DelegateHandle(root) {
+    fun update(block: SubagentWrites.() -> Unit) =
+        root.update { SubagentWrites(this).apply(block).applyTo(this) }
+}
+
+// ── OfficePreviewDelegate ─────────────────────────────────────────────────
+class OfficePreviewWrites internal constructor(state: ChatUiState) {
+    var content: MessagesState = state.content
+    var error: String? = state.error
+    internal fun applyTo(s: ChatUiState) = s.copy(content = content, error = error)
+}
+
+class OfficePreviewHandle(root: ChatStateHandle) : DelegateHandle(root) {
+    fun update(block: OfficePreviewWrites.() -> Unit) =
+        root.update { OfficePreviewWrites(this).apply(block).applyTo(this) }
+}
+
+// ── Platform voice input (VoiceInputDelegate / IosVoiceInput) ─────────────
+class VoiceWrites internal constructor(state: ChatUiState) {
+    var voice: VoiceState = state.voice
+    var composer: ComposerState = state.composer
+    var error: String? = state.error
+    internal fun applyTo(s: ChatUiState) = s.copy(voice = voice, composer = composer, error = error)
+}
+
+class VoiceHandle(root: ChatStateHandle) : DelegateHandle(root) {
+    fun update(block: VoiceWrites.() -> Unit) =
+        root.update { VoiceWrites(this).apply(block).applyTo(this) }
+}
+
+// ── Platform TTS (TextToSpeechDelegate / IosTts) ──────────────────────────
+class TtsWrites internal constructor(state: ChatUiState) {
+    var voice: VoiceState = state.voice
+    var error: String? = state.error
+    internal fun applyTo(s: ChatUiState) = s.copy(voice = voice, error = error)
+}
+
+class TtsHandle(root: ChatStateHandle) : DelegateHandle(root) {
+    fun update(block: TtsWrites.() -> Unit) =
+        root.update { TtsWrites(this).apply(block).applyTo(this) }
+}
+
+// ── Error-only (FileAttachmentDelegate / IosFileHandler) ──────────────────
+/** For delegates that keep their real data in a separate flow and only surface errors here. */
+class ErrorOnlyHandle(root: ChatStateHandle) : DelegateHandle(root)

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/ComparisonModeDelegate.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/ComparisonModeDelegate.kt
@@ -13,7 +13,7 @@ import com.garfiec.librechat.feature.chat.util.secondaryAgentId
 import com.garfiec.librechat.feature.chat.util.stripAgentIdSuffix
 import com.garfiec.librechat.feature.chat.viewmodel.ActiveToolCall
 import com.garfiec.librechat.feature.chat.viewmodel.ChatScreenState
-import com.garfiec.librechat.feature.chat.viewmodel.ChatStateHandle
+import com.garfiec.librechat.feature.chat.viewmodel.ComparisonHandle
 import com.garfiec.librechat.feature.chat.viewmodel.ComparisonState
 import com.garfiec.librechat.feature.chat.viewmodel.resolveEndpointDispatch
 import kotlinx.coroutines.launch
@@ -29,7 +29,7 @@ import kotlinx.coroutines.launch
  * server interleaves both agents' deltas on one stream (distinguished via [isSecondaryEvent]).
  */
 class ComparisonModeDelegate(
-    private val stateHandle: ChatStateHandle,
+    private val handle: ComparisonHandle,
     private val messageRepository: MessageRepository,
     /** Reloads the conversation from the server after branching (VM-owned Room observer). */
     private val reloadConversation: (String) -> Unit,
@@ -45,21 +45,25 @@ class ComparisonModeDelegate(
 
     /** Toggles comparison mode on/off, inheriting the primary endpoint/model when enabling. */
     fun toggleComparison() {
-        val current = stateHandle.state.comparisonState
-        if (current.isEnabled) {
+        val snapshot = handle.state
+        if (snapshot.comparisonState.isEnabled) {
             primaryBuffer.clear()
             secondaryBuffer.clear()
-            stateHandle.update { copy(comparisonState = ComparisonState()) }
+            handle.update { comparisonState = ComparisonState() }
         } else {
-            stateHandle.update {
-                copy(
-                    comparisonState = ComparisonState(
-                        isEnabled = true,
-                        secondaryEndpoint = selectedEndpoint,
-                        secondaryModel = selectedModel,
-                    ),
-                    // When enabling on LANDING, switch to ACTIVE so comparison tabs render
-                    screenState = if (screenState == ChatScreenState.LANDING) ChatScreenState.ACTIVE else screenState,
+            handle.update {
+                comparisonState = ComparisonState(
+                    isEnabled = true,
+                    secondaryEndpoint = snapshot.selectedEndpoint,
+                    secondaryModel = snapshot.selectedModel,
+                )
+                // When enabling on LANDING, switch to ACTIVE so comparison tabs render
+                content = content.copy(
+                    screenState = if (content.screenState == ChatScreenState.LANDING) {
+                        ChatScreenState.ACTIVE
+                    } else {
+                        content.screenState
+                    },
                 )
             }
         }
@@ -67,20 +71,20 @@ class ComparisonModeDelegate(
 
     /** Updates the secondary model selection for comparison mode. */
     fun setSecondaryModel(endpoint: String, model: String) {
-        val comparison = stateHandle.state.comparisonState
+        val comparison = handle.state.comparisonState
         if (!comparison.isEnabled) return
-        stateHandle.update {
-            copy(comparisonState = comparison.copy(secondaryEndpoint = endpoint, secondaryModel = model))
+        handle.update {
+            comparisonState = comparison.copy(secondaryEndpoint = endpoint, secondaryModel = model)
         }
     }
 
     /** Resolves a display-friendly name for the secondary model. */
     fun getSecondaryModelDisplayName(): String? {
-        val comparison = stateHandle.state.comparisonState
+        val comparison = handle.state.comparisonState
         val endpoint = comparison.secondaryEndpoint ?: return null
         val model = comparison.secondaryModel ?: return null
         return if (endpoint == EndpointConstants.AGENTS) {
-            stateHandle.state.agents.find { it.id == model }?.name ?: model
+            handle.state.agents.find { it.id == model }?.name ?: model
         } else {
             model
         }
@@ -95,7 +99,7 @@ class ComparisonModeDelegate(
      * `getKeyExpiry` GET — keeps the chat-send hot path off the network.
      */
     fun buildAddedConvo(parentMessageId: String? = null): AddedConversation? {
-        val state = stateHandle.state
+        val state = handle.state
         val comparison = state.comparisonState
         if (!comparison.isEnabled) return null
         val endpoint = comparison.secondaryEndpoint ?: return null
@@ -131,17 +135,21 @@ class ComparisonModeDelegate(
     fun rehydrateFromMessage(message: Message) {
         val secondaryId = secondaryAgentId(message) ?: return
         val (endpoint, model) = resolveSecondarySelection(secondaryId)
-        stateHandle.update {
-            copy(
-                comparisonState = ComparisonState(
-                    isEnabled = true,
-                    secondaryEndpoint = endpoint,
-                    secondaryModel = model,
-                    primaryAgentId = primaryAgentId(message),
-                    secondaryAgentId = secondaryId,
-                    parallelMessageId = message.messageId,
-                ),
-                screenState = if (screenState == ChatScreenState.LANDING) ChatScreenState.ACTIVE else screenState,
+        handle.update {
+            comparisonState = ComparisonState(
+                isEnabled = true,
+                secondaryEndpoint = endpoint,
+                secondaryModel = model,
+                primaryAgentId = primaryAgentId(message),
+                secondaryAgentId = secondaryId,
+                parallelMessageId = message.messageId,
+            )
+            content = content.copy(
+                screenState = if (content.screenState == ChatScreenState.LANDING) {
+                    ChatScreenState.ACTIVE
+                } else {
+                    content.screenState
+                },
             )
         }
     }
@@ -164,24 +172,22 @@ class ComparisonModeDelegate(
      * No-ops when comparison is disabled, so callers can invoke it unconditionally.
      */
     fun onSendStart() {
-        if (!stateHandle.state.comparisonState.isEnabled) return
+        if (!handle.state.comparisonState.isEnabled) return
         primaryBuffer.clear()
         secondaryBuffer.clear()
-        stateHandle.update {
-            copy(
-                comparisonState = comparisonState.copy(
-                    primaryIsStreaming = true,
-                    secondaryIsStreaming = true,
-                    primaryStreamingContent = "",
-                    secondaryStreamingContent = "",
-                    primaryActiveToolCalls = emptyList(),
-                    secondaryActiveToolCalls = emptyList(),
-                    primaryAgentId = null,
-                    secondaryAgentId = null,
-                    parallelMessageId = null,
-                    primaryFinalContent = null,
-                    secondaryFinalContent = null,
-                ),
+        handle.update {
+            comparisonState = comparisonState.copy(
+                primaryIsStreaming = true,
+                secondaryIsStreaming = true,
+                primaryStreamingContent = "",
+                secondaryStreamingContent = "",
+                primaryActiveToolCalls = emptyList(),
+                secondaryActiveToolCalls = emptyList(),
+                primaryAgentId = null,
+                secondaryAgentId = null,
+                parallelMessageId = null,
+                primaryFinalContent = null,
+                secondaryFinalContent = null,
             )
         }
     }
@@ -192,7 +198,7 @@ class ComparisonModeDelegate(
      * otherwise — including when comparison is disabled, leaving the standard path intact.
      */
     fun routeEvent(event: StreamEvent): Boolean {
-        if (!stateHandle.state.comparisonState.isEnabled) return false
+        if (!handle.state.comparisonState.isEnabled) return false
         return when (event) {
             // Thinking and content deltas both feed the same pane buffer in comparison mode.
             is StreamEvent.ContentDelta -> { routeTextDelta(event.agentId, event.chunk); true }
@@ -206,26 +212,22 @@ class ComparisonModeDelegate(
     private fun routeTextDelta(agentId: String?, chunk: String) {
         if (isSecondaryEvent(agentId)) {
             secondaryBuffer.append(chunk)
-            stateHandle.update {
-                copy(
-                    comparisonState = comparisonState.copy(
-                        secondaryStreamingContent = secondaryBuffer.toString(),
-                        secondaryIsStreaming = true,
-                        secondaryAgentId = comparisonState.secondaryAgentId ?: agentId,
-                    ),
+            handle.update {
+                comparisonState = comparisonState.copy(
+                    secondaryStreamingContent = secondaryBuffer.toString(),
+                    secondaryIsStreaming = true,
+                    secondaryAgentId = comparisonState.secondaryAgentId ?: agentId,
                 )
             }
         } else {
             primaryBuffer.append(chunk)
-            stateHandle.update {
-                copy(
-                    comparisonState = comparisonState.copy(
-                        primaryStreamingContent = primaryBuffer.toString(),
-                        primaryIsStreaming = true,
-                        primaryAgentId = comparisonState.primaryAgentId ?: agentId,
-                    ),
-                    streamingContent = primaryBuffer.toString(),
+            handle.update {
+                comparisonState = comparisonState.copy(
+                    primaryStreamingContent = primaryBuffer.toString(),
+                    primaryIsStreaming = true,
+                    primaryAgentId = comparisonState.primaryAgentId ?: agentId,
                 )
+                content = content.copy(streamingContent = primaryBuffer.toString())
             }
         }
     }
@@ -233,19 +235,15 @@ class ComparisonModeDelegate(
     private fun routeToolCallStart(event: StreamEvent.ToolCallStart) {
         val newToolCall = ActiveToolCall(id = event.toolCallId, name = event.toolName, input = event.input)
         if (isSecondaryEvent(event.agentId)) {
-            stateHandle.update {
-                copy(
-                    comparisonState = comparisonState.copy(
-                        secondaryActiveToolCalls = comparisonState.secondaryActiveToolCalls + newToolCall,
-                    ),
+            handle.update {
+                comparisonState = comparisonState.copy(
+                    secondaryActiveToolCalls = comparisonState.secondaryActiveToolCalls + newToolCall,
                 )
             }
         } else {
-            stateHandle.update {
-                copy(
-                    comparisonState = comparisonState.copy(
-                        primaryActiveToolCalls = comparisonState.primaryActiveToolCalls + newToolCall,
-                    ),
+            handle.update {
+                comparisonState = comparisonState.copy(
+                    primaryActiveToolCalls = comparisonState.primaryActiveToolCalls + newToolCall,
                 )
             }
         }
@@ -253,18 +251,18 @@ class ComparisonModeDelegate(
 
     private fun routeToolCallComplete(event: StreamEvent.ToolCallComplete) {
         if (isSecondaryEvent(event.agentId)) {
-            stateHandle.update {
+            handle.update {
                 val updated = comparisonState.secondaryActiveToolCalls.map { tc ->
                     if (tc.id == event.toolCallId) tc.copy(isComplete = true, output = event.output) else tc
                 }
-                copy(comparisonState = comparisonState.copy(secondaryActiveToolCalls = updated))
+                comparisonState = comparisonState.copy(secondaryActiveToolCalls = updated)
             }
         } else {
-            stateHandle.update {
+            handle.update {
                 val updated = comparisonState.primaryActiveToolCalls.map { tc ->
                     if (tc.id == event.toolCallId) tc.copy(isComplete = true, output = event.output) else tc
                 }
-                copy(comparisonState = comparisonState.copy(primaryActiveToolCalls = updated))
+                comparisonState = comparisonState.copy(primaryActiveToolCalls = updated)
             }
         }
     }
@@ -276,17 +274,15 @@ class ComparisonModeDelegate(
      * panes stay readable.
      */
     fun endStreaming(clearContent: Boolean = false) {
-        if (!stateHandle.state.comparisonState.isEnabled) return
-        stateHandle.update {
-            copy(
-                comparisonState = comparisonState.copy(
-                    primaryIsStreaming = false,
-                    secondaryIsStreaming = false,
-                    primaryActiveToolCalls = emptyList(),
-                    secondaryActiveToolCalls = emptyList(),
-                    primaryStreamingContent = if (clearContent) "" else comparisonState.primaryStreamingContent,
-                    secondaryStreamingContent = if (clearContent) "" else comparisonState.secondaryStreamingContent,
-                ),
+        if (!handle.state.comparisonState.isEnabled) return
+        handle.update {
+            comparisonState = comparisonState.copy(
+                primaryIsStreaming = false,
+                secondaryIsStreaming = false,
+                primaryActiveToolCalls = emptyList(),
+                secondaryActiveToolCalls = emptyList(),
+                primaryStreamingContent = if (clearContent) "" else comparisonState.primaryStreamingContent,
+                secondaryStreamingContent = if (clearContent) "" else comparisonState.secondaryStreamingContent,
             )
         }
     }
@@ -296,19 +292,17 @@ class ComparisonModeDelegate(
      * content and records the parallel response message id for branch-from-comparison.
      */
     fun onFinal(parallelMessageId: String?) {
-        stateHandle.update {
-            copy(
-                comparisonState = comparisonState.copy(
-                    primaryIsStreaming = false,
-                    secondaryIsStreaming = false,
-                    primaryStreamingContent = "",
-                    secondaryStreamingContent = "",
-                    primaryActiveToolCalls = emptyList(),
-                    secondaryActiveToolCalls = emptyList(),
-                    parallelMessageId = parallelMessageId,
-                    primaryFinalContent = primaryBuffer.toString(),
-                    secondaryFinalContent = secondaryBuffer.toString(),
-                ),
+        handle.update {
+            comparisonState = comparisonState.copy(
+                primaryIsStreaming = false,
+                secondaryIsStreaming = false,
+                primaryStreamingContent = "",
+                secondaryStreamingContent = "",
+                primaryActiveToolCalls = emptyList(),
+                secondaryActiveToolCalls = emptyList(),
+                parallelMessageId = parallelMessageId,
+                primaryFinalContent = primaryBuffer.toString(),
+                secondaryFinalContent = secondaryBuffer.toString(),
             )
         }
     }
@@ -319,24 +313,24 @@ class ComparisonModeDelegate(
      * chats that skipped it during comparison.
      */
     fun branchFromComparison(agentId: String) {
-        val messageId = stateHandle.state.comparisonState.parallelMessageId ?: return
-        val conversationId = stateHandle.state.conversationId ?: return
-        stateHandle.scope.launch {
+        val messageId = handle.state.comparisonState.parallelMessageId ?: return
+        val conversationId = handle.state.conversationId ?: return
+        handle.scope.launch {
             try {
                 messageRepository.branchMessage(
                     conversationId = conversationId,
                     messageId = messageId,
                     agentId = agentId,
                 )
-                stateHandle.update { copy(comparisonState = ComparisonState()) }
-                val cid = stateHandle.state.conversationId
-                if (cid != null && stateHandle.state.pendingNavigationConversationId == null) {
-                    stateHandle.update { copy(pendingNavigationConversationId = cid) }
+                handle.update { comparisonState = ComparisonState() }
+                val cid = handle.state.conversationId
+                if (cid != null && handle.state.pendingNavigationConversationId == null) {
+                    handle.update { conversation = conversation.copy(pendingNavigationConversationId = cid) }
                 }
                 reloadConversation(conversationId)
             } catch (e: Exception) {
                 Logger.e(e) { "Failed to branch comparison message" }
-                stateHandle.update { copy(error = "Failed to continue with selected response") }
+                handle.setError("Failed to continue with selected response")
             }
         }
     }
@@ -351,7 +345,7 @@ class ComparisonModeDelegate(
      */
     fun isSecondaryEvent(agentId: String?): Boolean {
         if (agentId == null) return false
-        val comparison = stateHandle.state.comparisonState
+        val comparison = handle.state.comparisonState
         // If we've already resolved the secondary agentId from earlier SSE events, use that
         if (comparison.secondaryAgentId != null) {
             return agentId == comparison.secondaryAgentId

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/ConversationActionsDelegate.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/ConversationActionsDelegate.kt
@@ -3,14 +3,14 @@ package com.garfiec.librechat.feature.chat.viewmodel.delegate
 import com.garfiec.librechat.core.common.result.Result
 import com.garfiec.librechat.core.data.repository.ConversationRepository
 import com.garfiec.librechat.core.data.repository.ShareRepository
-import com.garfiec.librechat.feature.chat.viewmodel.ChatStateHandle
+import com.garfiec.librechat.feature.chat.viewmodel.ConversationActionsHandle
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 
 class ConversationActionsDelegate(
-    private val stateHandle: ChatStateHandle,
+    private val handle: ConversationActionsHandle,
     private val conversationRepository: ConversationRepository,
     private val shareRepository: ShareRepository,
 ) {
@@ -19,23 +19,23 @@ class ConversationActionsDelegate(
     val shareLinkUrl: StateFlow<String?> = _shareLinkUrl.asStateFlow()
 
     fun showRenameDialog() {
-        stateHandle.update { copy(showRenameDialog = true) }
+        handle.update { actions = actions.copy(showRenameDialog = true) }
     }
 
     fun dismissRenameDialog() {
-        stateHandle.update { copy(showRenameDialog = false) }
+        handle.update { actions = actions.copy(showRenameDialog = false) }
     }
 
     fun renameConversation(newTitle: String) {
-        val conversationId = stateHandle.state.conversationId ?: return
-        stateHandle.update { copy(showRenameDialog = false) }
-        stateHandle.scope.launch {
+        val conversationId = handle.state.conversationId ?: return
+        handle.update { actions = actions.copy(showRenameDialog = false) }
+        handle.scope.launch {
             when (conversationRepository.updateTitle(conversationId, newTitle)) {
                 is Result.Success -> {
-                    stateHandle.update { copy(conversationTitle = newTitle) }
+                    handle.update { conversation = conversation.copy(conversationTitle = newTitle) }
                 }
                 is Result.Error -> {
-                    stateHandle.update { copy(error = "Failed to rename conversation") }
+                    handle.setError("Failed to rename conversation")
                 }
                 is Result.Loading -> { /* no-op */ }
             }
@@ -43,24 +43,24 @@ class ConversationActionsDelegate(
     }
 
     fun showDeleteConfirmation() {
-        stateHandle.update { copy(showDeleteConfirmation = true) }
+        handle.update { actions = actions.copy(showDeleteConfirmation = true) }
     }
 
     fun dismissDeleteConfirmation() {
-        stateHandle.update { copy(showDeleteConfirmation = false) }
+        handle.update { actions = actions.copy(showDeleteConfirmation = false) }
     }
 
     fun deleteConversation() {
-        val conversationId = stateHandle.state.conversationId ?: return
-        stateHandle.update { copy(showDeleteConfirmation = false) }
-        stateHandle.scope.launch {
+        val conversationId = handle.state.conversationId ?: return
+        handle.update { actions = actions.copy(showDeleteConfirmation = false) }
+        handle.scope.launch {
             when (conversationRepository.delete(conversationId)) {
                 is Result.Success -> {
                     // Signal navigation back by clearing the conversation
-                    stateHandle.update { copy(conversationId = null) }
+                    handle.update { conversation = conversation.copy(conversationId = null) }
                 }
                 is Result.Error -> {
-                    stateHandle.update { copy(error = "Failed to delete conversation") }
+                    handle.setError("Failed to delete conversation")
                 }
                 is Result.Loading -> { /* no-op */ }
             }
@@ -68,15 +68,15 @@ class ConversationActionsDelegate(
     }
 
     fun archiveConversation() {
-        val conversationId = stateHandle.state.conversationId ?: return
-        stateHandle.scope.launch {
+        val conversationId = handle.state.conversationId ?: return
+        handle.scope.launch {
             when (conversationRepository.archive(conversationId, true)) {
                 is Result.Success -> {
                     // Signal navigation back by clearing the conversation
-                    stateHandle.update { copy(conversationId = null) }
+                    handle.update { conversation = conversation.copy(conversationId = null) }
                 }
                 is Result.Error -> {
-                    stateHandle.update { copy(error = "Failed to archive conversation") }
+                    handle.setError("Failed to archive conversation")
                 }
                 is Result.Loading -> { /* no-op */ }
             }
@@ -84,15 +84,15 @@ class ConversationActionsDelegate(
     }
 
     fun duplicateConversation() {
-        val conversationId = stateHandle.state.conversationId ?: return
-        val title = stateHandle.state.conversationTitle
-        stateHandle.scope.launch {
+        val conversationId = handle.state.conversationId ?: return
+        val title = handle.state.conversationTitle
+        handle.scope.launch {
             when (val result = conversationRepository.duplicateConversation(conversationId, title)) {
                 is Result.Success -> {
-                    stateHandle.update { copy(duplicatedConversationId = result.data.conversationId) }
+                    handle.update { actions = actions.copy(duplicatedConversationId = result.data.conversationId) }
                 }
                 is Result.Error -> {
-                    stateHandle.update { copy(error = "Failed to duplicate conversation") }
+                    handle.setError("Failed to duplicate conversation")
                 }
                 is Result.Loading -> { /* no-op */ }
             }
@@ -100,20 +100,20 @@ class ConversationActionsDelegate(
     }
 
     fun onDuplicatedConversationHandled() {
-        stateHandle.update { copy(duplicatedConversationId = null) }
+        handle.update { actions = actions.copy(duplicatedConversationId = null) }
     }
 
     fun shareConversation() {
-        val conversationId = stateHandle.state.conversationId ?: return
-        stateHandle.scope.launch {
+        val conversationId = handle.state.conversationId ?: return
+        handle.scope.launch {
             when (val result = shareRepository.createShareLink(conversationId)) {
                 is Result.Success -> {
-                    stateHandle.update { copy(error = null) }
+                    handle.setError(null)
                     // Store the share URL to be copied by the UI
                     _shareLinkUrl.value = result.data
                 }
                 is Result.Error -> {
-                    stateHandle.update { copy(error = result.message ?: "Failed to create share link") }
+                    handle.setError(result.message ?: "Failed to create share link")
                 }
                 is Result.Loading -> { /* no-op */ }
             }
@@ -125,23 +125,23 @@ class ConversationActionsDelegate(
     }
 
     fun showForkOptions(messageId: String) {
-        stateHandle.update { copy(showForkOptionsForMessageId = messageId) }
+        handle.update { actions = actions.copy(showForkOptionsForMessageId = messageId) }
     }
 
     fun dismissForkOptions() {
-        stateHandle.update { copy(showForkOptionsForMessageId = null) }
+        handle.update { actions = actions.copy(showForkOptionsForMessageId = null) }
     }
 
     fun forkFromMessage(messageId: String, option: String, splitAtTarget: Boolean = false) {
-        val conversationId = stateHandle.state.conversationId ?: return
-        val latestMessageId = stateHandle.state.displayMessages.lastOrNull()?.message?.messageId
-        stateHandle.update {
-            copy(
+        val conversationId = handle.state.conversationId ?: return
+        val latestMessageId = handle.state.displayMessages.lastOrNull()?.message?.messageId
+        handle.update {
+            actions = actions.copy(
                 showForkOptionsForMessageId = null,
                 isForkInProgress = true,
             )
         }
-        stateHandle.scope.launch {
+        handle.scope.launch {
             val result = conversationRepository.forkConversation(
                 conversationId = conversationId,
                 messageId = messageId,
@@ -151,19 +151,17 @@ class ConversationActionsDelegate(
             )
             when (result) {
                 is Result.Success -> {
-                    stateHandle.update {
-                        copy(
+                    handle.update {
+                        actions = actions.copy(
                             forkedConversationId = result.data.conversationId,
                             isForkInProgress = false,
                         )
                     }
                 }
                 is Result.Error -> {
-                    stateHandle.update {
-                        copy(
-                            error = result.message ?: "Could not fork conversation",
-                            isForkInProgress = false,
-                        )
+                    handle.update {
+                        error = result.message ?: "Could not fork conversation"
+                        actions = actions.copy(isForkInProgress = false)
                     }
                 }
                 is Result.Loading -> { /* no-op */ }
@@ -172,6 +170,6 @@ class ConversationActionsDelegate(
     }
 
     fun onForkedConversationHandled() {
-        stateHandle.update { copy(forkedConversationId = null) }
+        handle.update { actions = actions.copy(forkedConversationId = null) }
     }
 }

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/EndpointKeyStatusDelegate.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/EndpointKeyStatusDelegate.kt
@@ -7,7 +7,7 @@ import com.garfiec.librechat.core.model.EndpointConfig
 import com.garfiec.librechat.core.model.endpoint.KeyInvalidation
 import com.garfiec.librechat.core.model.endpoint.KeyState
 import com.garfiec.librechat.core.model.endpoint.resolveProviderKeyName
-import com.garfiec.librechat.feature.chat.viewmodel.ChatStateHandle
+import com.garfiec.librechat.feature.chat.viewmodel.EndpointKeyHandle
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
@@ -21,7 +21,7 @@ import kotlinx.coroutines.sync.withLock
  * of letting the user pick a model that will fail at send time.
  */
 class EndpointKeyStatusDelegate(
-    private val stateHandle: ChatStateHandle,
+    private val handle: EndpointKeyHandle,
     private val keyRepository: KeyRepository,
 ) {
 
@@ -30,7 +30,7 @@ class EndpointKeyStatusDelegate(
     private var currentRecomputeJob: Job? = null
 
     init {
-        stateHandle.scope.launch {
+        handle.scope.launch {
             keyRepository.keyInvalidations.collect { invalidation ->
                 if (shouldRespondTo(invalidation)) {
                     launchFanOut(lastKnownConfigs, updateLastKnown = false)
@@ -43,7 +43,7 @@ class EndpointKeyStatusDelegate(
      * Re-fan-out the key-state fetch for every endpoint that requires a user-provided
      * key. Caches [configs] so a later invalidation-driven recompute can reuse them.
      *
-     * Launches the fan-out on [stateHandle.scope] so a slow `getKeyExpiry` GET
+     * Launches the fan-out on [handle.scope] so a slow `getKeyExpiry` GET
      * does not block the upstream `configRepository.endpointConfigs.collect`.
      */
     fun recomputeFor(configs: Map<String, EndpointConfig>) {
@@ -66,7 +66,7 @@ class EndpointKeyStatusDelegate(
      */
     private fun launchFanOut(configs: Map<String, EndpointConfig>, updateLastKnown: Boolean) {
         currentRecomputeJob?.cancel()
-        currentRecomputeJob = stateHandle.scope.launch {
+        currentRecomputeJob = handle.scope.launch {
             mutex.withLock {
                 if (updateLastKnown) lastKnownConfigs = configs
                 runFanOut(configs)
@@ -80,8 +80,8 @@ class EndpointKeyStatusDelegate(
         }
 
         if (gated.isEmpty()) {
-            if (stateHandle.state.endpointKeyStates.isNotEmpty()) {
-                stateHandle.update { copy(endpointKeyStates = emptyMap()) }
+            if (handle.state.endpointKeyStates.isNotEmpty()) {
+                handle.update { endpointKeyStates = emptyMap() }
             }
             return
         }
@@ -91,17 +91,15 @@ class EndpointKeyStatusDelegate(
         // mid-auth-token-refresh) breaks the per-endpoint fetch. Without this,
         // a single failed GET would demote every user-provide endpoint to greyed
         // even when the user has valid keys on file.
-        val prior = stateHandle.state.endpointKeyStates
+        val prior = handle.state.endpointKeyStates
 
         // Optimistic Loading push so the model sheet doesn't render an endpoint
         // as "active → greyed" while the fan-out is in flight. Already-resolved
         // values are preserved to avoid flicker on unrelated config tweaks.
-        stateHandle.update {
-            copy(
-                endpointKeyStates = gated.mapValues { (name, _) ->
-                    prior[name]?.takeIf { it != KeyState.Loading } ?: KeyState.Loading
-                },
-            )
+        handle.update {
+            endpointKeyStates = gated.mapValues { (name, _) ->
+                prior[name]?.takeIf { it != KeyState.Loading } ?: KeyState.Loading
+            }
         }
 
         val resolved: Map<String, KeyState> = coroutineScope {
@@ -115,7 +113,7 @@ class EndpointKeyStatusDelegate(
                 .toMap()
         }
 
-        stateHandle.update { copy(endpointKeyStates = resolved) }
+        handle.update { endpointKeyStates = resolved }
     }
 
     private suspend fun resolveKeyState(

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/FavoritesDelegate.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/FavoritesDelegate.kt
@@ -5,12 +5,12 @@ import com.garfiec.librechat.core.common.result.Result
 import com.garfiec.librechat.core.data.repository.FavoritesRepository
 import com.garfiec.librechat.core.model.FavoritesLimits
 import com.garfiec.librechat.core.model.UserFavorite
-import com.garfiec.librechat.feature.chat.viewmodel.ChatStateHandle
+import com.garfiec.librechat.feature.chat.viewmodel.FavoritesHandle
 import kotlinx.coroutines.launch
 
 /**
  * Routes pin/unpin actions from chat-side pickers (model/agent selector) to
- * [FavoritesRepository] and republishes the canonical list into [ChatStateHandle].
+ * [FavoritesRepository] and republishes the canonical list into its [FavoritesHandle].
  *
  * The repository owns the cached list and serializes writes via a Mutex, so
  * this delegate is a thin shim: it observes the shared flow and forwards
@@ -21,7 +21,7 @@ import kotlinx.coroutines.launch
  * clients' pinned specs survive a save from this client.
  */
 class FavoritesDelegate(
-    private val stateHandle: ChatStateHandle,
+    private val handle: FavoritesHandle,
     private val favoritesRepository: FavoritesRepository,
 ) {
 
@@ -38,7 +38,7 @@ class FavoritesDelegate(
      * The sheet-open refetch self-heals that and also picks up pins made elsewhere.
      */
     fun refresh() {
-        stateHandle.scope.launch {
+        handle.scope.launch {
             when (val result = favoritesRepository.refresh()) {
                 is Result.Success -> Unit
                 is Result.Error -> {
@@ -51,7 +51,7 @@ class FavoritesDelegate(
     }
 
     private fun observeFavorites() {
-        stateHandle.scope.launch {
+        handle.scope.launch {
             favoritesRepository.favorites.collect { list -> publish(list) }
         }
     }
@@ -91,18 +91,16 @@ class FavoritesDelegate(
     private fun atLimit(current: List<UserFavorite>): Boolean = current.size >= FavoritesLimits.MAX_FAVORITES
 
     private fun reportLimit() {
-        stateHandle.update {
-            copy(error = "You can pin up to ${FavoritesLimits.MAX_FAVORITES} favorites.")
-        }
+        handle.setError("You can pin up to ${FavoritesLimits.MAX_FAVORITES} favorites.")
     }
 
     private fun persist(nextList: List<UserFavorite>) {
-        stateHandle.scope.launch {
+        handle.scope.launch {
             when (val result = favoritesRepository.setFavorites(nextList)) {
                 is Result.Success -> Unit
                 is Result.Error -> {
                     Logger.w(result.exception) { "Failed to save favorites: ${result.message}" }
-                    stateHandle.update { copy(error = result.message ?: "Could not update favorites.") }
+                    handle.setError(result.message ?: "Could not update favorites.")
                 }
                 is Result.Loading -> Unit
             }
@@ -116,8 +114,8 @@ class FavoritesDelegate(
             val model = it.model
             if (endpoint != null && model != null) favoriteModelKey(endpoint, model) else null
         }
-        stateHandle.update {
-            copy(
+        handle.update {
+            favorites = favorites.copy(
                 favoriteAgentIds = agentIds,
                 favoriteModelKeys = modelKeys,
             )

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/InConversationSearchDelegate.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/InConversationSearchDelegate.kt
@@ -2,20 +2,20 @@ package com.garfiec.librechat.feature.chat.viewmodel.delegate
 
 import com.garfiec.librechat.feature.chat.components.countMessageOccurrences
 import com.garfiec.librechat.feature.chat.util.collapseParallelToPrimary
-import com.garfiec.librechat.feature.chat.viewmodel.ChatStateHandle
 import com.garfiec.librechat.feature.chat.viewmodel.SearchFocusRequest
+import com.garfiec.librechat.feature.chat.viewmodel.SearchHandle
 import com.garfiec.librechat.feature.chat.viewmodel.SearchMatch
 
 class InConversationSearchDelegate(
-    private val stateHandle: ChatStateHandle,
+    private val handle: SearchHandle,
 ) {
 
     /** Monotonic id so consecutive requests are never equal (see [SearchFocusRequest]). */
     private var nextFocusRequestId = 0L
 
     fun openSearch() {
-        stateHandle.update {
-            copy(
+        handle.update {
+            search = search.copy(
                 isSearchOpen = true,
                 searchQuery = "",
                 searchMatchIndices = emptyList(),
@@ -26,8 +26,8 @@ class InConversationSearchDelegate(
     }
 
     fun closeSearch() {
-        stateHandle.update {
-            copy(
+        handle.update {
+            search = search.copy(
                 isSearchOpen = false,
                 searchQuery = "",
                 searchMatchIndices = emptyList(),
@@ -38,10 +38,10 @@ class InConversationSearchDelegate(
     }
 
     fun onSearchQueryChanged(query: String) {
-        val state = stateHandle.state
+        val state = handle.state
         if (query.isBlank()) {
-            stateHandle.update {
-                copy(
+            handle.update {
+                search = search.copy(
                     searchQuery = query,
                     searchMatchIndices = emptyList(),
                     currentSearchMatchIndex = 0,
@@ -67,8 +67,8 @@ class InConversationSearchDelegate(
             }
         }
 
-        stateHandle.update {
-            copy(
+        handle.update {
+            search = search.copy(
                 searchQuery = query,
                 searchMatchIndices = allMatches,
                 currentSearchMatchIndex = 0,
@@ -78,35 +78,35 @@ class InConversationSearchDelegate(
     }
 
     fun nextSearchMatch() {
-        val state = stateHandle.state
+        val state = handle.state
         if (state.searchMatchIndices.isEmpty()) return
         val nextIndex = (state.currentSearchMatchIndex + 1) % state.searchMatchIndices.size
-        stateHandle.update {
-            copy(
+        handle.update {
+            search = search.copy(
                 currentSearchMatchIndex = nextIndex,
-                searchFocusRequest = focusRequestFor(searchMatchIndices[nextIndex]),
+                searchFocusRequest = focusRequestFor(search.searchMatchIndices[nextIndex]),
             )
         }
     }
 
     fun previousSearchMatch() {
-        val state = stateHandle.state
+        val state = handle.state
         if (state.searchMatchIndices.isEmpty()) return
         val prevIndex = if (state.currentSearchMatchIndex > 0) {
             state.currentSearchMatchIndex - 1
         } else {
             state.searchMatchIndices.size - 1
         }
-        stateHandle.update {
-            copy(
+        handle.update {
+            search = search.copy(
                 currentSearchMatchIndex = prevIndex,
-                searchFocusRequest = focusRequestFor(searchMatchIndices[prevIndex]),
+                searchFocusRequest = focusRequestFor(search.searchMatchIndices[prevIndex]),
             )
         }
     }
 
     fun onSearchScrollHandled() {
-        stateHandle.update { copy(searchFocusRequest = null) }
+        handle.update { search = search.copy(searchFocusRequest = null) }
     }
 
     private fun focusRequestFor(match: SearchMatch) = SearchFocusRequest(

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/MessageEditingDelegate.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/MessageEditingDelegate.kt
@@ -8,7 +8,7 @@ import com.garfiec.librechat.core.model.FileReference
 import com.garfiec.librechat.core.model.Message
 import com.garfiec.librechat.feature.chat.util.buildActiveMessagePath
 import com.garfiec.librechat.feature.chat.viewmodel.ChatRequestBuilder
-import com.garfiec.librechat.feature.chat.viewmodel.ChatStateHandle
+import com.garfiec.librechat.feature.chat.viewmodel.MessageEditingHandle
 import kotlinx.coroutines.launch
 import kotlin.time.Clock
 import kotlin.uuid.ExperimentalUuidApi
@@ -24,7 +24,7 @@ import kotlin.uuid.Uuid
  * the new-message send path and TTS); they're injected as [runWhenSendReady] / [getMessageText].
  */
 class MessageEditingDelegate(
-    private val stateHandle: ChatStateHandle,
+    private val handle: MessageEditingHandle,
     private val chatRepository: ChatRepository,
     private val messageRepository: MessageRepository,
     private val treeDelegate: MessageTreeDelegate,
@@ -35,9 +35,9 @@ class MessageEditingDelegate(
 ) {
 
     fun editMessage(messageId: String, newText: String) {
-        if (newText.isBlank() || stateHandle.state.isStreaming) return
+        if (newText.isBlank() || handle.state.isStreaming) return
 
-        val originalMessage = stateHandle.state.messages.find { it.messageId == messageId } ?: return
+        val originalMessage = handle.state.messages.find { it.messageId == messageId } ?: return
 
         runWhenSendReady {
             if (originalMessage.isCreatedByUser) {
@@ -62,7 +62,7 @@ class MessageEditingDelegate(
         // mergeFinalMessagesInMemory for temp chats (which never touch Room).
         val optimisticMessage = Message(
             messageId = Uuid.random().toString(),
-            conversationId = stateHandle.state.conversationId ?: "",
+            conversationId = handle.state.conversationId ?: "",
             parentMessageId = parentMessageId,
             text = newText,
             isCreatedByUser = true,
@@ -70,11 +70,11 @@ class MessageEditingDelegate(
             createdAt = Clock.System.now().toString(),
             files = originalMessage.files,
         )
-        stateHandle.update {
-            val updatedMessages = messages + optimisticMessage
-            copy(
+        handle.update {
+            val updatedMessages = content.messages + optimisticMessage
+            content = content.copy(
                 messages = updatedMessages,
-                displayMessages = buildActiveMessagePath(updatedMessages, activeBranches, optimisticMessage.messageId),
+                displayMessages = buildActiveMessagePath(updatedMessages, content.activeBranches, optimisticMessage.messageId),
             )
         }
 
@@ -89,7 +89,7 @@ class MessageEditingDelegate(
     }
 
     private fun editAiMessage(aiMessage: Message) {
-        val parentUserMessage = stateHandle.state.messages.find {
+        val parentUserMessage = handle.state.messages.find {
             it.messageId == aiMessage.parentMessageId
         } ?: return
 
@@ -99,7 +99,7 @@ class MessageEditingDelegate(
         // the old one. The web client seeds the placeholder with the edited content
         // for a transient preview; we don't (the regenerated server response is
         // authoritative on Final either way).
-        if (stateHandle.state.conversationId == null) return
+        if (handle.state.conversationId == null) return
         treeDelegate.anchorStreamTo(parentUserMessage.messageId)
         launchSend(
             text = parentUserMessage.text,
@@ -113,12 +113,12 @@ class MessageEditingDelegate(
     }
 
     fun regenerateMessage(messageId: String) {
-        if (stateHandle.state.isStreaming) return
+        if (handle.state.isStreaming) return
 
-        val aiMessage = stateHandle.state.messages.find { it.messageId == messageId } ?: return
+        val aiMessage = handle.state.messages.find { it.messageId == messageId } ?: return
         if (aiMessage.isCreatedByUser) return
 
-        val parentUserMessage = stateHandle.state.messages.find {
+        val parentUserMessage = handle.state.messages.find {
             it.messageId == aiMessage.parentMessageId
         } ?: return
 
@@ -138,12 +138,12 @@ class MessageEditingDelegate(
     }
 
     fun continueGeneration() {
-        if (stateHandle.state.isStreaming) return
-        val lastAiMessage = stateHandle.state.displayMessages.lastOrNull {
+        if (handle.state.isStreaming) return
+        val lastAiMessage = handle.state.displayMessages.lastOrNull {
             !it.message.isCreatedByUser
         } ?: return
 
-        val parentUserMessage = stateHandle.state.messages.find {
+        val parentUserMessage = handle.state.messages.find {
             it.messageId == lastAiMessage.message.parentMessageId
         } ?: return
 
@@ -190,7 +190,7 @@ class MessageEditingDelegate(
     ) {
         streamingManager.prepareForStreaming(isEdit = true)
 
-        val state = stateHandle.state
+        val state = handle.state
         val isAgent = state.selectedEndpoint == EndpointConstants.AGENTS
         val webSearchEnabled = state.modelParameters.webSearch
         val ephemeralAgent = requestBuilder.buildEphemeralAgent()
@@ -226,34 +226,34 @@ class MessageEditingDelegate(
 
     fun startEditing(messageId: String) {
         val text = getMessageText(messageId)
-        stateHandle.update { copy(editingMessageId = messageId, editingText = text) }
+        handle.update { editing = editing.copy(editingMessageId = messageId, editingText = text) }
     }
 
     fun onEditTextChanged(text: String) {
-        stateHandle.update { copy(editingText = text) }
+        handle.update { editing = editing.copy(editingText = text) }
     }
 
     fun cancelEditing() {
-        stateHandle.update { copy(editingMessageId = null, editingText = "") }
+        handle.update { editing = editing.copy(editingMessageId = null, editingText = "") }
     }
 
     fun submitEdit() {
-        val messageId = stateHandle.state.editingMessageId ?: return
-        val newText = stateHandle.state.editingText.trim()
+        val messageId = handle.state.editingMessageId ?: return
+        val newText = handle.state.editingText.trim()
         if (newText.isBlank()) return
 
-        stateHandle.update { copy(editingMessageId = null, editingText = "") }
+        handle.update { editing = editing.copy(editingMessageId = null, editingText = "") }
         editMessage(messageId, newText)
     }
 
     fun saveEditOnly() {
-        val messageId = stateHandle.state.editingMessageId ?: return
-        val conversationId = stateHandle.state.conversationId ?: return
-        val newText = stateHandle.state.editingText.trim()
+        val messageId = handle.state.editingMessageId ?: return
+        val conversationId = handle.state.conversationId ?: return
+        val newText = handle.state.editingText.trim()
         if (newText.isBlank()) return
 
-        stateHandle.update { copy(editingMessageId = null, editingText = "") }
-        stateHandle.scope.launch {
+        handle.update { editing = editing.copy(editingMessageId = null, editingText = "") }
+        handle.scope.launch {
             messageRepository.updateMessageText(conversationId, messageId, newText)
         }
     }

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/MessageQueueDelegate.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/MessageQueueDelegate.kt
@@ -2,12 +2,12 @@ package com.garfiec.librechat.feature.chat.viewmodel.delegate
 
 import com.garfiec.librechat.core.common.identity.ActiveAccountProvider
 import com.garfiec.librechat.core.common.identity.currentAccountId
-import com.garfiec.librechat.feature.chat.viewmodel.ChatStateHandle
+import com.garfiec.librechat.feature.chat.viewmodel.QueueHandle
 import com.garfiec.librechat.feature.chat.viewmodel.QueuedMessage
 
 /**
  * Owns the in-memory FIFO queue of follow-up messages the user staged while a reply was
- * streaming. Holds only the list + pause flag in [ChatStateHandle]; the actual send is
+ * streaming. Holds only the list + pause flag in its [QueueHandle]; the actual send is
  * delegated back to `ChatViewModel` via [sendWithSpec] so all the request-build / optimistic-
  * insert / lineage logic stays in one place.
  *
@@ -16,7 +16,7 @@ import com.garfiec.librechat.feature.chat.viewmodel.QueuedMessage
  * ([resume]). The queue is never persisted — it lives and dies with the ViewModel.
  */
 class MessageQueueDelegate(
-    private val stateHandle: ChatStateHandle,
+    private val handle: QueueHandle,
     private val activeAccountProvider: ActiveAccountProvider,
     /** Fires one queued message. Set by `ChatViewModel` to `doSendWithSpec` (wrapped in the
      *  send-ready gate). Recomputes lineage live; only config comes from the spec. [awaitSettle]
@@ -30,7 +30,7 @@ class MessageQueueDelegate(
 ) {
 
     fun enqueue(spec: QueuedMessage) {
-        stateHandle.update { copy(messageQueue = messageQueue + spec) }
+        handle.update { queue = queue.copy(messageQueue = queue.messageQueue + spec) }
     }
 
     /**
@@ -39,45 +39,45 @@ class MessageQueueDelegate(
      * the item is only borrowed, so a paused queue stays paused. Returns null if the id is gone.
      */
     fun takeForEdit(localId: String): IndexedValue<QueuedMessage>? {
-        val index = stateHandle.state.messageQueue.indexOfFirst { it.localId == localId }
+        val index = handle.state.messageQueue.indexOfFirst { it.localId == localId }
         if (index < 0) return null
-        val item = stateHandle.state.messageQueue[index]
-        stateHandle.update { copy(messageQueue = messageQueue.filterNot { it.localId == localId }) }
+        val item = handle.state.messageQueue[index]
+        handle.update { queue = queue.copy(messageQueue = queue.messageQueue.filterNot { it.localId == localId }) }
         return IndexedValue(index, item)
     }
 
     /** Re-inserts an item at [index] (clamped to the current bounds) — the commit/cancel counterpart
      *  to [takeForEdit]. */
     fun reinsert(index: Int, item: QueuedMessage) {
-        stateHandle.update {
-            val clamped = index.coerceIn(0, messageQueue.size)
-            copy(messageQueue = messageQueue.toMutableList().apply { add(clamped, item) })
+        handle.update {
+            val clamped = index.coerceIn(0, queue.messageQueue.size)
+            queue = queue.copy(messageQueue = queue.messageQueue.toMutableList().apply { add(clamped, item) })
         }
     }
 
     /** Clears a now-meaningless pause when the queue is empty (e.g. an edit was committed empty,
      *  deleting the last item). */
     fun clearPauseIfEmpty() {
-        stateHandle.update { if (messageQueue.isEmpty()) copy(isQueuePaused = false) else this }
+        handle.update { if (queue.messageQueue.isEmpty()) queue = queue.copy(isQueuePaused = false) }
     }
 
     fun cancel(localId: String) {
-        stateHandle.update {
-            val next = messageQueue.filterNot { it.localId == localId }
+        handle.update {
+            val next = queue.messageQueue.filterNot { it.localId == localId }
             // Clearing the last item while paused lifts the (now meaningless) pause.
-            copy(messageQueue = next, isQueuePaused = isQueuePaused && next.isNotEmpty())
+            queue = queue.copy(messageQueue = next, isQueuePaused = queue.isQueuePaused && next.isNotEmpty())
         }
     }
 
     fun reorder(fromIndex: Int, toIndex: Int) {
-        stateHandle.update {
-            val list = messageQueue
+        handle.update {
+            val list = queue.messageQueue
             if (fromIndex !in list.indices || toIndex !in list.indices || fromIndex == toIndex) {
-                return@update this
+                return@update
             }
             val mutable = list.toMutableList()
             mutable.add(toIndex, mutable.removeAt(fromIndex))
-            copy(messageQueue = mutable)
+            queue = queue.copy(messageQueue = mutable)
         }
     }
 
@@ -85,14 +85,14 @@ class MessageQueueDelegate(
      *  currently pulled out for editing still counts (it will return to the queue), so a Stop
      *  during the edit of the sole queued item correctly registers the pause. */
     fun pause() {
-        if (stateHandle.state.messageQueue.isEmpty() && !stateHandle.state.isEditingQueued) return
-        stateHandle.update { copy(isQueuePaused = true) }
+        if (handle.state.messageQueue.isEmpty() && !handle.state.isEditingQueued) return
+        handle.update { queue = queue.copy(isQueuePaused = true) }
     }
 
     /** User tapped "Send queued": lift the pause and start draining. The reply already settled
      *  while paused, so no settle-wait is needed. */
     fun resume() {
-        stateHandle.update { copy(isQueuePaused = false) }
+        handle.update { queue = queue.copy(isQueuePaused = false) }
         drainNext(awaitSettle = false)
     }
 
@@ -106,12 +106,12 @@ class MessageQueueDelegate(
         // Freeze the queue while a queued item is being edited: draining now would fire an item
         // out from under the user and shift the slots the edit session's originalIndex points at.
         // The edit's commit/cancel re-kicks draining once it completes.
-        if (stateHandle.state.isEditingQueued) return
+        if (handle.state.isEditingQueued) return
         // A paused queue must not be mutated: leave every item (foreign ones included) in place until
         // the user resumes, which re-enters here with the pause lifted and runs the purge below. Guard
         // before the purge so a stray drain trigger can't silently drop items — and fire a snackbar —
         // on a queue the user has deliberately parked.
-        if (stateHandle.state.isQueuePaused) return
+        if (handle.state.isQueuePaused) return
         // Purge items composed under a different account (the user switched accounts since queueing).
         // Sending one would POST account A's content to account B's server under B's bearer — a
         // content-to-wrong-server leak the same-owner reframe does not excuse. Surface a count so the
@@ -121,16 +121,16 @@ class MessageQueueDelegate(
         // accountId (pre-multi-account / tests) match any account.
         val current = activeAccountProvider.currentAccountId()?.value
         if (current != null) {
-            val foreign = stateHandle.state.messageQueue.count { it.accountId != null && it.accountId != current }
+            val foreign = handle.state.messageQueue.count { it.accountId != null && it.accountId != current }
             if (foreign > 0) {
-                stateHandle.update {
-                    copy(messageQueue = messageQueue.filter { it.accountId == null || it.accountId == current })
+                handle.update {
+                    queue = queue.copy(messageQueue = queue.messageQueue.filter { it.accountId == null || it.accountId == current })
                 }
                 onQueuedDropped(foreign)
             }
         }
-        val head = stateHandle.state.messageQueue.firstOrNull() ?: return
-        stateHandle.update { copy(messageQueue = messageQueue.drop(1)) }
+        val head = handle.state.messageQueue.firstOrNull() ?: return
+        handle.update { queue = queue.copy(messageQueue = queue.messageQueue.drop(1)) }
         sendWithSpec(head, awaitSettle)
     }
 }

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/MessageTreeDelegate.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/MessageTreeDelegate.kt
@@ -7,7 +7,7 @@ import com.garfiec.librechat.feature.chat.util.buildActiveMessagePath
 import com.garfiec.librechat.feature.chat.util.mergeFinalMessagesInMemory
 import com.garfiec.librechat.feature.chat.util.resolvedResponseMessage
 import com.garfiec.librechat.feature.chat.viewmodel.ChatScreenState
-import com.garfiec.librechat.feature.chat.viewmodel.ChatStateHandle
+import com.garfiec.librechat.feature.chat.viewmodel.MessageTreeHandle
 
 /**
  * Owns the message-tree branch state and the in-place streaming anchor — the parts
@@ -16,13 +16,13 @@ import com.garfiec.librechat.feature.chat.viewmodel.ChatStateHandle
  * display path. Also owns the temporary-chat toggle and the in-memory finalize
  * ([finalizeChatDisplay]) that drives the gap-free completion view.
  *
- * Pure state transforms over [ChatStateHandle] — no repositories, no coroutines.
+ * Pure state transforms over [MessageTreeHandle] — no repositories, no coroutines.
  * The streaming-anchor invariant lives here (see [anchorStreamTo]); the send/edit
  * paths call into this delegate to truncate the path so the trailing streaming
  * bubble renders as the pending child of the right branch.
  */
 class MessageTreeDelegate(
-    private val stateHandle: ChatStateHandle,
+    private val handle: MessageTreeHandle,
 ) {
 
     fun switchBranch(parentMessageId: String, siblingIndex: Int) {
@@ -32,19 +32,19 @@ class MessageTreeDelegate(
         // displayMessages WITHOUT the leaf — un-truncating the path and dropping the
         // streaming reply back to the end. editMessage/regenerateMessage are likewise
         // gated on isStreaming; this closes the same gap for sibling navigation.
-        if (stateHandle.state.isStreaming) return
+        if (handle.state.isStreaming) return
         // Only mutate the branch selection; the observeMessages/activeBranches combine in
         // loadConversation recomputes displayMessages off the Main thread in response, so the
         // tree walk no longer runs synchronously on this UI click path.
-        stateHandle.update {
-            val newBranches = activeBranches.toMutableMap()
+        handle.update {
+            val newBranches = content.activeBranches.toMutableMap()
             newBranches[parentMessageId] = siblingIndex
             // The sibling we're switching to has a different message history, so the seeded context
             // gauge no longer describes it. Clear it (we're !isStreaming here, so no live SSE to
             // disturb) and let observeContextProjection re-project once displayMessages rebuilds with
             // the new tail. sameWindowAs() ignores the tail, so without this the stale numerator
             // would linger until the next send.
-            copy(activeBranches = newBranches, contextUsage = null)
+            content = content.copy(activeBranches = newBranches, contextUsage = null)
         }
     }
 
@@ -66,9 +66,9 @@ class MessageTreeDelegate(
      * stream completes.
      */
     fun anchorStreamTo(parentMessageId: String) {
-        stateHandle.update {
-            copy(
-                displayMessages = buildActiveMessagePath(messages, activeBranches, parentMessageId),
+        handle.update {
+            content = content.copy(
+                displayMessages = buildActiveMessagePath(content.messages, content.activeBranches, parentMessageId),
             )
         }
     }
@@ -77,8 +77,8 @@ class MessageTreeDelegate(
         // Only togglable before the conversation exists. Once a temporary chat is
         // active the toggle is a read-only indicator — the server already created
         // it temporary, so flipping it off here would be misleading.
-        if (stateHandle.state.conversationId != null) return
-        stateHandle.update { copy(isTemporaryChat = !isTemporaryChat) }
+        if (handle.state.conversationId != null) return
+        handle.update { conversation = conversation.copy(isTemporaryChat = !conversation.isTemporaryChat) }
     }
 
     /**
@@ -103,22 +103,25 @@ class MessageTreeDelegate(
         // supports a backend version range. If the Final payload omitted a file that streamed in
         // via `attachment` SSE events, fold it back in (by fileId) so it survives the reload — the
         // streamed list is about to be cleared in the update below. Cheap insurance.
-        val streamedAttachments = stateHandle.state.streamingAttachments
+        val streamedAttachments = handle.state.streamingAttachments
         val response = event.resolvedResponseMessage()?.let { mergeStreamedAttachments(it, streamedAttachments) }
         val finalMessages = listOfNotNull(event.requestMessage, response)
         // Retiring the streaming bubble (clearing the streaming fields) and swapping in the
         // finalized message MUST be ONE update: with a Main.immediate StateFlow every write is
         // observed, so two updates leave a frame where the bubble is gone but the reply isn't
         // in displayMessages yet — the completion flash. (Comparison chats clear in handleFinal.)
-        stateHandle.update {
+        handle.update {
             val mergedMessages = if (finalMessages.isEmpty()) {
-                messages
+                content.messages
             } else {
-                mergeFinalMessagesInMemory(messages, finalMessages)
+                mergeFinalMessagesInMemory(content.messages, finalMessages)
             }
-            copy(
+            // Retire the streaming bubble and swap in the finalized message in ONE slice copy —
+            // all these fields live in `content`, so this stays a single StateFlow emission and
+            // the completion-flash invariant holds structurally.
+            content = content.copy(
                 messages = mergedMessages,
-                displayMessages = buildActiveMessagePath(mergedMessages, activeBranches),
+                displayMessages = buildActiveMessagePath(mergedMessages, content.activeBranches),
                 screenState = ChatScreenState.ACTIVE,
                 isStreaming = false,
                 streamingContent = "",
@@ -135,7 +138,7 @@ class MessageTreeDelegate(
         if (finalMessages.isEmpty()) return emptyList()
         val request = event.requestMessage
             ?: response?.parentMessageId?.let { parentId ->
-                stateHandle.state.messages.firstOrNull { it.messageId == parentId }
+                handle.state.messages.firstOrNull { it.messageId == parentId }
             }
         return listOfNotNull(request, response)
     }

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/ModelSelectionDelegate.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/ModelSelectionDelegate.kt
@@ -19,7 +19,7 @@ import com.garfiec.librechat.core.model.permissions.Permission
 import com.garfiec.librechat.core.model.permissions.PermissionType
 import com.garfiec.librechat.core.ui.components.ModelParameters
 import com.garfiec.librechat.feature.chat.model.McpServerDisplayData
-import com.garfiec.librechat.feature.chat.viewmodel.ChatStateHandle
+import com.garfiec.librechat.feature.chat.viewmodel.ModelSelectionHandle
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -32,7 +32,7 @@ import kotlinx.coroutines.launch
 private const val AGENTS_LOAD_ERROR = "Could not load available agents"
 
 class ModelSelectionDelegate(
-    private val stateHandle: ChatStateHandle,
+    private val handle: ModelSelectionHandle,
     private val configRepository: ConfigRepository,
     private val agentRepository: AgentRepository,
     private val mcpRepository: McpRepository,
@@ -200,7 +200,7 @@ class ModelSelectionDelegate(
             configRepository.availableModels.value,
             configRepository.endpointConfigs.value,
         )
-        stateHandle.update { copy(availableModels = filtered) }
+        handle.update { selection = selection.copy(availableModels = filtered) }
 
         // Don't validate against an empty models list — models haven't
         // loaded yet. When they arrive this method will be called again.
@@ -224,8 +224,8 @@ class ModelSelectionDelegate(
         // that selectedModel is actually one of the loaded agent IDs.
         // When modelsForEndpoint is absent (still loading), skip the check
         // rather than clobber the selection.
-        val currentEndpoint = stateHandle.state.selectedEndpoint
-        val currentModel = stateHandle.state.selectedModel
+        val currentEndpoint = handle.state.selectedEndpoint
+        val currentModel = handle.state.selectedModel
         val modelsForEndpoint = filtered[currentEndpoint]
         val selectionValid = currentModel != null &&
             (modelsForEndpoint == null || currentModel in modelsForEndpoint)
@@ -249,7 +249,7 @@ class ModelSelectionDelegate(
                 // re-runs refilterModels on success to un-stick this.
                 when {
                     !agentsLoaded.value -> return
-                    stateHandle.state.agents.any { it.id == lastModel } -> true
+                    handle.state.agents.any { it.id == lastModel } -> true
                     else -> false
                 }
             } else {
@@ -265,8 +265,8 @@ class ModelSelectionDelegate(
                         "endpoint" to lastEndpoint,
                     ),
                 ) { "refilterModels corrective fallback → last-used" }
-                stateHandle.update {
-                    copy(
+                handle.update {
+                    selection = selection.copy(
                         selectedEndpoint = lastEndpoint,
                         selectedModel = lastModel,
                     )
@@ -285,8 +285,8 @@ class ModelSelectionDelegate(
                     "endpoint" to firstEndpoint.key,
                 ),
             ) { "refilterModels corrective fallback → first model" }
-            stateHandle.update {
-                copy(
+            handle.update {
+                selection = selection.copy(
                     selectedEndpoint = firstEndpoint.key,
                     selectedModel = firstEndpoint.value.firstOrNull(),
                 )
@@ -312,7 +312,7 @@ class ModelSelectionDelegate(
      *   3. first available config model
      */
     fun seedInitialSelection(isNewConversation: Boolean) {
-        stateHandle.scope.launch {
+        handle.scope.launch {
             combine(
                 settingsDataStore.lastUsedEndpoint,
                 settingsDataStore.lastUsedModel,
@@ -353,7 +353,7 @@ class ModelSelectionDelegate(
      * the seeder and lets it fall through past the agents tier.
      */
     private fun agentsInput(): Flow<AgentsInput> = combine(
-        stateHandle.stateFlow.map { it.agents to it.conversationId }.distinctUntilChanged(),
+        handle.stateFlow.map { it.agents to it.conversationId }.distinctUntilChanged(),
         agentsLoaded,
     ) { agentsAndConvId, loaded ->
         AgentsInput(
@@ -397,7 +397,7 @@ class ModelSelectionDelegate(
 
     private fun applySeed(input: SeedInputs) {
         val filtered = filterModelsByEndpoint(input.rawModels, input.endpointConfigs)
-        val state = stateHandle.state
+        val state = handle.state
 
         val lastUsed = if (input.lastEndpoint != null && input.lastModel != null) {
             input.lastEndpoint to input.lastModel
@@ -516,10 +516,10 @@ class ModelSelectionDelegate(
     }
 
     private fun applySelection(endpoint: String, model: String?, reason: String) {
-        val previous = stateHandle.state
+        val previous = handle.state
         val changed = previous.selectedEndpoint != endpoint || previous.selectedModel != model
-        stateHandle.update {
-            copy(selectedEndpoint = endpoint, selectedModel = model)
+        handle.update {
+            selection = selection.copy(selectedEndpoint = endpoint, selectedModel = model)
         }
         if (changed) {
             Diag.d(
@@ -597,8 +597,8 @@ class ModelSelectionDelegate(
     )
 
     fun onModelSelected(endpoint: String, model: String) {
-        stateHandle.update {
-            copy(
+        handle.update {
+            selection = selection.copy(
                 selectedEndpoint = endpoint,
                 selectedModel = model,
             )
@@ -606,7 +606,7 @@ class ModelSelectionDelegate(
         // Keep cached values in sync so refilterModels uses the latest choice
         cachedLastUsedEndpoint = endpoint
         cachedLastUsedModel = model
-        stateHandle.scope.launch {
+        handle.scope.launch {
             settingsDataStore.setLastUsedModel(endpoint, model)
         }
     }
@@ -619,7 +619,7 @@ class ModelSelectionDelegate(
      */
     fun loadAgents(isNewConversation: Boolean) {
         agentsLoadFailed = false
-        agentsLoadJob = stateHandle.scope.launch {
+        agentsLoadJob = handle.scope.launch {
             // Skip the fetch entirely when the role denies AGENTS.USE; otherwise
             // the server would return 403 and we'd have to decide whether it's a
             // genuine 403 (rate limit, tenancy) vs. permission denial.
@@ -641,15 +641,13 @@ class ModelSelectionDelegate(
                     // otherwise tier 2 could fall through to a config model in the
                     // one-emission window before the flag flips.
                     agentsLoaded.value = true
-                    stateHandle.update {
-                        copy(
-                            agents = result.data,
-                            // A successful retry must not leave the failure banner from
-                            // the attempt it just recovered next to the populated list.
-                            // Clear only our own message — the error slot is shared
-                            // with other delegates.
-                            error = error.takeUnless { it == AGENTS_LOAD_ERROR },
-                        )
+                    handle.update {
+                        selection = selection.copy(agents = result.data)
+                        // A successful retry must not leave the failure banner from
+                        // the attempt it just recovered next to the populated list.
+                        // Clear only our own message — the error slot is shared
+                        // with other delegates.
+                        error = error.takeUnless { it == AGENTS_LOAD_ERROR }
                     }
                 }
                 is Result.Error -> {
@@ -658,7 +656,7 @@ class ModelSelectionDelegate(
                     // when the user next opens the selector. The AccountKeyedCache only
                     // stores successes, so the retry genuinely re-hits the network.
                     agentsLoadFailed = true
-                    stateHandle.update { copy(error = AGENTS_LOAD_ERROR) }
+                    handle.setError(AGENTS_LOAD_ERROR)
                     agentsLoaded.value = true
                     scheduleAgentsRetryOnReconnect(isNewConversation)
                 }
@@ -704,7 +702,7 @@ class ModelSelectionDelegate(
      */
     private fun scheduleAgentsRetryOnReconnect(isNewConversation: Boolean) {
         connectivityRetryJob?.cancel()
-        connectivityRetryJob = stateHandle.scope.launch {
+        connectivityRetryJob = handle.scope.launch {
             var wasConnected: Boolean? = null
             connectivityObserver.isConnected.collect { connected ->
                 val recovered = wasConnected == false && connected
@@ -719,7 +717,7 @@ class ModelSelectionDelegate(
     }
 
     fun loadMcpServers() {
-        stateHandle.scope.launch {
+        handle.scope.launch {
             when (val serversResult = mcpRepository.listServers()) {
                 is Result.Success -> {
                     val servers = serversResult.data
@@ -730,8 +728,8 @@ class ModelSelectionDelegate(
                         val status = statusMap[server.name]
                         server.copy(isConnected = status?.isConnected ?: false)
                     }
-                    stateHandle.update {
-                        copy(mcpServers = enriched.map { it.toDisplayData() })
+                    handle.update {
+                        selection = selection.copy(mcpServers = enriched.map { it.toDisplayData() })
                     }
                 }
                 is Result.Error -> {
@@ -743,46 +741,46 @@ class ModelSelectionDelegate(
     }
 
     fun toggleMcpServer(serverName: String) {
-        val current = stateHandle.state.selectedMcpServerNames
+        val current = handle.state.selectedMcpServerNames
         val updated = if (serverName in current) current - serverName else current + serverName
-        stateHandle.update { copy(selectedMcpServerNames = updated) }
-        stateHandle.scope.launch { settingsDataStore.setSelectedMcpServers(updated) }
+        handle.update { selection = selection.copy(selectedMcpServerNames = updated) }
+        handle.scope.launch { settingsDataStore.setSelectedMcpServers(updated) }
     }
 
     fun toggleTool(toolName: String) {
         if (toolName == ToolConstants.WEB_SEARCH) {
             // Web search is backed by modelParameters.webSearch (single source of truth).
-            val current = stateHandle.state.modelParameters.webSearch
-            stateHandle.update {
-                copy(modelParameters = modelParameters.copy(webSearch = !current))
+            val current = handle.state.modelParameters.webSearch
+            handle.update {
+                selection = selection.copy(modelParameters = selection.modelParameters.copy(webSearch = !current))
             }
         } else if (toolName == ToolConstants.URL_CONTEXT) {
             // URL context (Google-only) is backed by modelParameters.urlContext, like web search.
-            val current = stateHandle.state.modelParameters.urlContext
-            stateHandle.update {
-                copy(modelParameters = modelParameters.copy(urlContext = !current))
+            val current = handle.state.modelParameters.urlContext
+            handle.update {
+                selection = selection.copy(modelParameters = selection.modelParameters.copy(urlContext = !current))
             }
-        } else if (toolName == ToolConstants.CODE_INTERPRETER && !stateHandle.state.isCodeInterpreterAvailable) {
+        } else if (toolName == ToolConstants.CODE_INTERPRETER && !handle.state.isCodeInterpreterAvailable) {
             // Code interpreter is not available on this server; ignore toggle attempt.
             return
         } else {
-            val current = stateHandle.state.enabledTools
+            val current = handle.state.enabledTools
             val updated = if (toolName in current) current - toolName else current + toolName
-            stateHandle.update { copy(enabledTools = updated) }
-            stateHandle.scope.launch { settingsDataStore.setEnabledTools(updated) }
+            handle.update { selection = selection.copy(enabledTools = updated) }
+            handle.scope.launch { settingsDataStore.setEnabledTools(updated) }
         }
     }
 
     fun showModelParameters() {
-        stateHandle.update { copy(showModelParameters = true) }
+        handle.update { selection = selection.copy(showModelParameters = true) }
     }
 
     fun hideModelParameters() {
-        stateHandle.update { copy(showModelParameters = false) }
+        handle.update { selection = selection.copy(showModelParameters = false) }
     }
 
     fun updateModelParameters(parameters: ModelParameters) {
-        stateHandle.update { copy(modelParameters = parameters) }
+        handle.update { selection = selection.copy(modelParameters = parameters) }
     }
 }
 

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/OfficePreviewDelegate.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/OfficePreviewDelegate.kt
@@ -6,7 +6,7 @@ import com.garfiec.librechat.core.data.repository.FileRepository
 import com.garfiec.librechat.core.model.Attachment
 import com.garfiec.librechat.core.model.response.FilePreviewResponse
 import com.garfiec.librechat.feature.chat.components.artifact.ArtifactType
-import com.garfiec.librechat.feature.chat.viewmodel.ChatStateHandle
+import com.garfiec.librechat.feature.chat.viewmodel.OfficePreviewHandle
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 
@@ -18,7 +18,7 @@ import kotlinx.coroutines.launch
  * An office doc arrives on the SSE `attachment` event twice for one `file_id`:
  * first `status: "pending"` (no text), then `"ready"` (+ text/textFormat) or
  * `"failed"` (+ previewError). This delegate:
- *  - [onAttachment]: UPSERTS by `file_id` into [ChatStateHandle] `streamingAttachments`
+ *  - [onAttachment]: UPSERTS by `file_id` into the chat state's `streamingAttachments`
  *    — merging over an existing record rather than appending. NO-REGRESS: a
  *    terminal (`ready`/`failed`) record is never downgraded by a late `pending`
  *    for the same `file_id` (cross-turn file_id reuse), and a terminal incoming
@@ -35,7 +35,7 @@ import kotlinx.coroutines.launch
  * office-preview MIME types here; everything else keeps the plain append path.
  */
 class OfficePreviewDelegate(
-    private val stateHandle: ChatStateHandle,
+    private val handle: OfficePreviewHandle,
     private val fileRepository: FileRepository,
 ) {
 
@@ -45,8 +45,8 @@ class OfficePreviewDelegate(
     /** Upserts an office-doc attachment by `file_id` with the no-regress guard. */
     fun onAttachment(attachment: Attachment) {
         val fileId = attachment.fileId ?: return
-        stateHandle.update {
-            copy(streamingAttachments = upsertByFileId(streamingAttachments, attachment))
+        handle.update {
+            content = content.copy(streamingAttachments = upsertByFileId(content.streamingAttachments, attachment))
         }
         // A terminal SSE update supersedes any in-flight poll for this file.
         if (attachment.status.isTerminal()) {
@@ -60,7 +60,7 @@ class OfficePreviewDelegate(
      * merges the resolved record back in. Idempotent per `file_id`.
      */
     fun onStreamEnded() {
-        val pending = stateHandle.state.streamingAttachments.filter {
+        val pending = handle.state.streamingAttachments.filter {
             ArtifactType.isOfficePreviewMime(it.type) &&
                 it.fileId != null &&
                 it.status == FilePreviewResponse.STATUS_PENDING
@@ -68,7 +68,7 @@ class OfficePreviewDelegate(
         for (attachment in pending) {
             val fileId = attachment.fileId ?: continue
             if (activePolls.containsKey(fileId)) continue
-            activePolls[fileId] = stateHandle.scope.launch {
+            activePolls[fileId] = handle.scope.launch {
                 try {
                     when (val result = fileRepository.pollFilePreview(fileId)) {
                         is Result.Success -> mergePreviewResult(fileId, result.data)
@@ -93,8 +93,8 @@ class OfficePreviewDelegate(
     }
 
     private fun mergePreviewResult(fileId: String, preview: FilePreviewResponse) {
-        stateHandle.update {
-            val merged = streamingAttachments.map { att ->
+        handle.update {
+            val merged = content.streamingAttachments.map { att ->
                 if (att.fileId != fileId) {
                     att
                 } else {
@@ -111,7 +111,7 @@ class OfficePreviewDelegate(
                     }
                 }
             }
-            copy(streamingAttachments = merged)
+            content = content.copy(streamingAttachments = merged)
         }
     }
 

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/PlatformDelegateFactory.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/PlatformDelegateFactory.kt
@@ -1,20 +1,23 @@
 package com.garfiec.librechat.feature.chat.viewmodel.delegate
 
-import com.garfiec.librechat.feature.chat.viewmodel.ChatStateHandle
+import com.garfiec.librechat.feature.chat.viewmodel.ErrorOnlyHandle
+import com.garfiec.librechat.feature.chat.viewmodel.TtsHandle
+import com.garfiec.librechat.feature.chat.viewmodel.VoiceHandle
 
 /**
- * Factory that creates platform-specific delegates once the ChatStateHandle is available.
+ * Factory that creates platform-specific delegates once the narrowed handles are available.
  * This is necessary because delegates need the ViewModel's state handle and coroutine scope,
- * which aren't available until the ViewModel is constructed.
+ * which aren't available until the ViewModel is constructed. Each delegate gets only the
+ * narrowed handle it may write through.
  */
 interface PlatformDelegateFactory {
-    fun createFileHandler(stateHandle: ChatStateHandle): PlatformFileHandler
+    fun createFileHandler(handle: ErrorOnlyHandle): PlatformFileHandler
     fun createVoiceInput(
-        stateHandle: ChatStateHandle,
+        handle: VoiceHandle,
         onTranscriptionComplete: () -> Unit,
     ): PlatformVoiceInput
     fun createTts(
-        stateHandle: ChatStateHandle,
+        handle: TtsHandle,
         getMessageText: (String) -> String,
     ): PlatformTts
     fun createShareConsumer(): PlatformShareConsumer

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/PresetPromptDelegate.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/PresetPromptDelegate.kt
@@ -9,11 +9,11 @@ import com.garfiec.librechat.core.model.PromptGroup
 import com.garfiec.librechat.core.ui.components.ModelParameters
 import com.garfiec.librechat.feature.chat.model.PresetDisplayData
 import com.garfiec.librechat.feature.chat.model.PromptMentionDisplayData
-import com.garfiec.librechat.feature.chat.viewmodel.ChatStateHandle
+import com.garfiec.librechat.feature.chat.viewmodel.PresetPromptHandle
 import kotlinx.coroutines.launch
 
 class PresetPromptDelegate(
-    private val stateHandle: ChatStateHandle,
+    private val handle: PresetPromptHandle,
     private val presetRepository: PresetRepository,
     private val promptRepository: PromptRepository,
 ) {
@@ -23,12 +23,12 @@ class PresetPromptDelegate(
     private var cachedPromptGroups: List<PromptGroup> = emptyList()
 
     fun loadPresets() {
-        stateHandle.scope.launch {
+        handle.scope.launch {
             when (val result = presetRepository.getAll()) {
                 is Result.Success -> {
                     cachedPresets = result.data
-                    stateHandle.update {
-                        copy(presets = result.data.map { it.toDisplayData() })
+                    handle.update {
+                        presetPrompts = presetPrompts.copy(presets = result.data.map { it.toDisplayData() })
                     }
                 }
                 is Result.Error -> {
@@ -41,12 +41,12 @@ class PresetPromptDelegate(
     }
 
     fun loadAvailablePrompts() {
-        stateHandle.scope.launch {
+        handle.scope.launch {
             when (val result = promptRepository.getGroups(pageSize = 100)) {
                 is Result.Success -> {
                     cachedPromptGroups = result.data.promptGroups
-                    stateHandle.update {
-                        copy(availablePrompts = result.data.promptGroups.map { it.toDisplayData() })
+                    handle.update {
+                        presetPrompts = presetPrompts.copy(availablePrompts = result.data.promptGroups.map { it.toDisplayData() })
                     }
                 }
                 is Result.Error -> {
@@ -59,7 +59,7 @@ class PresetPromptDelegate(
     }
 
     fun savePreset(name: String) {
-        val state = stateHandle.state
+        val state = handle.state
         val params = state.modelParameters
         val dyn = params.dynamicValues
         val preset = Preset(
@@ -113,23 +113,23 @@ class PresetPromptDelegate(
             region = dyn["region"],
             resendFiles = params.resendFiles,
         )
-        stateHandle.scope.launch {
+        handle.scope.launch {
             try {
                 presetRepository.create(preset)
                 loadPresets()
             } catch (e: Exception) {
                 Logger.e(e) { "Could not save preset" }
-                stateHandle.update { copy(error = "Could not save preset") }
+                handle.setError("Could not save preset")
             }
         }
     }
 
     fun loadPreset(displayData: PresetDisplayData) {
         val preset = cachedPresets.find { it.presetId == displayData.presetId } ?: return
-        stateHandle.update {
-            copy(
-                selectedEndpoint = preset.endpoint ?: selectedEndpoint,
-                selectedModel = preset.model ?: selectedModel,
+        handle.update {
+            selection = selection.copy(
+                selectedEndpoint = preset.endpoint ?: selection.selectedEndpoint,
+                selectedModel = preset.model ?: selection.selectedModel,
                 // Authoritative load: a preset represents a complete saved
                 // configuration. Merging from current parameters would let
                 // unrelated fields (e.g. a temperature from the previous
@@ -141,11 +141,11 @@ class PresetPromptDelegate(
     }
 
     fun deletePreset(presetId: String) {
-        stateHandle.scope.launch {
+        handle.scope.launch {
             when (presetRepository.delete(presetId)) {
                 is Result.Success -> loadPresets()
                 is Result.Error -> {
-                    stateHandle.update { copy(error = "Could not delete preset") }
+                    handle.setError("Could not delete preset")
                 }
                 is Result.Loading -> { /* no-op */ }
             }
@@ -153,11 +153,11 @@ class PresetPromptDelegate(
     }
 
     fun editPreset(preset: Preset) {
-        stateHandle.scope.launch {
+        handle.scope.launch {
             when (presetRepository.update(preset)) {
                 is Result.Success -> loadPresets()
                 is Result.Error -> {
-                    stateHandle.update { copy(error = "Could not update preset") }
+                    handle.setError("Could not update preset")
                 }
                 is Result.Loading -> { /* no-op */ }
             }
@@ -165,14 +165,14 @@ class PresetPromptDelegate(
     }
 
     fun handlePromptMention(displayData: PromptMentionDisplayData) {
-        val currentInput = stateHandle.state.inputText
+        val currentInput = handle.state.inputText
         val atIndex = currentInput.lastIndexOf('@')
         val newText = if (atIndex >= 0) {
             currentInput.substring(0, atIndex) + (displayData.command ?: displayData.name) + " "
         } else {
             currentInput + (displayData.command ?: displayData.name) + " "
         }
-        stateHandle.update { copy(inputText = newText) }
+        handle.update { composer = composer.copy(inputText = newText) }
         recordUseFor(displayData)
     }
 
@@ -191,8 +191,8 @@ class PresetPromptDelegate(
         } else {
             null
         }
-        stateHandle.update {
-            copy(inputText = promptText ?: (displayData.command ?: displayData.name))
+        handle.update {
+            composer = composer.copy(inputText = promptText ?: (displayData.command ?: displayData.name))
         }
         recordUseFor(displayData)
     }
@@ -206,7 +206,7 @@ class PresetPromptDelegate(
             it.name == displayData.name && it.command == displayData.command
         } ?: return
         val groupId = group.id ?: return
-        stateHandle.scope.launch {
+        handle.scope.launch {
             when (val result = promptRepository.recordPromptGroupUse(groupId)) {
                 is Result.Error -> Logger.d(result.exception) { "recordPromptGroupUse failed (non-fatal): ${result.message}" }
                 else -> Unit

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/SendCompletionDelegate.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/SendCompletionDelegate.kt
@@ -11,8 +11,8 @@ import com.garfiec.librechat.core.logging.Diag
 import com.garfiec.librechat.core.model.Message
 import com.garfiec.librechat.core.model.StreamEvent
 import com.garfiec.librechat.feature.chat.util.NEW_CHAT_DRAFT_KEY
-import com.garfiec.librechat.feature.chat.viewmodel.ChatStateHandle
 import com.garfiec.librechat.feature.chat.viewmodel.NewChatSelectionHandoff
+import com.garfiec.librechat.feature.chat.viewmodel.SendCompletionHandle
 import com.garfiec.librechat.feature.chat.viewmodel.shouldRequestTitleGeneration
 import kotlinx.coroutines.launch
 
@@ -28,7 +28,7 @@ import kotlinx.coroutines.launch
  * cleanup (buffer flush, connectivity reset) stays on the caller's side.
  */
 class SendCompletionDelegate(
-    private val stateHandle: ChatStateHandle,
+    private val handle: SendCompletionHandle,
     private val conversationRepository: ConversationRepository,
     private val messageRepository: MessageRepository,
     private val draftRepository: DraftRepository,
@@ -58,10 +58,10 @@ class SendCompletionDelegate(
         // new Chat(id) VM via the Chat route's isTemporary flag (durable across process death), so
         // that VM starts temp-aware and skips its own loadConversation / loadConversationModel
         // upserts — see ChatViewModel.init and Navigator.navigateToChat.
-        val isTemporary = stateHandle.state.isTemporaryChat
+        val isTemporary = handle.state.isTemporaryChat
         if (isNewConversation) {
             if (!isTemporary) {
-                stateHandle.scope.launch {
+                handle.scope.launch {
                     val existingDraft = draftRepository.getDraft(NEW_CHAT_DRAFT_KEY)
                     if (existingDraft != null) {
                         draftRepository.saveDraft(conversationId, existingDraft)
@@ -73,24 +73,23 @@ class SendCompletionDelegate(
             // apply it directly instead of re-deriving it from a GET that races the server's
             // unawaited conversation save. Keyed by id, so a deferred nav (comparison-mode
             // branch) still picks it up. See NewChatSelectionHandoff.
-            val sent = stateHandle.state
+            val sent = handle.state
             // Hand off the optimistic user message too, so the about-to-be-created Chat(id) VM
             // can keep it on screen during the resumed stream — the server doesn't persist the
             // request message until the reply completes. See NewChatSelectionHandoff.
             val optimisticUserMessage = sent.messages.lastOrNull { it.isCreatedByUser }
             selectionHandoff.put(conversationId, sent.selectedEndpoint, sent.selectedModel, optimisticUserMessage)
-            stateHandle.update {
-                if (pendingNavigationConversationId == null && !comparisonState.isEnabled) {
-                    copy(pendingNavigationConversationId = conversationId)
-                } else {
-                    this
+            val snapshot = handle.state
+            if (snapshot.pendingNavigationConversationId == null && !snapshot.comparisonState.isEnabled) {
+                handle.update {
+                    conversation = conversation.copy(pendingNavigationConversationId = conversationId)
                 }
             }
         }
         // Eagerly fetch and cache the conversation the server just created, so it appears in the
         // conversation list even if the stream fails later — but never for temp chats (see guard).
         if (!isTemporary) {
-            stateHandle.scope.launch {
+            handle.scope.launch {
                 conversationRepository.getConversation(conversationId, originAccount)
             }
         }
@@ -131,9 +130,9 @@ class SendCompletionDelegate(
         // Temporary chats are kept out of normal history — the server excludes
         // them from the conversation list, so don't cache them to Room either (it would
         // leak a temp chat into the local list the server hides).
-        val isTemporary = stateHandle.state.isTemporaryChat || finalConversation?.isTemporary == true
+        val isTemporary = handle.state.isTemporaryChat || finalConversation?.isTemporary == true
         if (finalConversation?.conversationId != null && !isTemporary) {
-            stateHandle.scope.launch {
+            handle.scope.launch {
                 conversationRepository.saveConversation(finalConversation, originAccount)
             }
         }
@@ -166,7 +165,7 @@ class SendCompletionDelegate(
                 val shouldGenerate = shouldRequestTitleGeneration(
                     isNewConversation = isNewConversation,
                     isHandedOffNewChat = isHandedOffNewChat,
-                    currentTitle = stateHandle.state.conversationTitle,
+                    currentTitle = handle.state.conversationTitle,
                     alreadyRequested = titleGenerationRequested,
                 )
                 if (shouldGenerate) {
@@ -190,25 +189,25 @@ class SendCompletionDelegate(
      */
     private fun cacheTurn(turn: List<Message>, originAccount: AccountId?) {
         if (turn.isEmpty()) return
-        stateHandle.scope.launch {
+        handle.scope.launch {
             runCatching { messageRepository.cacheMessages(turn, originAccount) }
                 .onFailure { Logger.e(it) { "Failed to cache final messages for the completed turn" } }
         }
     }
 
     private fun refreshConversationTitle(conversationId: String, originAccount: AccountId?) {
-        stateHandle.scope.launch {
-            val conversation = conversationRepository.getConversation(conversationId, originAccount).getOrNull()
+        handle.scope.launch {
+            val fetched = conversationRepository.getConversation(conversationId, originAccount).getOrNull()
                 ?: return@launch
-            stateHandle.update { copy(conversationTitle = conversation.title) }
+            handle.update { conversation = conversation.copy(conversationTitle = fetched.title) }
         }
     }
 
     private fun generateAndSetTitle(conversationId: String, originAccount: AccountId?) {
-        stateHandle.scope.launch {
+        handle.scope.launch {
             when (val result = conversationRepository.generateTitle(conversationId, originAccount)) {
                 is Result.Success -> {
-                    stateHandle.update { copy(conversationTitle = result.data) }
+                    handle.update { conversation = conversation.copy(conversationTitle = result.data) }
                 }
                 is Result.Error -> {
                     Logger.d { "Title generation failed for $conversationId: ${result.message}" }
@@ -218,8 +217,8 @@ class SendCompletionDelegate(
                     // still holds the "New Chat" placeholder, so cache-first getConversation
                     // could never observe the title, and refreshConversation's upsert also
                     // propagates it to the Room-observing conversation list.
-                    conversationRepository.refreshConversation(conversationId, originAccount).getOrNull()?.let { conversation ->
-                        stateHandle.update { copy(conversationTitle = conversation.title) }
+                    conversationRepository.refreshConversation(conversationId, originAccount).getOrNull()?.let { fetched ->
+                        handle.update { conversation = conversation.copy(conversationTitle = fetched.title) }
                     }
                 }
                 is Result.Loading -> { /* no-op */ }

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/StreamingManagerDelegate.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/StreamingManagerDelegate.kt
@@ -14,8 +14,8 @@ import com.garfiec.librechat.core.model.error.parseUserKeyError
 import com.garfiec.librechat.feature.chat.components.artifact.ArtifactType
 import com.garfiec.librechat.feature.chat.viewmodel.ActiveToolCall
 import com.garfiec.librechat.feature.chat.viewmodel.ChatScreenState
-import com.garfiec.librechat.feature.chat.viewmodel.ChatStateHandle
 import com.garfiec.librechat.feature.chat.viewmodel.RetryInfo
+import com.garfiec.librechat.feature.chat.viewmodel.StreamingHandle
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -34,7 +34,7 @@ import kotlinx.coroutines.launch
  * build a request flow and hand it to [launchStream]; everything downstream lives here.
  */
 class StreamingManagerDelegate(
-    private val stateHandle: ChatStateHandle,
+    private val handle: StreamingHandle,
     private val chatRepository: ChatRepository,
     private val activeAccountProvider: ActiveAccountProvider,
     private val connectivityObserver: ConnectivityObserver,
@@ -51,7 +51,7 @@ class StreamingManagerDelegate(
     private val isHandedOffNewChat: () -> Boolean,
 ) {
 
-    private val scope get() = stateHandle.scope
+    private val scope get() = handle.scope
 
     private var streamJob: Job? = null
     private var streamingUpdateJob: Job? = null
@@ -80,7 +80,7 @@ class StreamingManagerDelegate(
 
     /**
      * Resets the streaming-internal session state (buffer, edit flag, traces) and starts the
-     * throttled updater. Does NOT touch [stateHandle] — callers that already mutate UI state
+     * throttled updater. Does NOT touch UI state — callers that already mutate UI state
      * for their send (e.g. the optimistic-insert path) use this; [prepareForStreaming] wraps
      * it with the standard streaming-field reset.
      */
@@ -100,14 +100,14 @@ class StreamingManagerDelegate(
      * (edit, regenerate, or continue).
      */
     fun prepareForStreaming(isEdit: Boolean) {
-        stateHandle.update {
-            copy(
+        handle.update {
+            content = content.copy(
                 isStreaming = true,
                 streamingContent = "",
                 activeToolCalls = emptyList(),
                 streamingAttachments = emptyList(),
-                error = null,
             )
+            error = null
         }
         beginStreaming(isEdit)
     }
@@ -144,21 +144,21 @@ class StreamingManagerDelegate(
             stopStreamingUpdater()
             // Preserve partial content so users can read/copy what was received
             val partialContent = streamingBuffer.toString()
-            stateHandle.update {
-                copy(
+            handle.update {
+                content = content.copy(
                     isStreaming = false,
                     streamingContent = partialContent,
                     activeToolCalls = emptyList(),
                     streamingAttachments = emptyList(),
-                    error = e.message ?: "Chat request failed",
                 )
+                error = e.message ?: "Chat request failed"
             }
             comparisonDelegate.endStreaming()
             // Don't auto-drain into a failed turn — hold the queue for the user (mirrors the
             // StreamEvent.Error branch; a flow-level exception ends the stream the same way).
             queueDelegate.pause()
             // If the server already created a conversation, fetch whatever it persisted
-            val conversationId = stateHandle.state.conversationId
+            val conversationId = handle.state.conversationId
             if (conversationId != null) {
                 reloadConversation(conversationId)
             }
@@ -194,15 +194,15 @@ class StreamingManagerDelegate(
                 val keyError = parseUserKeyError(event.message)
                 // Preserve partial content so users can read/copy what was received
                 val partialContent = streamingBuffer.toString()
-                stateHandle.update {
-                    copy(
+                handle.update {
+                    content = content.copy(
                         isStreaming = false,
                         streamingContent = partialContent,
-                        error = if (keyError != null) null else event.message,
                         retryInfo = null,
                         activeToolCalls = emptyList(),
                         streamingAttachments = emptyList(),
                     )
+                    error = if (keyError != null) null else event.message
                 }
                 comparisonDelegate.endStreaming()
                 // Don't auto-drain into a failed turn — hold the queue for the user.
@@ -211,14 +211,14 @@ class StreamingManagerDelegate(
                     emitUserKeyError(keyError)
                 }
                 // If the server already created a conversation, fetch whatever it persisted
-                val conversationId = stateHandle.state.conversationId
+                val conversationId = handle.state.conversationId
                 if (conversationId != null) {
                     reloadConversation(conversationId)
                 }
             }
             is StreamEvent.Retrying -> {
-                stateHandle.update {
-                    copy(
+                handle.update {
+                    content = content.copy(
                         retryInfo = RetryInfo(
                             attempt = event.attempt,
                             maxAttempts = event.maxAttempts,
@@ -232,20 +232,20 @@ class StreamingManagerDelegate(
                     name = event.toolName,
                     input = event.input,
                 )
-                stateHandle.update {
-                    copy(activeToolCalls = activeToolCalls + newToolCall)
+                handle.update {
+                    content = content.copy(activeToolCalls = content.activeToolCalls + newToolCall)
                 }
             }
             is StreamEvent.ToolCallComplete -> {
-                stateHandle.update {
-                    val updated = activeToolCalls.map { tc ->
+                handle.update {
+                    val updated = content.activeToolCalls.map { tc ->
                         if (tc.id == event.toolCallId) {
                             tc.copy(isComplete = true, output = event.output)
                         } else {
                             tc
                         }
                     }
-                    copy(activeToolCalls = updated)
+                    content = content.copy(activeToolCalls = updated)
                 }
                 // If this was a `subagent` tool_call, freeze its live trace —
                 // the child run is done; stop accumulating for that key.
@@ -271,8 +271,8 @@ class StreamingManagerDelegate(
                 if (ArtifactType.isOfficePreviewMime(event.type)) {
                     officePreviewDelegate.onAttachment(attachment)
                 } else {
-                    stateHandle.update {
-                        copy(streamingAttachments = streamingAttachments + attachment)
+                    handle.update {
+                        content = content.copy(streamingAttachments = content.streamingAttachments + attachment)
                     }
                 }
             }
@@ -286,8 +286,8 @@ class StreamingManagerDelegate(
                     lastErrorWasNetwork = false
                     cancelConnectivityObserver()
                 }
-                stateHandle.update {
-                    if (retryInfo != null) copy(retryInfo = null) else this
+                handle.update {
+                    if (content.retryInfo != null) content = content.copy(retryInfo = null)
                 }
                 val textContent = event.aggregatedContent
                     .mapNotNull { it.text }
@@ -312,7 +312,7 @@ class StreamingManagerDelegate(
                             output = tc.output,
                         )
                     }
-                stateHandle.update { copy(activeToolCalls = syncedToolCalls) }
+                handle.update { content = content.copy(activeToolCalls = syncedToolCalls) }
                 flushStreamingBuffer()
             }
             is StreamEvent.Step -> { /* no-op */ }
@@ -325,12 +325,12 @@ class StreamingManagerDelegate(
             is StreamEvent.TitleUpdate -> handleTitleUpdate(event)
             is StreamEvent.ContextUsageUpdate -> {
                 // Latest context-window snapshot drives the gauge. In-memory only.
-                stateHandle.update { copy(contextUsage = event.usage) }
+                handle.update { content = content.copy(contextUsage = event.usage) }
             }
             is StreamEvent.TokenUsageUpdate -> {
                 // Per-call provider usage; the gauge denominator comes from the context
                 // snapshot, but the breakdown sheet shows Input/Output from this. In-memory only.
-                stateHandle.update { copy(tokenUsage = event.usage) }
+                handle.update { content = content.copy(tokenUsage = event.usage) }
             }
         }
     }
@@ -342,9 +342,9 @@ class StreamingManagerDelegate(
      * streaming-anchor invariant). The post-stream title refetch persists it.
      */
     private fun handleTitleUpdate(event: StreamEvent.TitleUpdate) {
-        val current = stateHandle.state.conversationId
+        val current = handle.state.conversationId
         if (current != null && current != event.conversationId) return
-        stateHandle.update { copy(conversationTitle = event.title) }
+        handle.update { conversation = conversation.copy(conversationTitle = event.title) }
     }
 
     private fun handleCreated(event: StreamEvent.Created) {
@@ -352,11 +352,10 @@ class StreamingManagerDelegate(
             lastErrorWasNetwork = false
             cancelConnectivityObserver()
         }
-        stateHandle.update {
-            if (retryInfo != null) {
-                copy(conversationId = event.conversationId, retryInfo = null)
-            } else {
-                copy(conversationId = event.conversationId)
+        handle.update {
+            conversation = conversation.copy(conversationId = event.conversationId)
+            if (content.retryInfo != null) {
+                content = content.copy(retryInfo = null)
             }
         }
         completionDelegate.onConversationCreated(event.conversationId, isNewConversation(), streamOriginAccountId)
@@ -368,8 +367,8 @@ class StreamingManagerDelegate(
         // `ready` SSE update may never arrive once the run closes) now falls back
         // to polling GET /api/files/:id/preview. De-duped + bounded in the delegate.
         officePreviewDelegate.onStreamEnded()
-        val isComparison = stateHandle.state.comparisonState.isEnabled
-        val conversationId = stateHandle.state.conversationId
+        val isComparison = handle.state.comparisonState.isEnabled
+        val conversationId = handle.state.conversationId
             ?: event.conversation?.conversationId
         val completedResponseText = if (isComparison) {
             comparisonDelegate.primaryContent()
@@ -379,13 +378,13 @@ class StreamingManagerDelegate(
         val shouldAutoRead = !isEditOrRegenerate
         // Make sure the resolved conversation id is in state for the completion handlers.
         if (conversationId != null) {
-            stateHandle.update { copy(conversationId = conversationId) }
+            handle.update { conversation = conversation.copy(conversationId = conversationId) }
         }
         if (isComparison) {
             // Comparison reconciles via background reload (no in-memory finalize to fold the
             // streaming-clear into), so clear the single-stream UI fields now.
-            stateHandle.update {
-                copy(
+            handle.update {
+                content = content.copy(
                     isStreaming = false,
                     streamingContent = "",
                     activeToolCalls = emptyList(),
@@ -410,9 +409,9 @@ class StreamingManagerDelegate(
         // conversation id (and thus nothing to finalize) never reaches finalizeChatDisplay,
         // so its streaming fields would otherwise stay set. No-op once the in-memory
         // finalize (normal/temp) or the comparison branch above has already cleared them.
-        if (stateHandle.state.isStreaming) {
-            stateHandle.update {
-                copy(
+        if (handle.state.isStreaming) {
+            handle.update {
+                content = content.copy(
                     isStreaming = false,
                     streamingContent = "",
                     activeToolCalls = emptyList(),
@@ -448,7 +447,7 @@ class StreamingManagerDelegate(
     private fun flushStreamingBuffer() {
         if (!streamingBufferDirty) return
         streamingBufferDirty = false
-        stateHandle.update { copy(streamingContent = streamingBuffer.toString()) }
+        handle.update { content = content.copy(streamingContent = streamingBuffer.toString()) }
     }
 
     /**
@@ -462,7 +461,7 @@ class StreamingManagerDelegate(
     }
 
     fun stopGeneration() {
-        val conversationId = stateHandle.state.conversationId ?: return
+        val conversationId = handle.state.conversationId ?: return
         // A manual stop usually means "wait" — hold the queue instead of firing the next item.
         queueDelegate.pause()
         streamJob?.cancel()
@@ -474,8 +473,8 @@ class StreamingManagerDelegate(
             if (abortResult is Result.Error) {
                 Logger.w(abortResult.exception) { "Failed to abort chat: ${abortResult.message}" }
             }
-            stateHandle.update {
-                copy(
+            handle.update {
+                content = content.copy(
                     isStreaming = false,
                     streamingContent = "",
                     activeToolCalls = emptyList(),
@@ -490,7 +489,7 @@ class StreamingManagerDelegate(
     }
 
     fun onPause() {
-        wasStreaming = stateHandle.state.isStreaming
+        wasStreaming = handle.state.isStreaming
         if (wasStreaming) {
             streamJob?.cancel()
             stopStreamingUpdater()
@@ -501,26 +500,26 @@ class StreamingManagerDelegate(
         if (!wasStreaming) return
         wasStreaming = false
 
-        val conversationId = stateHandle.state.conversationId ?: return
+        val conversationId = handle.state.conversationId ?: return
 
         scope.launch {
             try {
                 val status = chatRepository.checkStreamStatus(conversationId)
                 if (status.active) {
-                    stateHandle.update { copy(isStreaming = true) }
+                    handle.update { content = content.copy(isStreaming = true) }
                     resumeStream(conversationId)
                 } else {
-                    stateHandle.update { copy(isStreaming = false, streamingContent = "") }
+                    handle.update { content = content.copy(isStreaming = false, streamingContent = "") }
                     reloadConversation(conversationId)
                 }
             } catch (e: Exception) {
                 Logger.e(e) { "Could not resume stream" }
-                stateHandle.update {
-                    copy(
+                handle.update {
+                    content = content.copy(
                         isStreaming = false,
                         streamingContent = "",
-                        error = "Could not resume stream",
                     )
+                    error = "Could not resume stream"
                 }
             }
         }
@@ -549,8 +548,8 @@ class StreamingManagerDelegate(
             try {
                 val status = chatRepository.checkStreamStatus(conversationId)
                 if (status.active) {
-                    stateHandle.update {
-                        copy(
+                    handle.update {
+                        content = content.copy(
                             isStreaming = true,
                             screenState = ChatScreenState.ACTIVE,
                         )
@@ -594,7 +593,7 @@ class StreamingManagerDelegate(
      */
     private fun attemptNetworkRecovery() {
         if (!lastErrorWasNetwork) return
-        val state = stateHandle.state
+        val state = handle.state
         val conversationId = state.conversationId ?: return
         if (state.isStreaming) return
 
@@ -606,17 +605,20 @@ class StreamingManagerDelegate(
             try {
                 val status = chatRepository.checkStreamStatus(conversationId)
                 if (status.active) {
-                    stateHandle.update {
-                        copy(
+                    handle.update {
+                        content = content.copy(
                             isStreaming = true,
-                            error = null,
                             retryInfo = null,
                         )
+                        error = null
                     }
                     resumeStream(conversationId)
                 } else {
                     // Stream expired while offline — reload conversation from server
-                    stateHandle.update { copy(error = null, retryInfo = null) }
+                    handle.update {
+                        error = null
+                        content = content.copy(retryInfo = null)
+                    }
                     reloadConversation(conversationId)
                 }
             } catch (e: Exception) {

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/SubagentTraceDelegate.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/SubagentTraceDelegate.kt
@@ -6,14 +6,14 @@ import com.garfiec.librechat.core.model.StreamEvent
 import com.garfiec.librechat.core.model.SubagentPhase
 import com.garfiec.librechat.core.model.content.AgentToolCall
 import com.garfiec.librechat.core.model.content.MessageContentPart
-import com.garfiec.librechat.feature.chat.viewmodel.ChatStateHandle
+import com.garfiec.librechat.feature.chat.viewmodel.SubagentHandle
 import com.garfiec.librechat.feature.chat.viewmodel.SubagentTrace
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 
 /**
  * Folds live `on_subagent_update` SSE envelopes (v0.8.6 subagents) into a
- * per-parent-tool-call [SubagentTrace] buffer in [ChatStateHandle], so the chat
+ * per-parent-tool-call [SubagentTrace] buffer in the chat state, so the chat
  * UI can show a child agent's reasoning / tool calls / text as it streams.
  *
  * Correlation mirrors the web client (useStepHandler): prefer the envelope's
@@ -34,7 +34,7 @@ import kotlinx.serialization.json.JsonElement
  * delegate only owns the live path.
  */
 class SubagentTraceDelegate(
-    private val stateHandle: ChatStateHandle,
+    private val handle: SubagentHandle,
     private val json: Json,
 ) {
 
@@ -52,15 +52,15 @@ class SubagentTraceDelegate(
         runToToolCallId.clear()
         claimedToolCallIds.clear()
         pendingByRunId.clear()
-        stateHandle.update { copy(subagentProgress = emptyMap()) }
+        handle.update { subagents = subagents.copy(subagentProgress = emptyMap()) }
     }
 
     /** Marks the trace for a resolved parent tool_call complete (stops accumulation). */
     fun onParentToolCallResolved(toolCallId: String) {
-        val existing = stateHandle.state.subagentProgress[toolCallId] ?: return
+        val existing = handle.state.subagentProgress[toolCallId] ?: return
         if (existing.isComplete) return
-        stateHandle.update {
-            copy(subagentProgress = subagentProgress + (toolCallId to existing.copy(isComplete = true)))
+        handle.update {
+            subagents = subagents.copy(subagentProgress = subagents.subagentProgress + (toolCallId to existing.copy(isComplete = true)))
         }
     }
 
@@ -98,7 +98,7 @@ class SubagentTraceDelegate(
             return explicit
         }
         // Fallback: oldest unclaimed subagent tool_call in the active stream.
-        val candidate = stateHandle.state.activeToolCalls.firstOrNull {
+        val candidate = handle.state.activeToolCalls.firstOrNull {
             it.name.equals(ToolConstants.SUBAGENT, ignoreCase = true) && it.id !in claimedToolCallIds
         } ?: return null
         if (runId != null) runToToolCallId[runId] = candidate.id
@@ -107,7 +107,7 @@ class SubagentTraceDelegate(
     }
 
     private fun applyToTrace(toolCallId: String, event: StreamEvent.SubagentUpdate) {
-        val current = stateHandle.state.subagentProgress[toolCallId] ?: SubagentTrace(
+        val current = handle.state.subagentProgress[toolCallId] ?: SubagentTrace(
             parentToolCallId = toolCallId,
             subagentRunId = event.subagentRunId,
         )
@@ -116,9 +116,9 @@ class SubagentTraceDelegate(
         val isTerminal = SubagentPhase.isTerminal(event.phase)
         val nextParts = event.inner?.let { foldInner(current.parts, it) } ?: current.parts
 
-        stateHandle.update {
-            copy(
-                subagentProgress = subagentProgress + (
+        handle.update {
+            subagents = subagents.copy(
+                subagentProgress = subagents.subagentProgress + (
                     toolCallId to current.copy(
                         subagentRunId = current.subagentRunId ?: event.subagentRunId,
                         subagentType = event.subagentType ?: current.subagentType,

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/state/AccountConfigState.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/state/AccountConfigState.kt
@@ -1,0 +1,19 @@
+package com.garfiec.librechat.feature.chat.viewmodel
+
+import androidx.compose.runtime.Immutable
+import com.garfiec.librechat.core.model.response.FileUploadConfig
+
+/**
+ * Per-account server-derived config: the signed-in user's display fields (for message avatars)
+ * and the server upload config. Written only by [ChatViewModel] on config/user load.
+ */
+@Immutable
+data class AccountConfigState(
+    val userName: String? = null,
+    val userAvatarUrl: String? = null,
+    /**
+     * Server upload config (`GET /api/files/config`).
+     * Null before fetch or on fetch failure; treated as no constraint (controls fail open).
+     */
+    val fileUploadConfig: FileUploadConfig? = null,
+)

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/state/ChatPrefsState.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/state/ChatPrefsState.kt
@@ -1,0 +1,65 @@
+package com.garfiec.librechat.feature.chat.viewmodel
+
+import androidx.compose.runtime.Immutable
+import com.garfiec.librechat.core.common.ChatLayoutConstants
+import com.garfiec.librechat.core.data.datastore.ChatHeaderAlignment
+import com.garfiec.librechat.core.data.datastore.ChatHeaderContent
+import com.garfiec.librechat.core.data.datastore.ContextBarPlacement
+import com.garfiec.librechat.core.data.datastore.ChatFontSize
+import com.garfiec.librechat.core.data.datastore.InlineArtifactPrefs
+import com.garfiec.librechat.core.data.datastore.LatexRenderer
+import com.garfiec.librechat.core.data.datastore.StarredModelsDisplay
+
+/**
+ * DataStore-backed chat preferences merged into [ChatUiState] by the `uiState` combine in
+ * [ChatViewModel] (the sole writer). These are layered over the inner `_uiState` on every
+ * emission, so a navigation reset need not carry them.
+ */
+@Immutable
+data class ChatPrefsState(
+    val serverUrl: String = "",
+    val chatFontSize: ChatFontSize = ChatFontSize.MEDIUM,
+    /**
+     * Mobile-only preference for how pinned models/agents are surfaced in [ModelSelectorSheet]:
+     * off (float within group), grouped (collapsible top section), or top (flat top list).
+     */
+    val starredModelsDisplay: StarredModelsDisplay = StarredModelsDisplay.OFF,
+    /**
+     * Mobile-only preferences for the chat floating top bar: what its bubble shows
+     * ([chatHeaderContent]) and how the bubble is positioned ([chatHeaderAlignment]).
+     */
+    val chatHeaderContent: ChatHeaderContent = ChatHeaderContent.TITLE,
+    val chatHeaderAlignment: ChatHeaderAlignment = ChatHeaderAlignment.LEFT,
+    /** User preference (Settings → Chat) for where the context gauge is surfaced. */
+    val contextBarPlacement: ContextBarPlacement = ContextBarPlacement.OPTIONS_SHEET,
+)
+
+/**
+ * Consolidated chat-related user preferences from [SettingsDataStore].
+ * Exposed as a single [StateFlow] to reduce the number of individual subscriptions
+ * in the UI layer.
+ */
+@Immutable
+data class ChatPreferences(
+    val showImageDescriptions: Boolean = false,
+    val dismissKeyboardOnSend: Boolean = false,
+    val chatLayoutStyle: String = ChatLayoutConstants.THREAD,
+    val showAvatars: Boolean = true,
+    val showBubbles: Boolean = false,
+    val latexRenderer: LatexRenderer = LatexRenderer.KATEX,
+    val autoSendAfterStt: Boolean = false,
+    val sttEngine: String = "",
+    val sttLanguage: String = "",
+    val inlineArtifactPrefs: InlineArtifactPrefs = InlineArtifactPrefs(),
+)
+
+/**
+ * The chat floating top bar's mobile-only display preferences, bundled into a single
+ * flow so [ChatViewModel]'s `uiState` combine stays within Kotlin's 5-arg typed limit.
+ */
+@Immutable
+data class ChatHeaderPrefs(
+    val content: ChatHeaderContent = ChatHeaderContent.TITLE,
+    val alignment: ChatHeaderAlignment = ChatHeaderAlignment.LEFT,
+    val contextBarPlacement: ContextBarPlacement = ContextBarPlacement.OPTIONS_SHEET,
+)

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/state/ChatSearchState.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/state/ChatSearchState.kt
@@ -1,0 +1,39 @@
+package com.garfiec.librechat.feature.chat.viewmodel
+
+import androidx.compose.runtime.Immutable
+
+/**
+ * In-conversation find-in-page state. Owned by
+ * [com.garfiec.librechat.feature.chat.viewmodel.delegate.InConversationSearchDelegate].
+ */
+@Immutable
+data class ChatSearchState(
+    val isSearchOpen: Boolean = false,
+    val searchQuery: String = "",
+    val searchMatchIndices: List<SearchMatch> = emptyList(),
+    val currentSearchMatchIndex: Int = 0,
+    /** The search occurrence to scroll to when the focused match changes. Consumed by MessageList. */
+    val searchFocusRequest: SearchFocusRequest? = null,
+)
+
+/**
+ * Represents a single occurrence of a search query match.
+ * @param messageIndex Index into [ChatUiState.displayMessages] containing this occurrence.
+ * @param occurrenceInMessage 0-based index of this occurrence within the message text.
+ */
+@Immutable
+data class SearchMatch(
+    val messageIndex: Int,
+    val occurrenceInMessage: Int,
+)
+
+/**
+ * A request to scroll the message list to one specific search occurrence. [messageIndex] is the
+ * scroll target; [requestId] is a monotonic id that both makes repeat jumps to the same occurrence
+ * distinct (so the list's LaunchedEffect re-fires) and identifies the position report to act on.
+ */
+@Immutable
+data class SearchFocusRequest(
+    val messageIndex: Int,
+    val requestId: Long,
+)

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/state/ComposerState.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/state/ComposerState.kt
@@ -1,0 +1,66 @@
+package com.garfiec.librechat.feature.chat.viewmodel
+
+import androidx.compose.runtime.Immutable
+import com.garfiec.librechat.core.ui.components.ModelParameters
+import com.garfiec.librechat.feature.chat.components.AttachedFile
+
+/**
+ * The editable composer surface: the draft text, any send-block reason, and the active
+ * queued-edit session. Written by [ChatViewModel], PresetPromptDelegate, and the platform
+ * voice-input delegates.
+ */
+@Immutable
+data class ComposerState(
+    val inputText: String = "",
+    /** Set when a send was blocked for a selection/readiness reason. Resolved to a
+     *  user-facing string in the Compose layer. Null means no send-block to show. */
+    val sendBlockReason: SendBlockReason? = null,
+    /** Non-null while a queued item is being edited in the composer (queued-edit mode). Holds the
+     *  stashed new-message draft + the item's slot so both are restored on commit/cancel. */
+    val editingQueuedItem: QueuedEditSession? = null,
+)
+
+/**
+ * Reasons why a send attempt was blocked. Resolved to a user-facing string in the Compose
+ * layer via `stringResource`, so the ViewModel stays free of hard-coded English UI copy.
+ */
+sealed interface SendBlockReason {
+    data object SelectAgent : SendBlockReason
+    data object SelectModel : SendBlockReason
+    data object AgentsUnavailable : SendBlockReason
+    data object AgentNotAvailable : SendBlockReason
+    data object ModelNotAvailable : SendBlockReason
+    data object ModelLoadFailed : SendBlockReason
+}
+
+/**
+ * Snapshot of the editable composer surface (the "new message" draft) stashed when entering
+ * queued-edit mode and restored on commit/cancel, so editing a queued item never clobbers what
+ * the user was already composing.
+ *
+ * These fields mirror [QueuedMessage]'s source-config fields (model/endpoint/tools/mcp/params) and
+ * are captured/applied by `ChatViewModel.captureComposer`/`applyComposer`/`toComposerSnapshot` — a
+ * new composer setting must be threaded through all of them (no compiler enforcement).
+ */
+@Immutable
+data class ComposerSnapshot(
+    val text: String,
+    val attachments: List<AttachedFile> = emptyList(),
+    val endpoint: String,
+    val model: String?,
+    val enabledTools: Set<String> = emptySet(),
+    val mcpServerNames: Set<String> = emptySet(),
+    val modelParameters: ModelParameters = ModelParameters.DEFAULT,
+)
+
+/**
+ * Active queued-edit session: the composer is loaded with [original]'s content + config for
+ * editing, while [stashed] holds the new-message draft to restore afterward and [originalIndex]
+ * is the FIFO slot to put the (possibly edited) item back into on commit/cancel.
+ */
+@Immutable
+data class QueuedEditSession(
+    val original: QueuedMessage,
+    val originalIndex: Int,
+    val stashed: ComposerSnapshot,
+)

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/state/ConversationActionsState.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/state/ConversationActionsState.kt
@@ -1,0 +1,17 @@
+package com.garfiec.librechat.feature.chat.viewmodel
+
+import androidx.compose.runtime.Immutable
+
+/**
+ * Dialog / in-flight state for conversation-level actions (rename, delete, duplicate, fork).
+ * Owned by [com.garfiec.librechat.feature.chat.viewmodel.delegate.ConversationActionsDelegate].
+ */
+@Immutable
+data class ConversationActionsState(
+    val showRenameDialog: Boolean = false,
+    val showDeleteConfirmation: Boolean = false,
+    val duplicatedConversationId: String? = null,
+    val showForkOptionsForMessageId: String? = null,
+    val isForkInProgress: Boolean = false,
+    val forkedConversationId: String? = null,
+)

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/state/ConversationMetaState.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/state/ConversationMetaState.kt
@@ -1,0 +1,20 @@
+package com.garfiec.librechat.feature.chat.viewmodel
+
+import androidx.compose.runtime.Immutable
+
+/**
+ * Identity and top-level metadata of the current conversation. Written by [ChatViewModel],
+ * StreamingManagerDelegate, SendCompletionDelegate, ConversationActionsDelegate,
+ * ComparisonModeDelegate and MessageTreeDelegate.
+ */
+@Immutable
+data class ConversationMetaState(
+    val conversationId: String? = null,
+    val conversationTitle: String? = null,
+    val isTemporaryChat: Boolean = false,
+    val sharedLinksEnabled: Boolean = false,
+    /** Set at StreamEvent.Created when a new conversation's conversationId becomes available.
+     *  The UI navigates to Chat(id) and then clears this via [ChatViewModel.onPendingNavigationHandled],
+     *  which also resets this ViewModel to a clean landing state. */
+    val pendingNavigationConversationId: String? = null,
+)

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/state/FavoritesState.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/state/FavoritesState.kt
@@ -1,0 +1,21 @@
+package com.garfiec.librechat.feature.chat.viewmodel
+
+import androidx.compose.runtime.Immutable
+
+/**
+ * User-pinned agents/models (v0.8.5 favorites) surfaced in [ModelSelectorSheet]. Owned by
+ * [com.garfiec.librechat.feature.chat.viewmodel.delegate.FavoritesDelegate].
+ */
+@Immutable
+data class FavoritesState(
+    /**
+     * User-pinned agent IDs. Pinned agents sort to the top of the "My Agents" group
+     * in [ModelSelectorSheet] and get a filled star.
+     */
+    val favoriteAgentIds: Set<String> = emptySet(),
+    /**
+     * User-pinned model keys. Each key is `"$endpoint::$model"` — compare with
+     * `FavoritesDelegate.favoriteModelKey(endpoint, model)`.
+     */
+    val favoriteModelKeys: Set<String> = emptySet(),
+)

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/state/FeatureGatesState.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/state/FeatureGatesState.kt
@@ -1,0 +1,56 @@
+package com.garfiec.librechat.feature.chat.viewmodel
+
+import androidx.compose.runtime.Immutable
+
+/**
+ * Feature availability gates loaded from the server's `interface.*` config AND role
+ * permissions (effective value = flag AND permission, matching the web client). Default
+ * permissive (true) until both the RoleRepository and the interface config emit; fails open
+ * when a flag is absent (older backends). Written only by [ChatViewModel]'s config load.
+ */
+@Immutable
+data class FeatureGatesState(
+    val promptsEnabled: Boolean = true,
+    val promptsCreateEnabled: Boolean = true,
+    val agentsEnabled: Boolean = true,
+    val agentsCreateEnabled: Boolean = true,
+    val mcpServersEnabled: Boolean = true,
+    val multiConvoEnabled: Boolean = true,
+    val temporaryChatEnabled: Boolean = true,
+    val webSearchEnabled: Boolean = true,
+    val runCodeEnabled: Boolean = true,
+    val fileSearchEnabled: Boolean = true,
+    val bookmarksEnabled: Boolean = true,
+    /**
+     * Interface-only gates (no corresponding role permission on web). Driven solely by
+     * the server's `interface.*` config: presets on `interface.presets && interface.modelSelect`,
+     * model select on `interface.modelSelect`, parameters on `interface.parameters`.
+     */
+    val presetsEnabled: Boolean = true,
+    val modelSelectEnabled: Boolean = true,
+    val parametersEnabled: Boolean = true,
+    /** `interface.defaultPinnedTools` (v0.8.7): tool keys the server pins to the prompt bar.
+     *  Raw, as sent; mapped/filtered to renderable chips by [ChatUiState.pinnedToolChips]. */
+    val pinnedTools: List<String> = emptyList(),
+    /**
+     * Context-usage gauge gate (v0.8.7). = `interface.contextUsage` AND backend ≥ 0.8.7.
+     * Fails closed on older/unknown servers (the gauge has no data source there).
+     */
+    val contextUsageEnabled: Boolean = false,
+)
+
+/**
+ * Feature gates that flow into the composer ([ChatInput] → [ChatToolsBottomSheet]),
+ * bundled so they thread as one value across Android and iOS. Each defaults to true
+ * (shown) so a default-constructed bundle is fully permissive. Built by
+ * [ChatUiState.chatInputGates]; see [ChatUiState.modelSelectEnabled] /
+ * [ChatUiState.parametersEnabled] / [ChatUiState.showEphemeralTools] /
+ * [ChatUiState.fileUploadEnabled] for the individual gating rules.
+ */
+@Immutable
+data class ChatInputGates(
+    val modelSelectEnabled: Boolean = true,
+    val parametersEnabled: Boolean = true,
+    val showEphemeralTools: Boolean = true,
+    val fileUploadEnabled: Boolean = true,
+)

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/state/MessageEditingState.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/state/MessageEditingState.kt
@@ -1,0 +1,13 @@
+package com.garfiec.librechat.feature.chat.viewmodel
+
+import androidx.compose.runtime.Immutable
+
+/**
+ * Inline edit-field UI state for editing a message's text in place. Owned by
+ * [com.garfiec.librechat.feature.chat.viewmodel.delegate.MessageEditingDelegate].
+ */
+@Immutable
+data class MessageEditingState(
+    val editingMessageId: String? = null,
+    val editingText: String = "",
+)

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/state/MessagesState.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/state/MessagesState.kt
@@ -1,0 +1,63 @@
+package com.garfiec.librechat.feature.chat.viewmodel
+
+import androidx.compose.runtime.Immutable
+import com.garfiec.librechat.core.model.Attachment
+import com.garfiec.librechat.core.model.Message
+import com.garfiec.librechat.core.model.usage.ContextUsage
+import com.garfiec.librechat.core.model.usage.TokenUsage
+import com.garfiec.librechat.feature.chat.util.MessageNode
+
+enum class ChatScreenState { LANDING, LOADING, ACTIVE }
+
+/**
+ * The message tree + live streaming surface: persisted messages, the active display path,
+ * branch selection, and everything the SSE stream mutates (streaming text, tool calls,
+ * attachments, retry/refresh flags, context/token usage). All five audited atomic transactions
+ * (completion flash, begin-stream, reset, applyComposer, branch switch) live within this one
+ * slice so they stay single StateFlow emissions. Written by [ChatViewModel],
+ * StreamingManagerDelegate, MessageTreeDelegate, MessageEditingDelegate, ComparisonModeDelegate
+ * and OfficePreviewDelegate.
+ */
+@Immutable
+data class MessagesState(
+    val screenState: ChatScreenState = ChatScreenState.LANDING,
+    val messages: List<Message> = emptyList(),
+    val displayMessages: List<MessageNode> = emptyList(),
+    /**
+     * A just-sent optimistic user message handed off from the NewChat landing VM, kept on screen
+     * until the server persists its own copy. `loadConversation` reconciles it away by id once the
+     * server's copy arrives. Null in every other case. See [NewChatSelectionHandoff].
+     */
+    val pendingResumeUserMessage: Message? = null,
+    val activeBranches: Map<String, Int> = emptyMap(),
+    val isStreaming: Boolean = false,
+    val streamingContent: String = "",
+    val activeToolCalls: List<ActiveToolCall> = emptyList(),
+    /** Attachments received during SSE streaming (e.g., tool-generated images). Cleared when
+     *  streaming ends. */
+    val streamingAttachments: List<Attachment> = emptyList(),
+    /** SSE reconnection retry state (null when not retrying). */
+    val retryInfo: RetryInfo? = null,
+    val isRefreshingMessages: Boolean = false,
+    /** Latest context-window usage snapshot for the gauge (`on_context_usage` SSE / projection). */
+    val contextUsage: ContextUsage? = null,
+    /** Latest per-call provider token usage (`on_token_usage` SSE). */
+    val tokenUsage: TokenUsage? = null,
+)
+
+@Immutable
+data class RetryInfo(
+    val attempt: Int,
+    val maxAttempts: Int,
+)
+
+@Immutable
+data class ActiveToolCall(
+    val id: String,
+    val name: String,
+    val isComplete: Boolean = false,
+    val output: String? = null,
+    /** Raw tool-call arguments JSON from [StreamEvent.ToolCallStart]. Holds the
+     *  image prompt/quality for image-gen tools so a placeholder can render mid-stream. */
+    val input: String? = null,
+)

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/state/ModelSelectionState.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/state/ModelSelectionState.kt
@@ -1,0 +1,46 @@
+package com.garfiec.librechat.feature.chat.viewmodel
+
+import androidx.compose.runtime.Immutable
+import com.garfiec.librechat.core.common.EndpointConstants
+import com.garfiec.librechat.core.model.Agent
+import com.garfiec.librechat.core.model.EndpointConfig
+import com.garfiec.librechat.core.model.endpoint.KeyState
+import com.garfiec.librechat.core.ui.components.ModelParameters
+import com.garfiec.librechat.feature.chat.model.McpServerDisplayData
+
+/**
+ * Endpoint/model selection, per-request tool + MCP config, model parameters, and the
+ * model-selector sheet's open state. Written by [ChatViewModel], ModelSelectionDelegate,
+ * PresetPromptDelegate and EndpointKeyStatusDelegate.
+ */
+@Immutable
+data class ModelSelectionState(
+    val selectedModel: String? = null,
+    val selectedEndpoint: String = EndpointConstants.AGENTS,
+    val endpointConfigs: Map<String, EndpointConfig> = emptyMap(),
+    /**
+     * Per-endpoint user-provided-key state for endpoints with `userProvide=true`
+     * (or `userProvideURL=true`). Drives the model selector's greyed-out group +
+     * "Set API Key" CTA. Endpoints absent from this map are implicitly "doesn't
+     * need a key" (built-ins) — [ModelSelectorSheet] fail-opens on `null` and
+     * on [KeyState.Loading] so the cold-start window doesn't flash to greyed.
+     */
+    val endpointKeyStates: Map<String, KeyState> = emptyMap(),
+    val availableModels: Map<String, List<String>> = emptyMap(),
+    val agents: List<Agent> = emptyList(),
+    val modelParameters: ModelParameters = ModelParameters.DEFAULT,
+    val showModelParameters: Boolean = false,
+    /** Single source of truth for whether the model-selector sheet is open. Preflight
+     *  failures and readiness timeouts flip this to true so the user sees the sheet with
+     *  a send-block banner. */
+    val showModelSheet: Boolean = false,
+    val enabledTools: Set<String> = emptySet(),
+    val mcpServers: List<McpServerDisplayData> = emptyList(),
+    val selectedMcpServerNames: Set<String> = emptySet(),
+    /**
+     * Whether the detected backend is v0.8.5+ and therefore accepts the `xhigh`
+     * and `max` values in the reasoning-effort and effort dropdowns. False on
+     * older or unknown servers (per VERSION_GATES.md guideline #2).
+     */
+    val extendedEffortSupported: Boolean = false,
+)

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/state/PresetPromptState.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/state/PresetPromptState.kt
@@ -1,0 +1,15 @@
+package com.garfiec.librechat.feature.chat.viewmodel
+
+import androidx.compose.runtime.Immutable
+import com.garfiec.librechat.feature.chat.model.PresetDisplayData
+import com.garfiec.librechat.feature.chat.model.PromptMentionDisplayData
+
+/**
+ * Saved presets and available prompt-mention groups. Written only by
+ * [com.garfiec.librechat.feature.chat.viewmodel.delegate.PresetPromptDelegate].
+ */
+@Immutable
+data class PresetPromptState(
+    val presets: List<PresetDisplayData> = emptyList(),
+    val availablePrompts: List<PromptMentionDisplayData> = emptyList(),
+)

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/state/QueueState.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/state/QueueState.kt
@@ -1,0 +1,80 @@
+package com.garfiec.librechat.feature.chat.viewmodel
+
+import androidx.compose.runtime.Immutable
+import com.garfiec.librechat.core.data.endpoint.EndpointDispatch
+import com.garfiec.librechat.core.model.request.EphemeralAgent
+import com.garfiec.librechat.core.ui.components.ModelParameters
+import com.garfiec.librechat.feature.chat.components.AttachedFile
+import kotlinx.serialization.json.JsonObject
+
+/**
+ * The in-memory FIFO follow-up queue staged while a reply streams. Owned by
+ * [com.garfiec.librechat.feature.chat.viewmodel.delegate.MessageQueueDelegate];
+ * never persisted (lives and dies with the ViewModel).
+ */
+@Immutable
+data class QueueState(
+    /** Follow-up messages queued while a reply streams, drained FIFO on each successful
+     *  completion. Rendered as ghost bubbles after the streaming bubble; never part of the
+     *  message tree. In-memory only (dropped on conversation switch / process death). */
+    val messageQueue: List<QueuedMessage> = emptyList(),
+    /** True after Stop/stream-error with a non-empty queue: draining is held until the user
+     *  explicitly taps "Send queued". A successful Final drains automatically instead. */
+    val isQueuePaused: Boolean = false,
+)
+
+/**
+ * A follow-up message the user queued while a response was streaming, waiting to be
+ * auto-sent (FIFO) once the current reply completes. Rendered as a dimmed "ghost" bubble
+ * after the streaming bubble — it is NOT part of the message tree.
+ *
+ * Captures a full snapshot of the send config **at queue time** (model/endpoint/tools/
+ * webSearch/attachments + the resolved [dispatch]/[ephemeralAgent]), so a mid-stream model
+ * switch never retro-edits an already-queued item. The live-lineage fields
+ * (conversationId / parentMessageId / userMessageId) are deliberately NOT snapshotted — they
+ * are recomputed from the current tree when the item actually fires.
+ *
+ * [attachments] holds the already-uploaded [AttachedFile]s (not bare FileReferences) so editing
+ * a queued item restores its composer chips — including the local-uri image thumbnail — intact.
+ */
+@Immutable
+data class QueuedMessage(
+    /** Stable local id for list keying, edit, and reorder. Not a server message id. */
+    val localId: String,
+    val text: String,
+    val attachments: List<AttachedFile> = emptyList(),
+    val endpoint: String,
+    val model: String?,
+    val agentId: String?,
+    val enabledTools: Set<String> = emptySet(),
+    /** Selected ephemeral MCP servers — snapshotted so editing the item restores its tool state. */
+    val mcpServerNames: Set<String> = emptySet(),
+    /** Full composer parameters (web search, reasoning effort, etc.) — restored to the composer on edit. */
+    val modelParameters: ModelParameters = ModelParameters.DEFAULT,
+    /**
+     * Non-default model params (provider-keyed) serialized for the wire, snapshotted at enqueue time
+     * so a queued send carries the params it was composed with. Null when nothing was customized.
+     */
+    val modelParamsPayload: JsonObject? = null,
+    val ephemeralAgent: EphemeralAgent? = null,
+    val dispatch: EndpointDispatch,
+    val isTemporary: Boolean = false,
+    /**
+     * The active account when this item was queued. A drain guard drops any item whose account no
+     * longer matches the active one (the user switched accounts since queueing), so a follow-up
+     * composed under account A can never be POSTed to account B's server under B's bearer. Null for
+     * items composed before multi-account (or in tests) — treated as "matches any", never dropped.
+     */
+    val accountId: String? = null,
+)
+
+/** Loads a queued item's content + config onto the composer surface when entering edit mode. */
+fun QueuedMessage.toComposerSnapshot(): ComposerSnapshot = ComposerSnapshot(
+    text = text,
+    attachments = attachments,
+    endpoint = endpoint,
+    model = model,
+    enabledTools = enabledTools,
+    mcpServerNames = mcpServerNames,
+    modelParameters = modelParameters,
+)

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/state/SubagentState.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/state/SubagentState.kt
@@ -1,0 +1,42 @@
+package com.garfiec.librechat.feature.chat.viewmodel
+
+import androidx.compose.runtime.Immutable
+import com.garfiec.librechat.core.model.SubagentPhase
+import com.garfiec.librechat.core.model.content.MessageContentPart
+
+/**
+ * Live subagent traces (v0.8.6) keyed by the parent `subagent` tool_call id. Owned by
+ * [com.garfiec.librechat.feature.chat.viewmodel.delegate.SubagentTraceDelegate].
+ */
+@Immutable
+data class SubagentState(
+    /** Folded from `on_subagent_update` SSE events while streaming; reset on each new run and
+     *  conversation switch alongside `activeToolCalls`. On reload the persisted
+     *  `AgentToolCall.subagentContent` is authoritative instead. */
+    val subagentProgress: Map<String, SubagentTrace> = emptyMap(),
+)
+
+/**
+ * Live progress of a single child agent's run (v0.8.6 subagents), accumulated
+ * from `on_subagent_update` SSE envelopes and keyed in
+ * [ChatUiState.subagentProgress] by the parent `subagent` tool_call id.
+ *
+ * [parts] are the child's flat content (reasoning / tool calls / text) folded in
+ * arrival order — the same shapes a normal message renders, so the trace card
+ * reuses the existing content-part renderers (depth 1; a subagent never nests
+ * another subagent card). On reload this live trace is superseded by the
+ * authoritative persisted `AgentToolCall.subagentContent`.
+ */
+@Immutable
+data class SubagentTrace(
+    val parentToolCallId: String,
+    val subagentRunId: String? = null,
+    val subagentType: String? = null,
+    /** Latest phase label for the live ticker (e.g. the agent's display name). */
+    val label: String? = null,
+    /** Latest lifecycle/content phase reported by the server. */
+    val phase: String = SubagentPhase.START,
+    val parts: List<MessageContentPart> = emptyList(),
+    /** True once the server reports a terminal phase (`stop`/`error`). */
+    val isComplete: Boolean = false,
+)

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/state/VoiceState.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/state/VoiceState.kt
@@ -1,0 +1,16 @@
+package com.garfiec.librechat.feature.chat.viewmodel
+
+import androidx.compose.runtime.Immutable
+
+/**
+ * Speech-to-text and text-to-speech UI state. Written by the platform voice-input delegates
+ * (VoiceInputDelegate / IosVoiceInput) and TTS delegates (TextToSpeechDelegate / IosTts).
+ */
+@Immutable
+data class VoiceState(
+    val isRecording: Boolean = false,
+    val isTranscribing: Boolean = false,
+    /** Whether the server has STT configured. When false, use device speech recognition. */
+    val serverSttEnabled: Boolean = false,
+    val currentlyReadingMessageId: String? = null,
+)

--- a/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/IosDelegateFactory.kt
+++ b/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/IosDelegateFactory.kt
@@ -3,7 +3,9 @@ package com.garfiec.librechat.feature.chat.viewmodel.delegate
 import com.garfiec.librechat.core.data.datastore.SettingsDataStore
 import com.garfiec.librechat.core.data.repository.FileRepository
 import com.garfiec.librechat.core.data.repository.SpeechRepository
-import com.garfiec.librechat.feature.chat.viewmodel.ChatStateHandle
+import com.garfiec.librechat.feature.chat.viewmodel.ErrorOnlyHandle
+import com.garfiec.librechat.feature.chat.viewmodel.TtsHandle
+import com.garfiec.librechat.feature.chat.viewmodel.VoiceHandle
 import kotlinx.coroutines.CoroutineDispatcher
 
 class IosDelegateFactory(
@@ -13,23 +15,23 @@ class IosDelegateFactory(
     private val ioDispatcher: CoroutineDispatcher,
 ) : PlatformDelegateFactory {
 
-    override fun createFileHandler(stateHandle: ChatStateHandle): PlatformFileHandler {
-        return IosFileHandler(stateHandle, fileRepository, ioDispatcher)
+    override fun createFileHandler(handle: ErrorOnlyHandle): PlatformFileHandler {
+        return IosFileHandler(handle, fileRepository, ioDispatcher)
     }
 
     override fun createVoiceInput(
-        stateHandle: ChatStateHandle,
+        handle: VoiceHandle,
         onTranscriptionComplete: () -> Unit,
     ): PlatformVoiceInput {
-        return IosVoiceInput(stateHandle, onTranscriptionComplete)
+        return IosVoiceInput(handle, onTranscriptionComplete)
     }
 
     override fun createTts(
-        stateHandle: ChatStateHandle,
+        handle: TtsHandle,
         getMessageText: (String) -> String,
     ): PlatformTts {
         return IosTts(
-            stateHandle = stateHandle,
+            handle = handle,
             speechRepository = speechRepository,
             settingsDataStore = settingsDataStore,
             getMessageText = getMessageText,

--- a/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/IosFileHandler.kt
+++ b/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/IosFileHandler.kt
@@ -7,7 +7,7 @@ import com.garfiec.librechat.core.data.repository.FileRepository
 import com.garfiec.librechat.feature.chat.components.AttachedFile
 import com.garfiec.librechat.feature.chat.util.IosFileData
 import com.garfiec.librechat.feature.chat.util.IosImageData
-import com.garfiec.librechat.feature.chat.viewmodel.ChatStateHandle
+import com.garfiec.librechat.feature.chat.viewmodel.ErrorOnlyHandle
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Job
@@ -25,7 +25,7 @@ import kotlin.uuid.Uuid
  * Handles file uploads from clipboard paste and (future) photo picker.
  */
 class IosFileHandler(
-    private val stateHandle: ChatStateHandle,
+    private val handle: ErrorOnlyHandle,
     private val fileRepository: FileRepository,
     private val ioDispatcher: CoroutineDispatcher,
 ) : PlatformFileHandler {
@@ -55,9 +55,9 @@ class IosFileHandler(
         )
         _attachedFiles.update { it + pendingFile }
 
-        stateHandle.scope.launch(ioDispatcher) {
+        handle.scope.launch(ioDispatcher) {
             try {
-                val state = stateHandle.state
+                val state = handle.state
                 val isAgent = state.selectedEndpoint == EndpointConstants.AGENTS
                 val fileId = Uuid.random().toString()
 
@@ -107,9 +107,7 @@ class IosFileHandler(
                                 if (f.uri == uniqueId) f.copy(uploadFailed = true, uploadProgress = null) else f
                             }
                         }
-                        stateHandle.update {
-                            copy(error = "Failed to upload ${imageData.filename}: ${result.message ?: "Unknown error"}")
-                        }
+                        handle.setError("Failed to upload ${imageData.filename}: ${result.message ?: "Unknown error"}")
                     }
                     is Result.Loading -> { /* unexpected */ }
                 }
@@ -122,7 +120,7 @@ class IosFileHandler(
                         if (f.uri == uniqueId) f.copy(uploadFailed = true, uploadProgress = null) else f
                     }
                 }
-                stateHandle.update { copy(error = "Failed to upload ${imageData.filename}: ${e.message}") }
+                handle.setError("Failed to upload ${imageData.filename}: ${e.message}")
             }
         }
     }
@@ -140,9 +138,9 @@ class IosFileHandler(
         )
         _attachedFiles.update { it + pendingFile }
 
-        stateHandle.scope.launch(ioDispatcher) {
+        handle.scope.launch(ioDispatcher) {
             try {
-                val state = stateHandle.state
+                val state = handle.state
                 val isAgent = state.selectedEndpoint == EndpointConstants.AGENTS
                 val fileId = Uuid.random().toString()
 
@@ -188,9 +186,7 @@ class IosFileHandler(
                                 if (f.uri == uniqueId) f.copy(uploadFailed = true, uploadProgress = null) else f
                             }
                         }
-                        stateHandle.update {
-                            copy(error = "Failed to upload ${fileData.filename}: ${result.message ?: "Unknown error"}")
-                        }
+                        handle.setError("Failed to upload ${fileData.filename}: ${result.message ?: "Unknown error"}")
                     }
                     is Result.Loading -> { /* unexpected */ }
                 }
@@ -203,7 +199,7 @@ class IosFileHandler(
                         if (f.uri == uniqueId) f.copy(uploadFailed = true, uploadProgress = null) else f
                     }
                 }
-                stateHandle.update { copy(error = "Failed to upload ${fileData.filename}: ${e.message}") }
+                handle.setError("Failed to upload ${fileData.filename}: ${e.message}")
             }
         }
     }

--- a/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/IosTts.kt
+++ b/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/IosTts.kt
@@ -3,7 +3,7 @@ package com.garfiec.librechat.feature.chat.viewmodel.delegate
 import com.garfiec.librechat.core.common.result.Result
 import com.garfiec.librechat.core.data.datastore.SettingsDataStore
 import com.garfiec.librechat.core.data.repository.SpeechRepository
-import com.garfiec.librechat.feature.chat.viewmodel.ChatStateHandle
+import com.garfiec.librechat.feature.chat.viewmodel.TtsHandle
 import kotlinx.cinterop.ObjCSignatureOverride
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -21,7 +21,7 @@ private const val MIN_SPEECH_RATE = 0.0f
 private const val MAX_SPEECH_RATE = 1.0f
 
 class IosTts(
-    private val stateHandle: ChatStateHandle,
+    private val handle: TtsHandle,
     private val speechRepository: SpeechRepository,
     private val settingsDataStore: SettingsDataStore,
     private val getMessageText: (String) -> String,
@@ -35,7 +35,7 @@ class IosTts(
             synthesizer: AVSpeechSynthesizer,
             didFinishSpeechUtterance: AVSpeechUtterance,
         ) {
-            stateHandle.update { copy(currentlyReadingMessageId = null) }
+            handle.update { voice = voice.copy(currentlyReadingMessageId = null) }
         }
 
         @ObjCSignatureOverride
@@ -43,7 +43,7 @@ class IosTts(
             synthesizer: AVSpeechSynthesizer,
             didCancelSpeechUtterance: AVSpeechUtterance,
         ) {
-            stateHandle.update { copy(currentlyReadingMessageId = null) }
+            handle.update { voice = voice.copy(currentlyReadingMessageId = null) }
         }
     }
 
@@ -52,7 +52,7 @@ class IosTts(
     }
 
     override fun readAloud(messageId: String) {
-        if (stateHandle.state.currentlyReadingMessageId == messageId) {
+        if (handle.state.currentlyReadingMessageId == messageId) {
             stopReading()
             return
         }
@@ -62,9 +62,9 @@ class IosTts(
         val text = getMessageText(messageId)
         if (text.isBlank()) return
 
-        stateHandle.update { copy(currentlyReadingMessageId = messageId) }
+        handle.update { voice = voice.copy(currentlyReadingMessageId = messageId) }
 
-        stateHandle.scope.launch {
+        handle.scope.launch {
             val source = settingsDataStore.ttsSource.first()
             if (source == "server") {
                 readAloudViaServer(text)
@@ -97,11 +97,9 @@ class IosTts(
                 readAloudViaDevice(text, rate, pitch)
             }
             is Result.Error -> {
-                stateHandle.update {
-                    copy(
-                        currentlyReadingMessageId = null,
-                        error = result.message ?: "Server TTS request failed",
-                    )
+                handle.update {
+                    voice = voice.copy(currentlyReadingMessageId = null)
+                    error = result.message ?: "Server TTS request failed"
                 }
             }
             is Result.Loading -> { /* no-op */ }
@@ -112,18 +110,18 @@ class IosTts(
         if (synthesizer.isSpeaking()) {
             synthesizer.stopSpeakingAtBoundary(AVSpeechBoundary.AVSpeechBoundaryImmediate)
         }
-        stateHandle.update { copy(currentlyReadingMessageId = null) }
+        handle.update { voice = voice.copy(currentlyReadingMessageId = null) }
     }
 
     override fun maybeAutoReadResponse(responseText: String) {
-        if (stateHandle.state.inputText.isNotBlank()) return
+        if (handle.state.inputText.isNotBlank()) return
 
-        stateHandle.scope.launch {
+        handle.scope.launch {
             val autoRead = settingsDataStore.autoReadEnabled.first()
             if (!autoRead) return@launch
 
             val syntheticId = "auto_read_${NSDate().timeIntervalSince1970().toLong()}"
-            stateHandle.update { copy(currentlyReadingMessageId = syntheticId) }
+            handle.update { voice = voice.copy(currentlyReadingMessageId = syntheticId) }
 
             val source = settingsDataStore.ttsSource.first()
             if (source == "server") {

--- a/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/IosVoiceInput.kt
+++ b/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/IosVoiceInput.kt
@@ -1,7 +1,7 @@
 package com.garfiec.librechat.feature.chat.viewmodel.delegate
 
 import co.touchlab.kermit.Logger
-import com.garfiec.librechat.feature.chat.viewmodel.ChatStateHandle
+import com.garfiec.librechat.feature.chat.viewmodel.VoiceHandle
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.coroutines.launch
 import platform.AVFAudio.AVAudioEngine
@@ -23,7 +23,7 @@ import platform.Speech.SFSpeechRecognizerAuthorizationStatus
  * for real-time on-device speech recognition.
  */
 class IosVoiceInput(
-    private val stateHandle: ChatStateHandle,
+    private val handle: VoiceHandle,
     private val onTranscriptionComplete: () -> Unit,
 ) : PlatformVoiceInput {
 
@@ -36,8 +36,8 @@ class IosVoiceInput(
 
     @OptIn(ExperimentalForeignApi::class)
     override fun startRecording() {
-        log.d { "startRecording() called, isRecording=${stateHandle.state.isRecording}" }
-        if (stateHandle.state.isRecording) return
+        log.d { "startRecording() called, isRecording=${handle.state.isRecording}" }
+        if (handle.state.isRecording) return
 
         // Check authorization
         val authStatus = SFSpeechRecognizer.authorizationStatus()
@@ -48,10 +48,10 @@ class IosVoiceInput(
                 SFSpeechRecognizer.requestAuthorization { status ->
                     log.d { "Authorization callback: status=$status" }
                     if (status == SFSpeechRecognizerAuthorizationStatus.SFSpeechRecognizerAuthorizationStatusAuthorized) {
-                        stateHandle.scope.launch { beginRecording() }
+                        handle.scope.launch { beginRecording() }
                     } else {
                         log.w { "Speech recognition permission denied" }
-                        stateHandle.update { copy(error = "Speech recognition permission denied") }
+                        handle.setError("Speech recognition permission denied")
                     }
                 }
                 return
@@ -62,7 +62,7 @@ class IosVoiceInput(
             }
             else -> {
                 log.w { "Speech recognition not available, authStatus=$authStatus" }
-                stateHandle.update { copy(error = "Speech recognition not available. Check Settings > Privacy > Speech Recognition.") }
+                handle.setError("Speech recognition not available. Check Settings > Privacy > Speech Recognition.")
                 return
             }
         }
@@ -79,7 +79,7 @@ class IosVoiceInput(
             if (!available) {
                 val msg = "Speech recognition not available on this device (locale: ${locale.languageCode}). This feature requires a real device."
                 log.w { msg }
-                stateHandle.update { copy(error = msg) }
+                handle.setError(msg)
                 return
             }
             speechRecognizer = recognizer
@@ -108,19 +108,23 @@ class IosVoiceInput(
                 if (result != null) {
                     val text = result.bestTranscription.formattedString
                     log.d { "Recognition result: '$text', isFinal=${result.isFinal()}" }
-                    stateHandle.update { copy(inputText = text) }
+                    handle.update { composer = composer.copy(inputText = text) }
 
                     if (result.isFinal()) {
                         log.d { "Final result received, stopping" }
                         cleanupAudio()
-                        stateHandle.update { copy(isRecording = false) }
+                        handle.update { voice = voice.copy(isRecording = false) }
                     }
                 }
                 if (error != null) {
-                    log.e { "Recognition error: ${error.localizedDescription}, isRecording=${stateHandle.state.isRecording}" }
-                    if (stateHandle.state.isRecording) {
+                    log.e { "Recognition error: ${error.localizedDescription}, isRecording=${handle.state.isRecording}" }
+                    if (handle.state.isRecording) {
                         cleanupAudio()
-                        stateHandle.update { copy(isRecording = false, error = "Speech recognition error: ${error.localizedDescription}") }
+                        val message = "Speech recognition error: ${error.localizedDescription}"
+                        handle.update {
+                            voice = voice.copy(isRecording = false)
+                            this.error = message
+                        }
                     }
                 }
             }
@@ -144,35 +148,38 @@ class IosVoiceInput(
             engine.startAndReturnError(null)
             log.d { "Audio engine started, setting isRecording=true" }
 
-            stateHandle.update { copy(isRecording = true) }
+            handle.update { voice = voice.copy(isRecording = true) }
         } catch (e: Exception) {
             log.e(e) { "Failed to start recording: ${e.message}" }
             cleanupAudio()
-            stateHandle.update { copy(error = "Could not start recording: ${e.message}") }
+            handle.setError("Could not start recording: ${e.message}")
         }
     }
 
     override fun stopRecording() {
-        if (!stateHandle.state.isRecording) return
+        if (!handle.state.isRecording) return
 
         // End the recognition request so we get the final result
         recognitionRequest?.endAudio()
         cleanupAudio()
-        stateHandle.update { copy(isRecording = false) }
+        handle.update { voice = voice.copy(isRecording = false) }
     }
 
     override fun cancelRecording() {
         recognitionTask?.cancel()
         cleanupAudio()
-        stateHandle.update { copy(isRecording = false, inputText = "") }
+        handle.update {
+            voice = voice.copy(isRecording = false)
+            composer = composer.copy(inputText = "")
+        }
     }
 
     override fun onDeviceSpeechResult(transcribedText: String) {
         if (transcribedText.isBlank()) return
-        val currentInput = stateHandle.state.inputText
+        val currentInput = handle.state.inputText
         val separator = if (currentInput.isNotBlank() && !currentInput.endsWith(" ")) " " else ""
-        stateHandle.update {
-            copy(inputText = currentInput + separator + transcribedText)
+        handle.update {
+            composer = composer.copy(inputText = currentInput + separator + transcribedText)
         }
     }
 


### PR DESCRIPTION
## Summary
Decomposes the 86-field `ChatUiState` god-object into 16 `@Immutable` sub-state slices and replaces the single open state handle with per-delegate narrowed write handles, so each delegate can mutate only the slices it owns — enforced at compile time. No behavior change: every UI read site keeps compiling via flat compat accessors.

## Changes
- **Slices** — `ChatUiState` becomes 16 `@Immutable` sub-state slices (`content`, `conversation`, `selection`, `composer`, `editing`, `queue`, `search`, `presetPrompts`, `voice`, `favorites`, `subagents`, `comparisonState`, `gates`, `account`, `actions`, `prefs`) — 15 new files under `viewmodel/state/` plus the pre-existing `comparisonState` — plus two top-level fields (`error` shared banner, `mediaPreview`). Nested types moved into their own files.
- **Narrowed write handles** — `DelegateHandles.kt` gives each delegate a handle whose `update {}` exposes only its owned slices (via a `*Writes` class); a `DelegateHandle` base holds the shared read/`setError` surface. `ChatViewModel` alone holds the root `ChatStateHandle`.
- **Compat accessors** — flat `val field get() = slice.field` on `ChatUiState` keep the ~250 UI read sites and test assertions unchanged.
- **Atomic transactions preserved** — completion-flash finalize, begin-stream, reset-with-carryover, `applyComposer`, and `switchBranch` each stay a single `StateFlow` emission (single slice or single writer block).
- Updated `feature/chat/CLAUDE.md` with the slice/handle architecture.

## Testing
- `:feature:chat:testDebugUnitTest` — pass
- `detekt` — pass
- iOS `:shared:linkDebugFrameworkIosSimulatorArm64` — links clean
- On-device regression walkthrough (Pixel 10 Pro Fold emulator, against a local LibreChat server): streaming completion (no flash — frame-verified), branch switching, edit + regenerate in place, comparison mode, queued follow-up, voice input, TTS, rename/delete/fork dialogs, model/endpoint switching, and landing↔conversation reset carry-over (selection survives, tree/composer clear). No crashes, blank frames, scroll jumps, or state leaks.

## Notes
Pure internal refactor resolving the architecture-audit #1 finding (ChatUiState god-state). UI still reads flat; migrating read sites onto slices is a deliberate later step.
