### PR TITLE
fix(network): scope HTTP retries to safe methods and guard the browser User-Agent

### DIFF
--- a/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/client/HttpRetryScopingTest.kt
+++ b/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/client/HttpRetryScopingTest.kt
@@ -1,0 +1,69 @@
+package com.garfiec.librechat.core.network.client
+
+import com.google.common.truth.Truth.assertThat
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.HttpRequestRetry
+import io.ktor.client.request.delete
+import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import java.io.IOException
+
+/**
+ * Locks the retry-scoping invariant: the shared [configureRetryPolicy] must replay only
+ * side-effect-free methods, so a retried chat POST / upload can never mint a duplicate server-side
+ * job. Exercises the real production policy on a minimal client (the seam both `create()` installs).
+ */
+class HttpRetryScopingTest {
+
+    // maxRetries = 2 → 1 initial attempt + 2 retries = 3 total for a retry-safe method.
+    private companion object {
+        const val SAFE_ATTEMPTS = 3
+        const val UNSAFE_ATTEMPTS = 1
+    }
+
+    private fun countingClient(engine: MockEngine): HttpClient = HttpClient(engine) {
+        install(HttpRequestRetry) { configureRetryPolicy() }
+    }
+
+    @Test
+    fun `retries GET on 5xx but not POST or DELETE`() = runTest {
+        val attempts = mutableMapOf<String, Int>()
+        val engine = MockEngine { request ->
+            attempts.merge(request.method.value, 1, Int::plus)
+            respond("boom", HttpStatusCode.InternalServerError)
+        }
+        val client = countingClient(engine)
+
+        client.get("https://example.com/api/data")
+        client.post("https://example.com/api/agents/chat/x")
+        client.delete("https://example.com/api/files/f1")
+
+        assertThat(attempts["GET"]).isEqualTo(SAFE_ATTEMPTS)
+        assertThat(attempts["POST"]).isEqualTo(UNSAFE_ATTEMPTS)
+        assertThat(attempts["DELETE"]).isEqualTo(UNSAFE_ATTEMPTS)
+    }
+
+    @Test
+    fun `retries GET on exception but not POST or DELETE`() = runTest {
+        val attempts = mutableMapOf<String, Int>()
+        val engine = MockEngine {
+            attempts.merge(it.method.value, 1, Int::plus)
+            throw IOException("connection reset")
+        }
+        val client = countingClient(engine)
+
+        // The call ultimately throws once retries are exhausted (or immediately for unsafe methods).
+        runCatching { client.get("https://example.com/api/data") }
+        runCatching { client.post("https://example.com/api/agents/chat/x") }
+        runCatching { client.delete("https://example.com/api/files/f1") }
+
+        assertThat(attempts["GET"]).isEqualTo(SAFE_ATTEMPTS)
+        assertThat(attempts["POST"]).isEqualTo(UNSAFE_ATTEMPTS)
+        assertThat(attempts["DELETE"]).isEqualTo(UNSAFE_ATTEMPTS)
+    }
+}

--- a/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/client/UserAgentGuardTest.kt
+++ b/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/client/UserAgentGuardTest.kt
@@ -1,0 +1,51 @@
+package com.garfiec.librechat.core.network.client
+
+import com.google.common.truth.Truth.assertThat
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.defaultRequest
+import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+/**
+ * Locks the browser-UA invariant: the stock LibreChat server soft-bans on the first non-browser
+ * User-Agent hitting a `ua-parser-js` route. [applyBrowserDefaults] is the single site both the main
+ * and streaming clients route through, so a regression that drops the header — or mangles the
+ * constant the iOS SSE transport also references — is caught here.
+ */
+class UserAgentGuardTest {
+
+    private class FakeServerUrlProvider(private val baseUrl: String) : ServerUrlProvider {
+        override fun getBaseUrl(): String = baseUrl
+    }
+
+    @Test
+    fun `applyBrowserDefaults sends the browser UA on every method`() = runTest {
+        val captured = mutableMapOf<String, String?>()
+        val engine = MockEngine { request ->
+            captured[request.method.value] = request.headers[HttpHeaders.UserAgent]
+            respond("OK", HttpStatusCode.OK)
+        }
+        val client = HttpClient(engine) {
+            defaultRequest { applyBrowserDefaults(FakeServerUrlProvider("https://chat.example.com")) }
+        }
+
+        client.get("/api/agents")
+        client.post("/api/agents/chat/x")
+
+        assertThat(captured["GET"]).isEqualTo(LibreChatHttpClient.BROWSER_USER_AGENT)
+        assertThat(captured["POST"]).isEqualTo(LibreChatHttpClient.BROWSER_USER_AGENT)
+    }
+
+    @Test
+    fun `the browser UA constant looks like a real browser`() {
+        // ua-parser-js keys off these tokens; a constant edit that drops them re-opens the ban.
+        assertThat(LibreChatHttpClient.BROWSER_USER_AGENT).contains("Mozilla")
+        assertThat(LibreChatHttpClient.BROWSER_USER_AGENT).contains("Chrome")
+    }
+}

--- a/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/LibreChatHttpClient.kt
+++ b/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/LibreChatHttpClient.kt
@@ -6,7 +6,9 @@ import com.garfiec.librechat.core.logging.LogOrigin
 import com.garfiec.librechat.core.logging.redact.LogRedactor
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.HttpClientEngineFactory
+import io.ktor.client.plugins.DefaultRequest.DefaultRequestBuilder
 import io.ktor.client.plugins.HttpRequestRetry
+import io.ktor.client.plugins.HttpRequestRetryConfig
 import io.ktor.client.plugins.HttpResponseValidator
 import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
@@ -16,6 +18,7 @@ import io.ktor.client.plugins.logging.Logging
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
 import io.ktor.http.contentType
 import io.ktor.http.isSuccess
 import io.ktor.http.takeFrom
@@ -59,9 +62,7 @@ object LibreChatHttpClient {
         }
 
         install(HttpRequestRetry) {
-            retryOnServerErrors(maxRetries = 2)
-            retryOnException(maxRetries = 2, retryOnTimeout = true)
-            exponentialDelay()
+            configureRetryPolicy()
         }
 
         install(AuthInterceptorPlugin) {
@@ -128,12 +129,8 @@ object LibreChatHttpClient {
         }
 
         defaultRequest {
-            val baseUrl = serverUrlProvider.getBaseUrl()
-            if (baseUrl.isNotEmpty()) {
-                url.takeFrom(baseUrl)
-            }
+            applyBrowserDefaults(serverUrlProvider)
             contentType(ContentType.Application.Json)
-            headers.append(HttpHeaders.UserAgent, BROWSER_USER_AGENT)
         }
     }
 
@@ -165,4 +162,41 @@ object LibreChatHttpClient {
             else -> "Request failed (HTTP $statusCode)"
         }
     }
+}
+
+/**
+ * Retry policy shared by production and the guard test so they can't drift. Replays only
+ * side-effect-free methods: a retried POST/PATCH would mint a duplicate chat job + orphaned
+ * generation or a duplicate upload, and a retried DELETE that already succeeded server-side would
+ * surface a spurious 404. The allow-list means an unknown or newly added method defaults to *not*
+ * retried.
+ */
+internal fun HttpRequestRetryConfig.configureRetryPolicy() {
+    // A 5xx can arrive as a response (retryIf) or, once HttpResponseValidator throws, as an
+    // ApiException (retryOnExceptionIf) — so both predicates carry the same method gate.
+    retryIf(maxRetries = 2) { request, response ->
+        request.method.isRetrySafe() && response.status.value in 500..599
+    }
+    retryOnExceptionIf(maxRetries = 2) { request, cause ->
+        request.method.isRetrySafe() && cause !is kotlinx.coroutines.CancellationException
+    }
+    exponentialDelay()
+}
+
+private val RETRY_SAFE_METHODS = setOf(HttpMethod.Get, HttpMethod.Head, HttpMethod.Options)
+
+private fun HttpMethod.isRetrySafe(): Boolean = this in RETRY_SAFE_METHODS
+
+/**
+ * Applies the base URL and the browser [User-Agent][LibreChatHttpClient.BROWSER_USER_AGENT] that
+ * the stock LibreChat server's `ua-parser-js` middleware requires — a single audited definition
+ * point shared by the main and streaming clients so the browser-UA invariant lives in one place.
+ * The refresh client deliberately omits this (its `/auth/refresh` route is UA-ungated).
+ */
+internal fun DefaultRequestBuilder.applyBrowserDefaults(serverUrlProvider: ServerUrlProvider) {
+    val baseUrl = serverUrlProvider.getBaseUrl()
+    if (baseUrl.isNotEmpty()) {
+        url.takeFrom(baseUrl)
+    }
+    headers.append(HttpHeaders.UserAgent, LibreChatHttpClient.BROWSER_USER_AGENT)
 }

--- a/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/di/NetworkModule.kt
+++ b/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/di/NetworkModule.kt
@@ -37,6 +37,7 @@ import com.garfiec.librechat.core.network.client.ServerUrlReadyPlugin
 import com.garfiec.librechat.core.network.client.SwitchBarrierPlugin
 import com.garfiec.librechat.core.network.client.SwitchGate
 import com.garfiec.librechat.core.network.client.TokenManager
+import com.garfiec.librechat.core.network.client.applyBrowserDefaults
 import com.garfiec.librechat.core.network.sse.SseClient
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.HttpClientEngineFactory
@@ -44,7 +45,6 @@ import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.defaultRequest
 import io.ktor.http.ContentType
-import io.ktor.http.HttpHeaders
 import io.ktor.http.contentType
 import io.ktor.http.takeFrom
 import io.ktor.serialization.kotlinx.json.json
@@ -110,11 +110,7 @@ val networkModule = module {
                 socketTimeoutMillis = Long.MAX_VALUE
             }
             defaultRequest {
-                val baseUrl = serverUrlProvider.getBaseUrl()
-                if (baseUrl.isNotEmpty()) {
-                    url.takeFrom(baseUrl)
-                }
-                headers.append(HttpHeaders.UserAgent, LibreChatHttpClient.BROWSER_USER_AGENT)
+                applyBrowserDefaults(serverUrlProvider)
             }
         }
     }


### PR DESCRIPTION
## Summary
The main Ktor client retried every HTTP method, so a transient 5xx or timeout on a chat send or file upload replayed a non-idempotent POST — a retried phase-1 chat POST on a *new* conversation minted a duplicate server-side job plus an orphaned generation (real token cost), and uploads replayed too. This restricts retries to side-effect-free methods, and in the same pass collapses the duplicated browser-User-Agent wiring into one tested helper so the stock server's `ua-parser-js` soft-ban can't be re-triggered by a stray refactor.

## Changes
- **Retry scoping** — extract the retry policy into a shared `configureRetryPolicy()` seam and gate both the response (5xx) and exception predicates on an allow-list of `GET`/`HEAD`/`OPTIONS`. Transient-error resilience is preserved for reads; `POST`/`PATCH`/`PUT`/`DELETE` no longer replay. The `exponentialDelay()` backoff (which still honors `Retry-After`) is unchanged.
- **Browser User-Agent** — collapse the duplicated base-URL + User-Agent blocks in the main and streaming clients into one `applyBrowserDefaults()` helper, giving the browser-UA invariant a single definition point. The refresh client deliberately keeps no User-Agent (its `/auth/refresh` route is UA-ungated).

## Testing
- New `HttpRetryScopingTest` — `GET` runs 3× (1 + 2 retries), `POST` and `DELETE` run 1× each, on both the 5xx-response and exception paths.
- New `UserAgentGuardTest` — the browser UA is sent on `GET` and `POST` via the shared helper, plus a constant-shape check.
- `:core:network:testDebugUnitTest`, `detekt`, `:app:assembleDebug`, and `:shared:linkDebugFrameworkIosSimulatorArm64` all pass.

## Notes
- Not yet exercised on-device; the change is commonMain and covered by unit tests, and will be verified on a device before merge.
