### PR TITLE
feat(speech): web-parity STT engines with on-device live transcription

### DIFF
--- a/core/common/src/androidMain/kotlin/com/garfiec/librechat/core/common/speech/SttCapability.android.kt
+++ b/core/common/src/androidMain/kotlin/com/garfiec/librechat/core/common/speech/SttCapability.android.kt
@@ -1,0 +1,9 @@
+package com.garfiec.librechat.core.common.speech
+
+import android.os.Build
+
+/** The in-process [android.speech.SpeechRecognizer] path is only available from API 31+. */
+actual fun sttSupportsLiveRecognition(): Boolean = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
+
+/** Browser uses the live recognizer; External records and uploads to the server. */
+actual fun sttEngineSelectsRecognizer(): Boolean = true

--- a/core/common/src/commonMain/kotlin/com/garfiec/librechat/core/common/speech/SttCapability.kt
+++ b/core/common/src/commonMain/kotlin/com/garfiec/librechat/core/common/speech/SttCapability.kt
@@ -1,0 +1,21 @@
+package com.garfiec.librechat.core.common.speech
+
+/**
+ * Whether this platform runs the in-process live recognizer that honors the on-device and
+ * end-of-speech ("stop when I pause") preferences. Android: only on API 31+ (older OS falls back to
+ * the one-shot full-screen Intent overlay, which reads neither). iOS: always (SFSpeechRecognizer).
+ *
+ * Single source of truth: both feature/settings (toggle visibility) and feature/chat (mic routing)
+ * consume this so the API-level boundary can't drift between the two modules, which can't depend on
+ * each other.
+ */
+expect fun sttSupportsLiveRecognition(): Boolean
+
+/**
+ * Whether the STT *engine* choice (Browser vs External) actually selects the recognizer/transport on
+ * this platform. Android: true (Browser = live recognizer, External = record→upload). iOS: false —
+ * there is no iOS External transport yet, so [com.garfiec.librechat.core.model.speech.SttEngine]
+ * External falls through to the same SFSpeechRecognizer path as Browser, and the on-device/
+ * end-of-speech prefs apply regardless of the selected engine.
+ */
+expect fun sttEngineSelectsRecognizer(): Boolean

--- a/core/common/src/commonMain/kotlin/com/garfiec/librechat/core/common/speech/SttLanguage.kt
+++ b/core/common/src/commonMain/kotlin/com/garfiec/librechat/core/common/speech/SttLanguage.kt
@@ -1,0 +1,35 @@
+package com.garfiec.librechat.core.common.speech
+
+/**
+ * Supported STT dictation languages as a single source of truth shared by the settings language
+ * picker (display names) and the platform recognizers (locale tags). Lives in core/common — a
+ * pure-Kotlin utilities layer both feature modules depend on — rather than duplicated as a hardcoded
+ * picker list in feature/settings and a separate `when` map in feature/chat (which can't depend on
+ * each other), so a language can't be offered in the picker while silently mapping to no locale, or
+ * vice-versa.
+ *
+ * Each entry is a display name (stored verbatim in the `stt_language` pref) → BCP-47 locale tag, or
+ * `null` for the device-default "Auto-detect".
+ */
+private val STT_LANGUAGES: List<Pair<String, String?>> = listOf(
+    "Auto-detect" to null,
+    "English" to "en-US",
+    "Spanish" to "es-ES",
+    "French" to "fr-FR",
+    "German" to "de-DE",
+    "Japanese" to "ja-JP",
+    "Chinese" to "zh-CN",
+)
+
+/** Display names for the STT language picker; first entry is the device-default "Auto-detect". */
+val sttLanguageOptions: List<String> = STT_LANGUAGES.map { it.first }
+
+/**
+ * Maps a stored STT language name to a BCP-47 locale tag. Returns null for "Auto-detect", empty, and
+ * any unmapped name so the recognizer falls back to the device default.
+ *
+ * Android feeds the tag to `RecognizerIntent.EXTRA_LANGUAGE` (on-device controller + legacy Intent
+ * overlay); iOS feeds it to `SFSpeechRecognizer(locale:)`.
+ */
+fun mapSttLanguageToLocale(language: String): String? =
+    STT_LANGUAGES.firstOrNull { it.first.equals(language, ignoreCase = true) }?.second

--- a/core/common/src/iosMain/kotlin/com/garfiec/librechat/core/common/speech/SttCapability.ios.kt
+++ b/core/common/src/iosMain/kotlin/com/garfiec/librechat/core/common/speech/SttCapability.ios.kt
@@ -1,0 +1,11 @@
+package com.garfiec.librechat.core.common.speech
+
+/** iOS always uses the SFSpeechRecognizer live path, which honors both toggles. */
+actual fun sttSupportsLiveRecognition(): Boolean = true
+
+/**
+ * iOS has no External (server-upload) transport yet, so the engine choice doesn't select the
+ * recognizer — External falls through to the same SFSpeechRecognizer path as Browser, and the
+ * on-device / end-of-speech prefs apply regardless of the selected engine.
+ */
+actual fun sttEngineSelectsRecognizer(): Boolean = false

--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/datastore/DataStoreRoundTripTest.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/datastore/DataStoreRoundTripTest.kt
@@ -140,6 +140,8 @@ class DataStoreRoundTripTest {
         assertThat(store.showAvatars.first()).isTrue()
         assertThat(store.showBubbles.first()).isFalse()
         assertThat(store.selectedLanguage.first()).isEqualTo("system")
+        assertThat(store.sttOnDevice.first()).isTrue()
+        assertThat(store.sttEndOfSpeech.first()).isFalse()
     }
 
     @Test
@@ -152,12 +154,16 @@ class DataStoreRoundTripTest {
         store.setAutoReadEnabled(true)
         store.setDismissKeyboardOnSend(false)
         store.setShowImageDescriptions(true)
+        store.setSttOnDevice(false)
+        store.setSttEndOfSpeech(true)
 
         assertThat(store.autoScrollEnabled.first()).isFalse()
         assertThat(store.showThinkingBlocks.first()).isFalse()
         assertThat(store.autoReadEnabled.first()).isTrue()
         assertThat(store.dismissKeyboardOnSend.first()).isFalse()
         assertThat(store.showImageDescriptions.first()).isTrue()
+        assertThat(store.sttOnDevice.first()).isFalse()
+        assertThat(store.sttEndOfSpeech.first()).isTrue()
     }
 
     @Test

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/SettingsDataStore.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/SettingsDataStore.kt
@@ -188,6 +188,27 @@ class SettingsDataStore(
         prefs[KEY_STT_LANGUAGE] ?: ""
     }
 
+    /**
+     * Mobile-only preference: when the Browser STT engine is selected, prefer the platform's
+     * on-device recognizer (Android `createOnDeviceSpeechRecognizer` / iOS
+     * `requiresOnDeviceRecognition`) over the cloud recognizer. Defaults ON. Irrelevant for the
+     * External engine (server transcription is inherently remote). Has no web counterpart.
+     */
+    val sttOnDevice: Flow<Boolean> = dataStore.data.map { prefs ->
+        prefs[KEY_STT_ON_DEVICE] ?: true
+    }
+
+    /**
+     * Mobile-only preference for the Built-in STT engine: when ON, dictation stops as soon as the
+     * recognizer detects you've finished speaking (end-of-speech), enabling a hands-free flow where
+     * [autoSendAfterStt] then sends the message. When OFF (default) dictation runs continuously until
+     * the user taps stop. Irrelevant for the External engine (single-shot record→upload). No web
+     * counterpart.
+     */
+    val sttEndOfSpeech: Flow<Boolean> = dataStore.data.map { prefs ->
+        prefs[KEY_STT_END_OF_SPEECH] ?: false
+    }
+
     val ttsEngine: Flow<String> = dataStore.data.map { prefs ->
         prefs[KEY_TTS_ENGINE] ?: ""
     }
@@ -495,6 +516,18 @@ class SettingsDataStore(
         }
     }
 
+    suspend fun setSttOnDevice(enabled: Boolean) {
+        dataStore.edit { prefs ->
+            prefs[KEY_STT_ON_DEVICE] = enabled
+        }
+    }
+
+    suspend fun setSttEndOfSpeech(enabled: Boolean) {
+        dataStore.edit { prefs ->
+            prefs[KEY_STT_END_OF_SPEECH] = enabled
+        }
+    }
+
     suspend fun setTtsEngine(engine: String) {
         dataStore.edit { prefs ->
             prefs[KEY_TTS_ENGINE] = engine
@@ -639,6 +672,8 @@ class SettingsDataStore(
         private val KEY_AUTO_SEND_AFTER_STT = booleanPreferencesKey("auto_send_after_stt")
         private val KEY_STT_ENGINE = stringPreferencesKey("stt_engine")
         private val KEY_STT_LANGUAGE = stringPreferencesKey("stt_language")
+        private val KEY_STT_ON_DEVICE = booleanPreferencesKey("stt_on_device")
+        private val KEY_STT_END_OF_SPEECH = booleanPreferencesKey("stt_end_of_speech")
         private val KEY_TTS_ENGINE = stringPreferencesKey("tts_engine")
         private val KEY_TTS_VOICE = stringPreferencesKey("tts_voice")
         private val KEY_TTS_CACHING = booleanPreferencesKey("tts_caching")

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/ServerSttGate.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/ServerSttGate.kt
@@ -1,0 +1,34 @@
+package com.garfiec.librechat.core.data.repository
+
+import com.garfiec.librechat.core.common.result.Result
+
+/**
+ * Loads "is server STT enabled" once and latches the first success, so a transient fetch failure
+ * reads as *unknown* (retry on the next user action) rather than a definitive "disabled" that would
+ * hide the External engine for the whole session.
+ *
+ * Extracted so the chat mic path ([VoiceInputDelegate]) and the settings STT dialog
+ * ([SpeechSettingsDelegate]) share one retry/latch policy instead of each re-deriving the
+ * Success/Error/Loading decision — the two speech surfaces would otherwise drift on when External is
+ * offered. Not thread-safe: confine to a single (Main-dispatched) scope like its callers do.
+ */
+class ServerSttGate(private val speechRepository: SpeechRepository) {
+
+    /** True once a fetch has succeeded at least once — until then a `false` value is "unknown". */
+    var loaded: Boolean = false
+        private set
+
+    /**
+     * Fetch the server STT flag. Returns the definitive `true`/`false` on success (and latches
+     * [loaded]); `null` when the fetch couldn't determine it (transient error / still loading) so the
+     * caller keeps treating it as unknown and retries later rather than reporting STT disabled.
+     */
+    suspend fun refresh(): Boolean? = when (val result = speechRepository.isServerSttEnabled()) {
+        is Result.Success -> {
+            loaded = true
+            result.data
+        }
+        is Result.Error -> null
+        is Result.Loading -> null
+    }
+}

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/SpeechRepository.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/SpeechRepository.kt
@@ -10,4 +10,11 @@ interface SpeechRepository {
     suspend fun synthesizeSpeech(text: String, voice: String? = null, model: String? = null): Result<ByteArray>
     suspend fun getVoices(): Result<List<TtsVoice>>
     suspend fun getSpeechConfig(): Result<SpeechConfig>
+
+    /**
+     * Whether the server has external (Whisper) STT configured — the `sttExternal` flag from
+     * [getSpeechConfig]. Centralizes the config→boolean mapping shared by the chat and settings
+     * speech delegates (each keeps its own retry/latch policy around this call).
+     */
+    suspend fun isServerSttEnabled(): Result<Boolean>
 }

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/SpeechRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/SpeechRepositoryImpl.kt
@@ -30,4 +30,11 @@ class SpeechRepositoryImpl(
 
     override suspend fun getSpeechConfig(): Result<SpeechConfig> =
         safeApiCall { speechApi.getSpeechConfig() }
+
+    override suspend fun isServerSttEnabled(): Result<Boolean> =
+        when (val result = getSpeechConfig()) {
+            is Result.Success -> Result.Success(result.data.sttExternal)
+            is Result.Error -> result
+            is Result.Loading -> Result.Loading
+        }
 }

--- a/core/model/src/commonMain/kotlin/com/garfiec/librechat/core/model/speech/SttEngine.kt
+++ b/core/model/src/commonMain/kotlin/com/garfiec/librechat/core/model/speech/SttEngine.kt
@@ -1,0 +1,24 @@
+package com.garfiec.librechat.core.model.speech
+
+/**
+ * Speech-to-text engine choice, aligned with the web app: [BROWSER] (the platform's native
+ * on-device / cloud recognizer) vs [EXTERNAL] (server-side transcription, e.g. Whisper).
+ *
+ * Persisted lower-case in `KEY_STT_ENGINE` to match the web client, where `engineSTT`
+ * defaults to `'browser'` (`client/src/store/settings.ts`). Reads are lenient for
+ * back-compat with the pre-parity mobile values (no migration write): `"external"`/`"whisper"`
+ * map to [EXTERNAL]; everything else (`""`, `"default"`, `"google"`, `"device"`) maps to
+ * [BROWSER], which matches the web default for a blank value.
+ */
+enum class SttEngine(val storedValue: String) {
+    BROWSER("browser"),
+    EXTERNAL("external"),
+    ;
+
+    companion object {
+        fun fromStored(value: String?): SttEngine = when (value?.trim()?.lowercase()) {
+            "external", "whisper" -> EXTERNAL
+            else -> BROWSER
+        }
+    }
+}

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/audio/SpeechRecognizerController.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/audio/SpeechRecognizerController.kt
@@ -1,0 +1,340 @@
+package com.garfiec.librechat.feature.chat.audio
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import android.speech.RecognitionListener
+import android.speech.RecognizerIntent
+import android.speech.SpeechRecognizer
+import co.touchlab.kermit.Logger
+import com.garfiec.librechat.core.common.speech.sttSupportsLiveRecognition
+
+/**
+ * Drives an in-process [SpeechRecognizer] for continuous live dictation with partial results.
+ * Owns the single-shot→continuous restart loop, the on-device vs network recognizer choice with
+ * fallback, and error recovery.
+ *
+ * All methods and callbacks run on the main thread — [SpeechRecognizer] requires a Looper and its
+ * `destroy()` must be called on the thread that created it. The owner ([VoiceInputDelegate]) drives
+ * this from the (main-dispatched) ViewModel scope.
+ *
+ * Continuous behavior: [SpeechRecognizer] is single-shot per `startListening`, so on each final
+ * segment (or a recoverable no-speech error) the recognizer restarts until [stop]/[cancel]. A cap on
+ * consecutive empty restarts prevents indefinite silence from spinning it forever.
+ */
+class SpeechRecognizerController(private val appContext: Context) {
+
+    private val log = Logger.withTag("SpeechRecognizer")
+    private val handler = Handler(Looper.getMainLooper())
+
+    private var recognizer: SpeechRecognizer? = null
+    private var languageTag: String? = null
+    private var usingOnDevice = false
+    private var endOfSpeech = false
+    private var stopped = false
+    private var finished = false
+    private var triedNetworkFallback = false
+    private var consecutiveEmptyRestarts = 0
+    private var recoveryAttempts = 0
+    private var startWatchdog: Runnable? = null
+
+    /** Cumulative partial transcript for the current listening session (replaces prior partial). */
+    var onPartial: (String) -> Unit = {}
+
+    /** A finalized segment at a silence boundary; commit it and keep listening (continuous). */
+    var onSegment: (String) -> Unit = {}
+
+    /** Unrecoverable error; the session is over (recognizer already destroyed). */
+    var onError: (String) -> Unit = {}
+
+    /** The session finished cleanly after a [stop] (last result committed or watchdog fired). */
+    var onFinished: () -> Unit = {}
+
+    fun start(preferOnDevice: Boolean, endOfSpeech: Boolean, languageTag: String?) {
+        this.languageTag = languageTag
+        this.endOfSpeech = endOfSpeech
+        stopped = false
+        finished = false
+        triedNetworkFallback = false
+        consecutiveEmptyRestarts = 0
+        recoveryAttempts = 0
+
+        if (!SpeechRecognizer.isRecognitionAvailable(appContext)) {
+            fail("Speech recognition is not available on this device")
+            return
+        }
+        // Prefer the on-device recognizer when asked and supported (API 31+, via the shared capability
+        // seam). If the on-device model for the chosen language is missing, the recognizer errors with
+        // a language-unavailable code and we transparently fall back to the network recognizer (onError).
+        usingOnDevice = preferOnDevice && sttSupportsLiveRecognition()
+        createAndListen()
+    }
+
+    private fun createAndListen() {
+        recognizer?.destroy()
+        // usingOnDevice is only ever set true behind an API 31+ check in start(), so it already
+        // implies createOnDeviceSpeechRecognizer is available.
+        val recognizer = if (usingOnDevice) {
+            SpeechRecognizer.createOnDeviceSpeechRecognizer(appContext)
+        } else {
+            SpeechRecognizer.createSpeechRecognizer(appContext)
+        }
+        recognizer.setRecognitionListener(listener)
+        this.recognizer = recognizer
+        recognizer.startListening(buildIntent())
+        // Guard against a recognizer that binds but never calls back (wedged on-device service, no
+        // language pack): if nothing arrives, fall back to network once, then surface a failure —
+        // otherwise the mic stays hot with isRecording=true forever.
+        armStartWatchdog()
+    }
+
+    private fun buildIntent(): Intent =
+        Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH).apply {
+            putExtra(RecognizerIntent.EXTRA_LANGUAGE_MODEL, RecognizerIntent.LANGUAGE_MODEL_FREE_FORM)
+            putExtra(RecognizerIntent.EXTRA_PARTIAL_RESULTS, true)
+            putExtra(RecognizerIntent.EXTRA_CALLING_PACKAGE, appContext.packageName)
+            languageTag?.let {
+                putExtra(RecognizerIntent.EXTRA_LANGUAGE, it)
+                putExtra(RecognizerIntent.EXTRA_LANGUAGE_PREFERENCE, it)
+            }
+        }
+
+    /** User asked to stop. Ask for the final result; a watchdog finishes if none arrives. */
+    fun stop() {
+        if (stopped) return
+        stopped = true
+        recognizer?.stopListening()
+        handler.postDelayed({ if (!finished) finish() }, STOP_WATCHDOG_MS)
+    }
+
+    /** Discard the session with no final callback. */
+    fun cancel() {
+        stopped = true
+        finished = true
+        handler.removeCallbacksAndMessages(null)
+        recognizer?.cancel()
+        recognizer?.destroy()
+        recognizer = null
+    }
+
+    /** Release from onCleared(); safe to call on the main thread synchronously. */
+    fun destroy() {
+        handler.removeCallbacksAndMessages(null)
+        recognizer?.destroy()
+        recognizer = null
+    }
+
+    private fun finish() {
+        if (finished) return
+        finished = true
+        handler.removeCallbacksAndMessages(null)
+        recognizer?.destroy()
+        recognizer = null
+        onFinished()
+    }
+
+    private fun fail(message: String) {
+        if (finished) return
+        finished = true
+        handler.removeCallbacksAndMessages(null)
+        recognizer?.destroy()
+        recognizer = null
+        onError(message)
+    }
+
+    private fun extractText(bundle: Bundle?): String =
+        bundle?.getStringArrayList(SpeechRecognizer.RESULTS_RECOGNITION)?.firstOrNull().orEmpty()
+
+    private val listener = object : RecognitionListener {
+        override fun onReadyForSpeech(params: Bundle?) {
+            disarmStartWatchdog()
+            // Deliberately does NOT reset recoveryAttempts. A device whose on-device recognizer
+            // alternates onReadyForSpeech → BUSY/DISCONNECTED on every restart would otherwise
+            // oscillate the counter 0→1→0 forever, never reach MAX_RECOVERY_ATTEMPTS, never fall
+            // back to the network recognizer, and spin restarts with the mic held open. The budget
+            // is instead refreshed on a real partial/final (proof the recognizer actually works).
+        }
+        override fun onBeginningOfSpeech() { disarmStartWatchdog() }
+        override fun onBufferReceived(buffer: ByteArray?) {}
+        override fun onEndOfSpeech() {}
+        override fun onEvent(eventType: Int, params: Bundle?) {}
+        override fun onRmsChanged(rmsdB: Float) { disarmStartWatchdog() }
+
+        override fun onPartialResults(partialResults: Bundle?) {
+            // Ignore partials once the session has stopped/finished: after a user-stop the watchdog
+            // may already have committed the final and (with auto-send) cleared the composer, and a
+            // late queued partial would rebase onto the now-empty field and re-inject stale text.
+            // Mirrors the `if (finished) return` guard in onResults()/onError().
+            if (finished || stopped) return
+            val text = extractText(partialResults)
+            if (text.isNotBlank()) {
+                // Real recognition proves the recognizer is healthy — refresh the churn-recovery
+                // budget so a genuinely long, working session that later drops still gets a full set
+                // of retries (see onReadyForSpeech for why the reset lives here, not there).
+                recoveryAttempts = 0
+                onPartial(text)
+            }
+        }
+
+        override fun onResults(results: Bundle?) {
+            if (finished) return
+            val text = extractText(results)
+            if (text.isNotBlank()) {
+                consecutiveEmptyRestarts = 0
+                recoveryAttempts = 0
+                onSegment(text)
+            }
+            when {
+                stopped -> finish()
+                // End-of-speech mode: the recognizer detected the user finished a phrase — stop here
+                // (hands-free) instead of restarting. finish() → onFinished lets the delegate auto-send
+                // (gated on the separate auto-send-after-STT preference).
+                text.isNotBlank() && endOfSpeech -> finish()
+                text.isNotBlank() -> restartListening()
+                // Empty final: some OEM recognizers deliver an empty onResults at a silence boundary
+                // instead of ERROR_NO_MATCH. Bound it like the ERROR_NO_MATCH path so indefinite
+                // silence can't spin restarts forever with the mic held open (isRecording=true).
+                ++consecutiveEmptyRestarts >= MAX_EMPTY_SEGMENTS ->
+                    fail("Didn't catch that. Tap the mic to try again.")
+                else -> restartListening()
+            }
+        }
+
+        override fun onError(error: Int) {
+            if (finished) return
+            disarmStartWatchdog()
+            log.d { "onError code=$error stopped=$stopped onDevice=$usingOnDevice" }
+            when {
+                // A stop() races the final; treat a post-stop error as "no more results".
+                stopped -> finish()
+
+                // On-device model missing for this language → retry once on the network recognizer.
+                usingOnDevice && !triedNetworkFallback && isLanguageError(error) ->
+                    fallBackToNetwork(::createAndListen)
+
+                // No speech this turn → keep listening (continuous), but cap consecutive silence.
+                error == SpeechRecognizer.ERROR_NO_MATCH ||
+                    error == SpeechRecognizer.ERROR_SPEECH_TIMEOUT -> {
+                    consecutiveEmptyRestarts++
+                    if (consecutiveEmptyRestarts >= MAX_EMPTY_SEGMENTS) {
+                        fail("Didn't catch that. Tap the mic to try again.")
+                    } else {
+                        restartListening()
+                    }
+                }
+
+                // Startup/connection churn: while the on-device recognizer (Soda) warms up its
+                // language pack it emits a rapid mix of ERROR_RECOGNIZER_BUSY /
+                // ERROR_SERVER_DISCONNECTED / ERROR_CLIENT for a few hundred ms. Recreate with a
+                // backoff (never hammer an already-busy service with an immediate recreate),
+                // bounded; then fall back to the network recognizer once, and only surface a
+                // failure if that also can't connect. The budget resets on onReadyForSpeech.
+                isRecoverableChurn(error) -> when {
+                    recoveryAttempts < MAX_RECOVERY_ATTEMPTS -> {
+                        recoveryAttempts++
+                        restartAfterDelay()
+                    }
+                    usingOnDevice && !triedNetworkFallback -> fallBackToNetwork(::restartAfterDelay)
+                    else -> fail(errorMessage(error))
+                }
+
+                else -> fail(errorMessage(error))
+            }
+        }
+    }
+
+    private fun isRecoverableChurn(error: Int): Boolean =
+        error == SpeechRecognizer.ERROR_RECOGNIZER_BUSY ||
+            error == SpeechRecognizer.ERROR_SERVER_DISCONNECTED ||
+            error == SpeechRecognizer.ERROR_CLIENT
+
+    /** Recreate + restart after a backoff, unless the session was stopped/finished meanwhile. */
+    private fun restartAfterDelay() {
+        handler.postDelayed({ if (!stopped && !finished) createAndListen() }, RECOVERY_RETRY_DELAY_MS)
+    }
+
+    /**
+     * Continue the continuous session by REUSING the existing recognizer instance rather than
+     * destroying and recreating it. Repeated destroy/create cycles are what stress the on-device
+     * service into the BUSY/DISCONNECTED churn, so a plain [SpeechRecognizer.startListening] on the
+     * live instance is both lighter and lower-latency. Falls back to a full recreate if the
+     * instance is gone or rejects the restart (its binding died).
+     */
+    private fun restartListening() {
+        val r = recognizer ?: run { createAndListen(); return }
+        handler.postDelayed({
+            if (stopped || finished) return@postDelayed
+            try {
+                r.startListening(buildIntent())
+                // Re-arm the start watchdog on the reuse path too: a reused instance can silently
+                // wedge (bound, no callback, no exception) if the on-device service dies mid-session,
+                // which would otherwise leave the mic hot with isRecording=true and no recovery.
+                armStartWatchdog()
+            } catch (e: Exception) {
+                log.d { "reuse restart failed (${e.message}); recreating" }
+                createAndListen()
+            }
+        }, RESTART_DELAY_MS)
+    }
+
+    /** Arm a timeout that recovers if the freshly-started recognizer never calls back at all. */
+    private fun armStartWatchdog() {
+        disarmStartWatchdog()
+        val watchdog = Runnable {
+            startWatchdog = null
+            if (stopped || finished) return@Runnable
+            log.d { "start watchdog fired; recognizer never called back (onDevice=$usingOnDevice)" }
+            when {
+                usingOnDevice && !triedNetworkFallback -> fallBackToNetwork(::createAndListen)
+                else -> fail("Speech recognition didn't start. Tap the mic to try again.")
+            }
+        }
+        startWatchdog = watchdog
+        handler.postDelayed(watchdog, START_WATCHDOG_MS)
+    }
+
+    /**
+     * Switch from the on-device recognizer to the network recognizer and restart via [restart]. Used
+     * by the language-error, churn, and start-watchdog paths so the fallback flag/counter resets live
+     * in one place. Resets both the empty-restart and churn-recovery budgets since the network
+     * recognizer is a fresh attempt.
+     */
+    private fun fallBackToNetwork(restart: () -> Unit) {
+        triedNetworkFallback = true
+        usingOnDevice = false
+        consecutiveEmptyRestarts = 0
+        recoveryAttempts = 0
+        restart()
+    }
+
+    /** Any recognizer callback proves it's alive — cancel the start watchdog. */
+    private fun disarmStartWatchdog() {
+        startWatchdog?.let { handler.removeCallbacks(it) }
+        startWatchdog = null
+    }
+
+    private fun isLanguageError(error: Int): Boolean =
+        error == SpeechRecognizer.ERROR_LANGUAGE_NOT_SUPPORTED ||
+            error == SpeechRecognizer.ERROR_LANGUAGE_UNAVAILABLE ||
+            // Older on-device implementations report a missing model as a generic server error.
+            (usingOnDevice && error == SpeechRecognizer.ERROR_SERVER)
+
+    private fun errorMessage(error: Int): String = when (error) {
+        SpeechRecognizer.ERROR_INSUFFICIENT_PERMISSIONS -> "Microphone permission is required for voice input"
+        SpeechRecognizer.ERROR_NETWORK, SpeechRecognizer.ERROR_NETWORK_TIMEOUT ->
+            "Speech recognition needs a network connection"
+        SpeechRecognizer.ERROR_AUDIO -> "Couldn't access the microphone"
+        else -> "Speech recognition failed"
+    }
+
+    private companion object {
+        // Generous — on-device model warmup + churn recovery can legitimately take a few seconds; a
+        // false positive here would abort a healthy session. Only a truly wedged recognizer trips it.
+        const val START_WATCHDOG_MS = 8000L
+        const val MAX_RECOVERY_ATTEMPTS = 5
+        const val RECOVERY_RETRY_DELAY_MS = 250L
+        const val RESTART_DELAY_MS = 100L
+    }
+}

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatScreen.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatScreen.kt
@@ -100,7 +100,6 @@ actual fun ChatScreen(
         viewModel = viewModel,
         sttEngine = sttEngine,
         sttLanguage = sttLanguage,
-        serverSttEnabled = uiState.serverSttEnabled,
         snackbarHostState = snackbarHostState,
         coroutineScope = coroutineScope,
     )

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatSpeechToText.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatSpeechToText.kt
@@ -11,31 +11,36 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalContext
 import androidx.core.content.ContextCompat
+import com.garfiec.librechat.core.common.speech.mapSttLanguageToLocale
+import com.garfiec.librechat.core.common.speech.sttSupportsLiveRecognition
+import com.garfiec.librechat.core.model.speech.SttEngine
 import com.garfiec.librechat.feature.chat.viewmodel.ChatViewModel
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
 /**
- * Builds the "start recording" action for the chat composer, routing between the
- * server speech-to-text path (record audio + upload for transcription) and the
- * device speech recognizer based on the user's STT engine preference. This keeps
- * the Android permission + intent plumbing out of [ChatScreen].
+ * Builds the "start recording" action for the chat composer.
  *
- * Returns a lambda to invoke when the user taps the mic; it is rebuilt on each
- * recomposition so it always sees the latest [serverSttEnabled].
+ * Routing here is only about *which mechanism* to use, decided by OS capability:
+ * - API 31+ (or the External engine): defer to [ChatViewModel.startRecording]; the voice-input
+ *   delegate owns the Browser-vs-External and on-device-vs-network choice (it already collects the
+ *   `sttEngine`/`sttOnDevice` preferences).
+ * - API 26–30 with the Browser engine: `createOnDeviceSpeechRecognizer` isn't available, so fall
+ *   back to today's full-screen Intent-overlay recognizer.
+ *
+ * Rebuilt on each recomposition so it always sees the latest [sttEngine]/[sttLanguage].
  */
 @Composable
 internal fun rememberChatStartRecording(
     viewModel: ChatViewModel,
     sttEngine: String,
     sttLanguage: String,
-    serverSttEnabled: Boolean,
     snackbarHostState: SnackbarHostState,
     coroutineScope: CoroutineScope,
 ): () -> Unit {
     val context = LocalContext.current
 
-    // Device speech recognizer launcher (used when server STT is not available)
+    // Legacy full-screen Intent-overlay recognizer (API 26–30 Browser fallback).
     val speechRecognizerLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.StartActivityForResult(),
     ) { result ->
@@ -48,7 +53,7 @@ internal fun rememberChatStartRecording(
         }
     }
 
-    // Runtime permission request for RECORD_AUDIO (server STT path)
+    // Runtime permission request for RECORD_AUDIO (in-process recognizer + External upload paths).
     val audioPermissionLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.RequestPermission(),
     ) { isGranted ->
@@ -62,33 +67,12 @@ internal fun rememberChatStartRecording(
     }
 
     return {
-        val useServerStt = sttEngine.equals("whisper", ignoreCase = true) ||
-            (sttEngine.isBlank() || sttEngine.equals("default", ignoreCase = true)) &&
-            serverSttEnabled
+        val engine = SttEngine.fromStored(sttEngine)
+        // The in-process live recognizer needs API 31+ (shared capability seam, same predicate the
+        // settings toggles gate on). Below that, Browser falls back to the full-screen Intent overlay.
+        val useIntentOverlay = engine == SttEngine.BROWSER && !sttSupportsLiveRecognition()
 
-        if (useServerStt) {
-            if (!serverSttEnabled && sttEngine.equals("whisper", ignoreCase = true)) {
-                // User selected Whisper but server STT is not configured
-                coroutineScope.launch {
-                    snackbarHostState.showSnackbar(
-                        "Server speech-to-text is not enabled. " +
-                            "Ask your server admin to enable STT, or switch to Device or Google engine.",
-                    )
-                }
-            } else {
-                // Server STT path: record audio and upload for transcription
-                val hasPermission = ContextCompat.checkSelfPermission(
-                    context,
-                    Manifest.permission.RECORD_AUDIO,
-                ) == PackageManager.PERMISSION_GRANTED
-                if (hasPermission) {
-                    viewModel.startRecording()
-                } else {
-                    audioPermissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
-                }
-            }
-        } else {
-            // Device speech recognizer path (Device, Google, or Default without server)
+        if (useIntentOverlay) {
             val intent = Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH).apply {
                 putExtra(
                     RecognizerIntent.EXTRA_LANGUAGE_MODEL,
@@ -101,55 +85,25 @@ internal fun rememberChatStartRecording(
                     putExtra(RecognizerIntent.EXTRA_LANGUAGE_PREFERENCE, languageLocale)
                 }
             }
-            val enginePackage = mapSttEngineToPackage(sttEngine)
-            if (enginePackage != null) {
-                intent.setPackage(enginePackage)
-            }
             try {
                 speechRecognizerLauncher.launch(intent)
             } catch (_: Exception) {
-                val engineLabel = if (sttEngine.equals("google", ignoreCase = true)) {
-                    "Google speech recognition is not available. Is the Google app installed?"
-                } else {
-                    "Speech recognition is not available on this device"
-                }
                 coroutineScope.launch {
-                    snackbarHostState.showSnackbar(engineLabel)
+                    snackbarHostState.showSnackbar("Speech recognition is not available on this device")
                 }
+            }
+        } else {
+            // API 31+ Browser (in-process recognizer) or External (record + upload); the delegate
+            // routes. Both need RECORD_AUDIO.
+            val hasPermission = ContextCompat.checkSelfPermission(
+                context,
+                Manifest.permission.RECORD_AUDIO,
+            ) == PackageManager.PERMISSION_GRANTED
+            if (hasPermission) {
+                viewModel.startRecording()
+            } else {
+                audioPermissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
             }
         }
     }
-}
-
-/**
- * Maps the user-facing STT engine name (from settings) to an Android package name
- * that can be set on the device speech recognition intent. Returns null for "Default",
- * empty/unknown values, or "Whisper" (which uses server-side STT, not a device package).
- *
- * Note: "Whisper" is handled separately in [rememberChatStartRecording] above --
- * it routes through the server STT path (record audio + upload) rather than the device
- * speech recognizer. This function is only called for the device recognizer path.
- */
-private fun mapSttEngineToPackage(engine: String): String? = when (engine.lowercase()) {
-    "google" -> "com.google.android.googlequicksearchbox"
-    "whisper" -> null // Server-side engine; never reaches device recognizer path
-    "device" -> null // Explicit on-device; uses system default speech recognizer
-    "default", "" -> null
-    else -> null
-}
-
-/**
- * Maps the user-facing STT language name (from settings) to a BCP-47 locale tag
- * for [RecognizerIntent.EXTRA_LANGUAGE]. Returns null for "Auto-detect" or
- * empty values, which lets the recognizer use the device default.
- */
-private fun mapSttLanguageToLocale(language: String): String? = when (language.lowercase()) {
-    "english" -> "en-US"
-    "spanish" -> "es-ES"
-    "french" -> "fr-FR"
-    "german" -> "de-DE"
-    "japanese" -> "ja-JP"
-    "chinese" -> "zh-CN"
-    "auto-detect", "" -> null
-    else -> null
 }

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/AndroidDelegateFactory.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/AndroidDelegateFactory.kt
@@ -39,6 +39,14 @@ class AndroidDelegateFactory(
                 speechRepository = speechRepository,
                 autoSendAfterStt = settingsDataStore.autoSendAfterStt
                     .stateIn(stateHandle.scope, SharingStarted.Eagerly, false),
+                sttEngine = settingsDataStore.sttEngine
+                    .stateIn(stateHandle.scope, SharingStarted.Eagerly, ""),
+                sttLanguage = settingsDataStore.sttLanguage
+                    .stateIn(stateHandle.scope, SharingStarted.Eagerly, ""),
+                sttOnDevice = settingsDataStore.sttOnDevice
+                    .stateIn(stateHandle.scope, SharingStarted.Eagerly, true),
+                sttEndOfSpeech = settingsDataStore.sttEndOfSpeech
+                    .stateIn(stateHandle.scope, SharingStarted.Eagerly, false),
                 ioDispatcher = ioDispatcher,
                 onTranscriptionComplete = onTranscriptionComplete,
             ),

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/VoiceInputDelegate.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/VoiceInputDelegate.kt
@@ -2,38 +2,240 @@ package com.garfiec.librechat.feature.chat.viewmodel.delegate
 
 import android.content.Context
 import com.garfiec.librechat.core.common.result.Result
+import com.garfiec.librechat.core.common.speech.mapSttLanguageToLocale
+import com.garfiec.librechat.core.data.repository.ServerSttGate
 import com.garfiec.librechat.core.data.repository.SpeechRepository
+import com.garfiec.librechat.core.model.speech.SttEngine
+import com.garfiec.librechat.feature.chat.audio.DictationBuffer
+import com.garfiec.librechat.feature.chat.audio.SpeechRecognizerController
 import com.garfiec.librechat.feature.chat.audio.VoiceRecorder
+import com.garfiec.librechat.feature.chat.audio.appendToBase
+import com.garfiec.librechat.feature.chat.audio.shouldAutoSendTranscript
 import com.garfiec.librechat.feature.chat.viewmodel.ChatStateHandle
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 class VoiceInputDelegate(
     private val stateHandle: ChatStateHandle,
     private val appContext: Context,
     private val speechRepository: SpeechRepository,
     private val autoSendAfterStt: StateFlow<Boolean>,
+    private val sttEngine: StateFlow<String>,
+    private val sttLanguage: StateFlow<String>,
+    private val sttOnDevice: StateFlow<Boolean>,
+    private val sttEndOfSpeech: StateFlow<Boolean>,
     private val ioDispatcher: CoroutineDispatcher,
     private val onTranscriptionComplete: () -> Unit,
 ) {
 
+    // ── External (server Whisper) session state ──
     private var voiceRecorder: VoiceRecorder? = null
     // Tracks the in-flight VoiceRecorder.start(). stop()/cancel() join it before touching the
     // recorder so a tap-stop (or second tap) during the MediaRecorder warm-up can't race the
     // not-yet-finished start() and orphan a recording that keeps the mic hot.
     private var startJob: Job? = null
+    // The in-flight stop→upload→transcribe coroutine. Held so cancelRecording() can abort a slow or
+    // hung server upload — otherwise the mic sat unresponsive (the isTranscribing start-guard blocks a
+    // retry) with no way to cancel until the network call resolved on its own.
+    private var transcribeJob: Job? = null
+
+    // Loads + latches the server-STT flag with the shared "unknown vs disabled" retry policy. Until
+    // it has resolved once (gate.loaded), serverSttEnabled=false is "unknown", not "disabled" — so
+    // the External path awaits a fetch before deciding rather than falsely reporting STT off.
+    private val serverSttGate = ServerSttGate(speechRepository)
+
+    // Guards the async config-fetch window in startExternalRecording so a double mic-tap (isRecording
+    // isn't set until the fetch resolves) can't spawn two recorders.
+    private var externalStartPending = false
+
+    // ── Browser (in-process SpeechRecognizer) session state ──
+    private var speechController: SpeechRecognizerController? = null
+
+    /** Composer merge/rebase/revert bookkeeping for the browser session (shared with iOS). */
+    private val browserBuffer = DictationBuffer()
 
     fun startRecording() {
-        if (stateHandle.state.isRecording) return
-        // Set state + assign the recorder synchronously on Main so the isRecording guard above
-        // and stopRecording()/cancelRecording() see a consistent recorder during start()'s warm-up.
+        // Reject a start while any session is live OR winding down. isRecording is only true during an
+        // active session; the stop→final windows (browser stopListening, External Whisper upload) run
+        // with isRecording=false + isTranscribing=true and the controller/recorder ref still set until
+        // finalize, and externalStartPending covers the async speech-config fetch before an External
+        // recorder is assigned. Guarding on isRecording alone let a second mic tap in any of these
+        // windows spawn a parallel session that orphaned the first recognizer and left the mic hot.
+        if (stateHandle.state.isRecording ||
+            stateHandle.state.isTranscribing ||
+            speechController != null ||
+            voiceRecorder != null ||
+            externalStartPending
+        ) {
+            return
+        }
+        when (SttEngine.fromStored(sttEngine.value)) {
+            SttEngine.EXTERNAL -> startExternalRecording()
+            SttEngine.BROWSER -> startBrowserRecording()
+        }
+    }
+
+    fun stopRecording() {
+        // Route by the active session, not by re-reading the pref — a pref change mid-recording
+        // must not stop the wrong path.
+        val controller = speechController
+        val recorder = voiceRecorder
+        when {
+            controller != null -> {
+                stateHandle.update { copy(isRecording = false, isTranscribing = true) }
+                controller.stop()
+            }
+            recorder != null -> stopExternalRecording(recorder)
+            // Stop tapped while an External start is still resolving its config fetch: clear the flag
+            // so the pending coroutine aborts instead of beginning a recording the user cancelled.
+            externalStartPending -> externalStartPending = false
+        }
+    }
+
+    fun cancelRecording() {
+        // Abort any pending External start too (stopRecording clears this for the same reason); without
+        // it a cancel during the async speech-config fetch would still open a recorder the user aborted.
+        externalStartPending = false
+        val controller = speechController
+        val recorder = voiceRecorder
+        when {
+            controller != null -> {
+                speechController = null
+                controller.cancel()
+                // Drop the in-progress dictation if the user hasn't edited the field since our last write.
+                stateHandle.update {
+                    copy(
+                        isRecording = false,
+                        isTranscribing = false,
+                        inputText = browserBuffer.revert(inputText),
+                    )
+                }
+            }
+            recorder != null -> {
+                voiceRecorder = null
+                stateHandle.update { copy(isRecording = false) }
+                // Join start() first so cancel() can't race the in-flight warm-up; cancel() then runs
+                // MediaRecorder.stop()/release() off the Main thread.
+                stateHandle.scope.launch {
+                    startJob?.join()
+                    recorder.cancel()
+                }
+            }
+            // Cancel tapped while the External upload is transcribing (or its recorder is still
+            // warming up): cancel the job — its finally releases the recorder + warm-up under
+            // NonCancellable so the mic can't stay hot — and drop the pending transcript.
+            transcribeJob != null -> {
+                transcribeJob?.cancel()
+                transcribeJob = null
+                stateHandle.update { copy(isTranscribing = false) }
+            }
+        }
+    }
+
+    // ── Browser engine: in-process SpeechRecognizer with live partials ──
+
+    private fun startBrowserRecording() {
+        browserBuffer.begin(stateHandle.state.inputText)
+
+        val controller = SpeechRecognizerController(appContext).apply {
+            onPartial = { partial -> applyBrowserPartial(partial) }
+            onSegment = { segment -> commitBrowserSegment(segment) }
+            onError = { message -> onBrowserError(message) }
+            onFinished = { finalizeBrowserSession() }
+        }
+        speechController = controller
+        // Clear any error left by a prior failed session so a stale message can't re-surface over a
+        // successful dictation.
+        stateHandle.update { copy(isRecording = true, error = null) }
+        controller.start(
+            preferOnDevice = sttOnDevice.value,
+            endOfSpeech = sttEndOfSpeech.value,
+            languageTag = mapSttLanguageToLocale(sttLanguage.value),
+        )
+    }
+
+    private fun applyBrowserPartial(partial: String) {
+        val text = browserBuffer.merge(stateHandle.state.inputText, partial)
+        // Partials fire ~10×/s and often re-deliver the same text during a pause; skip the ~86-field
+        // ChatUiState copy + uiState re-emit when nothing actually changed.
+        if (text != stateHandle.state.inputText) stateHandle.update { copy(inputText = text) }
+    }
+
+    private fun commitBrowserSegment(segment: String) {
+        val committed = browserBuffer.commit(stateHandle.state.inputText, segment)
+        stateHandle.update { copy(inputText = committed) }
+    }
+
+    private fun onBrowserError(message: String) {
+        speechController = null
+        stateHandle.update { copy(isRecording = false, isTranscribing = false, error = message) }
+    }
+
+    private fun finalizeBrowserSession() {
+        speechController = null
+        stateHandle.update { copy(isRecording = false, isTranscribing = false) }
+        // Auto-send only on user-stop (this callback), never per silence-boundary segment, and only
+        // when dictation actually produced text so a pre-typed field isn't sent by an empty session.
+        if (browserBuffer.shouldAutoSend(
+                stateHandle.state.inputText,
+                autoSendAfterStt.value,
+                stateHandle.state.isStreaming,
+            )
+        ) {
+            onTranscriptionComplete()
+        }
+    }
+
+    // ── External engine: record + upload to server Whisper ──
+
+    private fun startExternalRecording() {
+        // serverSttEnabled is populated by an async loadSpeechConfig() launched at VM init. If that
+        // hasn't resolved yet (fast mic-tap on a fresh screen, or an earlier transient fetch error),
+        // fetch it now before deciding — otherwise the default `false` would falsely report STT off.
+        if (serverSttGate.loaded) {
+            beginExternalRecording()
+        } else {
+            externalStartPending = true
+            stateHandle.scope.launch {
+                try {
+                    fetchSpeechConfig()
+                    // stopRecording() during the fetch clears externalStartPending to cancel this
+                    // pending start — honor it rather than beginning a recording the user aborted.
+                    if (externalStartPending) beginExternalRecording()
+                } finally {
+                    externalStartPending = false
+                }
+            }
+        }
+    }
+
+    private fun beginExternalRecording() {
+        if (!stateHandle.state.serverSttEnabled) {
+            // Distinguish "server reachable, STT genuinely off" from "couldn't reach the server to
+            // check": gate.loaded is only set once a fetch succeeds, so a false here with the latch
+            // still down means the fetch failed (transient) — don't tell the user STT is disabled.
+            val message = if (serverSttGate.loaded) {
+                "Server speech-to-text is not enabled. Ask your server admin to enable STT, or " +
+                    "switch the engine to Browser in Speech settings."
+            } else {
+                "Couldn't reach the server to check speech settings. Check your connection and try " +
+                    "again, or switch the engine to Browser in Speech settings."
+            }
+            stateHandle.update { copy(error = message) }
+            return
+        }
+        // Set state + assign the recorder synchronously on Main so the isRecording guard and
+        // stopRecording()/cancelRecording() see a consistent recorder during start()'s warm-up.
         val recorder = VoiceRecorder(appContext, ioDispatcher)
         voiceRecorder = recorder
-        stateHandle.update { copy(isRecording = true) }
+        stateHandle.update { copy(isRecording = true, error = null) }
         startJob = stateHandle.scope.launch {
             try {
                 recorder.start()
@@ -50,95 +252,113 @@ class VoiceInputDelegate(
         }
     }
 
-    fun stopRecording() {
-        val recorder = voiceRecorder ?: return
+    private fun stopExternalRecording(recorder: VoiceRecorder) {
         val mimeType = recorder.mimeType
         voiceRecorder = null
         stateHandle.update { copy(isRecording = false, isTranscribing = true) }
 
-        stateHandle.scope.launch {
-            // Ensure start() finished before we stop the recorder.
-            startJob?.join()
-            val audioData = recorder.stop()
-            if (audioData == null || audioData.isEmpty()) {
-                stateHandle.update { copy(isTranscribing = false, error = "Recording was empty") }
-                return@launch
-            }
+        // Capture the warm-up job for THIS recorder. The isTranscribing guard blocks a new session
+        // until this coroutine (or cancelRecording) clears the flag, so startJob can't be reassigned
+        // out from under us before the coroutine's first line runs.
+        val warmup = startJob
+        val job = stateHandle.scope.launch {
+            try {
+                // Ensure start() finished before we stop the recorder.
+                warmup?.join()
+                val audioData = recorder.stop()
+                if (audioData == null || audioData.isEmpty()) {
+                    stateHandle.update { copy(isTranscribing = false, error = "Recording was empty") }
+                    return@launch
+                }
 
-            when (val result = speechRepository.transcribeAudio(audioData, mimeType)) {
-                is Result.Success -> {
-                    val transcribedText = result.data.text
-                    val currentInput = stateHandle.state.inputText
-                    val separator = if (currentInput.isNotBlank() && !currentInput.endsWith(" ")) " " else ""
-                    stateHandle.update {
-                        copy(
-                            inputText = currentInput + separator + transcribedText,
-                            isTranscribing = false,
-                        )
+                when (val result = speechRepository.transcribeAudio(audioData, mimeType)) {
+                    is Result.Success -> {
+                        val transcribedText = result.data.text
+                        val merged = appendToBase(stateHandle.state.inputText, transcribedText)
+                        stateHandle.update {
+                            copy(
+                                inputText = merged,
+                                isTranscribing = false,
+                            )
+                        }
+                        // Auto-send via the shared gate so this path can't drift from Browser/iOS.
+                        if (shouldAutoSendTranscript(
+                                transcribedText.isNotBlank(),
+                                autoSendAfterStt.value,
+                                stateHandle.state.isStreaming,
+                            )
+                        ) {
+                            onTranscriptionComplete()
+                        }
                     }
-                    // Auto-send if enabled and transcribed text is non-empty and not already streaming
-                    if (autoSendAfterStt.value && transcribedText.isNotBlank() && !stateHandle.state.isStreaming) {
-                        onTranscriptionComplete()
+                    is Result.Error -> {
+                        stateHandle.update {
+                            copy(
+                                isTranscribing = false,
+                                error = result.message ?: "Transcription failed",
+                            )
+                        }
                     }
+                    // safeApiCall never emits Loading, but clear the flag defensively so a future
+                    // change can't strand isTranscribing=true and permanently lock out the mic.
+                    is Result.Loading -> stateHandle.update { copy(isTranscribing = false) }
                 }
-                is Result.Error -> {
-                    stateHandle.update {
-                        copy(
-                            isTranscribing = false,
-                            error = result.message ?: "Transcription failed",
-                        )
-                    }
+            } finally {
+                // On cancellation (cancelRecording during the warm-up or the upload) recorder.stop()
+                // may never have run: cancel the still-warming recorder so start()'s own
+                // CancellationException cleanup releases the mic, then release directly (idempotent —
+                // a no-op after a normal stop()). NonCancellable so it still runs from a cancelled job.
+                withContext(NonCancellable) {
+                    warmup?.cancelAndJoin()
+                    recorder.cancel()
                 }
-                is Result.Loading -> { /* no-op */ }
             }
         }
-    }
-
-    fun cancelRecording() {
-        val recorder = voiceRecorder ?: return
-        voiceRecorder = null
-        stateHandle.update { copy(isRecording = false) }
-        // Join start() first so cancel() can't race the in-flight warm-up; cancel() then runs
-        // MediaRecorder.stop()/release() off the Main thread.
-        stateHandle.scope.launch {
-            startJob?.join()
-            recorder.cancel()
-        }
+        transcribeJob = job
+        // Null the field only when THIS job completes and it's still the current one — a later session
+        // may have replaced it, and cancelRecording nulls it synchronously.
+        job.invokeOnCompletion { if (transcribeJob === job) transcribeJob = null }
     }
 
     /**
-     * Called when Android's on-device speech recognizer returns a result.
+     * Called when the legacy Intent-overlay recognizer (API 26–30 fallback) returns a result.
      * Appends the transcribed text to the input field, and auto-sends if enabled.
      */
     fun onDeviceSpeechResult(transcribedText: String) {
         if (transcribedText.isBlank()) return
-        val currentInput = stateHandle.state.inputText
-        val separator = if (currentInput.isNotBlank() && !currentInput.endsWith(" ")) " " else ""
+        val merged = appendToBase(stateHandle.state.inputText, transcribedText)
         stateHandle.update {
-            copy(inputText = currentInput + separator + transcribedText)
+            copy(inputText = merged, error = null)
         }
-        // Auto-send if enabled and not already streaming
-        if (autoSendAfterStt.value && !stateHandle.state.isStreaming) {
+        // Auto-send via the shared gate (transcribedText is non-blank — guarded above).
+        if (shouldAutoSendTranscript(
+                transcribedText.isNotBlank(),
+                autoSendAfterStt.value,
+                stateHandle.state.isStreaming,
+            )
+        ) {
             onTranscriptionComplete()
         }
     }
 
     fun loadSpeechConfig() {
-        stateHandle.scope.launch {
-            when (val result = speechRepository.getSpeechConfig()) {
-                is Result.Success -> {
-                    stateHandle.update { copy(serverSttEnabled = result.data.sttExternal) }
-                }
-                is Result.Error -> {
-                    // If we can't fetch the config, assume server STT is not available
-                    stateHandle.update { copy(serverSttEnabled = false) }
-                }
-                is Result.Loading -> { /* no-op */ }
-            }
-        }
+        stateHandle.scope.launch { fetchSpeechConfig() }
+    }
+
+    private suspend fun fetchSpeechConfig() {
+        // A null result means the fetch couldn't determine the flag (transient error) — leave the gate
+        // unlatched so a later External tap retries rather than trusting this as a definitive "off".
+        val enabled = serverSttGate.refresh() ?: false
+        stateHandle.update { copy(serverSttEnabled = enabled) }
     }
 
     fun release() {
+        // SpeechRecognizer.destroy() must run on the thread that created it (Main). onCleared() is
+        // Main, so destroy synchronously here — do NOT push it onto the detached IO scope used for
+        // MediaRecorder cleanup below.
+        speechController?.destroy()
+        speechController = null
+
         val recorder = voiceRecorder ?: return
         voiceRecorder = null
         // Called from onCleared(), at which point stateHandle.scope is already cancelled — a

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/audio/TranscriptText.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/audio/TranscriptText.kt
@@ -1,0 +1,118 @@
+package com.garfiec.librechat.feature.chat.audio
+
+/**
+ * Appends dictated [addition] onto [base], inserting a single space separator only when [base] is
+ * non-blank and doesn't already end in whitespace. Returns [base] unchanged for a blank [addition].
+ *
+ * Shared across platforms (Android [VoiceInputDelegate], iOS `IosVoiceInput`) so the composer's
+ * live-transcript merge behaves identically instead of each platform inlining a slightly different
+ * separator rule.
+ */
+internal fun appendToBase(base: String, addition: String): String {
+    if (addition.isBlank()) return base
+    val separator = if (base.isNotBlank() && !base.endsWith(" ")) " " else ""
+    return base + separator + addition
+}
+
+/**
+ * Tracks composer text across a live-dictation session so the transcript appends after any pre-typed
+ * text, a user edit mid-dictation isn't clobbered by the next cumulative transcript, and a cancel
+ * restores the original text unless the user edited since.
+ *
+ * Shared by the Android [VoiceInputDelegate] (browser/on-device path) and iOS `IosVoiceInput` so the
+ * merge / rebase-on-edit / revert-on-cancel rules can't drift between platforms — each platform only
+ * owns its recognizer transport and feeds transcripts through here. Not thread-safe: callers must
+ * confine access to a single thread (the Main-dispatched ViewModel scope on both platforms).
+ */
+internal class DictationBuffer {
+    /** Composer text before dictation began — restored verbatim if the session is cancelled. */
+    private var originalText: String = ""
+
+    /** Committed base the live transcript appends onto; rebased to the user's text if they edit. */
+    private var baseText: String = ""
+
+    /** The last value written to the composer — used to detect the user typing mid-dictation. */
+    private var lastApplied: String = ""
+
+    /**
+     * The transcript last appended to [baseText] this segment. Recognizer partials are *cumulative*
+     * (each replaces the prior one) on both platforms, so a mid-dictation user edit must re-derive the
+     * base by stripping this suffix — otherwise re-appending the cumulative transcript duplicates the
+     * words already shown (e.g. "hello world" + edit + next cumulative → "hello world! hello world…").
+     */
+    private var lastTranscript: String = ""
+
+    /** Whether this session produced any (non-blank) transcript. Gates auto-send. */
+    var producedText: Boolean = false
+        private set
+
+    /** Snapshot the composer as the base future transcripts append onto. */
+    fun begin(currentText: String) {
+        originalText = currentText
+        baseText = currentText
+        lastApplied = currentText
+        lastTranscript = ""
+        producedText = false
+    }
+
+    /**
+     * Merge a (partial or cumulative) [transcript] onto the base and return the composer text to show.
+     * If the user typed/deleted since our last write, their edit survives: the base is re-derived by
+     * stripping the previously-applied cumulative [transcript] suffix (so it isn't duplicated), falling
+     * back to their text verbatim when they edited inside the live-transcript region itself.
+     */
+    fun merge(currentText: String, transcript: String): String {
+        if (currentText != lastApplied) baseText = stripTranscriptSuffix(currentText, lastTranscript)
+        if (transcript.isNotBlank()) producedText = true
+        val merged = appendToBase(baseText, transcript)
+        lastApplied = merged
+        lastTranscript = transcript
+        return merged
+    }
+
+    /**
+     * Commit a finalized [transcript] segment as the new base (continuous dictation, where each
+     * segment is independent), returning the composer text to show.
+     */
+    fun commit(currentText: String, transcript: String): String {
+        val merged = merge(currentText, transcript)
+        baseText = merged
+        lastTranscript = ""
+        return merged
+    }
+
+    /** The composer text to show after a cancel: the original unless the user edited since our last write. */
+    fun revert(currentText: String): String =
+        if (currentText == lastApplied) originalText else currentText
+
+    /**
+     * Whether an ended live-dictation session should auto-send: the user enabled it, this session
+     * actually [producedText], the composer isn't blank, and we're not already streaming. Shared by
+     * the Android browser path and iOS so the predicate can't drift between platforms.
+     */
+    fun shouldAutoSend(currentText: String, autoSendEnabled: Boolean, isStreaming: Boolean): Boolean =
+        shouldAutoSendTranscript(producedText && currentText.isNotBlank(), autoSendEnabled, isStreaming)
+}
+
+/**
+ * The single auto-send-after-STT gate: send only when the user enabled it, dictation actually
+ * produced content, and we're not already streaming. Every STT path routes through this so the rule
+ * can't drift — [DictationBuffer.shouldAutoSend] feeds it `producedText && composer-non-blank`; the
+ * External (record→upload) and legacy Intent-overlay paths feed it their transcript-non-blank.
+ */
+internal fun shouldAutoSendTranscript(
+    hasContent: Boolean,
+    autoSendEnabled: Boolean,
+    isStreaming: Boolean,
+): Boolean = autoSendEnabled && hasContent && !isStreaming
+
+/**
+ * Strip a trailing cumulative [transcript] (plus the single separator space [appendToBase] may have
+ * inserted) from [text] to recover the base it was appended onto. Returns [text] unchanged when the
+ * suffix isn't present (blank transcript, or the user edited inside the transcript region).
+ */
+internal fun stripTranscriptSuffix(text: String, transcript: String): String {
+    if (transcript.isEmpty() || !text.endsWith(transcript)) return text
+    val base = text.dropLast(transcript.length)
+    return if (base.endsWith(" ")) base.dropLast(1) else base
+}

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/audio/VoiceConstants.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/audio/VoiceConstants.kt
@@ -1,0 +1,28 @@
+package com.garfiec.librechat.feature.chat.audio
+
+/**
+ * How long to wait after the user stops dictation for the recognizer to deliver its final result
+ * before force-finalizing (committing whatever partial is already shown in the composer).
+ *
+ * Shared by the Android [SpeechRecognizerController] and iOS `IosVoiceInput` so both platforms apply
+ * one stop→final policy instead of each redeclaring the constant and keeping it in sync by comment.
+ */
+internal const val STOP_WATCHDOG_MS = 1200L
+
+/**
+ * Stop→final watchdog for the (slower) cloud recognizer. Apple/Google cloud finals routinely take
+ * ~1.5–3s after the user stops, so the short on-device [STOP_WATCHDOG_MS] would pre-empt the
+ * corrected final and commit/auto-send a rougher partial; the cloud path waits longer before
+ * force-finalizing. Shared so both platforms apply the same on-device-vs-cloud grace policy.
+ */
+internal const val CLOUD_STOP_WATCHDOG_MS = 4000L
+
+/**
+ * How many consecutive recognizer-initiated finals that heard nothing to allow before ending a
+ * continuous-dictation session, so unbroken silence can't spin the mic open forever.
+ *
+ * Shared by the Android [SpeechRecognizerController] and iOS `IosVoiceInput` so both platforms apply
+ * one continuous-restart policy instead of each redeclaring the constant and keeping it in sync by
+ * comment.
+ */
+internal const val MAX_EMPTY_SEGMENTS = 4

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/PlatformVoiceInput.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/PlatformVoiceInput.kt
@@ -2,8 +2,9 @@ package com.garfiec.librechat.feature.chat.viewmodel.delegate
 
 /**
  * Platform-abstracted voice input handling.
- * Android: wraps VoiceInputDelegate with MediaRecorder.
- * iOS: no-op initially (voice input not yet supported on iOS).
+ * Android: wraps VoiceInputDelegate (in-process SpeechRecognizer for the Browser engine,
+ * MediaRecorder + upload for the External engine).
+ * iOS: SFSpeechRecognizer live transcription.
  */
 interface PlatformVoiceInput {
     fun startRecording()

--- a/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/IosDelegateFactory.kt
+++ b/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/IosDelegateFactory.kt
@@ -5,6 +5,8 @@ import com.garfiec.librechat.core.data.repository.FileRepository
 import com.garfiec.librechat.core.data.repository.SpeechRepository
 import com.garfiec.librechat.feature.chat.viewmodel.ChatStateHandle
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.stateIn
 
 class IosDelegateFactory(
     private val fileRepository: FileRepository,
@@ -21,7 +23,18 @@ class IosDelegateFactory(
         stateHandle: ChatStateHandle,
         onTranscriptionComplete: () -> Unit,
     ): PlatformVoiceInput {
-        return IosVoiceInput(stateHandle, onTranscriptionComplete)
+        return IosVoiceInput(
+            stateHandle = stateHandle,
+            autoSendAfterStt = settingsDataStore.autoSendAfterStt
+                .stateIn(stateHandle.scope, SharingStarted.Eagerly, false),
+            sttOnDevice = settingsDataStore.sttOnDevice
+                .stateIn(stateHandle.scope, SharingStarted.Eagerly, true),
+            sttEndOfSpeech = settingsDataStore.sttEndOfSpeech
+                .stateIn(stateHandle.scope, SharingStarted.Eagerly, false),
+            sttLanguage = settingsDataStore.sttLanguage
+                .stateIn(stateHandle.scope, SharingStarted.Eagerly, ""),
+            onTranscriptionComplete = onTranscriptionComplete,
+        )
     }
 
     override fun createTts(

--- a/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/IosVoiceInput.kt
+++ b/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/IosVoiceInput.kt
@@ -1,8 +1,17 @@
 package com.garfiec.librechat.feature.chat.viewmodel.delegate
 
 import co.touchlab.kermit.Logger
+import com.garfiec.librechat.core.common.speech.mapSttLanguageToLocale
+import com.garfiec.librechat.feature.chat.audio.CLOUD_STOP_WATCHDOG_MS
+import com.garfiec.librechat.feature.chat.audio.DictationBuffer
+import com.garfiec.librechat.feature.chat.audio.MAX_EMPTY_SEGMENTS
+import com.garfiec.librechat.feature.chat.audio.STOP_WATCHDOG_MS
+import com.garfiec.librechat.feature.chat.audio.appendToBase
 import com.garfiec.librechat.feature.chat.viewmodel.ChatStateHandle
 import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import platform.AVFAudio.AVAudioEngine
 import platform.AVFAudio.AVAudioSession
@@ -13,6 +22,7 @@ import platform.AVFAudio.setActive
 import platform.Foundation.NSLocale
 import platform.Foundation.currentLocale
 import platform.Foundation.languageCode
+import platform.Foundation.localeIdentifier
 import platform.Speech.SFSpeechAudioBufferRecognitionRequest
 import platform.Speech.SFSpeechRecognitionTask
 import platform.Speech.SFSpeechRecognizer
@@ -24,6 +34,10 @@ import platform.Speech.SFSpeechRecognizerAuthorizationStatus
  */
 class IosVoiceInput(
     private val stateHandle: ChatStateHandle,
+    private val autoSendAfterStt: StateFlow<Boolean>,
+    private val sttOnDevice: StateFlow<Boolean>,
+    private val sttEndOfSpeech: StateFlow<Boolean>,
+    private val sttLanguage: StateFlow<String>,
     private val onTranscriptionComplete: () -> Unit,
 ) : PlatformVoiceInput {
 
@@ -34,10 +48,92 @@ class IosVoiceInput(
     private var recognitionTask: SFSpeechRecognitionTask? = null
     private var speechRecognizer: SFSpeechRecognizer? = null
 
+    /** Composer merge/rebase/revert bookkeeping for the current session (shared with Android). */
+    private val buffer = DictationBuffer()
+
+    /**
+     * Latched once the session is torn down (user stop, cancel, natural final, or error). Guards the
+     * recognition callback so a result already queued before teardown can't re-inject stale text into
+     * a cancelled/cleared/sent composer. Only touched on the Main-dispatched [ChatStateHandle.scope]
+     * (the callback hops there — see [startRecognitionTask]) so the check-then-set can't race.
+     */
+    private var finished = false
+
+    /**
+     * Monotonic id for the current recognition task. A continuous restart / cloud fallback cancels the
+     * live task and starts a new one; [SFSpeechRecognitionTask.cancel] delivers its cancellation on an
+     * arbitrary queue *after* the new task is already running (with [finished] back to false), so the
+     * `finished` guard alone can't tell that stale callback apart from the new task's. Each task
+     * captures its token and the callback ignores anything whose token no longer matches — otherwise a
+     * cancelled task's error would spuriously trigger a cloud fallback or abort live dictation.
+     */
+    private var sessionToken = 0
+
+    /** True once the user tapped stop — distinguishes a user-finished session (auto-sends) from a
+     * recognizer-initiated final at a silence pause (commits only, never auto-sends). */
+    private var stopRequested = false
+
+    /** Whether the *current* recognition task forced on-device recognition (drives the cloud fallback
+     * on a runtime failure). Distinct from [triedCloudFallback], which records that the *session* has
+     * given up on-device for good. */
+    private var requestedOnDevice = false
+
+    /**
+     * Latched once this session fell back to Apple's cloud after an on-device runtime failure. Kept
+     * for the rest of the session (across continuous restarts) so we don't re-attempt — and re-fail —
+     * on-device on every segment; reset only on a fresh session ([beginRecording]).
+     */
+    private var triedCloudFallback = false
+
+    /**
+     * Consecutive recognizer-initiated finals that carried no transcript. Bounds the continuous
+     * restart loop so a recognizer that finals on silence can't spin the mic open forever.
+     */
+    private var consecutiveEmptyFinals = 0
+
+    /**
+     * The stop→final watchdog coroutine. Held so it can be cancelled when the session finalizes early
+     * (final arrived, error, cancel) or a new session starts — otherwise a stale watchdog from a prior
+     * session could force-finalize and auto-send a *later* session started within [STOP_WATCHDOG_MS].
+     */
+    private var stopWatchdogJob: Job? = null
+
+    /**
+     * End-of-speech silence timer (only armed in end-of-speech mode). Rescheduled on every transcript
+     * change; if it elapses with no new speech, the session finalizes (and auto-sends when enabled) —
+     * SFSpeechRecognizer gives no reliable silence callback for buffer requests, so we debounce here.
+     */
+    private var silenceJob: Job? = null
+
+    /**
+     * Latched between requesting speech-recognition authorization and its async callback. On the very
+     * first use the status is NotDetermined and [startRecording] returns while the permission prompt is
+     * up — with isRecording/isTranscribing false and no task yet, so the normal guard can't tell a
+     * second mic tap apart from a fresh start. Without this latch that second tap would kick off a
+     * second beginRecording() once auth resolves, installing two taps on the input node. Mirrors the
+     * Android [VoiceInputDelegate] externalStartPending guard for its analogous async window.
+     */
+    private var authorizationInFlight = false
+
     @OptIn(ExperimentalForeignApi::class)
     override fun startRecording() {
         log.d { "startRecording() called, isRecording=${stateHandle.state.isRecording}" }
-        if (stateHandle.state.isRecording) return
+        // Reject a start while a session is live OR winding down. isRecording is only true mid-session,
+        // but after stopRecording() the task stays alive with isTranscribing=true until the final or
+        // watchdog finalizes it; starting again in that window orphaned the first engine (mic stayed
+        // hot) and cross-wired its callbacks. Mirrors the Android VoiceInputDelegate guard.
+        if (stateHandle.state.isRecording ||
+            stateHandle.state.isTranscribing ||
+            recognitionTask != null ||
+            authorizationInFlight
+        ) {
+            return
+        }
+
+        // External (server Whisper) has no iOS transport yet — SFSpeechRecognizer only does on-device/
+        // cloud Apple recognition. Rather than dead-ending the mic with an error (which regressed
+        // users who had External/Whisper selected), fall through to Browser recognition. iOS treats
+        // External as Browser (documented divergence; follow-up: iOS External via transcribeAudio).
 
         // Check authorization
         val authStatus = SFSpeechRecognizer.authorizationStatus()
@@ -45,13 +141,23 @@ class IosVoiceInput(
         when (authStatus) {
             SFSpeechRecognizerAuthorizationStatus.SFSpeechRecognizerAuthorizationStatusNotDetermined -> {
                 log.d { "Requesting speech recognition authorization..." }
+                // Latch so a second mic tap during the permission prompt can't start a second session.
+                authorizationInFlight = true
                 SFSpeechRecognizer.requestAuthorization { status ->
                     log.d { "Authorization callback: status=$status" }
-                    if (status == SFSpeechRecognizerAuthorizationStatus.SFSpeechRecognizerAuthorizationStatusAuthorized) {
-                        stateHandle.scope.launch { beginRecording() }
-                    } else {
-                        log.w { "Speech recognition permission denied" }
-                        stateHandle.update { copy(error = "Speech recognition permission denied") }
+                    // requestAuthorization delivers on an arbitrary queue — hop to the Main-dispatched
+                    // scope for BOTH outcomes so every state write in this class stays main-confined.
+                    stateHandle.scope.launch {
+                        authorizationInFlight = false
+                        // A cancel/release during the prompt set finished — don't start a session (or
+                        // surface a denial error) after the user already backed out.
+                        if (finished) return@launch
+                        if (status == SFSpeechRecognizerAuthorizationStatus.SFSpeechRecognizerAuthorizationStatusAuthorized) {
+                            beginRecording()
+                        } else {
+                            log.w { "Speech recognition permission denied" }
+                            stateHandle.update { copy(error = "Speech recognition permission denied") }
+                        }
                     }
                 }
                 return
@@ -68,18 +174,48 @@ class IosVoiceInput(
         }
     }
 
+    /**
+     * Configure the audio session + recognizer and start a fresh dictation session. The audio engine,
+     * input tap, and recognizer are set up ONCE here and REUSED across continuous restarts / cloud
+     * fallbacks (which only swap the recognition request+task via [restartRecognition]) — tearing the
+     * whole audio stack down and rebuilding it per silence-boundary segment added latency and audible
+     * gaps.
+     */
     @OptIn(ExperimentalForeignApi::class)
     private fun beginRecording() {
         try {
-            val locale = NSLocale.currentLocale
+            // Reset all session-scoped state for the fresh session.
+            buffer.begin(stateHandle.state.inputText)
+            triedCloudFallback = false
+            consecutiveEmptyFinals = 0
+            stopRequested = false
+            finished = false
+            stopWatchdogJob?.cancel()
+            stopWatchdogJob = null
+            silenceJob?.cancel()
+            silenceJob = null
+
+            // Honor the shared STT language setting (parity with Android's mapSttLanguageToLocale).
+            // SFSpeechRecognizer(locale:) is a FAILABLE initializer: an unsupported identifier yields
+            // nil and crashes on first use, so resolve to a locale the framework actually supports.
+            // bestSupportedLocale tolerates script subtags / region-rich device identifiers
+            // (e.g. a device locale of "zh_Hans_CN" resolves to the supported "zh-CN") instead of
+            // demanding an exact string match, and returns null only when nothing matches at all.
+            val requestedTag = mapSttLanguageToLocale(sttLanguage.value)
+            val locale: NSLocale? = bestSupportedLocale(requestedTag ?: NSLocale.currentLocale.localeIdentifier)
+            if (locale == null) {
+                failStart("Speech recognition isn't available for this language on this device.")
+                return
+            }
             log.d { "beginRecording() locale=${locale.languageCode}" }
             val recognizer = SFSpeechRecognizer(locale = locale)
             val available = recognizer.isAvailable()
             log.d { "SFSpeechRecognizer available=$available" }
             if (!available) {
-                val msg = "Speech recognition not available on this device (locale: ${locale.languageCode}). This feature requires a real device."
-                log.w { msg }
-                stateHandle.update { copy(error = msg) }
+                failStart(
+                    "Speech recognition not available on this device (locale: ${locale.languageCode}). " +
+                        "This feature requires a real device.",
+                )
                 return
             }
             speechRecognizer = recognizer
@@ -97,83 +233,262 @@ class IosVoiceInput(
             log.d { "Audio session configured" }
 
             val engine = AVAudioEngine()
-            val request = SFSpeechAudioBufferRecognitionRequest()
-            request.shouldReportPartialResults = true
-
-            recognitionRequest = request
             audioEngine = engine
 
-            log.d { "Creating recognition task..." }
-            val task = recognizer.recognitionTaskWithRequest(request) { result, error ->
-                if (result != null) {
-                    val text = result.bestTranscription.formattedString
-                    log.d { "Recognition result: '$text', isFinal=${result.isFinal()}" }
-                    stateHandle.update { copy(inputText = text) }
-
-                    if (result.isFinal()) {
-                        log.d { "Final result received, stopping" }
-                        cleanupAudio()
-                        stateHandle.update { copy(isRecording = false) }
-                    }
-                }
-                if (error != null) {
-                    log.e { "Recognition error: ${error.localizedDescription}, isRecording=${stateHandle.state.isRecording}" }
-                    if (stateHandle.state.isRecording) {
-                        cleanupAudio()
-                        stateHandle.update { copy(isRecording = false, error = "Speech recognition error: ${error.localizedDescription}") }
-                    }
-                }
-            }
-            recognitionTask = task
-
-            // Install audio tap
+            // Install the audio tap ONCE; it feeds whichever request is current, so a continuous
+            // restart that swaps recognitionRequest doesn't need to reinstall it.
             val inputNode = engine.inputNode
             val recordingFormat = inputNode.outputFormatForBus(0u)
             log.d { "Installing audio tap, format=$recordingFormat" }
+            // installTapOnBus throws an Obj-C NSException (which Kotlin's try/catch can't intercept — it
+            // would terminate the app) when the input format is invalid. AVAudioEngine asserts
+            // IsFormatSampleRateAndChannelCountValid — BOTH a non-zero sample rate AND channel count —
+            // and either is 0 when the mic is held by another app / a call, or the audio route changed
+            // mid-setup. Guard both fields and fail gracefully instead.
+            if (recordingFormat.sampleRate <= 0.0 || recordingFormat.channelCount == 0u) {
+                failStart("Could not start recording: the microphone is unavailable (another app may be using it).")
+                return
+            }
             inputNode.installTapOnBus(
                 bus = 0u,
                 bufferSize = 1024u,
                 format = recordingFormat,
-            ) { buffer, _ ->
-                if (buffer != null) {
-                    request.appendAudioPCMBuffer(buffer)
+            ) { pcmBuffer, _ ->
+                if (pcmBuffer != null) {
+                    recognitionRequest?.appendAudioPCMBuffer(pcmBuffer)
                 }
             }
 
-            engine.prepare()
-            engine.startAndReturnError(null)
-            log.d { "Audio engine started, setting isRecording=true" }
+            // Start the first recognition task before the engine so no leading audio is dropped.
+            startRecognitionTask(useOnDevice = shouldUseOnDevice())
 
-            stateHandle.update { copy(isRecording = true) }
+            engine.prepare()
+            // startAndReturnError returns false (without throwing) when the engine can't start — e.g.
+            // the audio session is held by an active call. Dropping that result left isRecording=true
+            // with no audio, no error, and (unlike Android) no start-watchdog to recover.
+            if (!engine.startAndReturnError(null)) {
+                failStart("Could not start recording: the audio engine failed to start.")
+                return
+            }
+            log.d { "Audio engine started, setting isRecording=true" }
+            // The recognition callback now hops to Main (this same thread), so it can't have torn the
+            // session down during this synchronous setup — no need to re-check `finished` here. Clear
+            // any error left by a prior failed session so a stale message can't re-surface.
+            stateHandle.update { copy(isRecording = true, error = null) }
         } catch (e: Exception) {
             log.e(e) { "Failed to start recording: ${e.message}" }
-            cleanupAudio()
-            stateHandle.update { copy(error = "Could not start recording: ${e.message}") }
+            failStart("Could not start recording: ${e.message}")
         }
     }
 
-    override fun stopRecording() {
-        if (!stateHandle.state.isRecording) return
+    /**
+     * Whether the next recognition task should force on-device recognition: the user asked, the
+     * session hasn't already fallen back to the cloud, and the recognizer + locale support it.
+     */
+    private fun shouldUseOnDevice(): Boolean =
+        !triedCloudFallback && sttOnDevice.value && (speechRecognizer?.supportsOnDeviceRecognition() ?: false)
 
-        // End the recognition request so we get the final result
+    /**
+     * Create a recognition request+task on the (already-running) engine and wire its callback. Bumps
+     * [sessionToken] so a still-in-flight callback from a just-cancelled task is ignored (see the
+     * field doc). [useOnDevice] sets `requiresOnDeviceRecognition` and is recorded in
+     * [requestedOnDevice] for the runtime cloud fallback.
+     */
+    private fun startRecognitionTask(useOnDevice: Boolean) {
+        val recognizer = speechRecognizer ?: return
+        sessionToken += 1
+        val token = sessionToken
+        val request = SFSpeechAudioBufferRecognitionRequest()
+        request.shouldReportPartialResults = true
+        if (useOnDevice) request.requiresOnDeviceRecognition = true
+        requestedOnDevice = useOnDevice
+        recognitionRequest = request
+
+        log.d { "Creating recognition task (token=$token, onDevice=$useOnDevice)..." }
+        recognitionTask = recognizer.recognitionTaskWithRequest(request) { result, recognitionError ->
+            // SFSpeechRecognizer delivers on an arbitrary queue; hop to the Main-dispatched scope so
+            // the session guards (finished/token), the transcript buffer, and the watchdogs are all
+            // single-threaded (parity with the Android controller's main-thread contract).
+            stateHandle.scope.launch {
+                // Ignore anything from a superseded task (continuous restart / cloud fallback) or after
+                // teardown — a late queued result must not re-inject stale text or drive a restart.
+                if (token != sessionToken || finished) return@launch
+                if (result != null) {
+                    val transcript = result.bestTranscription.formattedString
+                    log.d { "Recognition result: '$transcript', isFinal=${result.isFinal()}" }
+                    if (result.isFinal() && !stopRequested) {
+                        if (sttEndOfSpeech.value) {
+                            // End-of-speech mode: the recognizer finished a phrase — commit and end the
+                            // session (hands-free) instead of restarting. Auto-send fires here when
+                            // enabled (gated inside finalizeSession → maybeAutoSend).
+                            val merged = buffer.merge(stateHandle.state.inputText, transcript)
+                            if (merged != stateHandle.state.inputText) {
+                                stateHandle.update { copy(inputText = merged) }
+                            }
+                            finalizeSession(autoSend = true)
+                            return@launch
+                        }
+                        // Continuous mode: recognizer-initiated final (silence pause / ~1-min duration
+                        // cap) with no user stop — commit this segment and restart the recognition task
+                        // on the live engine so dictation stays continuous. Bound consecutive empty
+                        // finals so silence can't spin forever.
+                        val committed = buffer.commit(stateHandle.state.inputText, transcript)
+                        if (committed != stateHandle.state.inputText) {
+                            stateHandle.update { copy(inputText = committed) }
+                        }
+                        if (transcript.isBlank() && ++consecutiveEmptyFinals >= MAX_EMPTY_SEGMENTS) {
+                            log.d { "empty-final cap reached; ending session" }
+                            finalizeSession(autoSend = false)
+                        } else {
+                            if (transcript.isNotBlank()) consecutiveEmptyFinals = 0
+                            restartRecognition(useOnDevice = shouldUseOnDevice())
+                        }
+                        return@launch
+                    }
+                    // Live partials (~10×/s, often unchanged during a pause) and the user-stop final:
+                    // merge and only re-emit the ~86-field state when the text changed.
+                    val merged = buffer.merge(stateHandle.state.inputText, transcript)
+                    if (merged != stateHandle.state.inputText) {
+                        stateHandle.update { copy(inputText = merged) }
+                        // In end-of-speech mode, (re)start the silence debounce on each new word so a
+                        // pause after speech ends the session even without a recognizer final.
+                        if (sttEndOfSpeech.value && buffer.producedText) armSilenceTimer()
+                    }
+                    if (result.isFinal()) {
+                        log.d { "Final result after user stop, finalizing" }
+                        finalizeSession(autoSend = true)
+                    }
+                }
+                if (recognitionError != null && !finished) {
+                    val wasStop = stopRequested
+                    if (!wasStop && requestedOnDevice) {
+                        // On-device recognition failed at runtime (e.g. the language model isn't
+                        // installed for this locale). Retry on Apple's cloud recognizer before
+                        // surfacing an error — mirrors the Android controller's network fallback. The
+                        // latch keeps subsequent continuous restarts on the cloud too.
+                        triedCloudFallback = true
+                        log.w { "on-device recognition failed; retrying on cloud: ${recognitionError.localizedDescription}" }
+                        restartRecognition(useOnDevice = false)
+                        return@launch
+                    }
+                    log.e { "Recognition error: ${recognitionError.localizedDescription}" }
+                    // Route through the single teardown path so the watchdog/cleanup/state logic can't
+                    // drift. A cancelled/expected error after a user stop+endAudio isn't worth surfacing
+                    // (and still auto-sends what was captured); a mid-session error surfaces.
+                    finalizeSession(
+                        autoSend = wasStop,
+                        errorMessage = if (wasStop) {
+                            null
+                        } else {
+                            "Speech recognition error: ${recognitionError.localizedDescription}"
+                        },
+                    )
+                }
+            }
+        }
+    }
+
+    /**
+     * Continuous-restart / cloud-fallback: cancel just the current recognition task+request and start
+     * a new one on the still-running audio engine (the tap keeps feeding [recognitionRequest]). The
+     * cancelled task may still deliver a queued callback, but its token no longer matches so it's
+     * ignored (see [sessionToken]).
+     */
+    private fun restartRecognition(useOnDevice: Boolean) {
+        // Cancel any end-of-speech silence timer armed against the OLD task: it would otherwise keep
+        // counting down across the restart/cloud-fallback and finalize (and auto-send) the session
+        // mid-utterance before the new task's first partial re-arms it.
+        silenceJob?.cancel()
+        silenceJob = null
+        recognitionTask?.cancel()
+        recognitionTask = null
+        recognitionRequest = null
+        startRecognitionTask(useOnDevice)
+    }
+
+    override fun stopRecording() {
+        if (!stateHandle.state.isRecording || stopRequested) return
+        stopRequested = true
+        // A user stop supersedes the end-of-speech silence debounce.
+        silenceJob?.cancel()
+        silenceJob = null
+        // Flush buffered audio so words spoken just before the tap make the final transcript, then
+        // stop feeding the recognizer but KEEP the task alive so its isFinal callback commits the
+        // complete text and fires auto-send. A watchdog force-finalizes (committing the last partial
+        // already shown in the composer) if no final arrives.
         recognitionRequest?.endAudio()
+        stopAudioEngine()
+        stateHandle.update { copy(isRecording = false, isTranscribing = true) }
+        // The cloud recognizer's final lags well past the on-device timeout; wait longer for it before
+        // force-finalizing so we don't commit/auto-send the rougher last partial instead of the final.
+        val watchdogMs = if (requestedOnDevice) STOP_WATCHDOG_MS else CLOUD_STOP_WATCHDOG_MS
+        stopWatchdogJob = stateHandle.scope.launch {
+            delay(watchdogMs)
+            finalizeSession(autoSend = true)
+        }
+    }
+
+    /** Terminal failure while starting a session: tear down and surface [message]. */
+    private fun failStart(message: String) {
+        finalizeSession(autoSend = false, errorMessage = message)
+    }
+
+    /**
+     * Tear down once and (optionally) fire auto-send. Idempotent via [finished]. [errorMessage], when
+     * non-null, replaces the composer error; null preserves whatever's there. Only invoked from the
+     * Main-dispatched scope (recognition callback / watchdog / stop / cancel / release / failStart).
+     */
+    private fun finalizeSession(autoSend: Boolean, errorMessage: String? = null) {
+        if (finished) return
+        finished = true
+        stopWatchdogJob?.cancel()
+        stopWatchdogJob = null
+        silenceJob?.cancel()
+        silenceJob = null
         cleanupAudio()
-        stateHandle.update { copy(isRecording = false) }
+        stateHandle.update {
+            copy(isRecording = false, isTranscribing = false, error = errorMessage ?: error)
+        }
+        if (autoSend) maybeAutoSend()
+    }
+
+    /**
+     * Fire auto-send-after-STT. Reachable only from [finalizeSession] (guarded by [finished]) on the
+     * Main thread, so it runs at most once per session without a separate latch.
+     */
+    private fun maybeAutoSend() {
+        if (buffer.shouldAutoSend(
+                stateHandle.state.inputText,
+                autoSendAfterStt.value,
+                stateHandle.state.isStreaming,
+            )
+        ) {
+            onTranscriptionComplete()
+        }
     }
 
     override fun cancelRecording() {
-        recognitionTask?.cancel()
+        finished = true
+        // Also drop a pending permission prompt so its grant callback can't start a session after
+        // this cancel (the callback re-checks finished, but clearing the latch keeps startRecording
+        // usable again immediately once permission is resolved).
+        authorizationInFlight = false
+        stopWatchdogJob?.cancel()
+        stopWatchdogJob = null
+        silenceJob?.cancel()
+        silenceJob = null
         cleanupAudio()
-        stateHandle.update { copy(isRecording = false, inputText = "") }
+        // Drop the dictated suffix and restore the pre-dictation text — but only if the user hasn't
+        // edited the field since our last write; if they have, keep their edit (see DictationBuffer).
+        stateHandle.update {
+            copy(isRecording = false, isTranscribing = false, inputText = buffer.revert(inputText))
+        }
     }
 
     override fun onDeviceSpeechResult(transcribedText: String) {
         if (transcribedText.isBlank()) return
-        val currentInput = stateHandle.state.inputText
-        val separator = if (currentInput.isNotBlank() && !currentInput.endsWith(" ")) " " else ""
-        stateHandle.update {
-            copy(inputText = currentInput + separator + transcribedText)
-        }
+        val merged = appendToBase(stateHandle.state.inputText, transcribedText)
+        stateHandle.update { copy(inputText = merged) }
     }
 
     override fun loadSpeechConfig() {
@@ -181,18 +496,34 @@ class IosVoiceInput(
     }
 
     override fun release() {
-        recognitionTask?.cancel()
+        finished = true
+        authorizationInFlight = false
+        stopWatchdogJob?.cancel()
+        stopWatchdogJob = null
+        silenceJob?.cancel()
+        silenceJob = null
         cleanupAudio()
     }
 
+    /** Stop feeding audio to the recognizer without releasing the task/request (keeps a pending final alive). */
     @OptIn(ExperimentalForeignApi::class)
-    private fun cleanupAudio() {
+    private fun stopAudioEngine() {
         audioEngine?.let { engine ->
             if (engine.isRunning()) {
                 engine.stop()
                 engine.inputNode.removeTapOnBus(0u)
             }
         }
+    }
+
+    @OptIn(ExperimentalForeignApi::class)
+    private fun cleanupAudio() {
+        // Cancel before nulling so an abandoned task can't keep delivering callbacks. Harmless on the
+        // natural teardown paths where the task is already complete. This is the SINGLE full-teardown
+        // cancel site — finalize/cancel/release all funnel here, so no teardown path can forget it.
+        // (Continuous restart uses restartRecognition, which cancels only the task, not the engine.)
+        recognitionTask?.cancel()
+        stopAudioEngine()
         audioEngine = null
         recognitionRequest = null
         recognitionTask = null
@@ -208,5 +539,64 @@ class IosVoiceInput(
         } catch (_: Exception) {
             // Best effort
         }
+    }
+
+    /**
+     * (Re)start the end-of-speech silence debounce. Called on each new transcript word in
+     * end-of-speech mode; if [END_OF_SPEECH_SILENCE_MS] elapses with no further speech, finalize the
+     * session (auto-send fires when enabled). Runs on the Main-dispatched scope like every other guard.
+     */
+    private fun armSilenceTimer() {
+        silenceJob?.cancel()
+        silenceJob = stateHandle.scope.launch {
+            delay(END_OF_SPEECH_SILENCE_MS)
+            if (!finished) {
+                log.d { "end-of-speech silence elapsed; finalizing" }
+                finalizeSession(autoSend = true)
+            }
+        }
+    }
+
+    /**
+     * Resolve [tag] (a requested BCP-47 tag, or a device `localeIdentifier`) to the SFSpeechRecognizer
+     * supported locale that best matches, or null when none does. Tolerant of case, `_`-vs-`-`,
+     * `@keyword` extensions, and script subtags: tries an exact normalized match, then language+region
+     * dropping any script (so a device `zh-Hans-CN` resolves to the supported `zh-CN`), then
+     * language-only (so `zh-Hans` resolves to the first supported `zh-…`). Returns the supported
+     * NSLocale itself, so the failable `SFSpeechRecognizer(locale:)` is only ever handed a locale it
+     * accepts — a verbatim string compare would false-negative on script/region-rich device locales
+     * and wrongly abort dictation that the framework actually supports.
+     */
+    private fun bestSupportedLocale(tag: String): NSLocale? {
+        val supported = SFSpeechRecognizer.supportedLocales().mapNotNull { it as? NSLocale }
+        val target = normalizeLocaleTag(tag)
+        supported.firstOrNull { normalizeLocaleTag(it.localeIdentifier) == target }?.let { return it }
+
+        val targetLang = languageSubtag(target)
+        val targetRegion = regionSubtag(target)
+        if (targetRegion != null) {
+            supported.firstOrNull {
+                val n = normalizeLocaleTag(it.localeIdentifier)
+                languageSubtag(n) == targetLang && regionSubtag(n) == targetRegion
+            }?.let { return it }
+        }
+        return supported.firstOrNull { languageSubtag(normalizeLocaleTag(it.localeIdentifier)) == targetLang }
+    }
+
+    /** Normalize a locale tag: drop any `@keyword` extension, unify separators, lowercase. */
+    private fun normalizeLocaleTag(tag: String): String =
+        tag.substringBefore('@').replace('_', '-').lowercase()
+
+    /** Language subtag of a normalized tag ("zh-hans-cn" → "zh"). */
+    private fun languageSubtag(normalized: String): String = normalized.substringBefore('-')
+
+    /** Region subtag of a normalized tag: the 2-alpha or 3-digit subtag ("zh-hans-cn" → "cn"), else null. */
+    private fun regionSubtag(normalized: String): String? =
+        normalized.split('-').drop(1).lastOrNull { it.length == 2 || (it.length == 3 && it.all(Char::isDigit)) }
+
+    private companion object {
+        // End-of-speech silence debounce: how long after the last recognized word to treat dictation
+        // as finished. Long enough to ride out natural mid-sentence pauses, short enough for hands-free.
+        const val END_OF_SPEECH_SILENCE_MS = 1800L
     }
 }

--- a/feature/settings/src/androidMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/delegate/SpeechSettingsDelegate.kt
+++ b/feature/settings/src/androidMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/delegate/SpeechSettingsDelegate.kt
@@ -7,6 +7,7 @@ import android.speech.tts.UtteranceProgressListener
 import co.touchlab.kermit.Logger
 import com.garfiec.librechat.core.common.result.Result
 import com.garfiec.librechat.core.data.datastore.SettingsDataStore
+import com.garfiec.librechat.core.data.repository.ServerSttGate
 import com.garfiec.librechat.core.data.repository.SpeechRepository
 import com.garfiec.librechat.core.model.speech.TtsVoice
 import com.garfiec.librechat.feature.settings.screen.DeviceVoiceInfo
@@ -30,6 +31,11 @@ class SpeechSettingsDelegate(
 
     private var currentMediaPlayer: MediaPlayer? = null
     private var deviceTtsEngine: TextToSpeech? = null
+
+    // Loads + latches the server-STT flag with the shared "unknown vs disabled" retry policy. Until
+    // it has resolved once (gate.loaded), serverSttEnabled=false is "unknown", not "disabled" — so
+    // opening the STT dialog retries rather than permanently hiding the External engine.
+    private val serverSttGate = ServerSttGate(speechRepository)
 
     override fun loadVoices() {
         stateHandle.scope.launch {
@@ -69,6 +75,15 @@ class SpeechSettingsDelegate(
                 tts
             }
             deviceTtsEngine = engine
+        }
+    }
+
+    override fun loadSpeechConfig() {
+        stateHandle.scope.launch {
+            // A null result means a transient failure — leave the gate unlatched so opening the STT
+            // dialog retries rather than trusting it as a definitive "server STT disabled".
+            val enabled = serverSttGate.refresh() ?: false
+            stateHandle.update { copy(serverSttEnabled = enabled) }
         }
     }
 
@@ -171,6 +186,9 @@ class SpeechSettingsDelegate(
     // STT detail dialogs
 
     override fun showSttDetailDialog() {
+        // Retry the speech-config fetch if it hasn't succeeded yet, so a transient error at settings
+        // launch doesn't permanently hide the External engine for the whole session.
+        if (!serverSttGate.loaded) loadSpeechConfig()
         stateHandle.update { copy(showSttDetailDialog = true) }
     }
 
@@ -178,13 +196,21 @@ class SpeechSettingsDelegate(
         stateHandle.update { copy(showSttDetailDialog = false) }
     }
 
-    override fun saveSttSettings(engine: String, language: String) {
+    override fun saveSttSettings(engine: String, language: String, onDevice: Boolean, endOfSpeech: Boolean) {
         stateHandle.update {
-            copy(sttEngine = engine, sttLanguage = language, showSttDetailDialog = false)
+            copy(
+                sttEngine = engine,
+                sttLanguage = language,
+                sttOnDevice = onDevice,
+                sttEndOfSpeech = endOfSpeech,
+                showSttDetailDialog = false,
+            )
         }
         stateHandle.scope.launch {
             settingsDataStore.setSttEngine(engine)
             settingsDataStore.setSttLanguage(language)
+            settingsDataStore.setSttOnDevice(onDevice)
+            settingsDataStore.setSttEndOfSpeech(endOfSpeech)
         }
     }
 

--- a/feature/settings/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/settings/viewmodel/SettingsViewModelTest.kt
+++ b/feature/settings/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/settings/viewmodel/SettingsViewModelTest.kt
@@ -23,6 +23,7 @@ import com.garfiec.librechat.core.data.repository.UserRepository
 import com.garfiec.librechat.core.data.util.PermissionGate
 import com.garfiec.librechat.core.logging.DiagnosticLogRepository
 import com.garfiec.librechat.core.model.User
+import com.garfiec.librechat.core.model.speech.SpeechConfig
 import com.garfiec.librechat.feature.settings.util.ContentReader
 import com.garfiec.librechat.feature.settings.util.PlatformCacheCleaner
 import com.garfiec.librechat.feature.settings.viewmodel.delegate.SpeechSettingsContract
@@ -107,6 +108,8 @@ class SettingsViewModelTest {
         every { settingsDataStore.autoSendAfterStt } returns MutableStateFlow(false)
         every { settingsDataStore.sttEngine } returns MutableStateFlow("")
         every { settingsDataStore.sttLanguage } returns MutableStateFlow("")
+        every { settingsDataStore.sttOnDevice } returns MutableStateFlow(true)
+        every { settingsDataStore.sttEndOfSpeech } returns MutableStateFlow(false)
         every { settingsDataStore.chatLayoutStyle } returns MutableStateFlow(ChatLayoutConstants.THREAD)
         every { settingsDataStore.showAvatars } returns MutableStateFlow(true)
         every { settingsDataStore.showBubbles } returns MutableStateFlow(false)
@@ -120,6 +123,7 @@ class SettingsViewModelTest {
         coEvery { mcpRepository.getConnectionStatus() } returns Result.Success(emptyMap())
         coEvery { memoryRepository.getMemories() } returns Result.Success(emptyList())
         coEvery { speechRepository.getVoices() } returns Result.Success(emptyList())
+        coEvery { speechRepository.getSpeechConfig() } returns Result.Success(SpeechConfig())
         coEvery { balanceRepository.getBalance() } returns Result.Error(message = "Not available")
 
         // Permissive-null defaults so existing tests continue to exercise the

--- a/feature/settings/src/commonMain/composeResources/values-ar/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-ar/strings.xml
@@ -291,12 +291,15 @@
     <!-- STT detail dialog -->
     <string name="stt_engine_label">المحرك</string>
     <string name="stt_language_label">اللغة</string>
-    <string name="stt_on_device">على الجهاز</string>
     <string name="stt_default">افتراضي</string>
-    <string name="stt_hint_whisper">يستخدم Whisper النسخ على جانب الخادم. يجب أن يكون تحويل الكلام إلى نص مُفعّلًا في خادمك.</string>
-    <string name="stt_hint_device">يستخدم مُتعرّف الكلام المدمج في جهازك. يعمل دون اتصال على الأجهزة المدعومة.</string>
-    <string name="stt_hint_google">يستخدم مُتعرّف الكلام من Google. يتطلب تثبيت تطبيق Google.</string>
-    <string name="stt_hint_default">يستخدم النسخ على الخادم (Whisper) عند توفّره، وإلا يعود إلى التعرّف على الجهاز.</string>
+    <string name="stt_engine_browser">مدمج</string>
+    <string name="stt_engine_external">الخادم</string>
+    <string name="stt_hint_browser">يستخدم أداة التعرف على الكلام المدمجة في جهازك للنسخ المباشر.</string>
+    <string name="stt_hint_external">يرفع الصوت إلى الخادم لتحويل الكلام إلى نص (Whisper). يجب تفعيل التعرف على الكلام على الخادم.</string>
+    <string name="stt_on_device_toggle">التعرف على الجهاز</string>
+    <string name="stt_on_device_toggle_desc">النسخ على هذا الجهاز بدلاً من السحابة. يعود إلى أداة التعرف السحابية إذا لم تكن متوفرة.</string>
+    <string name="stt_end_of_speech_toggle">التوقف عند التوقف مؤقتًا</string>
+    <string name="stt_end_of_speech_toggle_desc">ينهي الإملاء تلقائيًا بمجرد توقفك عن الكلام، بدلاً من الاستمرار حتى تنقر على إيقاف. مع تفعيل الإرسال التلقائي بعد الكلام، يتم إرسال الرسالة دون استخدام اليدين.</string>
     <string name="stt_auto_detect">كشف تلقائي</string>
 
     <!-- TTS detail dialog -->

--- a/feature/settings/src/commonMain/composeResources/values-de/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-de/strings.xml
@@ -291,12 +291,15 @@
     <!-- STT detail dialog -->
     <string name="stt_engine_label">Engine</string>
     <string name="stt_language_label">Sprache</string>
-    <string name="stt_on_device">Auf dem Gerät</string>
     <string name="stt_default">Standard</string>
-    <string name="stt_hint_whisper">Whisper verwendet serverseitige Transkription. Auf deinem Server muss STT aktiviert sein.</string>
-    <string name="stt_hint_device">Verwendet die integrierte Spracherkennung deines Geräts. Funktioniert offline auf unterstützten Geräten.</string>
-    <string name="stt_hint_google">Verwendet die Spracherkennung von Google. Erfordert die installierte Google-App.</string>
-    <string name="stt_hint_default">Verwendet die Server-Transkription (Whisper), sofern verfügbar, andernfalls die Erkennung auf dem Gerät.</string>
+    <string name="stt_engine_browser">Integriert</string>
+    <string name="stt_engine_external">Server</string>
+    <string name="stt_hint_browser">Verwendet die integrierte Spracherkennung deines Geräts für die Live-Transkription.</string>
+    <string name="stt_hint_external">Lädt Audio zur Sprache-zu-Text-Umwandlung (Whisper) auf deinen Server hoch. Auf dem Server muss STT aktiviert sein.</string>
+    <string name="stt_on_device_toggle">Erkennung auf dem Gerät</string>
+    <string name="stt_on_device_toggle_desc">Transkribiert auf diesem Gerät statt in der Cloud. Fällt auf die Cloud-Erkennung zurück, falls nicht verfügbar.</string>
+    <string name="stt_end_of_speech_toggle">Anhalten, wenn ich pausiere</string>
+    <string name="stt_end_of_speech_toggle_desc">Beendet das Diktat automatisch, sobald du aufhörst zu sprechen, statt bis zum Tippen auf Stopp weiterzulaufen. Mit aktiviertem automatischem Senden nach der Sprache wird die Nachricht freihändig gesendet.</string>
     <string name="stt_auto_detect">Automatisch erkennen</string>
 
     <!-- TTS detail dialog -->

--- a/feature/settings/src/commonMain/composeResources/values-es/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-es/strings.xml
@@ -291,12 +291,15 @@
     <!-- STT detail dialog -->
     <string name="stt_engine_label">Motor</string>
     <string name="stt_language_label">Idioma</string>
-    <string name="stt_on_device">En el dispositivo</string>
     <string name="stt_default">Predeterminado</string>
-    <string name="stt_hint_whisper">Whisper usa transcripción del lado del servidor. Tu servidor debe tener el STT activado.</string>
-    <string name="stt_hint_device">Usa el reconocedor de voz integrado de tu dispositivo. Funciona sin conexión en los dispositivos compatibles.</string>
-    <string name="stt_hint_google">Usa el reconocedor de voz de Google. Requiere que la app de Google esté instalada.</string>
-    <string name="stt_hint_default">Usa la transcripción del servidor (Whisper) cuando esté disponible; de lo contrario, recurre al reconocimiento en el dispositivo.</string>
+    <string name="stt_engine_browser">Integrado</string>
+    <string name="stt_engine_external">Servidor</string>
+    <string name="stt_hint_browser">Usa el reconocimiento de voz integrado de tu dispositivo para la transcripción en vivo.</string>
+    <string name="stt_hint_external">Sube el audio a tu servidor para la conversión de voz a texto (Whisper). Tu servidor debe tener STT habilitado.</string>
+    <string name="stt_on_device_toggle">Reconocimiento en el dispositivo</string>
+    <string name="stt_on_device_toggle_desc">Transcribe en este dispositivo en lugar de en la nube. Recurre al reconocimiento en la nube si no está disponible.</string>
+    <string name="stt_end_of_speech_toggle">Detener cuando haga una pausa</string>
+    <string name="stt_end_of_speech_toggle_desc">Finaliza el dictado automáticamente cuando dejas de hablar, en lugar de seguir hasta que tocas detener. Con el envío automático tras el habla activado, envía el mensaje con manos libres.</string>
     <string name="stt_auto_detect">Detección automática</string>
 
     <!-- TTS detail dialog -->

--- a/feature/settings/src/commonMain/composeResources/values-fr/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-fr/strings.xml
@@ -291,12 +291,15 @@
     <!-- STT detail dialog -->
     <string name="stt_engine_label">Moteur</string>
     <string name="stt_language_label">Langue</string>
-    <string name="stt_on_device">Sur l\'appareil</string>
     <string name="stt_default">Par défaut</string>
-    <string name="stt_hint_whisper">Whisper utilise la transcription côté serveur. La reconnaissance vocale doit être activée sur votre serveur.</string>
-    <string name="stt_hint_device">Utilise le système de reconnaissance vocale intégré de votre appareil. Fonctionne hors ligne sur les appareils pris en charge.</string>
-    <string name="stt_hint_google">Utilise le système de reconnaissance vocale de Google. Nécessite l\'installation de l\'application Google.</string>
-    <string name="stt_hint_default">Utilise la transcription du serveur (Whisper) lorsqu\'elle est disponible, sinon revient à la reconnaissance sur l\'appareil.</string>
+    <string name="stt_engine_browser">Intégré</string>
+    <string name="stt_engine_external">Serveur</string>
+    <string name="stt_hint_browser">Utilise le moteur de reconnaissance vocale intégré de votre appareil pour la transcription en direct.</string>
+    <string name="stt_hint_external">Envoie l\'audio à votre serveur pour la reconnaissance vocale (Whisper). La reconnaissance vocale doit être activée sur votre serveur.</string>
+    <string name="stt_on_device_toggle">Reconnaissance sur l\'appareil</string>
+    <string name="stt_on_device_toggle_desc">Transcrit sur cet appareil plutôt que dans le cloud. Bascule sur la reconnaissance cloud si indisponible.</string>
+    <string name="stt_end_of_speech_toggle">Arrêter quand je fais une pause</string>
+    <string name="stt_end_of_speech_toggle_desc">Termine la dictée automatiquement dès que vous arrêtez de parler, au lieu de continuer jusqu\'à ce que vous touchiez arrêter. Avec l\'envoi automatique après la parole activé, le message est envoyé en mode mains libres.</string>
     <string name="stt_auto_detect">Détection automatique</string>
 
     <!-- TTS detail dialog -->

--- a/feature/settings/src/commonMain/composeResources/values-ja/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-ja/strings.xml
@@ -291,12 +291,15 @@
     <!-- STT detail dialog -->
     <string name="stt_engine_label">エンジン</string>
     <string name="stt_language_label">言語</string>
-    <string name="stt_on_device">オンデバイス</string>
     <string name="stt_default">デフォルト</string>
-    <string name="stt_hint_whisper">Whisperはサーバー側の文字起こしを使用します。サーバーでSTTを有効にする必要があります。</string>
-    <string name="stt_hint_device">デバイス内蔵の音声認識を使用します。対応デバイスではオフラインで動作します。</string>
-    <string name="stt_hint_google">Googleの音声認識を使用します。Googleアプリがインストールされている必要があります。</string>
-    <string name="stt_hint_default">利用可能な場合はサーバーの文字起こし（Whisper）を使用し、そうでない場合はオンデバイス認識にフォールバックします。</string>
+    <string name="stt_engine_browser">内蔵</string>
+    <string name="stt_engine_external">サーバー</string>
+    <string name="stt_hint_browser">デバイス内蔵の音声認識を使用してリアルタイムで文字起こしします。</string>
+    <string name="stt_hint_external">音声をサーバーにアップロードして音声認識（Whisper）を行います。サーバーでSTTを有効にする必要があります。</string>
+    <string name="stt_on_device_toggle">デバイス上で認識</string>
+    <string name="stt_on_device_toggle_desc">クラウドではなくこのデバイスで文字起こしします。利用できない場合はクラウド認識に切り替わります。</string>
+    <string name="stt_end_of_speech_toggle">一時停止したら停止</string>
+    <string name="stt_end_of_speech_toggle_desc">停止をタップするまで続ける代わりに、話し終えると自動的に口述を終了します。音声後の自動送信をオンにすると、ハンズフリーでメッセージを送信します。</string>
     <string name="stt_auto_detect">自動検出</string>
 
     <!-- TTS detail dialog -->

--- a/feature/settings/src/commonMain/composeResources/values-ko/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-ko/strings.xml
@@ -291,12 +291,15 @@
     <!-- STT detail dialog -->
     <string name="stt_engine_label">엔진</string>
     <string name="stt_language_label">언어</string>
-    <string name="stt_on_device">기기 내</string>
     <string name="stt_default">기본값</string>
-    <string name="stt_hint_whisper">Whisper는 서버 측 전사를 사용합니다. 서버에 STT가 사용 설정되어 있어야 합니다.</string>
-    <string name="stt_hint_device">기기에 내장된 음성 인식기를 사용합니다. 지원되는 기기에서는 오프라인으로 작동합니다.</string>
-    <string name="stt_hint_google">Google 음성 인식기를 사용합니다. Google 앱이 설치되어 있어야 합니다.</string>
-    <string name="stt_hint_default">가능한 경우 서버 전사(Whisper)를 사용하고, 그렇지 않으면 기기 내 인식으로 대체합니다.</string>
+    <string name="stt_engine_browser">내장</string>
+    <string name="stt_engine_external">서버</string>
+    <string name="stt_hint_browser">기기에 내장된 음성 인식을 사용하여 실시간으로 받아씁니다.</string>
+    <string name="stt_hint_external">오디오를 서버에 업로드하여 음성을 텍스트로 변환합니다(Whisper). 서버에서 STT가 활성화되어 있어야 합니다.</string>
+    <string name="stt_on_device_toggle">기기에서 인식</string>
+    <string name="stt_on_device_toggle_desc">클라우드 대신 이 기기에서 받아씁니다. 사용할 수 없으면 클라우드 인식으로 전환됩니다.</string>
+    <string name="stt_end_of_speech_toggle">멈추면 중지</string>
+    <string name="stt_end_of_speech_toggle_desc">중지를 누를 때까지 계속하는 대신, 말을 멈추면 자동으로 받아쓰기를 종료합니다. 음성 후 자동 전송이 켜져 있으면 핸즈프리로 메시지를 보냅니다.</string>
     <string name="stt_auto_detect">자동 감지</string>
 
     <!-- TTS detail dialog -->

--- a/feature/settings/src/commonMain/composeResources/values-pt/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-pt/strings.xml
@@ -291,12 +291,15 @@
     <!-- STT detail dialog -->
     <string name="stt_engine_label">Mecanismo</string>
     <string name="stt_language_label">Idioma</string>
-    <string name="stt_on_device">No dispositivo</string>
     <string name="stt_default">Padrão</string>
-    <string name="stt_hint_whisper">O Whisper usa transcrição no lado do servidor. Seu servidor precisa ter o STT ativado.</string>
-    <string name="stt_hint_device">Usa o reconhecedor de fala integrado do seu dispositivo. Funciona offline em dispositivos compatíveis.</string>
-    <string name="stt_hint_google">Usa o reconhecedor de fala do Google. Requer que o app do Google esteja instalado.</string>
-    <string name="stt_hint_default">Usa a transcrição do servidor (Whisper) quando disponível; caso contrário, recorre ao reconhecimento no dispositivo.</string>
+    <string name="stt_engine_browser">Integrado</string>
+    <string name="stt_engine_external">Servidor</string>
+    <string name="stt_hint_browser">Usa o reconhecimento de voz integrado do seu dispositivo para transcrição ao vivo.</string>
+    <string name="stt_hint_external">Envia o áudio para o seu servidor para conversão de voz em texto (Whisper). O seu servidor precisa ter o STT ativado.</string>
+    <string name="stt_on_device_toggle">Reconhecimento no dispositivo</string>
+    <string name="stt_on_device_toggle_desc">Transcreve neste dispositivo em vez de na nuvem. Recorre ao reconhecimento na nuvem se não estiver disponível.</string>
+    <string name="stt_end_of_speech_toggle">Parar quando eu pausar</string>
+    <string name="stt_end_of_speech_toggle_desc">Encerra o ditado automaticamente quando você para de falar, em vez de continuar até você tocar em parar. Com o envio automático após a fala ativado, envia a mensagem com as mãos livres.</string>
     <string name="stt_auto_detect">Detecção automática</string>
 
     <!-- TTS detail dialog -->

--- a/feature/settings/src/commonMain/composeResources/values-ru/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-ru/strings.xml
@@ -291,12 +291,15 @@
     <!-- STT detail dialog -->
     <string name="stt_engine_label">Движок</string>
     <string name="stt_language_label">Язык</string>
-    <string name="stt_on_device">На устройстве</string>
     <string name="stt_default">По умолчанию</string>
-    <string name="stt_hint_whisper">Whisper использует транскрипцию на стороне сервера. На вашем сервере должно быть включено распознавание речи (STT).</string>
-    <string name="stt_hint_device">Использует встроенный распознаватель речи вашего устройства. Работает офлайн на поддерживаемых устройствах.</string>
-    <string name="stt_hint_google">Использует распознаватель речи Google. Требуется установленное приложение Google.</string>
-    <string name="stt_hint_default">Использует серверную транскрипцию (Whisper), когда она доступна, иначе переключается на распознавание на устройстве.</string>
+    <string name="stt_engine_browser">Встроенный</string>
+    <string name="stt_engine_external">Сервер</string>
+    <string name="stt_hint_browser">Использует встроенное распознавание речи вашего устройства для транскрипции в реальном времени.</string>
+    <string name="stt_hint_external">Загружает аудио на ваш сервер для преобразования речи в текст (Whisper). На сервере должно быть включено распознавание речи.</string>
+    <string name="stt_on_device_toggle">Распознавание на устройстве</string>
+    <string name="stt_on_device_toggle_desc">Транскрибирует на этом устройстве, а не в облаке. При недоступности переключается на облачное распознавание.</string>
+    <string name="stt_end_of_speech_toggle">Останавливать при паузе</string>
+    <string name="stt_end_of_speech_toggle_desc">Автоматически завершает диктовку, когда вы перестаёте говорить, вместо того чтобы продолжать до нажатия «Стоп». При включённой автоотправке после речи сообщение отправляется без помощи рук.</string>
     <string name="stt_auto_detect">Автоопределение</string>
 
     <!-- TTS detail dialog -->

--- a/feature/settings/src/commonMain/composeResources/values-zh/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-zh/strings.xml
@@ -291,12 +291,15 @@
     <!-- STT detail dialog -->
     <string name="stt_engine_label">引擎</string>
     <string name="stt_language_label">语言</string>
-    <string name="stt_on_device">设备端</string>
     <string name="stt_default">默认</string>
-    <string name="stt_hint_whisper">Whisper 使用服务器端转录。你的服务器必须已启用 STT。</string>
-    <string name="stt_hint_device">使用设备内置的语音识别器。在受支持的设备上可离线使用。</string>
-    <string name="stt_hint_google">使用 Google 的语音识别器。需要安装 Google 应用。</string>
-    <string name="stt_hint_default">在可用时使用服务器转录（Whisper），否则回退到设备端识别。</string>
+    <string name="stt_engine_browser">内置</string>
+    <string name="stt_engine_external">服务器</string>
+    <string name="stt_hint_browser">使用设备内置的语音识别进行实时转写。</string>
+    <string name="stt_hint_external">将音频上传到您的服务器进行语音转文字（Whisper）。您的服务器必须已启用 STT。</string>
+    <string name="stt_on_device_toggle">在设备上识别</string>
+    <string name="stt_on_device_toggle_desc">在本设备而非云端进行转写。不可用时回退到云端识别。</string>
+    <string name="stt_end_of_speech_toggle">停顿时停止</string>
+    <string name="stt_end_of_speech_toggle_desc">在你停止说话后自动结束听写，而不是持续到你点击停止。开启语音后自动发送时，将免提发送消息。</string>
     <string name="stt_auto_detect">自动检测</string>
 
     <!-- TTS detail dialog -->

--- a/feature/settings/src/commonMain/composeResources/values/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values/strings.xml
@@ -314,12 +314,15 @@
     <!-- STT detail dialog -->
     <string name="stt_engine_label">Engine</string>
     <string name="stt_language_label">Language</string>
-    <string name="stt_on_device">On Device</string>
     <string name="stt_default">Default</string>
-    <string name="stt_hint_whisper">Whisper uses server-side transcription. Your server must have STT enabled.</string>
-    <string name="stt_hint_device">Uses your device\'s built-in speech recognizer. Works offline on supported devices.</string>
-    <string name="stt_hint_google">Uses Google\'s speech recognizer. Requires the Google app to be installed.</string>
-    <string name="stt_hint_default">Uses server transcription (Whisper) when available, otherwise falls back to on-device recognition.</string>
+    <string name="stt_engine_browser">Built-in</string>
+    <string name="stt_engine_external">Server</string>
+    <string name="stt_hint_browser">Uses your device\'s built-in speech recognizer for live transcription.</string>
+    <string name="stt_hint_external">Uploads audio to your server for speech-to-text (Whisper). Your server must have STT enabled.</string>
+    <string name="stt_on_device_toggle">On-device recognition</string>
+    <string name="stt_on_device_toggle_desc">Transcribe on this device instead of the cloud. Falls back to the cloud recognizer if unavailable.</string>
+    <string name="stt_end_of_speech_toggle">Stop when I pause</string>
+    <string name="stt_end_of_speech_toggle_desc">End dictation automatically once you stop speaking, instead of running until you tap stop. With Auto-send after speech on, this sends the message hands-free.</string>
     <string name="stt_auto_detect">Auto-detect</string>
 
     <!-- TTS detail dialog -->

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/ChatSettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/ChatSettingsScreen.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.garfiec.librechat.core.common.ChatLayoutConstants
+import com.garfiec.librechat.core.common.speech.sttLanguageOptions
 import com.garfiec.librechat.core.data.datastore.ArtifactDisplayMode
 import com.garfiec.librechat.core.data.datastore.ChatFontSize
 import com.garfiec.librechat.core.data.datastore.ContextBarPlacement
@@ -345,8 +346,10 @@ fun ChatSettingsContent(
             SttDetailDialog(
                 selectedEngine = uiState.sttEngine,
                 selectedLanguage = uiState.sttLanguage,
-                availableEngines = listOf("Default", "Whisper", "Google"),
-                availableLanguages = listOf("Auto-detect", "English", "Spanish", "French", "German", "Japanese", "Chinese"),
+                selectedOnDevice = uiState.sttOnDevice,
+                selectedEndOfSpeech = uiState.sttEndOfSpeech,
+                serverSttEnabled = uiState.serverSttEnabled,
+                availableLanguages = sttLanguageOptions,
                 onConfirm = viewModel::saveSttSettings,
                 onDismiss = viewModel::dismissSttDetailDialog,
             )

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/SpeechDetailDialogs.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/SpeechDetailDialogs.kt
@@ -16,7 +16,6 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.FilledTonalButton
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.MenuAnchorType
@@ -36,6 +35,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
+import com.garfiec.librechat.core.common.speech.sttEngineSelectsRecognizer
+import com.garfiec.librechat.core.common.speech.sttSupportsLiveRecognition
+import com.garfiec.librechat.core.model.speech.SttEngine
 import com.garfiec.librechat.feature.settings.resources.*
 import com.garfiec.librechat.feature.settings.resources.Res
 import org.jetbrains.compose.resources.stringResource
@@ -45,15 +47,28 @@ import org.jetbrains.compose.resources.stringResource
 internal fun SttDetailDialog(
     selectedEngine: String,
     selectedLanguage: String,
-    availableEngines: List<String>,
+    selectedOnDevice: Boolean,
+    selectedEndOfSpeech: Boolean,
+    serverSttEnabled: Boolean,
     availableLanguages: List<String>,
-    onConfirm: (engine: String, language: String) -> Unit,
+    onConfirm: (engine: String, language: String, onDevice: Boolean, endOfSpeech: Boolean) -> Unit,
     onDismiss: () -> Unit,
 ) {
-    var engine by remember { mutableStateOf(selectedEngine) }
+    var engine by remember { mutableStateOf(SttEngine.fromStored(selectedEngine)) }
     var language by remember { mutableStateOf(selectedLanguage) }
+    var onDevice by remember { mutableStateOf(selectedOnDevice) }
+    var endOfSpeech by remember { mutableStateOf(selectedEndOfSpeech) }
     var engineExpanded by remember { mutableStateOf(false) }
     var languageExpanded by remember { mutableStateOf(false) }
+
+    // Browser is always available. External is offered when the server has STT configured OR when
+    // it's already the selected engine — so a stored "external" that predates a failed/negative
+    // config fetch stays selectable and the dropdown never disagrees with the shown value (rather
+    // than showing "External" selected while listing only "Built-in").
+    val engineOptions = buildList {
+        add(SttEngine.BROWSER)
+        if (serverSttEnabled || engine == SttEngine.EXTERNAL) add(SttEngine.EXTERNAL)
+    }
 
     AlertDialog(
         onDismissRequest = onDismiss,
@@ -72,11 +87,7 @@ internal fun SttDetailDialog(
                     onExpandedChange = { engineExpanded = it },
                 ) {
                     OutlinedTextField(
-                        value = when {
-                            engine.equals("Device", ignoreCase = true) -> stringResource(Res.string.stt_on_device)
-                            engine.isBlank() -> stringResource(Res.string.stt_default)
-                            else -> engine
-                        },
+                        value = sttEngineLabel(engine),
                         onValueChange = {},
                         readOnly = true,
                         trailingIcon = {
@@ -90,21 +101,11 @@ internal fun SttDetailDialog(
                         expanded = engineExpanded,
                         onDismissRequest = { engineExpanded = false },
                     ) {
-                        // On-device option first, separated by a divider
-                        DropdownMenuItem(
-                            text = { Text(stringResource(Res.string.stt_on_device)) },
-                            onClick = {
-                                engine = "Device"
-                                engineExpanded = false
-                            },
-                        )
-                        HorizontalDivider()
-                        // Server-related options
-                        availableEngines.filter { !it.equals("Device", ignoreCase = true) }.forEach { item ->
+                        engineOptions.forEach { option ->
                             DropdownMenuItem(
-                                text = { Text(item) },
+                                text = { Text(sttEngineLabel(option)) },
                                 onClick = {
-                                    engine = item
+                                    engine = option
                                     engineExpanded = false
                                 },
                             )
@@ -113,30 +114,70 @@ internal fun SttDetailDialog(
                 }
 
                 // Engine-specific hint
-                if (engine.equals("Whisper", ignoreCase = true)) {
-                    Text(
-                        text = stringResource(Res.string.stt_hint_whisper),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                } else if (engine.equals("Device", ignoreCase = true)) {
-                    Text(
-                        text = stringResource(Res.string.stt_hint_device),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                } else if (engine.equals("Google", ignoreCase = true)) {
-                    Text(
-                        text = stringResource(Res.string.stt_hint_google),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                } else if (engine.equals("Default", ignoreCase = true) || engine.isBlank()) {
-                    Text(
-                        text = stringResource(Res.string.stt_hint_default),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
+                Text(
+                    text = when (engine) {
+                        SttEngine.BROWSER -> stringResource(Res.string.stt_hint_browser)
+                        SttEngine.EXTERNAL -> stringResource(Res.string.stt_hint_external)
+                    },
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+
+                // On-device + listening-mode toggles: shown only where the live recognizer actually
+                // honors them. That needs a platform that runs it (Android <31 uses the one-shot
+                // Intent overlay, which reads neither) AND — where the engine choice selects the
+                // transport (Android) — the Built-in engine, since External is a single-shot
+                // record→upload with no live recognizer. On iOS the engine doesn't select the
+                // transport (External falls through to SFSpeechRecognizer), so both prefs apply and
+                // the toggles show regardless of the selected engine.
+                val liveRecognizerHonorsPrefs = sttSupportsLiveRecognition() &&
+                    (engine == SttEngine.BROWSER || !sttEngineSelectsRecognizer())
+                if (liveRecognizerHonorsPrefs) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                text = stringResource(Res.string.stt_on_device_toggle),
+                                style = MaterialTheme.typography.bodyMedium,
+                            )
+                            Text(
+                                text = stringResource(Res.string.stt_on_device_toggle_desc),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Switch(
+                            checked = onDevice,
+                            onCheckedChange = { onDevice = it },
+                        )
+                    }
+
+                    // End-of-speech: stop automatically when the user pauses (hands-free). With
+                    // "Auto-send after STT" on, reaching end-of-speech also sends the message.
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                text = stringResource(Res.string.stt_end_of_speech_toggle),
+                                style = MaterialTheme.typography.bodyMedium,
+                            )
+                            Text(
+                                text = stringResource(Res.string.stt_end_of_speech_toggle_desc),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Switch(
+                            checked = endOfSpeech,
+                            onCheckedChange = { endOfSpeech = it },
+                        )
+                    }
                 }
 
                 // Language selector
@@ -177,7 +218,7 @@ internal fun SttDetailDialog(
             }
         },
         confirmButton = {
-            TextButton(onClick = { onConfirm(engine, language) }) {
+            TextButton(onClick = { onConfirm(engine.storedValue, language, onDevice, endOfSpeech) }) {
                 Text(stringResource(Res.string.action_save))
             }
         },
@@ -187,6 +228,13 @@ internal fun SttDetailDialog(
             }
         },
     )
+}
+
+/** Display label for an [SttEngine], resolved independently of which options are offered. */
+@Composable
+private fun sttEngineLabel(engine: SttEngine): String = when (engine) {
+    SttEngine.BROWSER -> stringResource(Res.string.stt_engine_browser)
+    SttEngine.EXTERNAL -> stringResource(Res.string.stt_engine_external)
 }
 
 data class DeviceVoiceInfo(

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/SettingsPreferencesController.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/SettingsPreferencesController.kt
@@ -58,6 +58,8 @@ private data class AdditionalPreferences(
     val sttEngine: String,
     val sttLanguage: String,
     val ttsCaching: Boolean,
+    val sttOnDevice: Boolean = true,
+    val sttEndOfSpeech: Boolean = false,
     val chatLayoutStyle: String = ChatLayoutConstants.THREAD,
     val showAvatars: Boolean = true,
     val showBubbles: Boolean = false,
@@ -206,6 +208,10 @@ class SettingsPreferencesController(
         additional.copy(chatHeaderAlignment = headerAlignment)
     }.combine(contextBarPlacementPref) { additional, contextBarPlacement ->
         additional.copy(contextBarPlacement = contextBarPlacement)
+    }.combine(settingsDataStore.sttOnDevice) { additional, sttOnDevice ->
+        additional.copy(sttOnDevice = sttOnDevice)
+    }.combine(settingsDataStore.sttEndOfSpeech) { additional, sttEndOfSpeech ->
+        additional.copy(sttEndOfSpeech = sttEndOfSpeech)
     }.stateIn(scope, SharingStarted.Eagerly, AdditionalPreferences(true, false, "", "", true))
 
     /** The single public UI state that merges DataStore preferences with imperative state. */
@@ -241,6 +247,8 @@ class SettingsPreferencesController(
             sttAutoSend = additional.autoSendAfterStt,
             sttEngine = additional.sttEngine,
             sttLanguage = additional.sttLanguage,
+            sttOnDevice = additional.sttOnDevice,
+            sttEndOfSpeech = additional.sttEndOfSpeech,
             chatLayoutStyle = additional.chatLayoutStyle,
             showAvatars = additional.showAvatars,
             showBubbles = additional.showBubbles,

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/SettingsUiState.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/SettingsUiState.kt
@@ -166,6 +166,12 @@ data class SettingsUiState(
     val sttEngine: String = "",
     val sttLanguage: String = "",
     val sttAutoSend: Boolean = false,
+    /** Mobile-only: prefer the platform on-device recognizer for the Browser engine. Default ON. */
+    val sttOnDevice: Boolean = true,
+    /** Mobile-only: stop dictation at end-of-speech (hands-free) vs. run continuously. Default OFF. */
+    val sttEndOfSpeech: Boolean = false,
+    /** Whether the server has external STT (Whisper) configured — gates the External engine option. */
+    val serverSttEnabled: Boolean = false,
     val ttsEngine: String = "",
     val ttsVoice: String = "",
     val ttsSpeechRate: Float = 1.0f,

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/SettingsViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/SettingsViewModel.kt
@@ -113,6 +113,7 @@ class SettingsViewModel(
     init {
         accountDelegate.loadUser()
         speechDelegate.loadVoices()
+        speechDelegate.loadSpeechConfig()
         accountDelegate.loadBalance()
         speechDelegate.loadDeviceVoices()
         loadRoleGatedData()
@@ -440,7 +441,8 @@ class SettingsViewModel(
     fun stopTtsPreview() = speechDelegate.stopTtsPreview()
     fun showSttDetailDialog() = speechDelegate.showSttDetailDialog()
     fun dismissSttDetailDialog() = speechDelegate.dismissSttDetailDialog()
-    fun saveSttSettings(engine: String, language: String) = speechDelegate.saveSttSettings(engine, language)
+    fun saveSttSettings(engine: String, language: String, onDevice: Boolean, endOfSpeech: Boolean) =
+        speechDelegate.saveSttSettings(engine, language, onDevice, endOfSpeech)
     fun showTtsDetailDialog() = speechDelegate.showTtsDetailDialog()
     fun dismissTtsDetailDialog() = speechDelegate.dismissTtsDetailDialog()
     fun saveTtsSettings(

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/delegate/SpeechSettingsContract.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/delegate/SpeechSettingsContract.kt
@@ -5,6 +5,7 @@ import com.garfiec.librechat.core.model.speech.TtsVoice
 interface SpeechSettingsContract {
     fun loadVoices()
     fun loadDeviceVoices()
+    fun loadSpeechConfig()
     fun setAutoSendAfterStt(enabled: Boolean)
     fun setAutoReadEnabled(enabled: Boolean)
     fun selectVoice(voice: TtsVoice)
@@ -14,7 +15,7 @@ interface SpeechSettingsContract {
     fun stopTtsPreview()
     fun showSttDetailDialog()
     fun dismissSttDetailDialog()
-    fun saveSttSettings(engine: String, language: String)
+    fun saveSttSettings(engine: String, language: String, onDevice: Boolean, endOfSpeech: Boolean)
     fun showTtsDetailDialog()
     fun dismissTtsDetailDialog()
     fun saveTtsSettings(

--- a/feature/settings/src/iosMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/delegate/IosSpeechSettingsDelegate.kt
+++ b/feature/settings/src/iosMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/delegate/IosSpeechSettingsDelegate.kt
@@ -77,6 +77,14 @@ class IosSpeechSettingsDelegate(
         stateHandle.update { copy(availableDeviceVoices = voices) }
     }
 
+    override fun loadSpeechConfig() {
+        // iOS has no server-STT (External) recording path yet — IosVoiceInput always uses
+        // SFSpeechRecognizer — so intentionally leave serverSttEnabled=false. This keeps the
+        // External engine hidden in the shared STT dialog rather than offering an option that would
+        // silently do nothing when selected. (Follow-up: implement iOS External via AVAudioRecorder
+        // + speechRepository.transcribeAudio, then fetch getSpeechConfig() here like Android does.)
+    }
+
     override fun setAutoSendAfterStt(enabled: Boolean) {
         stateHandle.scope.launch {
             settingsDataStore.setAutoSendAfterStt(enabled)
@@ -179,13 +187,21 @@ class IosSpeechSettingsDelegate(
         stateHandle.update { copy(showSttDetailDialog = false) }
     }
 
-    override fun saveSttSettings(engine: String, language: String) {
+    override fun saveSttSettings(engine: String, language: String, onDevice: Boolean, endOfSpeech: Boolean) {
         stateHandle.update {
-            copy(sttEngine = engine, sttLanguage = language, showSttDetailDialog = false)
+            copy(
+                sttEngine = engine,
+                sttLanguage = language,
+                sttOnDevice = onDevice,
+                sttEndOfSpeech = endOfSpeech,
+                showSttDetailDialog = false,
+            )
         }
         stateHandle.scope.launch {
             settingsDataStore.setSttEngine(engine)
             settingsDataStore.setSttLanguage(language)
+            settingsDataStore.setSttOnDevice(onDevice)
+            settingsDataStore.setSttEndOfSpeech(endOfSpeech)
         }
     }
 


### PR DESCRIPTION
## Summary

Reworks mobile speech-to-text to match the web app's engine model and adds live, streaming dictation on both Android and iOS. The old free-text engine setting (Default / Whisper / Google / Device) is replaced by the web's **Browser | External** model, and the Browser engine now streams partial results in real time (previously Android used a one-shot full-screen overlay and iOS a single-shot recognizer).

## Changes

**Engine model (web parity)**
- New `SttEngine` enum (`browser` | `external`) in `core/model`, persisted lowercase to match the web client. Parsing is lenient for back-compat: `whisper`/`external` → External, everything else (blank, `default`, `google`, `device`) → Browser.
- Settings dialog offers Browser always, and External only when the server has STT configured (or External is already the stored engine).

**Android**
- New `SpeechRecognizerController` drives an in-process `SpeechRecognizer` for the Browser engine: live partials, continuous restart until the user stops, on-device→network fallback, churn/no-callback recovery watchdogs, and an empty-segment cap so silence can't hold the mic open.
- API 26–30 (no on-device recognizer) falls back to the existing full-screen Intent overlay.
- The External engine records and uploads to the server (Whisper); the upload is now abortable and cancellation releases the recorder so the mic can't stay hot.

**iOS**
- `IosVoiceInput` reworked from a single-shot recognizer to live `SFSpeechRecognizer` transcription: on-device recognition (`requiresOnDeviceRecognition`) with cloud fallback, continuous restart, end-of-speech silence detection, tolerant locale resolution for the STT language setting, and graceful handling of authorization, engine-start, and invalid-audio-format failures.

**Shared (commonMain)**
- `DictationBuffer` + `appendToBase` centralize the composer merge (append after pre-typed text, rebase on a mid-dictation edit, revert on cancel) so Android and iOS behave identically.
- Shared auto-send gate and watchdog/empty-segment constants so the "auto-send only on user stop, only when text was produced" rule and the on-device-vs-cloud finalize timing can't drift between platforms.
- `sttSupportsLiveRecognition()` / `sttEngineSelectsRecognizer()` capability seam and a shared STT language list (picker names + BCP-47 tags), replacing predicates and language maps that were duplicated across the chat and settings modules.

**Preferences & settings UI**
- New mobile-only prefs: **on-device recognition** (default on) and **"stop when I pause"** end-of-speech (default off); both shown only where the live recognizer honors them.
- `ServerSttGate` latches the first successful server-STT fetch so a transient failure reads as *unknown* (retry on the next action) rather than a definitive "disabled" that would hide the External engine.
- Updated STT strings across the base locale and all 9 translations; removed the obsolete engine/hint strings.

## Behavior change

Blank and legacy engine values now resolve to **Browser** (the web default). This intentionally drops the old implicit "blank + server STT → Whisper" routing — existing users on a blank/legacy value get on-device Browser dictation instead of silent server transcription. Users who had Whisper selected map to the External engine.

## Testing

- Unit tests updated and passing: DataStore round-trip (new prefs) and SettingsViewModel.
- Both platforms compile: Android `assembleDebug` + module unit tests, iOS `linkDebugFrameworkIosSimulatorArm64`.

## Notes

- iOS has no External (server-upload) transport yet; the External engine falls through to `SFSpeechRecognizer` there, so the option stays hidden in the iOS settings dialog. Adding an iOS External upload path is a follow-up.
