### PR TITLE
fix(chat): render web search results as a sources card

### DIFF
--- a/core/model/src/commonMain/kotlin/com/garfiec/librechat/core/model/FileModel.kt
+++ b/core/model/src/commonMain/kotlin/com/garfiec/librechat/core/model/FileModel.kt
@@ -99,4 +99,7 @@ data class Attachment(
     val textFormat: String? = null,
     /** Short machine-readable reason when [status] == `failed`. */
     val previewError: String? = null,
+    /** Web-search sources, present only when [type] == `web_search` (no file_id/filename).
+     *  Null for ordinary file attachments. */
+    @SerialName("web_search") val webSearch: WebSearchData? = null,
 )

--- a/core/model/src/commonMain/kotlin/com/garfiec/librechat/core/model/StreamEvent.kt
+++ b/core/model/src/commonMain/kotlin/com/garfiec/librechat/core/model/StreamEvent.kt
@@ -49,6 +49,8 @@ sealed interface StreamEvent {
         val text: String? = null,
         val textFormat: String? = null,
         val previewError: String? = null,
+        /** Web-search sources when this is a `web_search` attachment (no file). */
+        val webSearch: WebSearchData? = null,
     ) : StreamEvent
 
     data class Final(

--- a/core/model/src/commonMain/kotlin/com/garfiec/librechat/core/model/WebSearch.kt
+++ b/core/model/src/commonMain/kotlin/com/garfiec/librechat/core/model/WebSearch.kt
@@ -1,0 +1,30 @@
+package com.garfiec.librechat.core.model
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Web-search sources carried on an assistant message. The server attaches these as an
+ * attachment whose `type == "web_search"`, with this payload nested under the `web_search`
+ * key (see upstream `api/server/services/Tools/search.js` `buildAttachment`). Unlike file
+ * attachments it has no `file_id`/`filename` — the sources themselves are the payload.
+ *
+ * Mirrors the server's `SearchResultData` (`packages/data-provider/src/types/web.ts`); we keep
+ * only the fields the mobile UI renders — `organic` results and `topStories`.
+ */
+@Serializable
+data class WebSearchData(
+    val turn: Int? = null,
+    val organic: List<WebSearchSource>? = null,
+    val topStories: List<WebSearchSource>? = null,
+)
+
+/** A single web-search source (an organic result or a top story). */
+@Serializable
+data class WebSearchSource(
+    val link: String? = null,
+    val title: String? = null,
+    val snippet: String? = null,
+    /** Publisher name — present on `topStories`, absent on `organic` results. */
+    val source: String? = null,
+    val date: String? = null,
+)

--- a/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/sse/SseEventMapperTest.kt
+++ b/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/sse/SseEventMapperTest.kt
@@ -367,6 +367,24 @@ class SseEventMapperTest {
         assertThat(result.fileId).isEqualTo("f2")
     }
 
+    @Test
+    fun `maps web_search attachment carrying sources without a file`() {
+        // Web-search results arrive as an attachment with no file_id/filename — the sources
+        // are nested under the `web_search` key (organic + topStories).
+        val event = SseEvent(
+            event = "attachment",
+            data = """{"type":"web_search","toolCallId":"call_ws","messageId":"m1","web_search":{"turn":0,"organic":[{"link":"https://en.wikipedia.org/wiki/Photosynthesis","title":"Photosynthesis - Wikipedia"}],"topStories":[{"link":"https://en.wiktionary.org/wiki/photosynthesis","title":"photosynthesis - Wiktionary","source":"en.wiktionary.org"}]}}""",
+        )
+        val result = mapper.map(event) as StreamEvent.AttachmentCreated
+        assertThat(result.type).isEqualTo("web_search")
+        assertThat(result.toolCallId).isEqualTo("call_ws")
+        assertThat(result.webSearch).isNotNull()
+        assertThat(result.webSearch!!.organic).hasSize(1)
+        assertThat(result.webSearch!!.organic!!.single().link)
+            .isEqualTo("https://en.wikipedia.org/wiki/Photosynthesis")
+        assertThat(result.webSearch!!.topStories!!.single().title).isEqualTo("photosynthesis - Wiktionary")
+    }
+
     // --- Legacy Flat Format ---
 
     @Test

--- a/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/sse/SseEventMapper.kt
+++ b/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/sse/SseEventMapper.kt
@@ -538,7 +538,18 @@ class SseEventMapper(private val json: Json) {
         val fileId = data["file_id"]?.jsonPrimitive?.contentOrNull ?: ""
         val filename = data["filename"]?.jsonPrimitive?.contentOrNull ?: ""
         val type = data["type"]?.jsonPrimitive?.contentOrNull ?: ""
-        if (fileId.isBlank() && filename.isBlank()) return null
+        // Web-search results ride in as an attachment with no file — `type == "web_search"`
+        // and the sources nested under the `web_search` key. Parse it before the file guard
+        // so these aren't dropped as "empty" attachments.
+        val webSearch = data["web_search"]?.let { element ->
+            try {
+                json.decodeFromJsonElement(com.garfiec.librechat.core.model.WebSearchData.serializer(), element)
+            } catch (e: Exception) {
+                Logger.w("SSE", e) { "Failed to parse web_search attachment data" }
+                null
+            }
+        }
+        if (fileId.isBlank() && filename.isBlank() && webSearch == null) return null
         return StreamEvent.AttachmentCreated(
             fileId = fileId,
             filename = filename,
@@ -553,6 +564,7 @@ class SseEventMapper(private val json: Json) {
             text = data["text"]?.jsonPrimitive?.contentOrNull,
             textFormat = data["textFormat"]?.jsonPrimitive?.contentOrNull,
             previewError = data["previewError"]?.jsonPrimitive?.contentOrNull,
+            webSearch = webSearch,
         )
     }
 

--- a/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/components/WebSearchSourcesTest.kt
+++ b/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/components/WebSearchSourcesTest.kt
@@ -1,0 +1,107 @@
+package com.garfiec.librechat.feature.chat.components
+
+import com.garfiec.librechat.core.model.Attachment
+import com.garfiec.librechat.core.model.WebSearchData
+import com.garfiec.librechat.core.model.WebSearchSource
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class WebSearchSourcesTest {
+
+    private fun webAttachment(
+        toolCallId: String?,
+        organic: List<WebSearchSource> = emptyList(),
+        topStories: List<WebSearchSource> = emptyList(),
+    ) = Attachment(
+        type = "web_search",
+        toolCallId = toolCallId,
+        webSearch = WebSearchData(organic = organic, topStories = topStories),
+    )
+
+    @Test
+    fun `collects organic then top-story sources for the matching tool call`() {
+        val attachments = listOf(
+            webAttachment(
+                toolCallId = "c1",
+                organic = listOf(WebSearchSource(link = "https://a.com/x", title = "A")),
+                topStories = listOf(WebSearchSource(link = "https://b.com/y", title = "B")),
+            ),
+        )
+
+        val results = collectWebSearchSources(attachments, "c1")
+
+        assertThat(results.map { it.url }).containsExactly("https://a.com/x", "https://b.com/y").inOrder()
+        assertThat(results.first().title).isEqualTo("A")
+    }
+
+    @Test
+    fun `dedups repeated sources by link across accumulating attachments`() {
+        // Streaming re-emits the attachment once per processed source, each a superset.
+        val attachments = listOf(
+            webAttachment("c1", organic = listOf(WebSearchSource(link = "https://a.com", title = "A"))),
+            webAttachment(
+                "c1",
+                organic = listOf(
+                    WebSearchSource(link = "https://a.com", title = "A"),
+                    WebSearchSource(link = "https://b.com", title = "B"),
+                ),
+            ),
+        )
+
+        val results = collectWebSearchSources(attachments, "c1")
+
+        assertThat(results.map { it.url }).containsExactly("https://a.com", "https://b.com").inOrder()
+    }
+
+    @Test
+    fun `excludes attachments belonging to a different tool call`() {
+        // A second search turn (its own toolCallId) must not duplicate its sources here.
+        val attachments = listOf(
+            webAttachment("other", organic = listOf(WebSearchSource(link = "https://a.com", title = "A"))),
+        )
+        assertThat(collectWebSearchSources(attachments, "c1")).isEmpty()
+    }
+
+    @Test
+    fun `id-less attachments attach to any search call`() {
+        // Older payloads didn't always set a toolCallId — attach them best-effort.
+        val attachments = listOf(
+            webAttachment(toolCallId = null, organic = listOf(WebSearchSource(link = "https://a.com", title = "A"))),
+        )
+        assertThat(collectWebSearchSources(attachments, "c1").map { it.url })
+            .containsExactly("https://a.com")
+    }
+
+    @Test
+    fun `falls back to all attachments when the tool call itself has no id`() {
+        val attachments = listOf(
+            webAttachment("other", organic = listOf(WebSearchSource(link = "https://a.com", title = "A"))),
+        )
+        assertThat(collectWebSearchSources(attachments, null).map { it.url })
+            .containsExactly("https://a.com")
+    }
+
+    @Test
+    fun `ignores non web-search attachments and sources without a link`() {
+        val attachments = listOf(
+            Attachment(fileId = "f", filename = "x.pdf", type = "application/pdf", toolCallId = "c1"),
+            webAttachment("c1", organic = listOf(WebSearchSource(link = null, title = "no link"))),
+        )
+        assertThat(collectWebSearchSources(attachments, "c1")).isEmpty()
+    }
+
+    @Test
+    fun `titles missing on a source fall back to the host`() {
+        val attachments = listOf(
+            webAttachment("c1", organic = listOf(WebSearchSource(link = "https://www.example.com/page", title = null))),
+        )
+        assertThat(collectWebSearchSources(attachments, "c1").single().title).isEqualTo("example.com")
+    }
+
+    @Test
+    fun `hostOf strips scheme port path and www`() {
+        assertThat(hostOf("https://www.example.com:8080/a/b?q=1")).isEqualTo("example.com")
+        assertThat(hostOf("http://en.wikipedia.org/wiki/X")).isEqualTo("en.wikipedia.org")
+        assertThat(hostOf("example.com")).isEqualTo("example.com")
+    }
+}

--- a/feature/chat/src/commonMain/composeResources/values/strings.xml
+++ b/feature/chat/src/commonMain/composeResources/values/strings.xml
@@ -153,6 +153,7 @@
     <string name="tool_model_parameters_desc">Adjust temperature, tokens, and more</string>
     <string name="tool_web_search">Web Search</string>
     <string name="tool_web_search_desc">Search the web for information</string>
+    <string name="web_searched">Searched the web</string>
     <string name="tool_url_context">URL Context</string>
     <string name="tool_url_context_desc">Let the model read URLs and YouTube you reference</string>
     <string name="tool_code">Code</string>

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/StreamingToolCallCard.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/StreamingToolCallCard.kt
@@ -61,6 +61,37 @@ fun StreamingToolCallCard(
         return
     }
 
+    // Web search: as soon as `web_search` attachments arrive (streamed once per source
+    // processed) render the same "Searched the web" sources card the finalized message uses,
+    // so sources appear live instead of a generic spinner that only resolves on reload.
+    val webSearchSources = remember(toolCall, streamingAttachments) {
+        if (isWebSearchToolCall(toolCall.name.lowercase())) {
+            collectWebSearchSources(streamingAttachments, toolCall.id)
+        } else {
+            emptyList()
+        }
+    }
+    if (webSearchSources.isNotEmpty()) {
+        WebSearchSourcesCard(results = webSearchSources, modifier = modifier)
+    } else {
+        GenericStreamingToolCard(
+            toolCall = toolCall,
+            baseUrl = baseUrl,
+            streamingAttachments = streamingAttachments,
+            modifier = modifier,
+        )
+    }
+}
+
+/** The default streaming tool-call card: name, progress/complete state, expandable output, and
+ *  any files this tool call has generated so far. Used when no specialized card applies. */
+@Composable
+private fun GenericStreamingToolCard(
+    toolCall: ActiveToolCall,
+    baseUrl: String,
+    streamingAttachments: List<Attachment>,
+    modifier: Modifier = Modifier,
+) {
     var isExpanded by remember { mutableStateOf(false) }
     val canExpand = toolCall.isComplete && !toolCall.output.isNullOrBlank()
 

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ToolCallContentPart.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ToolCallContentPart.kt
@@ -91,14 +91,15 @@ internal fun ToolCallDispatcher(
                     modifier = cardModifier,
                 )
             }
-            // file_search / retrieval carry their sources in an attachment payload the mobile model
-            // doesn't parse yet — route to the generic card, not the web-search list.
-            toolNameLower != ToolConstants.FILE_SEARCH &&
-                toolNameLower != ToolConstants.RETRIEVAL &&
-                toolNameLower.contains("search") -> {
-                val results = remember(output) { parseWebSearchResults(output) }
+            isWebSearchToolCall(toolNameLower) -> {
+                // The real sources arrive as `web_search` attachments (organic + topStories),
+                // not in the tool-call output — prefer them, falling back to output parsing.
+                val results = remember(attachments, toolCall?.id, output) {
+                    collectWebSearchSources(attachments, toolCall?.id)
+                        .ifEmpty { parseWebSearchResults(output) }
+                }
                 if (results.isNotEmpty()) {
-                    WebSearchResultList(results = results, modifier = cardModifier)
+                    WebSearchSourcesCard(results = results, modifier = cardModifier)
                 } else {
                     GenericToolCallCard(toolName, toolCall?.function?.arguments, output, cardModifier)
                 }

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ToolCallParsing.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ToolCallParsing.kt
@@ -61,7 +61,71 @@ internal fun isCodeExecutionToolCall(toolNameLower: String): Boolean {
     return toolNameLower == ToolConstants.PROGRAMMATIC_TOOL_CALLING || toolNameLower in BASH_TOOL_NAMES
 }
 
+/**
+ * Web-search-style tool calls that render as the "Searched the web" sources card. `file_search`
+ * and `retrieval` also contain "search" but carry their sources in an attachment payload the
+ * mobile model doesn't parse yet, so they're excluded and fall through to the generic card.
+ */
+internal fun isWebSearchToolCall(toolNameLower: String): Boolean =
+    toolNameLower != ToolConstants.FILE_SEARCH &&
+        toolNameLower != ToolConstants.RETRIEVAL &&
+        toolNameLower.contains("search")
+
 // --- Parsing helpers ---
+
+/**
+ * Collects web-search sources from a message's `web_search` attachments (the shape the server
+ * actually sends — `organic` + `topStories`, not a `results` array in the tool-call output).
+ *
+ * Takes attachments whose `toolCallId` matches this tool call, plus any that carry no id at all
+ * (older payloads didn't always set one — those attach to any search call as a best effort).
+ * Attachments belonging to a *different* tool call are excluded so a second search turn can't
+ * duplicate its sources here. When this tool call itself has no id we can't disambiguate, so we
+ * fall back to every web-search attachment (there is normally only one). During streaming the
+ * server re-emits the attachment once per source processed, each a superset of the last, so we
+ * dedup by link — that naturally yields the final full set. Mirrors upstream `collectSources`
+ * in `WebSearch.tsx`.
+ */
+internal fun collectWebSearchSources(
+    attachments: List<Attachment>,
+    toolCallId: String?,
+): List<WebSearchResult> {
+    val webAttachments = attachments.filter {
+        it.type == ToolConstants.WEB_SEARCH && it.webSearch != null
+    }
+    if (webAttachments.isEmpty()) return emptyList()
+    val scoped = if (toolCallId == null) {
+        webAttachments
+    } else {
+        webAttachments.filter { it.toolCallId == toolCallId || it.toolCallId == null }
+    }
+
+    val seen = LinkedHashSet<String>()
+    val results = mutableListOf<WebSearchResult>()
+    scoped.forEach { att ->
+        val data = att.webSearch ?: return@forEach
+        (data.organic.orEmpty() + data.topStories.orEmpty()).forEach { s ->
+            val url = s.link ?: return@forEach
+            if (seen.add(url)) {
+                results += WebSearchResult(
+                    title = s.title?.takeIf { it.isNotBlank() } ?: hostOf(url) ?: url,
+                    url = url,
+                    snippet = s.snippet.orEmpty(),
+                    favicon = null,
+                )
+            }
+        }
+    }
+    return results
+}
+
+/** Bare host of a URL (no scheme, no port, no path), or null if it can't be extracted. */
+internal fun hostOf(url: String): String? =
+    url.substringAfter("://", url)
+        .substringBefore("/")
+        .substringBefore(":")
+        .removePrefix("www.")
+        .takeIf { it.isNotEmpty() }
 
 internal fun parseWebSearchResults(output: String?): List<WebSearchResult> {
     if (output.isNullOrBlank()) return emptyList()

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/WebSearchResultCard.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/WebSearchResultCard.kt
@@ -1,20 +1,27 @@
 package com.garfiec.librechat.feature.chat.components
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ExpandLess
+import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.filled.Language
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -33,14 +40,18 @@ import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import coil3.compose.SubcomposeAsyncImage
-import com.garfiec.librechat.feature.chat.resources.*
 import com.garfiec.librechat.feature.chat.resources.Res
+import com.garfiec.librechat.feature.chat.resources.cd_search_result
+import com.garfiec.librechat.feature.chat.resources.web_searched
 import org.jetbrains.compose.resources.stringResource
 
 /**
- * Data class representing a single web search result parsed from tool call output.
+ * A single web search source parsed from a message's `web_search` attachment (or, as a
+ * fallback, the tool-call output). [url] is the canonical dedup key.
  */
 data class WebSearchResult(
     val title: String,
@@ -49,138 +60,181 @@ data class WebSearchResult(
     val favicon: String? = null,
 )
 
+private const val MAX_STACKED_FAVICONS = 3
+
+/** Google's favicon service — same source the source cards already use. */
+private fun faviconUrl(host: String): String =
+    "https://www.google.com/s2/favicons?domain=$host&sz=48"
+
+/** Globe placeholder shown while a favicon loads or when it fails to load. */
+@Composable
+private fun GlobeIcon(size: Dp) {
+    Icon(
+        imageVector = Icons.Default.Language,
+        contentDescription = null,
+        modifier = Modifier.size(size),
+        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+}
+
 /**
- * Card displaying a web search result with favicon, title, URL, and expandable snippet.
- * Clicking the card opens the URL in an external browser.
+ * A favicon image with a globe fallback while loading / on error. [model] is a fully-resolved
+ * image URL — an explicit per-source favicon when the payload carries one, otherwise the
+ * host-derived [faviconUrl].
  */
 @Composable
-fun WebSearchResultCard(
-    result: WebSearchResult,
-    modifier: Modifier = Modifier,
-) {
-    val uriHandler = LocalUriHandler.current
-    var isSnippetExpanded by remember { mutableStateOf(false) }
+private fun Favicon(model: String, size: Dp, modifier: Modifier = Modifier) {
+    SubcomposeAsyncImage(
+        model = model,
+        contentDescription = null,
+        modifier = modifier.size(size).clip(CircleShape),
+        error = { GlobeIcon(size) },
+        loading = { GlobeIcon(size) },
+    )
+}
 
-    val searchResultCd = stringResource(Res.string.cd_search_result, result.title)
-    Card(
-        modifier = modifier
-            .fillMaxWidth()
-            .clickable {
-                try {
-                    uriHandler.openUri(result.url)
-                } catch (_: Exception) {
-                    // URL might be malformed
-                }
-            }
-            .semantics {
-                role = Role.Button
-                contentDescription = searchResultCd
-            },
-        colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
-        ),
-        shape = RoundedCornerShape(8.dp),
+/** Overlapping stack of up to [MAX_STACKED_FAVICONS] domain favicons (first drawn on top). */
+@Composable
+private fun SourceFaviconStack(hosts: List<String>, modifier: Modifier = Modifier) {
+    Row(
+        modifier = modifier.semantics { },
+        horizontalArrangement = Arrangement.spacedBy((-7).dp),
     ) {
-        Row(
-            modifier = Modifier.padding(12.dp),
-            verticalAlignment = Alignment.Top,
-        ) {
-            // Favicon
-            val faviconUrl = result.favicon
-                ?: result.url.let { url ->
-                    try {
-                        // Extract host from URL without android.net.Uri (KMP-compatible)
-                        val withoutScheme = url.substringAfter("://")
-                        val host = withoutScheme.substringBefore("/").substringBefore(":")
-                        if (host.isNotEmpty()) "https://www.google.com/s2/favicons?domain=$host&sz=48" else null
-                    } catch (_: Exception) {
-                        null
-                    }
-                }
-
-            if (faviconUrl != null) {
-                SubcomposeAsyncImage(
-                    model = faviconUrl,
-                    contentDescription = null,
-                    modifier = Modifier
-                        .size(24.dp)
-                        .clip(CircleShape),
-                    error = {
-                        Icon(
-                            imageVector = Icons.Default.Language,
-                            contentDescription = null,
-                            modifier = Modifier.size(24.dp),
-                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
-                    },
-                )
-            } else {
-                Icon(
-                    imageVector = Icons.Default.Language,
-                    contentDescription = null,
-                    modifier = Modifier.size(24.dp),
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
-
-            Spacer(modifier = Modifier.width(10.dp))
-
-            Column(modifier = Modifier.weight(1f)) {
-                // Title
-                Text(
-                    text = result.title,
-                    style = MaterialTheme.typography.titleSmall.copy(
-                        fontWeight = FontWeight.Bold,
-                    ),
-                    color = MaterialTheme.colorScheme.onSurface,
-                    maxLines = 2,
-                    overflow = TextOverflow.Ellipsis,
-                )
-
-                Spacer(modifier = Modifier.height(2.dp))
-
-                // URL
-                Text(
-                    text = result.url,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                )
-
-                if (result.snippet.isNotBlank()) {
-                    Spacer(modifier = Modifier.height(4.dp))
-
-                    // Snippet (expandable)
-                    Text(
-                        text = result.snippet,
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurface,
-                        maxLines = if (isSnippetExpanded) Int.MAX_VALUE else 3,
-                        overflow = TextOverflow.Ellipsis,
-                        modifier = Modifier.clickable(
-                            onClick = { isSnippetExpanded = !isSnippetExpanded },
-                        ),
-                    )
-                }
+        hosts.forEachIndexed { i, host ->
+            Box(
+                modifier = Modifier
+                    .zIndex((hosts.size - i).toFloat())
+                    .size(22.dp)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.surfaceContainerHighest)
+                    .border(1.dp, MaterialTheme.colorScheme.outlineVariant, CircleShape)
+                    .padding(3.dp),
+                contentAlignment = Alignment.Center,
+            ) {
+                Favicon(model = faviconUrl(host), size = 14.dp)
             }
         }
     }
 }
 
 /**
- * Renders a list of web search results as stacked cards.
+ * Web-search results rendered to match the web client: a collapsed "Searched the web" pill
+ * with a stacked-favicon preview, expanding to a bordered list of sources (favicon, title,
+ * domain). Each row opens its URL in an external browser. See upstream `WebSearch.tsx`.
  */
 @Composable
-fun WebSearchResultList(
+fun WebSearchSourcesCard(
     results: List<WebSearchResult>,
     modifier: Modifier = Modifier,
 ) {
-    Column(modifier = modifier) {
-        results.forEachIndexed { index, result ->
-            WebSearchResultCard(result = result)
-            if (index < results.lastIndex) {
-                Spacer(modifier = Modifier.height(6.dp))
+    val uriHandler = LocalUriHandler.current
+    var isExpanded by remember { mutableStateOf(false) }
+
+    val previewHosts = remember(results) {
+        val seen = LinkedHashSet<String>()
+        results.mapNotNull { hostOf(it.url) }
+            .filter { seen.add(it) }
+            .take(MAX_STACKED_FAVICONS)
+    }
+
+    val label = stringResource(Res.string.web_searched)
+
+    Column(modifier = modifier.fillMaxWidth()) {
+        Row(
+            modifier = Modifier
+                .clip(RoundedCornerShape(999.dp))
+                .clickable { isExpanded = !isExpanded }
+                .padding(vertical = 4.dp, horizontal = 2.dp)
+                .semantics {
+                    role = Role.Button
+                    contentDescription = label
+                },
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            if (previewHosts.isNotEmpty()) {
+                SourceFaviconStack(previewHosts)
+            } else {
+                Icon(
+                    imageVector = Icons.Default.Language,
+                    contentDescription = null,
+                    modifier = Modifier.size(16.dp),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+                text = label,
+                style = MaterialTheme.typography.titleSmall.copy(fontWeight = FontWeight.Medium),
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(modifier = Modifier.width(4.dp))
+            Icon(
+                imageVector = if (isExpanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
+                contentDescription = null,
+                modifier = Modifier.size(16.dp),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+
+        AnimatedVisibility(
+            visible = isExpanded,
+            enter = expandVertically(),
+            exit = shrinkVertically(),
+        ) {
+            Column(
+                modifier = Modifier
+                    .padding(top = 6.dp)
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(8.dp))
+                    .border(
+                        1.dp,
+                        MaterialTheme.colorScheme.outlineVariant,
+                        RoundedCornerShape(8.dp),
+                    ),
+            ) {
+                results.forEachIndexed { index, result ->
+                    val domain = hostOf(result.url) ?: result.url
+                    val rowCd = stringResource(Res.string.cd_search_result, result.title)
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable {
+                                try {
+                                    uriHandler.openUri(result.url)
+                                } catch (_: Exception) {
+                                    // URL might be malformed
+                                }
+                            }
+                            .padding(horizontal = 12.dp, vertical = 10.dp)
+                            .semantics {
+                                role = Role.Button
+                                contentDescription = rowCd
+                            },
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Favicon(model = result.favicon ?: faviconUrl(domain), size = 16.dp)
+                        Spacer(modifier = Modifier.width(10.dp))
+                        Text(
+                            text = result.title,
+                            style = MaterialTheme.typography.bodySmall.copy(fontWeight = FontWeight.Medium),
+                            color = MaterialTheme.colorScheme.onSurface,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                            modifier = Modifier.weight(1f),
+                        )
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text(
+                            text = domain,
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    }
+                    if (index < results.lastIndex) {
+                        HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+                    }
+                }
             }
         }
     }

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/StreamingManagerDelegate.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/StreamingManagerDelegate.kt
@@ -1,6 +1,7 @@
 package com.garfiec.librechat.feature.chat.viewmodel.delegate
 
 import co.touchlab.kermit.Logger
+import com.garfiec.librechat.core.common.ToolConstants
 import com.garfiec.librechat.core.common.identity.AccountId
 import com.garfiec.librechat.core.common.identity.ActiveAccountProvider
 import com.garfiec.librechat.core.common.identity.currentAccountId
@@ -264,12 +265,23 @@ class StreamingManagerDelegate(
                     text = event.text,
                     textFormat = event.textFormat,
                     previewError = event.previewError,
+                    webSearch = event.webSearch,
                 )
                 // Office-doc previews (v0.8.6) arrive twice per file_id (pending →
                 // ready/failed) — route through the delegate for upsert-by-file_id +
                 // poll-while-pending. Ordinary attachments keep the simple append path.
                 if (ArtifactType.isOfficePreviewMime(event.type)) {
                     officePreviewDelegate.onAttachment(attachment)
+                } else if (attachment.webSearch != null && attachment.toolCallId != null) {
+                    // Web-search re-emits an accumulating superset per source processed —
+                    // upsert by toolCallId so we keep only the latest (fullest) one rather
+                    // than piling up near-duplicate copies for the stream's duration.
+                    handle.update {
+                        val kept = content.streamingAttachments.filterNot {
+                            it.type == ToolConstants.WEB_SEARCH && it.toolCallId == attachment.toolCallId
+                        }
+                        content = content.copy(streamingAttachments = kept + attachment)
+                    }
                 } else {
                     handle.update {
                         content = content.copy(streamingAttachments = content.streamingAttachments + attachment)


### PR DESCRIPTION
## Summary
On the web client a web-search step renders as a "Searched the web" card with website favicons that expands to a source list. On mobile it showed a generic tool-call card with no sources: the results ride in as a file-less `web_search` attachment — sources nested under a `web_search` key — rather than in the tool-call output the mobile card parsed, so it had nothing to render and fell back to the generic card. This wires that attachment through the model, SSE, and chat layers and renders a matching sources card.

## Changes
- **core/model** — add `WebSearchData`/`WebSearchSource` (`organic` + `topStories`) mirroring the server payload; add a `webSearch` field to `Attachment` and to the `AttachmentCreated` stream event.
- **core/network** — `SseEventMapper` parses the `web_search` payload from `attachment` events *before* the file-id guard, so file-less web-search attachments are no longer dropped as empty.
- **feature/chat** — `StreamingManagerDelegate` carries the payload into streaming attachments and upserts by `toolCallId` (the server re-emits an accumulating superset per source). `collectWebSearchSources` gathers and dedups sources; `WebSearchSourcesCard` renders a collapsed "Searched the web" pill with a stacked-favicon preview that expands to a bordered source list (favicon · title · domain), each row opening its URL. Both the completed-message and live-streaming render paths use it, gated by a shared `isWebSearchToolCall` classifier (`file_search`/`retrieval` excluded).

## Testing
- Unit tests: `WebSearchSourcesTest` (collection, dedup, tool-call scoping, host fallback) and a new `SseEventMapperTest` case for a file-less `web_search` attachment.
- `:feature:chat` compiles (Android); module unit tests green.
- Device-tested on a Pixel 9 Pro Fold.

## Notes
- Replaces the previous `WebSearchResultCard`/`WebSearchResultList` rendering. The new card shows favicon · title · domain per source (matching the web client) rather than the old title + URL + snippet layout.
- `file_search`/`retrieval` also contain "search" but carry sources in a payload the card doesn't parse yet — they deliberately fall through to the generic card.
- English-only string added (`web_searched`), matching the repo's default-locale convention for new strings.
