### PR TITLE
refactor(nav): extract the drawer out of :shared into :feature:conversations

### DIFF
--- a/feature/conversations/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/conversations/di/ConversationsModuleVerificationTest.kt
+++ b/feature/conversations/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/conversations/di/ConversationsModuleVerificationTest.kt
@@ -2,7 +2,9 @@ package com.garfiec.librechat.feature.conversations.di
 
 import android.app.Application
 import android.content.Context
+import com.garfiec.librechat.core.common.identity.ActiveAccountProvider
 import com.garfiec.librechat.core.data.datastore.ServerDataStore
+import com.garfiec.librechat.core.data.datastore.SettingsDataStore
 import com.garfiec.librechat.core.data.repository.ConfigRepository
 import com.garfiec.librechat.core.data.repository.ConversationRepository
 import com.garfiec.librechat.core.data.repository.MessageRepository
@@ -32,6 +34,9 @@ class ConversationsModuleVerificationTest {
                 RoleRepository::class,
                 ServerDataStore::class,
                 CoroutineDispatcher::class,
+                // DrawerViewModel deps sourced from other modules.
+                ActiveAccountProvider::class,
+                SettingsDataStore::class,
             ),
         )
     }

--- a/feature/conversations/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/conversations/drawer/ConversationListStateHolderTest.kt
+++ b/feature/conversations/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/conversations/drawer/ConversationListStateHolderTest.kt
@@ -1,0 +1,94 @@
+package com.garfiec.librechat.feature.conversations.drawer
+
+import com.garfiec.librechat.core.common.result.Result
+import com.garfiec.librechat.core.data.repository.ConversationRepository
+import com.garfiec.librechat.core.model.Conversation
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ConversationListStateHolderTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private lateinit var scope: CoroutineScope
+
+    private val conversationRepository = mockk<ConversationRepository>(relaxed = true)
+
+    private val convos = listOf(
+        Conversation(conversationId = "c1", title = "Alpha One", updatedAt = "2026-02-19T10:00:00.000Z"),
+        Conversation(conversationId = "c2", title = "Alpha Two", updatedAt = "2026-02-19T09:00:00.000Z"),
+    )
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        scope = CoroutineScope(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        scope.cancel()
+        Dispatchers.resetMain()
+    }
+
+    private fun visibleIds(holder: ConversationListStateHolder) =
+        holder.groupedConversations.value.flatMap { it.second }.mapNotNull { it.conversationId }
+
+    @Test
+    fun `delete during active drawer search removes the row without a query change`() = runTest {
+        // Punted Bug #25 (drawer side): the drawer search is a client-side filter over live Room
+        // data, so a delete (Room re-emits) must vanish from the visible results immediately, not
+        // wait for the next keystroke.
+        val roomFlow = MutableStateFlow<Result<List<Conversation>>>(Result.Success(convos))
+        every { conversationRepository.observeConversations(any()) } returns roomFlow
+
+        val holder = ConversationListStateHolder(conversationRepository, scope)
+        advanceUntilIdle()
+
+        holder.onSearchQueryChanged("Alpha")
+        advanceUntilIdle() // clears the search debounce
+        assertThat(visibleIds(holder)).containsExactly("c1", "c2")
+
+        // c1 deleted from the drawer: Room re-emits without it while the search is still active.
+        roomFlow.value = Result.Success(convos.filter { it.conversationId == "c2" })
+        advanceUntilIdle()
+
+        assertThat(visibleIds(holder)).containsExactly("c2")
+    }
+
+    @Test
+    fun `rename during active drawer search updates the visible title`() = runTest {
+        val roomFlow = MutableStateFlow<Result<List<Conversation>>>(Result.Success(convos))
+        every { conversationRepository.observeConversations(any()) } returns roomFlow
+
+        val holder = ConversationListStateHolder(conversationRepository, scope)
+        advanceUntilIdle()
+
+        holder.onSearchQueryChanged("Alpha")
+        advanceUntilIdle()
+
+        roomFlow.value = Result.Success(
+            convos.map { if (it.conversationId == "c1") it.copy(title = "Alpha One Renamed") else it },
+        )
+        advanceUntilIdle()
+
+        val titles = holder.groupedConversations.value.flatMap { it.second }
+            .associate { it.conversationId to it.title }
+        assertThat(titles["c1"]).isEqualTo("Alpha One Renamed")
+        assertThat(titles.keys).containsExactly("c1", "c2")
+    }
+}

--- a/feature/conversations/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/conversations/drawer/DrawerDisplayMappingTest.kt
+++ b/feature/conversations/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/conversations/drawer/DrawerDisplayMappingTest.kt
@@ -1,10 +1,9 @@
-package com.garfiec.librechat.shared.navigation
+package com.garfiec.librechat.feature.conversations.drawer
 
 import com.garfiec.librechat.core.model.Conversation
 import com.garfiec.librechat.core.model.EndpointConfig
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertNull
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
 
 class DrawerDisplayMappingTest {
 
@@ -21,7 +20,7 @@ class DrawerDisplayMappingTest {
 
         val data = convo.toDrawerDisplayData(activeConversationId = null, endpointConfigs = configs)
 
-        assertEquals("https://convo-icon.example.com/icon.png", data.endpointIconUrl)
+        assertThat(data.endpointIconUrl).isEqualTo("https://convo-icon.example.com/icon.png")
     }
 
     @Test
@@ -37,7 +36,7 @@ class DrawerDisplayMappingTest {
 
         val data = convo.toDrawerDisplayData(activeConversationId = null, endpointConfigs = configs)
 
-        assertEquals("https://config-icon.example.com/icon.png", data.endpointIconUrl)
+        assertThat(data.endpointIconUrl).isEqualTo("https://config-icon.example.com/icon.png")
     }
 
     @Test
@@ -53,7 +52,7 @@ class DrawerDisplayMappingTest {
 
         val data = convo.toDrawerDisplayData(activeConversationId = null, endpointConfigs = configs)
 
-        assertNull(data.endpointIconUrl)
+        assertThat(data.endpointIconUrl).isNull()
     }
 
     @Test
@@ -69,6 +68,6 @@ class DrawerDisplayMappingTest {
             endpointConfigs = emptyMap(),
         )
 
-        assertNull(data.endpointIconUrl)
+        assertThat(data.endpointIconUrl).isNull()
     }
 }

--- a/feature/conversations/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/conversations/viewmodel/ConversationListViewModelTest.kt
+++ b/feature/conversations/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/conversations/viewmodel/ConversationListViewModelTest.kt
@@ -548,6 +548,115 @@ class ConversationListViewModelTest {
     }
 
     @Test
+    fun `delete from Room during active search removes the row from visible results`() = runTest {
+        // Regression (Punted Bug #25): a drawer-side delete used to stay visible in the list
+        // screen's active search until search was cleared, because Room emissions were dropped
+        // wholesale during search. Now a present -> absent transition subtracts the deleted row.
+        val roomFlow = MutableStateFlow<Result<List<Conversation>>>(Result.Success(testConversations))
+        every { conversationRepository.observeConversations(any()) } returns roomFlow
+        coEvery { searchRepository.search("q") } returns Result.Success(testConversations)
+
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.onSearchQueryChanged("q")
+        advanceUntilIdle()
+        assertThat(
+            viewModel.uiState.value.groupedConversations.flatMap { it.second }.map { it.conversationId },
+        ).containsExactly("convo-1", "convo-2")
+
+        // Room re-emits without convo-1 (deleted from the drawer) while search is still active.
+        roomFlow.value = Result.Success(testConversations.filter { it.conversationId == "convo-2" })
+        advanceUntilIdle()
+
+        assertThat(
+            viewModel.uiState.value.groupedConversations.flatMap { it.second }.map { it.conversationId },
+        ).containsExactly("convo-2")
+    }
+
+    @Test
+    fun `rename in Room during active search refreshes the visible row`() = runTest {
+        val roomFlow = MutableStateFlow<Result<List<Conversation>>>(Result.Success(testConversations))
+        every { conversationRepository.observeConversations(any()) } returns roomFlow
+        coEvery { searchRepository.search("q") } returns Result.Success(testConversations)
+
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.onSearchQueryChanged("q")
+        advanceUntilIdle()
+
+        // Room re-emits convo-1 with a new title (drawer rename); the visible search row updates
+        // in place, and rows Room no longer holds are not pulled in.
+        val renamed = testConversations.map {
+            if (it.conversationId == "convo-1") it.copy(title = "Renamed First") else it
+        }
+        roomFlow.value = Result.Success(renamed)
+        advanceUntilIdle()
+
+        val titles = viewModel.uiState.value.groupedConversations.flatMap { it.second }
+            .associate { it.conversationId to it.title }
+        assertThat(titles["convo-1"]).isEqualTo("Renamed First")
+        assertThat(titles.keys).containsExactly("convo-1", "convo-2")
+    }
+
+    @Test
+    fun `stale Room row during active search does not clobber a server-fresher search hit`() = runTest {
+        // Server search returns a fresher copy (newer updatedAt) than the local Room cache holds —
+        // e.g. the title was changed on another device and hasn't synced down yet. A Room re-emission
+        // during the search must NOT revert the visible row to the stale cached title.
+        val freshHit = Conversation(
+            conversationId = "convo-1",
+            title = "Fresh Title",
+            updatedAt = "2026-02-19T12:00:00.000Z",
+        )
+        val staleRoom = Conversation(
+            conversationId = "convo-1",
+            title = "Stale Title",
+            updatedAt = "2026-02-19T10:00:00.000Z",
+        )
+        val roomFlow = MutableStateFlow<Result<List<Conversation>>>(Result.Success(listOf(staleRoom)))
+        every { conversationRepository.observeConversations(any()) } returns roomFlow
+        coEvery { searchRepository.search("q") } returns Result.Success(listOf(freshHit))
+
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.onSearchQueryChanged("q")
+        advanceUntilIdle()
+
+        // Room re-emits the stale copy while search is active.
+        roomFlow.value = Result.Success(listOf(staleRoom.copy()))
+        advanceUntilIdle()
+
+        val titles = viewModel.uiState.value.groupedConversations.flatMap { it.second }
+            .associate { it.conversationId to it.title }
+        assertThat(titles["convo-1"]).isEqualTo("Fresh Title")
+    }
+
+    @Test
+    fun `empty Room emission during active search does not blank the results`() = runTest {
+        // An empty emission is the account-scoped gate resetting on switch, not a per-row delete;
+        // blanking the active search here would leave a stale query over an empty list.
+        val roomFlow = MutableStateFlow<Result<List<Conversation>>>(Result.Success(testConversations))
+        every { conversationRepository.observeConversations(any()) } returns roomFlow
+        coEvery { searchRepository.search("q") } returns Result.Success(testConversations)
+
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.onSearchQueryChanged("q")
+        advanceUntilIdle()
+
+        roomFlow.value = Result.Success(emptyList())
+        advanceUntilIdle()
+
+        assertThat(
+            viewModel.uiState.value.groupedConversations.flatMap { it.second }.map { it.conversationId },
+        ).containsExactly("convo-1", "convo-2")
+    }
+
+    @Test
     fun `endpointConfigs arriving late re-groups rows with iconURL`() = runTest {
         // Conversation has no per-convo iconURL; relies on the endpoint config fallback.
         val convo = Conversation(

--- a/feature/conversations/src/commonMain/composeResources/values-ar/strings.xml
+++ b/feature/conversations/src/commonMain/composeResources/values-ar/strings.xml
@@ -76,4 +76,12 @@
 
     <!-- Conversation item fallback -->
     <string name="chat">محادثة</string>
+    <!-- Drawer strings (moved from :shared) -->
+    <string name="agents">الوكلاء</string>
+    <string name="favorites">المفضلة</string>
+    <string name="files">الملفات</string>
+    <string name="no_conversations_found">لم يتم العثور على محادثات</string>
+    <string name="search_conversations_placeholder">البحث في المحادثات…</string>
+    <string name="settings">الإعدادات</string>
+    <string name="skills">المهارات</string>
 </resources>

--- a/feature/conversations/src/commonMain/composeResources/values-de/strings.xml
+++ b/feature/conversations/src/commonMain/composeResources/values-de/strings.xml
@@ -76,4 +76,12 @@
 
     <!-- Conversation item fallback -->
     <string name="chat">Chat</string>
+    <!-- Drawer strings (moved from :shared) -->
+    <string name="agents">Agenten</string>
+    <string name="favorites">Favoriten</string>
+    <string name="files">Dateien</string>
+    <string name="no_conversations_found">Keine Unterhaltungen gefunden</string>
+    <string name="search_conversations_placeholder">Unterhaltungen suchen…</string>
+    <string name="settings">Einstellungen</string>
+    <string name="skills">Skills</string>
 </resources>

--- a/feature/conversations/src/commonMain/composeResources/values-es/strings.xml
+++ b/feature/conversations/src/commonMain/composeResources/values-es/strings.xml
@@ -76,4 +76,12 @@
 
     <!-- Conversation item fallback -->
     <string name="chat">Chat</string>
+    <!-- Drawer strings (moved from :shared) -->
+    <string name="agents">Agentes</string>
+    <string name="favorites">Favoritos</string>
+    <string name="files">Archivos</string>
+    <string name="no_conversations_found">No se encontraron conversaciones</string>
+    <string name="search_conversations_placeholder">Buscar conversaciones…</string>
+    <string name="settings">Ajustes</string>
+    <string name="skills">Habilidades</string>
 </resources>

--- a/feature/conversations/src/commonMain/composeResources/values-fr/strings.xml
+++ b/feature/conversations/src/commonMain/composeResources/values-fr/strings.xml
@@ -76,4 +76,12 @@
 
     <!-- Conversation item fallback -->
     <string name="chat">Discussion</string>
+    <!-- Drawer strings (moved from :shared) -->
+    <string name="agents">Agents</string>
+    <string name="favorites">Favoris</string>
+    <string name="files">Fichiers</string>
+    <string name="no_conversations_found">Aucune conversation trouvée</string>
+    <string name="search_conversations_placeholder">Rechercher des conversations…</string>
+    <string name="settings">Paramètres</string>
+    <string name="skills">Compétences</string>
 </resources>

--- a/feature/conversations/src/commonMain/composeResources/values-ja/strings.xml
+++ b/feature/conversations/src/commonMain/composeResources/values-ja/strings.xml
@@ -76,4 +76,12 @@
 
     <!-- Conversation item fallback -->
     <string name="chat">チャット</string>
+    <!-- Drawer strings (moved from :shared) -->
+    <string name="agents">エージェント</string>
+    <string name="favorites">お気に入り</string>
+    <string name="files">ファイル</string>
+    <string name="no_conversations_found">会話が見つかりません</string>
+    <string name="search_conversations_placeholder">会話を検索…</string>
+    <string name="settings">設定</string>
+    <string name="skills">スキル</string>
 </resources>

--- a/feature/conversations/src/commonMain/composeResources/values-ko/strings.xml
+++ b/feature/conversations/src/commonMain/composeResources/values-ko/strings.xml
@@ -76,4 +76,12 @@
 
     <!-- Conversation item fallback -->
     <string name="chat">채팅</string>
+    <!-- Drawer strings (moved from :shared) -->
+    <string name="agents">에이전트</string>
+    <string name="favorites">즐겨찾기</string>
+    <string name="files">파일</string>
+    <string name="no_conversations_found">대화를 찾을 수 없습니다</string>
+    <string name="search_conversations_placeholder">대화 검색…</string>
+    <string name="settings">설정</string>
+    <string name="skills">스킬</string>
 </resources>

--- a/feature/conversations/src/commonMain/composeResources/values-pt/strings.xml
+++ b/feature/conversations/src/commonMain/composeResources/values-pt/strings.xml
@@ -76,4 +76,12 @@
 
     <!-- Conversation item fallback -->
     <string name="chat">Conversa</string>
+    <!-- Drawer strings (moved from :shared) -->
+    <string name="agents">Agentes</string>
+    <string name="favorites">Favoritos</string>
+    <string name="files">Arquivos</string>
+    <string name="no_conversations_found">Nenhuma conversa encontrada</string>
+    <string name="search_conversations_placeholder">Buscar conversas…</string>
+    <string name="settings">Configurações</string>
+    <string name="skills">Habilidades</string>
 </resources>

--- a/feature/conversations/src/commonMain/composeResources/values-ru/strings.xml
+++ b/feature/conversations/src/commonMain/composeResources/values-ru/strings.xml
@@ -76,4 +76,12 @@
 
     <!-- Conversation item fallback -->
     <string name="chat">Чат</string>
+    <!-- Drawer strings (moved from :shared) -->
+    <string name="agents">Агенты</string>
+    <string name="favorites">Избранное</string>
+    <string name="files">Файлы</string>
+    <string name="no_conversations_found">Беседы не найдены</string>
+    <string name="search_conversations_placeholder">Поиск бесед…</string>
+    <string name="settings">Настройки</string>
+    <string name="skills">Навыки</string>
 </resources>

--- a/feature/conversations/src/commonMain/composeResources/values-zh/strings.xml
+++ b/feature/conversations/src/commonMain/composeResources/values-zh/strings.xml
@@ -76,4 +76,12 @@
 
     <!-- Conversation item fallback -->
     <string name="chat">聊天</string>
+    <!-- Drawer strings (moved from :shared) -->
+    <string name="agents">智能体</string>
+    <string name="favorites">收藏</string>
+    <string name="files">文件</string>
+    <string name="no_conversations_found">未找到对话</string>
+    <string name="search_conversations_placeholder">搜索对话…</string>
+    <string name="settings">设置</string>
+    <string name="skills">技能</string>
 </resources>

--- a/feature/conversations/src/commonMain/composeResources/values/strings.xml
+++ b/feature/conversations/src/commonMain/composeResources/values/strings.xml
@@ -101,4 +101,27 @@
 
     <!-- Conversation item fallback -->
     <string name="chat">Chat</string>
+    <!-- Drawer strings (moved from :shared) -->
+    <string name="agents">Agents</string>
+    <string name="cd_collapse_section">Collapse section</string>
+    <string name="cd_expand_section">Expand section</string>
+    <string name="chats">Chats</string>
+    <string name="favorites">Favorites</string>
+    <string name="files">Files</string>
+    <string name="library">Library</string>
+    <string name="no_conversations_found">No conversations found</string>
+    <string name="pinned">Pinned</string>
+    <string name="projects">Projects</string>
+    <string name="search_conversations_placeholder">Search conversations\u2026</string>
+    <string name="settings">Settings</string>
+    <string name="show_less">Show less</string>
+    <string name="show_more">Show more</string>
+    <string name="skills">Skills</string>
+    <string name="accounts">Accounts</string>
+    <string name="add_account">Add account</string>
+    <string name="cd_active_account">Active account</string>
+    <string name="remove">Remove</string>
+    <string name="remove_account">Remove account</string>
+    <string name="remove_account_message">%1$s and its data will be removed from this device. The account on the server is not affected.</string>
+    <string name="remove_account_title">Remove account?</string>
 </resources>

--- a/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/di/ConversationsModule.kt
+++ b/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/di/ConversationsModule.kt
@@ -1,6 +1,7 @@
 package com.garfiec.librechat.feature.conversations.di
 
 import com.garfiec.librechat.core.common.di.KoinQualifiers
+import com.garfiec.librechat.feature.conversations.drawer.DrawerViewModel
 import com.garfiec.librechat.feature.conversations.export.ConversationExporter
 import com.garfiec.librechat.feature.conversations.export.ConversationImporter
 import com.garfiec.librechat.feature.conversations.viewmodel.ArchivedConversationsViewModel
@@ -28,6 +29,8 @@ val conversationsModule = module {
     viewModelOf(::ConversationListViewModel)
     viewModelOf(::ArchivedConversationsViewModel)
     viewModelOf(::ProjectsViewModel)
+    // Drawer-data half of the nav shell's NavHostViewModel.
+    viewModelOf(::DrawerViewModel)
     // projectId arrives from the navigation layer via parametersOf.
     @Suppress("DeprecatedKoinApi")
     viewModel { params ->

--- a/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/drawer/AccountSwitcherSheet.kt
+++ b/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/drawer/AccountSwitcherSheet.kt
@@ -1,4 +1,4 @@
-package com.garfiec.librechat.shared.navigation
+package com.garfiec.librechat.feature.conversations.drawer
 
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.core.Spring
@@ -52,15 +52,15 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.garfiec.librechat.core.ui.components.AvatarImage
 import com.garfiec.librechat.core.ui.components.avatarColorForSeed
-import com.garfiec.librechat.shared.resources.Res
-import com.garfiec.librechat.shared.resources.accounts
-import com.garfiec.librechat.shared.resources.add_account
-import com.garfiec.librechat.shared.resources.cancel
-import com.garfiec.librechat.shared.resources.cd_active_account
-import com.garfiec.librechat.shared.resources.remove
-import com.garfiec.librechat.shared.resources.remove_account
-import com.garfiec.librechat.shared.resources.remove_account_message
-import com.garfiec.librechat.shared.resources.remove_account_title
+import com.garfiec.librechat.feature.conversations.resources.Res
+import com.garfiec.librechat.feature.conversations.resources.accounts
+import com.garfiec.librechat.feature.conversations.resources.add_account
+import com.garfiec.librechat.feature.conversations.resources.cancel
+import com.garfiec.librechat.feature.conversations.resources.cd_active_account
+import com.garfiec.librechat.feature.conversations.resources.remove
+import com.garfiec.librechat.feature.conversations.resources.remove_account
+import com.garfiec.librechat.feature.conversations.resources.remove_account_message
+import com.garfiec.librechat.feature.conversations.resources.remove_account_title
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource

--- a/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/drawer/ConversationListStateHolder.kt
+++ b/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/drawer/ConversationListStateHolder.kt
@@ -1,4 +1,4 @@
-package com.garfiec.librechat.shared.navigation
+package com.garfiec.librechat.feature.conversations.drawer
 
 import co.touchlab.kermit.Logger
 import com.garfiec.librechat.core.common.extensions.toInstantOrNull
@@ -64,9 +64,15 @@ class ConversationListStateHolder(
                 conversationRepository.observeConversations().collect { result ->
                     if (result is Result.Success) {
                         _recentConversations.value = result.data
-                        if (_searchQuery.value.isBlank()) {
-                            _groupedConversations.value =
-                                groupConversationsByDate(result.data.withoutPinned())
+                        // Regroup on every Room emission — including during an active search. Search
+                        // is a client-side filter over live Room data, so a delete/rename/pin/favorite
+                        // (which re-emits Room) must reflect in the visible results immediately, not
+                        // wait for the next query keystroke (Punted Bug #25, drawer side).
+                        val query = _searchQuery.value
+                        _groupedConversations.value = if (query.isBlank()) {
+                            groupConversationsByDate(result.data.withoutPinned())
+                        } else {
+                            groupConversationsByDate(filterByQuery(result.data, query))
                         }
                     }
                 }
@@ -141,13 +147,14 @@ class ConversationListStateHolder(
                 .filter { it.isNotBlank() }
                 .debounce(SEARCH_DEBOUNCE_MS)
                 .collectLatest { query ->
-                    val filtered = _recentConversations.value.filter { conversation ->
-                        conversation.title?.contains(query, ignoreCase = true) == true
-                    }
-                    _groupedConversations.value = groupConversationsByDate(filtered)
+                    _groupedConversations.value =
+                        groupConversationsByDate(filterByQuery(_recentConversations.value, query))
                 }
         }
     }
+
+    private fun filterByQuery(conversations: List<Conversation>, query: String): List<Conversation> =
+        conversations.filter { it.title?.contains(query, ignoreCase = true) == true }
 
     fun reset() {
         searchObserverJob?.cancel()

--- a/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/drawer/DrawerContent.kt
+++ b/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/drawer/DrawerContent.kt
@@ -1,4 +1,4 @@
-package com.garfiec.librechat.shared.navigation
+package com.garfiec.librechat.feature.conversations.drawer
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.animateFloatAsState
@@ -100,31 +100,31 @@ import com.garfiec.librechat.feature.conversations.components.ProjectPicker
 import com.garfiec.librechat.feature.conversations.components.TagPicker
 import com.garfiec.librechat.feature.conversations.export.ExportFormat
 import com.garfiec.librechat.feature.conversations.export.ExportFormatPicker
-import com.garfiec.librechat.shared.resources.Res
-import com.garfiec.librechat.shared.resources.agents
-import com.garfiec.librechat.shared.resources.bookmark
-import com.garfiec.librechat.shared.resources.cd_clear_search
-import com.garfiec.librechat.shared.resources.cd_collapse_section
-import com.garfiec.librechat.shared.resources.cd_conversation_actions
-import com.garfiec.librechat.shared.resources.cd_expand_section
-import com.garfiec.librechat.shared.resources.cd_search
-import com.garfiec.librechat.shared.resources.chats
-import com.garfiec.librechat.shared.resources.favorites
-import com.garfiec.librechat.shared.resources.files
-import com.garfiec.librechat.shared.resources.library
-import com.garfiec.librechat.shared.resources.new_chat
-import com.garfiec.librechat.shared.resources.no_conversations_found
-import com.garfiec.librechat.shared.resources.pinned
-import com.garfiec.librechat.shared.resources.project_new
-import com.garfiec.librechat.shared.resources.project_unassigned
-import com.garfiec.librechat.shared.resources.projects
-import com.garfiec.librechat.shared.resources.projects_all
-import com.garfiec.librechat.shared.resources.remove_bookmark
-import com.garfiec.librechat.shared.resources.search_conversations_placeholder
-import com.garfiec.librechat.shared.resources.settings
-import com.garfiec.librechat.shared.resources.show_less
-import com.garfiec.librechat.shared.resources.show_more
-import com.garfiec.librechat.shared.resources.skills
+import com.garfiec.librechat.feature.conversations.resources.Res
+import com.garfiec.librechat.feature.conversations.resources.agents
+import com.garfiec.librechat.feature.conversations.resources.bookmark
+import com.garfiec.librechat.feature.conversations.resources.cd_clear_search
+import com.garfiec.librechat.feature.conversations.resources.cd_collapse_section
+import com.garfiec.librechat.feature.conversations.resources.cd_conversation_actions
+import com.garfiec.librechat.feature.conversations.resources.cd_expand_section
+import com.garfiec.librechat.feature.conversations.resources.cd_search
+import com.garfiec.librechat.feature.conversations.resources.chats
+import com.garfiec.librechat.feature.conversations.resources.favorites
+import com.garfiec.librechat.feature.conversations.resources.files
+import com.garfiec.librechat.feature.conversations.resources.library
+import com.garfiec.librechat.feature.conversations.resources.new_chat
+import com.garfiec.librechat.feature.conversations.resources.no_conversations_found
+import com.garfiec.librechat.feature.conversations.resources.pinned
+import com.garfiec.librechat.feature.conversations.resources.project_new
+import com.garfiec.librechat.feature.conversations.resources.project_unassigned
+import com.garfiec.librechat.feature.conversations.resources.projects
+import com.garfiec.librechat.feature.conversations.resources.projects_all
+import com.garfiec.librechat.feature.conversations.resources.remove_bookmark
+import com.garfiec.librechat.feature.conversations.resources.search_conversations_placeholder
+import com.garfiec.librechat.feature.conversations.resources.settings
+import com.garfiec.librechat.feature.conversations.resources.show_less
+import com.garfiec.librechat.feature.conversations.resources.show_more
+import com.garfiec.librechat.feature.conversations.resources.skills
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
 
@@ -162,16 +162,20 @@ fun DrawerContent(
     onAgentsClick: () -> Unit,
     onFilesClick: () -> Unit,
     onSkillsClick: () -> Unit,
+    accounts: List<AccountUiModel>,
     modifier: Modifier = Modifier,
     onOpenProjectsIndex: () -> Unit = {},
     onSwitchAccount: (String) -> Unit = {},
     onAddAccount: () -> Unit = {},
-    viewModel: NavHostViewModel = koinViewModel(),
+    // Round-robin swipe switch (in place, drawer stays open) + sheet remove — both are nav-shell
+    // account operations, hoisted in because DrawerViewModel owns only drawer data now.
+    onSwitchAccountInPlace: (String) -> Unit = {},
+    onRemoveAccount: (String) -> Unit = {},
+    viewModel: DrawerViewModel = koinViewModel(),
 ) {
     val uiState by viewModel.drawerUiState.collectAsStateWithLifecycle()
     val projects by viewModel.projects.collectAsStateWithLifecycle()
     val inlineProjectChats by viewModel.inlineProjectChats.collectAsStateWithLifecycle()
-    val accounts by viewModel.accounts.collectAsStateWithLifecycle()
     val libraryTab by viewModel.drawerLibraryTab.collectAsStateWithLifecycle()
 
     // Account switcher: the header chip opens the roster sheet; remove asks for confirmation.
@@ -214,7 +218,7 @@ fun DrawerContent(
                         // keeps the drawer open too (the host no longer closes it on switch).
                         // Disabled (null) with a single account.
                         onSwitchAdjacent = if (accounts.size > 1) {
-                            { delta -> adjacentAccountId(accounts, delta)?.let(viewModel::switchAccount) }
+                            { delta -> adjacentAccountId(accounts, delta)?.let(onSwitchAccountInPlace) }
                         } else {
                             null
                         },
@@ -274,7 +278,7 @@ fun DrawerContent(
         RemoveAccountDialog(
             account = target,
             onConfirm = {
-                viewModel.removeAccount(target.accountId)
+                onRemoveAccount(target.accountId)
                 removeAccountTarget = null
             },
             onDismiss = { removeAccountTarget = null },

--- a/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/drawer/DrawerDisplayMapping.kt
+++ b/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/drawer/DrawerDisplayMapping.kt
@@ -1,4 +1,4 @@
-package com.garfiec.librechat.shared.navigation
+package com.garfiec.librechat.feature.conversations.drawer
 
 import com.garfiec.librechat.core.common.extensions.formatMonthAbbrev
 import com.garfiec.librechat.core.common.extensions.toInstantOrNull

--- a/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/drawer/DrawerTab.kt
+++ b/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/drawer/DrawerTab.kt
@@ -1,4 +1,4 @@
-package com.garfiec.librechat.shared.navigation
+package com.garfiec.librechat.feature.conversations.drawer
 
 /**
  * The drawer "Library" section's two modes: the recents history vs. the project folders. Persisted

--- a/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/drawer/DrawerUiModels.kt
+++ b/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/drawer/DrawerUiModels.kt
@@ -1,4 +1,4 @@
-package com.garfiec.librechat.shared.navigation
+package com.garfiec.librechat.feature.conversations.drawer
 
 import androidx.compose.runtime.Immutable
 import com.garfiec.librechat.core.model.ConversationTag

--- a/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/drawer/DrawerViewModel.kt
+++ b/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/drawer/DrawerViewModel.kt
@@ -1,0 +1,471 @@
+package com.garfiec.librechat.feature.conversations.drawer
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import co.touchlab.kermit.Logger
+import com.garfiec.librechat.core.common.BackendVersion
+import com.garfiec.librechat.core.common.identity.AccountTransition
+import com.garfiec.librechat.core.common.identity.ActiveAccountProvider
+import com.garfiec.librechat.core.common.identity.accountTransitions
+import com.garfiec.librechat.core.common.result.Result
+import com.garfiec.librechat.core.data.datastore.SettingsDataStore
+import com.garfiec.librechat.core.data.repository.ConfigRepository
+import com.garfiec.librechat.core.data.repository.ConversationRepository
+import com.garfiec.librechat.core.data.repository.ProjectRepository
+import com.garfiec.librechat.core.data.repository.RoleRepository
+import com.garfiec.librechat.core.data.repository.ShareRepository
+import com.garfiec.librechat.core.data.repository.TagRepository
+import com.garfiec.librechat.core.model.ChatProject
+import com.garfiec.librechat.core.model.Conversation
+import com.garfiec.librechat.core.model.ConversationTag
+import com.garfiec.librechat.core.model.SAVED_TAG
+import com.garfiec.librechat.core.model.permissions.Permission
+import com.garfiec.librechat.core.model.permissions.PermissionType
+import com.garfiec.librechat.core.model.permissions.canCreateSharedLinks
+import com.garfiec.librechat.core.model.permissions.hasAccessOrPermissive
+import com.garfiec.librechat.feature.conversations.export.ConversationExporter
+import com.garfiec.librechat.feature.conversations.export.ExportFormat
+import com.garfiec.librechat.feature.conversations.viewmodel.ConversationListActionsDelegate
+import com.garfiec.librechat.feature.conversations.viewmodel.ConversationListEvent
+import com.garfiec.librechat.feature.conversations.viewmodel.ProjectActionsDelegate
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+/**
+ * Drawer-data half of the navigation shell, split out of `NavHostViewModel` so `:shared` stays nav
+ * glue rather than a stealth feature module. Owns the drawer's conversation list, favorites/pinned sections,
+ * long-press action menu, Projects tab, and the drawer's "Library" tab preference. Activity-scoped
+ * (registered as a plain `viewModelOf`), so a single instance is shared by the phone drawer, the
+ * tablet sidebar, and the nav host's active-conversation tracking.
+ */
+class DrawerViewModel(
+    private val conversationRepository: ConversationRepository,
+    private val roleRepository: RoleRepository,
+    private val tagRepository: TagRepository,
+    private val projectRepository: ProjectRepository,
+    private val configRepository: ConfigRepository,
+    private val shareRepository: ShareRepository,
+    private val conversationExporter: ConversationExporter,
+    private val activeAccountProvider: ActiveAccountProvider,
+    private val settingsDataStore: SettingsDataStore,
+) : ViewModel() {
+
+    private val conversationListStateHolder = ConversationListStateHolder(conversationRepository, viewModelScope)
+
+    private val favoriteConversations: StateFlow<List<Conversation>> =
+        conversationListStateHolder.recentConversations
+            .map { list -> list.filter { SAVED_TAG in it.tags } }
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
+    private val pinnedConversations: StateFlow<List<Conversation>> =
+        conversationListStateHolder.recentConversations
+            .map { list -> list.filter { it.pinned == true } }
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
+    // Inputs for the drawer long-press action menu: the user-defined tags (excluding favorites,
+    // same filter as ConversationListViewModel.observeTags) for the tag picker, plus the
+    // config-driven shared-links flag and the SHARED_LINKS role permission that gate the Share action.
+    private val drawerActionMenuState: StateFlow<DrawerActionMenuState> =
+        combine(
+            tagRepository.observeTags()
+                .map { tags -> tags.filter { it.count > 0 && it.tag != SAVED_TAG } },
+            configRepository.startupConfig,
+            configRepository.detectedBackendVersion,
+            roleRepository.userPermissions,
+        ) { tags, config, version, permissions ->
+            // Pin requires POST /api/convos/pin (v0.8.7+). Gate fail-closed on unknown
+            // version so older servers don't surface an action they'd 404 on.
+            val supportsV087 = version != null && BackendVersion.isCompatibleOrNewer(version, "0.8.7")
+            val canShare = permissions.canCreateSharedLinks(config?.sharedLinksEnabled ?: false)
+            DrawerActionMenuState(tags, canShare, supportsV087, supportsV087)
+        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), DrawerActionMenuState())
+
+    // Chat Projects (v0.8.7). Loaded lazily for the move-to-project picker and the drawer's Projects
+    // tab folder list; the server is the source of truth (no local cache).
+    private val _projects = MutableStateFlow<List<ChatProject>>(emptyList())
+    val projects: StateFlow<List<ChatProject>> = _projects.asStateFlow()
+
+    // Inline project-chat accordion for the drawer Projects tab. Network-direct per project (Room
+    // can't filter by project — see ProjectChatsViewModel), single-expand: only the open project's
+    // chats are held. Mapped to the drawer row type against the active id + endpoint configs so the
+    // rows match the recents list.
+    private val _expandedProjectId = MutableStateFlow<String?>(null)
+    private val _expandedProjectChats = MutableStateFlow<List<Conversation>>(emptyList())
+    private val _expandedProjectLoading = MutableStateFlow(false)
+
+    val inlineProjectChats: StateFlow<InlineProjectChatsState> = combine(
+        _expandedProjectId,
+        _expandedProjectChats,
+        _expandedProjectLoading,
+        conversationListStateHolder.activeConversationId,
+        configRepository.endpointConfigs,
+    ) { expandedId, convos, loading, activeId, configs ->
+        InlineProjectChatsState(
+            expandedProjectId = expandedId,
+            conversations = convos.map { it.toDrawerDisplayData(activeId, configs) },
+            isLoading = loading,
+        )
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), InlineProjectChatsState())
+
+    // One-shot events for the drawer action menu (share-link copied, export-ready,
+    // navigate-to-duplicate, errors). Reuses the conversation-list event type. extraBufferCapacity
+    // lets emit() return immediately instead of suspending if the collector (ConversationActionEffects)
+    // is momentarily absent — e.g. an action's result arriving as the drawer leaves composition.
+    private val _events = MutableSharedFlow<ConversationListEvent>(extraBufferCapacity = 1)
+    val events: SharedFlow<ConversationListEvent> = _events.asSharedFlow()
+
+    // Shared row-action logic (rename/archive/delete/share/duplicate/export) — the same delegate
+    // ConversationListViewModel and ProjectChatsViewModel use, so the drawer long-press menu surfaces
+    // Result.Error failures (toast) instead of swallowing them in a dead try/catch around a
+    // Result-returning repo call. Room-backed here, so onMutated is a no-op: the conversation
+    // observe-Flow already re-emits after a mutation.
+    private val conversationActions = ConversationListActionsDelegate(
+        scope = viewModelScope,
+        events = _events,
+        conversationRepository = conversationRepository,
+        tagRepository = tagRepository,
+        shareRepository = shareRepository,
+        conversationExporter = conversationExporter,
+        onMutated = {},
+    )
+
+    // Shared project CRUD (same delegate ProjectsViewModel uses).
+    private val projectActions = ProjectActionsDelegate(
+        scope = viewModelScope,
+        projectRepository = projectRepository,
+        onChanged = { loadProjects() },
+        onDeleted = { loadProjects() },
+        emitError = { _events.emit(ConversationListEvent.ShowError(it)) },
+    )
+
+    // Drawer "Library" tab is optimistic local state (instant toggle) with DataStore as a write-behind
+    // cache: hydrated once in init and written on change. Null = not yet hydrated; the drawer shows
+    // Chats for the brief window until the persisted value loads, and the seed's update { it ?: ... }
+    // lets a tap in that window win over the incoming persisted value.
+    private val _drawerLibraryTab = MutableStateFlow<DrawerTab?>(null)
+    val drawerLibraryTab: StateFlow<DrawerTab?> = _drawerLibraryTab.asStateFlow()
+
+    fun setDrawerLibraryTab(tab: DrawerTab) {
+        _drawerLibraryTab.value = tab
+        viewModelScope.launch { settingsDataStore.setDrawerLibraryTab(tab.toStorageString()) }
+    }
+
+    /**
+     * Role-permission flags for drawer UI. Permissive-default (`?: true`) until the
+     * role loads; once it does, denied permissions flip the flags off and the drawer
+     * re-composes to hide the corresponding surfaces.
+     */
+    private val drawerPermissionFlags: StateFlow<DrawerPermissionFlags> =
+        roleRepository.userPermissions
+            .map { role ->
+                DrawerPermissionFlags(
+                    agentsEnabled = role.hasAccessOrPermissive(PermissionType.AGENTS, Permission.USE),
+                    bookmarksEnabled = role.hasAccessOrPermissive(PermissionType.BOOKMARKS, Permission.USE),
+                    // USE gate is fail-OPEN (read/list visibility); mutation gating
+                    // lives fail-CLOSED inside feature/skills.
+                    skillsEnabled = role.hasAccessOrPermissive(PermissionType.SKILLS, Permission.USE),
+                )
+            }
+            .stateIn(viewModelScope, SharingStarted.Eagerly, DrawerPermissionFlags())
+
+    val drawerUiState: StateFlow<DrawerUiState> = combine(
+        combine(
+            conversationListStateHolder.groupedConversations,
+            conversationListStateHolder.activeConversationId,
+            favoriteConversations,
+            pinnedConversations,
+            conversationListStateHolder.searchQuery,
+        ) { grouped, activeId, favConvos, pinnedConvos, query ->
+            DrawerDataSnapshot(grouped, activeId, favConvos, pinnedConvos, query)
+        },
+        combine(
+            conversationListStateHolder.isRefreshing,
+            conversationListStateHolder.isLoadingMore,
+            conversationListStateHolder.hasMore,
+        ) { refreshing, loadingMore, hasMore ->
+            Triple(refreshing, loadingMore, hasMore)
+        },
+        drawerPermissionFlags,
+        configRepository.endpointConfigs,
+        drawerActionMenuState,
+    ) { data, refreshState, perms, endpointConfigs, actionMenu ->
+        val (refreshing, loadingMore, hasMore) = refreshState
+        DrawerUiState(
+            groupedConversations = data.grouped.map { (group, convos) ->
+                group to convos.map { it.toDrawerDisplayData(data.activeId, endpointConfigs) }
+            },
+            favoriteConversations = data.favConvos.map {
+                it.toDrawerDisplayData(data.activeId, endpointConfigs)
+            },
+            pinnedConversations = data.pinnedConvos.map {
+                it.toDrawerDisplayData(data.activeId, endpointConfigs)
+            },
+            searchQuery = data.query,
+            isRefreshing = refreshing,
+            isLoadingMore = loadingMore,
+            hasMore = hasMore,
+            agentsEnabled = perms.agentsEnabled,
+            bookmarksEnabled = perms.bookmarksEnabled,
+            skillsEnabled = perms.skillsEnabled,
+            availableTags = actionMenu.availableTags,
+            sharedLinksEnabled = actionMenu.sharedLinksEnabled,
+            pinEnabled = actionMenu.pinEnabled,
+            projectsEnabled = actionMenu.projectsEnabled,
+        )
+    }.stateIn(viewModelScope, SharingStarted.Eagerly, DrawerUiState())
+
+    private data class DrawerPermissionFlags(
+        val agentsEnabled: Boolean = true,
+        val bookmarksEnabled: Boolean = true,
+        val skillsEnabled: Boolean = true,
+    )
+
+    private data class DrawerActionMenuState(
+        val availableTags: List<ConversationTag> = emptyList(),
+        val sharedLinksEnabled: Boolean = false,
+        val pinEnabled: Boolean = false,
+        val projectsEnabled: Boolean = false,
+    )
+
+    init {
+        viewModelScope.launch {
+            val persisted = DrawerTab.fromString(settingsDataStore.drawerLibraryTab.first())
+            _drawerLibraryTab.update { it ?: persisted }
+        }
+        // Load the Chat Projects folders once the backend is known to support them (v0.8.7+).
+        // detectedBackendVersion is a StateFlow (already conflated), so no distinctUntilChanged.
+        viewModelScope.launch {
+            configRepository.detectedBackendVersion.collect { version ->
+                if (version != null && BackendVersion.isCompatibleOrNewer(version, "0.8.7")) {
+                    loadProjects()
+                }
+            }
+        }
+        // The active account changed underneath this Activity-scoped VM. This is the drawer half of
+        // the reset the nav shell also performs (NavHostViewModel runs the nav/session half against
+        // its own independent accountTransitions() subscription — the flow is cold per-collector, so
+        // two subscribers are safe). Everything held in-memory here or in the singleton repos below
+        // is account- or server-blind and must not survive the flip; Room-backed state re-filters
+        // reactively via the active-account gate.
+        viewModelScope.launch {
+            activeAccountProvider.accountTransitions().collect { transition ->
+                _projects.value = emptyList()
+                _expandedProjectId.value = null
+                _expandedProjectChats.value = emptyList()
+                _expandedProjectLoading.value = false
+                conversationListStateHolder.reset()
+                // No tagRepository.clearCache() here: observeTags() is account-scoped, so the
+                // outgoing account's tags never show, and RefreshTagsSessionTask (fired by the nav
+                // shell's runAll on Switched) does an atomic replaceAllForAccount. A clearCache() in
+                // this separate collector would race that write with no happens-before and could wipe
+                // the freshly-fetched tags (they ran sequentially in one collector before the split).
+                if (transition is AccountTransition.Switched) {
+                    // The switch path never runs the login-side session machinery, so the incoming
+                    // account's conversation list is fetched here. loadProjects() is NOT called here:
+                    // it rides the version-gated collector above once the nav shell's re-detect
+                    // re-emits detectedBackendVersion. Not refreshed on Ended (logout) — that would
+                    // fire network calls with no active session.
+                    conversationListStateHolder.refreshConversations()
+                }
+            }
+        }
+    }
+
+    fun loadMoreConversations() {
+        conversationListStateHolder.loadMoreConversations()
+    }
+
+    /**
+     * Pull-to-refresh: refreshes the drawer conversation list + favorites + tags. The explicit tag
+     * refresh is wanted here because a manual refresh has no session-task machinery behind it.
+     */
+    fun refreshConversations() {
+        conversationListStateHolder.refreshConversations()
+        viewModelScope.launch { tagRepository.refreshTags() }
+    }
+
+    /**
+     * Fresh-login refresh (conversations + favorites only). accountTransitions() does not fire on
+     * login-from-logged-out, so the nav host's onAuthComplete drives this. Tags/roles/favorites
+     * session tasks already fired from AuthRepositoryImpl on the login success, so we must NOT
+     * refresh tags here — that was the source of the double-fetch on fresh login.
+     */
+    fun refreshConversationsAfterLogin() {
+        conversationListStateHolder.refreshConversations()
+    }
+
+    fun setActiveConversation(conversationId: String?) {
+        conversationListStateHolder.setActiveConversation(conversationId)
+    }
+
+    fun onSearchQueryChanged(query: String) {
+        conversationListStateHolder.onSearchQueryChanged(query)
+    }
+
+    fun toggleFavorite(conversationId: String, currentTags: List<String>) {
+        viewModelScope.launch {
+            val result = tagRepository.toggleFavorite(conversationId, currentTags)
+            if (result is Result.Error) {
+                Logger.w(result.exception) { "Failed to toggle favorite for $conversationId" }
+                // Surface the failure like the row-action delegate does, instead of only logging —
+                // otherwise a failed favorite from the drawer gives the user no feedback.
+                _events.emit(ConversationListEvent.ShowError(result.message ?: "Failed to update favorite"))
+            }
+        }
+    }
+
+    // --- Drawer conversation action menu (long-press). Row actions route through the shared
+    // ConversationListActionsDelegate; favorite/pin/tags stay local (different signatures). ---
+
+    fun renameConversation(id: String, newTitle: String) = conversationActions.renameConversation(id, newTitle)
+
+    fun archiveConversation(id: String) = conversationActions.archiveConversation(id)
+
+    fun pinConversation(id: String, pinned: Boolean) {
+        viewModelScope.launch {
+            val result = conversationRepository.pin(id, pinned)
+            if (result is Result.Error) {
+                Logger.e(result.exception) { "Failed to pin conversation" }
+                _events.emit(ConversationListEvent.ShowError("Failed to pin conversation"))
+            }
+        }
+    }
+
+    /**
+     * Toggles the inline accordion for [projectId] in the drawer's Projects tab. Expanding loads that
+     * project's chats network-direct (single-expand: the previously open project collapses); tapping
+     * the open project collapses it. [ChatProject.UNASSIGNED] is a valid id (loose chats).
+     */
+    fun toggleProjectExpanded(projectId: String) {
+        if (_expandedProjectId.value == projectId) {
+            _expandedProjectId.value = null
+            _expandedProjectChats.value = emptyList()
+            return
+        }
+        _expandedProjectId.value = projectId
+        _expandedProjectChats.value = emptyList()
+        _expandedProjectLoading.value = true
+        viewModelScope.launch {
+            val result = conversationRepository.getConversationsForProject(projectId = projectId)
+            // The user may have collapsed or opened another folder while this was in flight.
+            if (_expandedProjectId.value != projectId) return@launch
+            when (result) {
+                is Result.Success -> _expandedProjectChats.value = result.data.conversations
+                is Result.Error -> Logger.w(result.exception) { "Failed to load project chats" }
+                is Result.Loading -> Unit
+            }
+            _expandedProjectLoading.value = false
+        }
+    }
+
+    /** Loads the user's projects for the move-to-project picker. */
+    fun loadProjects() {
+        viewModelScope.launch {
+            when (val result = projectRepository.listProjects()) {
+                is Result.Success -> _projects.value = result.data.projects
+                is Result.Error -> Logger.w(result.exception) { "Failed to load projects" }
+                is Result.Loading -> Unit
+            }
+        }
+    }
+
+    /** Assigns [conversationId] to [projectId], or unassigns it when null. */
+    fun moveConversationToProject(conversationId: String, projectId: String?) {
+        viewModelScope.launch {
+            when (val result = projectRepository.assignConversation(conversationId, projectId)) {
+                is Result.Success -> onProjectAssignmentChanged()
+                is Result.Error -> {
+                    Logger.e(result.exception) { "Failed to move conversation to project" }
+                    _events.emit(ConversationListEvent.ShowError("Failed to move conversation"))
+                }
+                is Result.Loading -> Unit
+            }
+        }
+    }
+
+    /** Creates a project named [name] and assigns [conversationId] to it. */
+    fun createProjectAndAssign(conversationId: String, name: String) {
+        viewModelScope.launch {
+            when (val created = projectRepository.createProject(name)) {
+                is Result.Success -> {
+                    when (val assign = projectRepository.assignConversation(conversationId, created.data.id)) {
+                        is Result.Error -> {
+                            Logger.e(assign.exception) { "Failed to assign new project" }
+                            _events.emit(ConversationListEvent.ShowError("Failed to move conversation"))
+                        }
+                        is Result.Success -> onProjectAssignmentChanged()
+                        is Result.Loading -> Unit
+                    }
+                }
+                is Result.Error -> {
+                    Logger.e(created.exception) { "Failed to create project" }
+                    _events.emit(ConversationListEvent.ShowError("Failed to create project"))
+                }
+                is Result.Loading -> Unit
+            }
+        }
+    }
+
+    /**
+     * Refresh the Projects mode after a conversation's project assignment changes: reload the
+     * folders, whose conversationCount is now stale.
+     */
+    private fun onProjectAssignmentChanged() {
+        loadProjects()
+    }
+
+    fun createProject(name: String) = projectActions.create(name)
+
+    fun renameProject(projectId: String, name: String) = projectActions.rename(projectId, name)
+
+    fun deleteProject(projectId: String) {
+        // Collapse the inline accordion if the deleted project was open, so its stale chats clear.
+        if (_expandedProjectId.value == projectId) {
+            _expandedProjectId.value = null
+            _expandedProjectChats.value = emptyList()
+        }
+        projectActions.delete(projectId)
+    }
+
+    fun deleteConversation(id: String) = conversationActions.deleteConversation(id)
+
+    fun shareConversation(conversationId: String) = conversationActions.shareConversation(conversationId)
+
+    fun duplicateConversation(conversationId: String, title: String?) =
+        conversationActions.duplicateConversation(conversationId, title)
+
+    fun exportConversation(conversationId: String, title: String?, format: ExportFormat) =
+        conversationActions.exportConversation(conversationId, title, format)
+
+    /**
+     * Persists the user-chosen tags for [conversationId], preserving favorite status.
+     * [currentTags] is the conversation's existing tag list (to detect the SAVED_TAG).
+     */
+    fun updateConversationTags(conversationId: String, currentTags: List<String>, userTags: List<String>) {
+        val wasFavorited = SAVED_TAG in currentTags
+        val cleaned = userTags.filterNot { it == SAVED_TAG }
+        val finalTags = if (wasFavorited) cleaned + SAVED_TAG else cleaned
+        viewModelScope.launch {
+            when (tagRepository.setConversationTags(conversationId, finalTags)) {
+                is Result.Success -> {
+                    tagRepository.refreshTags()
+                }
+                is Result.Error -> {
+                    _events.emit(ConversationListEvent.ShowError("Failed to update tags"))
+                }
+                is Result.Loading -> { /* no-op */ }
+            }
+        }
+    }
+}

--- a/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/viewmodel/ConversationListViewModel.kt
+++ b/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/viewmodel/ConversationListViewModel.kt
@@ -3,6 +3,7 @@ package com.garfiec.librechat.feature.conversations.viewmodel
 import androidx.compose.runtime.Immutable
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.garfiec.librechat.core.common.extensions.toInstantOrNull
 import com.garfiec.librechat.core.common.result.Result
 import com.garfiec.librechat.core.data.repository.ConfigRepository
 import com.garfiec.librechat.core.data.repository.ConversationRepository
@@ -30,6 +31,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 @Immutable
@@ -78,6 +80,11 @@ class ConversationListViewModel(
     private val _conversations = MutableStateFlow<List<Conversation>>(emptyList())
     private var searchJob: Job? = null
 
+    // The last Room emission, so an active search can tell a genuine delete/archive (present ->
+    // absent) from a row merely outside Room's fetched window. Kept as the raw list (a reference,
+    // not a Set) so the non-search path allocates nothing; the id sets are built only while searching.
+    private var lastRoomData: List<Conversation> = emptyList()
+
     private val actions = ConversationListActionsDelegate(
         scope = viewModelScope,
         events = _events,
@@ -115,11 +122,32 @@ class ConversationListViewModel(
             conversationRepository.observeConversations().collect { result ->
                 when (result) {
                     is Result.Success -> {
-                        // Only update from Room when not in search mode
                         if (_uiState.value.searchQuery.isEmpty()) {
                             _conversations.value = result.data
                             _uiState.value = _uiState.value.copy(isLoading = false)
+                        } else if (result.data.isNotEmpty()) {
+                            // Active search: results are server-sourced and not written to Room, so
+                            // don't replace them wholesale (that wipes server-only hits) nor union
+                            // Room in (that pollutes results). Room still re-emits on local mutations,
+                            // so reconcile the visible results against it: drop rows that just left
+                            // Room (delete/archive from the drawer) and pull in locally-edited rows
+                            // (rename/tags/pin/favorite stamp updatedAt = now, so Room is >= as fresh),
+                            // but never let a stale cache row clobber a server-fresher hit that hasn't
+                            // synced to Room yet. An empty emission is an account-scoped reset (the
+                            // active-account gate), not a per-row delete, so it is ignored here — the
+                            // screen reloads for the new account rather than blanking the old results.
+                            val roomIds = result.data.mapNotNullTo(HashSet()) { it.conversationId }
+                            val lastIds = lastRoomData.mapNotNullTo(HashSet()) { it.conversationId }
+                            val removed = lastIds - roomIds
+                            val byId = result.data.associateBy { it.conversationId }
+                            _conversations.update { current ->
+                                current.mapNotNull { c ->
+                                    val id = c.conversationId ?: return@mapNotNull c
+                                    if (id in removed) null else byId[id]?.takeIf { it.isNotOlderThan(c) } ?: c
+                                }
+                            }
                         }
+                        lastRoomData = result.data
                     }
                     is Result.Error -> {
                         _uiState.value = _uiState.value.copy(
@@ -131,6 +159,18 @@ class ConversationListViewModel(
                 }
             }
         }
+    }
+
+    /**
+     * True when `this` (a Room row) is at least as fresh as [other] (a server search hit), by
+     * `updatedAt`. Local edits stamp `updatedAt = now`, so they compare newer and are reflected;
+     * a cross-device change not yet synced leaves Room strictly older, so it is not swapped in.
+     * Falls back to `false` (keep the server hit) when either timestamp is missing/unparseable.
+     */
+    private fun Conversation.isNotOlderThan(other: Conversation): Boolean {
+        val mine = updatedAt?.toInstantOrNull() ?: return false
+        val theirs = other.updatedAt?.toInstantOrNull() ?: return false
+        return mine >= theirs
     }
 
     private fun observeTags() {

--- a/shared/src/commonMain/composeResources/values-ar/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ar/strings.xml
@@ -4,23 +4,12 @@
     <string name="no_connection">لا يوجد اتصال بالإنترنت</string>
 
     <!-- Drawer -->
-    <string name="new_chat">محادثة جديدة</string>
-    <string name="favorites">المفضلة</string>
-    <string name="no_conversations_found">لم يتم العثور على محادثات</string>
-    <string name="remove_bookmark">إزالة الإشارة المرجعية</string>
-    <string name="bookmark">إشارة مرجعية</string>
-    <string name="agents">الوكلاء</string>
-    <string name="skills">المهارات</string>
-    <string name="files">الملفات</string>
     <string name="settings">الإعدادات</string>
 
     <!-- Content descriptions -->
-    <string name="cd_search">بحث</string>
-    <string name="cd_clear_search">مسح البحث</string>
     <string name="cd_back_to_conversations">العودة إلى المحادثات</string>
 
     <!-- Search -->
-    <string name="search_conversations_placeholder">البحث في المحادثات…</string>
 
     <!-- Version mismatch dialog -->
     <string name="version_mismatch_title">عدم تطابق إصدار الخادم</string>

--- a/shared/src/commonMain/composeResources/values-de/strings.xml
+++ b/shared/src/commonMain/composeResources/values-de/strings.xml
@@ -4,23 +4,12 @@
     <string name="no_connection">Keine Internetverbindung</string>
 
     <!-- Drawer -->
-    <string name="new_chat">Neuer Chat</string>
-    <string name="favorites">Favoriten</string>
-    <string name="no_conversations_found">Keine Unterhaltungen gefunden</string>
-    <string name="remove_bookmark">Lesezeichen entfernen</string>
-    <string name="bookmark">Lesezeichen</string>
-    <string name="agents">Agenten</string>
-    <string name="skills">Skills</string>
-    <string name="files">Dateien</string>
     <string name="settings">Einstellungen</string>
 
     <!-- Content descriptions -->
-    <string name="cd_search">Suchen</string>
-    <string name="cd_clear_search">Suche löschen</string>
     <string name="cd_back_to_conversations">Zurück zu den Unterhaltungen</string>
 
     <!-- Search -->
-    <string name="search_conversations_placeholder">Unterhaltungen suchen…</string>
 
     <!-- Version mismatch dialog -->
     <string name="version_mismatch_title">Backend-Versionskonflikt</string>

--- a/shared/src/commonMain/composeResources/values-es/strings.xml
+++ b/shared/src/commonMain/composeResources/values-es/strings.xml
@@ -4,23 +4,12 @@
     <string name="no_connection">Sin conexión a internet</string>
 
     <!-- Drawer -->
-    <string name="new_chat">Nuevo chat</string>
-    <string name="favorites">Favoritos</string>
-    <string name="no_conversations_found">No se encontraron conversaciones</string>
-    <string name="remove_bookmark">Quitar marcador</string>
-    <string name="bookmark">Marcador</string>
-    <string name="agents">Agentes</string>
-    <string name="skills">Habilidades</string>
-    <string name="files">Archivos</string>
     <string name="settings">Ajustes</string>
 
     <!-- Content descriptions -->
-    <string name="cd_search">Buscar</string>
-    <string name="cd_clear_search">Borrar búsqueda</string>
     <string name="cd_back_to_conversations">Volver a conversaciones</string>
 
     <!-- Search -->
-    <string name="search_conversations_placeholder">Buscar conversaciones…</string>
 
     <!-- Version mismatch dialog -->
     <string name="version_mismatch_title">Versión del servidor incompatible</string>

--- a/shared/src/commonMain/composeResources/values-fr/strings.xml
+++ b/shared/src/commonMain/composeResources/values-fr/strings.xml
@@ -4,23 +4,12 @@
     <string name="no_connection">Aucune connexion Internet</string>
 
     <!-- Drawer -->
-    <string name="new_chat">Nouvelle discussion</string>
-    <string name="favorites">Favoris</string>
-    <string name="no_conversations_found">Aucune conversation trouvée</string>
-    <string name="remove_bookmark">Supprimer le signet</string>
-    <string name="bookmark">Signet</string>
-    <string name="agents">Agents</string>
-    <string name="skills">Compétences</string>
-    <string name="files">Fichiers</string>
     <string name="settings">Paramètres</string>
 
     <!-- Content descriptions -->
-    <string name="cd_search">Rechercher</string>
-    <string name="cd_clear_search">Effacer la recherche</string>
     <string name="cd_back_to_conversations">Retour aux conversations</string>
 
     <!-- Search -->
-    <string name="search_conversations_placeholder">Rechercher des conversations…</string>
 
     <!-- Version mismatch dialog -->
     <string name="version_mismatch_title">Incompatibilité de version du backend</string>

--- a/shared/src/commonMain/composeResources/values-ja/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ja/strings.xml
@@ -4,23 +4,12 @@
     <string name="no_connection">インターネット接続がありません</string>
 
     <!-- Drawer -->
-    <string name="new_chat">新しいチャット</string>
-    <string name="favorites">お気に入り</string>
-    <string name="no_conversations_found">会話が見つかりません</string>
-    <string name="remove_bookmark">ブックマークを解除</string>
-    <string name="bookmark">ブックマーク</string>
-    <string name="agents">エージェント</string>
-    <string name="skills">スキル</string>
-    <string name="files">ファイル</string>
     <string name="settings">設定</string>
 
     <!-- Content descriptions -->
-    <string name="cd_search">検索</string>
-    <string name="cd_clear_search">検索をクリア</string>
     <string name="cd_back_to_conversations">会話に戻る</string>
 
     <!-- Search -->
-    <string name="search_conversations_placeholder">会話を検索…</string>
 
     <!-- Version mismatch dialog -->
     <string name="version_mismatch_title">バックエンドのバージョン不一致</string>

--- a/shared/src/commonMain/composeResources/values-ko/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ko/strings.xml
@@ -4,23 +4,12 @@
     <string name="no_connection">인터넷 연결 없음</string>
 
     <!-- Drawer -->
-    <string name="new_chat">새 채팅</string>
-    <string name="favorites">즐겨찾기</string>
-    <string name="no_conversations_found">대화를 찾을 수 없습니다</string>
-    <string name="remove_bookmark">북마크 제거</string>
-    <string name="bookmark">북마크</string>
-    <string name="agents">에이전트</string>
-    <string name="skills">스킬</string>
-    <string name="files">파일</string>
     <string name="settings">설정</string>
 
     <!-- Content descriptions -->
-    <string name="cd_search">검색</string>
-    <string name="cd_clear_search">검색 지우기</string>
     <string name="cd_back_to_conversations">대화로 돌아가기</string>
 
     <!-- Search -->
-    <string name="search_conversations_placeholder">대화 검색…</string>
 
     <!-- Version mismatch dialog -->
     <string name="version_mismatch_title">백엔드 버전 불일치</string>

--- a/shared/src/commonMain/composeResources/values-pt/strings.xml
+++ b/shared/src/commonMain/composeResources/values-pt/strings.xml
@@ -4,23 +4,12 @@
     <string name="no_connection">Sem conexão com a internet</string>
 
     <!-- Drawer -->
-    <string name="new_chat">Nova conversa</string>
-    <string name="favorites">Favoritos</string>
-    <string name="no_conversations_found">Nenhuma conversa encontrada</string>
-    <string name="remove_bookmark">Remover marcador</string>
-    <string name="bookmark">Marcar</string>
-    <string name="agents">Agentes</string>
-    <string name="skills">Habilidades</string>
-    <string name="files">Arquivos</string>
     <string name="settings">Configurações</string>
 
     <!-- Content descriptions -->
-    <string name="cd_search">Buscar</string>
-    <string name="cd_clear_search">Limpar busca</string>
     <string name="cd_back_to_conversations">Voltar às conversas</string>
 
     <!-- Search -->
-    <string name="search_conversations_placeholder">Buscar conversas…</string>
 
     <!-- Version mismatch dialog -->
     <string name="version_mismatch_title">Incompatibilidade de versão do backend</string>

--- a/shared/src/commonMain/composeResources/values-ru/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ru/strings.xml
@@ -4,23 +4,12 @@
     <string name="no_connection">Нет подключения к интернету</string>
 
     <!-- Drawer -->
-    <string name="new_chat">Новый чат</string>
-    <string name="favorites">Избранное</string>
-    <string name="no_conversations_found">Беседы не найдены</string>
-    <string name="remove_bookmark">Убрать закладку</string>
-    <string name="bookmark">В закладки</string>
-    <string name="agents">Агенты</string>
-    <string name="skills">Навыки</string>
-    <string name="files">Файлы</string>
     <string name="settings">Настройки</string>
 
     <!-- Content descriptions -->
-    <string name="cd_search">Поиск</string>
-    <string name="cd_clear_search">Очистить поиск</string>
     <string name="cd_back_to_conversations">Назад к беседам</string>
 
     <!-- Search -->
-    <string name="search_conversations_placeholder">Поиск бесед…</string>
 
     <!-- Version mismatch dialog -->
     <string name="version_mismatch_title">Несоответствие версии бэкенда</string>

--- a/shared/src/commonMain/composeResources/values-zh/strings.xml
+++ b/shared/src/commonMain/composeResources/values-zh/strings.xml
@@ -4,23 +4,12 @@
     <string name="no_connection">无网络连接</string>
 
     <!-- Drawer -->
-    <string name="new_chat">新建聊天</string>
-    <string name="favorites">收藏</string>
-    <string name="no_conversations_found">未找到对话</string>
-    <string name="remove_bookmark">取消收藏</string>
-    <string name="bookmark">收藏</string>
-    <string name="agents">智能体</string>
-    <string name="skills">技能</string>
-    <string name="files">文件</string>
     <string name="settings">设置</string>
 
     <!-- Content descriptions -->
-    <string name="cd_search">搜索</string>
-    <string name="cd_clear_search">清除搜索</string>
     <string name="cd_back_to_conversations">返回对话</string>
 
     <!-- Search -->
-    <string name="search_conversations_placeholder">搜索对话…</string>
 
     <!-- Version mismatch dialog -->
     <string name="version_mismatch_title">后端版本不匹配</string>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -4,46 +4,15 @@
     <string name="no_connection">No internet connection</string>
 
     <!-- Drawer -->
-    <string name="new_chat">New chat</string>
-    <string name="library">Library</string>
-    <string name="chats">Chats</string>
-    <string name="favorites">Favorites</string>
-    <string name="pinned">Pinned</string>
-    <string name="projects">Projects</string>
-    <string name="projects_all">All projects</string>
-    <string name="project_unassigned">Unassigned</string>
-    <string name="project_new">New project</string>
-    <string name="no_conversations_found">No conversations found</string>
-    <string name="show_more">Show more</string>
-    <string name="show_less">Show less</string>
-    <string name="cd_collapse_section">Collapse section</string>
-    <string name="cd_expand_section">Expand section</string>
-    <string name="remove_bookmark">Remove bookmark</string>
-    <string name="bookmark">Bookmark</string>
-    <string name="agents">Agents</string>
-    <string name="skills">Skills</string>
-    <string name="files">Files</string>
     <string name="settings">Settings</string>
 
     <!-- Account switcher -->
-    <string name="accounts">Accounts</string>
-    <string name="add_account">Add account</string>
-    <string name="remove_account">Remove account</string>
-    <string name="remove_account_title">Remove account?</string>
-    <string name="remove_account_message">%1$s and its data will be removed from this device. The account on the server is not affected.</string>
-    <string name="remove">Remove</string>
-    <string name="cancel">Cancel</string>
     <string name="cd_switch_account">Switch account</string>
-    <string name="cd_active_account">Active account</string>
 
     <!-- Content descriptions -->
-    <string name="cd_search">Search</string>
-    <string name="cd_clear_search">Clear search</string>
     <string name="cd_back_to_conversations">Back to conversations</string>
-    <string name="cd_conversation_actions">Show conversation actions</string>
 
     <!-- Search -->
-    <string name="search_conversations_placeholder">Search conversations\u2026</string>
 
     <!-- Version mismatch dialog -->
     <string name="version_mismatch_title">Backend Version Mismatch</string>

--- a/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/LibreChatNavHost.kt
+++ b/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/LibreChatNavHost.kt
@@ -54,6 +54,7 @@ import com.garfiec.librechat.feature.chat.navigation.ModelShortcutBus
 import com.garfiec.librechat.feature.chat.navigation.NewChat
 import com.garfiec.librechat.feature.chat.navigation.chatEntries
 import com.garfiec.librechat.feature.chat.viewmodel.ServerFileSelectionHandoff
+import com.garfiec.librechat.feature.conversations.drawer.DrawerViewModel
 import com.garfiec.librechat.feature.conversations.navigation.ArchivedConversations
 import com.garfiec.librechat.feature.conversations.navigation.ProjectChats
 import com.garfiec.librechat.feature.conversations.navigation.Projects
@@ -99,6 +100,7 @@ fun LibreChatNavHost(
     appLocaleTag: String? = null,
     hasPendingDeepLink: Boolean = false,
     navHostViewModel: NavHostViewModel = koinViewModel(),
+    drawerViewModel: DrawerViewModel = koinViewModel(),
     content: (@Composable (Navigator, NavHostViewModel, Modifier) -> Unit)? = null,
 ) {
     val isLoggedIn by navHostViewModel.isLoggedIn.collectAsStateWithLifecycle()
@@ -138,7 +140,7 @@ fun LibreChatNavHost(
     // Track active conversation from nav back stack
     LaunchedEffect(navigator.currentRoute) {
         val conversationId = (navigator.currentRoute as? Chat)?.conversationId
-        navHostViewModel.setActiveConversation(conversationId)
+        drawerViewModel.setActiveConversation(conversationId)
 
         // Navigation breadcrumb: route type name only — low cardinality, content-free.
         val screen = navigator.currentRoute?.let { it::class.simpleName } ?: "none"
@@ -369,6 +371,7 @@ fun MainNavDisplay(
     modifier: Modifier = Modifier,
     onMenuClick: (() -> Unit)? = null,
     navHostViewModel: NavHostViewModel = koinViewModel(),
+    drawerViewModel: DrawerViewModel = koinViewModel(),
     serverFileSelectionHandoff: ServerFileSelectionHandoff = koinInject(),
 ) {
     NavDisplay(
@@ -411,6 +414,11 @@ fun MainNavDisplay(
                 onBack = { navigator.goBack() },
                 onAuthComplete = {
                     navHostViewModel.onAuthComplete()
+                    // accountTransitions() doesn't fire on login-from-logged-out, so the drawer's
+                    // conversation list is refreshed explicitly here (the other half — banners,
+                    // version — rides onAuthComplete above). Conversations-only: the login session
+                    // tasks already refreshed tags, so this must not re-fetch them (double-fetch).
+                    drawerViewModel.refreshConversationsAfterLogin()
                     navigator.navigateToChat()
                 },
             )

--- a/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/NavHostViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/NavHostViewModel.kt
@@ -3,14 +3,12 @@ package com.garfiec.librechat.shared.navigation
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import co.touchlab.kermit.Logger
-import com.garfiec.librechat.core.common.BackendVersion
 import com.garfiec.librechat.core.common.extensions.serverHostLabel
 import com.garfiec.librechat.core.common.identity.AccountState
 import com.garfiec.librechat.core.common.identity.AccountTransition
 import com.garfiec.librechat.core.common.identity.ActiveAccountProvider
 import com.garfiec.librechat.core.common.identity.accountTransitions
 import com.garfiec.librechat.core.common.network.ConnectivityObserver
-import com.garfiec.librechat.core.common.result.Result
 import com.garfiec.librechat.core.data.datastore.AccountEntry
 import com.garfiec.librechat.core.data.datastore.AccountRoster
 import com.garfiec.librechat.core.data.datastore.SettingsDataStore
@@ -18,62 +16,41 @@ import com.garfiec.librechat.core.data.repository.AccountSwitcher
 import com.garfiec.librechat.core.data.repository.AuthRepository
 import com.garfiec.librechat.core.data.repository.BannerRepository
 import com.garfiec.librechat.core.data.repository.ConfigRepository
-import com.garfiec.librechat.core.data.repository.ConversationRepository
 import com.garfiec.librechat.core.data.repository.EndpointTokenRepository
-import com.garfiec.librechat.core.data.repository.ProjectRepository
-import com.garfiec.librechat.core.data.repository.RoleRepository
-import com.garfiec.librechat.core.data.repository.ShareRepository
-import com.garfiec.librechat.core.data.repository.TagRepository
 import com.garfiec.librechat.core.data.util.SessionTaskRunner
 import com.garfiec.librechat.core.model.Banner
-import com.garfiec.librechat.core.model.ChatProject
-import com.garfiec.librechat.core.model.Conversation
-import com.garfiec.librechat.core.model.ConversationTag
-import com.garfiec.librechat.core.model.SAVED_TAG
-import com.garfiec.librechat.core.model.permissions.Permission
-import com.garfiec.librechat.core.model.permissions.PermissionType
-import com.garfiec.librechat.core.model.permissions.canCreateSharedLinks
-import com.garfiec.librechat.core.model.permissions.hasAccessOrPermissive
 import com.garfiec.librechat.core.network.client.AccountReadyGate
 import com.garfiec.librechat.core.network.client.ServerUrlProvider
 import com.garfiec.librechat.core.network.client.TokenManager
-import com.garfiec.librechat.feature.conversations.export.ConversationExporter
-import com.garfiec.librechat.feature.conversations.export.ExportFormat
-import com.garfiec.librechat.feature.conversations.viewmodel.ConversationListActionsDelegate
-import com.garfiec.librechat.feature.conversations.viewmodel.ConversationListEvent
-import com.garfiec.librechat.feature.conversations.viewmodel.ProjectActionsDelegate
+import com.garfiec.librechat.feature.conversations.drawer.AccountUiModel
 import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
-import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
+/**
+ * Navigation-shell ViewModel: auth/session routing, account identity + hygiene, banners, version
+ * check, and sidebar mode. The drawer's conversation-list data lives in [com.garfiec.librechat
+ * .feature.conversations.drawer.DrawerViewModel] (extracted so `:shared` is nav glue, not a stealth
+ * feature module); this VM keeps the account *list* the drawer footer renders, but not the drawer data.
+ */
 class NavHostViewModel(
     private val authRepository: AuthRepository,
     bannerRepository: BannerRepository,
     private val configRepository: ConfigRepository,
-    private val conversationRepository: ConversationRepository,
-    private val roleRepository: RoleRepository,
     private val sessionTaskRunner: SessionTaskRunner,
-    private val tagRepository: TagRepository,
-    private val projectRepository: ProjectRepository,
     private val tokenManager: TokenManager,
     private val accountReadyGate: AccountReadyGate,
     private val settingsDataStore: SettingsDataStore,
     private val serverUrlProvider: ServerUrlProvider,
-    private val shareRepository: ShareRepository,
-    private val conversationExporter: ConversationExporter,
     private val connectivityObserver: ConnectivityObserver,
     private val endpointTokenRepository: EndpointTokenRepository,
     private val activeAccountProvider: ActiveAccountProvider,
@@ -84,93 +61,6 @@ class NavHostViewModel(
     private val bannerStateHolder = BannerStateHolder(bannerRepository, viewModelScope)
     private val versionCheckStateHolder =
         VersionCheckStateHolder(configRepository, settingsDataStore, serverUrlProvider, viewModelScope)
-    private val conversationListStateHolder = ConversationListStateHolder(conversationRepository, viewModelScope)
-
-    private val favoriteConversations: StateFlow<List<Conversation>> =
-        conversationListStateHolder.recentConversations
-            .map { list -> list.filter { SAVED_TAG in it.tags } }
-            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
-
-    private val pinnedConversations: StateFlow<List<Conversation>> =
-        conversationListStateHolder.recentConversations
-            .map { list -> list.filter { it.pinned == true } }
-            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
-
-    // Inputs for the drawer long-press action menu: the user-defined tags (excluding favorites,
-    // same filter as ConversationListViewModel.observeTags) for the tag picker, plus the
-    // config-driven shared-links flag and the SHARED_LINKS role permission that gate the Share action.
-    private val drawerActionMenuState: StateFlow<DrawerActionMenuState> =
-        combine(
-            tagRepository.observeTags()
-                .map { tags -> tags.filter { it.count > 0 && it.tag != SAVED_TAG } },
-            configRepository.startupConfig,
-            configRepository.detectedBackendVersion,
-            roleRepository.userPermissions,
-        ) { tags, config, version, permissions ->
-            // Pin requires POST /api/convos/pin (v0.8.7+). Gate fail-closed on unknown
-            // version so older servers don't surface an action they'd 404 on.
-            val supportsV087 = version != null && BackendVersion.isCompatibleOrNewer(version, "0.8.7")
-            val canShare = permissions.canCreateSharedLinks(config?.sharedLinksEnabled ?: false)
-            DrawerActionMenuState(tags, canShare, supportsV087, supportsV087)
-        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), DrawerActionMenuState())
-
-    // Chat Projects (v0.8.7). Loaded lazily for the move-to-project picker and the drawer's Projects
-    // tab folder list; the server is the source of truth (no local cache).
-    private val _projects = MutableStateFlow<List<ChatProject>>(emptyList())
-    val projects: StateFlow<List<ChatProject>> = _projects.asStateFlow()
-
-    // Inline project-chat accordion for the drawer Projects tab. Network-direct per project (Room
-    // can't filter by project — see ProjectChatsViewModel), single-expand: only the open project's
-    // chats are held. Mapped to the drawer row type against the active id + endpoint configs so the
-    // rows match the recents list.
-    private val _expandedProjectId = MutableStateFlow<String?>(null)
-    private val _expandedProjectChats = MutableStateFlow<List<Conversation>>(emptyList())
-    private val _expandedProjectLoading = MutableStateFlow(false)
-
-    val inlineProjectChats: StateFlow<InlineProjectChatsState> = combine(
-        _expandedProjectId,
-        _expandedProjectChats,
-        _expandedProjectLoading,
-        conversationListStateHolder.activeConversationId,
-        configRepository.endpointConfigs,
-    ) { expandedId, convos, loading, activeId, configs ->
-        InlineProjectChatsState(
-            expandedProjectId = expandedId,
-            conversations = convos.map { it.toDrawerDisplayData(activeId, configs) },
-            isLoading = loading,
-        )
-    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), InlineProjectChatsState())
-
-    // One-shot events for the drawer action menu (share-link copied, export-ready,
-    // navigate-to-duplicate, errors). Reuses the conversation-list event type. extraBufferCapacity
-    // lets emit() return immediately instead of suspending if the collector (ConversationActionEffects)
-    // is momentarily absent — e.g. an action's result arriving as the drawer leaves composition.
-    private val _events = MutableSharedFlow<ConversationListEvent>(extraBufferCapacity = 1)
-    val events: SharedFlow<ConversationListEvent> = _events.asSharedFlow()
-
-    // Shared row-action logic (rename/archive/delete/share/duplicate/export) — the same delegate
-    // ConversationListViewModel and ProjectChatsViewModel use, so the drawer long-press menu surfaces
-    // Result.Error failures (toast) instead of swallowing them in a dead try/catch around a
-    // Result-returning repo call. Room-backed here, so onMutated is a no-op: the conversation
-    // observe-Flow already re-emits after a mutation.
-    private val conversationActions = ConversationListActionsDelegate(
-        scope = viewModelScope,
-        events = _events,
-        conversationRepository = conversationRepository,
-        tagRepository = tagRepository,
-        shareRepository = shareRepository,
-        conversationExporter = conversationExporter,
-        onMutated = {},
-    )
-
-    // Shared project CRUD (same delegate ProjectsViewModel uses).
-    private val projectActions = ProjectActionsDelegate(
-        scope = viewModelScope,
-        projectRepository = projectRepository,
-        onChanged = { loadProjects() },
-        onDeleted = { loadProjects() },
-        emitError = { _events.emit(ConversationListEvent.ShowError(it)) },
-    )
 
     // Seeded synchronously so first-frame routing (LibreChatNavHost reads isLoggedIn.value
     // once in a LaunchedEffect to redirect to auth) gets the correct value with no flash.
@@ -197,7 +87,9 @@ class NavHostViewModel(
     val accountState: StateFlow<AccountState> = activeAccountProvider.state
 
     // The signed-in accounts for the drawer chip + switcher sheet: active entry first, the rest by
-    // recency (matching "switch to most-recently-active" on remove).
+    // recency (matching "switch to most-recently-active" on remove). Account identity + switching
+    // stay in the nav shell; only the drawer *renders* this list ([AccountUiModel] lives with the
+    // drawer feature, hence the cross-module type reference).
     val accounts: StateFlow<List<AccountUiModel>> =
         combine(accountRoster.entriesFlow(), activeAccountProvider.state) { entries, accountState ->
             val activeId = (accountState as? AccountState.Resolved)?.id?.value
@@ -233,18 +125,6 @@ class NavHostViewModel(
     val tabletSidebarGestureEnabled: StateFlow<Boolean> = settingsDataStore.tabletSidebarGestureEnabled
         .stateIn(viewModelScope, SharingStarted.Eagerly, true)
 
-    // Drawer "Library" tab is optimistic local state (instant toggle) with DataStore as a write-behind
-    // cache: hydrated once in init and written on change. Null = not yet hydrated; the drawer shows
-    // Chats for the brief window until the persisted value loads, and the seed's update { it ?: ... }
-    // lets a tap in that window win over the incoming persisted value.
-    private val _drawerLibraryTab = MutableStateFlow<DrawerTab?>(null)
-    val drawerLibraryTab: StateFlow<DrawerTab?> = _drawerLibraryTab.asStateFlow()
-
-    fun setDrawerLibraryTab(tab: DrawerTab) {
-        _drawerLibraryTab.value = tab
-        viewModelScope.launch { settingsDataStore.setDrawerLibraryTab(tab.toStorageString()) }
-    }
-
     private val _sidebarMode = MutableStateFlow<SidebarMode>(SidebarMode.Conversations)
     val sidebarMode: StateFlow<SidebarMode> = _sidebarMode.asStateFlow()
 
@@ -259,88 +139,7 @@ class NavHostViewModel(
         _selectedSettingsCategory.value = category
     }
 
-    /**
-     * Role-permission flags for drawer UI. Permissive-default (`?: true`) until the
-     * role loads; once it does, denied permissions flip the flags off and the drawer
-     * re-composes to hide the corresponding surfaces.
-     */
-    private val drawerPermissionFlags: StateFlow<DrawerPermissionFlags> =
-        roleRepository.userPermissions
-            .map { role ->
-                DrawerPermissionFlags(
-                    agentsEnabled = role.hasAccessOrPermissive(PermissionType.AGENTS, Permission.USE),
-                    bookmarksEnabled = role.hasAccessOrPermissive(PermissionType.BOOKMARKS, Permission.USE),
-                    // USE gate is fail-OPEN (read/list visibility); mutation gating
-                    // lives fail-CLOSED inside feature/skills.
-                    skillsEnabled = role.hasAccessOrPermissive(PermissionType.SKILLS, Permission.USE),
-                )
-            }
-            .stateIn(viewModelScope, SharingStarted.Eagerly, DrawerPermissionFlags())
-
-    val drawerUiState: StateFlow<DrawerUiState> = combine(
-        combine(
-            conversationListStateHolder.groupedConversations,
-            conversationListStateHolder.activeConversationId,
-            favoriteConversations,
-            pinnedConversations,
-            conversationListStateHolder.searchQuery,
-        ) { grouped, activeId, favConvos, pinnedConvos, query ->
-            DrawerDataSnapshot(grouped, activeId, favConvos, pinnedConvos, query)
-        },
-        combine(
-            conversationListStateHolder.isRefreshing,
-            conversationListStateHolder.isLoadingMore,
-            conversationListStateHolder.hasMore,
-        ) { refreshing, loadingMore, hasMore ->
-            Triple(refreshing, loadingMore, hasMore)
-        },
-        drawerPermissionFlags,
-        configRepository.endpointConfigs,
-        drawerActionMenuState,
-    ) { data, refreshState, perms, endpointConfigs, actionMenu ->
-        val (refreshing, loadingMore, hasMore) = refreshState
-        DrawerUiState(
-            groupedConversations = data.grouped.map { (group, convos) ->
-                group to convos.map { it.toDrawerDisplayData(data.activeId, endpointConfigs) }
-            },
-            favoriteConversations = data.favConvos.map {
-                it.toDrawerDisplayData(data.activeId, endpointConfigs)
-            },
-            pinnedConversations = data.pinnedConvos.map {
-                it.toDrawerDisplayData(data.activeId, endpointConfigs)
-            },
-            searchQuery = data.query,
-            isRefreshing = refreshing,
-            isLoadingMore = loadingMore,
-            hasMore = hasMore,
-            agentsEnabled = perms.agentsEnabled,
-            bookmarksEnabled = perms.bookmarksEnabled,
-            skillsEnabled = perms.skillsEnabled,
-            availableTags = actionMenu.availableTags,
-            sharedLinksEnabled = actionMenu.sharedLinksEnabled,
-            pinEnabled = actionMenu.pinEnabled,
-            projectsEnabled = actionMenu.projectsEnabled,
-        )
-    }.stateIn(viewModelScope, SharingStarted.Eagerly, DrawerUiState())
-
-    private data class DrawerPermissionFlags(
-        val agentsEnabled: Boolean = true,
-        val bookmarksEnabled: Boolean = true,
-        val skillsEnabled: Boolean = true,
-    )
-
-    private data class DrawerActionMenuState(
-        val availableTags: List<ConversationTag> = emptyList(),
-        val sharedLinksEnabled: Boolean = false,
-        val pinEnabled: Boolean = false,
-        val projectsEnabled: Boolean = false,
-    )
-
     init {
-        viewModelScope.launch {
-            val persisted = DrawerTab.fromString(settingsDataStore.drawerLibraryTab.first())
-            _drawerLibraryTab.update { it ?: persisted }
-        }
         viewModelScope.launch {
             try {
                 // Wait for the server URL's async warm-up before any startup network work, so a
@@ -376,30 +175,15 @@ class NavHostViewModel(
             }
         }
         bannerStateHolder.fetchBanners()
-        // Load the Chat Projects folders once the backend is known to support them (v0.8.7+).
-        // detectedBackendVersion is a StateFlow (already conflated), so no distinctUntilChanged.
-        viewModelScope.launch {
-            configRepository.detectedBackendVersion.collect { version ->
-                if (version != null && BackendVersion.isCompatibleOrNewer(version, "0.8.7")) {
-                    loadProjects()
-                }
-            }
-        }
         // The active account changed underneath this Activity-scoped VM (switch / add-completion /
         // remove → Switched; remove-last → Ended; plain logout also lands here as Ended, where the
-        // clears below just repeat logout()'s — idempotent). Room-backed state re-filters
-        // reactively, but everything held in-memory here or in the singleton repos is account- or
-        // server-blind and must not survive the flip.
+        // clears below just repeat logout()'s — idempotent). This is the nav/session half of the
+        // reset; the drawer half (conversation list, tags, projects) runs in DrawerViewModel against
+        // its own independent accountTransitions() subscription.
         viewModelScope.launch {
             activeAccountProvider.accountTransitions().collect { transition ->
-                _projects.value = emptyList()
-                _expandedProjectId.value = null
-                _expandedProjectChats.value = emptyList()
-                _expandedProjectLoading.value = false
                 _sidebarMode.value = SidebarMode.Conversations
                 _selectedSettingsCategory.value = null
-                conversationListStateHolder.reset()
-                tagRepository.clearCache()
                 endpointTokenRepository.clear()
                 // Reseed the in-memory config from the (already-flipped) server's own srv:-keyed
                 // cache — warm on switch-back — instead of clear(), which would wipe every server's
@@ -409,7 +193,6 @@ class NavHostViewModel(
                     // The switch path never runs the login-side session machinery
                     // (AuthRepositoryImpl fires these on sign-in; logout/re-auth via onAuthComplete)
                     // so the incoming account's session state is fetched here.
-                    conversationListStateHolder.refreshConversations()
                     bannerStateHolder.fetchBanners()
                     versionCheckStateHolder.checkBackendVersion()
                     sessionTaskRunner.runAll()
@@ -478,184 +261,15 @@ class NavHostViewModel(
         }
     }
 
-    fun loadMoreConversations() {
-        conversationListStateHolder.loadMoreConversations()
-    }
-
     fun onAuthComplete() {
         _isLoggedIn.value = true
-        conversationListStateHolder.refreshConversations()
-        // Session tasks (role fetch, tag refresh, favorites sync) already fired from
-        // AuthRepositoryImpl on the preceding login/OAuth/2FA success, so we don't
-        // re-run them here — that was the source of the double-fetch on fresh login.
+        // The drawer conversation list is refreshed by the nav host alongside this call
+        // (DrawerViewModel.refreshConversationsAfterLogin) — accountTransitions() doesn't fire on a
+        // login-from-logged-out, so that crossing is wired explicitly there. Session tasks
+        // (role fetch, tag refresh, favorites sync) already fired from AuthRepositoryImpl on the
+        // preceding login/OAuth/2FA success, so we don't re-run them here.
         bannerStateHolder.fetchBanners()
         versionCheckStateHolder.checkBackendVersion()
-    }
-
-    fun refreshConversations() {
-        conversationListStateHolder.refreshConversations()
-        viewModelScope.launch { tagRepository.refreshTags() }
-    }
-
-    fun setActiveConversation(conversationId: String?) {
-        conversationListStateHolder.setActiveConversation(conversationId)
-    }
-
-    fun onSearchQueryChanged(query: String) {
-        conversationListStateHolder.onSearchQueryChanged(query)
-    }
-
-    fun toggleFavorite(conversationId: String, currentTags: List<String>) {
-        viewModelScope.launch {
-            val result = tagRepository.toggleFavorite(conversationId, currentTags)
-            if (result is Result.Error) {
-                Logger.w(result.exception) { "Failed to toggle favorite for $conversationId" }
-            }
-        }
-    }
-
-    // --- Drawer conversation action menu (long-press). Row actions route through the shared
-    // ConversationListActionsDelegate; favorite/pin/tags stay local (different signatures). ---
-
-    fun renameConversation(id: String, newTitle: String) = conversationActions.renameConversation(id, newTitle)
-
-    fun archiveConversation(id: String) = conversationActions.archiveConversation(id)
-
-    fun pinConversation(id: String, pinned: Boolean) {
-        viewModelScope.launch {
-            val result = conversationRepository.pin(id, pinned)
-            if (result is Result.Error) {
-                Logger.e(result.exception) { "Failed to pin conversation" }
-                _events.emit(ConversationListEvent.ShowError("Failed to pin conversation"))
-            }
-        }
-    }
-
-    /**
-     * Toggles the inline accordion for [projectId] in the drawer's Projects tab. Expanding loads that
-     * project's chats network-direct (single-expand: the previously open project collapses); tapping
-     * the open project collapses it. [ChatProject.UNASSIGNED] is a valid id (loose chats).
-     */
-    fun toggleProjectExpanded(projectId: String) {
-        if (_expandedProjectId.value == projectId) {
-            _expandedProjectId.value = null
-            _expandedProjectChats.value = emptyList()
-            return
-        }
-        _expandedProjectId.value = projectId
-        _expandedProjectChats.value = emptyList()
-        _expandedProjectLoading.value = true
-        viewModelScope.launch {
-            val result = conversationRepository.getConversationsForProject(projectId = projectId)
-            // The user may have collapsed or opened another folder while this was in flight.
-            if (_expandedProjectId.value != projectId) return@launch
-            when (result) {
-                is Result.Success -> _expandedProjectChats.value = result.data.conversations
-                is Result.Error -> Logger.w(result.exception) { "Failed to load project chats" }
-                is Result.Loading -> Unit
-            }
-            _expandedProjectLoading.value = false
-        }
-    }
-
-    /** Loads the user's projects for the move-to-project picker. */
-    fun loadProjects() {
-        viewModelScope.launch {
-            when (val result = projectRepository.listProjects()) {
-                is Result.Success -> _projects.value = result.data.projects
-                is Result.Error -> Logger.w(result.exception) { "Failed to load projects" }
-                is Result.Loading -> Unit
-            }
-        }
-    }
-
-    /** Assigns [conversationId] to [projectId], or unassigns it when null. */
-    fun moveConversationToProject(conversationId: String, projectId: String?) {
-        viewModelScope.launch {
-            when (val result = projectRepository.assignConversation(conversationId, projectId)) {
-                is Result.Success -> onProjectAssignmentChanged()
-                is Result.Error -> {
-                    Logger.e(result.exception) { "Failed to move conversation to project" }
-                    _events.emit(ConversationListEvent.ShowError("Failed to move conversation"))
-                }
-                is Result.Loading -> Unit
-            }
-        }
-    }
-
-    /** Creates a project named [name] and assigns [conversationId] to it. */
-    fun createProjectAndAssign(conversationId: String, name: String) {
-        viewModelScope.launch {
-            when (val created = projectRepository.createProject(name)) {
-                is Result.Success -> {
-                    when (val assign = projectRepository.assignConversation(conversationId, created.data.id)) {
-                        is Result.Error -> {
-                            Logger.e(assign.exception) { "Failed to assign new project" }
-                            _events.emit(ConversationListEvent.ShowError("Failed to move conversation"))
-                        }
-                        is Result.Success -> onProjectAssignmentChanged()
-                        is Result.Loading -> Unit
-                    }
-                }
-                is Result.Error -> {
-                    Logger.e(created.exception) { "Failed to create project" }
-                    _events.emit(ConversationListEvent.ShowError("Failed to create project"))
-                }
-                is Result.Loading -> Unit
-            }
-        }
-    }
-
-    /**
-     * Refresh the Projects mode after a conversation's project assignment changes: reload the
-     * folders, whose conversationCount is now stale.
-     */
-    private fun onProjectAssignmentChanged() {
-        loadProjects()
-    }
-
-    fun createProject(name: String) = projectActions.create(name)
-
-    fun renameProject(projectId: String, name: String) = projectActions.rename(projectId, name)
-
-    fun deleteProject(projectId: String) {
-        // Collapse the inline accordion if the deleted project was open, so its stale chats clear.
-        if (_expandedProjectId.value == projectId) {
-            _expandedProjectId.value = null
-            _expandedProjectChats.value = emptyList()
-        }
-        projectActions.delete(projectId)
-    }
-
-    fun deleteConversation(id: String) = conversationActions.deleteConversation(id)
-
-    fun shareConversation(conversationId: String) = conversationActions.shareConversation(conversationId)
-
-    fun duplicateConversation(conversationId: String, title: String?) =
-        conversationActions.duplicateConversation(conversationId, title)
-
-    fun exportConversation(conversationId: String, title: String?, format: ExportFormat) =
-        conversationActions.exportConversation(conversationId, title, format)
-
-    /**
-     * Persists the user-chosen tags for [conversationId], preserving favorite status.
-     * [currentTags] is the conversation's existing tag list (to detect the SAVED_TAG).
-     */
-    fun updateConversationTags(conversationId: String, currentTags: List<String>, userTags: List<String>) {
-        val wasFavorited = SAVED_TAG in currentTags
-        val cleaned = userTags.filterNot { it == SAVED_TAG }
-        val finalTags = if (wasFavorited) cleaned + SAVED_TAG else cleaned
-        viewModelScope.launch {
-            when (tagRepository.setConversationTags(conversationId, finalTags)) {
-                is Result.Success -> {
-                    tagRepository.refreshTags()
-                }
-                is Result.Error -> {
-                    _events.emit(ConversationListEvent.ShowError("Failed to update tags"))
-                }
-                is Result.Loading -> { /* no-op */ }
-            }
-        }
     }
 
     fun setTabletSidebarOpen(open: Boolean) {
@@ -686,9 +300,9 @@ class NavHostViewModel(
         // session server-side): it promotes the most-recently-used survivor — the user stays signed in
         // as that account — or, when this was the last account, tears down to logged-out and emits
         // session-expired to route to auth. Either way the accountTransitions collector above resets
-        // this VM's in-memory state (conversation list, tags, projects, config, …) for both the
-        // Switched and Ended cases, so nothing is cleared imperatively here. Not forcing the auth
-        // route here is what lets the successor promotion keep the user in the app.
+        // this VM's in-memory state (config, sidebar mode, …) for both the Switched and Ended cases
+        // (and DrawerViewModel resets the drawer data), so nothing is cleared imperatively here. Not
+        // forcing the auth route here is what lets the successor promotion keep the user in the app.
         viewModelScope.launch { authRepository.logout() }
     }
 }

--- a/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/SidebarScaffold.kt
+++ b/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/SidebarScaffold.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.garfiec.librechat.core.ui.components.PlatformBackHandler
+import com.garfiec.librechat.feature.conversations.drawer.DrawerContent
 import org.koin.compose.viewmodel.koinViewModel
 
 /**
@@ -36,6 +37,10 @@ fun SidebarScaffold(
 ) {
     val sidebarMode by viewModel.sidebarMode.collectAsStateWithLifecycle()
     val selectedCategory by viewModel.selectedSettingsCategory.collectAsStateWithLifecycle()
+    // Account list + switching stay in the nav shell; the drawer only renders the footer chip/sheet,
+    // so the list and account callbacks are hoisted down into DrawerContent (which owns only its own
+    // DrawerViewModel now).
+    val accounts by viewModel.accounts.collectAsStateWithLifecycle()
 
     // System back pops any sub-mode (Projects/Settings) back to Conversations, as if it were on the
     // back stack. A no-op on platforms without a system back (iOS), where the in-mode back arrow is
@@ -69,9 +74,13 @@ fun SidebarScaffold(
                     onAgentsClick = onAgentsClick,
                     onFilesClick = onFilesClick,
                     onSkillsClick = onSkillsClick,
+                    accounts = accounts,
                     onOpenProjectsIndex = onOpenProjectsIndex,
                     onSwitchAccount = onSwitchAccount,
                     onAddAccount = onAddAccount,
+                    // Swipe round-robins in place; the sheet's remove asks the nav shell directly.
+                    onSwitchAccountInPlace = viewModel::switchAccount,
+                    onRemoveAccount = viewModel::removeAccount,
                 )
             }
             is SidebarMode.Settings -> {


### PR DESCRIPTION
## Summary

The navigation drawer had grown into a stealth feature inside `:shared` — `DrawerContent`,
`AccountSwitcherSheet`, `ConversationListStateHolder`, the drawer string resources, and a
~700-line `NavHostViewModel`. This moves the drawer feature into `:feature:conversations`
where it belongs, so `:shared` stays genuine navigation glue, and splits the drawer-data
concerns out of `NavHostViewModel` into a new `DrawerViewModel`. It also fixes the
search-mode staleness this coupling was hiding, on both the list screen and the drawer.

## Changes

- Move the drawer feature (`DrawerContent`, `AccountSwitcherSheet`, `ConversationListStateHolder`,
  `DrawerDisplayMapping`, `DrawerTab`, `DrawerUiModels`) and its string resources from
  `:shared` into `feature/conversations/.../drawer/`. `:shared` sheds ~2,000 lines and the
  cross-module compile edge between the drawer and `:feature:conversations` disappears.
- Split `NavHostViewModel` into a slimmed nav-shell VM (banners, version check, auth/session,
  account identity, tablet sidebar) and a new activity-scoped `DrawerViewModel` that owns the
  drawer's conversation list, favorites/pinned sections, action menu, Projects tab, and Library
  tab preference. `DrawerViewModel` is registered via `viewModelOf` in `conversationsModule`, so
  it is covered by the existing Koin graph tests (its cross-module deps added to the verification
  test's allowlist) and resolves on iOS with no `IosSharedModule` change.
- Account list and switch/remove logic stay in `NavHostViewModel`; only the footer UI travels
  with the drawer via hoisted params passed through `SidebarScaffold`.
- Fix search-mode staleness on both search paths — a conversation deleted from the drawer
  previously stayed visible in an active search until search was cleared:
  - `ConversationListViewModel` (list screen) dropped every Room emission during an active
    search. It now reconciles visible results against Room — dropping rows that left Room and
    refreshing rows Room still holds (by `updatedAt`) — without pulling non-matching Room rows
    into the server-sourced results.
  - `ConversationListStateHolder` (drawer) now regroups on every Room emission during an active
    search rather than only on a query keystroke, so deletes/renames reflect live.
- `DrawerViewModel.toggleFavorite` now surfaces a `ShowError` toast on failure (the prior
  `NavHostViewModel` path only logged it).

## Testing

- `./gradlew testDebugUnitTest detekt assembleDebug` and `:shared:linkDebugFrameworkIosSimulatorArm64` green.
- New unit tests for the drawer's `ConversationListStateHolder` search reconciliation and for the
  list screen's search reconciliation in `ConversationListViewModel`; `DrawerDisplayMappingTest`
  moved with its subject.
- Device smoke on a Pixel 9 Pro Fold (folded + unfolded): drawer open, account swipe/sheet switch
  and remove, projects tab expand/create, settings carousel, and the staleness fix — search a
  conversation, delete it from the drawer, confirm it leaves the active search results.

## Notes

- The drawer (client-side, 300ms) and list screen (server-side, 500ms) still use different search
  *semantics*; this removes the duplicated drawer code and fixes the staleness on both, but does
  not unify the two search implementations.
