### PR TITLE
refactor(chat): extract context-usage projection into ContextProjectionDelegate

### DIFF
--- a/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModelContextProjectionInitTest.kt
+++ b/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModelContextProjectionInitTest.kt
@@ -47,25 +47,25 @@ import org.junit.Test
 /**
  * Regression guard for the context-gauge init-order crash (agents endpoint).
  *
- * `observeContextProjection()` launches a collector on `_uiState` during construction.
- * Once `loadFlags` enables the gauge (backend >= 0.8.7), that collector fires
- * `refreshContextProjection` -> `resolveProjectionModel`, which on the AGENTS endpoint
- * reads the `resolvedAgentModels` map. If that `val` is declared *after* the `init`
- * block, its initializer hasn't run when the collector re-enters the half-constructed
- * ViewModel, so the field is still null and the map lookup throws a `NullPointerException`
- * that crashes the app (surfaced via the coroutine's uncaught-exception path -> the
- * device sees `FATAL EXCEPTION: main`).
+ * The projection lives in `ContextProjectionDelegate`, whose `start()` is launched from
+ * `ChatViewModel.init` and collects the state flow during construction. Once `loadFlags`
+ * enables the gauge (backend >= 0.8.7), that collector fires `refreshContextProjection` ->
+ * `resolveProjectionModel`, which on the AGENTS endpoint reads the delegate's
+ * `resolvedAgentModels` map. The original crash was that this cache was a `ChatViewModel` `val`
+ * declared *after* `init`, so its initializer hadn't run when the collector re-entered the
+ * half-constructed ViewModel — the field was null and the map lookup threw a
+ * `NullPointerException` that crashed the app (`FATAL EXCEPTION: main`). Homing the cache inside
+ * the delegate makes that structurally impossible (the delegate — and its map — is fully
+ * constructed before `init` calls `start()`); this test locks the behavior in either shape.
  *
  * The crash only reproduces when an AGENT is the selection *at construction time* (a new
  * chat handed off with an agent selected), not when the agent is applied post-construction.
  * This test constructs that state directly under an [UnconfinedTestDispatcher], which (like
- * the device's `Dispatchers.Main.immediate`) runs the init-launched collectors inline during
+ * the device's `Dispatchers.Main.immediate`) runs the init-launched collector inline during
  * construction.
  *
  * The guard is a `coVerify` that the projection reached `getAgentForEditing` — i.e. it ran
- * to completion past the `resolvedAgentModels` map lookup on the agents branch. With the
- * init-order bug the map is null when the collector re-enters mid-construction, so the lookup
- * throws before that call and the verification fails; with the fix it passes.
+ * to completion past the `resolvedAgentModels` map lookup on the agents branch.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 class ChatViewModelContextProjectionInitTest {
@@ -172,11 +172,8 @@ class ChatViewModelContextProjectionInitTest {
 
         // The context projection reaches `resolveProjectionModel` on the agents branch, falls
         // through the (empty) `resolvedAgentModels` cache, and calls `getAgentForEditing` for the
-        // agent's real model. Verifying that call proves the projection ran to completion.
-        //
-        // This is the regression guard: with the init-order bug (the map declared after `init`),
-        // `resolvedAgentModels` is null when the collector re-enters mid-construction, so the map
-        // lookup throws before this call is ever reached and the verification fails.
+        // agent's real model. Verifying that call proves the projection ran to completion past the
+        // map lookup during construction — the point the init-order crash used to fail at.
         coVerify { agentRepository.getAgentForEditing(agentId) }
     }
 

--- a/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/ContextProjectionDelegateTest.kt
+++ b/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/ContextProjectionDelegateTest.kt
@@ -1,0 +1,137 @@
+package com.garfiec.librechat.feature.chat.viewmodel.delegate
+
+import com.garfiec.librechat.core.common.result.Result
+import com.garfiec.librechat.core.data.repository.AgentRepository
+import com.garfiec.librechat.core.data.repository.EndpointTokenRepository
+import com.garfiec.librechat.core.model.Message
+import com.garfiec.librechat.core.model.usage.ContextUsage
+import com.garfiec.librechat.core.ui.components.ModelParameters
+import com.garfiec.librechat.feature.chat.util.MessageNode
+import com.garfiec.librechat.feature.chat.viewmodel.ChatStateHandle
+import com.garfiec.librechat.feature.chat.viewmodel.ChatUiState
+import com.garfiec.librechat.feature.chat.viewmodel.ContextProjectionHandle
+import com.garfiec.librechat.feature.chat.viewmodel.ConversationMetaState
+import com.garfiec.librechat.feature.chat.viewmodel.FeatureGatesState
+import com.garfiec.librechat.feature.chat.viewmodel.MessagesState
+import com.garfiec.librechat.feature.chat.viewmodel.ModelSelectionState
+import com.google.common.truth.Truth.assertThat
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+/**
+ * Guards the gauge-refresh behavior of [ContextProjectionDelegate]: the projection re-runs once per
+ * completed turn (tail advance) so the gauge tracks the growing conversation on backends that don't
+ * stream `on_context_usage` — without re-projecting mid-stream (the live SSE owns the gauge then).
+ *
+ * The `maxContextTokens` override on the model params supplies the projection denominator directly,
+ * so the token-config network path is not exercised; the (non-agents) endpoint means the agent-model
+ * resolution path is skipped too. That keeps each test to the one behavior under test.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class ContextProjectionDelegateTest {
+
+    private val endpointTokenRepository = mockk<EndpointTokenRepository>(relaxed = true)
+    private val agentRepository = mockk<AgentRepository>(relaxed = true)
+
+    private fun state(tailId: String, streaming: Boolean = false, usage: ContextUsage? = null) =
+        ChatUiState(
+            gates = FeatureGatesState(contextUsageEnabled = true),
+            conversation = ConversationMetaState(conversationId = "c1"),
+            selection = ModelSelectionState(
+                selectedEndpoint = "openai",
+                selectedModel = "gpt-4o",
+                modelParameters = ModelParameters.DEFAULT.copy(maxContextTokens = 8000),
+            ),
+            content = MessagesState(
+                displayMessages = listOf(node(tailId)),
+                isStreaming = streaming,
+                contextUsage = usage,
+            ),
+        )
+
+    private fun node(id: String) = MessageNode(
+        message = Message(messageId = id, conversationId = "c1"),
+        children = emptyList(),
+        siblingIndex = 0,
+        siblingCount = 1,
+    )
+
+    @Test
+    fun `re-projects when the tail advances even over an existing gauge`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val usage = ContextUsage()
+            coEvery { endpointTokenRepository.getContextProjection(any()) } returns Result.Success(usage)
+            val flow = MutableStateFlow(state(tailId = "m1"))
+            val handle = ChatStateHandle(flow, backgroundScope)
+            ContextProjectionDelegate(
+                ContextProjectionHandle(handle),
+                agentRepository,
+                endpointTokenRepository,
+            ).start()
+            advanceUntilIdle()
+
+            // Initial load seeds the gauge.
+            assertThat(flow.value.contextUsage).isEqualTo(usage)
+            coVerify(exactly = 1) { endpointTokenRepository.getContextProjection(any()) }
+
+            // A turn completes: the tail advances in the same window and the gauge is already set.
+            // The `contextUsage != null` guard would freeze it; the forced refresh re-projects anyway.
+            flow.value = state(tailId = "m2", usage = usage)
+            advanceUntilIdle()
+            coVerify(exactly = 2) { endpointTokenRepository.getContextProjection(any()) }
+        }
+
+    @Test
+    fun `does not re-project when a live SSE reading already refreshed the gauge`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val projected = ContextUsage(remainingContextTokens = 100)
+            coEvery { endpointTokenRepository.getContextProjection(any()) } returns
+                Result.Success(projected)
+            val flow = MutableStateFlow(state(tailId = "m1"))
+            val handle = ChatStateHandle(flow, backgroundScope)
+            ContextProjectionDelegate(
+                ContextProjectionHandle(handle),
+                agentRepository,
+                endpointTokenRepository,
+            ).start()
+            advanceUntilIdle()
+            assertThat(flow.value.contextUsage).isEqualTo(projected)
+            coVerify(exactly = 1) { endpointTokenRepository.getContextProjection(any()) }
+
+            // The just-completed stream delivered an exact `on_context_usage` reading, so the gauge
+            // now differs from what we projected. The tail advance must NOT overwrite that exact
+            // reading with an estimate, nor fire a redundant projection.
+            val sseReading = ContextUsage(remainingContextTokens = 200)
+            flow.value = state(tailId = "m2", usage = sseReading)
+            advanceUntilIdle()
+            coVerify(exactly = 1) { endpointTokenRepository.getContextProjection(any()) }
+            assertThat(flow.value.contextUsage).isEqualTo(sseReading)
+        }
+
+    @Test
+    fun `does not re-project while streaming`() = runTest(UnconfinedTestDispatcher()) {
+        coEvery { endpointTokenRepository.getContextProjection(any()) } returns
+            Result.Success(ContextUsage())
+        val flow = MutableStateFlow(state(tailId = "m1"))
+        val handle = ChatStateHandle(flow, backgroundScope)
+        ContextProjectionDelegate(
+            ContextProjectionHandle(handle),
+            agentRepository,
+            endpointTokenRepository,
+        ).start()
+        advanceUntilIdle()
+        coVerify(exactly = 1) { endpointTokenRepository.getContextProjection(any()) }
+
+        // Tail advances while a stream is in flight (the live SSE owns the gauge): no projection.
+        flow.value = state(tailId = "m2", streaming = true, usage = ContextUsage())
+        advanceUntilIdle()
+        coVerify(exactly = 1) { endpointTokenRepository.getContextProjection(any()) }
+    }
+}

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModel.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModel.kt
@@ -43,7 +43,6 @@ import com.garfiec.librechat.core.model.permissions.Permission
 import com.garfiec.librechat.core.model.permissions.PermissionType
 import com.garfiec.librechat.core.model.permissions.canCreateSharedLinks
 import com.garfiec.librechat.core.model.permissions.hasAccessOrPermissive
-import com.garfiec.librechat.core.model.request.ContextProjectionRequest
 import com.garfiec.librechat.core.ui.components.ModelParameters
 import com.garfiec.librechat.core.ui.media.MediaItem
 import com.garfiec.librechat.core.ui.media.MediaPreviewState
@@ -58,6 +57,7 @@ import com.garfiec.librechat.feature.chat.util.hasParallelParts
 import com.garfiec.librechat.feature.chat.util.resolveFileReferenceUrl
 import com.garfiec.librechat.feature.chat.util.stabilizeMessageInstances
 import com.garfiec.librechat.feature.chat.viewmodel.delegate.ComparisonModeDelegate
+import com.garfiec.librechat.feature.chat.viewmodel.delegate.ContextProjectionDelegate
 import com.garfiec.librechat.feature.chat.viewmodel.delegate.ConversationActionsDelegate
 import com.garfiec.librechat.feature.chat.viewmodel.delegate.EndpointKeyStatusDelegate
 import com.garfiec.librechat.feature.chat.viewmodel.delegate.FavoritesDelegate
@@ -165,6 +165,11 @@ class ChatViewModel(
         handle = ComparisonHandle(stateHandle),
         messageRepository = messageRepository,
         reloadConversation = ::loadConversation,
+    )
+    private val contextProjectionDelegate = ContextProjectionDelegate(
+        ContextProjectionHandle(stateHandle),
+        agentRepository,
+        endpointTokenRepository,
     )
     private val searchDelegate = InConversationSearchDelegate(SearchHandle(stateHandle))
     private val conversationActionsDelegate =
@@ -368,22 +373,6 @@ class ChatViewModel(
      */
     private val isHandedOffNewChat: Boolean
 
-    /** Last seen projection key, to detect a real window change vs. a tail-only change. */
-    private var previousProjectionKey: ProjectionKey? = null
-
-    /**
-     * Resolved (provider, model) per agentId, cached for the session so the per-window projection
-     * refresh doesn't re-hit the network each time. The list that fills [ChatUiState.agents] comes
-     * from `GET /api/agents`, which strips `provider`/`model` (both come back null) — so the agent's
-     * real model is only obtainable from the per-agent detail endpoint.
-     *
-     * Declared before the `init` block because `observeContextProjection()` launches a
-     * `Main.immediate` collector on the `_uiState` StateFlow, whose current value replays
-     * synchronously during construction. On the agents endpoint that first emission reaches
-     * `resolveProjectionModel`, so this map must already be initialized by then.
-     */
-    private val resolvedAgentModels = mutableMapOf<String, Pair<String, String?>>()
-
     init {
         val conversationId = initialConversationId
         isNewConversation = conversationId == null
@@ -476,7 +465,7 @@ class ChatViewModel(
         }
 
         // Seed/refresh the context-usage gauge for a loaded or snapshot-less branch (v0.8.7).
-        observeContextProjection()
+        contextProjectionDelegate.start()
 
         // Single authority for a new chat's initial model selection. Continuous so
         // the retained NewChat landing VM re-syncs to last-used when it changes
@@ -678,145 +667,6 @@ class ChatViewModel(
                     }
                 }
         }
-    }
-
-    /**
-     * Watches the viewed branch tail + model/endpoint and asks the server to project the
-     * next call's context window so the gauge can show on a loaded or snapshot-less branch
-     * (v0.8.7). Read-only — it only sets [ChatUiState.contextUsage]; it never touches
-     * messages/branches/Room, so it can't disturb the streaming-anchor invariant. The live
-     * `on_context_usage` SSE event owns the gauge during a stream, so [refreshContextProjection]
-     * no-ops while [ChatUiState.isStreaming].
-     */
-    private fun observeContextProjection() {
-        viewModelScope.launch {
-            _uiState
-                .map {
-                    ProjectionKey(
-                        conversationId = it.conversationId,
-                        tailMessageId = it.displayMessages.lastOrNull()?.message?.messageId,
-                        endpoint = it.selectedEndpoint,
-                        model = it.selectedModel,
-                        enabled = it.contextUsageEnabled,
-                    )
-                }
-                .distinctUntilChanged()
-                .collect { key ->
-                    // When the projection *window* changes (conversation/endpoint/model — NOT the
-                    // streaming tail), the previously seeded window no longer describes the new model,
-                    // so clear it to let refreshContextProjection re-project. Never blank mid-stream:
-                    // the live SSE owns the gauge then, and clearing would kill the moving readout.
-                    val prev = previousProjectionKey
-                    if (prev != null && !prev.sameWindowAs(key) && !_uiState.value.isStreaming) {
-                        _uiState.update { it.copy(content = it.content.copy(contextUsage = null)) }
-                    }
-                    previousProjectionKey = key
-                    refreshContextProjection()
-                }
-        }
-    }
-
-    private data class ProjectionKey(
-        val conversationId: String?,
-        val tailMessageId: String?,
-        val endpoint: String,
-        val model: String?,
-        val enabled: Boolean,
-    ) {
-        /** True when the projected window (denominator: conversation/endpoint/model, not the
-         *  streaming tail) is unchanged — a tail-only move keeps the same window. */
-        fun sameWindowAs(other: ProjectionKey) =
-            conversationId == other.conversationId &&
-                endpoint == other.endpoint &&
-                model == other.model
-    }
-
-    /**
-     * Resolves the (endpoint, model) used both to look up the context window and to address the
-     * projection. For the agents endpoint [ChatUiState.selectedModel] is the agentId — not a
-     * token-config key — so substitute the selected agent's real provider/model (web does the same
-     * via useTokenLimits). Everything else passes through unchanged.
-     *
-     * The list-backed [ChatUiState.agents] entry has a null model (the list endpoint strips it), so
-     * fall back to the agent detail (`/api/agents/:id/expanded`, same AGENTS.USE gate as using the
-     * agent) to get the real model, cached per agentId.
-     */
-    private suspend fun resolveProjectionModel(state: ChatUiState): Pair<String, String?> {
-        if (state.selectedEndpoint != EndpointConstants.AGENTS) {
-            return state.selectedEndpoint to state.selectedModel
-        }
-        val agentId = state.selectedModel ?: return state.selectedEndpoint to null
-        // Honor a fully-populated list entry if one ever has a model; otherwise use the cache.
-        state.agents.firstOrNull { it.id == agentId && it.model != null }?.let {
-            return (it.provider ?: state.selectedEndpoint) to it.model
-        }
-        resolvedAgentModels[agentId]?.let { return it }
-        // getAgent short-circuits to the stripped list cache, so fetch the detail explicitly.
-        val detail = (agentRepository.getAgentForEditing(agentId) as? Result.Success)?.data
-        val resolved = (detail?.provider ?: state.selectedEndpoint) to detail?.model
-        // Only cache a real resolution; a transient failure should be retryable next window.
-        if (detail?.model != null) resolvedAgentModels[agentId] = resolved
-        return resolved
-    }
-
-    /**
-     * Resolves the model's context window from token-config (the gauge's denominator).
-     * token-config is memoized on the singleton [endpointTokenRepository], so this fetches
-     * over the network only once per session even though each chat gets its own ViewModel.
-     */
-    private suspend fun resolveMaxContextTokens(endpoint: String, model: String?): Int? {
-        if (model == null) return null
-        val config = endpointTokenRepository.getTokenConfig().getOrNull() ?: return null
-        return config[endpoint]?.get(model)?.context
-    }
-
-    private suspend fun refreshContextProjection() {
-        val state = _uiState.value
-        if (!state.contextUsageEnabled) return
-        // The live SSE snapshot owns the gauge mid-stream; don't fight it with a projection.
-        if (state.isStreaming) return
-        // Never re-project over an existing snapshot: a populated gauge already reflects the live
-        // `on_context_usage` SSE (or a prior projection) for this branch. Re-projecting would replace
-        // actual usage with an estimate, and a null projection result must never blank the gauge.
-        // Mirrors the web client's `branchSnapshot == null` gate (useTokenUsage.ts).
-        if (state.contextUsage != null) return
-        val conversationId = state.conversationId ?: return
-        val messageId = state.displayMessages.lastOrNull()?.message?.messageId ?: return
-        // For the agents endpoint, selectedModel is the agentId — resolve the agent's real
-        // provider/model so the token-config lookup and the projection target a real model.
-        val (lookupEndpoint, lookupModel) = resolveProjectionModel(state)
-        // The window is required: upstream `resolveContextProjection` returns null when
-        // `maxContextTokens <= 0`, so without it the projection always no-ops. Resolve it from
-        // token-config (web does the same), preferring any explicit per-conversation override.
-        val maxContextTokens = state.modelParameters.maxContextTokens?.takeIf { it > 0 }
-            ?: resolveMaxContextTokens(lookupEndpoint, lookupModel)
-            ?: run {
-                // No known context window (model absent from token-config, e.g. a custom/proxy/
-                // self-hosted model) ⇒ no denominator ⇒ no ratio, so the gauge stays hidden. This
-                // is intentional, but log it so the silent no-render is diagnosable.
-                Logger.d {
-                    "Context gauge skipped: no known context window for " +
-                        "endpoint=$lookupEndpoint model=$lookupModel"
-                }
-                return
-            }
-        // For agents, address the projection by agentId (the server resolves the agent's config)
-        // and send the resolved real model; otherwise pass the selected model directly.
-        val isAgent = state.selectedEndpoint == EndpointConstants.AGENTS
-        val result = endpointTokenRepository.getContextProjection(
-            ContextProjectionRequest(
-                conversationId = conversationId,
-                messageId = messageId,
-                endpoint = state.selectedEndpoint,
-                model = lookupModel,
-                agentId = if (isAgent) state.selectedModel else null,
-                maxContextTokens = maxContextTokens,
-            ),
-        )
-        // Only seed when the server actually returned a snapshot — never overwrite or blank an
-        // existing gauge. On null/error, leave the gauge as-is; the next turn's SSE refreshes it.
-        val usage = (result as? Result.Success)?.data ?: return
-        _uiState.update { it.copy(content = it.content.copy(contextUsage = usage)) }
     }
 
     /**

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/DelegateHandles.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/DelegateHandles.kt
@@ -1,6 +1,7 @@
 package com.garfiec.librechat.feature.chat.viewmodel
 
 import com.garfiec.librechat.core.model.endpoint.KeyState
+import com.garfiec.librechat.core.model.usage.ContextUsage
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.StateFlow
 
@@ -224,6 +225,23 @@ class OfficePreviewWrites internal constructor(state: ChatUiState) {
 class OfficePreviewHandle(root: ChatStateHandle) : DelegateHandle(root) {
     fun update(block: OfficePreviewWrites.() -> Unit) =
         root.update { OfficePreviewWrites(this).apply(block).applyTo(this) }
+}
+
+// ── ContextProjectionDelegate ─────────────────────────────────────────────
+// Narrow on purpose: this delegate only seeds/clears the context-usage gauge, so it may write
+// nothing on the content slice but `contextUsage`.
+class ContextProjectionWrites internal constructor(state: ChatUiState) {
+    var contextUsage: ContextUsage? = state.content.contextUsage
+    var error: String? = state.error
+    internal fun applyTo(s: ChatUiState) =
+        s.copy(content = s.content.copy(contextUsage = contextUsage), error = error)
+}
+
+class ContextProjectionHandle(root: ChatStateHandle) : DelegateHandle(root) {
+    /** Read-only observation of the full state (the observer keys off conversation/endpoint/model). */
+    val stateFlow: StateFlow<ChatUiState> get() = root.stateFlow
+    fun update(block: ContextProjectionWrites.() -> Unit) =
+        root.update { ContextProjectionWrites(this).apply(block).applyTo(this) }
 }
 
 // ── Platform voice input (VoiceInputDelegate / IosVoiceInput) ─────────────

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/ContextProjectionDelegate.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/ContextProjectionDelegate.kt
@@ -1,0 +1,212 @@
+package com.garfiec.librechat.feature.chat.viewmodel.delegate
+
+import co.touchlab.kermit.Logger
+import com.garfiec.librechat.core.common.EndpointConstants
+import com.garfiec.librechat.core.common.result.Result
+import com.garfiec.librechat.core.common.result.getOrNull
+import com.garfiec.librechat.core.data.repository.AgentRepository
+import com.garfiec.librechat.core.data.repository.EndpointTokenRepository
+import com.garfiec.librechat.core.model.request.ContextProjectionRequest
+import com.garfiec.librechat.core.model.usage.ContextUsage
+import com.garfiec.librechat.feature.chat.viewmodel.ChatUiState
+import com.garfiec.librechat.feature.chat.viewmodel.ContextProjectionHandle
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+
+/**
+ * Owns the context-usage gauge's projection path. Watches the viewed branch tail + model/endpoint
+ * and asks the server to project the next call's context window so the gauge can show on a loaded
+ * or snapshot-less branch (v0.8.7). Read-only over chat state — it only sets
+ * [ChatUiState.contextUsage]; it never touches messages/branches/Room, so it can't disturb the
+ * streaming-anchor invariant. The live `on_context_usage` SSE event owns the gauge during a stream,
+ * so [refreshContextProjection] no-ops while [ChatUiState.isStreaming].
+ */
+class ContextProjectionDelegate(
+    private val handle: ContextProjectionHandle,
+    private val agentRepository: AgentRepository,
+    private val endpointTokenRepository: EndpointTokenRepository,
+) {
+
+    /** Last seen projection key, to detect a real window change vs. a tail-only change. */
+    private var previousProjectionKey: ProjectionKey? = null
+
+    /**
+     * The last value this delegate itself wrote to the gauge. Lets the tail-advance path tell a
+     * stale projection (ours) from a fresh live `on_context_usage` reading (someone else's): if the
+     * gauge no longer equals what we projected, the just-completed stream delivered an exact reading
+     * and we must not overwrite it with an estimate.
+     */
+    private var lastProjectedUsage: ContextUsage? = null
+
+    /**
+     * Resolved (provider, model) per agentId, cached for the session so the per-window projection
+     * refresh doesn't re-hit the network each time. The list that fills [ChatUiState.agents] comes
+     * from `GET /api/agents`, which strips `provider`/`model` (both come back null) — so the agent's
+     * real model is only obtainable from the per-agent detail endpoint.
+     */
+    private val resolvedAgentModels = mutableMapOf<String, Pair<String, String?>>()
+
+    /**
+     * Starts the projection observer. Launches a `Main.immediate` collector on the state flow,
+     * whose current value replays synchronously — on the agents endpoint that first emission reaches
+     * [resolveProjectionModel], so [resolvedAgentModels] is already initialized by then.
+     */
+    fun start() {
+        handle.scope.launch {
+            handle.stateFlow
+                .map {
+                    ProjectionKey(
+                        conversationId = it.conversationId,
+                        tailMessageId = it.displayMessages.lastOrNull()?.message?.messageId,
+                        endpoint = it.selectedEndpoint,
+                        model = it.selectedModel,
+                        enabled = it.contextUsageEnabled,
+                    )
+                }
+                .distinctUntilChanged()
+                .collect { key ->
+                    val prev = previousProjectionKey
+                    // A window change (conversation/endpoint/model) makes the old gauge irrelevant, so
+                    // clear it — the previous window's value must not linger while the new projection
+                    // loads. Gated off mid-stream: the live SSE owns the gauge then and clearing would
+                    // kill the moving readout (begin-stream lands the new tail with isStreaming already
+                    // true, so this is skipped until the Final emission).
+                    if (prev != null && !prev.sameWindowAs(key) && !handle.state.isStreaming) {
+                        handle.update { contextUsage = null }
+                    }
+                    // Force a re-projection when the tail advances (a turn completed) so the gauge
+                    // tracks the growing conversation: without this the `contextUsage != null` guard
+                    // freezes it at its load-time value on backends that don't stream `on_context_usage`.
+                    // Forcing overwrites in place on success and never blanks, so the gauge refreshes
+                    // without flickering between turns. contextUsage is not part of [ProjectionKey], so
+                    // the write below can't re-trigger this collector.
+                    //
+                    // But only force when the gauge is still our own stale projection. Backends that
+                    // DO stream `on_context_usage` set an exact reading during the stream, so at Final
+                    // the gauge no longer equals what we last projected — forcing there would replace
+                    // that exact reading with an estimate AND fire a redundant projection every turn.
+                    // (contextUsage == null means it was just cleared for a new window; force is a
+                    // no-op over null, so the condition still lets the fresh window project.)
+                    val tailAdvanced = prev != null && prev.tailMessageId != key.tailMessageId
+                    val gaugeIsStaleProjection =
+                        handle.state.contextUsage == null || handle.state.contextUsage == lastProjectedUsage
+                    previousProjectionKey = key
+                    refreshContextProjection(force = tailAdvanced && gaugeIsStaleProjection)
+                }
+        }
+    }
+
+    private data class ProjectionKey(
+        val conversationId: String?,
+        val tailMessageId: String?,
+        val endpoint: String,
+        val model: String?,
+        // Not read directly — it exists only so the generated `equals` re-fires the collector when
+        // loadFlags flips `contextUsageEnabled` false->true after construction (the gate is enforced
+        // in refreshContextProjection). Keep it in the key; dropping it silently loses that emission.
+        val enabled: Boolean,
+    ) {
+        /** True when the projected window (denominator: conversation/endpoint/model, not the
+         *  streaming tail) is unchanged — a tail-only move keeps the same window. */
+        fun sameWindowAs(other: ProjectionKey) =
+            conversationId == other.conversationId &&
+                endpoint == other.endpoint &&
+                model == other.model
+    }
+
+    /**
+     * Resolves the (endpoint, model) used both to look up the context window and to address the
+     * projection. For the agents endpoint [ChatUiState.selectedModel] is the agentId — not a
+     * token-config key — so substitute the selected agent's real provider/model (web does the same
+     * via useTokenLimits). Everything else passes through unchanged.
+     *
+     * The list-backed [ChatUiState.agents] entry has a null model (the list endpoint strips it), so
+     * fall back to the agent detail (`/api/agents/:id/expanded`, same AGENTS.USE gate as using the
+     * agent) to get the real model, cached per agentId.
+     */
+    private suspend fun resolveProjectionModel(state: ChatUiState): Pair<String, String?> {
+        if (state.selectedEndpoint != EndpointConstants.AGENTS) {
+            return state.selectedEndpoint to state.selectedModel
+        }
+        val agentId = state.selectedModel ?: return state.selectedEndpoint to null
+        // Honor a fully-populated list entry if one ever has a model; otherwise use the cache.
+        state.agents.firstOrNull { it.id == agentId && it.model != null }?.let {
+            return (it.provider ?: state.selectedEndpoint) to it.model
+        }
+        resolvedAgentModels[agentId]?.let { return it }
+        // getAgent short-circuits to the stripped list cache, so fetch the detail explicitly.
+        val detail = (agentRepository.getAgentForEditing(agentId) as? Result.Success)?.data
+        val resolved = (detail?.provider ?: state.selectedEndpoint) to detail?.model
+        // Only cache a real resolution; a transient failure should be retryable next window.
+        if (detail?.model != null) resolvedAgentModels[agentId] = resolved
+        return resolved
+    }
+
+    /**
+     * Resolves the model's context window from token-config (the gauge's denominator).
+     * token-config is memoized on the singleton [endpointTokenRepository], so this fetches
+     * over the network only once per session even though each chat gets its own ViewModel.
+     */
+    private suspend fun resolveMaxContextTokens(endpoint: String, model: String?): Int? {
+        if (model == null) return null
+        val config = endpointTokenRepository.getTokenConfig().getOrNull() ?: return null
+        return config[endpoint]?.get(model)?.context
+    }
+
+    private suspend fun refreshContextProjection(force: Boolean = false) {
+        val state = handle.state
+        if (!state.contextUsageEnabled) return
+        // The live SSE snapshot owns the gauge mid-stream; don't fight it with a projection.
+        if (state.isStreaming) return
+        // Normally never re-project over an existing snapshot: a populated gauge already reflects the
+        // live `on_context_usage` SSE (or a prior projection) for this branch, and re-projecting would
+        // replace an actual reading with an estimate. A forced refresh (the tail advanced) overrides
+        // that — the snapshot is stale for the new tail — and still only overwrites on a successful
+        // projection below, so it never blanks the gauge. Mirrors the web client's `branchSnapshot ==
+        // null` gate (useTokenUsage.ts), extended to refresh once per completed turn.
+        if (!force && state.contextUsage != null) return
+        val conversationId = state.conversationId ?: return
+        val messageId = state.displayMessages.lastOrNull()?.message?.messageId ?: return
+        // For the agents endpoint, selectedModel is the agentId — resolve the agent's real
+        // provider/model so the token-config lookup and the projection target a real model.
+        val (lookupEndpoint, lookupModel) = resolveProjectionModel(state)
+        // The window is required: upstream `resolveContextProjection` returns null when
+        // `maxContextTokens <= 0`, so without it the projection always no-ops. Resolve it from
+        // token-config (web does the same), preferring any explicit per-conversation override.
+        val maxContextTokens = state.modelParameters.maxContextTokens?.takeIf { it > 0 }
+            ?: resolveMaxContextTokens(lookupEndpoint, lookupModel)
+            ?: run {
+                // No known context window (model absent from token-config, e.g. a custom/proxy/
+                // self-hosted model) ⇒ no denominator ⇒ no ratio, so the gauge stays hidden. This
+                // is intentional, but log it so the silent no-render is diagnosable.
+                Logger.d {
+                    "Context gauge skipped: no known context window for " +
+                        "endpoint=$lookupEndpoint model=$lookupModel"
+                }
+                return
+            }
+        // For agents, address the projection by agentId (the server resolves the agent's config)
+        // and send the resolved real model; otherwise pass the selected model directly.
+        val isAgent = state.selectedEndpoint == EndpointConstants.AGENTS
+        val result = endpointTokenRepository.getContextProjection(
+            ContextProjectionRequest(
+                conversationId = conversationId,
+                messageId = messageId,
+                endpoint = state.selectedEndpoint,
+                model = lookupModel,
+                agentId = if (isAgent) state.selectedModel else null,
+                maxContextTokens = maxContextTokens,
+            ),
+        )
+        // Only seed when the server actually returned a snapshot. On null/error, leave the gauge
+        // as-is; the next turn's SSE refreshes it.
+        val usage = (result as? Result.Success)?.data ?: return
+        // Re-check after the network round-trip: a stream may have started while we were awaiting
+        // the projection. Once streaming, the live `on_context_usage` SSE owns the gauge, so a
+        // now-stale projection (especially a forced one) must not clobber the fresh reading.
+        if (handle.state.isStreaming) return
+        lastProjectedUsage = usage
+        handle.update { contextUsage = usage }
+    }
+}

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/MessageTreeDelegate.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/MessageTreeDelegate.kt
@@ -41,8 +41,8 @@ class MessageTreeDelegate(
             newBranches[parentMessageId] = siblingIndex
             // The sibling we're switching to has a different message history, so the seeded context
             // gauge no longer describes it. Clear it (we're !isStreaming here, so no live SSE to
-            // disturb) and let observeContextProjection re-project once displayMessages rebuilds with
-            // the new tail. sameWindowAs() ignores the tail, so without this the stale numerator
+            // disturb) and let ContextProjectionDelegate re-project once displayMessages rebuilds
+            // with the new tail. sameWindowAs() ignores the tail, so without this the stale numerator
             // would linger until the next send.
             content = content.copy(activeBranches = newBranches, contextUsage = null)
         }


### PR DESCRIPTION
## Summary
Continues the `feature/chat` modularization by moving the context-usage-gauge projection logic out of the large `ChatViewModel` into a dedicated `ContextProjectionDelegate` with a narrowed write handle. Also fixes the gauge freezing at its load-time value on backends that don't stream `on_context_usage`.

## Changes
- **New `ContextProjectionDelegate`** — owns the projection observer, model/window resolution, and the `ProjectionKey` distinct-until-changed gate. `ChatViewModel` sheds ~150 lines and constructs the delegate before `init`.
- **Narrowed write handle** — `ContextProjectionHandle`/`ContextProjectionWrites` in `DelegateHandles.kt` let the delegate mutate only `contextUsage` (plus the shared `error` channel), compile-time enforced.
- **Gauge refresh on completed turns** — re-projects when the message tail advances so the gauge tracks a growing conversation instead of freezing at its load-time value on backends without `on_context_usage`.
- **Backends that do stream `on_context_usage` are unaffected** — the refresh is gated so a live SSE reading is never overwritten by an estimate (no redundant projection call per turn), and a projection in flight when a stream starts is discarded rather than clobbering the live gauge.

## Testing
- `:feature:chat` `compileDebugKotlin`, `ContextProjectionDelegateTest` (3 tests), and `detektMetadataCommonMain` all pass.
- Manually verified on a Pixel 9 Pro Fold.
- iOS: verification stops at the Gradle framework link (per project convention).

## Notes
- Behavior-preserving extraction, apart from the gauge-refresh behavior: it now re-projects on completed turns, gated so it never overwrites a live `on_context_usage` reading.
