### PR TITLE
fix(conversations): clear the chat pane when its open conversation is deleted

### DIFF
--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/repository/ConversationRepositoryImplTest.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/repository/ConversationRepositoryImplTest.kt
@@ -6,6 +6,7 @@ import com.garfiec.librechat.core.common.identity.InMemoryActiveAccountProvider
 import com.garfiec.librechat.core.common.result.Result
 import com.garfiec.librechat.core.data.datastore.AccountRoster
 import com.garfiec.librechat.core.data.db.dao.ConversationDao
+import com.garfiec.librechat.core.data.db.dao.MessageDao
 import com.garfiec.librechat.core.data.db.entity.ConversationEntity
 import com.garfiec.librechat.core.model.Conversation
 import com.garfiec.librechat.core.model.SAVED_TAG
@@ -30,6 +31,7 @@ class ConversationRepositoryImplTest {
 
     private val conversationsApi = mockk<ConversationsApi>(relaxed = true)
     private val conversationDao = mockk<ConversationDao>(relaxed = true)
+    private val messageDao = mockk<MessageDao>(relaxed = true)
     private val roster = mockk<AccountRoster>(relaxed = true)
     private val json = Json { ignoreUnknownKeys = true }
     private val account = AccountId("srv:user-1")
@@ -42,6 +44,7 @@ class ConversationRepositoryImplTest {
         repository = ConversationRepositoryImpl(
             conversationsApi = conversationsApi,
             conversationDao = conversationDao,
+            messageDao = messageDao,
             activeAccountProvider = activeAccountProvider,
             roster = roster,
             json = json,
@@ -81,6 +84,43 @@ class ConversationRepositoryImplTest {
         val entity = captured.captured.single()
         assertThat(entity.conversationId).isEqualTo("convo-1")
         assertThat(entity.title).isEqualTo("Server Title")
+    }
+
+    @Test
+    fun `delete cascades to the conversation's cached messages`() = runTest {
+        coEvery { conversationsApi.deleteConversation("convo-1") } just Runs
+
+        val result = repository.delete("convo-1")
+
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+        // Room has no FK cascade, so the row-only delete would strand the messages and let a bound
+        // chat pane keep rendering the deleted thread. Both deletes must be account-scoped.
+        coVerify(exactly = 1) { conversationDao.deleteById("convo-1", account.value) }
+        coVerify(exactly = 1) { messageDao.deleteAllForConversation("convo-1", account.value) }
+    }
+
+    @Test
+    fun `delete still succeeds when the message cascade fails`() = runTest {
+        coEvery { conversationsApi.deleteConversation("convo-1") } just Runs
+        // Server row + conversation row are already gone; a Room failure purging the cached
+        // messages must not flip delete() to Error (that would suppress the drawer's navigate-off).
+        coEvery { messageDao.deleteAllForConversation("convo-1", account.value) } throws RuntimeException("disk I/O")
+
+        val result = repository.delete("convo-1")
+
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+    }
+
+    @Test
+    fun `delete keeps local rows when no account is resolved`() = runTest {
+        activeAccountProvider.clear() // Resolved(null) — currentAccountId() is null
+        coEvery { conversationsApi.deleteConversation("convo-1") } just Runs
+
+        repository.delete("convo-1")
+
+        // Unresolved account: the by-PK local deletes can't be safely scoped, so neither runs.
+        coVerify(exactly = 0) { conversationDao.deleteById(any(), any()) }
+        coVerify(exactly = 0) { messageDao.deleteAllForConversation(any(), any()) }
     }
 
     @Test

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/ConversationRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/ConversationRepositoryImpl.kt
@@ -9,6 +9,7 @@ import com.garfiec.librechat.core.common.result.Result
 import com.garfiec.librechat.core.common.result.safeApiCall
 import com.garfiec.librechat.core.data.datastore.AccountRoster
 import com.garfiec.librechat.core.data.db.dao.ConversationDao
+import com.garfiec.librechat.core.data.db.dao.MessageDao
 import com.garfiec.librechat.core.data.mapper.toEntity
 import com.garfiec.librechat.core.data.mapper.toModel
 import com.garfiec.librechat.core.data.mapper.toModels
@@ -28,6 +29,7 @@ import kotlin.time.Clock
 class ConversationRepositoryImpl(
     private val conversationsApi: ConversationsApi,
     private val conversationDao: ConversationDao,
+    private val messageDao: MessageDao,
     private val activeAccountProvider: ActiveAccountProvider,
     private val roster: AccountRoster,
     private val json: Json,
@@ -198,6 +200,15 @@ class ConversationRepositoryImpl(
             // log it. In practice a delete is a foreground action where the account is resolved.
             if (accountId != null) {
                 conversationDao.deleteById(id, accountId)
+                // Cascade the cached messages too. MessageEntity has no FK to the conversation, so the
+                // row-only delete would strand this convo's messages in Room — and any chat pane still
+                // bound to [id] (deleted from a surface that doesn't navigate off it) keeps rendering
+                // them via observeMessages. Best-effort: the server row is already gone, so a Room
+                // failure here must NOT flip delete() to Result.Error (that would suppress the drawer's
+                // navigate-off and surface a spurious "failed to delete"). A lingering message cache is
+                // harmless — the pane navigates away, and it's cleared on the next sync/account wipe.
+                runCatching { messageDao.deleteAllForConversation(id, accountId) }
+                    .onFailure { Logger.w(it) { "Deleted $id but failed to purge its cached messages" } }
             } else {
                 Logger.w { "Server-deleted $id but kept local row: no resolved account to scope the delete" }
             }

--- a/feature/conversations/CLAUDE.md
+++ b/feature/conversations/CLAUDE.md
@@ -43,4 +43,4 @@
 - File I/O uses SAF (Storage Access Framework)
 
 ## Events
-`ConversationListEvent` sealed interface for one-shot UI events: `ShareLinkCopied`, `NavigateToConversation`, `ShowError`, `ExportReady`, `ImportSuccess`
+`ConversationListEvent` sealed interface for one-shot UI events: `ShareLinkCopied`, `NavigateToConversation`, `NavigateToNewChat` (emitted when the currently-open conversation is deleted, so the host moves off the now-gone thread), `ShowError`, `ExportReady`, `ImportSuccess`

--- a/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/components/ConversationActionEffects.kt
+++ b/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/components/ConversationActionEffects.kt
@@ -31,11 +31,13 @@ private val ExportFileNameSanitizer = Regex("[^a-zA-Z0-9._-]")
 fun ConversationActionEffects(
     events: Flow<ConversationListEvent>,
     onNavigateToConversation: (String) -> Unit,
+    onNavigateToNewChat: () -> Unit,
 ) {
     var pendingExportFileName by remember { mutableStateOf<String?>(null) }
     var pendingExportContent by remember { mutableStateOf<String?>(null) }
 
     val currentOnNavigate by rememberUpdatedState(onNavigateToConversation)
+    val currentOnNavigateToNewChat by rememberUpdatedState(onNavigateToNewChat)
 
     val linkCopiedMsg = stringResource(Res.string.link_copied)
     val conversationExportedMsg = stringResource(Res.string.conversation_exported)
@@ -65,6 +67,9 @@ fun ConversationActionEffects(
                 }
                 is ConversationListEvent.NavigateToConversation -> {
                     currentOnNavigate(event.conversationId)
+                }
+                is ConversationListEvent.NavigateToNewChat -> {
+                    currentOnNavigateToNewChat()
                 }
                 is ConversationListEvent.ShowError -> {
                     showToast(event.message)

--- a/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/drawer/DrawerContent.kt
+++ b/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/drawer/DrawerContent.kt
@@ -171,6 +171,10 @@ fun DrawerContent(
     // account operations, hoisted in because DrawerViewModel owns only drawer data now.
     onSwitchAccountInPlace: (String) -> Unit = {},
     onRemoveAccount: (String) -> Unit = {},
+    // Fired when the user deletes the conversation currently open in the pane: move the pane off the
+    // now-gone thread. Distinct from [onNewChat] because that also closes the phone drawer — here the
+    // drawer stays open so the user can keep browsing (defaults to [onNewChat] if a host doesn't wire it).
+    onActiveConversationDelete: () -> Unit = onNewChat,
     viewModel: DrawerViewModel = koinViewModel(),
 ) {
     val uiState by viewModel.drawerUiState.collectAsStateWithLifecycle()
@@ -190,6 +194,7 @@ fun DrawerContent(
     ConversationActionEffects(
         events = viewModel.events,
         onNavigateToConversation = onConversationClick,
+        onNavigateToNewChat = onActiveConversationDelete,
     )
 
     DrawerContent(

--- a/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/drawer/DrawerViewModel.kt
+++ b/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/drawer/DrawerViewModel.kt
@@ -438,7 +438,11 @@ class DrawerViewModel(
         projectActions.delete(projectId)
     }
 
-    fun deleteConversation(id: String) = conversationActions.deleteConversation(id)
+    fun deleteConversation(id: String) = conversationActions.deleteConversation(
+        id = id,
+        // See the delegate KDoc: isActive drives the navigate-off when the open chat is deleted.
+        isActive = conversationListStateHolder.activeConversationId.value == id,
+    )
 
     fun shareConversation(conversationId: String) = conversationActions.shareConversation(conversationId)
 

--- a/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/screen/ConversationListScreen.kt
+++ b/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/screen/ConversationListScreen.kt
@@ -123,6 +123,8 @@ fun ConversationListScreen(
                 is ConversationListEvent.NavigateToConversation -> {
                     currentOnConversationClick(event.conversationId)
                 }
+                // Only the drawer deletes with active-conversation awareness, so this never fires here.
+                is ConversationListEvent.NavigateToNewChat -> Unit
                 is ConversationListEvent.ShowError -> {
                     snackbarHostState.showSnackbar(event.message)
                 }

--- a/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/screen/ProjectChatsScreen.kt
+++ b/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/screen/ProjectChatsScreen.kt
@@ -122,6 +122,8 @@ fun ProjectChatsScreen(
                     snackbarHostState.showSnackbar(linkCopiedMsg)
                 }
                 is ConversationListEvent.NavigateToConversation -> currentOnConversationClick(event.conversationId)
+                // Only the drawer deletes with active-conversation awareness, so this never fires here.
+                is ConversationListEvent.NavigateToNewChat -> Unit
                 is ConversationListEvent.ShowError -> snackbarHostState.showSnackbar(event.message)
                 is ConversationListEvent.ExportReady -> {
                     pendingExportContent = event.content

--- a/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/viewmodel/ConversationListActionsDelegate.kt
+++ b/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/viewmodel/ConversationListActionsDelegate.kt
@@ -60,11 +60,21 @@ class ConversationListActionsDelegate(
         }
     }
 
-    fun deleteConversation(id: String) {
+    /**
+     * Deletes [id]. When [isActive] (the deleted conversation is the one currently open in the chat
+     * pane), emits [ConversationListEvent.NavigateToNewChat] on success so the host moves the pane off
+     * the now-deleted thread to a fresh chat. This is the clean-UX half: the repo's delete also purges
+     * the conversation's cached messages, so surfaces that DON'T navigate don't render a stale thread
+     * either — the two are complementary, not redundant.
+     */
+    fun deleteConversation(id: String, isActive: Boolean = false) {
         scope.launch {
             when (conversationRepository.delete(id)) {
                 is Result.Error -> events.emit(ConversationListEvent.ShowError("Failed to delete conversation"))
-                else -> onMutated()
+                else -> {
+                    if (isActive) events.emit(ConversationListEvent.NavigateToNewChat)
+                    onMutated()
+                }
             }
         }
     }

--- a/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/viewmodel/ConversationListViewModel.kt
+++ b/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/viewmodel/ConversationListViewModel.kt
@@ -54,6 +54,9 @@ data class ConversationListUiState(
 sealed interface ConversationListEvent {
     data class ShareLinkCopied(val url: String) : ConversationListEvent
     data class NavigateToConversation(val conversationId: String) : ConversationListEvent
+
+    /** The currently-open conversation was deleted: move off it to a fresh new chat. */
+    data object NavigateToNewChat : ConversationListEvent
     data class ShowError(val message: String) : ConversationListEvent
     data class ExportReady(val content: String, val format: ExportFormat, val title: String) : ConversationListEvent
     data class ImportSuccess(val title: String) : ConversationListEvent

--- a/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/LibreChatNavHost.kt
+++ b/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/LibreChatNavHost.kt
@@ -312,6 +312,11 @@ fun PhoneLayout(
                         scope.launch { drawerState.close() }
                         navigator.navigateToChat(conversationId)
                     },
+                    // Leave the drawer open (no drawerState.close()) so the user can keep browsing,
+                    // unlike onNewChat above.
+                    onActiveConversationDelete = {
+                        navigator.navigateToTopLevel(NewChat())
+                    },
                     onSettingsClick = {
                         scope.launch { drawerState.close() }
                         navigator.navigate(SettingsTabbed)

--- a/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/SidebarScaffold.kt
+++ b/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/SidebarScaffold.kt
@@ -33,6 +33,9 @@ fun SidebarScaffold(
     onOpenProjectsIndex: () -> Unit = {},
     onSwitchAccount: (String) -> Unit = {},
     onAddAccount: () -> Unit = {},
+    // Deleting the open conversation navigates the pane off it; see DrawerContent's param for the
+    // onNewChat distinction. Defaults to [onNewChat].
+    onActiveConversationDelete: () -> Unit = onNewChat,
     viewModel: NavHostViewModel = koinViewModel(),
 ) {
     val sidebarMode by viewModel.sidebarMode.collectAsStateWithLifecycle()
@@ -69,6 +72,7 @@ fun SidebarScaffold(
             is SidebarMode.Conversations -> {
                 DrawerContent(
                     onNewChat = onNewChat,
+                    onActiveConversationDelete = onActiveConversationDelete,
                     onConversationClick = onConversationClick,
                     onSettingsClick = onSettingsClick,
                     onAgentsClick = onAgentsClick,


### PR DESCRIPTION
## Summary
Deleting the conversation currently open in the chat pane left the deleted thread
still rendered on screen. This fixes it at two independent levels so no delete
surface can strand a stale thread.

## Changes
- **Repository purge (root cause):** `ConversationRepository.delete()` now also
  purges the conversation's cached messages from Room. `MessageEntity` has no FK
  cascade to the conversation, so a row-only delete previously left the messages
  behind and any chat pane bound to that id kept rendering them. The purge is
  best-effort — the server row is already gone, so a local purge failure logs and
  does not fail the delete.
- **Drawer navigate-off (UX):** deleting the open conversation from the drawer
  emits a new `ConversationListEvent.NavigateToNewChat`, moving the pane to a
  fresh chat. On phone the drawer stays open so the user can keep browsing; wired
  through a new `onActiveConversationDeleted` host callback that defaults to the
  existing new-chat action. On tablet the delete likewise navigates the pane off
  the deleted thread, and the persistent sidebar stays open.

## Testing
- New unit tests in `ConversationRepositoryImplTest`: delete cascades to cached
  messages, delete still succeeds when the message purge throws, and no local
  deletes run when the account is unresolved.
- `:core:data` unit tests pass; `:feature:conversations` compiles.
- Device tested on Pixel 9 Pro Fold (folded and unfolded).
