### PR TITLE
fix(chat): make large image uploads reliable

### DIFF
--- a/core/common/src/commonMain/kotlin/com/garfiec/librechat/core/common/extensions/ByteSizeFormat.kt
+++ b/core/common/src/commonMain/kotlin/com/garfiec/librechat/core/common/extensions/ByteSizeFormat.kt
@@ -1,0 +1,36 @@
+package com.garfiec.librechat.core.common.extensions
+
+import kotlin.math.roundToInt
+
+/**
+ * Formats a byte count as a human-readable size string, scaling to the largest unit under 1024
+ * and showing one decimal place with a trailing ".0" trimmed — e.g. `512 B`, `1.2 MB`, `20 MB`,
+ * `3.4 GB`. Pure Kotlin so it works in `commonMain` on both platforms.
+ *
+ * Note: `feature/files` keeps its own `formatFileSize` (an `expect/actual` that uses iOS's native
+ * `NSByteCountFormatter`), and `feature/settings` intentionally renders integer KB with no GB tier.
+ * Those deliberately diverge; this helper is the default for new call sites.
+ */
+fun formatByteSize(bytes: Long): String {
+    if (bytes < 1024) return "$bytes B"
+    var value = bytes / 1024.0
+    var unitIndex = 0
+    // Advance while the value would round (at one decimal) to 1024 or more, not just when it is
+    // literally >= 1024 — otherwise a value like 1023.99 stays in this tier and prints "1024 KB"
+    // instead of rolling up to "1 MB".
+    while (value >= 1023.95 && unitIndex < UNITS.lastIndex) {
+        value /= 1024.0
+        unitIndex++
+    }
+    return "${trimOneDecimal(value)} ${UNITS[unitIndex]}"
+}
+
+private val UNITS = listOf("KB", "MB", "GB", "TB")
+
+/** Rounds [value] to one decimal and drops a trailing ".0" (2.0 -> "2", 1.25 -> "1.3"). */
+private fun trimOneDecimal(value: Double): String {
+    val tenths = (value * 10).roundToInt()
+    val whole = tenths / 10
+    val fraction = tenths % 10
+    return if (fraction == 0) "$whole" else "$whole.$fraction"
+}

--- a/core/common/src/commonTest/kotlin/com/garfiec/librechat/core/common/extensions/ByteSizeFormatTest.kt
+++ b/core/common/src/commonTest/kotlin/com/garfiec/librechat/core/common/extensions/ByteSizeFormatTest.kt
@@ -1,0 +1,41 @@
+package com.garfiec.librechat.core.common.extensions
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ByteSizeFormatTest {
+
+    @Test
+    fun bytesUnderOneKbShowRawBytes() {
+        assertEquals("0 B", formatByteSize(0))
+        assertEquals("512 B", formatByteSize(512))
+        assertEquals("1023 B", formatByteSize(1023))
+    }
+
+    @Test
+    fun wholeUnitsDropTrailingDecimal() {
+        assertEquals("1 KB", formatByteSize(1024))
+        assertEquals("20 MB", formatByteSize(20L * 1024 * 1024))
+        assertEquals("1 GB", formatByteSize(1024L * 1024 * 1024))
+    }
+
+    @Test
+    fun fractionalUnitsShowOneDecimal() {
+        assertEquals("1.5 KB", formatByteSize(1536))
+        assertEquals("1.2 MB", formatByteSize((1.2 * 1024 * 1024).toLong()))
+    }
+
+    @Test
+    fun valueRoundingUpToUnitBoundaryRollsToNextUnit() {
+        // ~1023.99 KB must render as "1 MB", never "1024 KB".
+        assertEquals("1 MB", formatByteSize(1_048_565))
+        // Same at the MB->GB boundary.
+        assertEquals("1 GB", formatByteSize(1_073_741_772))
+    }
+
+    @Test
+    fun justBelowRoundUpStaysInUnit() {
+        // 1023.0 KB rounds to itself, stays "1023 KB".
+        assertEquals("1023 KB", formatByteSize(1023L * 1024))
+    }
+}

--- a/core/model/src/commonMain/kotlin/com/garfiec/librechat/core/model/response/FileUploadConfig.kt
+++ b/core/model/src/commonMain/kotlin/com/garfiec/librechat/core/model/response/FileUploadConfig.kt
@@ -30,3 +30,30 @@ data class EndpointFileConfig(
     val fileSizeLimit: Long? = null,
     val supportedMimeTypes: List<String> = emptyList(),
 )
+
+/**
+ * Resolves the effective per-file size limit (in **bytes**) for [endpoint], mirroring the web
+ * client's `getEndpointFileConfig`: the per-endpoint entry wins, falling back to the special
+ * `"default"` endpoint entry. The server reports these limits in bytes (`mbToBytes`).
+ *
+ * Resolution order matters: the served `/api/files/config` object carries the per-file limits
+ * **only** under `endpoints.<name>.fileSizeLimit` (with an `endpoints["default"]` catch-all) — its
+ * top-level `fileSizeLimit` is never populated by the stock backend (that level exposes
+ * `serverFileSizeLimit`, a separate server-wide cap we don't model). So an endpoint not explicitly
+ * listed (openAI, google, bedrock, custom, …) resolves through the `"default"` entry, not the
+ * always-null top-level field. The top-level [fileSizeLimit] is kept only as a last-ditch fallback
+ * for a non-standard backend that happens to send it.
+ *
+ * Returns null when no limit is configured (older backend, or no default entry) so callers can
+ * fail open. A limit of 0 — the server's marker for a disabled endpoint — is returned as-is;
+ * enforcement callers should treat non-positive limits as "no check" since disabled uploads are
+ * gated elsewhere.
+ */
+fun FileUploadConfig.effectiveFileSizeLimit(endpoint: String?): Long? {
+    val endpointLimit = endpoint?.let { endpoints[it]?.fileSizeLimit }
+    val defaultLimit = endpoints[DEFAULT_ENDPOINT_KEY]?.fileSizeLimit
+    return endpointLimit ?: defaultLimit ?: fileSizeLimit
+}
+
+/** Catch-all key in [FileUploadConfig.endpoints] the server uses for endpoints without an override. */
+private const val DEFAULT_ENDPOINT_KEY = "default"

--- a/core/model/src/commonTest/kotlin/com/garfiec/librechat/core/model/response/FileUploadConfigTest.kt
+++ b/core/model/src/commonTest/kotlin/com/garfiec/librechat/core/model/response/FileUploadConfigTest.kt
@@ -1,0 +1,57 @@
+package com.garfiec.librechat.core.model.response
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class FileUploadConfigTest {
+
+    @Test
+    fun effectiveLimitFallsBackToDefaultEndpointForUnlistedEndpoint() {
+        // The stock backend puts the real limit under endpoints["default"], not a top-level field.
+        // openAI is not in the base endpoints map, so it must resolve through "default".
+        val config = FileUploadConfig(
+            endpoints = mapOf("default" to EndpointFileConfig(fileSizeLimit = 10_000L)),
+        )
+        assertEquals(10_000L, config.effectiveFileSizeLimit("openAI"))
+    }
+
+    @Test
+    fun effectiveLimitPrefersPerEndpointOverrideOverDefault() {
+        val config = FileUploadConfig(
+            endpoints = mapOf(
+                "default" to EndpointFileConfig(fileSizeLimit = 10_000L),
+                "anthropic" to EndpointFileConfig(fileSizeLimit = 5_000L),
+            ),
+        )
+        assertEquals(5_000L, config.effectiveFileSizeLimit("anthropic"))
+        assertEquals(10_000L, config.effectiveFileSizeLimit("openAI"))
+    }
+
+    @Test
+    fun effectiveLimitIgnoresNeverSentTopLevelWhenDefaultPresent() {
+        // A non-standard top-level fileSizeLimit must not shadow the authoritative default entry.
+        val config = FileUploadConfig(
+            fileSizeLimit = 99_000L,
+            endpoints = mapOf("default" to EndpointFileConfig(fileSizeLimit = 10_000L)),
+        )
+        assertEquals(10_000L, config.effectiveFileSizeLimit("openAI"))
+    }
+
+    @Test
+    fun effectiveLimitUsesTopLevelOnlyAsLastResort() {
+        // No endpoints map at all (non-standard backend): fall back to top-level if present.
+        assertEquals(7_000L, FileUploadConfig(fileSizeLimit = 7_000L).effectiveFileSizeLimit("openAI"))
+    }
+
+    @Test
+    fun effectiveLimitNullWhenNothingConfigured() {
+        assertNull(FileUploadConfig().effectiveFileSizeLimit("openAI"))
+        assertNull(FileUploadConfig().effectiveFileSizeLimit(null))
+        // Endpoints map present but neither the endpoint nor "default" carries a limit.
+        val config = FileUploadConfig(
+            endpoints = mapOf("openAI" to EndpointFileConfig(fileSizeLimit = null)),
+        )
+        assertNull(config.effectiveFileSizeLimit("openAI"))
+    }
+}

--- a/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/api/FilesApi.kt
+++ b/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/api/FilesApi.kt
@@ -9,6 +9,7 @@ import com.garfiec.librechat.core.model.response.FileUploadConfig
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.plugins.onUpload
+import io.ktor.client.plugins.timeout
 import io.ktor.client.request.delete
 import io.ktor.client.request.forms.MultiPartFormDataContent
 import io.ktor.client.request.forms.formData
@@ -74,6 +75,15 @@ class FilesApi constructor(
 
         val response: FileObject = client.post {
             url { path("api/files") }
+            // Match the official web client, which sets no request timeout on uploads (axios
+            // default 0 = unlimited); the only interruption there is the user's cancel. The
+            // client-wide 30s requestTimeoutMillis bounds the *entire* request, which a large image
+            // on a slow link can exceed mid-transfer — and POSTs are not retried. Disable the
+            // whole-request cap for uploads; socketTimeoutMillis (120s) still aborts a genuinely
+            // stalled connection where no bytes are moving, so this can't hang forever.
+            timeout {
+                requestTimeoutMillis = Long.MAX_VALUE
+            }
             setBody(multipart)
             if (onProgress != null) {
                 var lastPct = -1

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/util/FileUtils.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/util/FileUtils.kt
@@ -106,69 +106,162 @@ internal fun fixFilenameExtension(filename: String, mimeType: String): String {
 }
 
 /**
- * Data class holding the result of image re-encoding.
+ * The bytes, MIME type, and pixel dimensions to upload for an image, after any PNG re-encode /
+ * downsample. [reEncoded] is false when the original bytes are used unchanged (already a PNG within
+ * budget), true when [bytes]/[mimeType] were produced by re-encoding. [width]/[height] are the
+ * decoded pixel dimensions of whatever [bytes] represents — always populated, since a result is
+ * only produced once valid bounds are read.
  */
-data class ReEncodedImage(
+data class ProcessedImage(
     val bytes: ByteArray,
     val mimeType: String,
+    val width: Int,
+    val height: Int,
+    val reEncoded: Boolean,
 )
 
 /**
- * Re-encodes ALL images to PNG to prevent MIME type mismatches.
- *
- * The LibreChat server has a bug in processAgentFileUpload: it converts
- * uploaded images to its configured imageOutputType (default: PNG) using
- * sharp, but stores the *original* MIME type from the upload Content-Type
- * header. When the AI provider (e.g. Anthropic) later receives the base64
- * image, it gets converted bytes (e.g. PNG) with the original media_type
- * (e.g. image/jpeg), causing a 400 "Image does not match the provided
- * media type" error.
- *
- * The only reliable client-side fix is to ensure NO conversion happens
- * on the server. The server skips conversion when the file extension
- * matches its imageOutputType. By always re-encoding to PNG (the server
- * default) and setting the extension to .png, the server sees
- * .png == .png and leaves the bytes untouched, so the stored MIME type
- * (image/png) matches the actual bytes.
- *
- * This means JPEG photos get re-encoded to PNG, which increases file
- * size, but the alternative is a 400 error that makes the app unusable.
- * The server will resize large images anyway, so the size impact on the
- * AI provider request is bounded.
- *
- * Returns null only if the image cannot be decoded by BitmapFactory.
+ * Longest-edge cap (px) applied when re-encoding an image. Bitmaps larger than this are
+ * downsampled before PNG encoding, which keeps the re-encoded upload from inflating to tens
+ * of MB and bounds peak memory (a full-res decode of a modern phone photo is a large ARGB_8888
+ * allocation). 2048 preserves ample detail — the server and AI providers resize past this
+ * anyway — while keeping the PNG small enough to upload reliably.
  */
-internal fun reEncodeImageIfNeeded(bytes: ByteArray, mimeType: String): ReEncodedImage? {
-    // Always re-encode to PNG to match the server's default imageOutputType.
-    // Previously we skipped JPEG/PNG/GIF/WebP as "safe", but the server
-    // converts non-matching extensions (e.g. .jpg when imageOutputType=png)
-    // while storing the original MIME type, causing the Anthropic 400 error.
-    return try {
-        val bitmap = BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
-            ?: return null // BitmapFactory can't decode this format
+private const val MAX_IMAGE_DIMENSION = 2048
 
-        // If already PNG with correct magic bytes, skip re-encoding to save CPU/memory
-        if (mimeType == "image/png" && detectMimeTypeFromBytes(bytes) == "image/png") {
-            bitmap.recycle()
-            return null
+/**
+ * Floor for the longest edge when downsampling further to fit a size limit: below this the image
+ * is too degraded to be useful, so we stop shrinking and let the caller's size pre-check reject it
+ * rather than upload something unreadable.
+ */
+private const val MIN_IMAGE_DIMENSION = 512
+
+/**
+ * Computes the power-of-two [BitmapFactory.Options.inSampleSize] that keeps the decoded image's
+ * longest edge at or below [maxDimension]. Returns 1 (no downsampling) when the source already
+ * fits or its dimensions are unknown. BitmapFactory only honors power-of-two sample sizes, so
+ * the result is always a power of two.
+ */
+internal fun computeInSampleSize(srcWidth: Int, srcHeight: Int, maxDimension: Int): Int {
+    if (srcWidth <= 0 || srcHeight <= 0 || maxDimension <= 0) return 1
+    var sampleSize = 1
+    while (srcWidth / sampleSize > maxDimension || srcHeight / sampleSize > maxDimension) {
+        sampleSize *= 2
+    }
+    return sampleSize
+}
+
+/**
+ * Prepares an image for upload: re-encodes it to PNG (unless it is already a PNG within the
+ * dimension budget) and reports the bytes, MIME type, and dimensions to send.
+ *
+ * **Why re-encode to PNG at all.** The LibreChat server has a bug in processAgentFileUpload: it
+ * converts uploaded images to its configured imageOutputType (default: PNG) using sharp, but stores
+ * the *original* MIME type from the upload Content-Type header. When the AI provider (e.g.
+ * Anthropic) later receives the base64 image, it gets converted bytes (e.g. PNG) with the original
+ * media_type (e.g. image/jpeg), causing a 400 "Image does not match the provided media type" error.
+ * The only reliable client-side fix is to ensure NO conversion happens on the server: the server
+ * skips conversion when the file extension matches its imageOutputType, so we always send PNG bytes
+ * with a `.png` extension and the server leaves them untouched.
+ *
+ * **Sizing.** An image that is already PNG and already within [maxEncodedBytes] is uploaded
+ * untouched at full resolution — no dimension cap — since it needs no re-encode and full detail is
+ * more useful to the model (this matches the web client's default). Downsampling applies only when
+ * the pixels must be touched anyway: a lossless PNG of a JPEG photo would inflate a 4-12 MB photo to
+ * tens of MB, so a re-encoded bitmap is downsampled to [MAX_IMAGE_DIMENSION] on its longest edge
+ * before encoding (this also bounds peak decode memory). When [maxEncodedBytes] is given and the PNG
+ * still exceeds it, the image is downsampled further (halving each pass) until it fits or the longest
+ * edge would drop below [MIN_IMAGE_DIMENSION] — so a detailed photo lands under the server's limit at
+ * production time instead of being rejected after the fact. If even the floor doesn't fit, the
+ * smallest result is returned and the caller's size pre-check rejects it.
+ *
+ * Returns null only when the bytes cannot be decoded as an image at all (caller should upload the
+ * raw bytes, e.g. for a non-image file or a format BitmapFactory can't read).
+ */
+internal fun processImageForUpload(
+    bytes: ByteArray,
+    mimeType: String,
+    maxEncodedBytes: Long? = null,
+): ProcessedImage? {
+    return try {
+        // Read dimensions first without allocating the full bitmap so we can size the decode.
+        val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+        BitmapFactory.decodeByteArray(bytes, 0, bytes.size, bounds)
+        val srcWidth = bounds.outWidth
+        val srcHeight = bounds.outHeight
+        if (srcWidth <= 0 || srcHeight <= 0) {
+            null // Not a decodable image — caller uploads the raw bytes.
+        } else {
+            // Already PNG and within the limit → upload untouched at full resolution (no decode, no
+            // dimension cap). Everything else falls through to re-encode/downsample. See the
+            // "Sizing" paragraph in the KDoc above for why fitting PNGs are passed through as-is.
+            val alreadyPng = mimeType == "image/png" && detectMimeTypeFromBytes(bytes) == "image/png"
+            val fitsLimit = maxEncodedBytes == null || bytes.size <= maxEncodedBytes
+            if (alreadyPng && fitsLimit) {
+                ProcessedImage(bytes, mimeType, srcWidth, srcHeight, reEncoded = false)
+            } else {
+                val initialSampleSize = computeInSampleSize(srcWidth, srcHeight, MAX_IMAGE_DIMENSION)
+                encodeToPngUnderLimit(bytes, mimeType, srcWidth, srcHeight, initialSampleSize, maxEncodedBytes)
+            }
         }
+    } catch (e: Exception) {
+        Logger.w(e) { "processImageForUpload: failed to process $mimeType, using original bytes" }
+        null
+    }
+}
+
+/**
+ * Decodes [bytes] at [initialSampleSize] and PNG-encodes it, halving dimensions each pass until the
+ * result is within [maxEncodedBytes] (if set) or the longest edge would fall below
+ * [MIN_IMAGE_DIMENSION]. Returns the original bytes (unchanged, [reEncoded] = false) if the PNG
+ * can't be verified, or null if the bitmap can't be decoded. [srcWidth]/[srcHeight] are the source
+ * dimensions used only for the fall-back result.
+ */
+private fun encodeToPngUnderLimit(
+    bytes: ByteArray,
+    mimeType: String,
+    srcWidth: Int,
+    srcHeight: Int,
+    initialSampleSize: Int,
+    maxEncodedBytes: Long?,
+): ProcessedImage {
+    var sampleSize = initialSampleSize
+    while (true) {
+        val decodeOptions = BitmapFactory.Options().apply { inSampleSize = sampleSize }
+        val bitmap = BitmapFactory.decodeByteArray(bytes, 0, bytes.size, decodeOptions)
+            // Header decoded (we have valid srcWidth/srcHeight) but the full pixel decode failed —
+            // upload the original bytes, but still report the dimensions read from the bounds pass.
+            ?: return ProcessedImage(bytes, mimeType, srcWidth, srcHeight, reEncoded = false)
+        val outWidth = bitmap.width
+        val outHeight = bitmap.height
 
         val outputStream = ByteArrayOutputStream()
         bitmap.compress(Bitmap.CompressFormat.PNG, 100, outputStream)
         bitmap.recycle()
-
         val encodedBytes = outputStream.toByteArray()
-        // Verify the re-encoded bytes are valid PNG
+
+        // Verify the re-encoded bytes are valid PNG; if not, fall back to the original bytes but
+        // keep the source dimensions (so the caller still reports width/height).
         val verifiedType = detectMimeTypeFromBytes(encodedBytes)
         if (verifiedType != "image/png") {
-            Logger.w { "reEncodeImageIfNeeded: re-encoded bytes don't match expected type image/png (got $verifiedType), using original" }
-            return null
+            Logger.w { "encodeToPngUnderLimit: re-encoded bytes are $verifiedType, not image/png; using original" }
+            return ProcessedImage(bytes, mimeType, srcWidth, srcHeight, reEncoded = false)
         }
 
-        Logger.d { "reEncodeImageIfNeeded: re-encoded $mimeType -> image/png (${bytes.size} -> ${encodedBytes.size} bytes)" }
-        ReEncodedImage(bytes = encodedBytes, mimeType = "image/png")
-    } catch (e: Exception) {
-        Logger.w(e) { "reEncodeImageIfNeeded: failed to re-encode $mimeType, using original bytes" }
-        null
+        // Stop when it fits, or when halving again would push the longest edge below the floor —
+        // checked against the *next* pass (longestEdge / 2), not the current edge, so we never
+        // overshoot and return an image well under MIN_IMAGE_DIMENSION.
+        val longestEdge = maxOf(outWidth, outHeight)
+        val underLimit = maxEncodedBytes == null || encodedBytes.size <= maxEncodedBytes
+        if (underLimit || longestEdge / 2 < MIN_IMAGE_DIMENSION) {
+            Logger.d {
+                "encodeToPngUnderLimit: $mimeType -> image/png (${bytes.size} -> ${encodedBytes.size} bytes, " +
+                    "${outWidth}x$outHeight, sampleSize=$sampleSize)"
+            }
+            return ProcessedImage(encodedBytes, "image/png", outWidth, outHeight, reEncoded = true)
+        }
+
+        // Overshot the limit and there's still room to shrink — halve dimensions and retry.
+        sampleSize *= 2
     }
 }

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/FileAttachmentDelegate.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/FileAttachmentDelegate.kt
@@ -1,17 +1,18 @@
 package com.garfiec.librechat.feature.chat.viewmodel.delegate
 
 import android.content.Context
-import android.graphics.BitmapFactory
 import android.net.Uri
 import co.touchlab.kermit.Logger
 import com.garfiec.librechat.core.common.EndpointConstants
+import com.garfiec.librechat.core.common.extensions.formatByteSize
 import com.garfiec.librechat.core.common.result.Result
 import com.garfiec.librechat.core.data.repository.FileRepository
+import com.garfiec.librechat.core.model.response.effectiveFileSizeLimit
 import com.garfiec.librechat.feature.chat.components.AttachedFile
 import com.garfiec.librechat.feature.chat.util.detectMimeTypeFromBytes
 import com.garfiec.librechat.feature.chat.util.fixFilenameExtension
 import com.garfiec.librechat.feature.chat.util.guessMimeType
-import com.garfiec.librechat.feature.chat.util.reEncodeImageIfNeeded
+import com.garfiec.librechat.feature.chat.util.processImageForUpload
 import com.garfiec.librechat.feature.chat.util.resolveFileName
 import com.garfiec.librechat.feature.chat.viewmodel.ErrorOnlyHandle
 import kotlinx.coroutines.CancellationException
@@ -94,16 +95,52 @@ class FileAttachmentDelegate(
                     preliminaryMimeType
                 }
 
-                // Re-encode images that are in formats the server may not handle well
+                // Snapshot the endpoint/model/config ONCE here and reuse it for both sizing and the
+                // upload below. Sizing the file against one endpoint's limit but registering it
+                // against a different one (if the user switched endpoints mid-encode) could upload an
+                // oversized file that the new endpoint 413-rejects — so the file is sized and
+                // registered against the same endpoint, even if that means not reflecting a switch
+                // made while this upload was already in flight.
+                val state = handle.state
+
+                // Resolve the server's per-file size limit up front so we can both (a) let the image
+                // re-encode downsample to fit it and (b) backstop-reject anything still over it.
+                // Non-positive limits (0 = disabled endpoint, gated elsewhere) mean "no check".
+                val sizeLimit = state.fileUploadConfig
+                    ?.effectiveFileSizeLimit(state.selectedEndpoint)
+                    ?.takeIf { it > 0 }
+
+                // Re-encode images to PNG (server media-type workaround), downsampling to fit the
+                // size limit where possible. This also yields the pixel dimensions in one decode, so
+                // there's no separate bounds read below.
                 var uploadBytes = bytes
+                var imageWidth: Int? = null
+                var imageHeight: Int? = null
                 val actualIsImage = mimeType.startsWith("image/")
                 if (actualIsImage) {
-                    val reEncoded = reEncodeImageIfNeeded(bytes, mimeType)
-                    if (reEncoded != null) {
-                        Logger.d { "uploadFile: re-encoded image from $mimeType to ${reEncoded.mimeType} (${bytes.size} -> ${reEncoded.bytes.size} bytes)" }
-                        uploadBytes = reEncoded.bytes
-                        mimeType = reEncoded.mimeType
+                    val processed = processImageForUpload(bytes, mimeType, maxEncodedBytes = sizeLimit)
+                    if (processed != null) {
+                        if (processed.reEncoded) {
+                            Logger.d { "uploadFile: re-encoded image from $mimeType to ${processed.mimeType} (${bytes.size} -> ${processed.bytes.size} bytes)" }
+                        }
+                        uploadBytes = processed.bytes
+                        mimeType = processed.mimeType
+                        imageWidth = processed.width
+                        imageHeight = processed.height
                     }
+                }
+
+                // Backstop the pre-check against the server's limit so an over-limit file fails fast
+                // with a clear message instead of after a long upload the server rejects. Fires for
+                // non-images and for images the re-encode couldn't shrink under the limit.
+                if (sizeLimit != null && uploadBytes.size > sizeLimit) {
+                    Logger.w { "uploadFile: $filename is ${uploadBytes.size} bytes, over server limit of $sizeLimit" }
+                    markUploadFailed(uri)
+                    // State only the limit — not the file's own size. The limit is the actionable
+                    // number, and rounding both to the same MB precision could otherwise print a
+                    // self-contradictory "X MB is larger than the X MB limit".
+                    handle.setError("$filename is larger than the server limit of ${formatByteSize(sizeLimit)}.")
+                    return@launch
                 }
 
                 // Rename the file extension to match the detected/re-encoded MIME type.
@@ -132,30 +169,15 @@ class FileAttachmentDelegate(
                     }
                 }
 
-                // For images, resolve width and height so the server can process them correctly
-                var imageWidth: Int? = null
-                var imageHeight: Int? = null
                 if (actualIsImage) {
-                    try {
-                        val options = BitmapFactory.Options().apply {
-                            inJustDecodeBounds = true
-                        }
-                        BitmapFactory.decodeByteArray(uploadBytes, 0, uploadBytes.size, options)
-                        if (options.outWidth > 0 && options.outHeight > 0) {
-                            imageWidth = options.outWidth
-                            imageHeight = options.outHeight
-                        }
-                        Logger.d { "uploadFile: image dimensions ${imageWidth}x$imageHeight for $uploadFilename" }
-                    } catch (e: Exception) {
-                        Logger.w(e) { "uploadFile: could not read image dimensions for $uploadFilename" }
-                    }
+                    Logger.d { "uploadFile: image dimensions ${imageWidth}x$imageHeight for $uploadFilename" }
                 }
 
                 // Generate a UUID for the file_id -- the backend requires this field
                 val fileId = UUID.randomUUID().toString()
 
-                // Upload to server with context about current endpoint/model
-                val state = handle.state
+                // Upload to server with context about current endpoint/model, using the same
+                // snapshot the file was sized against above (see the comment there).
                 val isAgent = state.selectedEndpoint == EndpointConstants.AGENTS
                 Logger.d { "uploadFile: sending to server -- fileId=$fileId, endpoint=${state.selectedEndpoint}, model=${state.selectedModel}, isAgent=$isAgent, mimeType=$mimeType, filename=$uploadFilename" }
                 val result = fileRepository.uploadFile(

--- a/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/util/FileUtilsTest.kt
+++ b/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/util/FileUtilsTest.kt
@@ -1,0 +1,35 @@
+package com.garfiec.librechat.feature.chat.util
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class FileUtilsTest {
+
+    @Test
+    fun `no downsample when image already within budget`() {
+        assertThat(computeInSampleSize(2048, 1536, 2048)).isEqualTo(1)
+        assertThat(computeInSampleSize(800, 600, 2048)).isEqualTo(1)
+    }
+
+    @Test
+    fun `sample size is a power of two that bounds the longest edge`() {
+        // 8000x6000 -> /4 = 2000x1500, both <= 2048; /2 would leave 4000 > 2048.
+        assertThat(computeInSampleSize(8000, 6000, 2048)).isEqualTo(4)
+        // 4096 on the long edge just over budget -> /2 = 2048.
+        assertThat(computeInSampleSize(4096, 100, 2048)).isEqualTo(2)
+        // 4097 -> /2 = 2048.5 truncates to 2048 which is within budget.
+        assertThat(computeInSampleSize(4097, 100, 2048)).isEqualTo(2)
+    }
+
+    @Test
+    fun `either dimension over budget triggers downsample`() {
+        assertThat(computeInSampleSize(100, 5000, 2048)).isEqualTo(4)
+    }
+
+    @Test
+    fun `degenerate dimensions return one`() {
+        assertThat(computeInSampleSize(0, 0, 2048)).isEqualTo(1)
+        assertThat(computeInSampleSize(-1, 100, 2048)).isEqualTo(1)
+        assertThat(computeInSampleSize(4000, 3000, 0)).isEqualTo(1)
+    }
+}

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/screen/ConversationMediaScreen.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/screen/ConversationMediaScreen.kt
@@ -47,6 +47,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil3.compose.AsyncImage
+import com.garfiec.librechat.core.common.extensions.formatByteSize
 import com.garfiec.librechat.core.ui.components.EmptyState
 import com.garfiec.librechat.core.ui.components.LibreChatTopBar
 import com.garfiec.librechat.core.ui.components.LoadingIndicator
@@ -279,7 +280,7 @@ private fun FilesList(
                         overflow = TextOverflow.Ellipsis,
                     )
                     val subtitle = listOfNotNull(
-                        file.bytes?.let { formatBytes(it) },
+                        file.bytes?.let { formatByteSize(it) },
                         file.type,
                     ).joinToString(" · ")
                     if (subtitle.isNotBlank()) {
@@ -369,16 +370,3 @@ private fun ArtifactsList(artifacts: List<List<Artifact>>) {
     }
 }
 
-private fun formatBytes(bytes: Long): String {
-    if (bytes < 1024) return "$bytes B"
-    val kb = bytes / 1024.0
-    if (kb < 1024) return "${kb.format1()} KB"
-    val mb = kb / 1024.0
-    if (mb < 1024) return "${mb.format1()} MB"
-    return "${(mb / 1024.0).format1()} GB"
-}
-
-private fun Double.format1(): String {
-    val rounded = (this * 10).toLong()
-    return "${rounded / 10}.${rounded % 10}"
-}


### PR DESCRIPTION
## Summary
Large device photos could fail to upload. This makes the image-attach path size-aware and aligns the upload request timeout with the web client, so large images either upload successfully or fail fast with a clear, actionable message.

## Changes
- **Image processing** (`feature/chat` `FileUtils`): replace `reEncodeImageIfNeeded` with `processImageForUpload`, which downsamples large bitmaps (power-of-two `inSampleSize`) to a 2048px longest edge before PNG re-encoding, instead of encoding a full-resolution PNG@100. An image already PNG and within the size limit is uploaded untouched at full resolution. When a size limit is known, it shrinks further (halving) to fit, down to a 512px floor. Pixel dimensions come from the same decode.
- **Size pre-check** (`FileAttachmentDelegate`): resolve the server's per-file limit from `/api/files/config` and reject an over-limit file up front with a clear message, instead of after a long upload the server 413-rejects. Endpoint/model/config are snapshotted once so a file is sized and registered against the same endpoint.
- **Limit resolution** (`core:model` `FileUploadConfig`): new `effectiveFileSizeLimit(endpoint)` mirroring the web client — per-endpoint entry, then the `"default"` endpoint entry, then the top-level `fileSizeLimit` as a last-ditch fallback (the stock backend populates the per-endpoint/`"default"` limits, not the top-level field).
- **Upload timeout** (`core:network` `FilesApi`): remove the client-wide 30s whole-request cap on the upload POST to match the web client (no upload timeout); the socket timeout still aborts a genuinely stalled connection.
- **Shared formatter** (`core:common`): add `formatByteSize`, replacing `ConversationMediaScreen`'s local byte formatter. The shared helper rounds (vs. the old truncation), trims a trailing `.0`, and adds a TB tier, so media-list sizes render slightly differently (e.g. `20 MB` rather than `20.0 MB`).

## Testing
- Unit tests: `ByteSizeFormatTest`, `FileUploadConfigTest` (limit resolution incl. default fallback), `FileUtilsTest` (`computeInSampleSize`). All green; `:core:common`, `:core:model`, `:feature:chat` build.

## Notes
- The PNG re-encode is retained (load-bearing: works around a server bug where converted image bytes keep the original media type, which Anthropic rejects with a 400). Consequence: a noisy JPEG forced to lossless PNG can, on an unusually small server limit, exceed that limit even at the 512px floor — it fails fast rather than late.
- iOS: shared code (`formatByteSize`, `effectiveFileSizeLimit`) is `commonMain`; image processing is Android-only. iOS not built.

Fixes #251
