### PR TITLE
fix(chat): warn when a server image the model can't read is attached

### DIFF
--- a/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/util/ServerImageVisionTest.kt
+++ b/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/util/ServerImageVisionTest.kt
@@ -1,0 +1,77 @@
+package com.garfiec.librechat.feature.chat.util
+
+import com.garfiec.librechat.core.model.FileObject
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class ServerImageVisionTest {
+
+    private fun file(
+        id: String,
+        type: String,
+        height: Int? = 100,
+        name: String = "$id.bin",
+    ) = FileObject(
+        fileId = id,
+        filename = name,
+        filepath = "/uploads/$id",
+        type = type,
+        bytes = 1024,
+        height = height,
+    )
+
+    @Test
+    fun isImageType_matchesImageMimePrefixOnly() {
+        assertThat(isImageType("image/png")).isTrue()
+        assertThat(isImageType("image/svg+xml")).isTrue()
+        assertThat(isImageType("application/pdf")).isFalse()
+        assertThat(isImageType("")).isFalse()
+    }
+
+    @Test
+    fun image_withHeight_isNotFlagged() {
+        val names = visionUnreadableImageNames(listOf(file("a", "image/png", height = 200)))
+
+        assertThat(names).isEmpty()
+    }
+
+    @Test
+    fun image_withNullHeight_isFlaggedByName() {
+        val names = visionUnreadableImageNames(
+            listOf(file("a", "image/jpeg", height = null, name = "photo.jpg")),
+        )
+
+        assertThat(names).containsExactly("photo.jpg")
+    }
+
+    @Test
+    fun image_withZeroHeight_isFlagged() {
+        // Mirrors the server's `!file.height`: 0 is as unusable as null.
+        val names = visionUnreadableImageNames(listOf(file("a", "image/png", height = 0)))
+
+        assertThat(names).hasSize(1)
+    }
+
+    @Test
+    fun nonImage_withNullHeight_isNotFlagged() {
+        // Documents attach as context on agents — they have no vision-height requirement.
+        val names = visionUnreadableImageNames(
+            listOf(file("doc", "application/pdf", height = null, name = "notes.pdf")),
+        )
+
+        assertThat(names).isEmpty()
+    }
+
+    @Test
+    fun mixedSelection_flagsOnlyHeightlessImages() {
+        val names = visionUnreadableImageNames(
+            listOf(
+                file("ok", "image/png", height = 300),
+                file("bad", "image/png", height = null, name = "scan.png"),
+                file("pdf", "application/pdf", height = null),
+            ),
+        )
+
+        assertThat(names).containsExactly("scan.png")
+    }
+}

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/screen/ConversationMediaScreen.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/screen/ConversationMediaScreen.kt
@@ -369,4 +369,3 @@ private fun ArtifactsList(artifacts: List<List<Artifact>>) {
         }
     }
 }
-

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/util/ServerImageVision.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/util/ServerImageVision.kt
@@ -1,0 +1,24 @@
+package com.garfiec.librechat.feature.chat.util
+
+import com.garfiec.librechat.core.model.FileObject
+
+/** True for any file the client treats as an image (mirrors the server's `image/` vision routing). */
+internal fun isImageType(type: String): Boolean = type.startsWith("image/")
+
+/**
+ * Filenames of picked server images the model won't be able to read as an image.
+ *
+ * The server's vision encoder (`api/server/services/Files/images/encode.js`) skips any file whose
+ * stored `height` is falsy (null/0): it never becomes an `image_url`, so the model never sees the
+ * pixels. The server re-resolves attachments by `file_id` from the same DB the file list reads, so
+ * this height is exactly the value the encoder will check — the result here is exact, not a guess.
+ *
+ * The file is still attached (the server keeps a heightless image as a plain file record, and an
+ * agent may route it to a tool); this only drives a heads-up so a picked image doesn't silently do
+ * nothing on a vision model (issue #252). Non-image files never appear here — they attach as
+ * document context with no height requirement, and freshly device-uploaded images always carry
+ * server-computed dimensions, which is why that path never trips this.
+ */
+internal fun visionUnreadableImageNames(files: List<FileObject>): List<String> =
+    files.filter { isImageType(it.type) && (it.height == null || it.height == 0) }
+        .map { it.filename }

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModel.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModel.kt
@@ -54,8 +54,10 @@ import com.garfiec.librechat.feature.chat.util.NEW_CHAT_DRAFT_KEY
 import com.garfiec.librechat.feature.chat.util.buildActiveMessagePath
 import com.garfiec.librechat.feature.chat.util.extractBranchMedia
 import com.garfiec.librechat.feature.chat.util.hasParallelParts
+import com.garfiec.librechat.feature.chat.util.isImageType
 import com.garfiec.librechat.feature.chat.util.resolveFileReferenceUrl
 import com.garfiec.librechat.feature.chat.util.stabilizeMessageInstances
+import com.garfiec.librechat.feature.chat.util.visionUnreadableImageNames
 import com.garfiec.librechat.feature.chat.viewmodel.delegate.ComparisonModeDelegate
 import com.garfiec.librechat.feature.chat.viewmodel.delegate.ContextProjectionDelegate
 import com.garfiec.librechat.feature.chat.viewmodel.delegate.ConversationActionsDelegate
@@ -1564,10 +1566,18 @@ class ChatViewModel(
      */
     private fun attachServerFiles(files: List<FileObject>) {
         if (files.isEmpty()) return
+        // Attach every pick — the server keeps a heightless image as a plain file record, and an
+        // agent may route it to a tool — but warn about images the vision encoder will skip so a
+        // picked image doesn't silently do nothing on a vision model (issue #252). Yield to any
+        // real error already showing so the heads-up can't clobber a more important notice.
+        val unreadable = visionUnreadableImageNames(files)
+        if (unreadable.isNotEmpty() && uiState.value.error == null) {
+            stateHandle.update { copy(error = unreadableImageWarning(unreadable)) }
+        }
         val baseUrl = uiState.value.serverUrl
         fileDelegate.addPreUploadedFiles(
             files.map { file ->
-                val isImage = file.type.startsWith("image/")
+                val isImage = isImageType(file.type)
                 // The preview row loads images from `uri`, so resolve the same server URL the
                 // message renderers use. Non-image files show an icon, so the bare id is fine as
                 // a stable key for removal.
@@ -1592,6 +1602,14 @@ class ChatViewModel(
                 )
             },
         )
+    }
+
+    /** Advisory shown when a picked server image has no stored dimensions the model can read. */
+    private fun unreadableImageWarning(names: List<String>): String = when (names.size) {
+        1 -> "\"${names.first()}\" has no saved dimensions, so the model may not read it as an " +
+            "image. Try re-uploading it from your device."
+        else -> "${names.size} picked images have no saved dimensions, so the model may not read " +
+            "them as images. Try re-uploading them from your device."
     }
 
     // Presets and prompts


### PR DESCRIPTION
## Summary

Picking an image from the **Server** file browser could produce a chip that
sends but is silently ignored by the model, while an image freshly uploaded
from the device works. The server's vision encoder skips any file whose stored
`height` is falsy — it never becomes an `image_url`, so the model never sees the
pixels — and the Server picker lists all of a user's files, so it can surface
such images. This adds a heads-up so the outcome is no longer silent.

Fixes #252.

## Changes

- `attachServerFiles` now surfaces a warning naming any picked image the vision
  encoder will skip (stored `height` null/0). The files still attach unchanged —
  the server keeps a heightless image as a file record, and an agent may route
  it to a tool — so no attach capability is removed; the warning is purely a
  heads-up.
- The advisory rides the existing transient banner and yields to any real error
  already showing, so it can't clobber a more important notice.
- New pure helper `visionUnreadableImageNames` (+ shared `isImageType`) in
  `feature:chat/util`, covered by unit tests. The height check is exact: the
  server re-resolves attachments by `file_id` from the same DB the file list
  reads, so the client checks the same `height` the encoder will.
- Non-image files are untouched — they attach as document context on agents
  with no height requirement.

## Testing

- Unit tests for the helper (image with/without height, zero height, non-image,
  mixed selection).
- `:feature:chat` compiles, detekt (commonMain) clean, unit tests pass.

## Notes

- Also strips a trailing blank line in `ConversationMediaScreen.kt` that tripped
  detekt's `NoConsecutiveBlankLines` on commonMain (separate `chore` commit).
- Model vision-capability gating is out of scope: the warning is keyed on the
  server's height gate, which is what actually decides whether the pixels reach
  the model.
