### PR TITLE
feat(chat): pull up on the thread to reveal the tools sheet

### DIFF
--- a/core/ui/src/commonMain/composeResources/values-ar/strings.xml
+++ b/core/ui/src/commonMain/composeResources/values-ar/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Accessibility label for the bottom-sheet drag handle -->
+    <string name="cd_drag_handle">مقبض السحب</string>
+</resources>

--- a/core/ui/src/commonMain/composeResources/values-de/strings.xml
+++ b/core/ui/src/commonMain/composeResources/values-de/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Accessibility label for the bottom-sheet drag handle -->
+    <string name="cd_drag_handle">Ziehpunkt</string>
+</resources>

--- a/core/ui/src/commonMain/composeResources/values-es/strings.xml
+++ b/core/ui/src/commonMain/composeResources/values-es/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Accessibility label for the bottom-sheet drag handle -->
+    <string name="cd_drag_handle">Controlador para arrastrar</string>
+</resources>

--- a/core/ui/src/commonMain/composeResources/values-fr/strings.xml
+++ b/core/ui/src/commonMain/composeResources/values-fr/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Accessibility label for the bottom-sheet drag handle -->
+    <string name="cd_drag_handle">Poignée de déplacement</string>
+</resources>

--- a/core/ui/src/commonMain/composeResources/values-ja/strings.xml
+++ b/core/ui/src/commonMain/composeResources/values-ja/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Accessibility label for the bottom-sheet drag handle -->
+    <string name="cd_drag_handle">ドラッグ ハンドル</string>
+</resources>

--- a/core/ui/src/commonMain/composeResources/values-ko/strings.xml
+++ b/core/ui/src/commonMain/composeResources/values-ko/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Accessibility label for the bottom-sheet drag handle -->
+    <string name="cd_drag_handle">드래그 핸들</string>
+</resources>

--- a/core/ui/src/commonMain/composeResources/values-pt/strings.xml
+++ b/core/ui/src/commonMain/composeResources/values-pt/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Accessibility label for the bottom-sheet drag handle -->
+    <string name="cd_drag_handle">Alça de arrasto</string>
+</resources>

--- a/core/ui/src/commonMain/composeResources/values-ru/strings.xml
+++ b/core/ui/src/commonMain/composeResources/values-ru/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Accessibility label for the bottom-sheet drag handle -->
+    <string name="cd_drag_handle">Маркер перемещения</string>
+</resources>

--- a/core/ui/src/commonMain/composeResources/values-zh/strings.xml
+++ b/core/ui/src/commonMain/composeResources/values-zh/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Accessibility label for the bottom-sheet drag handle -->
+    <string name="cd_drag_handle">拖动手柄</string>
+</resources>

--- a/core/ui/src/commonMain/composeResources/values/strings.xml
+++ b/core/ui/src/commonMain/composeResources/values/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Accessibility label for the bottom-sheet drag handle -->
+    <string name="cd_drag_handle">Drag handle</string>
+</resources>

--- a/core/ui/src/commonMain/kotlin/com/garfiec/librechat/core/ui/components/FilterChipBottomSheet.kt
+++ b/core/ui/src/commonMain/kotlin/com/garfiec/librechat/core/ui/components/FilterChipBottomSheet.kt
@@ -72,6 +72,7 @@ fun <T : Any> FilterChipBottomSheet(
         },
         modifier = modifier,
         sheetState = sheetState,
+        dragHandle = { LowProfileDragHandle() },
     ) {
         Column(
             modifier = Modifier

--- a/core/ui/src/commonMain/kotlin/com/garfiec/librechat/core/ui/components/LowProfileDragHandle.kt
+++ b/core/ui/src/commonMain/kotlin/com/garfiec/librechat/core/ui/components/LowProfileDragHandle.kt
@@ -1,0 +1,57 @@
+package com.garfiec.librechat.core.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import com.garfiec.librechat.core.ui.resources.Res
+import com.garfiec.librechat.core.ui.resources.cd_drag_handle
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * The app-wide bottom-sheet drag handle: a slim, low-profile pill. Replaces M3's
+ * heavier [androidx.compose.material3.BottomSheetDefaults.DragHandle] so every
+ * `ModalBottomSheet` (and the chat pull-up surface, which shares this look) reads the
+ * same. Pass to a sheet via `dragHandle = { LowProfileDragHandle() }`.
+ *
+ * Carries the same localized "Drag handle" accessibility label M3's default exposed, so
+ * screen-reader users still hear the handle. Pass `contentDescription = null` to omit it
+ * (e.g. a purely decorative surface where a sibling already announces the sheet).
+ */
+@Composable
+fun LowProfileDragHandle(
+    modifier: Modifier = Modifier,
+    contentDescription: String? = stringResource(Res.string.cd_drag_handle),
+) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(vertical = 12.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Box(
+            modifier = Modifier
+                .size(width = 36.dp, height = 5.dp)
+                .then(
+                    if (contentDescription != null) {
+                        Modifier.semantics { this.contentDescription = contentDescription }
+                    } else {
+                        Modifier
+                    },
+                )
+                .background(
+                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f),
+                    shape = RoundedCornerShape(2.dp),
+                ),
+        )
+    }
+}

--- a/core/ui/src/commonMain/kotlin/com/garfiec/librechat/core/ui/components/ModelParameterSheet.kt
+++ b/core/ui/src/commonMain/kotlin/com/garfiec/librechat/core/ui/components/ModelParameterSheet.kt
@@ -167,6 +167,7 @@ fun ModelParameterSheet(
         onDismissRequest = onDismiss,
         sheetState = sheetState,
         modifier = modifier,
+        dragHandle = { LowProfileDragHandle() },
     ) {
         ModelParameterContent(
             parameters = parameters,

--- a/feature/agents/src/commonMain/kotlin/com/garfiec/librechat/feature/agents/components/AgentModelPicker.kt
+++ b/feature/agents/src/commonMain/kotlin/com/garfiec/librechat/feature/agents/components/AgentModelPicker.kt
@@ -32,6 +32,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
+import com.garfiec.librechat.core.ui.components.LowProfileDragHandle
 import com.garfiec.librechat.feature.agents.resources.*
 import com.garfiec.librechat.feature.agents.resources.Res
 import org.jetbrains.compose.resources.stringResource
@@ -117,6 +118,7 @@ private fun ModelPickerSheet(
 
     ModalBottomSheet(
         onDismissRequest = onDismiss,
+        dragHandle = { LowProfileDragHandle() },
         sheetState = sheetState,
     ) {
         Column(

--- a/feature/agents/src/commonMain/kotlin/com/garfiec/librechat/feature/agents/components/AgentVersionHistory.kt
+++ b/feature/agents/src/commonMain/kotlin/com/garfiec/librechat/feature/agents/components/AgentVersionHistory.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.garfiec.librechat.core.ui.components.LowProfileDragHandle
 import com.garfiec.librechat.feature.agents.components.model.AgentVersion
 import com.garfiec.librechat.feature.agents.resources.Res
 import com.garfiec.librechat.feature.agents.resources.no_version_history
@@ -66,6 +67,7 @@ fun AgentVersionHistory(
 ) {
     ModalBottomSheet(
         onDismissRequest = onDismiss,
+        dragHandle = { LowProfileDragHandle() },
         sheetState = sheetState,
         modifier = modifier,
     ) {

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/components/ChatAttachmentActions.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/components/ChatAttachmentActions.kt
@@ -1,0 +1,128 @@
+package com.garfiec.librechat.feature.chat.components
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import android.net.Uri
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalContext
+import androidx.core.content.ContextCompat
+import androidx.core.content.FileProvider
+import java.io.File
+
+/**
+ * The three attachment entry points offered by the chat tools sheet, ready to invoke.
+ * Produced by [rememberChatAttachmentActions].
+ */
+@Immutable
+class ChatAttachmentActions(
+    val onAttachFiles: () -> Unit,
+    val onTakePhoto: () -> Unit,
+    val onPickPhotos: () -> Unit,
+)
+
+/**
+ * Registers the file-picker, photo-picker, camera, and camera-permission activity-result launchers
+ * and returns the [ChatAttachmentActions] that drive them. Call this **once** high in the chat
+ * screen and share the result: a launcher stays usable from any descendant composition while the
+ * one that registered it is alive, so the chat screen registers a single set and passes it down to
+ * both the composer's "+" sheet ([ChatInput]) and the pull-up sheet — no need for a second copy.
+ */
+@Composable
+fun rememberChatAttachmentActions(
+    onFilesSelected: (List<Uri>) -> Unit,
+): ChatAttachmentActions {
+    val context = LocalContext.current
+
+    val filePickerLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.OpenMultipleDocuments(),
+    ) { uris ->
+        if (uris.isNotEmpty()) {
+            onFilesSelected(uris)
+        }
+    }
+
+    val photoPickerLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.PickMultipleVisualMedia(),
+    ) { uris ->
+        if (uris.isNotEmpty()) {
+            onFilesSelected(uris)
+        }
+    }
+
+    var cameraPhotoUri by remember { mutableStateOf<Uri?>(null) }
+
+    val cameraLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.TakePicture(),
+    ) { success ->
+        val uri = cameraPhotoUri
+        if (success && uri != null) {
+            onFilesSelected(listOf(uri))
+        }
+        cameraPhotoUri = null
+    }
+
+    // Creates a fresh temp-file URI and fires the camera. Shared by the just-granted-permission
+    // callback and the already-have-permission path so the capture flow lives in exactly one place.
+    val launchCamera: () -> Unit = {
+        val photoFile = createCameraPhotoFile(context)
+        val uri = FileProvider.getUriForFile(
+            context,
+            "${context.packageName}.fileprovider",
+            photoFile,
+        )
+        cameraPhotoUri = uri
+        cameraLauncher.launch(uri)
+    }
+
+    val cameraPermissionLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestPermission(),
+    ) { isGranted ->
+        if (isGranted) {
+            launchCamera()
+        }
+    }
+
+    return remember(context) {
+        ChatAttachmentActions(
+            onAttachFiles = { filePickerLauncher.launch(arrayOf("*/*")) },
+            onTakePhoto = {
+                val hasCameraPermission = ContextCompat.checkSelfPermission(
+                    context,
+                    Manifest.permission.CAMERA,
+                ) == PackageManager.PERMISSION_GRANTED
+                if (hasCameraPermission) {
+                    launchCamera()
+                } else {
+                    cameraPermissionLauncher.launch(Manifest.permission.CAMERA)
+                }
+            },
+            onPickPhotos = {
+                photoPickerLauncher.launch(
+                    PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly),
+                )
+            },
+        )
+    }
+}
+
+/**
+ * Creates a temporary file for the camera to write a photo into.
+ * Stored in the app's cache directory under `camera_photos/` which is
+ * registered in the FileProvider paths XML.
+ */
+private fun createCameraPhotoFile(context: Context): File {
+    val cameraDir = File(context.cacheDir, "camera_photos")
+    if (!cameraDir.exists()) {
+        cameraDir.mkdirs()
+    }
+    return File.createTempFile("photo_", ".jpg", cameraDir)
+}

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/components/ChatInput.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/components/ChatInput.kt
@@ -1,12 +1,6 @@
 package com.garfiec.librechat.feature.chat.components
 
-import android.Manifest
-import android.content.Context
-import android.content.pm.PackageManager
 import android.net.Uri
-import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.PickVisualMediaRequest
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -39,7 +33,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.role
@@ -48,8 +41,6 @@ import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.core.content.ContextCompat
-import androidx.core.content.FileProvider
 import com.garfiec.librechat.core.data.datastore.ContextBarPlacement
 import com.garfiec.librechat.core.model.usage.ContextUsage
 import com.garfiec.librechat.core.model.usage.TokenUsage
@@ -60,7 +51,6 @@ import com.garfiec.librechat.feature.chat.viewmodel.QueuedMessage
 import com.garfiec.librechat.feature.chat.resources.*
 import com.garfiec.librechat.feature.chat.resources.Res
 import org.jetbrains.compose.resources.stringResource
-import java.io.File
 
 @Composable
 fun ChatInput(
@@ -85,7 +75,7 @@ fun ChatInput(
     onReorderQueuedMessages: (fromIndex: Int, toIndex: Int) -> Unit = { _, _ -> },
     fontSizeMultiplier: Float = 1f,
     attachedFiles: List<AttachedFile> = emptyList(),
-    onFilesSelected: (List<Uri>) -> Unit = {},
+    attachmentActions: ChatAttachmentActions,
     onRemoveFile: (AttachedFile) -> Unit = {},
     onAttachFromServer: () -> Unit = {},
     promptSuggestions: List<PromptMentionDisplayData> = emptyList(),
@@ -122,78 +112,6 @@ fun ChatInput(
     val cdMessageInput = stringResource(Res.string.cd_message_input)
     val cdStopVoiceRec = stringResource(Res.string.cd_stop_voice_recording)
     val cdStartVoiceRec = stringResource(Res.string.cd_start_voice_recording)
-    val context = LocalContext.current
-
-    val filePickerLauncher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.OpenMultipleDocuments(),
-    ) { uris ->
-        if (uris.isNotEmpty()) {
-            onFilesSelected(uris)
-        }
-    }
-
-    // Photo picker (gallery) launcher using modern PickMultipleVisualMedia
-    val photoPickerLauncher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.PickMultipleVisualMedia(),
-    ) { uris ->
-        if (uris.isNotEmpty()) {
-            onFilesSelected(uris)
-        }
-    }
-
-    // Camera launcher: stores the photo in a temp file via FileProvider
-    var cameraPhotoUri by remember { mutableStateOf<Uri?>(null) }
-
-    val cameraLauncher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.TakePicture(),
-    ) { success ->
-        val uri = cameraPhotoUri
-        if (success && uri != null) {
-            onFilesSelected(listOf(uri))
-        }
-        cameraPhotoUri = null
-    }
-
-    // Camera permission launcher
-    val cameraPermissionLauncher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.RequestPermission(),
-    ) { isGranted ->
-        if (isGranted) {
-            val photoFile = createCameraPhotoFile(context)
-            val uri = FileProvider.getUriForFile(
-                context,
-                "${context.packageName}.fileprovider",
-                photoFile,
-            )
-            cameraPhotoUri = uri
-            cameraLauncher.launch(uri)
-        }
-    }
-
-    val onTakePhoto: () -> Unit = {
-        val hasCameraPermission = ContextCompat.checkSelfPermission(
-            context,
-            Manifest.permission.CAMERA,
-        ) == PackageManager.PERMISSION_GRANTED
-        if (hasCameraPermission) {
-            val photoFile = createCameraPhotoFile(context)
-            val uri = FileProvider.getUriForFile(
-                context,
-                "${context.packageName}.fileprovider",
-                photoFile,
-            )
-            cameraPhotoUri = uri
-            cameraLauncher.launch(uri)
-        } else {
-            cameraPermissionLauncher.launch(Manifest.permission.CAMERA)
-        }
-    }
-
-    val onPickPhotos: () -> Unit = {
-        photoPickerLauncher.launch(
-            PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly),
-        )
-    }
 
     val focusRequester = remember { FocusRequester() }
     var showToolsSheet by remember { mutableStateOf(false) }
@@ -441,9 +359,9 @@ fun ChatInput(
             mcpServers = mcpServers,
             selectedMcpServerNames = selectedMcpServerNames,
             onToggleMcpServer = onToggleMcpServer,
-            onAttachFiles = { filePickerLauncher.launch(arrayOf("*/*")) },
-            onTakePhoto = onTakePhoto,
-            onPickPhotos = onPickPhotos,
+            onAttachFiles = attachmentActions.onAttachFiles,
+            onTakePhoto = attachmentActions.onTakePhoto,
+            onPickPhotos = attachmentActions.onPickPhotos,
             onAttachFromServer = onAttachFromServer,
             onOpenModelParameters = onOpenModelParameters,
             onOpenModelSelector = onOpenModelSelector,
@@ -462,17 +380,4 @@ fun ChatInput(
             contextBarPlacement = contextBarPlacement,
         )
     }
-}
-
-/**
- * Creates a temporary file for the camera to write a photo into.
- * Stored in the app's cache directory under `camera_photos/` which is
- * registered in the FileProvider paths XML.
- */
-private fun createCameraPhotoFile(context: Context): File {
-    val cameraDir = File(context.cacheDir, "camera_photos")
-    if (!cameraDir.exists()) {
-        cameraDir.mkdirs()
-    }
-    return File.createTempFile("photo_", ".jpg", cameraDir)
 }

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatContent.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatContent.kt
@@ -44,6 +44,11 @@ internal fun ColumnScope.ChatContent(
     topContentPadding: Dp,
     onShowSecondaryModelSheet: () -> Unit,
     onComparisonTabChange: (Int) -> Unit,
+    // Bridges the active message list's over-scroll-past-bottom into the pull-up tools sheet
+    // (nested-scroll) and re-arms the reveal on each pointer-down.
+    listPullUpModifier: Modifier,
+    // Drives the pull-up sheet directly from the (non-scrollable) landing surface.
+    pullUpModifier: Modifier,
 ) {
     // Non-scrolling bodies (landing, loading, comparison panes) clear the floating bar with a
     // plain top padding; only the single active MessageList takes the inset as scrollable
@@ -56,7 +61,7 @@ internal fun ColumnScope.ChatContent(
             LandingContent(
                 selectedModel = uiState.selectedModel,
                 selectedAgentName = agentName,
-                modifier = topInsetModifier,
+                modifier = topInsetModifier.then(pullUpModifier),
             )
         }
         ChatScreenState.LOADING -> {
@@ -115,7 +120,9 @@ internal fun ColumnScope.ChatContent(
                     activeToolCalls = uiState.activeToolCalls,
                     streamingSenderName = senderName,
                     bottomContentPadding = bottomContentPadding,
-                    modifier = Modifier.weight(1f),
+                    modifier = Modifier
+                        .weight(1f)
+                        .then(listPullUpModifier),
                 )
             }
         }

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatScreen.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatScreen.kt
@@ -2,42 +2,96 @@ package com.garfiec.librechat.feature.chat.screen
 
 import android.content.ClipboardManager
 import android.content.Context
+import androidx.activity.compose.BackHandler
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.gestures.AnchoredDraggableDefaults
+import androidx.compose.foundation.gestures.AnchoredDraggableState
+import androidx.compose.foundation.gestures.DraggableAnchors
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.anchoredDraggable
+import androidx.compose.foundation.gestures.animateTo
+import androidx.compose.foundation.gestures.animateToWithDecay
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.BottomSheetDefaults
+import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.Velocity
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.garfiec.librechat.core.data.datastore.ChatFontSize
 import com.garfiec.librechat.core.data.datastore.LatexRenderer
+import com.garfiec.librechat.core.ui.components.LowProfileDragHandle
 import com.garfiec.librechat.feature.chat.components.ChatFloatingTopBar
 import com.garfiec.librechat.feature.chat.components.ChatInput
 import com.garfiec.librechat.feature.chat.components.ChatRoot
+import com.garfiec.librechat.feature.chat.components.ChatToolsSheetContent
+import com.garfiec.librechat.feature.chat.components.rememberChatAttachmentActions
 import com.garfiec.librechat.feature.chat.viewmodel.ChatViewModel
 import com.garfiec.librechat.feature.chat.viewmodel.asString
+import kotlin.math.roundToInt
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.launch
 import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.parameter.parametersOf
+
+/** Anchor states for the finger-following pull-up tools sheet. */
+private enum class PullUpAnchor { Hidden, Revealed }
+
+/**
+ * Per-gesture bookkeeping for the pull-up reveal, held outside the [NestedScrollConnection] so it
+ * survives the connection being recreated and can be reset from a pointer-down handler. [listScrolled]
+ * is true once the thread list has consumed scroll within the current gesture — while set, the reveal
+ * is suppressed so a single drag from the top can't overshoot the bottom into opening the sheet.
+ */
+private class PullUpGesture {
+    var listScrolled = false
+}
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -104,6 +158,28 @@ actual fun ChatScreen(
         coroutineScope = coroutineScope,
     )
 
+    // Shared by the composer "+" sheet (ChatInput) and the pull-up sheet: opening the model selector
+    // routes to the secondary picker on the comparison screen's second tab, and the displayed model
+    // label follows the same tab. Hoisted here so both entry points behave identically.
+    val onOpenModelSelector: () -> Unit = {
+        if (uiState.comparisonState.isEnabled && activeComparisonTab == 1) {
+            showSecondaryModelSheet = true
+        } else {
+            viewModel.openModelSheet()
+        }
+    }
+    val effectiveSelectedModelDisplay = if (uiState.comparisonState.isEnabled && activeComparisonTab == 1) {
+        viewModel.getSecondaryModelDisplayName()
+            ?: uiState.comparisonState.secondaryModel
+            ?: displayModel
+    } else {
+        displayModel
+    }
+    // One launcher set, registered here and shared by both the composer "+" sheet (ChatInput) and
+    // the pull-up sheet: a launcher stays usable from descendant compositions while the one that
+    // registered it (this screen) is alive, so a second registration would be redundant.
+    val attachmentActions = rememberChatAttachmentActions(viewModel::onFilesSelected)
+
     ChatScreenEffects(
         uiState = uiState,
         shareLinkUrl = shareLinkUrl,
@@ -159,10 +235,148 @@ actual fun ChatScreen(
         Box(
             modifier = Modifier.fillMaxSize(),
         ) {
+            // ── Pull-up tools sheet ───────────────────────────────────────────────
+            // An upward pull on the thread surface (once it's scrolled to the bottom) progressively
+            // reveals the same "+" tools/attachment menu, following the finger via an anchored-drag
+            // surface. Material 3's ModalBottomSheet can't be driven by external over-scroll, so this
+            // is a custom surface rather than the ModalBottomSheet the composer's "+" still opens.
+            val pullUpState = remember { AnchoredDraggableState(PullUpAnchor.Hidden) }
+            var pullUpSheetHeightPx by remember { mutableIntStateOf(0) }
+            val pullUpGesture = remember { PullUpGesture() }
+            // Fling velocity above which a flick (rather than drag position) decides open/closed.
+            val pullUpMinFlingVelocityPx = with(LocalDensity.current) { 125.dp.toPx() }
+            // Cap the sheet's height to the space below the top bar so tall content (e.g. many MCP
+            // servers) can't push the bottom-anchored surface up past the screen top and clip the
+            // attachment cards off-screen. Excess content scrolls inside the sheet instead. No minimum
+            // floor: in a very short window (split-screen/freeform) a floor could itself exceed the
+            // window and reintroduce the top-clip. coerceAtLeast(0) only guards heightIn against a
+            // negative on a pathologically small window.
+            val pullUpMaxSheetHeight =
+                (LocalConfiguration.current.screenHeightDp.dp - topContentPadding - 8.dp)
+                    .coerceAtLeast(0.dp)
+            val pullUpFling = AnchoredDraggableDefaults.flingBehavior(
+                state = pullUpState,
+                positionalThreshold = { distance -> distance * 0.4f },
+                animationSpec = tween(),
+            )
+            LaunchedEffect(pullUpSheetHeightPx) {
+                if (pullUpSheetHeightPx > 0) {
+                    pullUpState.updateAnchors(
+                        DraggableAnchors {
+                            PullUpAnchor.Hidden at pullUpSheetHeightPx.toFloat()
+                            PullUpAnchor.Revealed at 0f
+                        },
+                    )
+                }
+            }
+            // Dismiss the IME the moment the sheet starts to reveal (the Scaffold uses imePadding()).
+            LaunchedEffect(pullUpState, pullUpSheetHeightPx) {
+                snapshotFlow {
+                    val o = pullUpState.offset
+                    !o.isNaN() && pullUpSheetHeightPx > 0 && o < pullUpSheetHeightPx
+                }.distinctUntilChanged().collect { revealing ->
+                    if (revealing) keyboardController?.hide()
+                }
+            }
+            // Bridges the message-list over-scroll into the sheet: reveal on leftover upward drag once
+            // the list is at its true bottom (onPostScroll), retract on downward drag while the sheet
+            // is open (onPreScroll). Reads pullUpSheetHeightPx live, so remember only on the state.
+            val pullUpConnection = remember(pullUpState, pullUpMinFlingVelocityPx) {
+                object : NestedScrollConnection {
+                    override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
+                        val o = pullUpState.offset
+                        val open = !o.isNaN() && o < pullUpSheetHeightPx
+                        return if (available.y > 0f && open) {
+                            Offset(0f, pullUpState.dispatchRawDelta(available.y))
+                        } else {
+                            Offset.Zero
+                        }
+                    }
+
+                    override fun onPostScroll(
+                        consumed: Offset,
+                        available: Offset,
+                        source: NestedScrollSource,
+                    ): Offset {
+                        if (consumed.y != 0f) {
+                            pullUpGesture.listScrolled = true
+                        }
+                        val o = pullUpState.offset
+                        val open = !o.isNaN() && o < pullUpSheetHeightPx
+                        // Only reveal from a gesture that began at the bottom (list never scrolled),
+                        // or keep responding once the sheet is already opening. The flag is reset on
+                        // each pointer-down (see pullUpListModifier), so a cancelled gesture can't
+                        // leave the reveal permanently suppressed.
+                        val allowReveal = !pullUpGesture.listScrolled || open
+                        return if (available.y < 0f && allowReveal) {
+                            Offset(0f, pullUpState.dispatchRawDelta(available.y))
+                        } else {
+                            Offset.Zero
+                        }
+                    }
+
+                    override suspend fun onPreFling(available: Velocity): Velocity {
+                        val o = pullUpState.offset
+                        val open = !o.isNaN() && o < pullUpSheetHeightPx
+                        return if (available.y > 0f && open) {
+                            settleSheet(available.y)
+                            available
+                        } else {
+                            Velocity.Zero
+                        }
+                    }
+
+                    override suspend fun onPostFling(consumed: Velocity, available: Velocity): Velocity {
+                        settleSheet(available.y)
+                        return available
+                    }
+
+                    // Velocity-aware settle to the nearest anchor. Only acts once the sheet is already
+                    // partly open, so a fling that merely reaches the bottom (sheet still hidden) can't
+                    // fling it open — the reveal must have been started by a deliberate pull. A fast
+                    // flick then wins on velocity; otherwise position decides (open past 40% revealed,
+                    // matching pullUpFling's 0.4 positionalThreshold). Uses the modifier-era
+                    // animateToWithDecay — NOT settle(velocity), which throws for a state built with
+                    // the threshold-less constructor.
+                    private suspend fun settleSheet(velocity: Float) {
+                        val height = pullUpSheetHeightPx.toFloat()
+                        val o = pullUpState.offset
+                        if (height <= 0f || o.isNaN() || o >= height) return
+                        val target = when {
+                            velocity <= -pullUpMinFlingVelocityPx -> PullUpAnchor.Revealed
+                            velocity >= pullUpMinFlingVelocityPx -> PullUpAnchor.Hidden
+                            o < height * 0.6f -> PullUpAnchor.Revealed
+                            else -> PullUpAnchor.Hidden
+                        }
+                        pullUpState.animateToWithDecay(target, velocity)
+                    }
+                }
+            }
+            // The active list gets the nested-scroll bridge plus a pointer-down reset of the
+            // per-gesture "list scrolled" flag, so every fresh touch re-arms the reveal even if a
+            // prior drag ended without a fling callback.
+            val pullUpListModifier = Modifier
+                .nestedScroll(pullUpConnection)
+                .pointerInput(pullUpGesture) {
+                    awaitEachGesture {
+                        awaitFirstDown(requireUnconsumed = false)
+                        pullUpGesture.listScrolled = false
+                    }
+                }
+            // The landing screen isn't scrollable, so nested-scroll never fires there — drive the same
+            // state with a direct drag modifier instead.
+            val pullUpLandingModifier = Modifier.anchoredDraggable(
+                state = pullUpState,
+                orientation = Orientation.Vertical,
+                flingBehavior = pullUpFling,
+            )
+
             Column(
                 modifier = Modifier.fillMaxSize(),
             ) {
                 ChatContent(
+                    listPullUpModifier = pullUpListModifier,
+                    pullUpModifier = pullUpLandingModifier,
                     uiState = uiState,
                     viewModel = viewModel,
                     clipboardManager = clipboardManager,
@@ -204,7 +418,7 @@ actual fun ChatScreen(
                 },
                 canQueue = uiState.canQueueFollowUp,
                 attachedFiles = attachedFiles,
-                onFilesSelected = viewModel::onFilesSelected,
+                attachmentActions = attachmentActions,
                 onRemoveFile = viewModel::removeFile,
                 onAttachFromServer = onAttachFromServer,
                 promptSuggestions = uiState.availablePrompts,
@@ -221,20 +435,8 @@ actual fun ChatScreen(
                 selectedMcpServerNames = uiState.selectedMcpServerNames,
                 onToggleMcpServer = viewModel::toggleMcpServer,
                 onOpenModelParameters = viewModel::showModelParameters,
-                onOpenModelSelector = {
-                    if (uiState.comparisonState.isEnabled && activeComparisonTab == 1) {
-                        showSecondaryModelSheet = true
-                    } else {
-                        viewModel.openModelSheet()
-                    }
-                },
-                selectedModelDisplay = if (uiState.comparisonState.isEnabled && activeComparisonTab == 1) {
-                    viewModel.getSecondaryModelDisplayName()
-                        ?: uiState.comparisonState.secondaryModel
-                        ?: displayModel
-                } else {
-                    displayModel
-                },
+                onOpenModelSelector = onOpenModelSelector,
+                selectedModelDisplay = effectiveSelectedModelDisplay,
                 isCodeInterpreterAvailable = uiState.isCodeInterpreterAvailable,
                 webSearchEnabled = uiState.webSearchEnabled,
                 urlContextEnabled = uiState.urlContextProviderGate,
@@ -279,6 +481,103 @@ actual fun ChatScreen(
                     .align(Alignment.TopCenter)
                     .onSizeChanged { topBarHeightPx = it.height },
             )
+
+            // Pull-up sheet overlay (drawn last so scrim + sheet sit above the composer and top bar).
+            // `pullUpVisible` is derived so the scrim/back-handler recompose only on the open<->closed
+            // transition; the scrim's dim level is drawn in the draw phase (drawBehind) and the sheet
+            // offset is read in the layout phase (offset {}), so a drag doesn't recompose the screen.
+            val pullUpVisible by remember {
+                derivedStateOf {
+                    val o = pullUpState.offset
+                    pullUpSheetHeightPx > 0 && !o.isNaN() && o < pullUpSheetHeightPx
+                }
+            }
+            if (pullUpVisible) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        // Drag the dimmed backdrop to push the sheet back down, or tap to dismiss.
+                        .anchoredDraggable(
+                            state = pullUpState,
+                            orientation = Orientation.Vertical,
+                            flingBehavior = pullUpFling,
+                        )
+                        .pointerInput(Unit) {
+                            detectTapGestures {
+                                coroutineScope.launch { pullUpState.animateTo(PullUpAnchor.Hidden) }
+                            }
+                        }
+                        .drawBehind {
+                            val o = pullUpState.offset
+                            val p = if (pullUpSheetHeightPx > 0 && !o.isNaN()) {
+                                (1f - o / pullUpSheetHeightPx).coerceIn(0f, 1f)
+                            } else {
+                                0f
+                            }
+                            drawRect(color = Color.Black, alpha = 0.5f * p)
+                        },
+                )
+            }
+            BackHandler(enabled = pullUpVisible) {
+                coroutineScope.launch { pullUpState.animateTo(PullUpAnchor.Hidden) }
+            }
+            Surface(
+                color = BottomSheetDefaults.ContainerColor,
+                shape = RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp),
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    // Match ModalBottomSheet: full-bleed on phones, capped + centered on wide
+                    // (fold/tablet) displays instead of edge-to-edge.
+                    .fillMaxWidth()
+                    .widthIn(max = BottomSheetDefaults.SheetMaxWidth)
+                    .heightIn(max = pullUpMaxSheetHeight)
+                    // Stay invisible until measured: on the very first frame the offset is NaN and the
+                    // measured height is still 0, so without this the sheet would place at offset 0
+                    // (fully revealed) and flash the whole menu open on every chat entry.
+                    .graphicsLayer { alpha = if (pullUpSheetHeightPx > 0) 1f else 0f }
+                    .onSizeChanged { pullUpSheetHeightPx = it.height }
+                    .offset {
+                        val o = pullUpState.offset
+                        IntOffset(0, if (o.isNaN()) pullUpSheetHeightPx else o.roundToInt())
+                    }
+                    .anchoredDraggable(
+                        state = pullUpState,
+                        orientation = Orientation.Vertical,
+                        flingBehavior = pullUpFling,
+                    ),
+            ) {
+                Column(modifier = Modifier.fillMaxWidth()) {
+                    LowProfileDragHandle()
+                    ChatToolsSheetContent(
+                        enabledTools = uiState.effectiveEnabledTools,
+                        onToggleTool = viewModel::toggleTool,
+                        mcpServers = uiState.mcpServers,
+                        selectedMcpServerNames = uiState.selectedMcpServerNames,
+                        onToggleMcpServer = viewModel::toggleMcpServer,
+                        onAttachFiles = attachmentActions.onAttachFiles,
+                        onTakePhoto = attachmentActions.onTakePhoto,
+                        onPickPhotos = attachmentActions.onPickPhotos,
+                        onAttachFromServer = onAttachFromServer,
+                        onOpenModelParameters = viewModel::showModelParameters,
+                        onOpenModelSelector = onOpenModelSelector,
+                        selectedModelDisplay = effectiveSelectedModelDisplay,
+                        onDismiss = {
+                            coroutineScope.launch { pullUpState.animateTo(PullUpAnchor.Hidden) }
+                        },
+                        isCodeInterpreterAvailable = uiState.isCodeInterpreterAvailable,
+                        webSearchEnabled = uiState.webSearchEnabled,
+                        urlContextEnabled = uiState.urlContextProviderGate,
+                        runCodeEnabled = uiState.runCodeEnabled,
+                        fileSearchEnabled = uiState.fileSearchEnabled,
+                        mcpServersEnabled = uiState.mcpServersEnabled,
+                        gates = uiState.chatInputGates,
+                        contextUsage = uiState.contextUsage,
+                        tokenUsage = uiState.tokenUsage,
+                        contextUsageEnabled = uiState.contextUsageEnabled,
+                        contextBarPlacement = uiState.contextBarPlacement,
+                    )
+                }
+            }
         }
     }
 

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ChatToolsBottomSheet.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ChatToolsBottomSheet.kt
@@ -14,8 +14,10 @@ import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.AttachFile
@@ -55,6 +57,7 @@ import com.garfiec.librechat.core.common.ToolConstants
 import com.garfiec.librechat.core.data.datastore.ContextBarPlacement
 import com.garfiec.librechat.core.model.usage.ContextUsage
 import com.garfiec.librechat.core.model.usage.TokenUsage
+import com.garfiec.librechat.core.ui.components.LowProfileDragHandle
 import com.garfiec.librechat.feature.chat.model.McpServerDisplayData
 import com.garfiec.librechat.feature.chat.resources.*
 import com.garfiec.librechat.feature.chat.resources.Res
@@ -101,253 +104,332 @@ fun ChatToolsBottomSheet(
     contextBarPlacement: ContextBarPlacement = ContextBarPlacement.OPTIONS_SHEET,
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
-    var showMcpServers by remember { mutableStateOf(false) }
 
     ModalBottomSheet(
         onDismissRequest = onDismiss,
         modifier = modifier,
         sheetState = sheetState,
+        dragHandle = { LowProfileDragHandle() },
     ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .navigationBarsPadding()
-                .padding(bottom = 16.dp),
-        ) {
-            // Top section: Camera, Photos, Files, Server cards — hidden when the selected
-            // endpoint can't accept uploads (mirrors web's AttachFileChat gate). "Server"
-            // attaches an already-uploaded file by reference (no re-upload).
-            if (gates.fileUploadEnabled) {
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 16.dp),
-                    horizontalArrangement = Arrangement.spacedBy(12.dp),
-                ) {
-                    AttachmentOptionCard(
-                        icon = Icons.Default.PhotoCamera,
-                        label = stringResource(Res.string.tool_camera),
-                        onClick = {
-                            onTakePhoto()
-                            onDismiss()
-                        },
-                        modifier = Modifier.weight(1f),
-                    )
-                    AttachmentOptionCard(
-                        icon = Icons.Default.PhotoLibrary,
-                        label = stringResource(Res.string.tool_photos),
-                        onClick = {
-                            onPickPhotos()
-                            onDismiss()
-                        },
-                        modifier = Modifier.weight(1f),
-                    )
-                    AttachmentOptionCard(
-                        icon = Icons.Default.AttachFile,
-                        label = stringResource(Res.string.tool_files),
-                        onClick = {
-                            onAttachFiles()
-                            onDismiss()
-                        },
-                        modifier = Modifier.weight(1f),
-                    )
-                    AttachmentOptionCard(
-                        icon = Icons.Default.CloudDownload,
-                        label = stringResource(Res.string.tool_server_files),
-                        onClick = {
-                            onAttachFromServer()
-                            onDismiss()
-                        },
-                        modifier = Modifier.weight(1f),
-                    )
-                }
+        ChatToolsSheetContent(
+            enabledTools = enabledTools,
+            onToggleTool = onToggleTool,
+            mcpServers = mcpServers,
+            selectedMcpServerNames = selectedMcpServerNames,
+            onToggleMcpServer = onToggleMcpServer,
+            onAttachFiles = onAttachFiles,
+            onTakePhoto = onTakePhoto,
+            onPickPhotos = onPickPhotos,
+            onAttachFromServer = onAttachFromServer,
+            onOpenModelParameters = onOpenModelParameters,
+            onOpenModelSelector = onOpenModelSelector,
+            selectedModelDisplay = selectedModelDisplay,
+            onDismiss = onDismiss,
+            isCodeInterpreterAvailable = isCodeInterpreterAvailable,
+            webSearchEnabled = webSearchEnabled,
+            urlContextEnabled = urlContextEnabled,
+            runCodeEnabled = runCodeEnabled,
+            fileSearchEnabled = fileSearchEnabled,
+            mcpServersEnabled = mcpServersEnabled,
+            gates = gates,
+            contextUsage = contextUsage,
+            tokenUsage = tokenUsage,
+            contextUsageEnabled = contextUsageEnabled,
+            contextBarPlacement = contextBarPlacement,
+        )
+    }
+}
 
-                Spacer(modifier = Modifier.height(12.dp))
-                HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
-                Spacer(modifier = Modifier.height(8.dp))
-            }
+/**
+ * The scrollable body of the chat tools/attachment menu, without the surrounding sheet chrome.
+ * Rendered inside the "+" [ChatToolsBottomSheet]'s [ModalBottomSheet] and inside the finger-following
+ * pull-up surface in `ChatScreen`, so both entry points show identical content. Each row invokes its
+ * action then [onDismiss] — the Modal path dismisses the sheet; the pull-up path animates its surface
+ * back to hidden.
+ */
+@Composable
+fun ChatToolsSheetContent(
+    enabledTools: Set<String>,
+    onToggleTool: (String) -> Unit,
+    mcpServers: List<McpServerDisplayData>,
+    selectedMcpServerNames: Set<String>,
+    onToggleMcpServer: (String) -> Unit,
+    onAttachFiles: () -> Unit,
+    onTakePhoto: () -> Unit,
+    onPickPhotos: () -> Unit,
+    onAttachFromServer: () -> Unit,
+    onOpenModelParameters: () -> Unit,
+    onOpenModelSelector: () -> Unit,
+    selectedModelDisplay: String?,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+    isCodeInterpreterAvailable: Boolean = true,
+    webSearchEnabled: Boolean = true,
+    /** Whether to offer the Google-only URL Context toggle (active provider is Google/Gemini). */
+    urlContextEnabled: Boolean = false,
+    runCodeEnabled: Boolean = true,
+    fileSearchEnabled: Boolean = true,
+    mcpServersEnabled: Boolean = true,
+    /**
+     * Server/endpoint feature gates for the sheet: model-select row, parameters row,
+     * ephemeral tool controls (web search / code / file search / MCP), and the
+     * Camera / Photos / Files attach controls. See [ChatInputGates].
+     */
+    gates: ChatInputGates = ChatInputGates(),
+    /** Latest context-window usage snapshot; drives the optional context gauge above the model row. */
+    contextUsage: ContextUsage? = null,
+    /** Latest per-call token usage, for the gauge's expanded Input/Output breakdown rows. */
+    tokenUsage: TokenUsage? = null,
+    /** Server/version gate for the context gauge (`interface.contextUsage` AND backend ≥ 0.8.7). */
+    contextUsageEnabled: Boolean = false,
+    /** Where the user chose to surface the gauge; the sheet only renders it when [ContextBarPlacement.OPTIONS_SHEET]. */
+    contextBarPlacement: ContextBarPlacement = ContextBarPlacement.OPTIONS_SHEET,
+) {
+    var showMcpServers by remember { mutableStateOf(false) }
 
-            // Context-usage gauge, surfaced here when the user picked the options-sheet placement.
-            // Full-width; tapping expands the breakdown inline (no nested modal sheet).
-            val sheetContextUsage = contextUsage
-            if (contextBarPlacement == ContextBarPlacement.OPTIONS_SHEET &&
-                contextUsageEnabled &&
-                sheetContextUsage != null &&
-                sheetContextUsage.usedTokens > 0
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            // Scroll so a tall configuration (uploads + every tool toggle + an expanded MCP list)
+            // stays fully reachable when the content exceeds the sheet's height — the pull-up surface
+            // caps its height, and even the "+" ModalBottomSheet clips a non-scrolling Column.
+            .verticalScroll(rememberScrollState())
+            .navigationBarsPadding()
+            .padding(bottom = 16.dp),
+    ) {
+        // Top section: Camera, Photos, Files, Server cards — hidden when the selected
+        // endpoint can't accept uploads (mirrors web's AttachFileChat gate). "Server"
+        // attaches an already-uploaded file by reference (no re-upload).
+        if (gates.fileUploadEnabled) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp),
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
             ) {
-                ContextUsageExpandableGauge(
-                    usage = sheetContextUsage,
-                    tokenUsage = tokenUsage,
-                    modifier = Modifier
-                        .padding(horizontal = 16.dp)
-                        .padding(bottom = 8.dp),
+                AttachmentOptionCard(
+                    icon = Icons.Default.PhotoCamera,
+                    label = stringResource(Res.string.tool_camera),
+                    onClick = {
+                        onTakePhoto()
+                        onDismiss()
+                    },
+                    modifier = Modifier.weight(1f),
+                )
+                AttachmentOptionCard(
+                    icon = Icons.Default.PhotoLibrary,
+                    label = stringResource(Res.string.tool_photos),
+                    onClick = {
+                        onPickPhotos()
+                        onDismiss()
+                    },
+                    modifier = Modifier.weight(1f),
+                )
+                AttachmentOptionCard(
+                    icon = Icons.Default.AttachFile,
+                    label = stringResource(Res.string.tool_files),
+                    onClick = {
+                        onAttachFiles()
+                        onDismiss()
+                    },
+                    modifier = Modifier.weight(1f),
+                )
+                AttachmentOptionCard(
+                    icon = Icons.Default.CloudDownload,
+                    label = stringResource(Res.string.tool_server_files),
+                    onClick = {
+                        onAttachFromServer()
+                        onDismiss()
+                    },
+                    modifier = Modifier.weight(1f),
                 )
             }
 
-            // Model selector row — hidden when the server disables `interface.modelSelect`.
-            if (gates.modelSelectEnabled) {
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .sheetRowRipple()
-                        .clickable {
-                            onOpenModelSelector()
-                            onDismiss()
-                        }
-                        .padding(horizontal = 12.dp, vertical = 12.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Icon(
-                        imageVector = Icons.Default.SmartToy,
-                        contentDescription = null,
-                        modifier = Modifier.size(24.dp),
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                    Spacer(modifier = Modifier.width(16.dp))
-                    Column(modifier = Modifier.weight(1f)) {
-                        Text(
-                            text = stringResource(Res.string.tool_model),
-                            style = MaterialTheme.typography.bodyLarge,
-                        )
-                        Text(
-                            text = selectedModelDisplay ?: stringResource(Res.string.select_model),
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
-                        )
-                    }
-                    Icon(
-                        imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
-            }
-
-            // Model Parameters — hidden when the server disables `interface.parameters`.
-            if (gates.parametersEnabled) {
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .sheetRowRipple()
-                        .clickable {
-                            onOpenModelParameters()
-                            onDismiss()
-                        }
-                        .padding(horizontal = 12.dp, vertical = 12.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Icon(
-                        imageVector = Icons.Default.Tune,
-                        contentDescription = null,
-                        modifier = Modifier.size(24.dp),
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                    Spacer(modifier = Modifier.width(16.dp))
-                    Column(modifier = Modifier.weight(1f)) {
-                        Text(
-                            text = stringResource(Res.string.tool_model_parameters),
-                            style = MaterialTheme.typography.bodyLarge,
-                        )
-                        Text(
-                            text = stringResource(Res.string.tool_model_parameters_desc),
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
-                    }
-                    Icon(
-                        imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
-            }
-
+            Spacer(modifier = Modifier.height(12.dp))
             HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
             Spacer(modifier = Modifier.height(8.dp))
+        }
 
-            // Tool toggle items — ephemeral tools are hidden for the agents endpoint
-            // (the agent uses its own configured tools), mirroring web's showEphemeralBadges.
-            // Each tool's icon/label comes from the shared [ephemeralToolMeta]; the per-tool
-            // enable gate stays inline (they differ per tool).
-            if (gates.showEphemeralTools) {
-                val toolRows = listOf(
-                    ToolConstants.WEB_SEARCH to webSearchEnabled,
-                    ToolConstants.URL_CONTEXT to urlContextEnabled,
-                    ToolConstants.CODE_INTERPRETER to (isCodeInterpreterAvailable && runCodeEnabled),
-                    ToolConstants.FILE_SEARCH to fileSearchEnabled,
-                )
-                toolRows.forEach { (toolKey, enabled) ->
-                    val meta = ephemeralToolMeta(toolKey)
-                    if (enabled && meta != null) {
-                        ToolToggleRow(
-                            icon = meta.icon,
-                            title = stringResource(meta.titleRes),
-                            subtitle = stringResource(meta.descriptionRes),
-                            isEnabled = toolKey in enabledTools,
-                            onToggle = { onToggleTool(toolKey) },
-                        )
+        // Context-usage gauge, surfaced here when the user picked the options-sheet placement.
+        // Full-width; tapping expands the breakdown inline (no nested modal sheet).
+        val sheetContextUsage = contextUsage
+        if (contextBarPlacement == ContextBarPlacement.OPTIONS_SHEET &&
+            contextUsageEnabled &&
+            sheetContextUsage != null &&
+            sheetContextUsage.usedTokens > 0
+        ) {
+            ContextUsageExpandableGauge(
+                usage = sheetContextUsage,
+                tokenUsage = tokenUsage,
+                modifier = Modifier
+                    .padding(horizontal = 16.dp)
+                    .padding(bottom = 8.dp),
+            )
+        }
+
+        // Model selector row — hidden when the server disables `interface.modelSelect`.
+        if (gates.modelSelectEnabled) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .sheetRowRipple()
+                    .clickable {
+                        onOpenModelSelector()
+                        onDismiss()
                     }
+                    .padding(horizontal = 12.dp, vertical = 12.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Icon(
+                    imageVector = Icons.Default.SmartToy,
+                    contentDescription = null,
+                    modifier = Modifier.size(24.dp),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(modifier = Modifier.width(16.dp))
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = stringResource(Res.string.tool_model),
+                        style = MaterialTheme.typography.bodyLarge,
+                    )
+                    Text(
+                        text = selectedModelDisplay ?: stringResource(Res.string.select_model),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+                Icon(
+                    imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+
+        // Model Parameters — hidden when the server disables `interface.parameters`.
+        if (gates.parametersEnabled) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .sheetRowRipple()
+                    .clickable {
+                        onOpenModelParameters()
+                        onDismiss()
+                    }
+                    .padding(horizontal = 12.dp, vertical = 12.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Tune,
+                    contentDescription = null,
+                    modifier = Modifier.size(24.dp),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(modifier = Modifier.width(16.dp))
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = stringResource(Res.string.tool_model_parameters),
+                        style = MaterialTheme.typography.bodyLarge,
+                    )
+                    Text(
+                        text = stringResource(Res.string.tool_model_parameters_desc),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                Icon(
+                    imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+
+        HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
+        Spacer(modifier = Modifier.height(8.dp))
+
+        // Tool toggle items — ephemeral tools are hidden for the agents endpoint
+        // (the agent uses its own configured tools), mirroring web's showEphemeralBadges.
+        // Each tool's icon/label comes from the shared [ephemeralToolMeta]; the per-tool
+        // enable gate stays inline (they differ per tool).
+        if (gates.showEphemeralTools) {
+            val toolRows = listOf(
+                ToolConstants.WEB_SEARCH to webSearchEnabled,
+                ToolConstants.URL_CONTEXT to urlContextEnabled,
+                ToolConstants.CODE_INTERPRETER to (isCodeInterpreterAvailable && runCodeEnabled),
+                ToolConstants.FILE_SEARCH to fileSearchEnabled,
+            )
+            toolRows.forEach { (toolKey, enabled) ->
+                val meta = ephemeralToolMeta(toolKey)
+                if (enabled && meta != null) {
+                    ToolToggleRow(
+                        icon = meta.icon,
+                        title = stringResource(meta.titleRes),
+                        subtitle = stringResource(meta.descriptionRes),
+                        isEnabled = toolKey in enabledTools,
+                        onToggle = { onToggleTool(toolKey) },
+                    )
+                }
+            }
+        }
+
+        // MCP section — hidden when role denies MCP_SERVERS.USE, and for the agents
+        // endpoint where dynamic MCP selections are silently ignored by the backend.
+        if (gates.showEphemeralTools && mcpServersEnabled && mcpServers.isNotEmpty()) {
+            val anyMcpSelected = selectedMcpServerNames.isNotEmpty()
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .sheetRowRipple()
+                    .clickable { showMcpServers = !showMcpServers }
+                    .padding(horizontal = 12.dp, vertical = 12.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Extension,
+                    contentDescription = null,
+                    modifier = Modifier.size(24.dp),
+                    tint = if (anyMcpSelected) {
+                        MaterialTheme.colorScheme.primary
+                    } else {
+                        MaterialTheme.colorScheme.onSurfaceVariant
+                    },
+                )
+                Spacer(modifier = Modifier.width(16.dp))
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = stringResource(Res.string.tool_mcp),
+                        style = MaterialTheme.typography.bodyLarge,
+                    )
+                    Text(
+                        text = stringResource(Res.string.tool_mcp_desc),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                if (anyMcpSelected) {
+                    Text(
+                        text = "${selectedMcpServerNames.size}",
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.padding(end = 8.dp),
+                    )
                 }
             }
 
-            // MCP section — hidden when role denies MCP_SERVERS.USE, and for the agents
-            // endpoint where dynamic MCP selections are silently ignored by the backend.
-            if (gates.showEphemeralTools && mcpServersEnabled && mcpServers.isNotEmpty()) {
-                val anyMcpSelected = selectedMcpServerNames.isNotEmpty()
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .sheetRowRipple()
-                        .clickable { showMcpServers = !showMcpServers }
-                        .padding(horizontal = 12.dp, vertical = 12.dp),
-                    verticalAlignment = Alignment.CenterVertically,
+            // MCP server sub-list
+            if (showMcpServers) {
+                Column(
+                    modifier = Modifier.padding(start = 40.dp),
                 ) {
-                    Icon(
-                        imageVector = Icons.Default.Extension,
-                        contentDescription = null,
-                        modifier = Modifier.size(24.dp),
-                        tint = if (anyMcpSelected) {
-                            MaterialTheme.colorScheme.primary
-                        } else {
-                            MaterialTheme.colorScheme.onSurfaceVariant
-                        },
-                    )
-                    Spacer(modifier = Modifier.width(16.dp))
-                    Column(modifier = Modifier.weight(1f)) {
-                        Text(
-                            text = stringResource(Res.string.tool_mcp),
-                            style = MaterialTheme.typography.bodyLarge,
+                    mcpServers.forEach { server ->
+                        McpServerToggleRow(
+                            server = server,
+                            isSelected = server.name in selectedMcpServerNames,
+                            onToggle = { onToggleMcpServer(server.name) },
                         )
-                        Text(
-                            text = stringResource(Res.string.tool_mcp_desc),
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
-                    }
-                    if (anyMcpSelected) {
-                        Text(
-                            text = "${selectedMcpServerNames.size}",
-                            style = MaterialTheme.typography.labelMedium,
-                            color = MaterialTheme.colorScheme.primary,
-                            modifier = Modifier.padding(end = 8.dp),
-                        )
-                    }
-                }
-
-                // MCP server sub-list
-                if (showMcpServers) {
-                    Column(
-                        modifier = Modifier.padding(start = 40.dp),
-                    ) {
-                        mcpServers.forEach { server ->
-                            McpServerToggleRow(
-                                server = server,
-                                isSelected = server.name in selectedMcpServerNames,
-                                onToggle = { onToggleMcpServer(server.name) },
-                            )
-                        }
                     }
                 }
             }

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ContextUsageGauge.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ContextUsageGauge.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.garfiec.librechat.core.model.usage.ContextUsage
 import com.garfiec.librechat.core.model.usage.TokenUsage
+import com.garfiec.librechat.core.ui.components.LowProfileDragHandle
 import com.garfiec.librechat.feature.chat.resources.Res
 import com.garfiec.librechat.feature.chat.resources.context_usage_free
 import com.garfiec.librechat.feature.chat.resources.context_usage_input
@@ -222,7 +223,10 @@ internal fun ContextUsageSheet(
     tokenUsage: TokenUsage?,
     onDismiss: () -> Unit,
 ) {
-    ModalBottomSheet(onDismissRequest = onDismiss) {
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        dragHandle = { LowProfileDragHandle() },
+    ) {
         ContextUsageBreakdown(
             usage = usage,
             tokenUsage = tokenUsage,

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ForkOptionsBottomSheet.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ForkOptionsBottomSheet.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
 import com.garfiec.librechat.core.model.request.ForkOption
+import com.garfiec.librechat.core.ui.components.LowProfileDragHandle
 import com.garfiec.librechat.feature.chat.resources.*
 import com.garfiec.librechat.feature.chat.resources.Res
 import org.jetbrains.compose.resources.stringResource
@@ -46,6 +47,7 @@ fun ForkOptionsBottomSheet(
 
     ModalBottomSheet(
         onDismissRequest = onDismiss,
+        dragHandle = { LowProfileDragHandle() },
         modifier = modifier,
         sheetState = sheetState,
     ) {

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ModelSelectorSheet.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ModelSelectorSheet.kt
@@ -58,6 +58,7 @@ import com.garfiec.librechat.core.model.EndpointConfig
 import com.garfiec.librechat.core.model.endpoint.KeyState
 import com.garfiec.librechat.core.ui.components.EndpointIcon
 import com.garfiec.librechat.core.ui.components.ErrorBanner
+import com.garfiec.librechat.core.ui.components.LowProfileDragHandle
 import com.garfiec.librechat.feature.chat.resources.*
 import com.garfiec.librechat.feature.chat.resources.Res
 import com.garfiec.librechat.feature.chat.util.FuzzyMatch
@@ -197,6 +198,7 @@ fun ModelSelectorSheet(
 
     ModalBottomSheet(
         onDismissRequest = onDismiss,
+        dragHandle = { LowProfileDragHandle() },
         sheetState = sheetState,
         modifier = modifier,
     ) {

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/PresetPicker.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/PresetPicker.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import com.garfiec.librechat.core.ui.components.LowProfileDragHandle
 import com.garfiec.librechat.feature.chat.model.PresetDisplayData
 import com.garfiec.librechat.feature.chat.resources.*
 import com.garfiec.librechat.feature.chat.resources.Res
@@ -46,6 +47,7 @@ fun PresetPicker(
 
     ModalBottomSheet(
         onDismissRequest = onDismiss,
+        dragHandle = { LowProfileDragHandle() },
         sheetState = sheetState,
         modifier = modifier,
     ) {

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/PlatformArtifactPanel.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/PlatformArtifactPanel.kt
@@ -20,7 +20,6 @@ import androidx.compose.material.icons.filled.Code
 import androidx.compose.material.icons.filled.Fullscreen
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.material.icons.filled.Visibility
-import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -42,6 +41,7 @@ import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import com.garfiec.librechat.core.ui.components.LowProfileDragHandle
 import com.garfiec.librechat.core.ui.theme.isSurfaceDark
 import com.garfiec.librechat.feature.chat.components.CodeBlock
 import com.garfiec.librechat.feature.chat.resources.Res
@@ -117,7 +117,7 @@ fun ArtifactPanel(
         onDismissRequest = onDismiss,
         sheetState = sheetState,
         modifier = modifier.fillMaxSize(),
-        dragHandle = { BottomSheetDefaults.DragHandle() },
+        dragHandle = { LowProfileDragHandle() },
         shape = RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp),
     ) {
         ArtifactViewer(

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/prompts/PromptVersionsSheet.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/prompts/PromptVersionsSheet.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.garfiec.librechat.core.model.Prompt
+import com.garfiec.librechat.core.ui.components.LowProfileDragHandle
 import com.garfiec.librechat.feature.chat.resources.*
 import com.garfiec.librechat.feature.chat.resources.Res
 import org.jetbrains.compose.resources.stringResource
@@ -46,6 +47,7 @@ fun PromptVersionsSheet(
 
     ModalBottomSheet(
         onDismissRequest = onDismiss,
+        dragHandle = { LowProfileDragHandle() },
         sheetState = sheetState,
         modifier = modifier,
     ) {

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/prompts/components/PromptFilterSheet.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/prompts/components/PromptFilterSheet.kt
@@ -19,6 +19,7 @@ import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.garfiec.librechat.core.ui.components.LowProfileDragHandle
 import com.garfiec.librechat.feature.chat.resources.*
 import com.garfiec.librechat.feature.chat.resources.Res
 import org.jetbrains.compose.resources.stringResource
@@ -43,6 +44,7 @@ fun PromptFilterSheet(
 ) {
     ModalBottomSheet(
         onDismissRequest = onDismiss,
+        dragHandle = { LowProfileDragHandle() },
         sheetState = sheetState,
         modifier = modifier,
     ) {

--- a/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/components/ConversationActions.kt
+++ b/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/components/ConversationActions.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
 import com.garfiec.librechat.core.model.Conversation
+import com.garfiec.librechat.core.ui.components.LowProfileDragHandle
 import com.garfiec.librechat.feature.conversations.resources.*
 import com.garfiec.librechat.feature.conversations.resources.Res
 import org.jetbrains.compose.resources.stringResource
@@ -68,6 +69,7 @@ fun ConversationActions(
 
     ModalBottomSheet(
         onDismissRequest = onDismiss,
+        dragHandle = { LowProfileDragHandle() },
         modifier = modifier,
         sheetState = sheetState,
     ) {

--- a/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/components/ProjectPicker.kt
+++ b/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/components/ProjectPicker.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import com.garfiec.librechat.core.model.ChatProject
+import com.garfiec.librechat.core.ui.components.LowProfileDragHandle
 import com.garfiec.librechat.feature.conversations.resources.Res
 import com.garfiec.librechat.feature.conversations.resources.project_create
 import com.garfiec.librechat.feature.conversations.resources.project_new_name
@@ -54,7 +55,11 @@ fun ProjectPicker(
 ) {
     var newName by remember { mutableStateOf("") }
 
-    ModalBottomSheet(onDismissRequest = onDismiss, modifier = modifier) {
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        modifier = modifier,
+        dragHandle = { LowProfileDragHandle() },
+    ) {
         Column(
             modifier = Modifier
                 .fillMaxWidth()

--- a/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/drawer/AccountSwitcherSheet.kt
+++ b/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/drawer/AccountSwitcherSheet.kt
@@ -51,6 +51,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.garfiec.librechat.core.ui.components.AvatarImage
+import com.garfiec.librechat.core.ui.components.LowProfileDragHandle
 import com.garfiec.librechat.core.ui.components.avatarColorForSeed
 import com.garfiec.librechat.feature.conversations.resources.Res
 import com.garfiec.librechat.feature.conversations.resources.accounts
@@ -218,6 +219,7 @@ fun AccountSwitcherSheet(
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     ModalBottomSheet(
         onDismissRequest = onDismiss,
+        dragHandle = { LowProfileDragHandle() },
         sheetState = sheetState,
     ) {
         Column(modifier = Modifier.navigationBarsPadding()) {

--- a/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/export/ExportFormatPicker.kt
+++ b/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/export/ExportFormatPicker.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
+import com.garfiec.librechat.core.ui.components.LowProfileDragHandle
 import com.garfiec.librechat.feature.conversations.resources.*
 import com.garfiec.librechat.feature.conversations.resources.Res
 import org.jetbrains.compose.resources.stringResource
@@ -36,6 +37,7 @@ fun ExportFormatPicker(
 
     ModalBottomSheet(
         onDismissRequest = onDismiss,
+        dragHandle = { LowProfileDragHandle() },
         modifier = modifier,
         sheetState = sheetState,
     ) {

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/McpToolsSheet.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/McpToolsSheet.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import com.garfiec.librechat.core.model.mcp.McpTool
+import com.garfiec.librechat.core.ui.components.LowProfileDragHandle
 import com.garfiec.librechat.feature.settings.resources.*
 import com.garfiec.librechat.feature.settings.resources.Res
 import org.jetbrains.compose.resources.stringResource
@@ -45,6 +46,7 @@ internal fun McpToolsSheet(
 
     ModalBottomSheet(
         onDismissRequest = onDismiss,
+        dragHandle = { LowProfileDragHandle() },
         sheetState = sheetState,
         modifier = modifier,
     ) {

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/providerkeys/SetProviderKeyDialog.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/providerkeys/SetProviderKeyDialog.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.garfiec.librechat.core.model.endpoint.KeyState
+import com.garfiec.librechat.core.ui.components.LowProfileDragHandle
 import com.garfiec.librechat.feature.settings.resources.Res
 import com.garfiec.librechat.feature.settings.resources.action_cancel
 import com.garfiec.librechat.feature.settings.resources.action_save
@@ -95,6 +96,7 @@ fun SetProviderKeyDialog(
 
     ModalBottomSheet(
         onDismissRequest = onDismiss,
+        dragHandle = { LowProfileDragHandle() },
         sheetState = sheetState,
     ) {
         Column(


### PR DESCRIPTION
## Summary

Adds a second, gesture-driven way into the chat tools/attachment menu: when the message thread is scrolled to the bottom (or on the new-chat landing surface), an upward pull progressively reveals the same sheet the composer's "+" button opens. The sheet tracks the finger 1:1 and retracts on a drag back down — it is not a binary show/hide. The "+" button remains an entry point to the same content.

The app also gains a single shared low-profile drag handle, used by all 18 bottom sheets.

## Changes

**Chat — pull-up gesture** (`feature/chat`, androidMain)
- `ChatScreen` hoists an `AnchoredDraggableState` plus a `NestedScrollConnection` that reveals the sheet from the message list's leftover over-scroll past the content end, and retracts it on a downward drag while open. Ordered above `PullToRefreshBox`, so pull-to-refresh is untouched.
- A reveal only engages while the list has consumed no scroll during the current gesture (flag reset on pointer-down), so one long drag up through the thread can't overshoot into opening the sheet.
- The sheet surface uses `BottomSheetDefaults.ContainerColor`, is capped at `BottomSheetDefaults.SheetMaxWidth` and at the window height less the floating top bar, and stays invisible until measured to avoid a first-frame flash.
- Scrim (draggable + tap-to-dismiss), `BackHandler`, and IME dismissal on reveal.
- The landing surface isn't scrollable, so it drives the same state via `Modifier.anchoredDraggable` directly.
- The gesture is available on the single active thread and the landing surface, not in comparison mode.

**Chat — shared plumbing**
- `ChatToolsBottomSheet`'s body extracted to a public `ChatToolsSheetContent`, rendered by both the "+" `ModalBottomSheet` and the pull-up surface, and made vertically scrollable so a tall configuration stays reachable under the height cap. Each instance owns its MCP-expansion state.
- New `rememberChatAttachmentActions` factory owns the file/photo/camera/permission launchers. `ChatScreen` registers one set and passes it down. `ChatInput`'s optional `onFilesSelected` is replaced by a required `attachmentActions` param.

**UI — drag handle** (`core/ui`)
- New `LowProfileDragHandle`: a slim pill carrying a localized "Drag handle" accessibility label. Applied to all 18 `ModalBottomSheet` call sites — 17 were on M3's default handle, and `ArtifactPanel` set `BottomSheetDefaults.DragHandle` explicitly.
- Adds `core/ui`'s first string resources (`cd_drag_handle`, base + 9 locales).

## Testing

`:app:assembleDebug`, `detektMetadataCommonMain`, and `:feature:chat:testDebugUnitTest` pass. No automated coverage is added for the gesture, and it has not been verified on hardware.

## Notes

- Android-only surface. The `core/ui` handle and `ChatToolsSheetContent` changes are in commonMain, so iOS picks them up; iOS was not built.
- The gesture has no TalkBack affordance — the "+" button remains the accessible entry point.
