### PR TITLE
fix(chat): full-height press highlight and persisted expansion for the context gauge

### DIFF
--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/SettingsDataStore.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/SettingsDataStore.kt
@@ -110,6 +110,11 @@ class SettingsDataStore(
         ContextBarPlacement.fromString(prefs[KEY_CONTEXT_BAR_PLACEMENT])
     }
 
+    /** Whether the options-sheet context gauge's inline breakdown is expanded. */
+    val contextGaugeExpanded: Flow<Boolean> = dataStore.data.map { prefs ->
+        prefs[KEY_CONTEXT_GAUGE_EXPANDED] ?: false
+    }
+
     val autoReadEnabled: Flow<Boolean> = dataStore.data.map { prefs ->
         prefs[KEY_AUTO_READ_ENABLED] ?: false
     }
@@ -341,6 +346,12 @@ class SettingsDataStore(
     suspend fun setContextBarPlacement(placement: ContextBarPlacement) {
         dataStore.edit { prefs ->
             prefs[KEY_CONTEXT_BAR_PLACEMENT] = placement.toStorageString()
+        }
+    }
+
+    suspend fun setContextGaugeExpanded(expanded: Boolean) {
+        dataStore.edit { prefs ->
+            prefs[KEY_CONTEXT_GAUGE_EXPANDED] = expanded
         }
     }
 
@@ -654,6 +665,7 @@ class SettingsDataStore(
         private val KEY_AUTO_SCROLL_ENABLED = booleanPreferencesKey("auto_scroll_enabled")
         private val KEY_SHOW_THINKING_BLOCKS = booleanPreferencesKey("show_thinking_blocks")
         private val KEY_CONTEXT_BAR_PLACEMENT = stringPreferencesKey("context_bar_placement")
+        private val KEY_CONTEXT_GAUGE_EXPANDED = booleanPreferencesKey("context_gauge_expanded")
         private val KEY_AUTO_READ_ENABLED = booleanPreferencesKey("auto_read_enabled")
         private val KEY_SHOW_IMAGE_DESCRIPTIONS = booleanPreferencesKey("show_image_descriptions")
         private val KEY_SELECTED_VOICE_ID = stringPreferencesKey("selected_voice_id")

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/components/ChatInput.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/components/ChatInput.kt
@@ -106,6 +106,8 @@ fun ChatInput(
     tokenUsage: TokenUsage? = null,
     contextUsageEnabled: Boolean = false,
     contextBarPlacement: ContextBarPlacement = ContextBarPlacement.OPTIONS_SHEET,
+    contextGaugeExpanded: Boolean = false,
+    onContextGaugeExpandedChange: (Boolean) -> Unit = {},
 ) {
     val cdOpenToolsMenu = stringResource(Res.string.cd_open_tools_menu)
     val cdPasteImage = stringResource(Res.string.cd_paste_image)
@@ -378,6 +380,8 @@ fun ChatInput(
             tokenUsage = tokenUsage,
             contextUsageEnabled = contextUsageEnabled,
             contextBarPlacement = contextBarPlacement,
+            contextGaugeExpanded = contextGaugeExpanded,
+            onContextGaugeExpandedChange = onContextGaugeExpandedChange,
         )
     }
 }

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatScreen.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatScreen.kt
@@ -448,6 +448,8 @@ actual fun ChatScreen(
                 tokenUsage = uiState.tokenUsage,
                 contextUsageEnabled = uiState.contextUsageEnabled,
                 contextBarPlacement = uiState.contextBarPlacement,
+                contextGaugeExpanded = uiState.contextGaugeExpanded,
+                onContextGaugeExpandedChange = viewModel::setContextGaugeExpanded,
                 // After a Stop/error pause, the queue waits for an explicit nudge.
                 queuedPausedCount = uiState.pausedQueueCount,
                 onSendQueuedMessages = viewModel::sendQueuedNow,
@@ -575,6 +577,8 @@ actual fun ChatScreen(
                         tokenUsage = uiState.tokenUsage,
                         contextUsageEnabled = uiState.contextUsageEnabled,
                         contextBarPlacement = uiState.contextBarPlacement,
+                        contextGaugeExpanded = uiState.contextGaugeExpanded,
+                        onContextGaugeExpandedChange = viewModel::setContextGaugeExpanded,
                     )
                 }
             }

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ChatToolsBottomSheet.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ChatToolsBottomSheet.kt
@@ -102,6 +102,9 @@ fun ChatToolsBottomSheet(
     contextUsageEnabled: Boolean = false,
     /** Where the user chose to surface the gauge; the sheet only renders it when [ContextBarPlacement.OPTIONS_SHEET]. */
     contextBarPlacement: ContextBarPlacement = ContextBarPlacement.OPTIONS_SHEET,
+    /** Persisted expanded/collapsed state of the gauge's inline breakdown. */
+    contextGaugeExpanded: Boolean = false,
+    onContextGaugeExpandedChange: (Boolean) -> Unit = {},
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
 
@@ -136,6 +139,8 @@ fun ChatToolsBottomSheet(
             tokenUsage = tokenUsage,
             contextUsageEnabled = contextUsageEnabled,
             contextBarPlacement = contextBarPlacement,
+            contextGaugeExpanded = contextGaugeExpanded,
+            onContextGaugeExpandedChange = onContextGaugeExpandedChange,
         )
     }
 }
@@ -184,6 +189,9 @@ fun ChatToolsSheetContent(
     contextUsageEnabled: Boolean = false,
     /** Where the user chose to surface the gauge; the sheet only renders it when [ContextBarPlacement.OPTIONS_SHEET]. */
     contextBarPlacement: ContextBarPlacement = ContextBarPlacement.OPTIONS_SHEET,
+    /** Persisted expanded/collapsed state of the gauge's inline breakdown. */
+    contextGaugeExpanded: Boolean = false,
+    onContextGaugeExpandedChange: (Boolean) -> Unit = {},
 ) {
     var showMcpServers by remember { mutableStateOf(false) }
 
@@ -260,6 +268,8 @@ fun ChatToolsSheetContent(
         ) {
             ContextUsageExpandableGauge(
                 usage = sheetContextUsage,
+                expanded = contextGaugeExpanded,
+                onExpandedChange = onContextGaugeExpandedChange,
                 tokenUsage = tokenUsage,
                 modifier = Modifier
                     .padding(horizontal = 16.dp)

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ContextUsageGauge.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ContextUsageGauge.kt
@@ -126,14 +126,16 @@ fun ContextUsageMenuItem(
  * Full-width gauge that expands in place to reveal the breakdown — for the composer "+" sheet,
  * where a tap can't open a modal sheet (that would nest modal surfaces) but the inline space is
  * available. The header pill fills the row; tapping it toggles the [ContextUsageBreakdown] below.
+ * The expanded state is hoisted so the caller can persist it across sheet openings.
  */
 @Composable
 fun ContextUsageExpandableGauge(
     usage: ContextUsage,
+    expanded: Boolean,
+    onExpandedChange: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
     tokenUsage: TokenUsage? = null,
 ) {
-    var expanded by remember { mutableStateOf(false) }
     val percent = (usage.usedFraction * 100).toInt()
     val chevronRotation by animateFloatAsState(if (expanded) 180f else 0f, label = "ctx_chevron")
 
@@ -144,7 +146,7 @@ fun ContextUsageExpandableGauge(
     ) {
         Column(modifier = Modifier.fillMaxWidth()) {
             Surface(
-                onClick = { expanded = !expanded },
+                onClick = { onExpandedChange(!expanded) },
                 color = Color.Transparent,
                 modifier = Modifier.fillMaxWidth().heightIn(min = 48.dp),
             ) {

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ContextUsageGauge.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ContextUsageGauge.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -145,7 +146,7 @@ fun ContextUsageExpandableGauge(
             Surface(
                 onClick = { expanded = !expanded },
                 color = Color.Transparent,
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier.fillMaxWidth().heightIn(min = 48.dp),
             ) {
                 ContextGaugePill(percent = percent, usedFraction = usage.usedFraction, fillWidth = true) {
                     Icon(

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatPrefsState.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatPrefsState.kt
@@ -32,6 +32,8 @@ data class ChatPrefsState(
     val chatHeaderAlignment: ChatHeaderAlignment = ChatHeaderAlignment.LEFT,
     /** User preference (Settings → Chat) for where the context gauge is surfaced. */
     val contextBarPlacement: ContextBarPlacement = ContextBarPlacement.OPTIONS_SHEET,
+    /** Whether the options-sheet context gauge's inline breakdown is expanded. */
+    val contextGaugeExpanded: Boolean = false,
 )
 
 /**
@@ -54,12 +56,14 @@ data class ChatPreferences(
 )
 
 /**
- * The chat floating top bar's mobile-only display preferences, bundled into a single
- * flow so [ChatViewModel]'s `uiState` combine stays within Kotlin's 5-arg typed limit.
+ * Chat-screen display preferences (floating top bar + options-sheet context gauge), bundled
+ * into a single flow so [ChatViewModel]'s `uiState` combine stays within Kotlin's 5-arg
+ * typed limit.
  */
 @Immutable
-data class ChatHeaderPrefs(
+data class ChatDisplayPrefs(
     val content: ChatHeaderContent = ChatHeaderContent.TITLE,
     val alignment: ChatHeaderAlignment = ChatHeaderAlignment.LEFT,
     val contextBarPlacement: ContextBarPlacement = ContextBarPlacement.OPTIONS_SHEET,
+    val contextGaugeExpanded: Boolean = false,
 )

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatUiState.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatUiState.kt
@@ -104,6 +104,7 @@ data class ChatUiState(
     val chatHeaderContent: ChatHeaderContent get() = prefs.chatHeaderContent
     val chatHeaderAlignment: ChatHeaderAlignment get() = prefs.chatHeaderAlignment
     val contextBarPlacement: ContextBarPlacement get() = prefs.contextBarPlacement
+    val contextGaugeExpanded: Boolean get() = prefs.contextGaugeExpanded
     val promptsEnabled: Boolean get() = gates.promptsEnabled
     val promptsCreateEnabled: Boolean get() = gates.promptsCreateEnabled
     val agentsEnabled: Boolean get() = gates.agentsEnabled

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModel.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModel.kt
@@ -77,6 +77,7 @@ import com.garfiec.librechat.feature.chat.viewmodel.delegate.SubagentTraceDelega
 import com.garfiec.librechat.feature.chat.viewmodel.delegate.toFileReference
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -91,6 +92,7 @@ import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.serialization.json.Json
 import kotlin.time.Clock
@@ -292,29 +294,44 @@ class ChatViewModel(
         )
     }.stateIn(viewModelScope, SharingStarted.Eagerly, ChatPreferences())
 
+    // In-memory echo of the gauge-expanded toggle: a tap flips the UI synchronously instead of
+    // waiting on the DataStore write round-trip (which would also make a quick second tap read
+    // stale state). The persisted value only seeds the session until the first tap.
+    private val contextGaugeExpandedOverride = MutableStateFlow<Boolean?>(null)
+
     // Bundled into one source so the uiState combine below stays within Kotlin's
     // 5-argument typed `combine` ceiling.
-    private val chatHeaderPrefs: Flow<ChatHeaderPrefs> = combine(
+    private val chatDisplayPrefs: Flow<ChatDisplayPrefs> = combine(
         settingsDataStore.chatHeaderContent,
         settingsDataStore.chatHeaderAlignment,
         settingsDataStore.contextBarPlacement,
-    ) { content, alignment, contextBarPlacement -> ChatHeaderPrefs(content, alignment, contextBarPlacement) }
+        settingsDataStore.contextGaugeExpanded,
+        contextGaugeExpandedOverride,
+    ) { content, alignment, contextBarPlacement, persistedGaugeExpanded, overrideGaugeExpanded ->
+        ChatDisplayPrefs(
+            content,
+            alignment,
+            contextBarPlacement,
+            overrideGaugeExpanded ?: persistedGaugeExpanded,
+        )
+    }
 
     val uiState: StateFlow<ChatUiState> = combine(
         _uiState,
         serverDataStore.currentUrlFlow,
         settingsDataStore.chatFontSize,
         settingsDataStore.starredModelsDisplay,
-        chatHeaderPrefs,
-    ) { state, url, fontSize, starredDisplay, headerPrefs ->
+        chatDisplayPrefs,
+    ) { state, url, fontSize, starredDisplay, displayPrefs ->
         state.copy(
             prefs = ChatPrefsState(
                 serverUrl = url,
                 chatFontSize = fontSize,
                 starredModelsDisplay = starredDisplay,
-                chatHeaderContent = headerPrefs.content,
-                chatHeaderAlignment = headerPrefs.alignment,
-                contextBarPlacement = headerPrefs.contextBarPlacement,
+                chatHeaderContent = displayPrefs.content,
+                chatHeaderAlignment = displayPrefs.alignment,
+                contextBarPlacement = displayPrefs.contextBarPlacement,
+                contextGaugeExpanded = displayPrefs.contextGaugeExpanded,
             ),
         )
     }.stateIn(viewModelScope, SharingStarted.Eagerly, ChatUiState())
@@ -1636,4 +1653,15 @@ class ChatViewModel(
     fun updateModelParameters(parameters: ModelParameters) = modelDelegate.updateModelParameters(parameters)
 
     fun branchFromComparison(agentId: String) = comparisonDelegate.branchFromComparison(agentId)
+
+    fun setContextGaugeExpanded(expanded: Boolean) {
+        contextGaugeExpandedOverride.value = expanded
+        viewModelScope.launch {
+            // Survive ViewModel teardown (tap, then navigate away) and never crash on a storage
+            // failure — the in-memory override above already reflects the user's choice.
+            runCatching {
+                withContext(NonCancellable) { settingsDataStore.setContextGaugeExpanded(expanded) }
+            }
+        }
+    }
 }

--- a/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/components/IosChatInput.kt
+++ b/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/components/IosChatInput.kt
@@ -91,6 +91,8 @@ fun IosChatInput(
     tokenUsage: TokenUsage? = null,
     contextUsageEnabled: Boolean = false,
     contextBarPlacement: ContextBarPlacement = ContextBarPlacement.OPTIONS_SHEET,
+    contextGaugeExpanded: Boolean = false,
+    onContextGaugeExpandedChange: (Boolean) -> Unit = {},
 ) {
     val snackbarHostState = remember { SnackbarHostState() }
     var showToolsSheet by remember { mutableStateOf(false) }
@@ -274,6 +276,8 @@ fun IosChatInput(
             tokenUsage = tokenUsage,
             contextUsageEnabled = contextUsageEnabled,
             contextBarPlacement = contextBarPlacement,
+            contextGaugeExpanded = contextGaugeExpanded,
+            onContextGaugeExpandedChange = onContextGaugeExpandedChange,
         )
     }
 }

--- a/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/screen/PlatformScreens.ios.kt
+++ b/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/screen/PlatformScreens.ios.kt
@@ -394,6 +394,8 @@ actual fun ChatScreen(
                 tokenUsage = uiState.tokenUsage,
                 contextUsageEnabled = uiState.contextUsageEnabled,
                 contextBarPlacement = uiState.contextBarPlacement,
+                contextGaugeExpanded = uiState.contextGaugeExpanded,
+                onContextGaugeExpandedChange = viewModel::setContextGaugeExpanded,
                 queuedPausedCount = uiState.pausedQueueCount,
                 isEditingQueued = uiState.isEditingQueued,
                 onCommitEdit = viewModel::commitQueuedEdit,


### PR DESCRIPTION
## Summary
Two improvements to the context usage gauge in the composer "+" tools sheet: the press
highlight now covers the card's full height instead of just the slim pill row, and the
expanded/collapsed state of the inline breakdown now persists across sheet openings and
app restarts.

## Changes
- **Press highlight** — the clickable `Surface` in `ContextUsageExpandableGauge` now enforces
  a 48dp minimum height, so the ripple covers the whole header row instead of just the slim pill.
- **Persisted expansion** — the gauge's expanded state is hoisted out of the composable and
  backed by a new `context_gauge_expanded` DataStore preference (`SettingsDataStore`). Both
  entry points share it: the "+" modal sheet and the pull-up surface (`ChatToolsSheetContent`).
- **Instant toggle** — `ChatViewModel` layers an in-memory override over the persisted flow
  (`override ?: persisted`), so a tap flips the UI synchronously instead of waiting on the
  disk-write round-trip; the DataStore write runs `NonCancellable` inside `runCatching` so it
  survives ViewModel teardown and never crashes on a storage failure.
- `ChatHeaderPrefs` renamed to `ChatDisplayPrefs` since it now bundles the gauge state
  alongside the top-bar prefs.
- iOS call sites (`PlatformScreens.ios.kt`, `IosChatInput.kt`) mirror the new wiring.

## Testing
- `:feature:chat` / `:core:data` compile, detekt, and unit tests pass.
- Device-tested on Pixel 9 Pro Fold: highlight fill, instant expand/collapse (including
  rapid double-tap), and persistence across sheet reopen and app restart.
- iOS not built (shared-code changes mirrored only).
