### PR TITLE
fix(settings): localize fork mode and retry labels, meet 48dp touch targets

### DIFF
--- a/feature/settings/CLAUDE.md
+++ b/feature/settings/CLAUDE.md
@@ -59,5 +59,5 @@
 
 ### Dialogs
 - `LanguageSelectorDialog` — 37+ locales with search, single-select radio
-- `ForkSettingsDialog` — 3 fork modes (TARGET, BRANCHES, ALL)
+- `ForkSettingsDialog` — 3 fork modes (`DIRECT_PATH`, `INCLUDE_BRANCHES`, `TARGET_LEVEL`); labels/descriptions come from `fork_mode_*` string resources via `forkModeLabel()` / `forkModeDescription()`, not from the enum
 - `PersonalizationDialog` — "About you" + "Response style" text areas with enable toggle

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/AccountSettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/AccountSettingsScreen.kt
@@ -117,6 +117,7 @@ fun AccountSettingsContent(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val currentOnLogout by rememberUpdatedState(onLogout)
+    val retryLabel = stringResource(Res.string.action_retry)
 
     var showDeleteDialog by remember { mutableStateOf(false) }
     var showLogoutDialog by remember { mutableStateOf(false) }
@@ -125,7 +126,7 @@ fun AccountSettingsContent(
         val error = uiState.error ?: return@LaunchedEffect
         val result = snackbarHostState.showSnackbar(
             message = error,
-            actionLabel = "Retry",
+            actionLabel = retryLabel,
         )
         viewModel.dismissError()
         if (result == SnackbarResult.ActionPerformed) {

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/ChatSettingsDialogs.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/ChatSettingsDialogs.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
@@ -317,6 +318,7 @@ private fun RadioOptionRow(
     Row(
         modifier = Modifier
             .fillMaxWidth()
+            .heightIn(min = 48.dp)
             .clip(RoundedCornerShape(8.dp))
             .selectable(
                 selected = selected,

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/ChatSettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/ChatSettingsScreen.kt
@@ -176,7 +176,7 @@ fun ChatSettingsContent(
                 ChatSettingsRow(
                     icon = Icons.AutoMirrored.Filled.Chat,
                     title = stringResource(Res.string.fork_behavior),
-                    subtitle = ForkMode.fromApiValue(uiState.forkMode).label,
+                    subtitle = forkModeLabel(ForkMode.fromApiValue(uiState.forkMode)),
                     onClick = viewModel::showForkSettingsDialog,
                 )
             }

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/ForkSettingsDialog.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/ForkSettingsDialog.kt
@@ -28,29 +28,32 @@ import com.garfiec.librechat.feature.settings.resources.*
 import com.garfiec.librechat.feature.settings.resources.Res
 import org.jetbrains.compose.resources.stringResource
 
-enum class ForkMode(val label: String, val description: String, val apiValue: String) {
-    DIRECT_PATH(
-        "Visible messages",
-        "Only the direct path of messages to the selected message",
-        ForkOption.DIRECT_PATH,
-    ),
-    INCLUDE_BRANCHES(
-        "Include branches",
-        "Direct path plus sibling messages at each level",
-        ForkOption.INCLUDE_BRANCHES,
-    ),
-    TARGET_LEVEL(
-        "All to target level",
-        "All messages and branches up to the target message level (default)",
-        ForkOption.TARGET_LEVEL,
-    );
+enum class ForkMode(val apiValue: String) {
+    DIRECT_PATH(ForkOption.DIRECT_PATH),
+    INCLUDE_BRANCHES(ForkOption.INCLUDE_BRANCHES),
+    TARGET_LEVEL(ForkOption.TARGET_LEVEL),
+    ;
 
     companion object {
         fun fromApiValue(value: String): ForkMode = entries.firstOrNull { it.apiValue == value } ?: TARGET_LEVEL
     }
 }
 
-/** Radio-select dialog for ForkMode (TARGET, BRANCHES, ALL) controlling conversation fork depth. */
+@Composable
+internal fun forkModeLabel(mode: ForkMode): String = when (mode) {
+    ForkMode.DIRECT_PATH -> stringResource(Res.string.fork_mode_direct_path)
+    ForkMode.INCLUDE_BRANCHES -> stringResource(Res.string.fork_mode_include_branches)
+    ForkMode.TARGET_LEVEL -> stringResource(Res.string.fork_mode_target_level)
+}
+
+@Composable
+internal fun forkModeDescription(mode: ForkMode): String = when (mode) {
+    ForkMode.DIRECT_PATH -> stringResource(Res.string.fork_mode_direct_path_desc)
+    ForkMode.INCLUDE_BRANCHES -> stringResource(Res.string.fork_mode_include_branches_desc)
+    ForkMode.TARGET_LEVEL -> stringResource(Res.string.fork_mode_target_level_desc)
+}
+
+/** Radio-select dialog controlling conversation fork depth. */
 @Composable
 internal fun ForkSettingsDialog(
     selectedMode: ForkMode,
@@ -86,11 +89,11 @@ internal fun ForkSettingsDialog(
                         Spacer(modifier = Modifier.width(8.dp))
                         Column(modifier = Modifier.weight(1f)) {
                             Text(
-                                text = mode.label,
+                                text = forkModeLabel(mode),
                                 style = MaterialTheme.typography.bodyLarge,
                             )
                             Text(
-                                text = mode.description,
+                                text = forkModeDescription(mode),
                                 style = MaterialTheme.typography.bodySmall,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                             )

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/GeneralSettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/GeneralSettingsScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -251,6 +252,7 @@ private fun ThemeSelector(
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
+                        .heightIn(min = 48.dp)
                         .clip(RoundedCornerShape(8.dp))
                         .selectable(
                             selected = selected == mode,

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/McpServersScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/McpServersScreen.kt
@@ -68,12 +68,13 @@ fun McpServersScreen(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val snackbarHostState = remember { SnackbarHostState() }
+    val retryLabel = stringResource(Res.string.action_retry)
 
     LaunchedEffect(uiState.error) {
         val error = uiState.error ?: return@LaunchedEffect
         val result = snackbarHostState.showSnackbar(
             message = error,
-            actionLabel = "Retry",
+            actionLabel = retryLabel,
         )
         viewModel.dismissError()
         if (result == SnackbarResult.ActionPerformed) {

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/MemoriesScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/MemoriesScreen.kt
@@ -67,12 +67,13 @@ fun MemoriesScreen(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val snackbarHostState = remember { SnackbarHostState() }
+    val retryLabel = stringResource(Res.string.action_retry)
 
     LaunchedEffect(uiState.error) {
         val error = uiState.error ?: return@LaunchedEffect
         val result = snackbarHostState.showSnackbar(
             message = error,
-            actionLabel = "Retry",
+            actionLabel = retryLabel,
         )
         viewModel.dismissError()
         if (result == SnackbarResult.ActionPerformed) {


### PR DESCRIPTION
## Summary

Three settings surfaces rendered hardcoded English regardless of app language, and two radio
row types fell below the 48dp minimum touch target. The strings involved were already
authored and translated in all 10 supported locales — the code simply never referenced them.

## Changes

- **Fork mode labels** — `ForkMode` no longer carries hardcoded `label`/`description`
  fields. Added `forkModeLabel()` / `forkModeDescription()` composable helpers reading
  `fork_mode_*` resources, following the existing `fontSizeLabel()` / `latexRendererLabel()`
  pattern. Updated both call sites: the fork dialog and the Advanced row subtitle on the
  chat settings screen.
- **Retry snackbars** — `AccountSettingsScreen`, `MemoriesScreen`, and `McpServersScreen`
  now resolve `action_retry` via `stringResource` hoisted above their `LaunchedEffect`,
  which cannot call composables itself.
- **Touch targets** — `heightIn(min = 48.dp)` on the theme selector rows and on
  `RadioOptionRow`. Both pass `onClick = null` to `RadioButton` (the parent `Row.selectable`
  owns the click), which bypasses Material3's built-in `minimumInteractiveComponentSize()`,
  leaving single-line rows at roughly 40dp. `RadioOptionRow` backs seven dialogs: font size,
  LaTeX, context bar, starred models, chat layout, artifact viewer, and chat header. Being a
  minimum, two-line variants are unaffected.
- **Docs** — corrected a stale KDoc and CLAUDE.md entry listing fork mode constants that
  never existed.

## Testing

- `:feature:settings:compileDebugKotlinAndroid` and `:feature:settings:testDebugUnitTest` pass.
- `:feature:settings:detektMetadataCommonMain` passes.
- Not device-tested.

## Notes

- No new strings; all keys and translations already existed across the 10 locale sets.
- `sections/AppearanceSection.kt` defines `ThemeSelector` and `TabletSidebarGestureToggle`,
  both unreferenced and shadowed by identically-named private copies in
  `GeneralSettingsScreen.kt`. Only the live `ThemeSelector` is fixed here.
