### PR TITLE
feat(chat): swap the "+" options sheet's content instead of stacking sheets

### DIFF
--- a/core/model/src/commonMain/kotlin/com/garfiec/librechat/core/model/ParameterDefinition.kt
+++ b/core/model/src/commonMain/kotlin/com/garfiec/librechat/core/model/ParameterDefinition.kt
@@ -5,7 +5,7 @@ import kotlinx.serialization.Serializable
 
 /**
  * Describes a dynamic model parameter that can be configured per-endpoint.
- * Used by ModelParameterSheet to render appropriate controls.
+ * Used by ModelParameterContent to render appropriate controls.
  */
 @Serializable
 data class ParameterDefinition(

--- a/core/ui/CLAUDE.md
+++ b/core/ui/CLAUDE.md
@@ -56,7 +56,7 @@ Material 3 theme and shared Compose components used across all feature modules. 
 - `ParameterDefinition` contains: key, type, label, description, default, min, max, step, options
 - `DynamicSlider` snaps to step increments; calculates stepCount from range
 - All controls are stateless — caller manages values via `Map<String, String>`
-- `ModelParameterSheet` falls back to existing fixed params when no schema available
+- `ModelParameterContent` falls back to existing fixed params when no schema available
 - **Gotcha**: Slider step count calculated as `((max - min) / step).toInt()` — ensure step divides range evenly to avoid drift
 
 ### Accessibility (`theme/AccessibilityUtils.kt`)

--- a/core/ui/src/commonMain/kotlin/com/garfiec/librechat/core/ui/components/EndpointParameterRegistry.kt
+++ b/core/ui/src/commonMain/kotlin/com/garfiec/librechat/core/ui/components/EndpointParameterRegistry.kt
@@ -6,7 +6,7 @@ import com.garfiec.librechat.core.model.ParameterType
 /**
  * Registry of parameter definitions per endpoint, matching the official LibreChat web app's
  * parameterSettings.ts. Each endpoint maps to an ordered list of ParameterDefinition that
- * drives the dynamic ModelParameterSheet rendering.
+ * drives the dynamic ModelParameterContent rendering.
  */
 @Suppress("TooManyFunctions") // Registry of per-endpoint/provider/variant param builders mirroring upstream parameterSettings.ts.
 object EndpointParameterRegistry {

--- a/core/ui/src/commonMain/kotlin/com/garfiec/librechat/core/ui/components/ModelParameterContent.kt
+++ b/core/ui/src/commonMain/kotlin/com/garfiec/librechat/core/ui/components/ModelParameterContent.kt
@@ -5,20 +5,13 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.imePadding
-import androidx.compose.foundation.layout.navigationBarsPadding
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedButton
-import androidx.compose.material3.SheetState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
-import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.remember
@@ -141,48 +134,6 @@ data class ModelParameters(
         val defaultNum = default.toDoubleOrNull()
         if (currentNum != null && defaultNum != null) return currentNum != defaultNum
         return current != default
-    }
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-fun ModelParameterSheet(
-    parameters: ModelParameters,
-    onParametersChange: (ModelParameters) -> Unit,
-    onDismiss: () -> Unit,
-    modifier: Modifier = Modifier,
-    selectedEndpoint: String = "",
-    dynamicParameterDefinitions: List<ParameterDefinition>? = null,
-    extendedEffortSupported: Boolean = false,
-    /** Underlying provider when [selectedEndpoint] is "agents". Routes the
-     *  agents dispatcher to the matching provider's parameter set. */
-    selectedProvider: String? = null,
-    /** Model id; consumed by the bedrock dispatcher (or the agents dispatcher
-     *  when its underlying provider is bedrock). */
-    selectedModel: String? = null,
-    onSaveAsPreset: () -> Unit = {},
-    sheetState: SheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
-) {
-    ModalBottomSheet(
-        onDismissRequest = onDismiss,
-        sheetState = sheetState,
-        modifier = modifier,
-        dragHandle = { LowProfileDragHandle() },
-    ) {
-        ModelParameterContent(
-            parameters = parameters,
-            onParametersChange = onParametersChange,
-            selectedEndpoint = selectedEndpoint,
-            dynamicParameterDefinitions = dynamicParameterDefinitions,
-            extendedEffortSupported = extendedEffortSupported,
-            selectedProvider = selectedProvider,
-            selectedModel = selectedModel,
-            onSaveAsPreset = onSaveAsPreset,
-            modifier = Modifier
-                .padding(horizontal = 24.dp)
-                .navigationBarsPadding()
-                .imePadding(),
-        )
     }
 }
 

--- a/feature/agents/src/commonMain/kotlin/com/garfiec/librechat/feature/agents/components/AgentModelParametersBridge.kt
+++ b/feature/agents/src/commonMain/kotlin/com/garfiec/librechat/feature/agents/components/AgentModelParametersBridge.kt
@@ -110,7 +110,7 @@ private val PRIMARY_TYPED_KEYS = setOf(
  * `ModelParameters.getValueForKey` / `withUpdatedKey`. When the editor saves
  * the def's canonical key, any legacy alias must be cleared so that an agent
  * doesn't carry two semantically-identical keys with potentially diverging
- * values. Pairs derive from `ModelParameterSheet.kt` aliases:
+ * values. Pairs derive from `ModelParameterContent.kt` aliases:
  *  - `system` / `promptPrefix` → customInstructions slot
  *  - `chatGptLabel` / `modelLabel` → customName slot
  *  - `topP` / `top_p` → handled separately via PRIMARY_TYPED_KEYS rewrite

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/components/ChatInput.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/components/ChatInput.kt
@@ -59,6 +59,11 @@ fun ChatInput(
     onInputChanged: (String) -> Unit,
     onSend: () -> Unit,
     onStop: () -> Unit,
+    /**
+     * Opens the chat options sheet from the "+" button. The sheet is hosted by `ChatScreen`, not
+     * here, because the pull-up surface opens the same one — see `ChatOptionsSheetController`.
+     */
+    onOpenTools: () -> Unit,
     modifier: Modifier = Modifier,
     onQueue: () -> Unit = {},
     canQueue: Boolean = false,
@@ -75,9 +80,7 @@ fun ChatInput(
     onReorderQueuedMessages: (fromIndex: Int, toIndex: Int) -> Unit = { _, _ -> },
     fontSizeMultiplier: Float = 1f,
     attachedFiles: List<AttachedFile> = emptyList(),
-    attachmentActions: ChatAttachmentActions,
     onRemoveFile: (AttachedFile) -> Unit = {},
-    onAttachFromServer: () -> Unit = {},
     promptSuggestions: List<PromptMentionDisplayData> = emptyList(),
     onPromptSelected: (PromptMentionDisplayData) -> Unit = {},
     onSlashCommandSelected: (PromptMentionDisplayData) -> Unit = {},
@@ -91,23 +94,13 @@ fun ChatInput(
     pinnedToolKeys: List<String> = emptyList(),
     mcpServers: List<McpServerDisplayData> = emptyList(),
     selectedMcpServerNames: Set<String> = emptySet(),
-    onToggleMcpServer: (String) -> Unit = {},
-    onOpenModelParameters: () -> Unit = {},
-    onOpenModelSelector: () -> Unit = {},
     selectedModelDisplay: String? = null,
     isCodeInterpreterAvailable: Boolean = true,
-    webSearchEnabled: Boolean = true,
-    urlContextEnabled: Boolean = false,
-    runCodeEnabled: Boolean = true,
-    fileSearchEnabled: Boolean = true,
-    mcpServersEnabled: Boolean = true,
     gates: ChatInputGates = ChatInputGates(),
     contextUsage: ContextUsage? = null,
     tokenUsage: TokenUsage? = null,
     contextUsageEnabled: Boolean = false,
     contextBarPlacement: ContextBarPlacement = ContextBarPlacement.OPTIONS_SHEET,
-    contextGaugeExpanded: Boolean = false,
-    onContextGaugeExpandedChange: (Boolean) -> Unit = {},
 ) {
     val cdOpenToolsMenu = stringResource(Res.string.cd_open_tools_menu)
     val cdPasteImage = stringResource(Res.string.cd_paste_image)
@@ -116,7 +109,6 @@ fun ChatInput(
     val cdStartVoiceRec = stringResource(Res.string.cd_start_voice_recording)
 
     val focusRequester = remember { FocusRequester() }
-    var showToolsSheet by remember { mutableStateOf(false) }
 
     // Use TextFieldValue internally so we can control cursor position.
     // When inputText changes externally (e.g. STT result, prompt insertion),
@@ -203,7 +195,7 @@ fun ChatInput(
             // "+" button to open tools bottom sheet
             Box {
                 FilledTonalIconButton(
-                    onClick = { showToolsSheet = true },
+                    onClick = onOpenTools,
                     modifier = Modifier
                         .size(48.dp)
                         .semantics {
@@ -352,36 +344,4 @@ fun ChatInput(
             Spacer(modifier = Modifier.width(8.dp))
         },
     )
-
-    // Tools bottom sheet
-    if (showToolsSheet) {
-        ChatToolsBottomSheet(
-            enabledTools = enabledTools,
-            onToggleTool = onToggleTool,
-            mcpServers = mcpServers,
-            selectedMcpServerNames = selectedMcpServerNames,
-            onToggleMcpServer = onToggleMcpServer,
-            onAttachFiles = attachmentActions.onAttachFiles,
-            onTakePhoto = attachmentActions.onTakePhoto,
-            onPickPhotos = attachmentActions.onPickPhotos,
-            onAttachFromServer = onAttachFromServer,
-            onOpenModelParameters = onOpenModelParameters,
-            onOpenModelSelector = onOpenModelSelector,
-            selectedModelDisplay = selectedModelDisplay,
-            onDismiss = { showToolsSheet = false },
-            isCodeInterpreterAvailable = isCodeInterpreterAvailable,
-            webSearchEnabled = webSearchEnabled,
-            urlContextEnabled = urlContextEnabled,
-            runCodeEnabled = runCodeEnabled,
-            fileSearchEnabled = fileSearchEnabled,
-            mcpServersEnabled = mcpServersEnabled,
-            gates = gates,
-            contextUsage = contextUsage,
-            tokenUsage = tokenUsage,
-            contextUsageEnabled = contextUsageEnabled,
-            contextBarPlacement = contextBarPlacement,
-            contextGaugeExpanded = contextGaugeExpanded,
-            onContextGaugeExpandedChange = onContextGaugeExpandedChange,
-        )
-    }
 }

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatScreen.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatScreen.kt
@@ -70,7 +70,9 @@ import com.garfiec.librechat.core.ui.components.LowProfileDragHandle
 import com.garfiec.librechat.feature.chat.components.ChatFloatingTopBar
 import com.garfiec.librechat.feature.chat.components.ChatInput
 import com.garfiec.librechat.feature.chat.components.ChatRoot
+import com.garfiec.librechat.feature.chat.components.ChatOptionsPage
 import com.garfiec.librechat.feature.chat.components.ChatToolsSheetContent
+import com.garfiec.librechat.feature.chat.components.rememberChatOptionsSheetController
 import com.garfiec.librechat.feature.chat.components.rememberChatAttachmentActions
 import com.garfiec.librechat.feature.chat.viewmodel.ChatViewModel
 import com.garfiec.librechat.feature.chat.viewmodel.asString
@@ -158,17 +160,14 @@ actual fun ChatScreen(
         coroutineScope = coroutineScope,
     )
 
-    // Shared by the composer "+" sheet (ChatInput) and the pull-up sheet: opening the model selector
-    // routes to the secondary picker on the comparison screen's second tab, and the displayed model
-    // label follows the same tab. Hoisted here so both entry points behave identically.
-    val onOpenModelSelector: () -> Unit = {
-        if (uiState.comparisonState.isEnabled && activeComparisonTab == 1) {
-            showSecondaryModelSheet = true
-        } else {
-            viewModel.openModelSheet()
-        }
-    }
-    val effectiveSelectedModelDisplay = if (uiState.comparisonState.isEnabled && activeComparisonTab == 1) {
+    // Options sheet ("+" menu, model selector/parameters as pages). Opened from the composer's "+"
+    // and the pull-up, hence the controller. Independent of uiState.showModelSheet (the standalone
+    // selector), which keeps dismissing straight to the chat.
+    val optionsController = rememberChatOptionsSheetController()
+    // On comparison tab 1 the composer edits the secondary model, so the selector page and label
+    // both follow the active tab.
+    val isSecondaryTab = uiState.comparisonState.isEnabled && activeComparisonTab == 1
+    val effectiveSelectedModelDisplay = if (isSecondaryTab) {
         viewModel.getSecondaryModelDisplayName()
             ?: uiState.comparisonState.secondaryModel
             ?: displayModel
@@ -243,6 +242,9 @@ actual fun ChatScreen(
             val pullUpState = remember { AnchoredDraggableState(PullUpAnchor.Hidden) }
             var pullUpSheetHeightPx by remember { mutableIntStateOf(0) }
             val pullUpGesture = remember { PullUpGesture() }
+            // ChatToolsSheetContent hoists the MCP sub-list's expansion (the paged options sheet
+            // needs it to survive a page swap), so this surface owns its own copy.
+            var pullUpMcpExpanded by remember { mutableStateOf(false) }
             // Fling velocity above which a flick (rather than drag position) decides open/closed.
             val pullUpMinFlingVelocityPx = with(LocalDensity.current) { 125.dp.toPx() }
             // Cap the sheet's height to the space below the top bar so tall content (e.g. many MCP
@@ -278,10 +280,29 @@ actual fun ChatScreen(
                     if (revealing) keyboardController?.hide()
                 }
             }
+            // Velocity-aware settle, only once the sheet is already partly open (so a fling that
+            // merely reaches the list bottom can't fling it open). Velocity wins, else position at
+            // 40%. animateToWithDecay, NOT settle(velocity) — the latter throws for this
+            // threshold-less state. Shared by both bridges; reads height live, remember on state.
+            val settlePullUpSheet: suspend (Float) -> Unit = remember(pullUpState, pullUpMinFlingVelocityPx) {
+                { velocity ->
+                    val height = pullUpSheetHeightPx.toFloat()
+                    val o = pullUpState.offset
+                    if (height > 0f && !o.isNaN() && o < height) {
+                        val target = when {
+                            velocity <= -pullUpMinFlingVelocityPx -> PullUpAnchor.Revealed
+                            velocity >= pullUpMinFlingVelocityPx -> PullUpAnchor.Hidden
+                            o < height * 0.6f -> PullUpAnchor.Revealed
+                            else -> PullUpAnchor.Hidden
+                        }
+                        pullUpState.animateToWithDecay(target, velocity)
+                    }
+                }
+            }
             // Bridges the message-list over-scroll into the sheet: reveal on leftover upward drag once
             // the list is at its true bottom (onPostScroll), retract on downward drag while the sheet
             // is open (onPreScroll). Reads pullUpSheetHeightPx live, so remember only on the state.
-            val pullUpConnection = remember(pullUpState, pullUpMinFlingVelocityPx) {
+            val pullUpConnection = remember(pullUpState, pullUpMinFlingVelocityPx, settlePullUpSheet) {
                 object : NestedScrollConnection {
                     override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
                         val o = pullUpState.offset
@@ -319,7 +340,7 @@ actual fun ChatScreen(
                         val o = pullUpState.offset
                         val open = !o.isNaN() && o < pullUpSheetHeightPx
                         return if (available.y > 0f && open) {
-                            settleSheet(available.y)
+                            settlePullUpSheet(available.y)
                             available
                         } else {
                             Velocity.Zero
@@ -327,28 +348,60 @@ actual fun ChatScreen(
                     }
 
                     override suspend fun onPostFling(consumed: Velocity, available: Velocity): Velocity {
-                        settleSheet(available.y)
+                        settlePullUpSheet(available.y)
                         return available
                     }
-
-                    // Velocity-aware settle to the nearest anchor. Only acts once the sheet is already
-                    // partly open, so a fling that merely reaches the bottom (sheet still hidden) can't
-                    // fling it open — the reveal must have been started by a deliberate pull. A fast
-                    // flick then wins on velocity; otherwise position decides (open past 40% revealed,
-                    // matching pullUpFling's 0.4 positionalThreshold). Uses the modifier-era
-                    // animateToWithDecay — NOT settle(velocity), which throws for a state built with
-                    // the threshold-less constructor.
-                    private suspend fun settleSheet(velocity: Float) {
-                        val height = pullUpSheetHeightPx.toFloat()
+                }
+            }
+            // Bridges the sheet's own content scroll into the surface: anchoredDraggable is
+            // pointer-input only and, unlike ModalBottomSheet, has no nested-scroll bridge, so
+            // ChatToolsSheetContent's verticalScroll would otherwise swallow every drag. onPostScroll
+            // for downward (content scrolls first, leftover retracts), onPreScroll for upward.
+            val pullUpSheetConnection = remember(pullUpState, settlePullUpSheet) {
+                object : NestedScrollConnection {
+                    // Upward before the content, so a half-retracted sheet pulls back up mid-drag.
+                    // Unconditional is safe: at Revealed, dispatchRawDelta consumes 0.
+                    override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
+                        // NaN guard: before onSizeChanged sets anchors, offset is NaN and
+                        // dispatchRawDelta would poison the child scrollable's delta.
                         val o = pullUpState.offset
-                        if (height <= 0f || o.isNaN() || o >= height) return
-                        val target = when {
-                            velocity <= -pullUpMinFlingVelocityPx -> PullUpAnchor.Revealed
-                            velocity >= pullUpMinFlingVelocityPx -> PullUpAnchor.Hidden
-                            o < height * 0.6f -> PullUpAnchor.Revealed
-                            else -> PullUpAnchor.Hidden
+                        return if (available.y < 0f && !o.isNaN()) {
+                            Offset(0f, pullUpState.dispatchRawDelta(available.y))
+                        } else {
+                            Offset.Zero
                         }
-                        pullUpState.animateToWithDecay(target, velocity)
+                    }
+
+                    override fun onPostScroll(
+                        consumed: Offset,
+                        available: Offset,
+                        source: NestedScrollSource,
+                    ): Offset {
+                        val o = pullUpState.offset
+                        val open = !o.isNaN() && o < pullUpSheetHeightPx
+                        return if (available.y > 0f && open) {
+                            Offset(0f, pullUpState.dispatchRawDelta(available.y))
+                        } else {
+                            Offset.Zero
+                        }
+                    }
+
+                    // Mirror of onPreScroll: an upward flick on a half-retracted sheet settles it
+                    // rather than handing velocity to the content.
+                    override suspend fun onPreFling(available: Velocity): Velocity {
+                        val o = pullUpState.offset
+                        val partlyRetracted = !o.isNaN() && o > 0f
+                        return if (available.y < 0f && partlyRetracted) {
+                            settlePullUpSheet(available.y)
+                            available
+                        } else {
+                            Velocity.Zero
+                        }
+                    }
+
+                    override suspend fun onPostFling(consumed: Velocity, available: Velocity): Velocity {
+                        settlePullUpSheet(available.y)
+                        return available
                     }
                 }
             }
@@ -410,6 +463,7 @@ actual fun ChatScreen(
                     }
                 },
                 onStop = viewModel::stopGeneration,
+                onOpenTools = { optionsController.open() },
                 onQueue = {
                     viewModel.queueMessage()
                     if (dismissKeyboardOnSend) {
@@ -418,9 +472,7 @@ actual fun ChatScreen(
                 },
                 canQueue = uiState.canQueueFollowUp,
                 attachedFiles = attachedFiles,
-                attachmentActions = attachmentActions,
                 onRemoveFile = viewModel::removeFile,
-                onAttachFromServer = onAttachFromServer,
                 promptSuggestions = uiState.availablePrompts,
                 onPromptSelected = viewModel::handlePromptMention,
                 onSlashCommandSelected = viewModel::handleSlashCommand,
@@ -433,23 +485,13 @@ actual fun ChatScreen(
                 onToggleTool = viewModel::toggleTool,
                 mcpServers = uiState.mcpServers,
                 selectedMcpServerNames = uiState.selectedMcpServerNames,
-                onToggleMcpServer = viewModel::toggleMcpServer,
-                onOpenModelParameters = viewModel::showModelParameters,
-                onOpenModelSelector = onOpenModelSelector,
                 selectedModelDisplay = effectiveSelectedModelDisplay,
                 isCodeInterpreterAvailable = uiState.isCodeInterpreterAvailable,
-                webSearchEnabled = uiState.webSearchEnabled,
-                urlContextEnabled = uiState.urlContextProviderGate,
-                runCodeEnabled = uiState.runCodeEnabled,
-                fileSearchEnabled = uiState.fileSearchEnabled,
-                mcpServersEnabled = uiState.mcpServersEnabled,
                 gates = uiState.chatInputGates,
                 contextUsage = uiState.contextUsage,
                 tokenUsage = uiState.tokenUsage,
                 contextUsageEnabled = uiState.contextUsageEnabled,
                 contextBarPlacement = uiState.contextBarPlacement,
-                contextGaugeExpanded = uiState.contextGaugeExpanded,
-                onContextGaugeExpandedChange = viewModel::setContextGaugeExpanded,
                 // After a Stop/error pause, the queue waits for an explicit nudge.
                 queuedPausedCount = uiState.pausedQueueCount,
                 onSendQueuedMessages = viewModel::sendQueuedNow,
@@ -546,7 +588,9 @@ actual fun ChatScreen(
                         state = pullUpState,
                         orientation = Orientation.Vertical,
                         flingBehavior = pullUpFling,
-                    ),
+                    )
+                    // Lets a drag over the scrolling content move the surface. See pullUpSheetConnection.
+                    .nestedScroll(pullUpSheetConnection),
             ) {
                 Column(modifier = Modifier.fillMaxWidth()) {
                     LowProfileDragHandle()
@@ -560,8 +604,17 @@ actual fun ChatScreen(
                         onTakePhoto = attachmentActions.onTakePhoto,
                         onPickPhotos = attachmentActions.onPickPhotos,
                         onAttachFromServer = onAttachFromServer,
-                        onOpenModelParameters = viewModel::showModelParameters,
-                        onOpenModelSelector = onOpenModelSelector,
+                        // The pull-up hands these two pages off to the options sheet rather than
+                        // swapping its own anchored-drag surface (which the selector's search/IME/list
+                        // would fight), retracting itself here.
+                        onOpenModelParameters = {
+                            optionsController.open(ChatOptionsPage.ModelParameters)
+                            coroutineScope.launch { pullUpState.animateTo(PullUpAnchor.Hidden) }
+                        },
+                        onOpenModelSelector = {
+                            optionsController.open(ChatOptionsPage.ModelSelector)
+                            coroutineScope.launch { pullUpState.animateTo(PullUpAnchor.Hidden) }
+                        },
                         selectedModelDisplay = effectiveSelectedModelDisplay,
                         onDismiss = {
                             coroutineScope.launch { pullUpState.animateTo(PullUpAnchor.Hidden) }
@@ -579,11 +632,27 @@ actual fun ChatScreen(
                         contextBarPlacement = uiState.contextBarPlacement,
                         contextGaugeExpanded = uiState.contextGaugeExpanded,
                         onContextGaugeExpandedChange = viewModel::setContextGaugeExpanded,
+                        mcpExpanded = pullUpMcpExpanded,
+                        onMcpExpandedChange = { pullUpMcpExpanded = it },
                     )
                 }
             }
         }
     }
+
+    ChatOptionsSheetHost(
+        controller = optionsController,
+        uiState = uiState,
+        viewModel = viewModel,
+        isSecondaryTab = isSecondaryTab,
+        selectedModelDisplay = effectiveSelectedModelDisplay,
+        onAttachFiles = attachmentActions.onAttachFiles,
+        onTakePhoto = attachmentActions.onTakePhoto,
+        onPickPhotos = attachmentActions.onPickPhotos,
+        onAttachFromServer = onAttachFromServer,
+        onNavigateToProviderKeys = onNavigateToProviderKeys,
+        onShowSavePresetDialog = { showSavePresetDialog = true },
+    )
 
     ChatScreenDialogs(
         uiState = uiState,

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatScreenDialogs.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatScreenDialogs.kt
@@ -17,10 +17,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import com.garfiec.librechat.core.common.EndpointConstants
-import com.garfiec.librechat.core.ui.components.ModelParameterSheet
 import com.garfiec.librechat.feature.chat.components.ForkOptionsBottomSheet
-import com.garfiec.librechat.feature.chat.components.ModelSelectorSheet
 import com.garfiec.librechat.feature.chat.components.PresetPicker
 import com.garfiec.librechat.feature.chat.components.SavePresetDialog
 import com.garfiec.librechat.feature.chat.resources.*
@@ -31,10 +28,13 @@ import org.jetbrains.compose.resources.stringResource
 
 /**
  * Hosts the chat screen's transient dialogs and bottom sheets — preset load/save,
- * fork options, model parameters, rename/delete confirmations, and the primary +
- * secondary model selectors — so [ChatScreen] only has to declare which are open.
+ * fork options, rename/delete confirmations, and the primary + secondary *standalone*
+ * model selectors — so [ChatScreen] only has to declare which are open.
  * Local-only visibility (preset picker, save-preset, secondary model sheet) is
  * hoisted to the caller via the boolean flags and their setters.
+ *
+ * The chat options sheet — the "+" menu, with the model selector and model parameters as
+ * swappable pages — is hosted separately in [ChatScreen], since two entry points open it.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -93,29 +93,6 @@ internal fun ChatScreenDialogs(
         )
     }
 
-    if (uiState.showModelParameters) {
-        val activeAgent = remember(uiState.agents, uiState.selectedModel, uiState.selectedEndpoint) {
-            if (uiState.selectedEndpoint == EndpointConstants.AGENTS) {
-                uiState.agents.find { it.id == uiState.selectedModel }
-            } else {
-                null
-            }
-        }
-        ModelParameterSheet(
-            parameters = uiState.modelParameters,
-            onParametersChange = viewModel::updateModelParameters,
-            onDismiss = viewModel::hideModelParameters,
-            selectedEndpoint = uiState.selectedEndpoint,
-            extendedEffortSupported = uiState.extendedEffortSupported,
-            selectedProvider = activeAgent?.provider,
-            selectedModel = activeAgent?.model ?: uiState.selectedModel,
-            onSaveAsPreset = {
-                viewModel.hideModelParameters()
-                onSetShowSavePresetDialog(true)
-            },
-        )
-    }
-
     if (uiState.showRenameDialog) {
         ChatRenameDialog(
             currentTitle = uiState.conversationTitle ?: "",
@@ -133,65 +110,21 @@ internal fun ChatScreenDialogs(
     }
 
     if (uiState.showModelSheet) {
-        ModelSelectorSheet(
-            endpointConfigs = uiState.endpointConfigs,
-            availableModels = uiState.availableModels,
-            agents = uiState.agents,
-            selectedEndpoint = uiState.selectedEndpoint,
-            selectedModel = uiState.selectedModel,
-            onModelSelect = { endpoint, model ->
-                viewModel.onModelSelected(endpoint, model)
-                // Clear any pending scaffold-level snackbar for the same error so it
-                // doesn't flash behind the sheet's close animation. Harmless no-op when
-                // error is already null.
-                viewModel.dismissError()
-                viewModel.dismissSendBlockReason()
-                viewModel.dismissModelSheet()
-            },
-            onDismiss = {
-                viewModel.dismissError()
-                viewModel.dismissSendBlockReason()
-                viewModel.dismissModelSheet()
-            },
-            serverUrl = uiState.serverUrl,
-            // Send-block reasons take precedence: when set, the sheet was auto-opened
-            // to help the user resolve the block, so surface that context inline.
-            errorMessage = sendBlockMessage ?: uiState.error,
-            onErrorDismiss = {
-                viewModel.dismissSendBlockReason()
-                viewModel.dismissError()
-            },
-            favoriteAgentIds = uiState.favoriteAgentIds,
-            favoriteModelKeys = uiState.favoriteModelKeys,
-            onToggleAgentFavorite = viewModel::toggleAgentFavorite,
-            onToggleModelFavorite = viewModel::toggleModelFavorite,
-            starredDisplay = uiState.starredModelsDisplay,
-            endpointKeyStates = uiState.endpointKeyStates,
-            onSetApiKey = { name -> onNavigateToProviderKeys(name) },
+        PrimaryModelSelectorSheet(
+            uiState = uiState,
+            viewModel = viewModel,
+            sendBlockMessage = sendBlockMessage,
+            onNavigateToProviderKeys = onNavigateToProviderKeys,
         )
     }
 
     // Secondary model selector sheet for comparison mode
     if (showSecondaryModelSheet) {
-        ModelSelectorSheet(
-            endpointConfigs = uiState.endpointConfigs,
-            availableModels = uiState.availableModels,
-            agents = uiState.agents,
-            selectedEndpoint = uiState.comparisonState.secondaryEndpoint,
-            selectedModel = uiState.comparisonState.secondaryModel,
-            onModelSelect = { endpoint, model ->
-                viewModel.setSecondaryModel(endpoint, model)
-                onSetShowSecondaryModelSheet(false)
-            },
+        SecondaryModelSelectorSheet(
+            uiState = uiState,
+            viewModel = viewModel,
             onDismiss = { onSetShowSecondaryModelSheet(false) },
-            serverUrl = uiState.serverUrl,
-            favoriteAgentIds = uiState.favoriteAgentIds,
-            favoriteModelKeys = uiState.favoriteModelKeys,
-            onToggleAgentFavorite = viewModel::toggleAgentFavorite,
-            onToggleModelFavorite = viewModel::toggleModelFavorite,
-            starredDisplay = uiState.starredModelsDisplay,
-            endpointKeyStates = uiState.endpointKeyStates,
-            onSetApiKey = { name -> onNavigateToProviderKeys(name) },
+            onNavigateToProviderKeys = onNavigateToProviderKeys,
         )
     }
 }

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ChatOptionsBottomSheet.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ChatOptionsBottomSheet.kt
@@ -1,0 +1,318 @@
+package com.garfiec.librechat.feature.chat.components
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.SizeTransform
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.garfiec.librechat.core.data.datastore.ContextBarPlacement
+import com.garfiec.librechat.core.data.datastore.StarredModelsDisplay
+import com.garfiec.librechat.core.model.Agent
+import com.garfiec.librechat.core.model.EndpointConfig
+import com.garfiec.librechat.core.model.endpoint.KeyState
+import com.garfiec.librechat.core.model.usage.ContextUsage
+import com.garfiec.librechat.core.model.usage.TokenUsage
+import com.garfiec.librechat.core.ui.components.LowProfileDragHandle
+import com.garfiec.librechat.core.ui.components.ModelParameterContent
+import com.garfiec.librechat.core.ui.components.ModelParameters
+import com.garfiec.librechat.core.ui.components.PlatformBackHandler
+import com.garfiec.librechat.feature.chat.model.McpServerDisplayData
+import com.garfiec.librechat.feature.chat.resources.Res
+import com.garfiec.librechat.feature.chat.resources.cd_back
+import com.garfiec.librechat.feature.chat.resources.tool_model_parameters
+import com.garfiec.librechat.feature.chat.viewmodel.ChatInputGates
+import org.jetbrains.compose.resources.stringResource
+
+/** Duration of the page slide + resize. */
+private const val PageSwapMillis = 250
+
+/** Sub-page height floor if the sheet ever measures unbounded (the selector's list needs bounds). */
+private val SubPageFallbackHeight = 560.dp
+
+/** Everything the Options (tools/attachment) page renders. See [ChatToolsSheetContent]. */
+@Immutable
+data class ChatToolsPageParams(
+    val enabledTools: Set<String>,
+    val onToggleTool: (String) -> Unit,
+    val mcpServers: List<McpServerDisplayData>,
+    val selectedMcpServerNames: Set<String>,
+    val onToggleMcpServer: (String) -> Unit,
+    val onAttachFiles: () -> Unit,
+    val onTakePhoto: () -> Unit,
+    val onPickPhotos: () -> Unit,
+    val onAttachFromServer: () -> Unit,
+    val selectedModelDisplay: String?,
+    val isCodeInterpreterAvailable: Boolean = true,
+    val webSearchEnabled: Boolean = true,
+    val urlContextEnabled: Boolean = false,
+    val runCodeEnabled: Boolean = true,
+    val fileSearchEnabled: Boolean = true,
+    val mcpServersEnabled: Boolean = true,
+    val gates: ChatInputGates = ChatInputGates(),
+    val contextUsage: ContextUsage? = null,
+    val tokenUsage: TokenUsage? = null,
+    val contextUsageEnabled: Boolean = false,
+    val contextBarPlacement: ContextBarPlacement = ContextBarPlacement.OPTIONS_SHEET,
+    val contextGaugeExpanded: Boolean = false,
+    val onContextGaugeExpandedChange: (Boolean) -> Unit = {},
+)
+
+/**
+ * Everything the ModelSelector page renders. In comparison mode the host points the selection
+ * fields at the secondary model, so this page is agnostic to which tab is active.
+ */
+@Immutable
+data class ModelSelectorPageParams(
+    val endpointConfigs: Map<String, EndpointConfig>,
+    val availableModels: Map<String, List<String>>,
+    val agents: List<Agent>,
+    val selectedEndpoint: String?,
+    val selectedModel: String?,
+    val onModelSelect: (endpoint: String, model: String) -> Unit,
+    val onSetApiKey: (endpointName: String) -> Unit,
+    /** Fired on each surfacing; hosts route it to `ChatViewModel.prepareModelSelector()`. */
+    val onSurfaced: () -> Unit = {},
+    /** Inline error; required because the Scaffold snackbar draws behind the sheet scrim. */
+    val errorMessage: String? = null,
+    val onErrorDismiss: () -> Unit = {},
+    val serverUrl: String = "",
+    val favoriteAgentIds: Set<String> = emptySet(),
+    val favoriteModelKeys: Set<String> = emptySet(),
+    val onToggleAgentFavorite: ((agentId: String) -> Unit)? = null,
+    val onToggleModelFavorite: ((endpoint: String, model: String) -> Unit)? = null,
+    val starredDisplay: StarredModelsDisplay = StarredModelsDisplay.OFF,
+    val endpointKeyStates: Map<String, KeyState> = emptyMap(),
+)
+
+/** Everything the ModelParameters page renders. See [ModelParameterContent]. */
+@Immutable
+data class ModelParametersPageParams(
+    val parameters: ModelParameters,
+    val onParametersChange: (ModelParameters) -> Unit,
+    val selectedEndpoint: String = "",
+    val extendedEffortSupported: Boolean = false,
+    /** Underlying provider when the endpoint is "agents"; routes to that provider's param set. */
+    val selectedProvider: String? = null,
+    val selectedModel: String? = null,
+    val onSaveAsPreset: () -> Unit = {},
+)
+
+/**
+ * The chat options sheet: one [ModalBottomSheet] that swaps between the tools menu and the model
+ * selector / parameters, so choosing a model returns to the Options page rather than the chat. The
+ * standalone selector (top-bar chip, send-block, dual-pane) lives in `ChatModelSheets.kt`. Opened
+ * via [ChatOptionsSheetController].
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ChatOptionsBottomSheet(
+    page: ChatOptionsPage,
+    onPageChange: (ChatOptionsPage) -> Unit,
+    onDismiss: () -> Unit,
+    tools: ChatToolsPageParams,
+    selector: ModelSelectorPageParams,
+    parameters: ModelParametersPageParams,
+    modifier: Modifier = Modifier,
+) {
+    // Held here, not in ChatToolsSheetContent: AnimatedContent drops the Options page from
+    // composition on a sub-page, so state remembered there would reset. Saveable to survive the
+    // host teardown the page survives (the "Set API Key" round trip, config change).
+    var mcpExpanded by rememberSaveable { mutableStateOf(false) }
+    val optionsScrollState = rememberScrollState()
+    // Or the Options page — the common path — would open at half height.
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    // On every arrival at the selector. Not latched: both side effects are idempotent (the agent
+    // retry self-guards; the favourites refetch conflates by equality), matching the pre-refactor
+    // "every open self-heals" behaviour.
+    LaunchedEffect(page) {
+        if (page == ChatOptionsPage.ModelSelector) {
+            selector.onSurfaced()
+        }
+    }
+
+    // Clear the selector's inline error when leaving that page, so its snackbar (drawn behind the
+    // scrim) doesn't re-surface after close. Scoped to the selector: an Options-page error must
+    // reach the snackbar untouched. onErrorDismiss no-ops when there's no error.
+    val leaveSelectorError: () -> Unit = {
+        if (page == ChatOptionsPage.ModelSelector) selector.onErrorDismiss()
+    }
+    val goTo: (ChatOptionsPage) -> Unit = { target ->
+        leaveSelectorError()
+        onPageChange(target)
+    }
+    val dismiss: () -> Unit = {
+        leaveSelectorError()
+        onDismiss()
+    }
+    val back: () -> Unit = {
+        if (page == ChatOptionsPage.Options) dismiss() else goTo(ChatOptionsPage.Options)
+    }
+
+    ModalBottomSheet(
+        onDismissRequest = dismiss,
+        modifier = modifier,
+        sheetState = sheetState,
+        dragHandle = { LowProfileDragHandle() },
+    ) {
+        // Inside the sheet: on Android the content is its own dialog window, so an outer handler
+        // never sees its back events. Takes precedence over Material3's back-to-dismiss so a
+        // sub-page pops to Options. Never fires on iOS — hence the header back arrows.
+        PlatformBackHandler(enabled = page != ChatOptionsPage.Options, onBack = back)
+
+        BoxWithConstraints {
+            // Sub-pages need a bounded height for the selector's weight(1f) LazyColumn; Options and
+            // Parameters wrap their content and SizeTransform animates between the heights.
+            val subPageHeight = if (constraints.hasBoundedHeight) maxHeight else SubPageFallbackHeight
+
+            AnimatedContent(
+                targetState = page,
+                transitionSpec = {
+                    // Forward slides in from the right, back from the left, reading as depth.
+                    val direction = if (initialState == ChatOptionsPage.Options) 1 else -1
+                    val spec = tween<Float>(PageSwapMillis)
+                    (
+                        slideInHorizontally(tween(PageSwapMillis)) { width -> direction * width } +
+                            fadeIn(spec)
+                        ).togetherWith(
+                        slideOutHorizontally(tween(PageSwapMillis)) { width -> -direction * width } +
+                            fadeOut(spec),
+                    ).using(SizeTransform { _, _ -> tween(PageSwapMillis) })
+                },
+                label = "chatOptionsPage",
+            ) { currentPage ->
+                when (currentPage) {
+                    ChatOptionsPage.Options -> ChatToolsSheetContent(
+                        enabledTools = tools.enabledTools,
+                        onToggleTool = tools.onToggleTool,
+                        mcpServers = tools.mcpServers,
+                        selectedMcpServerNames = tools.selectedMcpServerNames,
+                        onToggleMcpServer = tools.onToggleMcpServer,
+                        onAttachFiles = tools.onAttachFiles,
+                        onTakePhoto = tools.onTakePhoto,
+                        onPickPhotos = tools.onPickPhotos,
+                        onAttachFromServer = tools.onAttachFromServer,
+                        onOpenModelParameters = { goTo(ChatOptionsPage.ModelParameters) },
+                        onOpenModelSelector = { goTo(ChatOptionsPage.ModelSelector) },
+                        selectedModelDisplay = tools.selectedModelDisplay,
+                        onDismiss = dismiss,
+                        isCodeInterpreterAvailable = tools.isCodeInterpreterAvailable,
+                        webSearchEnabled = tools.webSearchEnabled,
+                        urlContextEnabled = tools.urlContextEnabled,
+                        runCodeEnabled = tools.runCodeEnabled,
+                        fileSearchEnabled = tools.fileSearchEnabled,
+                        mcpServersEnabled = tools.mcpServersEnabled,
+                        gates = tools.gates,
+                        contextUsage = tools.contextUsage,
+                        tokenUsage = tools.tokenUsage,
+                        contextUsageEnabled = tools.contextUsageEnabled,
+                        contextBarPlacement = tools.contextBarPlacement,
+                        contextGaugeExpanded = tools.contextGaugeExpanded,
+                        onContextGaugeExpandedChange = tools.onContextGaugeExpandedChange,
+                        mcpExpanded = mcpExpanded,
+                        onMcpExpandedChange = { mcpExpanded = it },
+                        scrollState = optionsScrollState,
+                    )
+
+                    ChatOptionsPage.ModelSelector -> ModelSelectorSheetContent(
+                        endpointConfigs = selector.endpointConfigs,
+                        availableModels = selector.availableModels,
+                        agents = selector.agents,
+                        selectedEndpoint = selector.selectedEndpoint,
+                        selectedModel = selector.selectedModel,
+                        onModelSelect = { endpoint, model ->
+                            selector.onModelSelect(endpoint, model)
+                            goTo(ChatOptionsPage.Options)
+                        },
+                        onSetApiKey = selector.onSetApiKey,
+                        modifier = Modifier.height(subPageHeight),
+                        serverUrl = selector.serverUrl,
+                        errorMessage = selector.errorMessage,
+                        onErrorDismiss = selector.onErrorDismiss,
+                        favoriteAgentIds = selector.favoriteAgentIds,
+                        favoriteModelKeys = selector.favoriteModelKeys,
+                        onToggleAgentFavorite = selector.onToggleAgentFavorite,
+                        onToggleModelFavorite = selector.onToggleModelFavorite,
+                        starredDisplay = selector.starredDisplay,
+                        endpointKeyStates = selector.endpointKeyStates,
+                        header = { SheetPageBackRow(title = null, onBack = back) },
+                    )
+
+                    ChatOptionsPage.ModelParameters -> Column {
+                        SheetPageBackRow(
+                            title = stringResource(Res.string.tool_model_parameters),
+                            onBack = back,
+                        )
+                        ModelParameterContent(
+                            parameters = parameters.parameters,
+                            onParametersChange = parameters.onParametersChange,
+                            selectedEndpoint = parameters.selectedEndpoint,
+                            extendedEffortSupported = parameters.extendedEffortSupported,
+                            selectedProvider = parameters.selectedProvider,
+                            selectedModel = parameters.selectedModel,
+                            onSaveAsPreset = parameters.onSaveAsPreset,
+                            // The back row above replaces the content's own title.
+                            showHeader = false,
+                            modifier = Modifier
+                                .padding(horizontal = 24.dp)
+                                .navigationBarsPadding()
+                                .imePadding(),
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+/** A sub-page's back affordance — the only way back on iOS, where `PlatformBackHandler` is inert. */
+@Composable
+private fun SheetPageBackRow(
+    title: String?,
+    onBack: () -> Unit,
+) {
+    Row(
+        modifier = Modifier.padding(start = 4.dp, end = 16.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        IconButton(onClick = onBack) {
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                contentDescription = stringResource(Res.string.cd_back),
+            )
+        }
+        if (title != null) {
+            Text(text = title, style = MaterialTheme.typography.titleMedium)
+        }
+    }
+}

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ChatOptionsSheet.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ChatOptionsSheet.kt
@@ -1,0 +1,70 @@
+package com.garfiec.librechat.feature.chat.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+
+/**
+ * The pages the shared chat-options sheet can show. [Options] is the root; the others stack over
+ * it and return to it, rather than each being its own sheet that dismisses to the chat.
+ *
+ * The [ChatOptionsSheetController] Saver persists an entry by [name][Enum.name] (a stable string,
+ * never the ordinal), so reordering the entries is safe but renaming one breaks a saved round trip.
+ */
+enum class ChatOptionsPage {
+    /** The tools/attachment menu — the "+" sheet's root. See [ChatToolsSheetContent]. */
+    Options,
+    ModelSelector,
+    ModelParameters,
+}
+
+/**
+ * Visibility state for [ChatOptionsBottomSheet], hoisted into a controller because two entry points
+ * drive it (the composer's "+" and the pull-up surface). Deliberately *not* ViewModel state:
+ * `ChatUiState.showModelSheet` means "the standalone selector is open" and must stay independent.
+ */
+@Stable
+class ChatOptionsSheetController {
+    /**
+     * Non-null while open; the page *currently* showing. In-sheet swaps write back through [open],
+     * so the [Saver] persists the visible page — what makes the "Set API Key" round trip return to
+     * the open selector rather than the Options menu.
+     */
+    var openPage: ChatOptionsPage? by mutableStateOf(null)
+        private set
+
+    /** Opens the sheet on [page], or navigates the already-open sheet to it — same effect either way. */
+    fun open(page: ChatOptionsPage = ChatOptionsPage.Options) {
+        openPage = page
+    }
+
+    fun close() {
+        openPage = null
+    }
+
+    internal companion object {
+        /**
+         * Persists the open page across host teardown — load-bearing for the selector's "Set API
+         * Key" CTA, which round-trips to Settings and back. `showModelSheet` got this free from the
+         * ViewModel; this state is screen-local, so it must be saved.
+         */
+        val Saver: Saver<ChatOptionsSheetController, String> = Saver(
+            save = { it.openPage?.name ?: CLOSED_KEY },
+            restore = { key ->
+                ChatOptionsSheetController().apply {
+                    ChatOptionsPage.entries.find { it.name == key }?.let { openPage = it }
+                }
+            },
+        )
+
+        private const val CLOSED_KEY = "closed"
+    }
+}
+
+@Composable
+fun rememberChatOptionsSheetController(): ChatOptionsSheetController =
+    rememberSaveable(saver = ChatOptionsSheetController.Saver) { ChatOptionsSheetController() }

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ChatToolsSheetContent.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ChatToolsSheetContent.kt
@@ -1,5 +1,6 @@
 package com.garfiec.librechat.feature.chat.components
 
+import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -30,20 +31,13 @@ import androidx.compose.material.icons.filled.Tune
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Checkbox
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
-import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -57,100 +51,18 @@ import com.garfiec.librechat.core.common.ToolConstants
 import com.garfiec.librechat.core.data.datastore.ContextBarPlacement
 import com.garfiec.librechat.core.model.usage.ContextUsage
 import com.garfiec.librechat.core.model.usage.TokenUsage
-import com.garfiec.librechat.core.ui.components.LowProfileDragHandle
 import com.garfiec.librechat.feature.chat.model.McpServerDisplayData
 import com.garfiec.librechat.feature.chat.resources.*
 import com.garfiec.librechat.feature.chat.resources.Res
 import com.garfiec.librechat.feature.chat.viewmodel.ChatInputGates
 import org.jetbrains.compose.resources.stringResource
 
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-fun ChatToolsBottomSheet(
-    enabledTools: Set<String>,
-    onToggleTool: (String) -> Unit,
-    mcpServers: List<McpServerDisplayData>,
-    selectedMcpServerNames: Set<String>,
-    onToggleMcpServer: (String) -> Unit,
-    onAttachFiles: () -> Unit,
-    onTakePhoto: () -> Unit,
-    onPickPhotos: () -> Unit,
-    onAttachFromServer: () -> Unit,
-    onOpenModelParameters: () -> Unit,
-    onOpenModelSelector: () -> Unit,
-    selectedModelDisplay: String?,
-    onDismiss: () -> Unit,
-    modifier: Modifier = Modifier,
-    isCodeInterpreterAvailable: Boolean = true,
-    webSearchEnabled: Boolean = true,
-    /** Whether to offer the Google-only URL Context toggle (active provider is Google/Gemini). */
-    urlContextEnabled: Boolean = false,
-    runCodeEnabled: Boolean = true,
-    fileSearchEnabled: Boolean = true,
-    mcpServersEnabled: Boolean = true,
-    /**
-     * Server/endpoint feature gates for the sheet: model-select row, parameters row,
-     * ephemeral tool controls (web search / code / file search / MCP), and the
-     * Camera / Photos / Files attach controls. See [ChatInputGates].
-     */
-    gates: ChatInputGates = ChatInputGates(),
-    /** Latest context-window usage snapshot; drives the optional context gauge above the model row. */
-    contextUsage: ContextUsage? = null,
-    /** Latest per-call token usage, for the gauge's expanded Input/Output breakdown rows. */
-    tokenUsage: TokenUsage? = null,
-    /** Server/version gate for the context gauge (`interface.contextUsage` AND backend ≥ 0.8.7). */
-    contextUsageEnabled: Boolean = false,
-    /** Where the user chose to surface the gauge; the sheet only renders it when [ContextBarPlacement.OPTIONS_SHEET]. */
-    contextBarPlacement: ContextBarPlacement = ContextBarPlacement.OPTIONS_SHEET,
-    /** Persisted expanded/collapsed state of the gauge's inline breakdown. */
-    contextGaugeExpanded: Boolean = false,
-    onContextGaugeExpandedChange: (Boolean) -> Unit = {},
-) {
-    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
-
-    ModalBottomSheet(
-        onDismissRequest = onDismiss,
-        modifier = modifier,
-        sheetState = sheetState,
-        dragHandle = { LowProfileDragHandle() },
-    ) {
-        ChatToolsSheetContent(
-            enabledTools = enabledTools,
-            onToggleTool = onToggleTool,
-            mcpServers = mcpServers,
-            selectedMcpServerNames = selectedMcpServerNames,
-            onToggleMcpServer = onToggleMcpServer,
-            onAttachFiles = onAttachFiles,
-            onTakePhoto = onTakePhoto,
-            onPickPhotos = onPickPhotos,
-            onAttachFromServer = onAttachFromServer,
-            onOpenModelParameters = onOpenModelParameters,
-            onOpenModelSelector = onOpenModelSelector,
-            selectedModelDisplay = selectedModelDisplay,
-            onDismiss = onDismiss,
-            isCodeInterpreterAvailable = isCodeInterpreterAvailable,
-            webSearchEnabled = webSearchEnabled,
-            urlContextEnabled = urlContextEnabled,
-            runCodeEnabled = runCodeEnabled,
-            fileSearchEnabled = fileSearchEnabled,
-            mcpServersEnabled = mcpServersEnabled,
-            gates = gates,
-            contextUsage = contextUsage,
-            tokenUsage = tokenUsage,
-            contextUsageEnabled = contextUsageEnabled,
-            contextBarPlacement = contextBarPlacement,
-            contextGaugeExpanded = contextGaugeExpanded,
-            onContextGaugeExpandedChange = onContextGaugeExpandedChange,
-        )
-    }
-}
-
 /**
- * The scrollable body of the chat tools/attachment menu, without the surrounding sheet chrome.
- * Rendered inside the "+" [ChatToolsBottomSheet]'s [ModalBottomSheet] and inside the finger-following
- * pull-up surface in `ChatScreen`, so both entry points show identical content. Each row invokes its
- * action then [onDismiss] — the Modal path dismisses the sheet; the pull-up path animates its surface
- * back to hidden.
+ * The scrollable body of the chat tools/attachment menu (the Options page), no sheet chrome.
+ * Rendered by both [ChatOptionsBottomSheet] and the pull-up surface in `ChatScreen`.
+ *
+ * The Model / Model Parameters rows do *not* call [onDismiss] (the paged sheet swaps in place, the
+ * pull-up hands off); every other row calls its action then [onDismiss].
  */
 @Composable
 fun ChatToolsSheetContent(
@@ -192,16 +104,17 @@ fun ChatToolsSheetContent(
     /** Persisted expanded/collapsed state of the gauge's inline breakdown. */
     contextGaugeExpanded: Boolean = false,
     onContextGaugeExpandedChange: (Boolean) -> Unit = {},
+    /** MCP sub-list expansion, hoisted so the paged sheet keeps it across a page swap (which drops this composable). */
+    mcpExpanded: Boolean = false,
+    onMcpExpandedChange: (Boolean) -> Unit = {},
+    /** Scroll position, hoisted for the same reason as [mcpExpanded]. Defaulted for hosts that keep it composed. */
+    scrollState: ScrollState = rememberScrollState(),
 ) {
-    var showMcpServers by remember { mutableStateOf(false) }
-
     Column(
         modifier = modifier
             .fillMaxWidth()
-            // Scroll so a tall configuration (uploads + every tool toggle + an expanded MCP list)
-            // stays fully reachable when the content exceeds the sheet's height — the pull-up surface
-            // caps its height, and even the "+" ModalBottomSheet clips a non-scrolling Column.
-            .verticalScroll(rememberScrollState())
+            // Tall configurations exceed the sheet height, so the content scrolls.
+            .verticalScroll(scrollState)
             .navigationBarsPadding()
             .padding(bottom = 16.dp),
     ) {
@@ -283,10 +196,8 @@ fun ChatToolsSheetContent(
                 modifier = Modifier
                     .fillMaxWidth()
                     .sheetRowRipple()
-                    .clickable {
-                        onOpenModelSelector()
-                        onDismiss()
-                    }
+                    // No onDismiss — see the KDoc above.
+                    .clickable { onOpenModelSelector() }
                     .padding(horizontal = 12.dp, vertical = 12.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
@@ -324,10 +235,7 @@ fun ChatToolsSheetContent(
                 modifier = Modifier
                     .fillMaxWidth()
                     .sheetRowRipple()
-                    .clickable {
-                        onOpenModelParameters()
-                        onDismiss()
-                    }
+                    .clickable { onOpenModelParameters() }
                     .padding(horizontal = 12.dp, vertical = 12.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
@@ -393,7 +301,7 @@ fun ChatToolsSheetContent(
                 modifier = Modifier
                     .fillMaxWidth()
                     .sheetRowRipple()
-                    .clickable { showMcpServers = !showMcpServers }
+                    .clickable { onMcpExpandedChange(!mcpExpanded) }
                     .padding(horizontal = 12.dp, vertical = 12.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
@@ -430,7 +338,7 @@ fun ChatToolsSheetContent(
             }
 
             // MCP server sub-list
-            if (showMcpServers) {
+            if (mcpExpanded) {
                 Column(
                     modifier = Modifier.padding(start = 40.dp),
                 ) {

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/EphemeralToolMeta.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/EphemeralToolMeta.kt
@@ -20,7 +20,7 @@ import org.jetbrains.compose.resources.StringResource
 
 /**
  * Single source of truth for the icon + label + description of the ephemeral chat tools,
- * shared by the tools bottom sheet ([ChatToolsBottomSheet]) and the input-bar pinned-tool
+ * shared by the tools bottom sheet ([ChatToolsSheetContent]) and the input-bar pinned-tool
  * chips ([PinnedToolsRow]) so the two surfaces can't drift. Returns null for keys mobile
  * doesn't surface as a toggle (e.g. `artifacts`, `mcp`, MCP server names).
  */

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ModelSelectorSheet.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ModelSelectorSheet.kt
@@ -131,15 +131,81 @@ fun ModelSelectorSheet(
     onSetApiKey: (endpointName: String) -> Unit,
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = false)
-    var searchQuery by remember { mutableStateOf("") }
-    val expandedGroups = remember {
-        mutableStateMapOf<String, Boolean>().apply {
-            availableModels.keys.forEach { put(it, false) }
-            if (agents.isNotEmpty()) put(EndpointConstants.AGENTS, false)
-            // Starred group starts collapsed too, matching the provider groups.
-            put(STARRED_GROUP_KEY, false)
-        }
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        dragHandle = { LowProfileDragHandle() },
+        sheetState = sheetState,
+        modifier = modifier,
+    ) {
+        ModelSelectorSheetContent(
+            endpointConfigs = endpointConfigs,
+            availableModels = availableModels,
+            agents = agents,
+            selectedEndpoint = selectedEndpoint,
+            selectedModel = selectedModel,
+            onModelSelect = onModelSelect,
+            onSetApiKey = onSetApiKey,
+            modifier = Modifier.fillMaxSize(),
+            serverUrl = serverUrl,
+            errorMessage = errorMessage,
+            onErrorDismiss = onErrorDismiss,
+            favoriteAgentIds = favoriteAgentIds,
+            favoriteModelKeys = favoriteModelKeys,
+            onToggleAgentFavorite = onToggleAgentFavorite,
+            onToggleModelFavorite = onToggleModelFavorite,
+            starredDisplay = starredDisplay,
+            endpointKeyStates = endpointKeyStates,
+        )
     }
+}
+
+/**
+ * The model selector body (header, search, grouped list), no sheet chrome. Rendered by the
+ * standalone [ModelSelectorSheet] and by `ChatOptionsBottomSheet`'s selector page. Has no
+ * `onDismiss` — each host decides what selection does (swap to Options vs. dismiss).
+ */
+@Composable
+fun ModelSelectorSheetContent(
+    endpointConfigs: Map<String, EndpointConfig>,
+    availableModels: Map<String, List<String>>,
+    agents: List<Agent>,
+    selectedEndpoint: String?,
+    selectedModel: String?,
+    onModelSelect: (endpoint: String, model: String) -> Unit,
+    /**
+     * Invoked with the endpoint name when the user taps the "Set API Key" CTA on
+     * a greyed group. Implementations should navigate to Settings → Provider API Keys.
+     */
+    onSetApiKey: (endpointName: String) -> Unit,
+    modifier: Modifier = Modifier,
+    serverUrl: String = "",
+    errorMessage: String? = null,
+    onErrorDismiss: () -> Unit = {},
+    favoriteAgentIds: Set<String> = emptySet(),
+    favoriteModelKeys: Set<String> = emptySet(),
+    onToggleAgentFavorite: ((agentId: String) -> Unit)? = null,
+    onToggleModelFavorite: ((endpoint: String, model: String) -> Unit)? = null,
+    /**
+     * Mobile-only preference controlling whether pinned items also appear in a
+     * dedicated section at the top of the sheet. [StarredModelsDisplay.OFF] keeps the
+     * historical behavior (favorites float to the top within their own group).
+     */
+    starredDisplay: StarredModelsDisplay = StarredModelsDisplay.OFF,
+    /**
+     * Per-endpoint user-provided-key state. Endpoints whose key is [KeyState.Unset]
+     * or [KeyState.Expired] render a greyed group with a "Set API Key" CTA. Absent
+     * keys (built-in endpoints) and [KeyState.Loading] / [KeyState.Set] all
+     * fail-open to the normal selectable rendering.
+     */
+    endpointKeyStates: Map<String, KeyState> = emptyMap(),
+    /** Rendered above the error banner and title; the paged host passes a back-arrow row. */
+    header: (@Composable () -> Unit)? = null,
+) {
+    var searchQuery by remember { mutableStateOf("") }
+    // Only user toggles land here; absent keys default collapsed via `== true` reads below. Not
+    // seeded — the sheet can mount before models/agents load, and a seed would miss late arrivals.
+    val expandedGroups = remember { mutableStateMapOf<String, Boolean>() }
     val isSearching = searchQuery.isNotBlank()
 
     // Filter to only show models for endpoints the user's server has enabled
@@ -196,199 +262,193 @@ fun ModelSelectorSheet(
     }
     val hasStarred = starredAgents.isNotEmpty() || starredModels.isNotEmpty()
 
-    ModalBottomSheet(
-        onDismissRequest = onDismiss,
-        dragHandle = { LowProfileDragHandle() },
-        sheetState = sheetState,
-        modifier = modifier,
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .imePadding()
+            .padding(bottom = 32.dp),
     ) {
-        Column(
+        header?.invoke()
+        // Banner applies its own 16dp inset, so it sits outside the Column's
+        // horizontal padding to line up with the other elements.
+        if (errorMessage != null) {
+            ErrorBanner(message = errorMessage, onDismiss = onErrorDismiss)
+        }
+        Text(
+            text = stringResource(Res.string.select_a_model),
+            style = MaterialTheme.typography.titleMedium,
             modifier = Modifier
-                .fillMaxSize()
-                .imePadding()
-                .padding(bottom = 32.dp),
-        ) {
-            // Banner applies its own 16dp inset, so it sits outside the Column's
-            // horizontal padding to line up with the other elements.
-            if (errorMessage != null) {
-                ErrorBanner(message = errorMessage, onDismiss = onErrorDismiss)
-            }
-            Text(
-                text = stringResource(Res.string.select_a_model),
-                style = MaterialTheme.typography.titleMedium,
-                modifier = Modifier
-                    .padding(horizontal = 16.dp)
-                    .padding(bottom = 16.dp),
-            )
+                .padding(horizontal = 16.dp)
+                .padding(bottom = 16.dp),
+        )
 
-            OutlinedTextField(
-                value = searchQuery,
-                onValueChange = { searchQuery = it },
-                placeholder = { Text("Search models...") },
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp),
-                singleLine = true,
-                trailingIcon = {
-                    if (searchQuery.isNotEmpty()) {
-                        IconButton(onClick = { searchQuery = "" }) {
-                            Icon(
-                                imageVector = Icons.Default.Clear,
-                                contentDescription = stringResource(Res.string.cd_clear_search),
-                            )
-                        }
-                    }
-                },
-            )
-
-            Spacer(modifier = Modifier.height(12.dp))
-
-            LazyColumn(
-                modifier = Modifier.weight(1f),
-            ) {
-                // Optional "Starred" section at the very top (mobile-only). Starred items
-                // are duplicated here — they still render in their own groups below.
-                if (showStarred && hasStarred) {
-                    // GROUPED renders a collapsible header and respects its toggle; TOP is a
-                    // flat, always-shown list closed off with a divider. OFF never reaches here.
-                    val starredItemsVisible = when (starredDisplay) {
-                        StarredModelsDisplay.GROUPED -> {
-                            val expanded = expandedGroups[STARRED_GROUP_KEY] != false
-                            item(key = "header_starred") {
-                                EndpointGroupHeader(
-                                    endpointName = STARRED_GROUP_KEY,
-                                    displayLabel = stringResource(Res.string.starred_group),
-                                    modelCount = starredAgents.size + starredModels.size,
-                                    isExpanded = expanded,
-                                    iconUrl = null,
-                                    leadingIcon = Icons.Default.Star,
-                                    onToggle = { expandedGroups[STARRED_GROUP_KEY] = !expanded },
-                                )
-                            }
-                            expanded
-                        }
-                        StarredModelsDisplay.TOP -> true
-                        StarredModelsDisplay.OFF -> false
-                    }
-                    if (starredItemsVisible) {
-                        // The flat TOP list reads as a dense quick-access strip; GROUPED keeps
-                        // the standard row rhythm since it sits behind a collapsible header.
-                        val starredPadding = if (starredDisplay == StarredModelsDisplay.TOP) {
-                            StarredItemVerticalPadding
-                        } else {
-                            ListItemVerticalPadding
-                        }
-                        items(starredAgents, key = { "starred_agent_${it.id}" }, contentType = { "agent" }) { agent ->
-                            AgentListItem(
-                                agent = agent,
-                                isSelected = selectedEndpoint == EndpointConstants.AGENTS && agent.id == selectedModel,
-                                serverUrl = serverUrl,
-                                onClick = { onModelSelect(EndpointConstants.AGENTS, agent.id) },
-                                isFavorite = true,
-                                onToggleFavorite = onToggleAgentFavorite?.let { toggle -> { toggle(agent.id) } },
-                                verticalPadding = starredPadding,
-                            )
-                        }
-                        items(
-                            starredModels,
-                            key = { (endpoint, model) -> "starred_model_$endpoint::$model" },
-                            contentType = { "model" },
-                        ) { (endpoint, model) ->
-                            ModelListItem(
-                                model = model,
-                                isSelected = endpoint == selectedEndpoint && model == selectedModel,
-                                isFavorite = true,
-                                onClick = { onModelSelect(endpoint, model) },
-                                onToggleFavorite = onToggleModelFavorite?.let { toggle -> { toggle(endpoint, model) } },
-                                verticalPadding = starredPadding,
-                            )
-                        }
-                    }
-                    if (starredDisplay == StarredModelsDisplay.TOP) {
-                        item(key = "starred_divider") {
-                            HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp))
-                        }
-                    }
-                }
-
-                // "My Agents" group (shown first, like the web frontend)
-                if (filteredAgents.isNotEmpty()) {
-                    val agentsExpanded = isSearching || expandedGroups[EndpointConstants.AGENTS] != false
-                    item(key = "header_agents") {
-                        EndpointGroupHeader(
-                            endpointName = EndpointConstants.AGENTS,
-                            displayLabel = "My Agents",
-                            modelCount = filteredAgents.size,
-                            isExpanded = agentsExpanded,
-                            iconUrl = null,
-                            onToggle = { if (!isSearching) expandedGroups[EndpointConstants.AGENTS] = !agentsExpanded },
+        OutlinedTextField(
+            value = searchQuery,
+            onValueChange = { searchQuery = it },
+            placeholder = { Text("Search models...") },
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp),
+            singleLine = true,
+            trailingIcon = {
+                if (searchQuery.isNotEmpty()) {
+                    IconButton(onClick = { searchQuery = "" }) {
+                        Icon(
+                            imageVector = Icons.Default.Clear,
+                            contentDescription = stringResource(Res.string.cd_clear_search),
                         )
                     }
-                    if (agentsExpanded) {
-                        items(filteredAgents, key = { "agents_${it.id}" }, contentType = { "agent" }) { agent ->
-                            AgentListItem(
-                                agent = agent,
-                                isSelected = selectedEndpoint == EndpointConstants.AGENTS && agent.id == selectedModel,
-                                serverUrl = serverUrl,
-                                onClick = { onModelSelect(EndpointConstants.AGENTS, agent.id) },
-                                isFavorite = agent.id in favoriteAgentIds,
-                                onToggleFavorite = onToggleAgentFavorite?.let { toggle -> { toggle(agent.id) } },
+                }
+            },
+        )
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        LazyColumn(
+            modifier = Modifier.weight(1f),
+        ) {
+            // Optional "Starred" section at the very top (mobile-only). Starred items
+            // are duplicated here — they still render in their own groups below.
+            if (showStarred && hasStarred) {
+                // GROUPED renders a collapsible header and respects its toggle; TOP is a
+                // flat, always-shown list closed off with a divider. OFF never reaches here.
+                val starredItemsVisible = when (starredDisplay) {
+                    StarredModelsDisplay.GROUPED -> {
+                        val expanded = expandedGroups[STARRED_GROUP_KEY] == true
+                        item(key = "header_starred") {
+                            EndpointGroupHeader(
+                                endpointName = STARRED_GROUP_KEY,
+                                displayLabel = stringResource(Res.string.starred_group),
+                                modelCount = starredAgents.size + starredModels.size,
+                                isExpanded = expanded,
+                                iconUrl = null,
+                                leadingIcon = Icons.Default.Star,
+                                onToggle = { expandedGroups[STARRED_GROUP_KEY] = !expanded },
                             )
                         }
+                        expanded
+                    }
+                    StarredModelsDisplay.TOP -> true
+                    StarredModelsDisplay.OFF -> false
+                }
+                if (starredItemsVisible) {
+                    // The flat TOP list reads as a dense quick-access strip; GROUPED keeps
+                    // the standard row rhythm since it sits behind a collapsible header.
+                    val starredPadding = if (starredDisplay == StarredModelsDisplay.TOP) {
+                        StarredItemVerticalPadding
+                    } else {
+                        ListItemVerticalPadding
+                    }
+                    items(starredAgents, key = { "starred_agent_${it.id}" }, contentType = { "agent" }) { agent ->
+                        AgentListItem(
+                            agent = agent,
+                            isSelected = selectedEndpoint == EndpointConstants.AGENTS && agent.id == selectedModel,
+                            serverUrl = serverUrl,
+                            onClick = { onModelSelect(EndpointConstants.AGENTS, agent.id) },
+                            isFavorite = true,
+                            onToggleFavorite = onToggleAgentFavorite?.let { toggle -> { toggle(agent.id) } },
+                            verticalPadding = starredPadding,
+                        )
+                    }
+                    items(
+                        starredModels,
+                        key = { (endpoint, model) -> "starred_model_$endpoint::$model" },
+                        contentType = { "model" },
+                    ) { (endpoint, model) ->
+                        ModelListItem(
+                            model = model,
+                            isSelected = endpoint == selectedEndpoint && model == selectedModel,
+                            isFavorite = true,
+                            onClick = { onModelSelect(endpoint, model) },
+                            onToggleFavorite = onToggleModelFavorite?.let { toggle -> { toggle(endpoint, model) } },
+                            verticalPadding = starredPadding,
+                        )
                     }
                 }
+                if (starredDisplay == StarredModelsDisplay.TOP) {
+                    item(key = "starred_divider") {
+                        HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp))
+                    }
+                }
+            }
 
-                // Endpoint model groups
-                filteredByEndpoint.forEach { (endpointName, models) ->
-                    val baseFiltered = if (!isSearching) {
-                        models
-                    } else if (searchQuery.length <= 2) {
-                        models.filter { fuzzyMatches(it, searchQuery) }
-                    } else {
-                        models.map { model -> model to fuzzyScore(model, searchQuery) }
-                            .filter { (_, score) -> score >= FUZZY_MATCH_THRESHOLD }
-                            .sortedByDescending { (_, score) -> score }
-                            .map { (model, _) -> model }
+            // "My Agents" group (shown first, like the web frontend)
+            if (filteredAgents.isNotEmpty()) {
+                val agentsExpanded = isSearching || expandedGroups[EndpointConstants.AGENTS] == true
+                item(key = "header_agents") {
+                    EndpointGroupHeader(
+                        endpointName = EndpointConstants.AGENTS,
+                        displayLabel = "My Agents",
+                        modelCount = filteredAgents.size,
+                        isExpanded = agentsExpanded,
+                        iconUrl = null,
+                        onToggle = { if (!isSearching) expandedGroups[EndpointConstants.AGENTS] = !agentsExpanded },
+                    )
+                }
+                if (agentsExpanded) {
+                    items(filteredAgents, key = { "agents_${it.id}" }, contentType = { "agent" }) { agent ->
+                        AgentListItem(
+                            agent = agent,
+                            isSelected = selectedEndpoint == EndpointConstants.AGENTS && agent.id == selectedModel,
+                            serverUrl = serverUrl,
+                            onClick = { onModelSelect(EndpointConstants.AGENTS, agent.id) },
+                            isFavorite = agent.id in favoriteAgentIds,
+                            onToggleFavorite = onToggleAgentFavorite?.let { toggle -> { toggle(agent.id) } },
+                        )
                     }
-                    // Pinned models (v0.8.5+) sort to the top when not searching.
-                    val filteredModels = if (isSearching) {
-                        baseFiltered
-                    } else {
-                        baseFiltered.sortedByDescending { "$endpointName::$it" in favoriteModelKeys }
+                }
+            }
+
+            // Endpoint model groups
+            filteredByEndpoint.forEach { (endpointName, models) ->
+                val baseFiltered = if (!isSearching) {
+                    models
+                } else if (searchQuery.length <= 2) {
+                    models.filter { fuzzyMatches(it, searchQuery) }
+                } else {
+                    models.map { model -> model to fuzzyScore(model, searchQuery) }
+                        .filter { (_, score) -> score >= FUZZY_MATCH_THRESHOLD }
+                        .sortedByDescending { (_, score) -> score }
+                        .map { (model, _) -> model }
+                }
+                // Pinned models (v0.8.5+) sort to the top when not searching.
+                val filteredModels = if (isSearching) {
+                    baseFiltered
+                } else {
+                    baseFiltered.sortedByDescending { "$endpointName::$it" in favoriteModelKeys }
+                }
+                if (filteredModels.isNotEmpty()) {
+                    val config = endpointConfigs[endpointName]
+                    val displayLabel = config?.modelDisplayLabel ?: endpointName
+                    // Auto-expand while searching so matches in collapsed groups are visible;
+                    // otherwise use manual toggle state.
+                    val isExpanded = isSearching || expandedGroups[endpointName] == true
+                    // Endpoints with userProvide=true and Unset/Expired key render disabled
+                    // with a "Set API Key" CTA. Loading and absent states fail-open.
+                    val keyState = endpointKeyStates[endpointName]
+                    val needsKey = keyState is KeyState.Unset || keyState is KeyState.Expired
+                    val effectiveExpanded = isExpanded && !needsKey
+                    item(key = "header_$endpointName") {
+                        EndpointGroupHeader(
+                            endpointName = endpointName,
+                            displayLabel = displayLabel,
+                            modelCount = filteredModels.size,
+                            isExpanded = effectiveExpanded,
+                            iconUrl = config?.iconURL,
+                            onToggle = { if (!isSearching) expandedGroups[endpointName] = !isExpanded },
+                            needsKey = needsKey,
+                            onSetApiKey = { onSetApiKey(endpointName) },
+                        )
                     }
-                    if (filteredModels.isNotEmpty()) {
-                        val config = endpointConfigs[endpointName]
-                        val displayLabel = config?.modelDisplayLabel ?: endpointName
-                        // Auto-expand while searching so matches in collapsed groups are visible;
-                        // otherwise use manual toggle state.
-                        val isExpanded = isSearching || expandedGroups[endpointName] != false
-                        // Endpoints with userProvide=true and Unset/Expired key render disabled
-                        // with a "Set API Key" CTA. Loading and absent states fail-open.
-                        val keyState = endpointKeyStates[endpointName]
-                        val needsKey = keyState is KeyState.Unset || keyState is KeyState.Expired
-                        val effectiveExpanded = isExpanded && !needsKey
-                        item(key = "header_$endpointName") {
-                            EndpointGroupHeader(
-                                endpointName = endpointName,
-                                displayLabel = displayLabel,
-                                modelCount = filteredModels.size,
-                                isExpanded = effectiveExpanded,
-                                iconUrl = config?.iconURL,
-                                onToggle = { if (!isSearching) expandedGroups[endpointName] = !isExpanded },
-                                needsKey = needsKey,
-                                onSetApiKey = { onSetApiKey(endpointName) },
+                    if (effectiveExpanded) {
+                        items(filteredModels, key = { "${endpointName}_$it" }, contentType = { "model" }) { model ->
+                            ModelListItem(
+                                model = model,
+                                isSelected = endpointName == selectedEndpoint && model == selectedModel,
+                                isFavorite = "$endpointName::$model" in favoriteModelKeys,
+                                onClick = { onModelSelect(endpointName, model) },
+                                onToggleFavorite = onToggleModelFavorite?.let { toggle -> { toggle(endpointName, model) } },
                             )
-                        }
-                        if (effectiveExpanded) {
-                            items(filteredModels, key = { "${endpointName}_$it" }, contentType = { "model" }) { model ->
-                                ModelListItem(
-                                    model = model,
-                                    isSelected = endpointName == selectedEndpoint && model == selectedModel,
-                                    isFavorite = "$endpointName::$model" in favoriteModelKeys,
-                                    onClick = { onModelSelect(endpointName, model) },
-                                    onToggleFavorite = onToggleModelFavorite?.let { toggle -> { toggle(endpointName, model) } },
-                                )
-                            }
                         }
                     }
                 }

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatModelSheets.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatModelSheets.kt
@@ -1,0 +1,97 @@
+package com.garfiec.librechat.feature.chat.screen
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import com.garfiec.librechat.feature.chat.components.ModelSelectorSheet
+import com.garfiec.librechat.feature.chat.viewmodel.ChatUiState
+import com.garfiec.librechat.feature.chat.viewmodel.ChatViewModel
+
+/*
+ * The standalone model-selector sheets, shared by the Android and iOS chat screens. Unlike the
+ * selector page in `ChatOptionsBottomSheet`, these open straight to the list and dismiss back to
+ * the chat on selection. Both surfaces share the list body, ModelSelectorSheetContent.
+ */
+
+/**
+ * The primary standalone selector, driven by `uiState.showModelSheet` (top-bar chip, dual-pane
+ * primary, send-block auto-open, which supplies [sendBlockMessage]). Renders unconditionally.
+ */
+@Composable
+internal fun PrimaryModelSelectorSheet(
+    uiState: ChatUiState,
+    viewModel: ChatViewModel,
+    sendBlockMessage: String?,
+    onNavigateToProviderKeys: (endpointName: String?) -> Unit,
+) {
+    ModelSelectorSheet(
+        endpointConfigs = uiState.endpointConfigs,
+        availableModels = uiState.availableModels,
+        agents = uiState.agents,
+        selectedEndpoint = uiState.selectedEndpoint,
+        selectedModel = uiState.selectedModel,
+        onModelSelect = { endpoint, model ->
+            viewModel.onModelSelected(endpoint, model)
+            // Clear a pending snackbar for the same error so it doesn't flash behind the close.
+            viewModel.dismissError()
+            viewModel.dismissSendBlockReason()
+            viewModel.dismissModelSheet()
+        },
+        onDismiss = {
+            viewModel.dismissError()
+            viewModel.dismissSendBlockReason()
+            viewModel.dismissModelSheet()
+        },
+        serverUrl = uiState.serverUrl,
+        // Send-block reasons take precedence: when set, the sheet was auto-opened
+        // to help the user resolve the block, so surface that context inline.
+        errorMessage = sendBlockMessage ?: uiState.error,
+        onErrorDismiss = {
+            viewModel.dismissSendBlockReason()
+            viewModel.dismissError()
+        },
+        favoriteAgentIds = uiState.favoriteAgentIds,
+        favoriteModelKeys = uiState.favoriteModelKeys,
+        onToggleAgentFavorite = viewModel::toggleAgentFavorite,
+        onToggleModelFavorite = viewModel::toggleModelFavorite,
+        starredDisplay = uiState.starredModelsDisplay,
+        endpointKeyStates = uiState.endpointKeyStates,
+        onSetApiKey = { name -> onNavigateToProviderKeys(name) },
+    )
+}
+
+/**
+ * The secondary selector for comparison mode's second model (dual-pane button only; the composer's
+ * "+" edits it through the options sheet). Renders unconditionally.
+ */
+@Composable
+internal fun SecondaryModelSelectorSheet(
+    uiState: ChatUiState,
+    viewModel: ChatViewModel,
+    onDismiss: () -> Unit,
+    onNavigateToProviderKeys: (endpointName: String?) -> Unit,
+) {
+    // Route through prepareModelSelector like every selector path, so a failed cold-start agent
+    // load can self-heal here too (see its KDoc).
+    LaunchedEffect(Unit) { viewModel.prepareModelSelector() }
+
+    ModelSelectorSheet(
+        endpointConfigs = uiState.endpointConfigs,
+        availableModels = uiState.availableModels,
+        agents = uiState.agents,
+        selectedEndpoint = uiState.comparisonState.secondaryEndpoint,
+        selectedModel = uiState.comparisonState.secondaryModel,
+        onModelSelect = { endpoint, model ->
+            viewModel.setSecondaryModel(endpoint, model)
+            onDismiss()
+        },
+        onDismiss = onDismiss,
+        serverUrl = uiState.serverUrl,
+        favoriteAgentIds = uiState.favoriteAgentIds,
+        favoriteModelKeys = uiState.favoriteModelKeys,
+        onToggleAgentFavorite = viewModel::toggleAgentFavorite,
+        onToggleModelFavorite = viewModel::toggleModelFavorite,
+        starredDisplay = uiState.starredModelsDisplay,
+        endpointKeyStates = uiState.endpointKeyStates,
+        onSetApiKey = { name -> onNavigateToProviderKeys(name) },
+    )
+}

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatOptionsSheetHost.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatOptionsSheetHost.kt
@@ -1,0 +1,137 @@
+package com.garfiec.librechat.feature.chat.screen
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import com.garfiec.librechat.core.common.EndpointConstants
+import com.garfiec.librechat.feature.chat.components.ChatOptionsBottomSheet
+import com.garfiec.librechat.feature.chat.components.ChatOptionsSheetController
+import com.garfiec.librechat.feature.chat.components.ChatToolsPageParams
+import com.garfiec.librechat.feature.chat.components.ModelParametersPageParams
+import com.garfiec.librechat.feature.chat.components.ModelSelectorPageParams
+import com.garfiec.librechat.feature.chat.viewmodel.ChatUiState
+import com.garfiec.librechat.feature.chat.viewmodel.ChatViewModel
+
+/**
+ * Hosts the chat options sheet (the "+" menu, with selector/parameters as pages) for both
+ * platforms, opened through [controller]. In commonMain so the Android compile type-checks the
+ * wiring iosMain shares. Callers pass their own attach actions, which are platform plumbing.
+ */
+@Composable
+internal fun ChatOptionsSheetHost(
+    controller: ChatOptionsSheetController,
+    uiState: ChatUiState,
+    viewModel: ChatViewModel,
+    /**
+     * True when comparison mode is on and its second tab is active, i.e. the composer is editing
+     * the secondary model. Points the selector page at that model instead of the primary.
+     */
+    isSecondaryTab: Boolean,
+    /** Model label for the tools page's Model row; the caller resolves it for the active tab. */
+    selectedModelDisplay: String?,
+    onAttachFiles: () -> Unit,
+    onTakePhoto: () -> Unit,
+    onPickPhotos: () -> Unit,
+    onAttachFromServer: () -> Unit,
+    onNavigateToProviderKeys: (endpointName: String?) -> Unit,
+    onShowSavePresetDialog: () -> Unit,
+) {
+    // A send-block auto-opens the standalone selector; close this one so they can't stack. Gate on
+    // the flag (not just its change) to also catch it being already true when this sheet opens.
+    LaunchedEffect(uiState.showModelSheet) {
+        if (uiState.showModelSheet) controller.close()
+    }
+    val page = controller.openPage
+    if (page == null || uiState.showModelSheet) return
+
+    // The agent behind the current selection, if the endpoint is "agents" — routes the parameters
+    // page to the agent's underlying provider rather than the "agents" pseudo-endpoint.
+    val activeAgent = remember(uiState.agents, uiState.selectedModel, uiState.selectedEndpoint) {
+        if (uiState.selectedEndpoint == EndpointConstants.AGENTS) {
+            uiState.agents.find { it.id == uiState.selectedModel }
+        } else {
+            null
+        }
+    }
+
+    ChatOptionsBottomSheet(
+        page = page,
+        onPageChange = controller::open,
+        onDismiss = controller::close,
+        tools = ChatToolsPageParams(
+            enabledTools = uiState.effectiveEnabledTools,
+            onToggleTool = viewModel::toggleTool,
+            mcpServers = uiState.mcpServers,
+            selectedMcpServerNames = uiState.selectedMcpServerNames,
+            onToggleMcpServer = viewModel::toggleMcpServer,
+            onAttachFiles = onAttachFiles,
+            onTakePhoto = onTakePhoto,
+            onPickPhotos = onPickPhotos,
+            onAttachFromServer = onAttachFromServer,
+            selectedModelDisplay = selectedModelDisplay,
+            isCodeInterpreterAvailable = uiState.isCodeInterpreterAvailable,
+            webSearchEnabled = uiState.webSearchEnabled,
+            urlContextEnabled = uiState.urlContextProviderGate,
+            runCodeEnabled = uiState.runCodeEnabled,
+            fileSearchEnabled = uiState.fileSearchEnabled,
+            mcpServersEnabled = uiState.mcpServersEnabled,
+            gates = uiState.chatInputGates,
+            contextUsage = uiState.contextUsage,
+            tokenUsage = uiState.tokenUsage,
+            contextUsageEnabled = uiState.contextUsageEnabled,
+            contextBarPlacement = uiState.contextBarPlacement,
+            contextGaugeExpanded = uiState.contextGaugeExpanded,
+            onContextGaugeExpandedChange = viewModel::setContextGaugeExpanded,
+        ),
+        // Point the selector page at the active tab's model, so the sheet needs no comparison branch.
+        selector = ModelSelectorPageParams(
+            endpointConfigs = uiState.endpointConfigs,
+            availableModels = uiState.availableModels,
+            agents = uiState.agents,
+            selectedEndpoint = if (isSecondaryTab) {
+                uiState.comparisonState.secondaryEndpoint
+            } else {
+                uiState.selectedEndpoint
+            },
+            selectedModel = if (isSecondaryTab) {
+                uiState.comparisonState.secondaryModel
+            } else {
+                uiState.selectedModel
+            },
+            // Neither branch clears the error: the sheet clears the selector's inline banner on
+            // page-leave itself (see ChatOptionsBottomSheet), the only error that can flash.
+            onModelSelect = if (isSecondaryTab) {
+                viewModel::setSecondaryModel
+            } else {
+                viewModel::onModelSelected
+            },
+            onSetApiKey = { name -> onNavigateToProviderKeys(name) },
+            onSurfaced = viewModel::prepareModelSelector,
+            // Inline because the Scaffold snackbar draws behind the sheet scrim.
+            errorMessage = uiState.error,
+            onErrorDismiss = viewModel::dismissError,
+            serverUrl = uiState.serverUrl,
+            favoriteAgentIds = uiState.favoriteAgentIds,
+            favoriteModelKeys = uiState.favoriteModelKeys,
+            onToggleAgentFavorite = viewModel::toggleAgentFavorite,
+            onToggleModelFavorite = viewModel::toggleModelFavorite,
+            starredDisplay = uiState.starredModelsDisplay,
+            endpointKeyStates = uiState.endpointKeyStates,
+        ),
+        // Always the primary model, even on the secondary tab: ComparisonState carries no per-pane
+        // parameters, so there is nothing else to point this at (pre-existing; porting web's
+        // per-addedConvo parameters would be the real fix).
+        parameters = ModelParametersPageParams(
+            parameters = uiState.modelParameters,
+            onParametersChange = viewModel::updateModelParameters,
+            selectedEndpoint = uiState.selectedEndpoint,
+            extendedEffortSupported = uiState.extendedEffortSupported,
+            selectedProvider = activeAgent?.provider,
+            selectedModel = activeAgent?.model ?: uiState.selectedModel,
+            onSaveAsPreset = {
+                controller.close()
+                onShowSavePresetDialog()
+            },
+        ),
+    )
+}

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatUiState.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatUiState.kt
@@ -79,7 +79,6 @@ data class ChatUiState(
     val availableModels: Map<String, List<String>> get() = selection.availableModels
     val agents: List<Agent> get() = selection.agents
     val modelParameters: ModelParameters get() = selection.modelParameters
-    val showModelParameters: Boolean get() = selection.showModelParameters
     val showModelSheet: Boolean get() = selection.showModelSheet
     val enabledTools: Set<String> get() = selection.enabledTools
     val mcpServers: List<McpServerDisplayData> get() = selection.mcpServers
@@ -244,7 +243,7 @@ data class ChatUiState(
 
     /**
      * Bundle of the feature gates that flow into the composer ([ChatInput] →
-     * [ChatToolsBottomSheet]), so the four are threaded as one value across both
+     * [ChatToolsSheetContent]), so the four are threaded as one value across both
      * platforms instead of four parallel params. Built from the existing fields;
      * see each property for its gating rule. (`presetsEnabled` is not included —
      * it flows to the top bar, a different path.)

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModel.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModel.kt
@@ -1420,16 +1420,21 @@ class ChatViewModel(
     fun openModelSheet() = surfaceModelSheet()
 
     /**
-     * Single choke point for showing the model-selector sheet — user-initiated (model
-     * chip) and send-blocked auto-opens alike. Opening the selector retries a failed
-     * agent load so the user can actually pick an agent, and refetches favorites to
-     * self-heal a failed cold-start fetch (see [FavoritesDelegate.refresh]); routing
-     * every open through here keeps both from being forgotten on a future open path. A
-     * null [reason] leaves the current sendBlockReason untouched.
+     * Side effects of surfacing the selector (retry a failed agent load, refetch favorites), split
+     * out for the paged sheet, which shows the selector without setting `showModelSheet`. Every
+     * selector path must route through here or these self-heals are lost.
      */
-    private fun surfaceModelSheet(reason: SendBlockReason? = null) {
+    fun prepareModelSelector() {
         modelDelegate.retryAgentsIfFailed(isNewConversation)
         favoritesDelegate.refresh()
+    }
+
+    /**
+     * Single choke point for the *standalone* selector sheet, layering the sheet flag over
+     * [prepareModelSelector]. A null [reason] leaves the current sendBlockReason untouched.
+     */
+    private fun surfaceModelSheet(reason: SendBlockReason? = null) {
+        prepareModelSelector()
         _uiState.update {
             it.copy(
                 composer = it.composer.copy(sendBlockReason = reason ?: it.sendBlockReason),
@@ -1648,8 +1653,6 @@ class ChatViewModel(
     fun getSecondaryModelDisplayName(): String? = comparisonDelegate.getSecondaryModelDisplayName()
     fun toggleMcpServer(serverName: String) = modelDelegate.toggleMcpServer(serverName)
     fun toggleTool(toolName: String) = modelDelegate.toggleTool(toolName)
-    fun showModelParameters() = modelDelegate.showModelParameters()
-    fun hideModelParameters() = modelDelegate.hideModelParameters()
     fun updateModelParameters(parameters: ModelParameters) = modelDelegate.updateModelParameters(parameters)
 
     fun branchFromComparison(agentId: String) = comparisonDelegate.branchFromComparison(agentId)

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/FeatureGatesState.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/FeatureGatesState.kt
@@ -40,7 +40,7 @@ data class FeatureGatesState(
 )
 
 /**
- * Feature gates that flow into the composer ([ChatInput] → [ChatToolsBottomSheet]),
+ * Feature gates that flow into the composer ([ChatInput] → [ChatToolsSheetContent]),
  * bundled so they thread as one value across Android and iOS. Each defaults to true
  * (shown) so a default-constructed bundle is fully permissive. Built by
  * [ChatUiState.chatInputGates]; see [ChatUiState.modelSelectEnabled] /

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ModelSelectionState.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ModelSelectionState.kt
@@ -29,10 +29,11 @@ data class ModelSelectionState(
     val availableModels: Map<String, List<String>> = emptyMap(),
     val agents: List<Agent> = emptyList(),
     val modelParameters: ModelParameters = ModelParameters.DEFAULT,
-    val showModelParameters: Boolean = false,
-    /** Single source of truth for whether the model-selector sheet is open. Preflight
-     *  failures and readiness timeouts flip this to true so the user sees the sheet with
-     *  a send-block banner. */
+    /** Single source of truth for whether the *standalone* model-selector sheet is open — the
+     *  top-bar chip, the comparison dual-pane, and send-block auto-opens. Preflight failures and
+     *  readiness timeouts flip this to true so the user sees the sheet with a send-block banner.
+     *  The chat options sheet shows the selector as an in-sheet page off its own local state, so
+     *  it never sets this. */
     val showModelSheet: Boolean = false,
     val enabledTools: Set<String> = emptySet(),
     val mcpServers: List<McpServerDisplayData> = emptyList(),

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/ModelSelectionDelegate.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/ModelSelectionDelegate.kt
@@ -771,14 +771,6 @@ class ModelSelectionDelegate(
         }
     }
 
-    fun showModelParameters() {
-        handle.update { selection = selection.copy(showModelParameters = true) }
-    }
-
-    fun hideModelParameters() {
-        handle.update { selection = selection.copy(showModelParameters = false) }
-    }
-
     fun updateModelParameters(parameters: ModelParameters) {
         handle.update { selection = selection.copy(modelParameters = parameters) }
     }

--- a/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/components/IosChatInput.kt
+++ b/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/components/IosChatInput.kt
@@ -19,10 +19,7 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -44,6 +41,11 @@ fun IosChatInput(
     onInputChanged: (String) -> Unit,
     onSend: () -> Unit,
     onStop: () -> Unit,
+    /**
+     * Opens the chat options sheet from the "+" button. The sheet is hosted by the chat screen,
+     * not here — see `ChatOptionsSheetController`.
+     */
+    onOpenTools: () -> Unit,
     modifier: Modifier = Modifier,
     onQueue: () -> Unit = {},
     canQueue: Boolean = false,
@@ -64,38 +66,23 @@ fun IosChatInput(
     onToggleTool: (String) -> Unit = {},
     mcpServers: List<McpServerDisplayData> = emptyList(),
     selectedMcpServerNames: Set<String> = emptySet(),
-    onToggleMcpServer: (String) -> Unit = {},
-    onOpenModelParameters: () -> Unit = {},
     isRecording: Boolean = false,
     isTranscribing: Boolean = false,
     onStartRecording: () -> Unit = {},
     onStopRecording: () -> Unit = {},
-    onOpenModelSelector: () -> Unit = {},
     selectedModelDisplay: String? = null,
     isCodeInterpreterAvailable: Boolean = true,
     attachedFiles: List<AttachedFile> = emptyList(),
     onRemoveFile: (AttachedFile) -> Unit = {},
     hasClipboardImage: Boolean = false,
     onPasteImage: (() -> Unit)? = null,
-    onAttachFiles: () -> Unit = {},
-    onTakePhoto: () -> Unit = {},
-    onPickPhotos: () -> Unit = {},
-    onAttachFromServer: () -> Unit = {},
-    webSearchEnabled: Boolean = true,
-    urlContextEnabled: Boolean = false,
-    runCodeEnabled: Boolean = true,
-    fileSearchEnabled: Boolean = true,
-    mcpServersEnabled: Boolean = true,
     gates: ChatInputGates = ChatInputGates(),
     contextUsage: ContextUsage? = null,
     tokenUsage: TokenUsage? = null,
     contextUsageEnabled: Boolean = false,
     contextBarPlacement: ContextBarPlacement = ContextBarPlacement.OPTIONS_SHEET,
-    contextGaugeExpanded: Boolean = false,
-    onContextGaugeExpandedChange: (Boolean) -> Unit = {},
 ) {
     val snackbarHostState = remember { SnackbarHostState() }
-    var showToolsSheet by remember { mutableStateOf(false) }
 
     val state = ChatInputState(
         inputText = inputText,
@@ -140,7 +127,7 @@ fun IosChatInput(
         leadingButtons = {
             // "+" button to open tools bottom sheet (matches Android behavior)
             FilledTonalIconButton(
-                onClick = { showToolsSheet = true },
+                onClick = onOpenTools,
                 modifier = Modifier.size(48.dp),
             ) {
                 Icon(
@@ -231,53 +218,4 @@ fun IosChatInput(
         },
     )
 
-    // Tools bottom sheet with native iOS file picker actions
-    if (showToolsSheet) {
-        ChatToolsBottomSheet(
-            enabledTools = enabledTools,
-            onToggleTool = onToggleTool,
-            mcpServers = mcpServers,
-            selectedMcpServerNames = selectedMcpServerNames,
-            onToggleMcpServer = onToggleMcpServer,
-            onAttachFiles = {
-                showToolsSheet = false
-                onAttachFiles()
-            },
-            onTakePhoto = {
-                showToolsSheet = false
-                onTakePhoto()
-            },
-            onPickPhotos = {
-                showToolsSheet = false
-                onPickPhotos()
-            },
-            onAttachFromServer = {
-                showToolsSheet = false
-                onAttachFromServer()
-            },
-            onOpenModelParameters = {
-                showToolsSheet = false
-                onOpenModelParameters()
-            },
-            onOpenModelSelector = {
-                showToolsSheet = false
-                onOpenModelSelector()
-            },
-            selectedModelDisplay = selectedModelDisplay,
-            onDismiss = { showToolsSheet = false },
-            isCodeInterpreterAvailable = isCodeInterpreterAvailable,
-            webSearchEnabled = webSearchEnabled,
-            urlContextEnabled = urlContextEnabled,
-            runCodeEnabled = runCodeEnabled,
-            fileSearchEnabled = fileSearchEnabled,
-            mcpServersEnabled = mcpServersEnabled,
-            gates = gates,
-            contextUsage = contextUsage,
-            tokenUsage = tokenUsage,
-            contextUsageEnabled = contextUsageEnabled,
-            contextBarPlacement = contextBarPlacement,
-            contextGaugeExpanded = contextGaugeExpanded,
-            onContextGaugeExpandedChange = onContextGaugeExpandedChange,
-        )
-    }
 }

--- a/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/screen/PlatformScreens.ios.kt
+++ b/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/screen/PlatformScreens.ios.kt
@@ -43,11 +43,11 @@ import com.garfiec.librechat.core.common.EndpointConstants
 import com.garfiec.librechat.core.data.datastore.ChatFontSize
 import com.garfiec.librechat.core.data.datastore.LatexRenderer
 import com.garfiec.librechat.feature.chat.components.ChatFloatingTopBar
+import com.garfiec.librechat.feature.chat.components.rememberChatOptionsSheetController
 import com.garfiec.librechat.feature.chat.components.IosChatInput
 import com.garfiec.librechat.feature.chat.components.LandingContent
 import com.garfiec.librechat.feature.chat.components.ChatRoot
 import com.garfiec.librechat.feature.chat.components.MessageList
-import com.garfiec.librechat.feature.chat.components.ModelSelectorSheet
 import com.garfiec.librechat.feature.chat.components.PresetPicker
 import com.garfiec.librechat.feature.chat.components.SavePresetDialog
 import com.garfiec.librechat.feature.chat.resources.*
@@ -135,6 +135,32 @@ actual fun ChatScreen(
     var showRenameDialog by remember { mutableStateOf(false) }
     var showSecondaryModelSheet by remember { mutableStateOf(false) }
     var activeComparisonTab by remember { mutableStateOf(0) }
+
+    // Secondary model on comparison tab 1, primary otherwise. Hoisted so IosChatInput and
+    // ChatOptionsSheetHost share one computation rather than each re-running the agents scan.
+    val isSecondaryTab = uiState.comparisonState.isEnabled && activeComparisonTab == 1
+    val selectedModelDisplay = if (isSecondaryTab) {
+        viewModel.getSecondaryModelDisplayName()
+            ?: uiState.comparisonState.secondaryModel
+            ?: displayModel
+    } else {
+        displayModel
+    }
+
+    // Options sheet ("+" menu, selector/parameters as pages). Independent of uiState.showModelSheet
+    // (the standalone selector), which still dismisses straight to the chat.
+    val optionsController = rememberChatOptionsSheetController()
+    // Native iOS picker actions. Hoisted here (they used to live on IosChatInput) because the
+    // options sheet that invokes them is now hosted at this level, not inside the composer.
+    val onAttachFilesAction: () -> Unit = {
+        openDocumentPicker { files -> if (files.isNotEmpty()) viewModel.onFilesSelected(files) }
+    }
+    val onTakePhotoAction: () -> Unit = {
+        openCamera { files -> if (files.isNotEmpty()) viewModel.onFilesSelected(files) }
+    }
+    val onPickPhotosAction: () -> Unit = {
+        openPhotoPicker { files -> if (files.isNotEmpty()) viewModel.onFilesSelected(files) }
+    }
 
     // Check clipboard for image content
     var hasClipboardImage by remember { mutableStateOf(false) }
@@ -312,7 +338,6 @@ actual fun ChatScreen(
             val isAnyStreaming = uiState.isStreaming ||
                 uiState.comparisonState.primaryIsStreaming ||
                 uiState.comparisonState.secondaryIsStreaming
-            val isSecondaryTab = uiState.comparisonState.isEnabled && activeComparisonTab == 1
             IosChatInput(
                 inputText = uiState.inputText,
                 isStreaming = isAnyStreaming,
@@ -321,6 +346,7 @@ actual fun ChatScreen(
                     viewModel.sendMessage()
                 },
                 onStop = viewModel::stopGeneration,
+                onOpenTools = { optionsController.open() },
                 onQueue = { viewModel.queueMessage() },
                 canQueue = uiState.canQueueFollowUp,
                 enabledTools = uiState.effectiveEnabledTools,
@@ -328,26 +354,11 @@ actual fun ChatScreen(
                 onToggleTool = viewModel::toggleTool,
                 mcpServers = uiState.mcpServers,
                 selectedMcpServerNames = uiState.selectedMcpServerNames,
-                onToggleMcpServer = viewModel::toggleMcpServer,
                 isRecording = uiState.isRecording,
                 isTranscribing = uiState.isTranscribing,
                 onStartRecording = viewModel::startRecording,
                 onStopRecording = viewModel::stopRecording,
-                onOpenModelParameters = viewModel::showModelParameters,
-                onOpenModelSelector = {
-                    if (isSecondaryTab) {
-                        showSecondaryModelSheet = true
-                    } else {
-                        viewModel.openModelSheet()
-                    }
-                },
-                selectedModelDisplay = if (isSecondaryTab) {
-                    viewModel.getSecondaryModelDisplayName()
-                        ?: uiState.comparisonState.secondaryModel
-                        ?: displayModel
-                } else {
-                    displayModel
-                },
+                selectedModelDisplay = selectedModelDisplay,
                 isCodeInterpreterAvailable = uiState.isCodeInterpreterAvailable,
                 attachedFiles = attachedFiles,
                 onRemoveFile = viewModel::removeFile,
@@ -362,40 +373,11 @@ actual fun ChatScreen(
                         hasClipboardImage = clipboardHasImage()
                     }
                 },
-                onAttachFiles = {
-                    openDocumentPicker { files ->
-                        if (files.isNotEmpty()) {
-                            viewModel.onFilesSelected(files)
-                        }
-                    }
-                },
-                onTakePhoto = {
-                    openCamera { files ->
-                        if (files.isNotEmpty()) {
-                            viewModel.onFilesSelected(files)
-                        }
-                    }
-                },
-                onAttachFromServer = onAttachFromServer,
-                onPickPhotos = {
-                    openPhotoPicker { files ->
-                        if (files.isNotEmpty()) {
-                            viewModel.onFilesSelected(files)
-                        }
-                    }
-                },
-                webSearchEnabled = uiState.webSearchEnabled,
-                urlContextEnabled = uiState.urlContextProviderGate,
-                runCodeEnabled = uiState.runCodeEnabled,
-                fileSearchEnabled = uiState.fileSearchEnabled,
-                mcpServersEnabled = uiState.mcpServersEnabled,
                 gates = uiState.chatInputGates,
                 contextUsage = uiState.contextUsage,
                 tokenUsage = uiState.tokenUsage,
                 contextUsageEnabled = uiState.contextUsageEnabled,
                 contextBarPlacement = uiState.contextBarPlacement,
-                contextGaugeExpanded = uiState.contextGaugeExpanded,
-                onContextGaugeExpandedChange = viewModel::setContextGaugeExpanded,
                 queuedPausedCount = uiState.pausedQueueCount,
                 isEditingQueued = uiState.isEditingQueued,
                 onCommitEdit = viewModel::commitQueuedEdit,
@@ -431,67 +413,37 @@ actual fun ChatScreen(
         }
     }
 
+    ChatOptionsSheetHost(
+        controller = optionsController,
+        uiState = uiState,
+        viewModel = viewModel,
+        isSecondaryTab = isSecondaryTab,
+        selectedModelDisplay = selectedModelDisplay,
+        onAttachFiles = onAttachFilesAction,
+        onTakePhoto = onTakePhotoAction,
+        onPickPhotos = onPickPhotosAction,
+        onAttachFromServer = onAttachFromServer,
+        onNavigateToProviderKeys = onNavigateToProviderKeys,
+        onShowSavePresetDialog = { showSavePresetDialog = true },
+    )
+
     // Model selector bottom sheet
     if (uiState.showModelSheet) {
-        ModelSelectorSheet(
-            endpointConfigs = uiState.endpointConfigs,
-            availableModels = uiState.availableModels,
-            agents = uiState.agents,
-            selectedEndpoint = uiState.selectedEndpoint,
-            selectedModel = uiState.selectedModel,
-            onModelSelect = { endpoint, model ->
-                viewModel.onModelSelected(endpoint, model)
-                // Clear any pending scaffold-level snackbar for the same error so it
-                // doesn't flash behind the sheet's close animation. Harmless no-op when
-                // error is already null.
-                viewModel.dismissError()
-                viewModel.dismissSendBlockReason()
-                viewModel.dismissModelSheet()
-            },
-            onDismiss = {
-                viewModel.dismissError()
-                viewModel.dismissSendBlockReason()
-                viewModel.dismissModelSheet()
-            },
-            serverUrl = uiState.serverUrl,
-            // Send-block reasons take precedence: when set, the sheet was auto-opened
-            // to help the user resolve the block, so surface that context inline.
-            errorMessage = sendBlockMessage ?: uiState.error,
-            onErrorDismiss = {
-                viewModel.dismissSendBlockReason()
-                viewModel.dismissError()
-            },
-            favoriteAgentIds = uiState.favoriteAgentIds,
-            favoriteModelKeys = uiState.favoriteModelKeys,
-            onToggleAgentFavorite = viewModel::toggleAgentFavorite,
-            onToggleModelFavorite = viewModel::toggleModelFavorite,
-            starredDisplay = uiState.starredModelsDisplay,
-            endpointKeyStates = uiState.endpointKeyStates,
-            onSetApiKey = { name -> onNavigateToProviderKeys(name) },
+        PrimaryModelSelectorSheet(
+            uiState = uiState,
+            viewModel = viewModel,
+            sendBlockMessage = sendBlockMessage,
+            onNavigateToProviderKeys = onNavigateToProviderKeys,
         )
     }
 
     // Secondary model selector sheet for comparison mode
     if (showSecondaryModelSheet) {
-        ModelSelectorSheet(
-            endpointConfigs = uiState.endpointConfigs,
-            availableModels = uiState.availableModels,
-            agents = uiState.agents,
-            selectedEndpoint = uiState.comparisonState.secondaryEndpoint,
-            selectedModel = uiState.comparisonState.secondaryModel,
-            onModelSelect = { endpoint, model ->
-                viewModel.setSecondaryModel(endpoint, model)
-                showSecondaryModelSheet = false
-            },
+        SecondaryModelSelectorSheet(
+            uiState = uiState,
+            viewModel = viewModel,
             onDismiss = { showSecondaryModelSheet = false },
-            serverUrl = uiState.serverUrl,
-            favoriteAgentIds = uiState.favoriteAgentIds,
-            favoriteModelKeys = uiState.favoriteModelKeys,
-            onToggleAgentFavorite = viewModel::toggleAgentFavorite,
-            onToggleModelFavorite = viewModel::toggleModelFavorite,
-            starredDisplay = uiState.starredModelsDisplay,
-            endpointKeyStates = uiState.endpointKeyStates,
-            onSetApiKey = { name -> onNavigateToProviderKeys(name) },
+            onNavigateToProviderKeys = onNavigateToProviderKeys,
         )
     }
 


### PR DESCRIPTION
**What**

The chat "+" options sheet's **Model** and **Model Parameters** rows used to open a *second* bottom sheet, and choosing an option dismissed straight back to the chat — so adjusting two settings meant reopening "+" and starting over. They now swap the sheet's content in place and return to the Options page, through a single `ModalBottomSheet` that pages between Options → Model Selector / Model Parameters.

**Behaviour**

- Tapping "+" → Model/Parameters swaps the panel; back returns to the Options page rather than the chat.
- The **standalone** selector — top-bar model chip, send-block auto-open, comparison dual-pane — stays independent and still opens its own sheet that dismisses to the chat. This independence is deliberate: `ChatUiState.showModelSheet` continues to mean "a standalone selector is open" and the paged sheet never touches it.
- The Android pull-up tools surface hands off to the paged sheet, and a drag on its content now moves the surface in both directions (previously a content drag didn't move it — only the drag handle did).

**Structure**

- New `ChatOptionsSheetController` (screen-local, `rememberSaveable`) drives visibility from the two entry points. The controller persists the *current* page, so the "Set API Key" → Settings → back round trip restores the open selector.
- The paged sheet's host (`ChatOptionsSheetHost`) and the standalone selector wiring (`ChatModelSheets`) both live in shared `commonMain`, replacing per-platform duplication — and the Android compile type-checks the code iOS runs.
- Deletes the unused `showModelParameters` state (set on iOS but never read there — the Parameters row was dead) and renames `ModelParameterSheet` / `ChatToolsBottomSheet` to their extracted `*Content` bodies.

22 files, +1099 / −711.
