### PR TITLE
perf(chat): parse streaming markdown off the main thread

### DIFF
--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/components/MarkdownContent.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/components/MarkdownContent.kt
@@ -99,7 +99,7 @@ actual fun MarkdownContent(
     immediate: Boolean,
     streaming: Boolean,
 ) {
-    val segments = remember(text) { parseMarkdownSegments(text) }
+    val segments = rememberMarkdownSegments(text, streaming)
     val isSearchActive = !searchQuery.isNullOrBlank()
 
     Column(

--- a/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/components/MarkdownSegmentStreamTest.kt
+++ b/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/components/MarkdownSegmentStreamTest.kt
@@ -1,0 +1,153 @@
+package com.garfiec.librechat.feature.chat.components
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlin.coroutines.EmptyCoroutineContext
+
+/** Concurrency contract for [collectMarkdownSegments]. */
+@OptIn(ExperimentalCoroutinesApi::class)
+class MarkdownSegmentStreamTest {
+
+    private fun text(segments: List<MarkdownSegment>): String =
+        (segments.single() as MarkdownSegment.TextBlock).text
+
+    @Test
+    fun publishesEachDistinctTextInOrder() = runTest {
+        val source = Channel<String>(Channel.UNLIMITED)
+        val published = mutableListOf<String>()
+        val job = launch {
+            collectMarkdownSegments(
+                texts = source.receiveAsFlow(),
+                alreadyParsed = "",
+                parse = { listOf(MarkdownSegment.TextBlock(it)) },
+                parseContext = StandardTestDispatcher(testScheduler),
+            ) { published += text(it) }
+        }
+        runCurrent()
+
+        source.trySend("a"); advanceUntilIdle()
+        source.trySend("ab"); advanceUntilIdle()
+        source.trySend("abc"); advanceUntilIdle()
+
+        assertEquals(listOf("a", "ab", "abc"), published)
+        job.cancel()
+    }
+
+    @Test
+    fun conflationSkipsIntermediateTexts() = runTest {
+        val source = Channel<String>(Channel.UNLIMITED)
+        val parsed = mutableListOf<String>()
+        val published = mutableListOf<String>()
+        val job = launch {
+            collectMarkdownSegments(
+                texts = source.receiveAsFlow(),
+                alreadyParsed = "",
+                parse = { parsed += it; listOf(MarkdownSegment.TextBlock(it)) },
+                parseContext = EmptyCoroutineContext,
+            ) { published += text(it) }
+        }
+        runCurrent()
+
+        source.trySend("a")
+        source.trySend("ab")
+        source.trySend("abc")
+        runCurrent()
+
+        assertEquals(listOf("a", "abc"), parsed)
+        assertEquals(listOf("a", "abc"), published)
+        job.cancel()
+    }
+
+    @Test
+    fun skipsEmissionEqualToAlreadyParsed() = runTest {
+        val source = Channel<String>(Channel.UNLIMITED)
+        val parsed = mutableListOf<String>()
+        val published = mutableListOf<String>()
+        val job = launch {
+            collectMarkdownSegments(
+                texts = source.receiveAsFlow(),
+                alreadyParsed = "hello",
+                parse = { parsed += it; listOf(MarkdownSegment.TextBlock(it)) },
+                parseContext = StandardTestDispatcher(testScheduler),
+            ) { published += text(it) }
+        }
+        runCurrent()
+
+        source.trySend("hello"); advanceUntilIdle()
+        assertTrue(parsed.isEmpty())
+        assertTrue(published.isEmpty())
+
+        source.trySend("hello world"); advanceUntilIdle()
+        assertEquals(listOf("hello world"), parsed)
+        job.cancel()
+    }
+
+    @Test
+    @Suppress("InjectDispatcher") // needs two genuinely distinct real dispatchers; see below
+    fun cancellationDiscardsInFlightParse() = runTest {
+        val parseEntered = CountDownLatch(1)
+        val releaseParse = CountDownLatch(1)
+        val published = CopyOnWriteArrayList<String>()
+        val source = Channel<String>(Channel.UNLIMITED)
+
+        // Distinct real dispatchers: withContext dispatches the resume, where a cancelled job
+        // discards the completed value rather than publishing it. Same-dispatcher would not.
+        val job = launch(Dispatchers.Default) {
+            collectMarkdownSegments(
+                texts = source.receiveAsFlow(),
+                alreadyParsed = "",
+                parse = {
+                    parseEntered.countDown()
+                    releaseParse.await()
+                    listOf(MarkdownSegment.TextBlock(it))
+                },
+                parseContext = Dispatchers.IO,
+            ) { published += text(it) }
+        }
+
+        source.trySend("a")
+        assertTrue(parseEntered.await(5, TimeUnit.SECONDS))
+
+        job.cancel()
+        releaseParse.countDown()
+        job.join()
+
+        assertTrue(published.isEmpty())
+    }
+
+    @Test
+    fun realParserShowsPlainTextUntilFenceCloses() = runTest {
+        val source = Channel<String>(Channel.UNLIMITED)
+        val published = mutableListOf<List<MarkdownSegment>>()
+        val job = launch {
+            collectMarkdownSegments(
+                texts = source.receiveAsFlow(),
+                alreadyParsed = "",
+                parseContext = StandardTestDispatcher(testScheduler),
+            ) { published += it }
+        }
+        runCurrent()
+
+        source.trySend("```kotlin\nval x = 1"); advanceUntilIdle()
+        source.trySend("```kotlin\nval x = 1\n```"); advanceUntilIdle()
+
+        assertTrue(published.first().none { it is MarkdownSegment.CodeBlock })
+        val code = published.last().filterIsInstance<MarkdownSegment.CodeBlock>().single()
+        assertEquals("kotlin", code.language)
+        assertEquals("val x = 1", code.code)
+        job.cancel()
+    }
+}

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/MarkdownSegmentState.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/MarkdownSegmentState.kt
@@ -1,0 +1,62 @@
+package com.garfiec.librechat.feature.chat.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.conflate
+import kotlinx.coroutines.withContext
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * Parses [text] into [MarkdownSegment]s. While [streaming], parsing runs off the main thread with
+ * the previous result retained (and the first text parsed synchronously) so the bubble never blanks.
+ */
+@Composable
+internal fun rememberMarkdownSegments(
+    text: String,
+    streaming: Boolean,
+): List<MarkdownSegment> {
+    if (!streaming) {
+        return remember(text) { parseMarkdownSegments(text) }
+    }
+
+    val latestText by rememberUpdatedState(text)
+    var segments by remember { mutableStateOf(parseMarkdownSegments(text)) }
+    val initialText = remember { text }
+
+    LaunchedEffect(Unit) {
+        collectMarkdownSegments(
+            texts = snapshotFlow { latestText },
+            alreadyParsed = initialText,
+        ) { segments = it }
+    }
+
+    return segments
+}
+
+/**
+ * Parses the latest text from [texts] on [parseContext]. [parseContext] must differ from the
+ * caller's dispatcher, or a cancelled parse publishes its result instead of being discarded.
+ */
+internal suspend fun collectMarkdownSegments(
+    texts: Flow<String>,
+    alreadyParsed: String,
+    parse: (String) -> List<MarkdownSegment> = ::parseMarkdownSegments,
+    parseContext: CoroutineContext = Dispatchers.Default,
+    onSegments: (List<MarkdownSegment>) -> Unit,
+) {
+    var lastParsed = alreadyParsed
+    texts.conflate().collect { t ->
+        if (t == lastParsed) return@collect
+        val parsed = withContext(parseContext) { parse(t) }
+        onSegments(parsed)
+        lastParsed = t
+    }
+}

--- a/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/components/PlatformChatComponents.ios.kt
+++ b/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/components/PlatformChatComponents.ios.kt
@@ -385,7 +385,7 @@ actual fun MarkdownContent(
     immediate: Boolean,
     streaming: Boolean,
 ) {
-    val segments = remember(text) { parseMarkdownSegments(text) }
+    val segments = rememberMarkdownSegments(text, streaming)
 
     val colors = markdownColor(
         text = MaterialTheme.colorScheme.onSurface,


### PR DESCRIPTION
## Problem

While a reply streams, `MarkdownContent` re-ran `parseMarkdownSegments()` over the **entire accumulated reply** on every ~50ms flush — synchronously in composition on the main thread. That's O(N^2) CPU over the course of a stream and the dominant cost on the app's hottest path; it grows worse the longer the reply.

## Change

Move the streaming-path segment parse to `Dispatchers.Default` via a conflated, latest-wins collector that retains the last parsed result until the next one lands, so the bubble never blanks between deltas. The first-seen text is parsed synchronously so it never mounts empty. Settled (finished) messages are unchanged — still parsed synchronously.

The diff is deliberately minimal for a regression-prone area: a new shared helper plus two one-line call-site swaps.

- `MarkdownSegmentState.kt` (new, commonMain) — `rememberMarkdownSegments(text, streaming)` and an extracted, unit-testable `collectMarkdownSegments` core.
- `MarkdownContent.kt` (Android) and `PlatformChatComponents.ios.kt` (iOS) — swap the one parse line to the new helper.

## Why it's safe

This area has regressed twice before (streaming flash #106, completion flicker #169). The change touches only *when/where* the streaming parse runs, never *what* it returns:

- Settled path is byte-for-byte the same synchronous parse — the cache-hit fast path, slot keying, and atomic finalize are all untouched.
- The parser and its output are unchanged; unterminated fences/tables/`$$` still render as plain text until they close (no mid-stream oscillation).
- Streaming partials are still never written to any shared cache.

## Testing

- New `MarkdownSegmentStreamTest` (5 tests): in-order publication, conflation drop, initial-text dedup, cross-dispatcher cancellation-discard, and a real-parser fence-snap guard.
- Full `feature:chat` unit suite green (378 tests).
- Manually verified streaming on a Pixel 9 Pro Fold: long prose (no per-token blanking, thread scrolls smoothly mid-stream), fence snap-once, completion with no flash, mid-stream scroll-away/back, and abort.