### PR TITLE
perf(nav): remember Navigator so the shell can skip on unrelated recomposition

### DIFF
--- a/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/LibreChatNavHost.kt
+++ b/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/LibreChatNavHost.kt
@@ -26,6 +26,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
@@ -107,7 +108,7 @@ fun LibreChatNavHost(
 
     // Stable start key — auth redirect handled via LaunchedEffect below.
     val backStack = rememberNavBackStack(navigationSavedStateConfig, NewChat())
-    val navigator = Navigator(backStack)
+    val navigator = remember(backStack) { Navigator(backStack) }
 
     // Redirect to auth if not logged in — once per saved-state lifecycle, NOT on every recreation.
     // LaunchedEffect(Unit) restarts on each Activity recreation (config change / process-death restore,


### PR DESCRIPTION
## What

Wrap the `Navigator` created in `LibreChatNavHost` in `remember(backStack)` so it isn't reallocated on every recomposition.

```kotlin
val backStack = rememberNavBackStack(navigationSavedStateConfig, NewChat())
- val navigator = Navigator(backStack)
+ val navigator = remember(backStack) { Navigator(backStack) }
```

## Why

`Navigator` is a stateless wrapper over the nav back stack (`val backStack` + computed getters + mutation methods — it stores no state of its own). The back stack itself is already remembered via `rememberNavBackStack`, so **navigation state was never lost** — this is not a state-loss bug.

The issue is reference stability. `navigator` is passed as a parameter into `PhoneLayout` / `MainNavDisplay` / `TabletLayout` and captured by the `onNavigate` / `onBack` lambdas in the `entryProvider`. A fresh `Navigator` instance on every recomposition reads as a changed input, so:

- Compose can't use referential equality to skip those children when the shell recomposes for a reason unrelated to navigation.
- The lambdas capturing `navigator` reallocate each pass.

The most visible waste is the offscreen drawer shell (`SidebarScaffold`) re-executing its composable function on shell recompositions. Its leaf content (the conversation `LazyColumn`) still skips on unchanged ViewModel state, so this is a modest stability/allocation improvement, not a hot-path fix.

## Scope / non-goals

This does **not** change the push/pop recomposition behavior — that is driven by `NavDisplay` reading the snapshot-backed `NavBackStack` (expected Nav3 behavior) and is unaffected by whether `Navigator` is remembered. Screen content remains isolated via `rememberSaveableStateHolderNavEntryDecorator` + `rememberViewModelStoreNavEntryDecorator`.

## Testing

- `:shared:compileDebugKotlinAndroid` — green
- `:shared:detektMetadataCommonMain` — green
- No behavior change; navigation state and back-stack restore are unaffected.

> [!NOTE]
> The iOS target has not been compiled in this environment (no Xcode). The change is in `commonMain` and is a plain Compose-runtime idiom, but a Mac build is worth confirming before merge.