### PR TITLE
fix(files): render PDF preview pages lazily instead of holding every page bitmap

### DIFF
--- a/core/ui/CLAUDE.md
+++ b/core/ui/CLAUDE.md
@@ -38,6 +38,14 @@ Material 3 theme and shared Compose components used across all feature modules. 
 - `ToolCallCard` - Expandable tool call display.
 - `FileAttachmentChip` - File reference chip.
 - `FeedbackButtons` - Thumbs up/down.
+
+### PDF (`pdf/`, androidMain only)
+- `PdfDocumentHolder` - Owns the `PdfRenderer`/fd; mutex-serialized on-demand `renderPage` with
+  dimension caps and a page-count bound. Created from bytes, closed by the owning composable.
+- `PdfPageContent` - One page rendered when it scrolls into a LazyColumn window and recycled when
+  it scrolls out. Shared by `:feature:chat`'s viewer (adds per-page pinch-zoom via the modifier
+  slot) and `:feature:files`' preview (adds page labels). Fix render/recycle logic HERE, not in the
+  feature copies — there are none.
 - `StreamingIndicator` - Pulsing indicator during SSE streaming.
 
 ## Rules
@@ -45,7 +53,7 @@ Material 3 theme and shared Compose components used across all feature modules. 
 - **No business logic.** No ViewModels, no repository calls, no use cases.
 - Components accept domain models from `:core:model` as parameters and render them.
 - All components must be stateless or hoist state to the caller.
-- Dependencies: `:core:model`, `:core:common`, Coil for image loading, Compose libraries.
+- Dependencies: `:core:model`, `:core:common`, Coil for image loading, Compose libraries, Kermit logging (androidMain, for the PDF holder).
 - Convention plugins: `librechat.mobile.library` + `librechat.mobile.compose`.
 - No DI in this module (no Koin modules, no injected classes).
 - Use `@Preview` annotations on all components for Android Studio preview support.

--- a/core/ui/build.gradle.kts
+++ b/core/ui/build.gradle.kts
@@ -23,5 +23,15 @@ kotlin {
             implementation(libs.activity.compose)
             implementation(libs.kermit)
         }
+        named("androidInstrumentedTest").dependencies {
+            implementation(libs.junit)
+            implementation(libs.android.test.runner)
+            implementation(libs.android.test.ext.junit)
+            implementation(libs.compose.ui.test)
+            implementation(libs.compose.ui.test.manifest)
+            // Pin espresso ≥3.7.0: the 3.5.x pulled in transitively by ui-test-junit4 injects
+            // input via InputManager.getInstance, which no longer exists on API 36+.
+            implementation(libs.espresso.core)
+        }
     }
 }

--- a/core/ui/build.gradle.kts
+++ b/core/ui/build.gradle.kts
@@ -21,6 +21,7 @@ kotlin {
         androidMain.dependencies {
             // Runtime-permission launcher for saving images to the gallery (API < 29).
             implementation(libs.activity.compose)
+            implementation(libs.kermit)
         }
     }
 }

--- a/core/ui/src/androidInstrumentedTest/kotlin/com/garfiec/librechat/core/ui/pdf/PdfPageContentInstrumentedTest.kt
+++ b/core/ui/src/androidInstrumentedTest/kotlin/com/garfiec/librechat/core/ui/pdf/PdfPageContentInstrumentedTest.kt
@@ -42,7 +42,6 @@ class PdfPageContentInstrumentedTest {
             assertEquals(3, holder.pageCount)
             val bitmap = runBlocking { holder.renderPage(0, widthPx = 500) }
             assertNotNull(bitmap)
-            // US-Letter page (612x792): rendered aspect and cached aspect both ≈ 0.7727.
             val expected = 612f / 792f
             assertEquals(expected, bitmap!!.width.toFloat() / bitmap.height, 0.01f)
             assertEquals(expected, holder.aspectRatio(0), 0.01f)
@@ -76,9 +75,7 @@ class PdfPageContentInstrumentedTest {
             }
         }
         try {
-            // Visiting pages across the document — each visited page must reach Ready (its Image
-            // node carries the content description). Revisiting page 1 after its bitmap was
-            // recycled on scroll-out must re-render, not crash.
+            // The final index revisits page 1 after its bitmap was recycled on scroll-out.
             for (target in intArrayOf(0, 12, 25, 39, 0)) {
                 composeRule.onNodeWithTag("pdfList").performScrollToIndex(target)
                 composeRule.waitUntilPageRendered(target + 1)
@@ -100,9 +97,8 @@ class PdfPageContentInstrumentedTest {
         }
         try {
             composeRule.waitUntilPageRendered(1)
-            // Each flip restarts the width-keyed producer: the superseded bitmap is recycled and
-            // the page re-renders at the new width. A recycle of a still-displayed bitmap would
-            // crash the draw pass and fail the test.
+            // Each flip recycles the superseded bitmap; recycling a still-displayed one would
+            // crash the draw pass.
             repeat(3) {
                 composeRule.runOnUiThread { narrow.value = !narrow.value }
                 composeRule.waitForIdle()
@@ -121,11 +117,7 @@ class PdfPageContentInstrumentedTest {
         }
     }
 
-    /**
-     * Builds a minimal but valid multi-page PDF (US-Letter pages, one text line and a numbered
-     * block per page) entirely in memory. Kept intentionally simple: one catalog, one pages node,
-     * one shared font, N page objects, N content streams, and a correct xref table.
-     */
+    /** Builds a minimal valid multi-page PDF (US-Letter, one text line + block per page) in memory. */
     private fun minimalPdf(pages: Int): ByteArray {
         val objects = ArrayList<Pair<Int, ByteArray>>(2 * pages + 3)
         val kids = (0 until pages).joinToString(" ") { "${4 + it} 0 R" }

--- a/core/ui/src/androidInstrumentedTest/kotlin/com/garfiec/librechat/core/ui/pdf/PdfPageContentInstrumentedTest.kt
+++ b/core/ui/src/androidInstrumentedTest/kotlin/com/garfiec/librechat/core/ui/pdf/PdfPageContentInstrumentedTest.kt
@@ -1,0 +1,176 @@
+package com.garfiec.librechat.core.ui.pdf
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performScrollToIndex
+import androidx.compose.ui.unit.dp
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * On-device tests for the shared PDF rendering path ([PdfDocumentHolder] + [PdfPageContent])
+ * against the real framework `PdfRenderer`, with locally generated documents — no server involved.
+ */
+@RunWith(AndroidJUnit4::class)
+class PdfPageContentInstrumentedTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    private val context get() = InstrumentationRegistry.getInstrumentation().targetContext
+
+    @Test
+    fun holderOpensDocumentAndRendersFirstPage() {
+        val holder = requireNotNull(PdfDocumentHolder.create(context, minimalPdf(pages = 3)))
+        try {
+            assertEquals(3, holder.pageCount)
+            val bitmap = runBlocking { holder.renderPage(0, widthPx = 500) }
+            assertNotNull(bitmap)
+            // US-Letter page (612x792): rendered aspect and cached aspect both ≈ 0.7727.
+            val expected = 612f / 792f
+            assertEquals(expected, bitmap!!.width.toFloat() / bitmap.height, 0.01f)
+            assertEquals(expected, holder.aspectRatio(0), 0.01f)
+        } finally {
+            holder.close()
+        }
+    }
+
+    @Test
+    fun pageCountIsCappedForPathologicalDocuments() {
+        val holder = requireNotNull(PdfDocumentHolder.create(context, minimalPdf(pages = 2001)))
+        try {
+            assertEquals(2000, holder.pageCount)
+        } finally {
+            holder.close()
+        }
+    }
+
+    @Test
+    fun scrollingThroughListRendersPagesOnDemandAndBack() {
+        val holder = requireNotNull(PdfDocumentHolder.create(context, minimalPdf(pages = 40)))
+        composeRule.setContent {
+            LazyColumn(modifier = Modifier.fillMaxSize().testTag("pdfList")) {
+                items(count = holder.pageCount, key = { it }) { index ->
+                    PdfPageContent(
+                        doc = holder,
+                        index = index,
+                        contentDescription = "page-${index + 1}",
+                    )
+                }
+            }
+        }
+        try {
+            // Visiting pages across the document — each visited page must reach Ready (its Image
+            // node carries the content description). Revisiting page 1 after its bitmap was
+            // recycled on scroll-out must re-render, not crash.
+            for (target in intArrayOf(0, 12, 25, 39, 0)) {
+                composeRule.onNodeWithTag("pdfList").performScrollToIndex(target)
+                composeRule.waitUntilPageRendered(target + 1)
+            }
+        } finally {
+            holder.close()
+        }
+    }
+
+    @Test
+    fun widthChangeReRendersVisiblePageWithoutCrash() {
+        val holder = requireNotNull(PdfDocumentHolder.create(context, minimalPdf(pages = 2)))
+        val narrow = mutableStateOf(false)
+        composeRule.setContent {
+            val isNarrow by narrow
+            Box(modifier = Modifier.width(if (isNarrow) 200.dp else 360.dp)) {
+                PdfPageContent(doc = holder, index = 0, contentDescription = "page-1")
+            }
+        }
+        try {
+            composeRule.waitUntilPageRendered(1)
+            // Each flip restarts the width-keyed producer: the superseded bitmap is recycled and
+            // the page re-renders at the new width. A recycle of a still-displayed bitmap would
+            // crash the draw pass and fail the test.
+            repeat(3) {
+                composeRule.runOnUiThread { narrow.value = !narrow.value }
+                composeRule.waitForIdle()
+                composeRule.waitUntilPageRendered(1)
+            }
+        } finally {
+            holder.close()
+        }
+    }
+
+    private fun androidx.compose.ui.test.junit4.ComposeContentTestRule.waitUntilPageRendered(
+        pageNumber: Int,
+    ) {
+        waitUntil(timeoutMillis = 10_000) {
+            onAllNodesWithContentDescription("page-$pageNumber").fetchSemanticsNodes().isNotEmpty()
+        }
+    }
+
+    /**
+     * Builds a minimal but valid multi-page PDF (US-Letter pages, one text line and a numbered
+     * block per page) entirely in memory. Kept intentionally simple: one catalog, one pages node,
+     * one shared font, N page objects, N content streams, and a correct xref table.
+     */
+    private fun minimalPdf(pages: Int): ByteArray {
+        val objects = ArrayList<Pair<Int, ByteArray>>(2 * pages + 3)
+        val kids = (0 until pages).joinToString(" ") { "${4 + it} 0 R" }
+        objects.add(1 to "<< /Type /Catalog /Pages 2 0 R >>".toByteArray())
+        objects.add(2 to "<< /Type /Pages /Kids [$kids] /Count $pages >>".toByteArray())
+        objects.add(3 to "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>".toByteArray())
+        for (i in 0 until pages) {
+            objects.add(
+                4 + i to (
+                    "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] " +
+                        "/Resources << /Font << /F1 3 0 R >> >> /Contents ${4 + pages + i} 0 R >>"
+                    ).toByteArray(),
+            )
+        }
+        for (i in 0 until pages) {
+            val stream = (
+                "BT /F1 36 Tf 72 700 Td (PAGE ${i + 1} of $pages) Tj ET\n" +
+                    "0.2 0.4 0.8 rg 72 300 468 300 re f"
+                ).toByteArray()
+            objects.add(
+                4 + pages + i to (
+                    "<< /Length ${stream.size} >>\nstream\n".toByteArray() +
+                        stream + "\nendstream".toByteArray()
+                    ),
+            )
+        }
+        val out = java.io.ByteArrayOutputStream()
+        out.write("%PDF-1.4\n".toByteArray())
+        val offsets = IntArray(objects.size + 1)
+        for ((num, body) in objects) {
+            offsets[num] = out.size()
+            out.write("$num 0 obj\n".toByteArray())
+            out.write(body)
+            out.write("\nendobj\n".toByteArray())
+        }
+        val xrefPos = out.size()
+        out.write("xref\n0 ${objects.size + 1}\n".toByteArray())
+        out.write("0000000000 65535 f \n".toByteArray())
+        for (num in 1..objects.size) {
+            out.write("%010d 00000 n \n".format(offsets[num]).toByteArray())
+        }
+        out.write(
+            "trailer\n<< /Size ${objects.size + 1} /Root 1 0 R >>\nstartxref\n$xrefPos\n%%EOF\n"
+                .toByteArray(),
+        )
+        return out.toByteArray()
+    }
+}

--- a/core/ui/src/androidMain/kotlin/com/garfiec/librechat/core/ui/pdf/PdfDocumentHolder.kt
+++ b/core/ui/src/androidMain/kotlin/com/garfiec/librechat/core/ui/pdf/PdfDocumentHolder.kt
@@ -8,6 +8,7 @@ import android.os.ParcelFileDescriptor
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asImageBitmap
 import co.touchlab.kermit.Logger
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -31,6 +32,13 @@ private const val DEFAULT_PAGE_ASPECT = 0.7071f
  */
 private const val MAX_PAGE_BITMAP_WIDTH_PX = 2048
 private const val MAX_PAGE_BITMAP_HEIGHT_PX = 8192
+
+/**
+ * Upper bound on the page count taken from the document. Per-page bookkeeping ([aspectRatios]) and
+ * the caller's LazyColumn item count are O(pageCount), so a corrupt or crafted PDF claiming
+ * millions of pages could otherwise allocate its way to an OOM before a single page renders.
+ */
+private const val MAX_PAGE_COUNT = 2000
 
 /**
  * Owns the [PdfRenderer] and its backing fd. [renderPage] is serialized by a [Mutex] because
@@ -63,33 +71,44 @@ class PdfDocumentHolder private constructor(
             ?: DEFAULT_PAGE_ASPECT
     }
 
-    suspend fun renderPage(index: Int, widthPx: Int): ImageBitmap? = withContext(Dispatchers.IO) {
-        runCatching {
-            mutex.withLock {
-                if (closed) return@withLock null
-                renderer.openPage(index).use { page ->
-                    if (page.width <= 0 || page.height <= 0) return@use null
-                    aspectRatios.set(index, (page.width.toFloat() / page.height).toRawBits())
+    suspend fun renderPage(index: Int, widthPx: Int): ImageBitmap? {
+        var rendered: Bitmap? = null
+        try {
+            return withContext(Dispatchers.IO) {
+                runCatching {
+                    mutex.withLock {
+                        if (closed) return@withLock null
+                        renderer.openPage(index).use { page ->
+                            if (page.width <= 0 || page.height <= 0) return@use null
+                            aspectRatios.set(index, (page.width.toFloat() / page.height).toRawBits())
 
-                    // Fit to width, then downscale by one factor so neither dimension exceeds its cap
-                    // (aspect preserved). FillWidth upscales the smaller bitmap back to the container.
-                    val fitHeight = widthPx.toFloat() * page.height / page.width
-                    val downscale = minOf(
-                        1f,
-                        MAX_PAGE_BITMAP_WIDTH_PX / widthPx.toFloat(),
-                        MAX_PAGE_BITMAP_HEIGHT_PX / fitHeight,
-                    )
-                    val renderWidth = (widthPx * downscale).toInt().coerceAtLeast(1)
-                    val renderHeight = (fitHeight * downscale).toInt().coerceAtLeast(1)
+                            // Fit to width, then downscale by one factor so neither dimension exceeds its cap
+                            // (aspect preserved). FillWidth upscales the smaller bitmap back to the container.
+                            val fitHeight = widthPx.toFloat() * page.height / page.width
+                            val downscale = minOf(
+                                1f,
+                                MAX_PAGE_BITMAP_WIDTH_PX / widthPx.toFloat(),
+                                MAX_PAGE_BITMAP_HEIGHT_PX / fitHeight,
+                            )
+                            val renderWidth = (widthPx * downscale).toInt().coerceAtLeast(1)
+                            val renderHeight = (fitHeight * downscale).toInt().coerceAtLeast(1)
 
-                    val bmp = Bitmap.createBitmap(renderWidth, renderHeight, Bitmap.Config.ARGB_8888)
-                    // PDF pages are transparent where unpainted; fill white so text is legible on dark themes.
-                    bmp.eraseColor(Color.WHITE)
-                    page.render(bmp, null, null, PdfRenderer.Page.RENDER_MODE_FOR_DISPLAY)
-                    bmp.asImageBitmap()
-                }
+                            val bmp = Bitmap.createBitmap(renderWidth, renderHeight, Bitmap.Config.ARGB_8888)
+                            rendered = bmp
+                            // PDF pages are transparent where unpainted; fill white so text is legible on dark themes.
+                            bmp.eraseColor(Color.WHITE)
+                            page.render(bmp, null, null, PdfRenderer.Page.RENDER_MODE_FOR_DISPLAY)
+                            bmp.asImageBitmap()
+                        }
+                    }
+                }.getOrNull()
             }
-        }.getOrNull()
+        } catch (e: CancellationException) {
+            // Prompt cancellation can discard a render that already completed on the IO thread —
+            // the caller never receives the bitmap, so free it here instead of leaving it to GC.
+            rendered?.recycle()
+            throw e
+        }
     }
 
     fun close() {
@@ -119,7 +138,11 @@ class PdfDocumentHolder private constructor(
                 // process is killed with the preview open — no orphaned cache files.
                 file.delete()
                 val renderer = PdfRenderer(fd)
-                PdfDocumentHolder(fd, renderer, renderer.pageCount)
+                val pageCount = minOf(renderer.pageCount, MAX_PAGE_COUNT)
+                if (renderer.pageCount > pageCount) {
+                    Logger.w { "PdfDocumentHolder: capping ${renderer.pageCount}-page document at $pageCount pages" }
+                }
+                PdfDocumentHolder(fd, renderer, pageCount)
             }.onFailure { e ->
                 Logger.e(e) { "PdfDocumentHolder.create failed" }
                 runCatching { opened?.close() }

--- a/core/ui/src/androidMain/kotlin/com/garfiec/librechat/core/ui/pdf/PdfDocumentHolder.kt
+++ b/core/ui/src/androidMain/kotlin/com/garfiec/librechat/core/ui/pdf/PdfDocumentHolder.kt
@@ -25,18 +25,15 @@ import java.util.concurrent.atomic.AtomicIntegerArray
 private const val DEFAULT_PAGE_ASPECT = 0.7071f
 
 /**
- * Hard caps on a rendered page bitmap's dimensions in pixels. A page fit to a large-screen width
- * (unfolded foldable, tablet) or a pathological aspect could otherwise demand hundreds of MB across
- * the visible window and OOM. We downscale by a single factor so *both* dimensions stay under their
- * cap while the aspect is preserved, and let `ContentScale.FillWidth` upscale the smaller bitmap.
+ * Hard caps on a rendered page bitmap's dimensions; a page fit to a tablet-width container or a
+ * pathological aspect could otherwise allocate hundreds of MB across the visible window.
  */
 private const val MAX_PAGE_BITMAP_WIDTH_PX = 2048
 private const val MAX_PAGE_BITMAP_HEIGHT_PX = 8192
 
 /**
- * Upper bound on the page count taken from the document. Per-page bookkeeping ([aspectRatios]) and
- * the caller's LazyColumn item count are O(pageCount), so a corrupt or crafted PDF claiming
- * millions of pages could otherwise allocate its way to an OOM before a single page renders.
+ * Per-page bookkeeping and the caller's LazyColumn are O(pageCount); a crafted PDF claiming
+ * millions of pages could otherwise OOM before a single page renders.
  */
 private const val MAX_PAGE_COUNT = 2000
 
@@ -55,13 +52,10 @@ class PdfDocumentHolder private constructor(
     @Volatile private var closed = false
     private val tornDown = AtomicBoolean(false)
 
-    // Holder-owned teardown scope (cancelled once teardown completes) rather than a fresh anonymous
-    // CoroutineScope per close() with no lifecycle owner.
     private val ioScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
-    // Real per-page width/height ratios, filled lazily by renderPage. Float bits in an
-    // AtomicIntegerArray so the render-thread write is visible to the main-thread aspectRatio() read
-    // (a plain FloatArray gives no cross-thread visibility guarantee). 0 bits == unset.
+    // Per-page width/height ratios as float bits, filled lazily by renderPage; atomic so the
+    // render-thread write is visible to the main-thread read. 0 bits == unset.
     private val aspectRatios = AtomicIntegerArray(pageCount)
 
     /** width / height, for placeholder sizing before the bitmap renders (real value once rendered). */
@@ -104,18 +98,17 @@ class PdfDocumentHolder private constructor(
                 }.getOrNull()
             }
         } catch (e: CancellationException) {
-            // Prompt cancellation can discard a render that already completed on the IO thread —
-            // the caller never receives the bitmap, so free it here instead of leaving it to GC.
+            // Prompt cancellation discards a completed render at the withContext boundary; free
+            // the bitmap the caller will never receive.
             rendered?.recycle()
             throw e
         }
     }
 
     fun close() {
-        // Idempotent: guard so a double-dispose doesn't launch teardown twice.
         if (!tornDown.compareAndSet(false, true)) return
-        // Flag first so in-flight renders bail; do the actual teardown under the lock so we never
-        // close the renderer out from under a page.render() that's mid-flight.
+        // Set the flag first so in-flight renders bail; tear down under the lock so the renderer
+        // is never closed out from under a mid-flight page.render().
         closed = true
         ioScope.launch {
             mutex.withLock {
@@ -134,8 +127,8 @@ class PdfDocumentHolder private constructor(
                 file.writeBytes(bytes)
                 val fd = ParcelFileDescriptor.open(file, ParcelFileDescriptor.MODE_READ_ONLY)
                 opened = fd
-                // Unlink now: the fd keeps the data readable, and the on-disk entry is gone even if the
-                // process is killed with the preview open — no orphaned cache files.
+                // Unlink now: the fd keeps the data readable and nothing is orphaned if the
+                // process dies with the preview open.
                 file.delete()
                 val renderer = PdfRenderer(fd)
                 val pageCount = minOf(renderer.pageCount, MAX_PAGE_COUNT)

--- a/core/ui/src/androidMain/kotlin/com/garfiec/librechat/core/ui/pdf/PdfDocumentHolder.kt
+++ b/core/ui/src/androidMain/kotlin/com/garfiec/librechat/core/ui/pdf/PdfDocumentHolder.kt
@@ -1,0 +1,130 @@
+package com.garfiec.librechat.core.ui.pdf
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.Color
+import android.graphics.pdf.PdfRenderer
+import android.os.ParcelFileDescriptor
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asImageBitmap
+import co.touchlab.kermit.Logger
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import java.io.File
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicIntegerArray
+
+/** Placeholder aspect (≈ A4 portrait, 1/√2) used before a page's real dimensions are known. */
+private const val DEFAULT_PAGE_ASPECT = 0.7071f
+
+/**
+ * Hard caps on a rendered page bitmap's dimensions in pixels. A page fit to a large-screen width
+ * (unfolded foldable, tablet) or a pathological aspect could otherwise demand hundreds of MB across
+ * the visible window and OOM. We downscale by a single factor so *both* dimensions stay under their
+ * cap while the aspect is preserved, and let `ContentScale.FillWidth` upscale the smaller bitmap.
+ */
+private const val MAX_PAGE_BITMAP_WIDTH_PX = 2048
+private const val MAX_PAGE_BITMAP_HEIGHT_PX = 8192
+
+/**
+ * Owns the [PdfRenderer] and its backing fd. [renderPage] is serialized by a [Mutex] because
+ * PdfRenderer allows only one open page at a time and the LazyColumn may render several pages
+ * concurrently as they scroll in.
+ */
+class PdfDocumentHolder private constructor(
+    private val fd: ParcelFileDescriptor,
+    private val renderer: PdfRenderer,
+    val pageCount: Int,
+) {
+    private val mutex = Mutex()
+
+    @Volatile private var closed = false
+    private val tornDown = AtomicBoolean(false)
+
+    // Holder-owned teardown scope (cancelled once teardown completes) rather than a fresh anonymous
+    // CoroutineScope per close() with no lifecycle owner.
+    private val ioScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    // Real per-page width/height ratios, filled lazily by renderPage. Float bits in an
+    // AtomicIntegerArray so the render-thread write is visible to the main-thread aspectRatio() read
+    // (a plain FloatArray gives no cross-thread visibility guarantee). 0 bits == unset.
+    private val aspectRatios = AtomicIntegerArray(pageCount)
+
+    /** width / height, for placeholder sizing before the bitmap renders (real value once rendered). */
+    fun aspectRatio(index: Int): Float {
+        if (index < 0 || index >= pageCount) return DEFAULT_PAGE_ASPECT
+        return Float.fromBits(aspectRatios.get(index)).takeIf { it.isFinite() && it > 0f }
+            ?: DEFAULT_PAGE_ASPECT
+    }
+
+    suspend fun renderPage(index: Int, widthPx: Int): ImageBitmap? = withContext(Dispatchers.IO) {
+        runCatching {
+            mutex.withLock {
+                if (closed) return@withLock null
+                renderer.openPage(index).use { page ->
+                    if (page.width <= 0 || page.height <= 0) return@use null
+                    aspectRatios.set(index, (page.width.toFloat() / page.height).toRawBits())
+
+                    // Fit to width, then downscale by one factor so neither dimension exceeds its cap
+                    // (aspect preserved). FillWidth upscales the smaller bitmap back to the container.
+                    val fitHeight = widthPx.toFloat() * page.height / page.width
+                    val downscale = minOf(
+                        1f,
+                        MAX_PAGE_BITMAP_WIDTH_PX / widthPx.toFloat(),
+                        MAX_PAGE_BITMAP_HEIGHT_PX / fitHeight,
+                    )
+                    val renderWidth = (widthPx * downscale).toInt().coerceAtLeast(1)
+                    val renderHeight = (fitHeight * downscale).toInt().coerceAtLeast(1)
+
+                    val bmp = Bitmap.createBitmap(renderWidth, renderHeight, Bitmap.Config.ARGB_8888)
+                    // PDF pages are transparent where unpainted; fill white so text is legible on dark themes.
+                    bmp.eraseColor(Color.WHITE)
+                    page.render(bmp, null, null, PdfRenderer.Page.RENDER_MODE_FOR_DISPLAY)
+                    bmp.asImageBitmap()
+                }
+            }
+        }.getOrNull()
+    }
+
+    fun close() {
+        // Idempotent: guard so a double-dispose doesn't launch teardown twice.
+        if (!tornDown.compareAndSet(false, true)) return
+        // Flag first so in-flight renders bail; do the actual teardown under the lock so we never
+        // close the renderer out from under a page.render() that's mid-flight.
+        closed = true
+        ioScope.launch {
+            mutex.withLock {
+                runCatching { renderer.close() }
+                runCatching { fd.close() }
+            }
+        }.invokeOnCompletion { ioScope.cancel() }
+    }
+
+    companion object {
+        fun create(context: Context, bytes: ByteArray): PdfDocumentHolder? {
+            val dir = File(context.cacheDir, "pdf_preview").apply { mkdirs() }
+            val file = File.createTempFile("preview_", ".pdf", dir)
+            var opened: ParcelFileDescriptor? = null
+            return runCatching {
+                file.writeBytes(bytes)
+                val fd = ParcelFileDescriptor.open(file, ParcelFileDescriptor.MODE_READ_ONLY)
+                opened = fd
+                // Unlink now: the fd keeps the data readable, and the on-disk entry is gone even if the
+                // process is killed with the preview open — no orphaned cache files.
+                file.delete()
+                val renderer = PdfRenderer(fd)
+                PdfDocumentHolder(fd, renderer, renderer.pageCount)
+            }.onFailure { e ->
+                Logger.e(e) { "PdfDocumentHolder.create failed" }
+                runCatching { opened?.close() }
+                runCatching { file.delete() }
+            }.getOrNull()
+        }
+    }
+}

--- a/core/ui/src/androidMain/kotlin/com/garfiec/librechat/core/ui/pdf/PdfPageContent.kt
+++ b/core/ui/src/androidMain/kotlin/com/garfiec/librechat/core/ui/pdf/PdfPageContent.kt
@@ -55,9 +55,8 @@ fun PdfPageContent(
 
     val widthPx = size.width
     val renderState = produceState<PageRender>(PageRender.Loading, doc, index, widthPx) {
-        // A width-change restart supersedes the previous bitmap. Blank the display first — this
-        // runs in the frame's effects, before draw — then free the old pixels; leaving them to GC
-        // lets native ARGB_8888 buffers pile up across fold/rotate re-renders.
+        // A width-change restart supersedes the previous bitmap: blank the display first (effects
+        // run before this frame draws), then it is safe to free the old pixels.
         val superseded = (value as? PageRender.Ready)?.bitmap
         value = PageRender.Loading
         superseded?.asAndroidBitmap()?.recycle()
@@ -66,11 +65,8 @@ fun PdfPageContent(
         }
     }
 
-    // Recycle when the page leaves composition (scrolls out of the window). Reads the State
-    // directly — not a value captured at the last recomposition — so a bitmap that landed after
-    // the final recomposition is still freed. Between this, the superseded-recycle above, and
-    // renderPage freeing a render its caller's cancellation discarded, every rendered bitmap has
-    // exactly one owner.
+    // Recycle when the page leaves composition. Must read the State directly — a value captured
+    // at the last recomposition misses a bitmap that lands just before disposal.
     DisposableEffect(renderState) {
         onDispose { (renderState.value as? PageRender.Ready)?.bitmap?.asAndroidBitmap()?.recycle() }
     }
@@ -78,8 +74,8 @@ fun PdfPageContent(
     val render = renderState.value
     val bitmap = (render as? PageRender.Ready)?.bitmap
 
-    // Once the bitmap is in, size the box to its true aspect (drives relayout); until then use the
-    // stored/placeholder ratio. Sanitize so Modifier.aspectRatio never sees 0 / NaN / ∞.
+    // True aspect once rendered, stored/placeholder ratio until then; sanitized so
+    // Modifier.aspectRatio never sees 0 / NaN / ∞.
     val aspect = bitmap
         ?.let { it.width.toFloat() / it.height.toFloat() }
         ?.takeIf { it.isFinite() && it > 0f }

--- a/core/ui/src/androidMain/kotlin/com/garfiec/librechat/core/ui/pdf/PdfPageContent.kt
+++ b/core/ui/src/androidMain/kotlin/com/garfiec/librechat/core/ui/pdf/PdfPageContent.kt
@@ -1,0 +1,112 @@
+package com.garfiec.librechat.core.ui.pdf
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asAndroidBitmap
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
+import com.garfiec.librechat.core.ui.resources.Res
+import com.garfiec.librechat.core.ui.resources.pdf_page_failed
+import org.jetbrains.compose.resources.stringResource
+
+/** Per-page render outcome. [Loading] and [Failed] are distinguished so a failed page can show an
+ *  inline indicator instead of a silent blank gap. */
+private sealed interface PageRender {
+    data object Loading : PageRender
+    data object Failed : PageRender
+    data class Ready(val bitmap: ImageBitmap) : PageRender
+}
+
+/**
+ * One PDF page from [doc], rendered on demand when it scrolls into a LazyColumn's window and freed
+ * when it scrolls out, so memory tracks the visible window rather than the whole document. Sized to
+ * the page's aspect ratio (a placeholder until the first render reports the real one) so the scroll
+ * position stays stable.
+ *
+ * [modifier] is appended after the size/aspect modifiers, so callers can attach draw-time
+ * transforms and gesture handling in the same order they would on their own page Box.
+ */
+@Composable
+fun PdfPageContent(
+    doc: PdfDocumentHolder,
+    index: Int,
+    modifier: Modifier = Modifier,
+    contentDescription: String? = null,
+) {
+    var size by remember { mutableStateOf(IntSize.Zero) }
+
+    val widthPx = size.width
+    val renderState = produceState<PageRender>(PageRender.Loading, doc, index, widthPx) {
+        // A width-change restart supersedes the previous bitmap. Blank the display first — this
+        // runs in the frame's effects, before draw — then free the old pixels; leaving them to GC
+        // lets native ARGB_8888 buffers pile up across fold/rotate re-renders.
+        val superseded = (value as? PageRender.Ready)?.bitmap
+        value = PageRender.Loading
+        superseded?.asAndroidBitmap()?.recycle()
+        if (widthPx > 0) {
+            value = doc.renderPage(index, widthPx)?.let { PageRender.Ready(it) } ?: PageRender.Failed
+        }
+    }
+
+    // Recycle when the page leaves composition (scrolls out of the window). Reads the State
+    // directly — not a value captured at the last recomposition — so a bitmap that landed after
+    // the final recomposition is still freed. Between this, the superseded-recycle above, and
+    // renderPage freeing a render its caller's cancellation discarded, every rendered bitmap has
+    // exactly one owner.
+    DisposableEffect(renderState) {
+        onDispose { (renderState.value as? PageRender.Ready)?.bitmap?.asAndroidBitmap()?.recycle() }
+    }
+
+    val render = renderState.value
+    val bitmap = (render as? PageRender.Ready)?.bitmap
+
+    // Once the bitmap is in, size the box to its true aspect (drives relayout); until then use the
+    // stored/placeholder ratio. Sanitize so Modifier.aspectRatio never sees 0 / NaN / ∞.
+    val aspect = bitmap
+        ?.let { it.width.toFloat() / it.height.toFloat() }
+        ?.takeIf { it.isFinite() && it > 0f }
+        ?: doc.aspectRatio(index)
+
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .aspectRatio(aspect)
+            .onSizeChanged { size = it }
+            .then(modifier),
+        contentAlignment = Alignment.Center,
+    ) {
+        when (render) {
+            is PageRender.Ready -> Image(
+                bitmap = render.bitmap,
+                contentDescription = contentDescription,
+                modifier = Modifier.fillMaxSize(),
+                contentScale = ContentScale.FillWidth,
+            )
+            is PageRender.Failed -> Text(
+                text = stringResource(Res.string.pdf_page_failed),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(16.dp),
+            )
+            is PageRender.Loading -> Unit // blank until the first render lands
+        }
+    }
+}

--- a/core/ui/src/commonMain/composeResources/values/strings.xml
+++ b/core/ui/src/commonMain/composeResources/values/strings.xml
@@ -2,4 +2,6 @@
 <resources>
     <!-- Accessibility label for the bottom-sheet drag handle -->
     <string name="cd_drag_handle">Drag handle</string>
+    <!-- Inline indicator for a PDF page that failed to render -->
+    <string name="pdf_page_failed">Couldn\'t render this page</string>
 </resources>

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/components/PdfViewer.android.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/components/PdfViewer.android.kt
@@ -1,10 +1,5 @@
 package com.garfiec.librechat.feature.chat.components
 
-import android.content.Context
-import android.graphics.Bitmap
-import android.graphics.Color
-import android.graphics.pdf.PdfRenderer
-import android.os.ParcelFileDescriptor
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
@@ -32,7 +27,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asAndroidBitmap
-import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.pointerInput
@@ -42,34 +36,13 @@ import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
-import co.touchlab.kermit.Logger
+import com.garfiec.librechat.core.ui.pdf.PdfDocumentHolder
 import com.garfiec.librechat.feature.chat.resources.Res
 import com.garfiec.librechat.feature.chat.resources.pdf_page_failed
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.NonCancellable
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import org.jetbrains.compose.resources.stringResource
-import java.io.File
-import java.util.concurrent.atomic.AtomicBoolean
-import java.util.concurrent.atomic.AtomicIntegerArray
-
-/** Placeholder aspect (≈ A4 portrait, 1/√2) used before a page's real dimensions are known. */
-private const val DEFAULT_PAGE_ASPECT = 0.7071f
-
-/**
- * Hard caps on a rendered page bitmap's dimensions in pixels. A page fit to a large-screen width
- * (unfolded foldable, tablet) or a pathological aspect could otherwise demand hundreds of MB across
- * the visible window and OOM. We downscale by a single factor so *both* dimensions stay under their
- * cap while the aspect is preserved, and let [ContentScale.FillWidth] upscale the smaller bitmap.
- */
-private const val MAX_PAGE_BITMAP_WIDTH_PX = 2048
-private const val MAX_PAGE_BITMAP_HEIGHT_PX = 8192
 
 /** Per-page render outcome. [Loading] and [Failed] are distinguished so a failed page can show an
  *  inline indicator instead of a silent blank gap. */
@@ -209,103 +182,6 @@ private fun PdfPage(doc: PdfDocumentHolder, index: Int) {
                 modifier = Modifier.padding(16.dp),
             )
             is PageRender.Loading -> Unit // blank until the first render lands
-        }
-    }
-}
-
-/**
- * Owns the [PdfRenderer] and its backing fd. [renderPage] is serialized by a [Mutex] because
- * PdfRenderer allows only one open page at a time and the LazyColumn may render several pages
- * concurrently as they scroll in.
- */
-private class PdfDocumentHolder private constructor(
-    private val fd: ParcelFileDescriptor,
-    private val renderer: PdfRenderer,
-    val pageCount: Int,
-) {
-    private val mutex = Mutex()
-
-    @Volatile private var closed = false
-    private val tornDown = AtomicBoolean(false)
-
-    // Holder-owned teardown scope (cancelled once teardown completes) rather than a fresh anonymous
-    // CoroutineScope per close() with no lifecycle owner.
-    private val ioScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
-
-    // Real per-page width/height ratios, filled lazily by renderPage. Float bits in an
-    // AtomicIntegerArray so the render-thread write is visible to the main-thread aspectRatio() read
-    // (a plain FloatArray gives no cross-thread visibility guarantee). 0 bits == unset.
-    private val aspectRatios = AtomicIntegerArray(pageCount)
-
-    /** width / height, for placeholder sizing before the bitmap renders (real value once rendered). */
-    fun aspectRatio(index: Int): Float {
-        if (index < 0 || index >= pageCount) return DEFAULT_PAGE_ASPECT
-        return Float.fromBits(aspectRatios.get(index)).takeIf { it.isFinite() && it > 0f }
-            ?: DEFAULT_PAGE_ASPECT
-    }
-
-    suspend fun renderPage(index: Int, widthPx: Int): ImageBitmap? = withContext(Dispatchers.IO) {
-        runCatching {
-            mutex.withLock {
-                if (closed) return@withLock null
-                renderer.openPage(index).use { page ->
-                    if (page.width <= 0 || page.height <= 0) return@use null
-                    aspectRatios.set(index, (page.width.toFloat() / page.height).toRawBits())
-
-                    // Fit to width, then downscale by one factor so neither dimension exceeds its cap
-                    // (aspect preserved). FillWidth upscales the smaller bitmap back to the container.
-                    val fitHeight = widthPx.toFloat() * page.height / page.width
-                    val downscale = minOf(
-                        1f,
-                        MAX_PAGE_BITMAP_WIDTH_PX / widthPx.toFloat(),
-                        MAX_PAGE_BITMAP_HEIGHT_PX / fitHeight,
-                    )
-                    val renderWidth = (widthPx * downscale).toInt().coerceAtLeast(1)
-                    val renderHeight = (fitHeight * downscale).toInt().coerceAtLeast(1)
-
-                    val bmp = Bitmap.createBitmap(renderWidth, renderHeight, Bitmap.Config.ARGB_8888)
-                    // PDF pages are transparent where unpainted; fill white so text is legible on dark themes.
-                    bmp.eraseColor(Color.WHITE)
-                    page.render(bmp, null, null, PdfRenderer.Page.RENDER_MODE_FOR_DISPLAY)
-                    bmp.asImageBitmap()
-                }
-            }
-        }.getOrNull()
-    }
-
-    fun close() {
-        // Idempotent: guard so a double-dispose doesn't launch teardown twice.
-        if (!tornDown.compareAndSet(false, true)) return
-        // Flag first so in-flight renders bail; do the actual teardown under the lock so we never
-        // close the renderer out from under a page.render() that's mid-flight.
-        closed = true
-        ioScope.launch {
-            mutex.withLock {
-                runCatching { renderer.close() }
-                runCatching { fd.close() }
-            }
-        }.invokeOnCompletion { ioScope.cancel() }
-    }
-
-    companion object {
-        fun create(context: Context, bytes: ByteArray): PdfDocumentHolder? {
-            val dir = File(context.cacheDir, "pdf_preview").apply { mkdirs() }
-            val file = File.createTempFile("preview_", ".pdf", dir)
-            var opened: ParcelFileDescriptor? = null
-            return runCatching {
-                file.writeBytes(bytes)
-                val fd = ParcelFileDescriptor.open(file, ParcelFileDescriptor.MODE_READ_ONLY)
-                opened = fd
-                // Unlink now: the fd keeps the data readable, and the on-disk entry is gone even if the
-                // process is killed with the preview open — no orphaned cache files.
-                file.delete()
-                val renderer = PdfRenderer(fd)
-                PdfDocumentHolder(fd, renderer, renderer.pageCount)
-            }.onFailure { e ->
-                Logger.e(e) { "PdfDocumentHolder.create failed" }
-                runCatching { opened?.close() }
-                runCatching { file.delete() }
-            }.getOrNull()
         }
     }
 }

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/components/PdfViewer.android.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/components/PdfViewer.android.kt
@@ -43,11 +43,9 @@ actual fun PdfViewer(bytes: ByteArray, onRenderError: () -> Unit, modifier: Modi
     val context = LocalContext.current
     val currentOnRenderError by rememberUpdatedState(onRenderError)
 
-    // The producer owns the holder's lifecycle: it publishes the instance it created and closes that
-    // same instance via awaitDispose. (A DisposableEffect keyed on the delegated holder would read
-    // the *live* value at dispose time and close the just-created holder on the null→holder swap.)
-    // NonCancellable so a create() that finishes after the composition scrolled away is still
-    // published-or-closed rather than leaking its fd/renderer.
+    // The producer owns the holder's lifecycle: it closes the same instance it published, via
+    // awaitDispose. NonCancellable so a create() finishing after disposal is still closed rather
+    // than leaking its fd/renderer.
     val holder by produceState<PdfDocumentHolder?>(null, bytes) {
         val fresh = withContext(Dispatchers.IO + NonCancellable) {
             PdfDocumentHolder.create(context, bytes)
@@ -69,8 +67,7 @@ actual fun PdfViewer(bytes: ByteArray, onRenderError: () -> Unit, modifier: Modi
  * One page, fit to width, with per-page pinch-zoom + pan. The zoom gesture is gated to multi-touch
  * (see the second `pointerInput`) so a one-finger drag is left unconsumed and the enclosing
  * [LazyColumn] scrolls; two fingers zoom/pan the page. Double-tap resets. Pan is clamped so the page
- * can't be dragged off its own bounds. Rendering, recycling, and aspect sizing live in the shared
- * [PdfPageContent].
+ * can't be dragged off its own bounds.
  */
 @Composable
 private fun PdfPage(doc: PdfDocumentHolder, index: Int) {

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/components/PdfViewer.android.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/components/PdfViewer.android.kt
@@ -1,21 +1,13 @@
 package com.garfiec.librechat.feature.chat.components
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.gestures.calculatePan
 import androidx.compose.foundation.gestures.calculateZoom
 import androidx.compose.foundation.gestures.detectTapGestures
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -23,38 +15,23 @@ import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.ImageBitmap
-import androidx.compose.ui.graphics.asAndroidBitmap
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.input.pointer.positionChanged
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.IntSize
-import androidx.compose.ui.unit.dp
 import com.garfiec.librechat.core.ui.pdf.PdfDocumentHolder
-import com.garfiec.librechat.feature.chat.resources.Res
-import com.garfiec.librechat.feature.chat.resources.pdf_page_failed
+import com.garfiec.librechat.core.ui.pdf.PdfPageContent
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.withContext
-import org.jetbrains.compose.resources.stringResource
-
-/** Per-page render outcome. [Loading] and [Failed] are distinguished so a failed page can show an
- *  inline indicator instead of a silent blank gap. */
-private sealed interface PageRender {
-    data object Loading : PageRender
-    data object Failed : PageRender
-    data class Ready(val bitmap: ImageBitmap) : PageRender
-}
 
 /**
  * Android PDF surface backed by [android.graphics.pdf.PdfRenderer]. The bytes are staged to a
- * cache file (PdfRenderer needs a seekable [ParcelFileDescriptor]), then each page is rendered to a
+ * cache file (PdfRenderer needs a seekable ParcelFileDescriptor), then each page is rendered to a
  * bitmap on demand as it scrolls into view — off-screen pages are disposed by the [LazyColumn], so
  * memory tracks the visible window rather than the whole document.
  *
@@ -92,7 +69,8 @@ actual fun PdfViewer(bytes: ByteArray, onRenderError: () -> Unit, modifier: Modi
  * One page, fit to width, with per-page pinch-zoom + pan. The zoom gesture is gated to multi-touch
  * (see the second `pointerInput`) so a one-finger drag is left unconsumed and the enclosing
  * [LazyColumn] scrolls; two fingers zoom/pan the page. Double-tap resets. Pan is clamped so the page
- * can't be dragged off its own bounds.
+ * can't be dragged off its own bounds. Rendering, recycling, and aspect sizing live in the shared
+ * [PdfPageContent].
  */
 @Composable
 private fun PdfPage(doc: PdfDocumentHolder, index: Int) {
@@ -101,34 +79,10 @@ private fun PdfPage(doc: PdfDocumentHolder, index: Int) {
     var offsetY by remember { mutableFloatStateOf(0f) }
     var size by remember { mutableStateOf(IntSize.Zero) }
 
-    val widthPx = size.width
-    val render by produceState<PageRender>(PageRender.Loading, doc, index, widthPx) {
-        value = PageRender.Loading
-        if (widthPx > 0) {
-            value = doc.renderPage(index, widthPx)?.let { PageRender.Ready(it) } ?: PageRender.Failed
-        }
-    }
-    val bitmap = (render as? PageRender.Ready)?.bitmap
-
-    // Recycle the page bitmap's native memory when the page leaves composition (scrolls out of the
-    // LazyColumn window); GC alone lets ARGB_8888 buffers pile up while the collector catches up.
-    // rememberUpdatedState so the effect frees whichever bitmap is current at dispose time.
-    val bitmapToRecycle by rememberUpdatedState(bitmap)
-    DisposableEffect(Unit) {
-        onDispose { bitmapToRecycle?.asAndroidBitmap()?.recycle() }
-    }
-
-    // Once the bitmap is in, size the box to its true aspect (drives relayout); until then use the
-    // stored/placeholder ratio. Sanitize so Modifier.aspectRatio never sees 0 / NaN / ∞.
-    val aspect = bitmap
-        ?.let { it.width.toFloat() / it.height.toFloat() }
-        ?.takeIf { it.isFinite() && it > 0f }
-        ?: doc.aspectRatio(index)
-
-    Box(
+    PdfPageContent(
+        doc = doc,
+        index = index,
         modifier = Modifier
-            .fillMaxWidth()
-            .aspectRatio(aspect)
             .onSizeChanged { size = it }
             .graphicsLayer {
                 scaleX = scale
@@ -166,22 +120,5 @@ private fun PdfPage(doc: PdfDocumentHolder, index: Int) {
                     } while (event.changes.any { it.pressed })
                 }
             },
-        contentAlignment = Alignment.Center,
-    ) {
-        when (val r = render) {
-            is PageRender.Ready -> Image(
-                bitmap = r.bitmap,
-                contentDescription = null,
-                modifier = Modifier.fillMaxSize(),
-                contentScale = ContentScale.FillWidth,
-            )
-            is PageRender.Failed -> Text(
-                text = stringResource(Res.string.pdf_page_failed),
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.padding(16.dp),
-            )
-            is PageRender.Loading -> Unit // blank until the first render lands
-        }
-    }
+    )
 }

--- a/feature/chat/src/commonMain/composeResources/values/strings.xml
+++ b/feature/chat/src/commonMain/composeResources/values/strings.xml
@@ -266,7 +266,6 @@
     <string name="cd_download_attachment">Download %1$s</string>
     <string name="pdf_document">PDF Document</string>
     <string name="pdf_load_failed">Couldn\'t load PDF</string>
-    <string name="pdf_page_failed">Couldn\'t render this page</string>
     <string name="cd_share_pdf">Share PDF</string>
     <string name="cd_open_pdf">Open PDF</string>
     <string name="retry">Retry</string>

--- a/feature/files/src/androidMain/kotlin/com/garfiec/librechat/feature/files/platform/PdfPreview.android.kt
+++ b/feature/files/src/androidMain/kotlin/com/garfiec/librechat/feature/files/platform/PdfPreview.android.kt
@@ -63,10 +63,9 @@ actual fun PdfPreview(
     val context = LocalContext.current
     val currentOnDownloadFile by rememberUpdatedState(onDownloadFile)
 
-    // The producer owns the holder's lifecycle: it publishes the instance it created and closes that
-    // same instance via awaitDispose. Download is cancellable (leaving mid-download just stops it);
-    // create() is NonCancellable so a create finishing after dismissal is still published-then-closed
-    // rather than leaking its fd/renderer.
+    // The producer owns the holder's lifecycle: it closes the same instance it published, via
+    // awaitDispose. The download stays cancellable; create() is NonCancellable so a create
+    // finishing after dismissal is still closed rather than leaking its fd/renderer.
     val loadState by produceState<PdfLoadState>(PdfLoadState.Loading, file.fileId) {
         value = PdfLoadState.Loading
         val bytes = try {

--- a/feature/files/src/androidMain/kotlin/com/garfiec/librechat/feature/files/platform/PdfPreview.android.kt
+++ b/feature/files/src/androidMain/kotlin/com/garfiec/librechat/feature/files/platform/PdfPreview.android.kt
@@ -1,13 +1,10 @@
 package com.garfiec.librechat.feature.files.platform
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.gestures.rememberTransformableState
 import androidx.compose.foundation.gestures.transformable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.aspectRatio
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -20,7 +17,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -31,18 +27,14 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.graphics.ImageBitmap
-import androidx.compose.ui.graphics.asAndroidBitmap
 import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import co.touchlab.kermit.Logger
 import com.garfiec.librechat.core.ui.pdf.PdfDocumentHolder
+import com.garfiec.librechat.core.ui.pdf.PdfPageContent
 import com.garfiec.librechat.feature.files.FilePreviewDisplayData
 import com.garfiec.librechat.feature.files.resources.*
 import com.garfiec.librechat.feature.files.resources.Res
@@ -51,20 +43,15 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.withContext
+import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.stringResource
 
 private sealed interface PdfLoadState {
     data object Loading : PdfLoadState
     data class Success(val doc: PdfDocumentHolder) : PdfLoadState
-    data class Error(val message: String) : PdfLoadState
-}
 
-/** Per-page render outcome. [Loading] and [Failed] are distinguished so a failed page can show an
- *  inline indicator instead of a silent blank gap. */
-private sealed interface PageRender {
-    data object Loading : PageRender
-    data object Failed : PageRender
-    data class Ready(val bitmap: ImageBitmap) : PageRender
+    /** [detail] carries the underlying cause (e.g. an HTTP error message) when one is known. */
+    data class Error(val message: StringResource, val detail: String? = null) : PdfLoadState
 }
 
 @Composable
@@ -88,17 +75,18 @@ actual fun PdfPreview(
             throw e
         } catch (e: Exception) {
             Logger.e(e) { "PdfPreview: download failed" }
-            null
+            value = PdfLoadState.Error(Res.string.failed_to_download_pdf, e.message)
+            return@produceState
         }
         if (bytes == null) {
-            value = PdfLoadState.Error("Failed to download PDF")
+            value = PdfLoadState.Error(Res.string.failed_to_download_pdf)
             return@produceState
         }
         val doc = withContext(Dispatchers.IO + NonCancellable) {
             PdfDocumentHolder.create(context, bytes)
         }
         if (doc == null) {
-            value = PdfLoadState.Error("Failed to render PDF")
+            value = PdfLoadState.Error(Res.string.failed_to_render_pdf)
             return@produceState
         }
         value = PdfLoadState.Success(doc)
@@ -127,7 +115,8 @@ actual fun PdfPreview(
         is PdfLoadState.Error -> {
             PdfErrorFallback(
                 file = file,
-                errorMessage = state.message,
+                message = state.message,
+                detail = state.detail,
                 modifier = modifier,
             )
         }
@@ -170,84 +159,31 @@ private fun PdfPagesList(
         verticalArrangement = Arrangement.spacedBy(2.dp),
     ) {
         items(count = doc.pageCount, key = { it }, contentType = { "pdf_page" }) { index ->
-            PdfPreviewPage(doc = doc, index = index, filename = filename)
-        }
-    }
-}
-
-/**
- * One page, rendered on demand as it scrolls into view and disposed when it scrolls out, so memory
- * tracks the visible window rather than the whole document. Sized to the page's aspect ratio (a
- * placeholder until the first render reports the real one) so the scroll position stays stable.
- */
-@Composable
-private fun PdfPreviewPage(doc: PdfDocumentHolder, index: Int, filename: String) {
-    var size by remember { mutableStateOf(IntSize.Zero) }
-
-    val widthPx = size.width
-    val render by produceState<PageRender>(PageRender.Loading, doc, index, widthPx) {
-        value = PageRender.Loading
-        if (widthPx > 0) {
-            value = doc.renderPage(index, widthPx)?.let { PageRender.Ready(it) } ?: PageRender.Failed
-        }
-    }
-    val bitmap = (render as? PageRender.Ready)?.bitmap
-
-    // Recycle the page bitmap's native memory when the page leaves composition (scrolls out of the
-    // LazyColumn window); GC alone lets ARGB_8888 buffers pile up while the collector catches up.
-    // rememberUpdatedState so the effect frees whichever bitmap is current at dispose time.
-    val bitmapToRecycle by rememberUpdatedState(bitmap)
-    DisposableEffect(Unit) {
-        onDispose { bitmapToRecycle?.asAndroidBitmap()?.recycle() }
-    }
-
-    // Once the bitmap is in, size the box to its true aspect (drives relayout); until then use the
-    // stored/placeholder ratio. Sanitize so Modifier.aspectRatio never sees 0 / NaN / ∞.
-    val aspect = bitmap
-        ?.let { it.width.toFloat() / it.height.toFloat() }
-        ?.takeIf { it.isFinite() && it > 0f }
-        ?: doc.aspectRatio(index)
-
-    Column {
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .aspectRatio(aspect)
-                .onSizeChanged { size = it },
-            contentAlignment = Alignment.Center,
-        ) {
-            when (val r = render) {
-                is PageRender.Ready -> Image(
-                    bitmap = r.bitmap,
+            Column {
+                PdfPageContent(
+                    doc = doc,
+                    index = index,
                     contentDescription = stringResource(Res.string.page_cd, index + 1, filename),
-                    modifier = Modifier.fillMaxSize(),
-                    contentScale = ContentScale.FillWidth,
                 )
-                is PageRender.Failed -> Text(
-                    text = stringResource(Res.string.pdf_page_failed),
-                    style = MaterialTheme.typography.bodySmall,
+                Text(
+                    text = stringResource(Res.string.page_of, index + 1, doc.pageCount),
+                    style = MaterialTheme.typography.labelSmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.padding(16.dp),
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 4.dp),
                 )
-                is PageRender.Loading -> Unit // blank until the first render lands
             }
         }
-        Text(
-            text = stringResource(Res.string.page_of, index + 1, doc.pageCount),
-            style = MaterialTheme.typography.labelSmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            textAlign = TextAlign.Center,
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(vertical = 4.dp),
-        )
     }
 }
 
 @Composable
 private fun PdfErrorFallback(
     file: FilePreviewDisplayData,
-    errorMessage: String,
+    message: StringResource,
+    detail: String?,
     modifier: Modifier = Modifier,
 ) {
     Box(
@@ -285,11 +221,20 @@ private fun PdfErrorFallback(
                 )
 
                 Text(
-                    text = errorMessage,
+                    text = stringResource(message),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.error,
                     textAlign = TextAlign.Center,
                 )
+
+                detail?.let {
+                    Text(
+                        text = it,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        textAlign = TextAlign.Center,
+                    )
+                }
 
                 Column(
                     verticalArrangement = Arrangement.spacedBy(8.dp),

--- a/feature/files/src/androidMain/kotlin/com/garfiec/librechat/feature/files/platform/PdfPreview.android.kt
+++ b/feature/files/src/androidMain/kotlin/com/garfiec/librechat/feature/files/platform/PdfPreview.android.kt
@@ -1,20 +1,17 @@
 package com.garfiec.librechat.feature.files.platform
 
-import android.graphics.Bitmap
-import android.graphics.Color
-import android.graphics.pdf.PdfRenderer
-import android.os.ParcelFileDescriptor
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.gestures.rememberTransformableState
 import androidx.compose.foundation.gestures.transformable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.PictureAsPdf
 import androidx.compose.material3.Card
@@ -24,37 +21,50 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asAndroidBitmap
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import co.touchlab.kermit.Logger
+import com.garfiec.librechat.core.ui.pdf.PdfDocumentHolder
 import com.garfiec.librechat.feature.files.FilePreviewDisplayData
 import com.garfiec.librechat.feature.files.resources.*
 import com.garfiec.librechat.feature.files.resources.Res
 import com.garfiec.librechat.feature.files.screen.InfoRow
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.withContext
 import org.jetbrains.compose.resources.stringResource
-import java.io.File
 
 private sealed interface PdfLoadState {
     data object Loading : PdfLoadState
-    data class Success(val pages: List<Bitmap>) : PdfLoadState
+    data class Success(val doc: PdfDocumentHolder) : PdfLoadState
     data class Error(val message: String) : PdfLoadState
+}
+
+/** Per-page render outcome. [Loading] and [Failed] are distinguished so a failed page can show an
+ *  inline indicator instead of a silent blank gap. */
+private sealed interface PageRender {
+    data object Loading : PageRender
+    data object Failed : PageRender
+    data class Ready(val bitmap: ImageBitmap) : PageRender
 }
 
 @Composable
@@ -64,90 +74,35 @@ actual fun PdfPreview(
     modifier: Modifier,
 ) {
     val context = LocalContext.current
-    var loadState by remember { mutableStateOf<PdfLoadState>(PdfLoadState.Loading) }
-    var tempFile by remember { mutableStateOf<File?>(null) }
+    val currentOnDownloadFile by rememberUpdatedState(onDownloadFile)
 
-    DisposableEffect(file.fileId) {
-        onDispose {
-            tempFile?.delete()
-            val currentState = loadState
-            if (currentState is PdfLoadState.Success) {
-                currentState.pages.forEach { bitmap ->
-                    if (!bitmap.isRecycled) {
-                        bitmap.recycle()
-                    }
-                }
-            }
-        }
-    }
-
-    LaunchedEffect(file.fileId) {
-        loadState = PdfLoadState.Loading
-        try {
-            // Download, disk write, and PdfRenderer page rendering are all blocking.
-            // Run them off the Main thread; only the resulting state lands on Main.
-            val result = withContext(Dispatchers.IO) {
-                val bytes = onDownloadFile?.invoke(file.fileId, file.userId)
-                    ?: return@withContext PdfLoadState.Error("Failed to download PDF")
-
-                val pdfPreviewDir = File(context.cacheDir, "pdf_preview").apply { mkdirs() }
-                val pdfTempFile = File(pdfPreviewDir, "pdf_preview_${file.fileId}.pdf")
-                pdfTempFile.writeBytes(bytes)
-                tempFile = pdfTempFile
-
-                val fd = ParcelFileDescriptor.open(
-                    pdfTempFile,
-                    ParcelFileDescriptor.MODE_READ_ONLY,
-                )
-                val renderer = PdfRenderer(fd)
-                val pageCount = renderer.pageCount
-                Logger.d { "PdfPreview: opened PDF with $pageCount pages" }
-
-                val maxPages = minOf(pageCount, 50)
-                val bitmaps = mutableListOf<Bitmap>()
-                val displayMetrics = context.resources.displayMetrics
-                val targetWidth = displayMetrics.widthPixels
-
-                for (i in 0 until maxPages) {
-                    val page = renderer.openPage(i)
-                    val scale = targetWidth.toFloat() / page.width
-                    val bitmapWidth = targetWidth
-                    val bitmapHeight = (page.height * scale).toInt()
-
-                    val bitmap = Bitmap.createBitmap(
-                        bitmapWidth,
-                        bitmapHeight,
-                        Bitmap.Config.ARGB_8888,
-                    )
-                    bitmap.eraseColor(Color.WHITE)
-                    page.render(
-                        bitmap,
-                        null,
-                        null,
-                        PdfRenderer.Page.RENDER_MODE_FOR_DISPLAY,
-                    )
-                    page.close()
-                    bitmaps.add(bitmap)
-                }
-
-                renderer.close()
-                fd.close()
-
-                if (pageCount > maxPages) {
-                    Logger.d { "PdfPreview: showing first $maxPages of $pageCount pages" }
-                }
-                PdfLoadState.Success(bitmaps)
-            }
-
-            loadState = result
+    // The producer owns the holder's lifecycle: it publishes the instance it created and closes that
+    // same instance via awaitDispose. Download is cancellable (leaving mid-download just stops it);
+    // create() is NonCancellable so a create finishing after dismissal is still published-then-closed
+    // rather than leaking its fd/renderer.
+    val loadState by produceState<PdfLoadState>(PdfLoadState.Loading, file.fileId) {
+        value = PdfLoadState.Loading
+        val bytes = try {
+            withContext(Dispatchers.IO) { currentOnDownloadFile?.invoke(file.fileId, file.userId) }
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
-            Logger.e(e) { "PdfPreview: failed to render PDF" }
-            loadState = PdfLoadState.Error(
-                e.message ?: "Failed to render PDF",
-            )
+            Logger.e(e) { "PdfPreview: download failed" }
+            null
         }
+        if (bytes == null) {
+            value = PdfLoadState.Error("Failed to download PDF")
+            return@produceState
+        }
+        val doc = withContext(Dispatchers.IO + NonCancellable) {
+            PdfDocumentHolder.create(context, bytes)
+        }
+        if (doc == null) {
+            value = PdfLoadState.Error("Failed to render PDF")
+            return@produceState
+        }
+        value = PdfLoadState.Success(doc)
+        awaitDispose { doc.close() }
     }
 
     when (val state = loadState) {
@@ -178,7 +133,7 @@ actual fun PdfPreview(
         }
         is PdfLoadState.Success -> {
             PdfPagesList(
-                pages = state.pages,
+                doc = state.doc,
                 filename = file.filename,
                 modifier = modifier,
             )
@@ -188,7 +143,7 @@ actual fun PdfPreview(
 
 @Composable
 private fun PdfPagesList(
-    pages: List<Bitmap>,
+    doc: PdfDocumentHolder,
     filename: String,
     modifier: Modifier = Modifier,
 ) {
@@ -214,28 +169,78 @@ private fun PdfPagesList(
             .transformable(state = transformableState),
         verticalArrangement = Arrangement.spacedBy(2.dp),
     ) {
-        itemsIndexed(
-            items = pages,
-            key = { index, _ -> "page_$index" },
-        ) { index, bitmap ->
-            Column {
-                Image(
-                    bitmap = bitmap.asImageBitmap(),
+        items(count = doc.pageCount, key = { it }, contentType = { "pdf_page" }) { index ->
+            PdfPreviewPage(doc = doc, index = index, filename = filename)
+        }
+    }
+}
+
+/**
+ * One page, rendered on demand as it scrolls into view and disposed when it scrolls out, so memory
+ * tracks the visible window rather than the whole document. Sized to the page's aspect ratio (a
+ * placeholder until the first render reports the real one) so the scroll position stays stable.
+ */
+@Composable
+private fun PdfPreviewPage(doc: PdfDocumentHolder, index: Int, filename: String) {
+    var size by remember { mutableStateOf(IntSize.Zero) }
+
+    val widthPx = size.width
+    val render by produceState<PageRender>(PageRender.Loading, doc, index, widthPx) {
+        value = PageRender.Loading
+        if (widthPx > 0) {
+            value = doc.renderPage(index, widthPx)?.let { PageRender.Ready(it) } ?: PageRender.Failed
+        }
+    }
+    val bitmap = (render as? PageRender.Ready)?.bitmap
+
+    // Recycle the page bitmap's native memory when the page leaves composition (scrolls out of the
+    // LazyColumn window); GC alone lets ARGB_8888 buffers pile up while the collector catches up.
+    // rememberUpdatedState so the effect frees whichever bitmap is current at dispose time.
+    val bitmapToRecycle by rememberUpdatedState(bitmap)
+    DisposableEffect(Unit) {
+        onDispose { bitmapToRecycle?.asAndroidBitmap()?.recycle() }
+    }
+
+    // Once the bitmap is in, size the box to its true aspect (drives relayout); until then use the
+    // stored/placeholder ratio. Sanitize so Modifier.aspectRatio never sees 0 / NaN / ∞.
+    val aspect = bitmap
+        ?.let { it.width.toFloat() / it.height.toFloat() }
+        ?.takeIf { it.isFinite() && it > 0f }
+        ?: doc.aspectRatio(index)
+
+    Column {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .aspectRatio(aspect)
+                .onSizeChanged { size = it },
+            contentAlignment = Alignment.Center,
+        ) {
+            when (val r = render) {
+                is PageRender.Ready -> Image(
+                    bitmap = r.bitmap,
                     contentDescription = stringResource(Res.string.page_cd, index + 1, filename),
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = Modifier.fillMaxSize(),
                     contentScale = ContentScale.FillWidth,
                 )
-                Text(
-                    text = stringResource(Res.string.page_of, index + 1, pages.size),
-                    style = MaterialTheme.typography.labelSmall,
+                is PageRender.Failed -> Text(
+                    text = stringResource(Res.string.pdf_page_failed),
+                    style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    textAlign = TextAlign.Center,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(vertical = 4.dp),
+                    modifier = Modifier.padding(16.dp),
                 )
+                is PageRender.Loading -> Unit // blank until the first render lands
             }
         }
+        Text(
+            text = stringResource(Res.string.page_of, index + 1, doc.pageCount),
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 4.dp),
+        )
     }
 }
 

--- a/feature/files/src/commonMain/composeResources/values/strings.xml
+++ b/feature/files/src/commonMain/composeResources/values/strings.xml
@@ -53,7 +53,6 @@
     <string name="page_of">Page %1$d of %2$d</string>
     <string name="page_cd">Page %1$d of %2$s</string>
     <string name="could_not_render_pdf">Could not render PDF preview</string>
-    <string name="pdf_page_failed">Couldn\'t render this page</string>
     <string name="failed_to_download_pdf">Failed to download PDF</string>
     <string name="failed_to_render_pdf">Failed to render PDF</string>
     <string name="loading_file_content">Loading file content…</string>

--- a/feature/files/src/commonMain/composeResources/values/strings.xml
+++ b/feature/files/src/commonMain/composeResources/values/strings.xml
@@ -53,6 +53,7 @@
     <string name="page_of">Page %1$d of %2$d</string>
     <string name="page_cd">Page %1$d of %2$s</string>
     <string name="could_not_render_pdf">Could not render PDF preview</string>
+    <string name="pdf_page_failed">Couldn\'t render this page</string>
     <string name="failed_to_download_pdf">Failed to download PDF</string>
     <string name="failed_to_render_pdf">Failed to render PDF</string>
     <string name="loading_file_content">Loading file content…</string>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -69,7 +69,7 @@ junit = "4.13.2"
 turbine = "1.2.1"
 mockk = "1.14.11"
 truth = "1.4.5"
-espresso = "3.6.1"
+espresso = "3.7.0"
 android-test-runner = "1.7.0"
 android-test-ext = "1.3.0"
 android-test-core = "1.6.1"
@@ -217,6 +217,7 @@ android-test-runner = { group = "androidx.test", name = "runner", version.ref = 
 android-test-ext-junit = { group = "androidx.test.ext", name = "junit", version.ref = "android-test-ext" }
 android-test-core = { group = "androidx.test", name = "core", version.ref = "android-test-core" }
 robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "robolectric" }
+espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espresso" }
 compose-ui-test = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 


### PR DESCRIPTION
## Problem

The files-screen PDF preview (`PdfPreview.android.kt`) eagerly rendered up to 50 pages to full-device-width ARGB_8888 bitmaps **with no dimension cap** and held them all in composition state until the dialog closed:

- ~330 MB for a 50-page A4 document on a 1080p phone, ~586 MB at 1440p, ~1.85 GB on a 2560px tablet — a real, reachable OOM from the ordinary action of opening a large PDF.
- Only a spinner was shown until *all* pages finished rendering.
- Pages beyond 50 were silently dropped, and "Page N of M" reported the truncated count.

## Fix

Port the lazy pattern the in-chat PDF viewer already uses:

- **Extract `PdfDocumentHolder`** from `feature/chat`'s `PdfViewer.android.kt` into `core:ui` (`core/ui/.../pdf/PdfDocumentHolder.kt`) verbatim — mutex-serialized `renderPage`, 2048×8192 dimension caps, lazily-cached per-page aspect ratios, idempotent async `close()`, temp-file staging with immediate unlink. Features can't depend on each other, and both already get `:core:ui` from the feature convention plugin. The chat viewer now imports it; behavior identical.
- **Rebuild `PdfPreview.android.kt` on the holder**: pages render on demand as they scroll into view (`produceState` keyed on measured item width), are recycled when they scroll out (per-item `DisposableEffect`), and placeholder aspect ratios keep the scroll position stable. Memory now tracks the visible window (~2–4 pages) instead of the whole document.
- **50-page cap dropped** — every page reachable, page labels truthful. Failed pages show an inline "Couldn't render this page" instead of a silent gap (new string in `feature/files`).
- The spinner now covers only download+open (sub-second) instead of a full 50-page render. The staging temp file is unlinked right after the fd opens, so no more orphaned `pdf_preview_<fileId>.pdf` cache files on process death.
- Preserved unchanged: whole-list pinch-zoom/pan, "Page N of M" labels, error fallback card with file metadata, download flow, iOS actual, commonMain `expect`.

## Verification

- `./gradlew :app:assembleDebug` — BUILD SUCCESSFUL
- `./gradlew :core:ui:detekt :feature:files:detekt :feature:chat:detekt` — clean
- `./gradlew :feature:files:testDebugUnitTest :feature:chat:testDebugUnitTest :core:ui:testDebugUnitTest` — green, no test edits
- Plan was adversarially audited before implementation (lifecycle of the producer-owned holder, use-after-recycle, zoom-pan interplay, detekt rules, string format specs) — no design flaws found.

**Known behavior change (by design):** a fast fling can show a brief blank while a newly-composed page renders — same tradeoff as the in-chat viewer. Worth a quick manual pass with a large PDF (all pages reachable, memory flat while flinging) and a chat-attachment PDF regression check.

**Caveat:** iOS targets can't compile in this environment (no Xcode); the iOS actual is untouched, but the `core:ui` change is androidMain-only so risk is minimal.