### PR TITLE
perf(chat): dedupe the screen chrome's state collection off the streaming hot path (Android + iOS)

### DIFF
--- a/feature/chat/CLAUDE.md
+++ b/feature/chat/CLAUDE.md
@@ -25,9 +25,10 @@
   (`MessagesState`) because all five couple them.
 - Adding a field: put it on the owning slice, add a flat compat accessor on `ChatUiState`, and
   add the slice to the writer of whichever delegate(s) own it.
-- **Chrome/hot collection split (Android `ChatScreen`).** The screen collects `uiState` twice:
-  `ChatContent` (the thread subtree) at full rate, the rest — top bar, composer, dialogs, sheets,
-  effects ("chrome") — as `map { it.neutralizeStreamingChurn() }.distinctUntilChanged()`
+- **Chrome/hot collection split (both `ChatScreen` actuals).** The screen collects `uiState` twice:
+  the thread subtree (`ChatContent` on Android, `IosChatBody` on iOS) at full rate, the rest — top
+  bar, composer, dialogs, sheets, effects ("chrome") — as
+  `map { it.neutralizeStreamingChurn() }.distinctUntilChanged()`
   (`ChatChromeEquivalence.kt`), so the 50ms flush doesn't re-execute the whole screen ~20×/s.
   The neutralized fields are always empty on the chrome's copy — chrome must not read them; if it
   needs one, drop it from `neutralizeStreamingChurn`. New high-frequency streaming fields go in

--- a/feature/chat/CLAUDE.md
+++ b/feature/chat/CLAUDE.md
@@ -25,6 +25,16 @@
   (`MessagesState`) because all five couple them.
 - Adding a field: put it on the owning slice, add a flat compat accessor on `ChatUiState`, and
   add the slice to the writer of whichever delegate(s) own it.
+- **Chrome/hot collection split (Android `ChatScreen`).** The screen collects `uiState` twice:
+  `ChatContent` (the thread subtree) at full rate, the rest — top bar, composer, dialogs, sheets,
+  effects ("chrome") — as `map { it.neutralizeStreamingChurn() }.distinctUntilChanged()`
+  (`ChatChromeEquivalence.kt`), so the 50ms flush doesn't re-execute the whole screen ~20×/s.
+  The neutralized fields are always empty on the chrome's copy — chrome must not read them; if it
+  needs one, drop it from `neutralizeStreamingChurn`. New high-frequency streaming fields go in
+  both `neutralizeStreamingChurn` and `ChatChromeEquivalenceTest`. Known exclusion:
+  `subagentProgress` is chrome-visible by design (ChatRoot → `LocalSubagentProgress`) and written
+  per SSE envelope unthrottled, so subagent-heavy runs still re-execute the chrome — needs a
+  separate collection path or a write-side throttle in `SubagentTraceDelegate` (open follow-up).
 
 ## Screen States
 `ChatScreenState` enum: `LANDING` | `LOADING` | `ACTIVE`

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatContent.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatContent.kt
@@ -5,9 +5,11 @@ import android.content.ClipboardManager
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.Dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.garfiec.librechat.core.common.EndpointConstants
 import com.garfiec.librechat.core.ui.components.LoadingIndicator
 import com.garfiec.librechat.feature.chat.components.LandingContent
@@ -26,10 +28,11 @@ import com.garfiec.librechat.feature.chat.viewmodel.ChatViewModel
  * wide screens, a tab pager on phones); otherwise it shows the single message
  * list. Lives in a [ColumnScope] so the panes can claim the remaining height via
  * `weight`, leaving the bottom of the box for the composer overlay.
+ *
+ * Collects `viewModel.uiState` at full rate — the one subtree that re-renders per streaming flush.
  */
 @Composable
 internal fun ColumnScope.ChatContent(
-    uiState: ChatUiState,
     viewModel: ChatViewModel,
     clipboardManager: ClipboardManager,
     agentName: String?,
@@ -50,6 +53,7 @@ internal fun ColumnScope.ChatContent(
     // Drives the pull-up sheet directly from the (non-scrollable) landing surface.
     pullUpModifier: Modifier,
 ) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     // Non-scrolling bodies (landing, loading, comparison panes) clear the floating bar with a
     // plain top padding; only the single active MessageList takes the inset as scrollable
     // contentPadding so its content scrolls up behind the bar's scrim.

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatScreen.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatScreen.kt
@@ -76,8 +76,10 @@ import com.garfiec.librechat.feature.chat.components.rememberChatOptionsSheetCon
 import com.garfiec.librechat.feature.chat.components.rememberChatAttachmentActions
 import com.garfiec.librechat.feature.chat.viewmodel.ChatViewModel
 import com.garfiec.librechat.feature.chat.viewmodel.asString
+import com.garfiec.librechat.feature.chat.viewmodel.neutralizeStreamingChurn
 import kotlin.math.roundToInt
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.parameter.parametersOf
@@ -117,7 +119,10 @@ actual fun ChatScreen(
         koinViewModel {
             parametersOf(conversationId, initialAgentId, isTemporaryRoute, initialEndpoint, initialModel)
         }
-    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    // Chrome-rate state; ChatContent collects at full rate. Never read a neutralized field here.
+    val uiState by remember(viewModel) {
+        viewModel.uiState.map { it.neutralizeStreamingChurn() }.distinctUntilChanged()
+    }.collectAsStateWithLifecycle(viewModel.uiState.value.neutralizeStreamingChurn())
     val attachedFiles by viewModel.attachedFiles.collectAsStateWithLifecycle()
     val shareLinkUrl by viewModel.shareLinkUrl.collectAsStateWithLifecycle()
     val prefs by viewModel.chatPreferences.collectAsStateWithLifecycle()
@@ -430,7 +435,6 @@ actual fun ChatScreen(
                 ChatContent(
                     listPullUpModifier = pullUpListModifier,
                     pullUpModifier = pullUpLandingModifier,
-                    uiState = uiState,
                     viewModel = viewModel,
                     clipboardManager = clipboardManager,
                     agentName = agentName,

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatScreen.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatScreen.kt
@@ -120,9 +120,11 @@ actual fun ChatScreen(
             parametersOf(conversationId, initialAgentId, isTemporaryRoute, initialEndpoint, initialModel)
         }
     // Chrome-rate state; ChatContent collects at full rate. Never read a neutralized field here.
-    val uiState by remember(viewModel) {
+    val chromeFlow = remember(viewModel) {
         viewModel.uiState.map { it.neutralizeStreamingChurn() }.distinctUntilChanged()
-    }.collectAsStateWithLifecycle(viewModel.uiState.value.neutralizeStreamingChurn())
+    }
+    val initialChrome = remember(viewModel) { viewModel.uiState.value.neutralizeStreamingChurn() }
+    val uiState by chromeFlow.collectAsStateWithLifecycle(initialChrome)
     val attachedFiles by viewModel.attachedFiles.collectAsStateWithLifecycle()
     val shareLinkUrl by viewModel.shareLinkUrl.collectAsStateWithLifecycle()
     val prefs by viewModel.chatPreferences.collectAsStateWithLifecycle()

--- a/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatChromeEquivalenceTest.kt
+++ b/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatChromeEquivalenceTest.kt
@@ -1,0 +1,214 @@
+package com.garfiec.librechat.feature.chat.viewmodel
+
+import com.garfiec.librechat.core.model.Attachment
+import com.garfiec.librechat.core.model.Message
+import com.garfiec.librechat.core.model.usage.ContextUsage
+import com.garfiec.librechat.feature.chat.util.MessageNode
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Two invariants for the chrome-rate dedupe: streaming churn must be equivalent, and every
+ * discrete transition the chrome renders must not be.
+ */
+class ChatChromeEquivalenceTest {
+
+    private val streaming = ChatUiState(
+        content = MessagesState(
+            screenState = ChatScreenState.ACTIVE,
+            isStreaming = true,
+            streamingContent = "Once upon",
+        ),
+    )
+
+    private fun ChatUiState.withContent(transform: MessagesState.() -> MessagesState) =
+        copy(content = content.transform())
+
+    @Test
+    fun `same instance is equivalent`() {
+        assertThat(streaming.chromeEquivalentTo(streaming)).isTrue()
+    }
+
+    @Test
+    fun `streaming text flush is equivalent`() {
+        val next = streaming.withContent { copy(streamingContent = "Once upon a time") }
+        assertThat(streaming.chromeEquivalentTo(next)).isTrue()
+    }
+
+    @Test
+    fun `active tool call updates are equivalent`() {
+        val next = streaming.withContent {
+            copy(activeToolCalls = listOf(ActiveToolCall(id = "t1", name = "web_search")))
+        }
+        assertThat(streaming.chromeEquivalentTo(next)).isTrue()
+    }
+
+    @Test
+    fun `streaming attachment arrival is equivalent`() {
+        val next = streaming.withContent {
+            copy(streamingAttachments = listOf(Attachment(messageId = "m1")))
+        }
+        assertThat(streaming.chromeEquivalentTo(next)).isTrue()
+    }
+
+    @Test
+    fun `comparison pane streaming churn is equivalent`() {
+        val base = streaming.copy(comparisonState = ComparisonState(isEnabled = true))
+        val next = base.copy(
+            comparisonState = base.comparisonState.copy(
+                primaryStreamingContent = "left",
+                secondaryStreamingContent = "right",
+                primaryActiveToolCalls = listOf(ActiveToolCall(id = "t1", name = "web_search")),
+                secondaryActiveToolCalls = listOf(ActiveToolCall(id = "t2", name = "execute_code")),
+            ),
+        )
+        assertThat(base.chromeEquivalentTo(next)).isTrue()
+    }
+
+    @Test
+    fun `each comparison streaming buffer is individually neutralized`() {
+        val base = streaming.copy(comparisonState = ComparisonState(isEnabled = true))
+        val toolCall = listOf(ActiveToolCall(id = "t1", name = "web_search"))
+        val churns = listOf<(ComparisonState) -> ComparisonState>(
+            { it.copy(primaryStreamingContent = "x") },
+            { it.copy(secondaryStreamingContent = "x") },
+            { it.copy(primaryActiveToolCalls = toolCall) },
+            { it.copy(secondaryActiveToolCalls = toolCall) },
+        )
+        churns.forEach { churn ->
+            val next = base.copy(comparisonState = churn(base.comparisonState))
+            assertThat(base.chromeEquivalentTo(next)).isTrue()
+        }
+    }
+
+    @Test
+    fun `isStreaming transition is not equivalent`() {
+        val next = streaming.withContent { copy(isStreaming = false, streamingContent = "") }
+        assertThat(streaming.chromeEquivalentTo(next)).isFalse()
+    }
+
+    @Test
+    fun `context usage update is not equivalent`() {
+        val next = streaming.withContent {
+            copy(contextUsage = ContextUsage(remainingContextTokens = 100_000))
+        }
+        assertThat(streaming.chromeEquivalentTo(next)).isFalse()
+    }
+
+    @Test
+    fun `retry info is not equivalent`() {
+        val next = streaming.withContent { copy(retryInfo = RetryInfo(attempt = 1, maxAttempts = 3)) }
+        assertThat(streaming.chromeEquivalentTo(next)).isFalse()
+    }
+
+    @Test
+    fun `composer input change is not equivalent`() {
+        val next = streaming.copy(composer = ComposerState(inputText = "hi"))
+        assertThat(streaming.chromeEquivalentTo(next)).isFalse()
+    }
+
+    @Test
+    fun `error change is not equivalent`() {
+        val next = streaming.copy(error = "boom")
+        assertThat(streaming.chromeEquivalentTo(next)).isFalse()
+    }
+
+    @Test
+    fun `message swap alone is not equivalent`() {
+        // finalizeChatDisplay swaps the tree in the same emission that clears streaming.
+        val finalized = Message(messageId = "m1", conversationId = "c1")
+        val messagesOnly = streaming.withContent { copy(messages = listOf(finalized)) }
+        val displayOnly = streaming.withContent {
+            copy(
+                displayMessages = listOf(
+                    MessageNode(
+                        message = finalized,
+                        children = emptyList(),
+                        siblingIndex = 0,
+                        siblingCount = 1,
+                    ),
+                ),
+            )
+        }
+        val branchesOnly = streaming.withContent { copy(activeBranches = mapOf("root" to 1)) }
+        assertThat(streaming.chromeEquivalentTo(messagesOnly)).isFalse()
+        assertThat(streaming.chromeEquivalentTo(displayOnly)).isFalse()
+        assertThat(streaming.chromeEquivalentTo(branchesOnly)).isFalse()
+    }
+
+    @Test
+    fun `neutralized copy resets churn fields and preserves the rest`() {
+        val loud = streaming
+            .withContent {
+                copy(
+                    activeToolCalls = listOf(ActiveToolCall(id = "t1", name = "web_search")),
+                    streamingAttachments = listOf(Attachment(messageId = "m1")),
+                )
+            }
+            .copy(
+                comparisonState = ComparisonState(
+                    isEnabled = true,
+                    primaryStreamingContent = "left",
+                    secondaryStreamingContent = "right",
+                ),
+            )
+        val neutral = loud.neutralizeStreamingChurn()
+        assertThat(neutral.streamingContent).isEmpty()
+        assertThat(neutral.activeToolCalls).isEmpty()
+        assertThat(neutral.streamingAttachments).isEmpty()
+        assertThat(neutral.comparisonState.primaryStreamingContent).isEmpty()
+        assertThat(neutral.comparisonState.secondaryStreamingContent).isEmpty()
+        assertThat(neutral.isStreaming).isTrue()
+        assertThat(neutral.comparisonState.isEnabled).isTrue()
+        assertThat(neutral.screenState).isEqualTo(ChatScreenState.ACTIVE)
+    }
+
+    @Test
+    fun `token usage update is not equivalent`() {
+        val next = streaming.withContent {
+            copy(tokenUsage = com.garfiec.librechat.core.model.usage.TokenUsage())
+        }
+        assertThat(streaming.chromeEquivalentTo(next)).isFalse()
+    }
+
+    @Test
+    fun `subagent trace update is not equivalent`() {
+        // Feeds the thread via ChatRoot's LocalSubagentProgress.
+        val next = streaming.copy(
+            subagents = SubagentState(
+                subagentProgress = mapOf("tc1" to SubagentTrace(parentToolCallId = "tc1")),
+            ),
+        )
+        assertThat(streaming.chromeEquivalentTo(next)).isFalse()
+    }
+
+    @Test
+    fun `navigation and action effect fields are not equivalent`() {
+        // ChatScreenEffects keys on these.
+        val navigated = streaming.copy(
+            conversation = ConversationMetaState(pendingNavigationConversationId = "c1"),
+        )
+        val forked = streaming.copy(
+            actions = ConversationActionsState(forkedConversationId = "c2"),
+        )
+        assertThat(streaming.chromeEquivalentTo(navigated)).isFalse()
+        assertThat(streaming.chromeEquivalentTo(forked)).isFalse()
+    }
+
+    @Test
+    fun `queue and voice changes are not equivalent`() {
+        val queued = streaming.copy(queue = QueueState(isQueuePaused = true))
+        val recording = streaming.copy(voice = VoiceState(isRecording = true))
+        assertThat(streaming.chromeEquivalentTo(queued)).isFalse()
+        assertThat(streaming.chromeEquivalentTo(recording)).isFalse()
+    }
+
+    @Test
+    fun `comparison secondary streaming flag transition is not equivalent`() {
+        val base = streaming.copy(comparisonState = ComparisonState(isEnabled = true))
+        val next = base.copy(
+            comparisonState = base.comparisonState.copy(secondaryIsStreaming = true),
+        )
+        assertThat(base.chromeEquivalentTo(next)).isFalse()
+    }
+}

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatChromeEquivalence.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatChromeEquivalence.kt
@@ -1,9 +1,5 @@
 package com.garfiec.librechat.feature.chat.viewmodel
 
-/** True when [this] and [other] differ only in the churn [neutralizeStreamingChurn] strips. */
-fun ChatUiState.chromeEquivalentTo(other: ChatUiState): Boolean =
-    this === other || neutralizeStreamingChurn() == other.neutralizeStreamingChurn()
-
 /**
  * [this] with the per-token streaming churn reset to at-rest values, letting the screen chrome
  * collect `map { it.neutralizeStreamingChurn() }.distinctUntilChanged()`. Chrome must not read

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatChromeEquivalence.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatChromeEquivalence.kt
@@ -1,0 +1,24 @@
+package com.garfiec.librechat.feature.chat.viewmodel
+
+/** True when [this] and [other] differ only in the churn [neutralizeStreamingChurn] strips. */
+fun ChatUiState.chromeEquivalentTo(other: ChatUiState): Boolean =
+    this === other || neutralizeStreamingChurn() == other.neutralizeStreamingChurn()
+
+/**
+ * [this] with the per-token streaming churn reset to at-rest values, letting the screen chrome
+ * collect `map { it.neutralizeStreamingChurn() }.distinctUntilChanged()`. Chrome must not read
+ * these fields — they are always empty there; if one is needed, drop it from this function.
+ */
+internal fun ChatUiState.neutralizeStreamingChurn(): ChatUiState = copy(
+    content = content.copy(
+        streamingContent = "",
+        activeToolCalls = emptyList(),
+        streamingAttachments = emptyList(),
+    ),
+    comparisonState = comparisonState.copy(
+        primaryStreamingContent = "",
+        secondaryStreamingContent = "",
+        primaryActiveToolCalls = emptyList(),
+        secondaryActiveToolCalls = emptyList(),
+    ),
+)

--- a/feature/chat/src/commonTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatChromeEquivalenceTest.kt
+++ b/feature/chat/src/commonTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatChromeEquivalenceTest.kt
@@ -4,14 +4,20 @@ import com.garfiec.librechat.core.model.Attachment
 import com.garfiec.librechat.core.model.Message
 import com.garfiec.librechat.core.model.usage.ContextUsage
 import com.garfiec.librechat.feature.chat.util.MessageNode
-import com.google.common.truth.Truth.assertThat
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 /**
  * Two invariants for the chrome-rate dedupe: streaming churn must be equivalent, and every
  * discrete transition the chrome renders must not be.
  */
 class ChatChromeEquivalenceTest {
+
+    /** What `distinctUntilChanged` sees downstream of `map { it.neutralizeStreamingChurn() }`. */
+    private fun ChatUiState.chromeEquivalentTo(other: ChatUiState): Boolean =
+        neutralizeStreamingChurn() == other.neutralizeStreamingChurn()
 
     private val streaming = ChatUiState(
         content = MessagesState(
@@ -26,13 +32,13 @@ class ChatChromeEquivalenceTest {
 
     @Test
     fun `same instance is equivalent`() {
-        assertThat(streaming.chromeEquivalentTo(streaming)).isTrue()
+        assertTrue(streaming.chromeEquivalentTo(streaming))
     }
 
     @Test
     fun `streaming text flush is equivalent`() {
         val next = streaming.withContent { copy(streamingContent = "Once upon a time") }
-        assertThat(streaming.chromeEquivalentTo(next)).isTrue()
+        assertTrue(streaming.chromeEquivalentTo(next))
     }
 
     @Test
@@ -40,7 +46,7 @@ class ChatChromeEquivalenceTest {
         val next = streaming.withContent {
             copy(activeToolCalls = listOf(ActiveToolCall(id = "t1", name = "web_search")))
         }
-        assertThat(streaming.chromeEquivalentTo(next)).isTrue()
+        assertTrue(streaming.chromeEquivalentTo(next))
     }
 
     @Test
@@ -48,7 +54,7 @@ class ChatChromeEquivalenceTest {
         val next = streaming.withContent {
             copy(streamingAttachments = listOf(Attachment(messageId = "m1")))
         }
-        assertThat(streaming.chromeEquivalentTo(next)).isTrue()
+        assertTrue(streaming.chromeEquivalentTo(next))
     }
 
     @Test
@@ -62,7 +68,7 @@ class ChatChromeEquivalenceTest {
                 secondaryActiveToolCalls = listOf(ActiveToolCall(id = "t2", name = "execute_code")),
             ),
         )
-        assertThat(base.chromeEquivalentTo(next)).isTrue()
+        assertTrue(base.chromeEquivalentTo(next))
     }
 
     @Test
@@ -77,14 +83,14 @@ class ChatChromeEquivalenceTest {
         )
         churns.forEach { churn ->
             val next = base.copy(comparisonState = churn(base.comparisonState))
-            assertThat(base.chromeEquivalentTo(next)).isTrue()
+            assertTrue(base.chromeEquivalentTo(next))
         }
     }
 
     @Test
     fun `isStreaming transition is not equivalent`() {
         val next = streaming.withContent { copy(isStreaming = false, streamingContent = "") }
-        assertThat(streaming.chromeEquivalentTo(next)).isFalse()
+        assertFalse(streaming.chromeEquivalentTo(next))
     }
 
     @Test
@@ -92,25 +98,25 @@ class ChatChromeEquivalenceTest {
         val next = streaming.withContent {
             copy(contextUsage = ContextUsage(remainingContextTokens = 100_000))
         }
-        assertThat(streaming.chromeEquivalentTo(next)).isFalse()
+        assertFalse(streaming.chromeEquivalentTo(next))
     }
 
     @Test
     fun `retry info is not equivalent`() {
         val next = streaming.withContent { copy(retryInfo = RetryInfo(attempt = 1, maxAttempts = 3)) }
-        assertThat(streaming.chromeEquivalentTo(next)).isFalse()
+        assertFalse(streaming.chromeEquivalentTo(next))
     }
 
     @Test
     fun `composer input change is not equivalent`() {
         val next = streaming.copy(composer = ComposerState(inputText = "hi"))
-        assertThat(streaming.chromeEquivalentTo(next)).isFalse()
+        assertFalse(streaming.chromeEquivalentTo(next))
     }
 
     @Test
     fun `error change is not equivalent`() {
         val next = streaming.copy(error = "boom")
-        assertThat(streaming.chromeEquivalentTo(next)).isFalse()
+        assertFalse(streaming.chromeEquivalentTo(next))
     }
 
     @Test
@@ -131,9 +137,9 @@ class ChatChromeEquivalenceTest {
             )
         }
         val branchesOnly = streaming.withContent { copy(activeBranches = mapOf("root" to 1)) }
-        assertThat(streaming.chromeEquivalentTo(messagesOnly)).isFalse()
-        assertThat(streaming.chromeEquivalentTo(displayOnly)).isFalse()
-        assertThat(streaming.chromeEquivalentTo(branchesOnly)).isFalse()
+        assertFalse(streaming.chromeEquivalentTo(messagesOnly))
+        assertFalse(streaming.chromeEquivalentTo(displayOnly))
+        assertFalse(streaming.chromeEquivalentTo(branchesOnly))
     }
 
     @Test
@@ -153,14 +159,14 @@ class ChatChromeEquivalenceTest {
                 ),
             )
         val neutral = loud.neutralizeStreamingChurn()
-        assertThat(neutral.streamingContent).isEmpty()
-        assertThat(neutral.activeToolCalls).isEmpty()
-        assertThat(neutral.streamingAttachments).isEmpty()
-        assertThat(neutral.comparisonState.primaryStreamingContent).isEmpty()
-        assertThat(neutral.comparisonState.secondaryStreamingContent).isEmpty()
-        assertThat(neutral.isStreaming).isTrue()
-        assertThat(neutral.comparisonState.isEnabled).isTrue()
-        assertThat(neutral.screenState).isEqualTo(ChatScreenState.ACTIVE)
+        assertTrue(neutral.streamingContent.isEmpty())
+        assertTrue(neutral.activeToolCalls.isEmpty())
+        assertTrue(neutral.streamingAttachments.isEmpty())
+        assertTrue(neutral.comparisonState.primaryStreamingContent.isEmpty())
+        assertTrue(neutral.comparisonState.secondaryStreamingContent.isEmpty())
+        assertTrue(neutral.isStreaming)
+        assertTrue(neutral.comparisonState.isEnabled)
+        assertEquals(ChatScreenState.ACTIVE, neutral.screenState)
     }
 
     @Test
@@ -168,7 +174,7 @@ class ChatChromeEquivalenceTest {
         val next = streaming.withContent {
             copy(tokenUsage = com.garfiec.librechat.core.model.usage.TokenUsage())
         }
-        assertThat(streaming.chromeEquivalentTo(next)).isFalse()
+        assertFalse(streaming.chromeEquivalentTo(next))
     }
 
     @Test
@@ -179,7 +185,7 @@ class ChatChromeEquivalenceTest {
                 subagentProgress = mapOf("tc1" to SubagentTrace(parentToolCallId = "tc1")),
             ),
         )
-        assertThat(streaming.chromeEquivalentTo(next)).isFalse()
+        assertFalse(streaming.chromeEquivalentTo(next))
     }
 
     @Test
@@ -191,16 +197,16 @@ class ChatChromeEquivalenceTest {
         val forked = streaming.copy(
             actions = ConversationActionsState(forkedConversationId = "c2"),
         )
-        assertThat(streaming.chromeEquivalentTo(navigated)).isFalse()
-        assertThat(streaming.chromeEquivalentTo(forked)).isFalse()
+        assertFalse(streaming.chromeEquivalentTo(navigated))
+        assertFalse(streaming.chromeEquivalentTo(forked))
     }
 
     @Test
     fun `queue and voice changes are not equivalent`() {
         val queued = streaming.copy(queue = QueueState(isQueuePaused = true))
         val recording = streaming.copy(voice = VoiceState(isRecording = true))
-        assertThat(streaming.chromeEquivalentTo(queued)).isFalse()
-        assertThat(streaming.chromeEquivalentTo(recording)).isFalse()
+        assertFalse(streaming.chromeEquivalentTo(queued))
+        assertFalse(streaming.chromeEquivalentTo(recording))
     }
 
     @Test
@@ -209,6 +215,6 @@ class ChatChromeEquivalenceTest {
         val next = base.copy(
             comparisonState = base.comparisonState.copy(secondaryIsStreaming = true),
         )
-        assertThat(base.chromeEquivalentTo(next)).isFalse()
+        assertFalse(base.chromeEquivalentTo(next))
     }
 }

--- a/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/screen/PlatformScreens.ios.kt
+++ b/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/screen/PlatformScreens.ios.kt
@@ -94,9 +94,11 @@ actual fun ChatScreen(
             parametersOf(conversationId, initialAgentId, isTemporaryRoute, initialEndpoint, initialModel)
         }
     // Chrome-rate state; IosChatBody collects at full rate. Never read a neutralized field here.
-    val uiState by remember(viewModel) {
+    val chromeFlow = remember(viewModel) {
         viewModel.uiState.map { it.neutralizeStreamingChurn() }.distinctUntilChanged()
-    }.collectAsStateWithLifecycle(viewModel.uiState.value.neutralizeStreamingChurn())
+    }
+    val initialChrome = remember(viewModel) { viewModel.uiState.value.neutralizeStreamingChurn() }
+    val uiState by chromeFlow.collectAsStateWithLifecycle(initialChrome)
     val attachedFiles by viewModel.attachedFiles.collectAsStateWithLifecycle()
     val prefs by viewModel.chatPreferences.collectAsStateWithLifecycle()
 
@@ -142,7 +144,7 @@ actual fun ChatScreen(
     // Secondary model on comparison tab 1, primary otherwise. Hoisted so IosChatInput and
     // ChatOptionsSheetHost share one computation rather than each re-running the agents scan.
     val isSecondaryTab = uiState.comparisonState.isEnabled && activeComparisonTab == 1
-    val selectedModelDisplay = if (isSecondaryTab) {
+    val effectiveSelectedModelDisplay = if (isSecondaryTab) {
         viewModel.getSecondaryModelDisplayName()
             ?: uiState.comparisonState.secondaryModel
             ?: displayModel
@@ -273,7 +275,7 @@ actual fun ChatScreen(
                 isTranscribing = uiState.isTranscribing,
                 onStartRecording = viewModel::startRecording,
                 onStopRecording = viewModel::stopRecording,
-                selectedModelDisplay = selectedModelDisplay,
+                selectedModelDisplay = effectiveSelectedModelDisplay,
                 isCodeInterpreterAvailable = uiState.isCodeInterpreterAvailable,
                 attachedFiles = attachedFiles,
                 onRemoveFile = viewModel::removeFile,
@@ -333,7 +335,7 @@ actual fun ChatScreen(
         uiState = uiState,
         viewModel = viewModel,
         isSecondaryTab = isSecondaryTab,
-        selectedModelDisplay = selectedModelDisplay,
+        selectedModelDisplay = effectiveSelectedModelDisplay,
         onAttachFiles = onAttachFilesAction,
         onTakePhoto = onTakePhotoAction,
         onPickPhotos = onPickPhotosAction,

--- a/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/screen/PlatformScreens.ios.kt
+++ b/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/screen/PlatformScreens.ios.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.garfiec.librechat.core.common.EndpointConstants
@@ -62,6 +63,9 @@ import com.garfiec.librechat.feature.chat.viewmodel.ChatScreenState
 import com.garfiec.librechat.feature.chat.viewmodel.ChatUiState
 import com.garfiec.librechat.feature.chat.viewmodel.ChatViewModel
 import com.garfiec.librechat.feature.chat.viewmodel.asString
+import com.garfiec.librechat.feature.chat.viewmodel.neutralizeStreamingChurn
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
@@ -89,13 +93,12 @@ actual fun ChatScreen(
         koinViewModel {
             parametersOf(conversationId, initialAgentId, isTemporaryRoute, initialEndpoint, initialModel)
         }
-    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    // Chrome-rate state; IosChatBody collects at full rate. Never read a neutralized field here.
+    val uiState by remember(viewModel) {
+        viewModel.uiState.map { it.neutralizeStreamingChurn() }.distinctUntilChanged()
+    }.collectAsStateWithLifecycle(viewModel.uiState.value.neutralizeStreamingChurn())
     val attachedFiles by viewModel.attachedFiles.collectAsStateWithLifecycle()
     val prefs by viewModel.chatPreferences.collectAsStateWithLifecycle()
-
-    val isLandingPage = uiState.screenState == ChatScreenState.LANDING
-    val isLoading = uiState.screenState == ChatScreenState.LOADING
-    val hasMessages = uiState.displayMessages.isNotEmpty() || uiState.isStreaming
 
     val useKatex = prefs.latexRenderer == LatexRenderer.KATEX
     val fontSizeMultiplier = when (uiState.chatFontSize) {
@@ -227,112 +230,24 @@ actual fun ChatScreen(
         val topContentPadding = with(LocalDensity.current) {
             maxOf(statusBarTop + 56.dp, topBarHeightPx.toDp())
         }
-        // Non-scrolling bodies (landing, loading) clear the floating bar with a plain top padding;
-        // only the active MessageList takes the inset as scrollable contentPadding.
-        val topPaddedFill = Modifier
-            .fillMaxSize()
-            .padding(top = topContentPadding)
-        // Streaming-bubble sender label for the active (primary) model: the agent's
-        // display name under the agents endpoint, else the raw model id.
-        val senderName = run {
-            val model = uiState.selectedModel
-            if (uiState.selectedEndpoint == EndpointConstants.AGENTS && model != null) {
-                uiState.agents.find { it.id == model }?.name ?: model
-            } else {
-                model ?: stringResource(Res.string.sender_assistant)
-            }
-        }
         Box(
             modifier = Modifier.fillMaxSize(),
         ) {
-            when {
-                isLandingPage && !hasMessages -> {
-                    Box(
-                        modifier = topPaddedFill,
-                        contentAlignment = Alignment.Center,
-                    ) {
-                        LandingContent(
-                            selectedModel = uiState.selectedModel,
-                            selectedAgentName = agentName,
-                        )
-                    }
-                }
-                isLoading && uiState.displayMessages.isEmpty() -> {
-                    Box(
-                        modifier = topPaddedFill,
-                        contentAlignment = Alignment.Center,
-                    ) {
-                        CircularProgressIndicator(modifier = Modifier.size(36.dp))
-                    }
-                }
-                uiState.comparisonState.isEnabled -> {
-                    ComparisonPanes(
-                        uiState = uiState,
-                        viewModel = viewModel,
-                        displayModel = displayModel,
-                        senderName = senderName,
-                        fontSizeMultiplier = fontSizeMultiplier,
-                        showImageDescriptions = prefs.showImageDescriptions,
-                        chatLayoutStyle = prefs.chatLayoutStyle,
-                        showAvatars = prefs.showAvatars,
-                        showBubbles = prefs.showBubbles,
-                        useKatex = useKatex,
-                        bottomContentPadding = bottomContentPadding,
-                        onCopyMessage = { messageId -> viewModel.getMessageText(messageId) },
-                        onShowSecondaryModelSheet = { showSecondaryModelSheet = true },
-                        onComparisonTabChange = { activeComparisonTab = it },
-                        modifier = topPaddedFill,
-                    )
-                }
-                else -> {
-                    val singleDisplayMessages = remember(uiState.displayMessages) {
-                        collapseParallelToPrimary(uiState.displayMessages)
-                    }
-                    MessageList(
-                        displayMessages = singleDisplayMessages,
-                        isStreaming = uiState.isStreaming,
-                        streamingContent = uiState.streamingContent,
-                        activeToolCalls = uiState.activeToolCalls,
-                        streamingAttachments = uiState.streamingAttachments,
-                        onSiblingNavigation = viewModel::switchBranch,
-                        onEditMessage = viewModel::startEditing,
-                        onRegenerateMessage = { messageId -> viewModel.regenerateMessage(messageId) },
-                        onCopyMessage = { messageId -> viewModel.getMessageText(messageId) },
-                        onFeedback = viewModel::submitFeedback,
-                        onContinue = { viewModel.continueGeneration() },
-                        onReadAloud = viewModel::readAloud,
-                        onFork = viewModel::showForkOptions,
-                        currentlyReadingMessageId = uiState.currentlyReadingMessageId,
-                        editingMessageId = uiState.editingMessageId,
-                        editingText = uiState.editingText,
-                        onEditTextChange = viewModel::onEditTextChanged,
-                        onEditSaveAndSubmit = viewModel::submitEdit,
-                        onEditSaveOnly = viewModel::saveEditOnly,
-                        onEditCancel = viewModel::cancelEditing,
-                        baseUrl = uiState.serverUrl,
-                        fontSizeMultiplier = fontSizeMultiplier,
-                        isRefreshing = uiState.isRefreshingMessages,
-                        onRefresh = viewModel::refreshMessages,
-                        userAvatarUrl = uiState.userAvatarUrl,
-                        userName = uiState.userName,
-                        selectedEndpoint = uiState.selectedEndpoint,
-                        streamingSenderName = senderName,
-                        showImageDescriptions = prefs.showImageDescriptions,
-                        chatLayoutStyle = prefs.chatLayoutStyle,
-                        showAvatars = prefs.showAvatars,
-                        showBubbles = prefs.showBubbles,
-                        useKatex = useKatex,
-                        searchQuery = if (uiState.isSearchOpen) uiState.searchQuery else null,
-                        searchMatchIndices = uiState.searchMatchIndices,
-                        currentSearchMatchIndex = uiState.currentSearchMatchIndex,
-                        searchFocusRequest = uiState.searchFocusRequest,
-                        onSearchScrollHandle = viewModel::onSearchScrollHandled,
-                        bottomContentPadding = bottomContentPadding,
-                        topContentPadding = topContentPadding,
-                        modifier = Modifier.fillMaxSize(),
-                    )
-                }
-            }
+            IosChatBody(
+                viewModel = viewModel,
+                agentName = agentName,
+                displayModel = displayModel,
+                fontSizeMultiplier = fontSizeMultiplier,
+                showImageDescriptions = prefs.showImageDescriptions,
+                chatLayoutStyle = prefs.chatLayoutStyle,
+                showAvatars = prefs.showAvatars,
+                showBubbles = prefs.showBubbles,
+                useKatex = useKatex,
+                bottomContentPadding = bottomContentPadding,
+                topContentPadding = topContentPadding,
+                onShowSecondaryModelSheet = { showSecondaryModelSheet = true },
+                onComparisonTabChange = { activeComparisonTab = it },
+            )
 
             // ChatInput overlays at the bottom so gradient shows content behind
             val isAnyStreaming = uiState.isStreaming ||
@@ -542,6 +457,137 @@ actual fun ChatScreen(
             },
         )
     }
+    }
+}
+
+/**
+ * The landing greeting, loading spinner, comparison panes, or message list for the current
+ * [ChatScreenState].
+ *
+ * Collects `viewModel.uiState` at full rate — the one subtree that re-renders per streaming flush.
+ */
+@Composable
+private fun IosChatBody(
+    viewModel: ChatViewModel,
+    agentName: String?,
+    displayModel: String?,
+    fontSizeMultiplier: Float,
+    showImageDescriptions: Boolean,
+    chatLayoutStyle: String,
+    showAvatars: Boolean,
+    showBubbles: Boolean,
+    useKatex: Boolean,
+    bottomContentPadding: Dp,
+    topContentPadding: Dp,
+    onShowSecondaryModelSheet: () -> Unit,
+    onComparisonTabChange: (Int) -> Unit,
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val isLandingPage = uiState.screenState == ChatScreenState.LANDING
+    val isLoading = uiState.screenState == ChatScreenState.LOADING
+    val hasMessages = uiState.displayMessages.isNotEmpty() || uiState.isStreaming
+    // Non-scrolling bodies (landing, loading) clear the floating bar with a plain top padding;
+    // only the active MessageList takes the inset as scrollable contentPadding.
+    val topPaddedFill = Modifier
+        .fillMaxSize()
+        .padding(top = topContentPadding)
+    // Streaming-bubble sender label for the active (primary) model: the agent's
+    // display name under the agents endpoint, else the raw model id.
+    val senderName = run {
+        val model = uiState.selectedModel
+        if (uiState.selectedEndpoint == EndpointConstants.AGENTS && model != null) {
+            uiState.agents.find { it.id == model }?.name ?: model
+        } else {
+            model ?: stringResource(Res.string.sender_assistant)
+        }
+    }
+    when {
+        isLandingPage && !hasMessages -> {
+            Box(
+                modifier = topPaddedFill,
+                contentAlignment = Alignment.Center,
+            ) {
+                LandingContent(
+                    selectedModel = uiState.selectedModel,
+                    selectedAgentName = agentName,
+                )
+            }
+        }
+        isLoading && uiState.displayMessages.isEmpty() -> {
+            Box(
+                modifier = topPaddedFill,
+                contentAlignment = Alignment.Center,
+            ) {
+                CircularProgressIndicator(modifier = Modifier.size(36.dp))
+            }
+        }
+        uiState.comparisonState.isEnabled -> {
+            ComparisonPanes(
+                uiState = uiState,
+                viewModel = viewModel,
+                displayModel = displayModel,
+                senderName = senderName,
+                fontSizeMultiplier = fontSizeMultiplier,
+                showImageDescriptions = showImageDescriptions,
+                chatLayoutStyle = chatLayoutStyle,
+                showAvatars = showAvatars,
+                showBubbles = showBubbles,
+                useKatex = useKatex,
+                bottomContentPadding = bottomContentPadding,
+                onCopyMessage = { messageId -> viewModel.getMessageText(messageId) },
+                onShowSecondaryModelSheet = onShowSecondaryModelSheet,
+                onComparisonTabChange = onComparisonTabChange,
+                modifier = topPaddedFill,
+            )
+        }
+        else -> {
+            val singleDisplayMessages = remember(uiState.displayMessages) {
+                collapseParallelToPrimary(uiState.displayMessages)
+            }
+            MessageList(
+                displayMessages = singleDisplayMessages,
+                isStreaming = uiState.isStreaming,
+                streamingContent = uiState.streamingContent,
+                activeToolCalls = uiState.activeToolCalls,
+                streamingAttachments = uiState.streamingAttachments,
+                onSiblingNavigation = viewModel::switchBranch,
+                onEditMessage = viewModel::startEditing,
+                onRegenerateMessage = { messageId -> viewModel.regenerateMessage(messageId) },
+                onCopyMessage = { messageId -> viewModel.getMessageText(messageId) },
+                onFeedback = viewModel::submitFeedback,
+                onContinue = { viewModel.continueGeneration() },
+                onReadAloud = viewModel::readAloud,
+                onFork = viewModel::showForkOptions,
+                currentlyReadingMessageId = uiState.currentlyReadingMessageId,
+                editingMessageId = uiState.editingMessageId,
+                editingText = uiState.editingText,
+                onEditTextChange = viewModel::onEditTextChanged,
+                onEditSaveAndSubmit = viewModel::submitEdit,
+                onEditSaveOnly = viewModel::saveEditOnly,
+                onEditCancel = viewModel::cancelEditing,
+                baseUrl = uiState.serverUrl,
+                fontSizeMultiplier = fontSizeMultiplier,
+                isRefreshing = uiState.isRefreshingMessages,
+                onRefresh = viewModel::refreshMessages,
+                userAvatarUrl = uiState.userAvatarUrl,
+                userName = uiState.userName,
+                selectedEndpoint = uiState.selectedEndpoint,
+                streamingSenderName = senderName,
+                showImageDescriptions = showImageDescriptions,
+                chatLayoutStyle = chatLayoutStyle,
+                showAvatars = showAvatars,
+                showBubbles = showBubbles,
+                useKatex = useKatex,
+                searchQuery = if (uiState.isSearchOpen) uiState.searchQuery else null,
+                searchMatchIndices = uiState.searchMatchIndices,
+                currentSearchMatchIndex = uiState.currentSearchMatchIndex,
+                searchFocusRequest = uiState.searchFocusRequest,
+                onSearchScrollHandle = viewModel::onSearchScrollHandled,
+                bottomContentPadding = bottomContentPadding,
+                topContentPadding = topContentPadding,
+                modifier = Modifier.fillMaxSize(),
+            )
+        }
     }
 }
 


### PR DESCRIPTION
## Problem

Both `ChatScreen` actuals collected one monolithic `ChatUiState`, so every 50ms streaming flush re-executed the entire screen body — top bar, composer (~60 `ChatInput` argument evaluations), dialogs, sheets, and effects — ~20×/s for the length of a stream. In comparison mode the per-token buffer writes aren't even throttled, so the churn rate there was unbounded. Any new read added to the body silently joined the hot path.

## Fix

Per-flush, exactly one field changes: `content.streamingContent` (plus event-driven tool-call/attachment churn). Nothing the chrome renders depends on those fields — verified by a field-level inventory of every consumer (`ChatFloatingTopBar`, `ChatScreenDialogs`, `ChatScreenEffects`, `ChatOptionsSheetHost`, the model sheets, every `ChatInput` arg, and all of `ChatUiState`'s derived vals).

So the screen now collects the same `StateFlow` twice:
- **The thread subtree** (`ChatContent` on Android, `IosChatBody` on iOS), which must re-render per token, collects `viewModel.uiState` at full rate itself.
- **The chrome** collects `map { it.neutralizeStreamingChurn() }.distinctUntilChanged()` — the same state with only the per-token churn fields (`streamingContent`, `activeToolCalls`, `streamingAttachments`, and `ComparisonState`'s four streaming buffers) reset to their at-rest empty values. A token flush is now a no-op for the chrome; discrete transitions (`isStreaming`, `contextUsage`/`tokenUsage`, `retryInfo`, the atomic finalize message swap, queue/voice/navigation-effect fields) all still emit. Emitting the neutralized copy also means an accidental future chrome read of a churn field sees a deterministic empty — its correct post-stream value — rather than content frozen mid-stream.

`neutralizeStreamingChurn` is commonMain, so both platforms share one definition of what "churn" means.

No slice, delegate, or write-path changes; the state-hoisting architecture is preserved (leaves still receive plain values); no per-field states introduced. The only signature change is `ChatContent` dropping its `uiState` param.

`ChatChromeEquivalenceTest` (18 tests) pins both directions: each neutralized field individually equivalent, each chrome-load-bearing transition (including the message swap with all streaming fields held constant) individually non-equivalent, plus the neutralized copy's exact field surface.

## Commits

1. **Android** — the split above, plus the shared `ChatChromeEquivalence.kt` and its tests.
2. **iOS** — the same split in `PlatformScreens.ios.kt`: the landing/loading/comparison/message-list body extracted into a private `IosChatBody` that collects at full rate, the screen moved onto the neutralized flow. No behavior, layout, or signature changes outside that file.

## Known follow-up

Documented in `feature/chat/CLAUDE.md`:

- **`subagentProgress`** is chrome-visible by design (`ChatRoot` → `LocalSubagentProgress`) and written per-SSE-envelope with no throttle, so subagent-heavy runs still re-execute the chrome per envelope. Pre-existing behavior, out of scope here.

## Verification

- `:app:assembleDebug` — green
- `:feature:chat:testDebugUnitTest` — green (includes 18 new equivalence tests)
- `:feature:chat:detekt` — clean
- Android behavior verified on a Pixel 9 Pro Fold (streaming, comparison mode, composer, sheets).

**iOS is unverified.** There's no Xcode on the machine this was written on, so `iosMain` was never compiled and the change was never run on a simulator or device. `detektMetadataIosMain` parses it clean apart from pre-existing issues (that task isn't in CI, which runs `detekt detektMetadataCommonMain :app:lint`). The iOS commit needs a build and a streaming smoke test before merge.
