### PR TITLE
perf(conversations): map the cached conversation list off the main thread

### DIFF
--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/repository/ConversationRepositoryImplTest.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/repository/ConversationRepositoryImplTest.kt
@@ -21,6 +21,7 @@ import io.mockk.mockk
 import io.mockk.slot
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
 import org.junit.Before
@@ -48,6 +49,7 @@ class ConversationRepositoryImplTest {
             activeAccountProvider = activeAccountProvider,
             roster = roster,
             json = json,
+            dispatcher = UnconfinedTestDispatcher(),
         )
     }
 

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/di/DataModule.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/di/DataModule.kt
@@ -265,6 +265,18 @@ val dataModule = module {
         )
     }
 
+    single<ConversationRepository> {
+        ConversationRepositoryImpl(
+            conversationsApi = get(),
+            conversationDao = get(),
+            messageDao = get(),
+            activeAccountProvider = get(),
+            roster = get(),
+            json = get(),
+            dispatcher = get(KoinQualifiers.Default),
+        )
+    }
+
     single<MessageRepository> {
         MessageRepositoryImpl(
             messagesApi = get(),
@@ -300,7 +312,6 @@ val dataModule = module {
             dispatcher = get(KoinQualifiers.Default),
         )
     } bind ConfigRepository::class
-    singleOf(::ConversationRepositoryImpl) bind ConversationRepository::class
     singleOf(::FileRepositoryImpl) bind FileRepository::class
     singleOf(::AgentRepositoryImpl) bind AgentRepository::class
     singleOf(::AgentToolsRepositoryImpl) bind AgentToolsRepository::class

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/ConversationRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/ConversationRepositoryImpl.kt
@@ -18,8 +18,10 @@ import com.garfiec.librechat.core.model.ConversationPage
 import com.garfiec.librechat.core.model.SAVED_TAG
 import com.garfiec.librechat.core.model.request.ForkConversationRequest
 import com.garfiec.librechat.core.network.api.ConversationsApi
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.json.Json
@@ -33,13 +35,17 @@ class ConversationRepositoryImpl(
     private val activeAccountProvider: ActiveAccountProvider,
     private val roster: AccountRoster,
     private val json: Json,
+    private val dispatcher: CoroutineDispatcher,
 ) : ConversationRepository {
 
+    // toModels() decodes each row's tags JSON and formats two timestamps, so the whole cached list
+    // is remapped on every Room emission (a rename/pin/delete re-emits). flowOn keeps that off the
+    // collector's thread — all three collectors observe from the main dispatcher.
     override fun observeConversations(isArchived: Boolean): Flow<Result<List<Conversation>>> =
         activeAccountProvider.flatMapAccountOrEmpty(Result.Success(emptyList())) { account ->
             conversationDao.observeConversationsForAccount(account.value, isArchived)
                 .map { entities -> Result.Success(entities.toModels()) as Result<List<Conversation>> }
-        }
+        }.flowOn(dispatcher)
 
     override suspend fun loadNextPage(
         cursor: String?,


### PR DESCRIPTION
## Problem

`ConversationRepositoryImpl.observeConversations` mapped Room entities to domain models inline, with no `flowOn`:

```kotlin
conversationDao.observeConversationsForAccount(account.value, isArchived)
    .map { entities -> Result.Success(entities.toModels()) as Result<List<Conversation>> }
```

Without `flowOn`, that `map` runs on whatever dispatcher collects it. All three collectors use `viewModelScope`, i.e. `Dispatchers.Main.immediate`:

- `ConversationListViewModel.kt:125`
- `ConversationListStateHolder.kt:64` (constructed with the drawer's `viewModelScope` at `DrawerViewModel.kt:64`)
- `ArchivedConversationsViewModel.kt:55`

Per row, `toModel()` does a `json.decodeFromString<List<String>>` for the tags column plus two `Instant` conversions (`ConversationMapper.kt:43-51`). So the entire cached list was remapped on the main thread on every Room emission — and a rename, pin, archive, or delete re-emits.

The drawer's `DrawerViewModel` is a nav-host-level `koinViewModel` (`LibreChatNavHost.kt:104`), so it stays alive across the session. While the conversation list route is on screen, its own `ConversationListViewModel` observes the same unarchived flow, and both decode the same rows on each emission.

## Fix

Inject a `CoroutineDispatcher` and terminate the flow with `.flowOn(dispatcher)`.

`KoinQualifiers.Default` rather than `IO`: the work is JSON parsing and timestamp conversion, i.e. CPU-bound. This matches `MessageRepositoryImpl.kt:36`, which already applies `flowOn(dispatcher)` on the `Default` qualifier for the structurally identical entity→model observe flow.

The Koin binding moves from `singleOf(::ConversationRepositoryImpl)` to an explicit `single<ConversationRepository> { ... }` block, because a qualified dependency can't be auto-wired by constructor reflection.

## Verification

Full CI job set run locally, all green:

- `./gradlew detekt detektMetadataCommonMain :app:lint --continue`
- `./gradlew test`
- `./gradlew :app:assembleDebug`

The `ios` job (`:shared:iosSimulatorArm64Test` + `xcodebuild`) was not run — no Xcode on the dev machine. `IosKoinGraphTest` asserts registration for five specific bindings (`LibreChatSDK`, `AgentToolsApi`, `PermissionsApi`, `SkillsApi`, `SseClient`), none of which this PR touches, and no iOS actual is involved in the change.

## Caveats

**This binding is no longer statically verified.** Both `DataModuleVerificationTest` and `:app`'s `KoinGraphVerificationTest` use Koin's `verify()`, which introspects constructor-DSL definitions but cannot see inside a `single { }` lambda body. Both still pass, but they now skip this definition rather than check it. A mistake in the new block would surface at app startup, not in CI. The same is already true of `ChatRepository`, `MessageRepository`, `DraftRepository`, and `ArtifactShortcutRepository`, which use the same explicit form. Worth launching the debug APK once before merge.

**The improvement is unmeasured.** The change is sound on inspection, but there are no before/after numbers — the size of the win scales with how many conversations are cached and how often Room re-emits. If the claim needs substantiating rather than arguing, a Profiler trace while renaming a conversation on a large cached list would do it.

## Scope

This is the first half of a performance audit finding about the conversation list pipeline. Not addressed here:

- `syncFavoritesFromServer` (`ConversationRepositoryImpl.kt:307-345`) does per-conversation `getByIdForAccount` reads and per-conversation tag writes inside its paging loop, then a second sequential pass for un-favorite reconciliation. It runs on every pull-to-refresh.
- `toModel()` converts the entity's epoch millis into an ISO-8601 string, which the drawer then parses back to millis on the grouping path.
