### PR TITLE
fix(conversations): keep relative timestamps and date groups current, map the drawer list once

### DIFF
--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -125,7 +125,7 @@ coroutines:
 Compose:
   CompositionLocalAllowlist:
     active: true
-    allowedCompositionLocals: LocalAddArtifactToHomeScreen,LocalAttachmentDownloader,LocalChatMediaViewer,LocalImmediateMarkdown,LocalInlineArtifactPrefs,LocalMermaidRenderCache,LocalOpenArtifact,LocalOpenPdf,LocalParsedMarkdownCache,LocalSearchFocusNonce,LocalSubagentProgress
+    allowedCompositionLocals: LocalAddArtifactToHomeScreen,LocalAttachmentDownloader,LocalChatMediaViewer,LocalImmediateMarkdown,LocalInlineArtifactPrefs,LocalMermaidRenderCache,LocalOpenArtifact,LocalOpenPdf,LocalParsedMarkdownCache,LocalRelativeTimeReference,LocalSearchFocusNonce,LocalSubagentProgress
 
 # detekt-koin rule overrides (defaults ship in plugin jar; buildUponDefaultConfig = true)
 koin-rules:

--- a/core/common/src/commonMain/kotlin/com/garfiec/librechat/core/common/extensions/DateExt.kt
+++ b/core/common/src/commonMain/kotlin/com/garfiec/librechat/core/common/extensions/DateExt.kt
@@ -24,11 +24,13 @@ data class RelativeTimeReference(
     val timeZone: TimeZone,
 ) {
     /**
-     * Lazy on purpose: only [toRelativeDateGroup] reads this. [toRelativeTimeString] — the per-row
-     * formatter, called once per visible row with a default reference — never does, and computing
-     * it eagerly would charge every one of those rows a `toLocalDateTime` it has no use for.
+     * Eager, and cheap to keep that way: references are hoisted, so this is computed roughly once
+     * per list emission and once per clock tick — never per row. (An earlier revision made this
+     * `by lazy` back when every row built its own reference from the default argument; that is no
+     * longer how any production call site works, and `by lazy` would now add a volatile read to
+     * [toRelativeDateGroup]'s per-row path to save a handful of conversions a minute.)
      */
-    val today: LocalDate by lazy { now.toLocalDateTime(timeZone).date }
+    val today: LocalDate = now.toLocalDateTime(timeZone).date
 
     companion object {
         fun current(): RelativeTimeReference =
@@ -60,8 +62,8 @@ fun Instant.toRelativeDateGroup(
  * passes. Either way the label rots.
  *
  * To get a label that actually advances, the caller must supply a [reference] that changes — see
- * `rememberRelativeTimeReference` in feature/conversations, which ticks one and thereby invalidates
- * exactly the composables reading it.
+ * `ProvideRelativeTimeReference` / `LocalRelativeTimeReference` in feature/conversations, which
+ * tick one and thereby invalidate exactly the composables reading it.
  */
 fun Instant.toRelativeTimeString(
     reference: RelativeTimeReference = RelativeTimeReference.current(),

--- a/core/common/src/commonMain/kotlin/com/garfiec/librechat/core/common/extensions/DateExt.kt
+++ b/core/common/src/commonMain/kotlin/com/garfiec/librechat/core/common/extensions/DateExt.kt
@@ -10,11 +10,37 @@ import kotlin.time.Instant
 fun String.toInstantOrNull(): Instant? =
     try { Instant.parse(this) } catch (_: Exception) { null }
 
-fun Instant.toRelativeDateGroup(): String {
-    val tz = TimeZone.currentSystemDefault()
-    val today = Clock.System.now().toLocalDateTime(tz).date
-    val date = toLocalDateTime(tz).date
-    val daysBetween = date.daysUntil(today)
+/**
+ * "Now", as the relative formatters below see it.
+ *
+ * Both formatters resolve the clock and the system timezone on every invocation, which for a list
+ * mapping means that loop-invariant work runs once per row. Hoisting it into a value lets a caller
+ * mapping N conversations resolve it once. Every formatter defaults to [current], so one-off call
+ * sites (a single row in a composable) read exactly as they did before; only list paths pass a
+ * shared instance.
+ */
+data class RelativeTimeReference(
+    val now: Instant,
+    val timeZone: TimeZone,
+) {
+    /**
+     * Lazy on purpose: only [toRelativeDateGroup] reads this. [toRelativeTimeString] — the per-row
+     * formatter, called once per visible row with a default reference — never does, and computing
+     * it eagerly would charge every one of those rows a `toLocalDateTime` it has no use for.
+     */
+    val today: LocalDate by lazy { now.toLocalDateTime(timeZone).date }
+
+    companion object {
+        fun current(): RelativeTimeReference =
+            RelativeTimeReference(Clock.System.now(), TimeZone.currentSystemDefault())
+    }
+}
+
+fun Instant.toRelativeDateGroup(
+    reference: RelativeTimeReference = RelativeTimeReference.current(),
+): String {
+    val date = toLocalDateTime(reference.timeZone).date
+    val daysBetween = date.daysUntil(reference.today)
     return when {
         daysBetween == 0 -> "Today"
         daysBetween == 1 -> "Yesterday"
@@ -24,8 +50,38 @@ fun Instant.toRelativeDateGroup(): String {
     }
 }
 
-fun Long.toRelativeDateGroup(): String =
-    Instant.fromEpochMilliseconds(this).toRelativeDateGroup()
+/**
+ * Short "time since" label for list rows: "Just now", "5m ago", "3h ago", "2d ago", then "Mar 14".
+ *
+ * The result depends on the wall clock, so **where you call this decides whether it ever updates**.
+ * Computing it during a ViewModel mapping freezes it into immutable state until unrelated data
+ * changes; computing it inside `remember(row.updatedAt)` freezes it just as hard, because `remember`
+ * exists precisely not to recompute across recompositions and `updatedAt` does not change as time
+ * passes. Either way the label rots.
+ *
+ * To get a label that actually advances, the caller must supply a [reference] that changes — see
+ * `rememberRelativeTimeReference` in feature/conversations, which ticks one and thereby invalidates
+ * exactly the composables reading it.
+ */
+fun Instant.toRelativeTimeString(
+    reference: RelativeTimeReference = RelativeTimeReference.current(),
+): String {
+    val duration = reference.now - this
+    val minutes = duration.inWholeMinutes
+    val hours = duration.inWholeHours
+    val days = duration.inWholeDays
+
+    return when {
+        minutes < 1 -> "Just now"
+        minutes < 60 -> "${minutes}m ago"
+        hours < 24 -> "${hours}h ago"
+        days < 7 -> "${days}d ago"
+        else -> {
+            val date = toLocalDateTime(reference.timeZone).date
+            "${formatMonthAbbrev(date.monthNumber)} ${date.dayOfMonth}"
+        }
+    }
+}
 
 private fun LocalDate.formatMonthYear(): String =
     formatMonthYear(monthNumber, year)

--- a/core/common/src/commonMain/kotlin/com/garfiec/librechat/core/common/extensions/DayBoundary.kt
+++ b/core/common/src/commonMain/kotlin/com/garfiec/librechat/core/common/extensions/DayBoundary.kt
@@ -1,0 +1,48 @@
+package com.garfiec.librechat.core.common.extensions
+
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.datetime.DateTimeUnit
+import kotlinx.datetime.atStartOfDayIn
+import kotlinx.datetime.plus
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Emits a [RelativeTimeReference] immediately, then again at each local midnight.
+ *
+ * Date *grouping* is the other half of the staleness problem that `LocalRelativeTimeReference`
+ * solves for row subtitles. "Today" / "Yesterday" / "Previous 7 Days" are not just labels — they
+ * decide which section a conversation belongs to — so unlike a subtitle they cannot be fixed by
+ * reformatting at render time; the grouping itself has to re-run. Combining this flow into a
+ * grouping pipeline gives it a clock input, so a list left open across midnight re-buckets instead
+ * of showing yesterday's sections until an unrelated Room emission happens to refresh it.
+ *
+ * One emission per day, so the cost is nil. The wait is a plain [delay], which on Android does not
+ * advance while the device is in deep sleep — a boundary crossed while asleep therefore lands late,
+ * on wake, rather than exactly at midnight. Each iteration re-reads the clock, so a late emission is
+ * still *correct*, just not punctual.
+ */
+fun dayBoundaryReferences(): Flow<RelativeTimeReference> = flow {
+    while (true) {
+        val reference = RelativeTimeReference.current()
+        emit(reference)
+        delay(reference.untilNextMidnight())
+    }
+}
+
+/**
+ * How long until the next local midnight, per this reference's own clock and zone.
+ *
+ * Split out from [dayBoundaryReferences] because it is the only part with logic worth testing: the
+ * flow itself reads the real clock while `runTest` advances a virtual one, so a test of the loop
+ * would observe two emissions at the same wall-clock instant and prove nothing.
+ */
+internal fun RelativeTimeReference.untilNextMidnight(): Duration {
+    val nextMidnight = today
+        .plus(1, DateTimeUnit.DAY)
+        .atStartOfDayIn(timeZone)
+    // Never zero: a non-positive wait (clock moved backwards, a DST jump) would spin the loop.
+    return (nextMidnight - now).coerceAtLeast(1.seconds)
+}

--- a/core/common/src/commonTest/kotlin/com/garfiec/librechat/core/common/extensions/DateExtTest.kt
+++ b/core/common/src/commonTest/kotlin/com/garfiec/librechat/core/common/extensions/DateExtTest.kt
@@ -73,27 +73,6 @@ class DateExtTest {
         )
     }
 
-    /**
-     * The list paths hoist a shared [RelativeTimeReference] out of their loops instead of letting
-     * each row resolve `Clock.System.now()` / `TimeZone.currentSystemDefault()`. That is only a safe
-     * optimization while an explicitly-passed reference produces the same answer as the default one,
-     * so pin it here — a drift in either overload's logic should fail loudly.
-     *
-     * The instants are chosen to sit mid-bucket (5 minutes / 3 days old) so the microseconds between
-     * the `current()` captured here and the one the default resolves internally cannot straddle a
-     * bucket edge and flake. They are recent enough that both formatters exercise their
-     * elapsed-time branches, which is what makes the assertion meaningful.
-     */
-    @Test
-    fun explicitReferenceMatchesDefaultForBothFormatters() {
-        val current = RelativeTimeReference.current()
-        val minutesAgo = current.now - 5.minutes
-        val daysAgo = current.now - 3.days
-
-        assertEquals(minutesAgo.toRelativeTimeString(), minutesAgo.toRelativeTimeString(current))
-        assertEquals(daysAgo.toRelativeDateGroup(), daysAgo.toRelativeDateGroup(current))
-    }
-
     @Test
     fun toInstantOrNullRejectsMalformedInput() {
         assertEquals(null, "not-a-timestamp".toInstantOrNull())

--- a/core/common/src/commonTest/kotlin/com/garfiec/librechat/core/common/extensions/DateExtTest.kt
+++ b/core/common/src/commonTest/kotlin/com/garfiec/librechat/core/common/extensions/DateExtTest.kt
@@ -1,0 +1,103 @@
+package com.garfiec.librechat.core.common.extensions
+
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.Instant
+
+class DateExtTest {
+
+    // Fixed reference so the assertions don't drift with the wall clock. UTC keeps the day
+    // arithmetic deterministic regardless of where the test runs.
+    private val now = Instant.parse("2026-07-19T12:00:00Z")
+    private val reference = RelativeTimeReference(now, TimeZone.UTC)
+
+    @Test
+    fun relativeTimeCoversEachBoundary() {
+        assertEquals("Just now", (now - 30.seconds).toRelativeTimeString(reference))
+        assertEquals("1m ago", (now - 1.minutes).toRelativeTimeString(reference))
+        assertEquals("59m ago", (now - 59.minutes).toRelativeTimeString(reference))
+        assertEquals("1h ago", (now - 1.hours).toRelativeTimeString(reference))
+        assertEquals("23h ago", (now - 23.hours).toRelativeTimeString(reference))
+        assertEquals("1d ago", (now - 1.days).toRelativeTimeString(reference))
+        assertEquals("6d ago", (now - 6.days).toRelativeTimeString(reference))
+        // 7 days is the first instant that falls through to an absolute month-day label. The month
+        // name is locale-dependent (formatMonthAbbrev delegates to the platform), so build the
+        // expectation the same way rather than hardcoding English — the branch is what's under test.
+        assertEquals("${formatMonthAbbrev(7)} 12", (now - 7.days).toRelativeTimeString(reference))
+    }
+
+    /**
+     * The whole point of taking a [RelativeTimeReference] rather than reading the clock internally:
+     * a caller that advances the reference gets an advanced label. This is what lets a row's
+     * relative time refresh — see `LocalRelativeTimeReference` in feature/conversations, which ticks
+     * the reference so the label doesn't freeze at whatever it said when the row was composed.
+     */
+    @Test
+    fun labelAdvancesWhenTheReferenceAdvances() {
+        val stamp = now - 30.seconds
+
+        assertEquals("Just now", stamp.toRelativeTimeString(reference))
+        assertEquals(
+            "5m ago",
+            stamp.toRelativeTimeString(RelativeTimeReference(now + 5.minutes, TimeZone.UTC)),
+        )
+        assertEquals(
+            "2h ago",
+            stamp.toRelativeTimeString(RelativeTimeReference(now + 2.hours, TimeZone.UTC)),
+        )
+    }
+
+    @Test
+    fun relativeDateGroupCoversEachBoundary() {
+        assertEquals("Today", now.toRelativeDateGroup(reference))
+        assertEquals("Yesterday", (now - 1.days).toRelativeDateGroup(reference))
+        // Assert the edges of each bucket, not their interiors: a `<=` slipping to `<` has to fail.
+        assertEquals("Previous 7 Days", (now - 2.days).toRelativeDateGroup(reference))
+        assertEquals("Previous 7 Days", (now - 7.days).toRelativeDateGroup(reference))
+        assertEquals("Previous 30 Days", (now - 8.days).toRelativeDateGroup(reference))
+        assertEquals("Previous 30 Days", (now - 30.days).toRelativeDateGroup(reference))
+
+        // Older than 30 days switches to a month-year label. Locale-dependent again, so derive the
+        // expectation from the same platform formatter.
+        val old = now - 31.days
+        val oldDate = old.toLocalDateTime(TimeZone.UTC).date
+        assertEquals(
+            formatMonthYear(oldDate.monthNumber, oldDate.year),
+            old.toRelativeDateGroup(reference),
+        )
+    }
+
+    /**
+     * The list paths hoist a shared [RelativeTimeReference] out of their loops instead of letting
+     * each row resolve `Clock.System.now()` / `TimeZone.currentSystemDefault()`. That is only a safe
+     * optimization while an explicitly-passed reference produces the same answer as the default one,
+     * so pin it here — a drift in either overload's logic should fail loudly.
+     *
+     * The instants are chosen to sit mid-bucket (5 minutes / 3 days old) so the microseconds between
+     * the `current()` captured here and the one the default resolves internally cannot straddle a
+     * bucket edge and flake. They are recent enough that both formatters exercise their
+     * elapsed-time branches, which is what makes the assertion meaningful.
+     */
+    @Test
+    fun explicitReferenceMatchesDefaultForBothFormatters() {
+        val current = RelativeTimeReference.current()
+        val minutesAgo = current.now - 5.minutes
+        val daysAgo = current.now - 3.days
+
+        assertEquals(minutesAgo.toRelativeTimeString(), minutesAgo.toRelativeTimeString(current))
+        assertEquals(daysAgo.toRelativeDateGroup(), daysAgo.toRelativeDateGroup(current))
+    }
+
+    @Test
+    fun toInstantOrNullRejectsMalformedInput() {
+        assertEquals(null, "not-a-timestamp".toInstantOrNull())
+        assertEquals(null, "".toInstantOrNull())
+        assertEquals(Instant.parse("2026-07-19T12:00:00Z"), "2026-07-19T12:00:00Z".toInstantOrNull())
+    }
+}

--- a/core/common/src/commonTest/kotlin/com/garfiec/librechat/core/common/extensions/DayBoundaryTest.kt
+++ b/core/common/src/commonTest/kotlin/com/garfiec/librechat/core/common/extensions/DayBoundaryTest.kt
@@ -1,0 +1,77 @@
+package com.garfiec.librechat.core.common.extensions
+
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.TimeZone
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Instant
+
+class DayBoundaryTest {
+
+    private fun referenceAt(iso: String, zone: TimeZone = TimeZone.UTC) =
+        RelativeTimeReference(Instant.parse(iso), zone)
+
+    /**
+     * Grouping `combine`s on this flow, and `combine` emits nothing until every source has emitted —
+     * so an implementation that waited for the first midnight before its first emission would leave
+     * the conversation list permanently *empty* rather than merely stale.
+     */
+    @Test
+    fun emitsImmediatelyWithoutWaitingForMidnight() = runTest {
+        val emissions = dayBoundaryReferences().take(1).toList()
+
+        assertEquals(1, emissions.size)
+    }
+
+    @Test
+    fun waitsUntilTheNextLocalMidnight() {
+        assertEquals(12.hours, referenceAt("2026-07-19T12:00:00Z").untilNextMidnight())
+        assertEquals(1.hours, referenceAt("2026-07-19T23:00:00Z").untilNextMidnight())
+        // Exactly at midnight, the *next* boundary is a full day out — not zero.
+        assertEquals(24.hours, referenceAt("2026-07-19T00:00:00Z").untilNextMidnight())
+    }
+
+    /** Midnight is local, so the same instant yields a different wait in a different zone. */
+    @Test
+    fun midnightIsResolvedInTheReferenceZone() {
+        val instant = "2026-07-19T12:00:00Z"
+
+        assertEquals(12.hours, referenceAt(instant, TimeZone.UTC).untilNextMidnight())
+        // 12:00Z is 08:00 EDT; the next New York midnight is 04:00Z the following day.
+        assertEquals(
+            16.hours,
+            referenceAt(instant, TimeZone.of("America/New_York")).untilNextMidnight(),
+        )
+    }
+
+    /**
+     * Whatever the zone or time of day, the wait is always positive — `delay(0)` in the flow's loop
+     * would spin, pegging a core and re-grouping the list continuously. (`today` is derived from
+     * `now`, so a reference cannot be constructed in a state where this is violated; the
+     * `coerceAtLeast` in the implementation is belt-and-braces against a future refactor that
+     * decouples them.)
+     */
+    @Test
+    fun waitIsAlwaysPositive() {
+        val zones = listOf(TimeZone.UTC, TimeZone.of("America/New_York"), TimeZone.of("Asia/Kolkata"))
+        val instants = listOf(
+            "2026-07-19T00:00:00Z",
+            "2026-07-19T12:00:00Z",
+            "2026-07-19T23:59:59Z",
+            // Spans a US DST transition.
+            "2026-11-01T05:30:00Z",
+        )
+
+        for (zone in zones) {
+            for (instant in instants) {
+                val wait = referenceAt(instant, zone).untilNextMidnight()
+                assertTrue(wait > Duration.ZERO, "non-positive wait for $instant in $zone: $wait")
+            }
+        }
+    }
+}

--- a/feature/conversations/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/conversations/drawer/ConversationListStateHolderTest.kt
+++ b/feature/conversations/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/conversations/drawer/ConversationListStateHolderTest.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
@@ -46,7 +47,9 @@ class ConversationListStateHolderTest {
     }
 
     private fun visibleIds(holder: ConversationListStateHolder) =
-        holder.groupedConversations.value.flatMap { it.second }.mapNotNull { it.conversationId }
+        holder.groupedConversations.value
+            .flatMap { it.second }
+            .mapNotNull { it.conversation.conversationId }
 
     @Test
     fun `delete during active drawer search removes the row without a query change`() = runTest {
@@ -56,7 +59,7 @@ class ConversationListStateHolderTest {
         val roomFlow = MutableStateFlow<Result<List<Conversation>>>(Result.Success(convos))
         every { conversationRepository.observeConversations(any()) } returns roomFlow
 
-        val holder = ConversationListStateHolder(conversationRepository, scope)
+        val holder = ConversationListStateHolder(conversationRepository, scope, dayBoundaries = emptyFlow())
         advanceUntilIdle()
 
         holder.onSearchQueryChanged("Alpha")
@@ -75,7 +78,7 @@ class ConversationListStateHolderTest {
         val roomFlow = MutableStateFlow<Result<List<Conversation>>>(Result.Success(convos))
         every { conversationRepository.observeConversations(any()) } returns roomFlow
 
-        val holder = ConversationListStateHolder(conversationRepository, scope)
+        val holder = ConversationListStateHolder(conversationRepository, scope, dayBoundaries = emptyFlow())
         advanceUntilIdle()
 
         holder.onSearchQueryChanged("Alpha")
@@ -87,7 +90,7 @@ class ConversationListStateHolderTest {
         advanceUntilIdle()
 
         val titles = holder.groupedConversations.value.flatMap { it.second }
-            .associate { it.conversationId to it.title }
+            .associate { it.conversation.conversationId to it.conversation.title }
         assertThat(titles["c1"]).isEqualTo("Alpha One Renamed")
         assertThat(titles.keys).containsExactly("c1", "c2")
     }

--- a/feature/conversations/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/conversations/drawer/DrawerDisplayMappingTest.kt
+++ b/feature/conversations/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/conversations/drawer/DrawerDisplayMappingTest.kt
@@ -4,6 +4,7 @@ import com.garfiec.librechat.core.model.Conversation
 import com.garfiec.librechat.core.model.EndpointConfig
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
+import kotlin.time.Instant
 
 class DrawerDisplayMappingTest {
 
@@ -69,5 +70,41 @@ class DrawerDisplayMappingTest {
         )
 
         assertThat(data.endpointIconUrl).isNull()
+    }
+
+    /**
+     * The mapping parses the timestamp but must NOT format it. Parsing is clock-independent, so
+     * doing it once here beats doing it per row; formatting is clock-dependent, so doing it here
+     * would freeze the label at whenever the mapping last ran — the stale-"Just now" bug.
+     */
+    @Test
+    fun updatedAtIsParsedNotFormatted() {
+        val convo = Conversation(
+            conversationId = "c1",
+            updatedAt = "2026-07-19T12:00:00Z",
+        )
+
+        val data = convo.toDrawerDisplayData(activeConversationId = null, endpointConfigs = emptyMap())
+
+        assertThat(data.updatedAt).isEqualTo(Instant.parse("2026-07-19T12:00:00Z"))
+    }
+
+    @Test
+    fun updatedAtNullSurvivesMapping() {
+        val convo = Conversation(conversationId = "c1", updatedAt = null)
+
+        val data = convo.toDrawerDisplayData(activeConversationId = null, endpointConfigs = emptyMap())
+
+        assertThat(data.updatedAt).isNull()
+    }
+
+    /** Malformed timestamps must not throw in the mapping — they degrade to a blank label. */
+    @Test
+    fun malformedUpdatedAtBecomesNull() {
+        val convo = Conversation(conversationId = "c1", updatedAt = "not-a-timestamp")
+
+        val data = convo.toDrawerDisplayData(activeConversationId = null, endpointConfigs = emptyMap())
+
+        assertThat(data.updatedAt).isNull()
     }
 }

--- a/feature/conversations/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/conversations/viewmodel/ConversationListViewModelTest.kt
+++ b/feature/conversations/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/conversations/viewmodel/ConversationListViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.garfiec.librechat.feature.conversations.viewmodel
 
+import com.garfiec.librechat.core.common.extensions.RelativeTimeReference
 import com.garfiec.librechat.core.common.result.Result
 import com.garfiec.librechat.core.data.repository.ConfigRepository
 import com.garfiec.librechat.core.data.repository.ConversationRepository
@@ -99,6 +100,10 @@ class ConversationListViewModelTest {
         conversationImporter = conversationImporter,
         roleRepository = roleRepository,
         configRepository = configRepository,
+        // Single emission. The production flow re-arms at each midnight and never completes, which
+        // would make advanceUntilIdle() advance virtual time forever. `combine` needs at least one
+        // emission from every source, so this can't be emptyFlow().
+        dayBoundaries = flowOf(RelativeTimeReference.current()),
     )
 
     @Test

--- a/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/components/ConversationDisplayData.kt
+++ b/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/components/ConversationDisplayData.kt
@@ -22,14 +22,19 @@ data class ConversationDisplayData(
     val endpointIconUrl: String? = null,
 )
 
+/**
+ * [parsedUpdatedAt] lets a caller that has already parsed the timestamp (grouping does, to pick a
+ * date bucket) hand it in rather than making this parse the same string a second time.
+ */
 fun Conversation.toDisplayData(
     endpointConfigs: Map<String, EndpointConfig>,
+    parsedUpdatedAt: Instant? = updatedAt?.toInstantOrNull(),
 ): ConversationDisplayData = ConversationDisplayData(
     conversationId = conversationId ?: "",
     title = title ?: "New Chat",
     endpoint = endpoint,
     model = model,
-    updatedAt = updatedAt?.toInstantOrNull(),
+    updatedAt = parsedUpdatedAt,
     isBookmarked = SAVED_TAG in tags,
     endpointIconUrl = resolveEndpointIconUrl(endpointConfigs),
 )

--- a/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/components/ConversationDisplayData.kt
+++ b/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/components/ConversationDisplayData.kt
@@ -1,10 +1,12 @@
 package com.garfiec.librechat.feature.conversations.components
 
 import androidx.compose.runtime.Immutable
+import com.garfiec.librechat.core.common.extensions.toInstantOrNull
 import com.garfiec.librechat.core.model.Conversation
 import com.garfiec.librechat.core.model.EndpointConfig
 import com.garfiec.librechat.core.model.SAVED_TAG
 import com.garfiec.librechat.core.model.resolveEndpointIconUrl
+import kotlin.time.Instant
 
 @Immutable
 data class ConversationDisplayData(
@@ -12,7 +14,10 @@ data class ConversationDisplayData(
     val title: String,
     val endpoint: String?,
     val model: String?,
-    val updatedAt: String?,
+    // Parsed here rather than in the row: the ISO-8601 wire string is clock-independent, so parsing
+    // it belongs upstream where it happens once per conversation. Only the *formatting* has to
+    // happen at render time — see LocalRelativeTimeReference.
+    val updatedAt: Instant?,
     val isBookmarked: Boolean,
     val endpointIconUrl: String? = null,
 )
@@ -24,7 +29,7 @@ fun Conversation.toDisplayData(
     title = title ?: "New Chat",
     endpoint = endpoint,
     model = model,
-    updatedAt = updatedAt,
+    updatedAt = updatedAt?.toInstantOrNull(),
     isBookmarked = SAVED_TAG in tags,
     endpointIconUrl = resolveEndpointIconUrl(endpointConfigs),
 )

--- a/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/components/ConversationItem.kt
+++ b/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/components/ConversationItem.kt
@@ -21,16 +21,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import com.garfiec.librechat.core.common.extensions.toInstantOrNull
+import com.garfiec.librechat.core.common.extensions.toRelativeTimeString
 import com.garfiec.librechat.core.model.EModelEndpoint
 import com.garfiec.librechat.core.ui.components.EndpointIcon
 import com.garfiec.librechat.feature.conversations.resources.*
 import com.garfiec.librechat.feature.conversations.resources.Res
-import kotlinx.datetime.TimeZone
-import kotlinx.datetime.toLocalDateTime
 import org.jetbrains.compose.resources.stringResource
-import kotlin.time.Clock
-import kotlin.time.Instant
 
 @Composable
 fun ConversationItem(
@@ -40,8 +36,12 @@ fun ConversationItem(
     modifier: Modifier = Modifier,
     bookmarksEnabled: Boolean = true,
 ) {
-    val relativeTime = remember(data.updatedAt) {
-        data.updatedAt?.toInstantOrNull()?.toRelativeTimeString() ?: ""
+    // Keyed on the reference as well as the row: the reference is what advances with the wall clock,
+    // so without it in the key this memo would outlive the label's correctness (see
+    // LocalRelativeTimeReference).
+    val reference = LocalRelativeTimeReference.current
+    val relativeTime = remember(data.updatedAt, reference) {
+        data.updatedAt?.toRelativeTimeString(reference) ?: ""
     }
 
     val endpointLabel = remember(data.endpoint) {
@@ -131,31 +131,6 @@ fun ConversationItem(
                 contentDescription = stringResource(Res.string.cd_conversation_actions),
                 tint = MaterialTheme.colorScheme.onSurfaceVariant,
             )
-        }
-    }
-}
-
-private fun Instant.toRelativeTimeString(): String {
-    val now = Clock.System.now()
-    val duration = now - this
-    val minutes = duration.inWholeMinutes
-    val hours = duration.inWholeHours
-    val days = duration.inWholeDays
-
-    return when {
-        minutes < 1 -> "Just now"
-        minutes < 60 -> "${minutes}m ago"
-        hours < 24 -> "${hours}h ago"
-        days < 7 -> "${days}d ago"
-        else -> {
-            val date = toLocalDateTime(TimeZone.currentSystemDefault()).date
-            val monthAbbr = when (date.monthNumber) {
-                1 -> "Jan"; 2 -> "Feb"; 3 -> "Mar"; 4 -> "Apr"
-                5 -> "May"; 6 -> "Jun"; 7 -> "Jul"; 8 -> "Aug"
-                9 -> "Sep"; 10 -> "Oct"; 11 -> "Nov"; 12 -> "Dec"
-                else -> ""
-            }
-            "$monthAbbr ${date.dayOfMonth}"
         }
     }
 }

--- a/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/components/LocalRelativeTimeReference.kt
+++ b/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/components/LocalRelativeTimeReference.kt
@@ -8,6 +8,9 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.compose.currentStateAsState
 import com.garfiec.librechat.core.common.extensions.RelativeTimeReference
 import kotlinx.coroutines.delay
 import kotlin.time.Duration
@@ -27,12 +30,19 @@ import kotlin.time.Duration.Companion.minutes
  * each tick instead of just the readers, which for a drawer full of rows is the opposite of what we
  * want.
  *
- * The default is a fixed reference captured at first read, i.e. a label that is correct when it
- * appears and then stops advancing. That is a deliberately harmless fallback for a surface that
- * forgets the provider — same behaviour as before this existed, not a crash — but it does mean
- * **the provider is required for labels to actually tick**.
+ * **There is no safe default, so there isn't one.** The obvious fallback —
+ * `compositionLocalOf { RelativeTimeReference.current() }` — is a trap: Compose memoizes a local's
+ * default in a `LazyValueHolder` for the lifetime of the process, so the *first* provider-less read
+ * anywhere freezes one `now` that every later provider-less read reuses. A row composed eight hours
+ * later would date itself against app-launch time and could render a future timestamp as
+ * "Just now". Failing loudly beats shipping that.
  */
-val LocalRelativeTimeReference = compositionLocalOf { RelativeTimeReference.current() }
+val LocalRelativeTimeReference = compositionLocalOf<RelativeTimeReference> {
+    error(
+        "No RelativeTimeReference provided. Wrap the surface in ProvideRelativeTimeReference — " +
+            "without it, relative-time labels would silently freeze.",
+    )
+}
 
 /**
  * Ticks [LocalRelativeTimeReference] for [content].
@@ -40,6 +50,13 @@ val LocalRelativeTimeReference = compositionLocalOf { RelativeTimeReference.curr
  * One coroutine per list surface, not one per row. [updateInterval] is the label's worst-case
  * staleness; a minute matches the finest bucket the formatter produces ("1m ago"), so a shorter
  * interval would only buy recompositions that render identical text.
+ *
+ * Gated on RESUMED, which does two jobs. It stops the tick while the app is backgrounded — the
+ * drawer is composed for the whole session (a closed `ModalNavigationDrawer` is offset off-screen,
+ * not removed from the tree), so an ungated loop would recompose rows nobody can see, forever. And
+ * because leaving RESUMED restarts the effect, coming back re-reads the clock immediately: `delay`
+ * runs on a monotonic clock that does not advance during device sleep, so a phone asleep for eight
+ * hours would otherwise resume still showing "2m ago" until the pending delay elapsed.
  */
 @Composable
 fun ProvideRelativeTimeReference(
@@ -47,11 +64,14 @@ fun ProvideRelativeTimeReference(
     content: @Composable () -> Unit,
 ) {
     var reference by remember { mutableStateOf(RelativeTimeReference.current()) }
+    val lifecycle = LocalLifecycleOwner.current.lifecycle
+    val lifecycleState by lifecycle.currentStateAsState()
 
-    LaunchedEffect(updateInterval) {
+    LaunchedEffect(updateInterval, lifecycleState) {
+        if (!lifecycleState.isAtLeast(Lifecycle.State.RESUMED)) return@LaunchedEffect
         while (true) {
-            delay(updateInterval)
             reference = RelativeTimeReference.current()
+            delay(updateInterval)
         }
     }
 

--- a/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/components/LocalRelativeTimeReference.kt
+++ b/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/components/LocalRelativeTimeReference.kt
@@ -1,0 +1,62 @@
+package com.garfiec.librechat.feature.conversations.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import com.garfiec.librechat.core.common.extensions.RelativeTimeReference
+import kotlinx.coroutines.delay
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
+
+/**
+ * The "now" that conversation rows format their relative-time labels against.
+ *
+ * Deliberately a *changing* value. A relative label ("5m ago") is only correct for about a minute,
+ * and neither of the obvious places to compute it ever refreshes: a ViewModel mapping re-runs only
+ * on a data change, and `remember(row.updatedAt)` re-runs only when the key changes — which it
+ * never does, since a row's timestamp is fixed while the clock is what moves. Reading this local
+ * inside a row gives Compose a reason to recompose it: when [ProvideRelativeTimeReference] ticks,
+ * every composable that read the local is invalidated, and nothing else is.
+ *
+ * Non-static on purpose. A `staticCompositionLocalOf` would recompose the whole provided subtree on
+ * each tick instead of just the readers, which for a drawer full of rows is the opposite of what we
+ * want.
+ *
+ * The default is a fixed reference captured at first read, i.e. a label that is correct when it
+ * appears and then stops advancing. That is a deliberately harmless fallback for a surface that
+ * forgets the provider — same behaviour as before this existed, not a crash — but it does mean
+ * **the provider is required for labels to actually tick**.
+ */
+val LocalRelativeTimeReference = compositionLocalOf { RelativeTimeReference.current() }
+
+/**
+ * Ticks [LocalRelativeTimeReference] for [content].
+ *
+ * One coroutine per list surface, not one per row. [updateInterval] is the label's worst-case
+ * staleness; a minute matches the finest bucket the formatter produces ("1m ago"), so a shorter
+ * interval would only buy recompositions that render identical text.
+ */
+@Composable
+fun ProvideRelativeTimeReference(
+    updateInterval: Duration = 1.minutes,
+    content: @Composable () -> Unit,
+) {
+    var reference by remember { mutableStateOf(RelativeTimeReference.current()) }
+
+    LaunchedEffect(updateInterval) {
+        while (true) {
+            delay(updateInterval)
+            reference = RelativeTimeReference.current()
+        }
+    }
+
+    CompositionLocalProvider(
+        LocalRelativeTimeReference provides reference,
+        content = content,
+    )
+}

--- a/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/di/ConversationsModule.kt
+++ b/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/di/ConversationsModule.kt
@@ -1,6 +1,8 @@
 package com.garfiec.librechat.feature.conversations.di
 
 import com.garfiec.librechat.core.common.di.KoinQualifiers
+import com.garfiec.librechat.core.common.extensions.RelativeTimeReference
+import com.garfiec.librechat.core.common.extensions.dayBoundaryReferences
 import com.garfiec.librechat.feature.conversations.drawer.DrawerViewModel
 import com.garfiec.librechat.feature.conversations.export.ConversationExporter
 import com.garfiec.librechat.feature.conversations.export.ConversationImporter
@@ -8,6 +10,7 @@ import com.garfiec.librechat.feature.conversations.viewmodel.ArchivedConversatio
 import com.garfiec.librechat.feature.conversations.viewmodel.ConversationListViewModel
 import com.garfiec.librechat.feature.conversations.viewmodel.ProjectChatsViewModel
 import com.garfiec.librechat.feature.conversations.viewmodel.ProjectsViewModel
+import kotlinx.coroutines.flow.Flow
 import org.koin.core.module.dsl.viewModel
 import org.koin.core.module.dsl.viewModelOf
 import org.koin.dsl.module
@@ -25,6 +28,11 @@ val conversationsModule = module {
             ioDispatcher = get(KoinQualifiers.IO),
         )
     }
+
+    // Clock input for date grouping: emits at each local midnight so an open list re-buckets
+    // instead of showing yesterday's sections. Registered (rather than defaulted) so
+    // ConversationListViewModel can stay on `viewModelOf` and keep its `verify()` coverage.
+    single<Flow<RelativeTimeReference>> { dayBoundaryReferences() }
 
     viewModelOf(::ConversationListViewModel)
     viewModelOf(::ArchivedConversationsViewModel)

--- a/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/drawer/ConversationListStateHolder.kt
+++ b/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/drawer/ConversationListStateHolder.kt
@@ -1,11 +1,10 @@
 package com.garfiec.librechat.feature.conversations.drawer
 
 import co.touchlab.kermit.Logger
-import com.garfiec.librechat.core.common.extensions.toInstantOrNull
-import com.garfiec.librechat.core.common.extensions.toRelativeDateGroup
 import com.garfiec.librechat.core.common.result.Result
 import com.garfiec.librechat.core.data.repository.ConversationRepository
 import com.garfiec.librechat.core.model.Conversation
+import com.garfiec.librechat.feature.conversations.viewmodel.groupedByDateBucket
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.Job
@@ -179,15 +178,5 @@ class ConversationListStateHolder(
 
     private fun groupConversationsByDate(
         conversations: List<Conversation>,
-    ): List<Pair<String, List<Conversation>>> {
-        if (conversations.isEmpty()) return emptyList()
-        return conversations
-            .groupBy { conversation ->
-                conversation.updatedAt
-                    ?.toInstantOrNull()
-                    ?.toRelativeDateGroup()
-                    ?: "Unknown"
-            }
-            .toList()
-    }
+    ): List<Pair<String, List<Conversation>>> = conversations.groupedByDateBucket()
 }

--- a/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/drawer/ConversationListStateHolder.kt
+++ b/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/drawer/ConversationListStateHolder.kt
@@ -1,14 +1,18 @@
 package com.garfiec.librechat.feature.conversations.drawer
 
 import co.touchlab.kermit.Logger
+import com.garfiec.librechat.core.common.extensions.RelativeTimeReference
+import com.garfiec.librechat.core.common.extensions.dayBoundaryReferences
 import com.garfiec.librechat.core.common.result.Result
 import com.garfiec.librechat.core.data.repository.ConversationRepository
 import com.garfiec.librechat.core.model.Conversation
+import com.garfiec.librechat.feature.conversations.viewmodel.DatedConversation
 import com.garfiec.librechat.feature.conversations.viewmodel.groupedByDateBucket
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -20,6 +24,9 @@ import kotlinx.coroutines.launch
 class ConversationListStateHolder(
     private val conversationRepository: ConversationRepository,
     private val scope: CoroutineScope,
+    // Injectable so tests can supply a finite flow: the production one never completes, and a
+    // repeating delay makes `advanceUntilIdle()` advance virtual time forever.
+    private val dayBoundaries: Flow<RelativeTimeReference> = dayBoundaryReferences(),
 ) {
 
     companion object {
@@ -29,8 +36,8 @@ class ConversationListStateHolder(
     private val _recentConversations = MutableStateFlow<List<Conversation>>(emptyList())
     val recentConversations: StateFlow<List<Conversation>> = _recentConversations.asStateFlow()
 
-    private val _groupedConversations = MutableStateFlow<List<Pair<String, List<Conversation>>>>(emptyList())
-    val groupedConversations: StateFlow<List<Pair<String, List<Conversation>>>> = _groupedConversations.asStateFlow()
+    private val _groupedConversations = MutableStateFlow<List<Pair<String, List<DatedConversation>>>>(emptyList())
+    val groupedConversations: StateFlow<List<Pair<String, List<DatedConversation>>>> = _groupedConversations.asStateFlow()
 
     private val _activeConversationId = MutableStateFlow<String?>(null)
     val activeConversationId: StateFlow<String?> = _activeConversationId.asStateFlow()
@@ -54,6 +61,7 @@ class ConversationListStateHolder(
     init {
         observeConversations()
         observeSearchQuery()
+        observeDayBoundary()
         loadInitialConversations()
     }
 
@@ -67,17 +75,35 @@ class ConversationListStateHolder(
                         // is a client-side filter over live Room data, so a delete/rename/pin/favorite
                         // (which re-emits Room) must reflect in the visible results immediately, not
                         // wait for the next query keystroke (Punted Bug #25, drawer side).
-                        val query = _searchQuery.value
-                        _groupedConversations.value = if (query.isBlank()) {
-                            groupConversationsByDate(result.data.withoutPinned())
-                        } else {
-                            groupConversationsByDate(filterByQuery(result.data, query))
-                        }
+                        regroup()
                     }
                 }
             } catch (e: Exception) {
                 Logger.w(e) { "Failed to observe conversations" }
             }
+        }
+    }
+
+    /**
+     * Re-bucket at each local midnight. Date groups are clock-dependent, and a conversation crossing
+     * midnight changes *section*, not just label — so unlike a row's "5m ago" this cannot be fixed
+     * by reformatting at render time. Without this, a drawer left open overnight keeps yesterday's
+     * sections until some unrelated Room emission happens to regroup.
+     */
+    private fun observeDayBoundary() {
+        scope.launch {
+            dayBoundaries.collect { regroup() }
+        }
+    }
+
+    /** Rebuilds [_groupedConversations] from the current cache, honouring any active search. */
+    private fun regroup() {
+        val conversations = _recentConversations.value
+        val query = _searchQuery.value
+        _groupedConversations.value = if (query.isBlank()) {
+            groupConversationsByDate(conversations.withoutPinned())
+        } else {
+            groupConversationsByDate(filterByQuery(conversations, query))
         }
     }
 
@@ -133,8 +159,7 @@ class ConversationListStateHolder(
     fun onSearchQueryChanged(query: String) {
         _searchQuery.value = query
         if (query.isBlank()) {
-            _groupedConversations.value =
-                groupConversationsByDate(_recentConversations.value.withoutPinned())
+            regroup()
         }
     }
 
@@ -178,5 +203,5 @@ class ConversationListStateHolder(
 
     private fun groupConversationsByDate(
         conversations: List<Conversation>,
-    ): List<Pair<String, List<Conversation>>> = conversations.groupedByDateBucket()
+    ): List<Pair<String, List<DatedConversation>>> = conversations.groupedByDateBucket()
 }

--- a/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/drawer/DrawerContent.kt
+++ b/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/drawer/DrawerContent.kt
@@ -87,16 +87,19 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.garfiec.librechat.core.common.extensions.toRelativeTimeString
 import com.garfiec.librechat.core.model.ChatProject
 import com.garfiec.librechat.core.model.SAVED_TAG
 import com.garfiec.librechat.core.ui.components.EndpointIcon
 import com.garfiec.librechat.feature.conversations.components.ConversationActionDialogs
 import com.garfiec.librechat.feature.conversations.components.ConversationActionEffects
 import com.garfiec.librechat.feature.conversations.components.ConversationActionsMenu
+import com.garfiec.librechat.feature.conversations.components.LocalRelativeTimeReference
 import com.garfiec.librechat.feature.conversations.components.ProjectActionsMenu
 import com.garfiec.librechat.feature.conversations.components.ProjectDeleteDialog
 import com.garfiec.librechat.feature.conversations.components.ProjectNameDialog
 import com.garfiec.librechat.feature.conversations.components.ProjectPicker
+import com.garfiec.librechat.feature.conversations.components.ProvideRelativeTimeReference
 import com.garfiec.librechat.feature.conversations.components.TagPicker
 import com.garfiec.librechat.feature.conversations.export.ExportFormat
 import com.garfiec.librechat.feature.conversations.export.ExportFormatPicker
@@ -359,443 +362,447 @@ fun DrawerContent(
         runCatching { focusAnchor.requestFocus() }
     }
 
-    Column(
-        modifier = modifier
-            .fillMaxHeight()
-            .width(300.dp)
-            .background(MaterialTheme.colorScheme.surfaceContainerLow)
-            .statusBarsPadding()
-            .navigationBarsPadding()
-            .padding(top = 16.dp),
-    ) {
-        Spacer(
-            modifier = Modifier
-                .size(1.dp)
-                .focusRequester(focusAnchor)
-                .focusable(),
-        )
-
-        // Search field is hidden by default and revealed by the toggle beside "New Chat". Seed the
-        // toggle from the current query so a restored search stays visible across recompositions.
-        var searchExpanded by remember { mutableStateOf(uiState.searchQuery.isNotEmpty()) }
-        val searchFocusRequester = remember { FocusRequester() }
-
-        // Focus the field (and pop the keyboard) only when the user opens search explicitly — the
-        // focusAnchor above still steals initial focus so opening the drawer doesn't do this.
-        LaunchedEffect(searchExpanded) {
-            if (searchExpanded) {
-                runCatching { searchFocusRequester.requestFocus() }
-            }
-        }
-
-        // "New Chat" button at top, with a search toggle to its right.
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(IntrinsicSize.Min)
-                .padding(horizontal = 12.dp),
-            verticalAlignment = Alignment.CenterVertically,
+    // One ticker for every row the drawer renders, so the relative-time labels below
+    // actually advance instead of freezing at whatever they said when composed.
+    ProvideRelativeTimeReference {
+        Column(
+            modifier = modifier
+                .fillMaxHeight()
+                .width(300.dp)
+                .background(MaterialTheme.colorScheme.surfaceContainerLow)
+                .statusBarsPadding()
+                .navigationBarsPadding()
+                .padding(top = 16.dp),
         ) {
-            Surface(
-                onClick = onNewChat,
-                modifier = Modifier.weight(1f),
-                shape = ItemShape,
-                color = MaterialTheme.colorScheme.primary,
-                contentColor = MaterialTheme.colorScheme.onPrimary,
-            ) {
-                Row(
-                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Icon(
-                        imageVector = Icons.Default.Add,
-                        contentDescription = null,
-                        modifier = Modifier.size(20.dp),
-                    )
-                    Spacer(modifier = Modifier.width(8.dp))
-                    Text(
-                        text = stringResource(Res.string.new_chat),
-                        style = MaterialTheme.typography.titleSmall,
-                    )
+            Spacer(
+                modifier = Modifier
+                    .size(1.dp)
+                    .focusRequester(focusAnchor)
+                    .focusable(),
+            )
+
+            // Search field is hidden by default and revealed by the toggle beside "New Chat". Seed the
+            // toggle from the current query so a restored search stays visible across recompositions.
+            var searchExpanded by remember { mutableStateOf(uiState.searchQuery.isNotEmpty()) }
+            val searchFocusRequester = remember { FocusRequester() }
+
+            // Focus the field (and pop the keyboard) only when the user opens search explicitly — the
+            // focusAnchor above still steals initial focus so opening the drawer doesn't do this.
+            LaunchedEffect(searchExpanded) {
+                if (searchExpanded) {
+                    runCatching { searchFocusRequester.requestFocus() }
                 }
             }
 
-            Spacer(modifier = Modifier.width(8.dp))
-
-            // Collapsing clears the query so the list resets to its normal (unsearched) state.
-            Surface(
-                onClick = {
-                    searchExpanded = !searchExpanded
-                    if (!searchExpanded) onSearchQueryChange("")
-                },
-                modifier = Modifier.fillMaxHeight(),
-                shape = ItemShape,
-                color = if (searchExpanded) {
-                    MaterialTheme.colorScheme.secondaryContainer
-                } else {
-                    MaterialTheme.colorScheme.surfaceContainerHighest
-                },
+            // "New Chat" button at top, with a search toggle to its right.
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(IntrinsicSize.Min)
+                    .padding(horizontal = 12.dp),
+                verticalAlignment = Alignment.CenterVertically,
             ) {
-                Box(
-                    modifier = Modifier
-                        .fillMaxHeight()
-                        .padding(horizontal = 12.dp),
-                    contentAlignment = Alignment.Center,
+                Surface(
+                    onClick = onNewChat,
+                    modifier = Modifier.weight(1f),
+                    shape = ItemShape,
+                    color = MaterialTheme.colorScheme.primary,
+                    contentColor = MaterialTheme.colorScheme.onPrimary,
                 ) {
-                    Icon(
-                        imageVector = if (searchExpanded) Icons.Default.Close else Icons.Default.Search,
-                        contentDescription = stringResource(Res.string.cd_search),
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.size(20.dp),
-                    )
-                }
-            }
-        }
-
-        // Search bar — revealed only when toggled on.
-        AnimatedVisibility(visible = searchExpanded) {
-            Column {
-                Spacer(modifier = Modifier.height(12.dp))
-                OutlinedTextField(
-                    value = uiState.searchQuery,
-                    onValueChange = onSearchQueryChange,
-                    leadingIcon = {
+                    Row(
+                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
                         Icon(
-                            imageVector = Icons.Default.Search,
+                            imageVector = Icons.Default.Add,
+                            contentDescription = null,
+                            modifier = Modifier.size(20.dp),
+                        )
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text(
+                            text = stringResource(Res.string.new_chat),
+                            style = MaterialTheme.typography.titleSmall,
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.width(8.dp))
+
+                // Collapsing clears the query so the list resets to its normal (unsearched) state.
+                Surface(
+                    onClick = {
+                        searchExpanded = !searchExpanded
+                        if (!searchExpanded) onSearchQueryChange("")
+                    },
+                    modifier = Modifier.fillMaxHeight(),
+                    shape = ItemShape,
+                    color = if (searchExpanded) {
+                        MaterialTheme.colorScheme.secondaryContainer
+                    } else {
+                        MaterialTheme.colorScheme.surfaceContainerHighest
+                    },
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxHeight()
+                            .padding(horizontal = 12.dp),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Icon(
+                            imageVector = if (searchExpanded) Icons.Default.Close else Icons.Default.Search,
                             contentDescription = stringResource(Res.string.cd_search),
                             tint = MaterialTheme.colorScheme.onSurfaceVariant,
                             modifier = Modifier.size(20.dp),
                         )
-                    },
-                    trailingIcon = {
-                        if (uiState.searchQuery.isNotEmpty()) {
-                            IconButton(onClick = { onSearchQueryChange("") }) {
-                                Icon(
-                                    imageVector = Icons.Default.Close,
-                                    contentDescription = stringResource(Res.string.cd_clear_search),
-                                    modifier = Modifier.size(20.dp),
-                                )
-                            }
-                        }
-                    },
-                    placeholder = {
-                        Text(
-                            text = stringResource(Res.string.search_conversations_placeholder),
-                            style = MaterialTheme.typography.bodySmall,
-                        )
-                    },
-                    singleLine = true,
-                    shape = ItemShape,
-                    textStyle = MaterialTheme.typography.bodySmall,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 12.dp)
-                        .focusRequester(searchFocusRequester),
-                )
-            }
-        }
-
-        // Chats / Projects toggle above the list — shown only where projects are supported. When
-        // hidden (older server / no permission) the drawer is always the recents list.
-        val projectsTabAvailable = uiState.projectsEnabled
-        if (projectsTabAvailable) {
-            Spacer(modifier = Modifier.height(8.dp))
-            // Section heading + a compact icon pill that slides between the recents and projects
-            // views (the label names the whole section; the pill toggles what the list shows).
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(start = 16.dp, end = 12.dp),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Text(
-                    text = stringResource(Res.string.library),
-                    style = MaterialTheme.typography.titleMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier
-                        .weight(1f)
-                        .semantics { heading() },
-                )
-                DrawerTabToggle(
-                    selectedTab = selectedTab,
-                    onSelect = onSelectTab,
-                )
-            }
-            // Keep the folder counts fresh whenever the user opens the Projects tab.
-            val currentOnLoadProjects by rememberUpdatedState(onLoadProjects)
-            LaunchedEffect(selectedTab) {
-                if (selectedTab == DrawerTab.Projects) currentOnLoadProjects()
-            }
-        }
-
-        Spacer(modifier = Modifier.height(8.dp))
-
-        val showProjectsTab = projectsTabAvailable && selectedTab == DrawerTab.Projects
-
-        // Conversation list with favorites section and date groups
-        val listState = rememberLazyListState()
-        val currentOnLoadMore by rememberUpdatedState(onLoadMore)
-
-        // Single item renderer shared by the favorites section and the date groups so the
-        // long-press action menu wiring isn't duplicated across both call sites. rowKey is the
-        // row's LazyColumn key (unique per rendered row, unlike the conversation id).
-        val renderConversationItem: @Composable (String, DrawerConversationDisplayData) -> Unit = { rowKey, data ->
-            DrawerConversationItem(
-                data = data,
-                onClick = { onConversationClick(data.conversationId) },
-                onToggleFavorite = { onToggleFavorite(data) },
-                showBookmarkToggle = uiState.bookmarksEnabled,
-                onLongPress = { menuRowKey = rowKey },
-                menuContent = { menuOffset ->
-                    // Only the open row materializes the menu, so there's one menu in the tree at
-                    // a time (and the dialogs it triggers are hoisted below, outside this row).
-                    if (menuRowKey == rowKey) {
-                        ConversationActionsMenu(
-                            expanded = true,
-                            onDismiss = { menuRowKey = null },
-                            title = data.title,
-                            offset = menuOffset,
-                            isBookmarked = data.isFavorite,
-                            bookmarksEnabled = uiState.bookmarksEnabled,
-                            isPinned = data.isPinned,
-                            showPinAction = uiState.pinEnabled,
-                            onPinToggle = { onPin(data.conversationId, !data.isPinned) },
-                            showMoveToProject = uiState.projectsEnabled,
-                            onMoveToProject = {
-                                onLoadProjects()
-                                projectPickerTarget = data
-                            },
-                            // Share is shown here when the server enables shared links; the
-                            // full-screen list intentionally omits it (passes showShareAction=false).
-                            showShareAction = uiState.sharedLinksEnabled,
-                            onBookmarkToggle = { onToggleFavorite(data) },
-                            onRenameRequest = { renameTarget = data },
-                            onArchive = { onArchive(data.conversationId) },
-                            onDeleteRequest = { deleteTarget = data },
-                            onShare = { onShare(data.conversationId) },
-                            onDuplicate = { newTitle -> onDuplicate(data.conversationId, newTitle) },
-                            onTags = { tagPickerTarget = data },
-                            onExport = { exportPickerTarget = data },
-                        )
-                    }
-                },
-            )
-        }
-
-        val shouldLoadMore = remember {
-            derivedStateOf {
-                val lastVisibleItem = listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
-                val totalItems = listState.layoutInfo.totalItemsCount
-                lastVisibleItem >= totalItems - 8 && totalItems > 0
-            }
-        }
-
-        LaunchedEffect(shouldLoadMore.value) {
-            if (shouldLoadMore.value && uiState.hasMore && !uiState.isLoadingMore) {
-                currentOnLoadMore()
-            }
-        }
-
-        if (!showProjectsTab) {
-            PullToRefreshBox(
-                isRefreshing = uiState.isRefreshing,
-                onRefresh = onRefresh,
-                modifier = Modifier.weight(1f),
-            ) {
-                LazyColumn(
-                    state = listState,
-                    modifier = Modifier.fillMaxSize(),
-                ) {
-                // Pinned section (v0.8.7) — pinned conversations surfaced above favorites. This is
-                // their canonical home: when shown, they're filtered out of the date-grouped buckets
-                // (see ConversationListStateHolder.withoutPinned) so they don't appear twice. The
-                // section is hidden during search, where pinned rows instead surface in the results.
-                if (uiState.pinnedConversations.isNotEmpty() && uiState.searchQuery.isEmpty()) {
-                    item(key = "pinned_header") {
-                        SectionHeader(
-                            icon = Icons.Default.PushPin,
-                            title = stringResource(Res.string.pinned),
-                        )
-                    }
-
-                    items(
-                        items = uiState.pinnedConversations,
-                        key = { "pin_${it.conversationId}" },
-                        contentType = { "conversation" },
-                    ) { data ->
-                        renderConversationItem("pin_${data.conversationId}", data)
-                    }
-
-                    item(key = "pinned_divider") {
-                        HorizontalDivider(
-                            modifier = Modifier.padding(horizontal = 12.dp, vertical = 4.dp),
-                            color = MaterialTheme.colorScheme.outlineVariant,
-                        )
                     }
                 }
+            }
 
-                // Favorites section — hidden entirely when BOOKMARKS.USE is denied so
-                // any locally-cached favorites from a prior permissive session don't leak.
-                // The header collapses the whole section; when expanded, only the top
-                // [FavoritesPreviewCount] show until "Show more" reveals the rest.
-                if (uiState.bookmarksEnabled && uiState.favoriteConversations.isNotEmpty() && uiState.searchQuery.isEmpty()) {
-                    val favorites = uiState.favoriteConversations
-                    stickyHeader(key = "favorites_header") {
-                        Box(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .background(MaterialTheme.colorScheme.surfaceContainerLow),
-                        ) {
+            // Search bar — revealed only when toggled on.
+            AnimatedVisibility(visible = searchExpanded) {
+                Column {
+                    Spacer(modifier = Modifier.height(12.dp))
+                    OutlinedTextField(
+                        value = uiState.searchQuery,
+                        onValueChange = onSearchQueryChange,
+                        leadingIcon = {
+                            Icon(
+                                imageVector = Icons.Default.Search,
+                                contentDescription = stringResource(Res.string.cd_search),
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier.size(20.dp),
+                            )
+                        },
+                        trailingIcon = {
+                            if (uiState.searchQuery.isNotEmpty()) {
+                                IconButton(onClick = { onSearchQueryChange("") }) {
+                                    Icon(
+                                        imageVector = Icons.Default.Close,
+                                        contentDescription = stringResource(Res.string.cd_clear_search),
+                                        modifier = Modifier.size(20.dp),
+                                    )
+                                }
+                            }
+                        },
+                        placeholder = {
+                            Text(
+                                text = stringResource(Res.string.search_conversations_placeholder),
+                                style = MaterialTheme.typography.bodySmall,
+                            )
+                        },
+                        singleLine = true,
+                        shape = ItemShape,
+                        textStyle = MaterialTheme.typography.bodySmall,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 12.dp)
+                            .focusRequester(searchFocusRequester),
+                    )
+                }
+            }
+
+            // Chats / Projects toggle above the list — shown only where projects are supported. When
+            // hidden (older server / no permission) the drawer is always the recents list.
+            val projectsTabAvailable = uiState.projectsEnabled
+            if (projectsTabAvailable) {
+                Spacer(modifier = Modifier.height(8.dp))
+                // Section heading + a compact icon pill that slides between the recents and projects
+                // views (the label names the whole section; the pill toggles what the list shows).
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(start = 16.dp, end = 12.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        text = stringResource(Res.string.library),
+                        style = MaterialTheme.typography.titleMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier
+                            .weight(1f)
+                            .semantics { heading() },
+                    )
+                    DrawerTabToggle(
+                        selectedTab = selectedTab,
+                        onSelect = onSelectTab,
+                    )
+                }
+                // Keep the folder counts fresh whenever the user opens the Projects tab.
+                val currentOnLoadProjects by rememberUpdatedState(onLoadProjects)
+                LaunchedEffect(selectedTab) {
+                    if (selectedTab == DrawerTab.Projects) currentOnLoadProjects()
+                }
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            val showProjectsTab = projectsTabAvailable && selectedTab == DrawerTab.Projects
+
+            // Conversation list with favorites section and date groups
+            val listState = rememberLazyListState()
+            val currentOnLoadMore by rememberUpdatedState(onLoadMore)
+
+            // Single item renderer shared by the favorites section and the date groups so the
+            // long-press action menu wiring isn't duplicated across both call sites. rowKey is the
+            // row's LazyColumn key (unique per rendered row, unlike the conversation id).
+            val renderConversationItem: @Composable (String, DrawerConversationDisplayData) -> Unit = { rowKey, data ->
+                DrawerConversationItem(
+                    data = data,
+                    onClick = { onConversationClick(data.conversationId) },
+                    onToggleFavorite = { onToggleFavorite(data) },
+                    showBookmarkToggle = uiState.bookmarksEnabled,
+                    onLongPress = { menuRowKey = rowKey },
+                    menuContent = { menuOffset ->
+                        // Only the open row materializes the menu, so there's one menu in the tree at
+                        // a time (and the dialogs it triggers are hoisted below, outside this row).
+                        if (menuRowKey == rowKey) {
+                            ConversationActionsMenu(
+                                expanded = true,
+                                onDismiss = { menuRowKey = null },
+                                title = data.title,
+                                offset = menuOffset,
+                                isBookmarked = data.isFavorite,
+                                bookmarksEnabled = uiState.bookmarksEnabled,
+                                isPinned = data.isPinned,
+                                showPinAction = uiState.pinEnabled,
+                                onPinToggle = { onPin(data.conversationId, !data.isPinned) },
+                                showMoveToProject = uiState.projectsEnabled,
+                                onMoveToProject = {
+                                    onLoadProjects()
+                                    projectPickerTarget = data
+                                },
+                                // Share is shown here when the server enables shared links; the
+                                // full-screen list intentionally omits it (passes showShareAction=false).
+                                showShareAction = uiState.sharedLinksEnabled,
+                                onBookmarkToggle = { onToggleFavorite(data) },
+                                onRenameRequest = { renameTarget = data },
+                                onArchive = { onArchive(data.conversationId) },
+                                onDeleteRequest = { deleteTarget = data },
+                                onShare = { onShare(data.conversationId) },
+                                onDuplicate = { newTitle -> onDuplicate(data.conversationId, newTitle) },
+                                onTags = { tagPickerTarget = data },
+                                onExport = { exportPickerTarget = data },
+                            )
+                        }
+                    },
+                )
+            }
+
+            val shouldLoadMore = remember {
+                derivedStateOf {
+                    val lastVisibleItem = listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
+                    val totalItems = listState.layoutInfo.totalItemsCount
+                    lastVisibleItem >= totalItems - 8 && totalItems > 0
+                }
+            }
+
+            LaunchedEffect(shouldLoadMore.value) {
+                if (shouldLoadMore.value && uiState.hasMore && !uiState.isLoadingMore) {
+                    currentOnLoadMore()
+                }
+            }
+
+            if (!showProjectsTab) {
+                PullToRefreshBox(
+                    isRefreshing = uiState.isRefreshing,
+                    onRefresh = onRefresh,
+                    modifier = Modifier.weight(1f),
+                ) {
+                    LazyColumn(
+                        state = listState,
+                        modifier = Modifier.fillMaxSize(),
+                    ) {
+                    // Pinned section (v0.8.7) — pinned conversations surfaced above favorites. This is
+                    // their canonical home: when shown, they're filtered out of the date-grouped buckets
+                    // (see ConversationListStateHolder.withoutPinned) so they don't appear twice. The
+                    // section is hidden during search, where pinned rows instead surface in the results.
+                    if (uiState.pinnedConversations.isNotEmpty() && uiState.searchQuery.isEmpty()) {
+                        item(key = "pinned_header") {
                             SectionHeader(
-                                icon = Icons.Default.Star,
-                                title = stringResource(Res.string.favorites),
-                                collapsed = favoritesCollapsed,
-                                onToggle = { favoritesCollapsed = !favoritesCollapsed },
+                                icon = Icons.Default.PushPin,
+                                title = stringResource(Res.string.pinned),
+                            )
+                        }
+
+                        items(
+                            items = uiState.pinnedConversations,
+                            key = { "pin_${it.conversationId}" },
+                            contentType = { "conversation" },
+                        ) { data ->
+                            renderConversationItem("pin_${data.conversationId}", data)
+                        }
+
+                        item(key = "pinned_divider") {
+                            HorizontalDivider(
+                                modifier = Modifier.padding(horizontal = 12.dp, vertical = 4.dp),
+                                color = MaterialTheme.colorScheme.outlineVariant,
                             )
                         }
                     }
 
-                    // The whole body (preview rows + show-more + divider) lives in one item so it can
-                    // expand/collapse as a unit; the extra rows past the preview get their own nested
-                    // reveal. Favorites are a small curated set, so composing them eagerly is cheap.
-                    item(key = "favorites_body") {
-                        Column {
-                            AnimatedVisibility(
-                                visible = !favoritesCollapsed,
-                                enter = expandVertically() + fadeIn(),
-                                exit = shrinkVertically() + fadeOut(),
+                    // Favorites section — hidden entirely when BOOKMARKS.USE is denied so
+                    // any locally-cached favorites from a prior permissive session don't leak.
+                    // The header collapses the whole section; when expanded, only the top
+                    // [FavoritesPreviewCount] show until "Show more" reveals the rest.
+                    if (uiState.bookmarksEnabled && uiState.favoriteConversations.isNotEmpty() && uiState.searchQuery.isEmpty()) {
+                        val favorites = uiState.favoriteConversations
+                        stickyHeader(key = "favorites_header") {
+                            Box(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .background(MaterialTheme.colorScheme.surfaceContainerLow),
                             ) {
-                                Column {
-                                    favorites.take(FavoritesPreviewCount).forEach { data ->
-                                        renderConversationItem("fav_${data.conversationId}", data)
-                                    }
+                                SectionHeader(
+                                    icon = Icons.Default.Star,
+                                    title = stringResource(Res.string.favorites),
+                                    collapsed = favoritesCollapsed,
+                                    onToggle = { favoritesCollapsed = !favoritesCollapsed },
+                                )
+                            }
+                        }
 
-                                    if (favorites.size > FavoritesPreviewCount) {
-                                        AnimatedVisibility(
-                                            visible = showAllFavorites,
-                                            enter = expandVertically() + fadeIn(),
-                                            exit = shrinkVertically() + fadeOut(),
-                                        ) {
-                                            Column {
-                                                favorites.drop(FavoritesPreviewCount).forEach { data ->
-                                                    renderConversationItem("fav_${data.conversationId}", data)
+                        // The whole body (preview rows + show-more + divider) lives in one item so it can
+                        // expand/collapse as a unit; the extra rows past the preview get their own nested
+                        // reveal. Favorites are a small curated set, so composing them eagerly is cheap.
+                        item(key = "favorites_body") {
+                            Column {
+                                AnimatedVisibility(
+                                    visible = !favoritesCollapsed,
+                                    enter = expandVertically() + fadeIn(),
+                                    exit = shrinkVertically() + fadeOut(),
+                                ) {
+                                    Column {
+                                        favorites.take(FavoritesPreviewCount).forEach { data ->
+                                            renderConversationItem("fav_${data.conversationId}", data)
+                                        }
+
+                                        if (favorites.size > FavoritesPreviewCount) {
+                                            AnimatedVisibility(
+                                                visible = showAllFavorites,
+                                                enter = expandVertically() + fadeIn(),
+                                                exit = shrinkVertically() + fadeOut(),
+                                            ) {
+                                                Column {
+                                                    favorites.drop(FavoritesPreviewCount).forEach { data ->
+                                                        renderConversationItem("fav_${data.conversationId}", data)
+                                                    }
                                                 }
                                             }
+                                            ShowMoreLessRow(
+                                                expanded = showAllFavorites,
+                                                onClick = { showAllFavorites = !showAllFavorites },
+                                            )
                                         }
-                                        ShowMoreLessRow(
-                                            expanded = showAllFavorites,
-                                            onClick = { showAllFavorites = !showAllFavorites },
+
+                                        HorizontalDivider(
+                                            modifier = Modifier.padding(horizontal = 12.dp, vertical = 4.dp),
+                                            color = MaterialTheme.colorScheme.outlineVariant,
                                         )
                                     }
-
-                                    HorizontalDivider(
-                                        modifier = Modifier.padding(horizontal = 12.dp, vertical = 4.dp),
-                                        color = MaterialTheme.colorScheme.outlineVariant,
-                                    )
                                 }
                             }
                         }
                     }
-                }
 
-                if (uiState.groupedConversations.isEmpty() && uiState.searchQuery.isNotEmpty()) {
-                    item(key = "empty_search") {
-                        Text(
-                            text = stringResource(Res.string.no_conversations_found),
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 24.dp),
-                        )
-                    }
-                }
-
-                uiState.groupedConversations.forEach { (dateGroup, displayItems) ->
-                    stickyHeader(key = "header_$dateGroup") {
-                        Text(
-                            text = dateGroup,
-                            style = MaterialTheme.typography.labelSmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .background(MaterialTheme.colorScheme.surfaceContainerLow)
-                                .padding(
-                                    start = 16.dp,
-                                    end = 16.dp,
-                                    top = 12.dp,
-                                    bottom = 4.dp,
-                                ),
-                        )
-                    }
-
-                    items(
-                        items = displayItems,
-                        key = { it.conversationId },
-                        contentType = { "conversation" },
-                    ) { data ->
-                        renderConversationItem(data.conversationId, data)
-                    }
-                }
-
-                if (uiState.isLoadingMore) {
-                    item(key = "loading_more") {
-                        Box(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(16.dp),
-                            contentAlignment = Alignment.Center,
-                        ) {
-                            CircularProgressIndicator(
-                                modifier = Modifier.size(24.dp),
-                                strokeWidth = 2.dp,
+                    if (uiState.groupedConversations.isEmpty() && uiState.searchQuery.isNotEmpty()) {
+                        item(key = "empty_search") {
+                            Text(
+                                text = stringResource(Res.string.no_conversations_found),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier.padding(horizontal = 16.dp, vertical = 24.dp),
                             )
                         }
                     }
+
+                    uiState.groupedConversations.forEach { (dateGroup, displayItems) ->
+                        stickyHeader(key = "header_$dateGroup") {
+                            Text(
+                                text = dateGroup,
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .background(MaterialTheme.colorScheme.surfaceContainerLow)
+                                    .padding(
+                                        start = 16.dp,
+                                        end = 16.dp,
+                                        top = 12.dp,
+                                        bottom = 4.dp,
+                                    ),
+                            )
+                        }
+
+                        items(
+                            items = displayItems,
+                            key = { it.conversationId },
+                            contentType = { "conversation" },
+                        ) { data ->
+                            renderConversationItem(data.conversationId, data)
+                        }
+                    }
+
+                    if (uiState.isLoadingMore) {
+                        item(key = "loading_more") {
+                            Box(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(16.dp),
+                                contentAlignment = Alignment.Center,
+                            ) {
+                                CircularProgressIndicator(
+                                    modifier = Modifier.size(24.dp),
+                                    strokeWidth = 2.dp,
+                                )
+                            }
+                        }
+                    }
+                    }
                 }
-                }
+            } else {
+                DrawerProjectsList(
+                    projects = projects,
+                    inlineProjectChats = inlineProjectChats,
+                    onToggleProject = onToggleProject,
+                    onOpenProjectsIndex = onOpenProjectsIndex,
+                    onCreateProject = onCreateProject,
+                    onRenameProject = onRenameProject,
+                    onDeleteProject = onDeleteProject,
+                    renderChat = renderConversationItem,
+                    modifier = Modifier.weight(1f),
+                )
             }
-        } else {
-            DrawerProjectsList(
-                projects = projects,
-                inlineProjectChats = inlineProjectChats,
-                onToggleProject = onToggleProject,
-                onOpenProjectsIndex = onOpenProjectsIndex,
-                onCreateProject = onCreateProject,
-                onRenameProject = onRenameProject,
-                onDeleteProject = onDeleteProject,
-                renderChat = renderConversationItem,
-                modifier = Modifier.weight(1f),
+
+            // Bottom section: divider + footer links
+            HorizontalDivider(
+                modifier = Modifier.padding(horizontal = 12.dp),
+                color = MaterialTheme.colorScheme.outlineVariant,
             )
-        }
 
-        // Bottom section: divider + footer links
-        HorizontalDivider(
-            modifier = Modifier.padding(horizontal = 12.dp),
-            color = MaterialTheme.colorScheme.outlineVariant,
-        )
-
-        if (uiState.agentsEnabled) {
+            if (uiState.agentsEnabled) {
+                DrawerFooterItem(
+                    icon = Icons.Default.SmartToy,
+                    label = stringResource(Res.string.agents),
+                    onClick = onAgentsClick,
+                )
+            }
+            if (uiState.skillsEnabled) {
+                DrawerFooterItem(
+                    icon = Icons.Default.Extension,
+                    label = stringResource(Res.string.skills),
+                    onClick = onSkillsClick,
+                )
+            }
             DrawerFooterItem(
-                icon = Icons.Default.SmartToy,
-                label = stringResource(Res.string.agents),
-                onClick = onAgentsClick,
+                icon = Icons.Default.Folder,
+                label = stringResource(Res.string.files),
+                onClick = onFilesClick,
             )
-        }
-        if (uiState.skillsEnabled) {
-            DrawerFooterItem(
-                icon = Icons.Default.Extension,
-                label = stringResource(Res.string.skills),
-                onClick = onSkillsClick,
-            )
-        }
-        DrawerFooterItem(
-            icon = Icons.Default.Folder,
-            label = stringResource(Res.string.files),
-            onClick = onFilesClick,
-        )
 
-        footerContent?.invoke()
+            footerContent?.invoke()
 
-        Spacer(modifier = Modifier.height(8.dp))
+            Spacer(modifier = Modifier.height(8.dp))
+        }
     }
 
     // Rename/Delete confirmation dialogs for the long-press action menu. Single hoisted instance
@@ -1263,14 +1270,20 @@ private fun DrawerConversationItem(
                     overflow = TextOverflow.Ellipsis,
                 )
 
-                val subtitle = remember(data.model, data.relativeTime) {
+                // Relative time is formatted here rather than in the ViewModel mapping: it depends
+                // on the clock, so a pre-formatted value in immutable state goes stale. The
+                // reference is a key, not just an input — it is the thing that advances, and
+                // without it this memo would never recompute. Same shape as ConversationItem.
+                val reference = LocalRelativeTimeReference.current
+                val subtitle = remember(data.model, data.updatedAt, reference) {
                     buildString {
                         data.model?.let { model ->
                             append(model.take(20))
                         }
-                        if (data.relativeTime.isNotEmpty()) {
+                        val relativeTime = data.updatedAt?.toRelativeTimeString(reference)
+                        if (!relativeTime.isNullOrEmpty()) {
                             if (isNotEmpty()) append(" \u00B7 ")
-                            append(data.relativeTime)
+                            append(relativeTime)
                         }
                     }
                 }

--- a/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/drawer/DrawerDisplayMapping.kt
+++ b/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/drawer/DrawerDisplayMapping.kt
@@ -1,22 +1,22 @@
 package com.garfiec.librechat.feature.conversations.drawer
 
-import com.garfiec.librechat.core.common.extensions.formatMonthAbbrev
 import com.garfiec.librechat.core.common.extensions.toInstantOrNull
 import com.garfiec.librechat.core.model.Conversation
 import com.garfiec.librechat.core.model.EndpointConfig
 import com.garfiec.librechat.core.model.SAVED_TAG
 import com.garfiec.librechat.core.model.resolveEndpointIconUrl
-import kotlinx.datetime.TimeZone
-import kotlinx.datetime.toLocalDateTime
-import kotlin.time.Clock
-import kotlin.time.Instant
 
-internal data class DrawerDataSnapshot(
-    val grouped: List<Pair<String, List<Conversation>>>,
-    val activeId: String?,
-    val favConvos: List<Conversation>,
-    val pinnedConvos: List<Conversation>,
-    val query: String,
+/**
+ * The drawer's conversation sections, already mapped to row data.
+ *
+ * Derived upstream of the search query (see [DrawerViewModel.displayConversations]) so a keystroke
+ * re-assembles `DrawerUiState` from these rows instead of re-running the mapping — the grouped list
+ * in particular is debounced, so it is usually unchanged between keystrokes.
+ */
+internal data class DrawerDisplaySnapshot(
+    val grouped: List<Pair<String, List<DrawerConversationDisplayData>>> = emptyList(),
+    val favorites: List<DrawerConversationDisplayData> = emptyList(),
+    val pinned: List<DrawerConversationDisplayData> = emptyList(),
 )
 
 internal fun Conversation.toDrawerDisplayData(
@@ -29,7 +29,7 @@ internal fun Conversation.toDrawerDisplayData(
         title = title ?: "New Chat",
         model = model,
         endpoint = endpoint,
-        relativeTime = updatedAt?.toInstantOrNull()?.toRelativeTimeString() ?: "",
+        updatedAt = updatedAt?.toInstantOrNull(),
         isActive = convId == activeConversationId,
         isFavorite = SAVED_TAG in tags,
         isPinned = pinned == true,
@@ -37,23 +37,4 @@ internal fun Conversation.toDrawerDisplayData(
         tags = tags,
         endpointIconUrl = resolveEndpointIconUrl(endpointConfigs),
     )
-}
-
-internal fun Instant.toRelativeTimeString(): String {
-    val now = Clock.System.now()
-    val duration = now - this
-    val minutes = duration.inWholeMinutes
-    val hours = duration.inWholeHours
-    val days = duration.inWholeDays
-
-    return when {
-        minutes < 1 -> "Just now"
-        minutes < 60 -> "${minutes}m ago"
-        hours < 24 -> "${hours}h ago"
-        days < 7 -> "${days}d ago"
-        else -> {
-            val date = toLocalDateTime(TimeZone.currentSystemDefault()).date
-            "${formatMonthAbbrev(date.monthNumber)} ${date.dayOfMonth}"
-        }
-    }
 }

--- a/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/drawer/DrawerDisplayMapping.kt
+++ b/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/drawer/DrawerDisplayMapping.kt
@@ -5,6 +5,7 @@ import com.garfiec.librechat.core.model.Conversation
 import com.garfiec.librechat.core.model.EndpointConfig
 import com.garfiec.librechat.core.model.SAVED_TAG
 import com.garfiec.librechat.core.model.resolveEndpointIconUrl
+import kotlin.time.Instant
 
 /**
  * The drawer's conversation sections, already mapped to row data.
@@ -19,9 +20,14 @@ internal data class DrawerDisplaySnapshot(
     val pinned: List<DrawerConversationDisplayData> = emptyList(),
 )
 
+/**
+ * [parsedUpdatedAt] lets a caller that has already parsed the timestamp (grouping does, to pick a
+ * date bucket) hand it in rather than making this parse the same string a second time.
+ */
 internal fun Conversation.toDrawerDisplayData(
     activeConversationId: String?,
     endpointConfigs: Map<String, EndpointConfig>,
+    parsedUpdatedAt: Instant? = updatedAt?.toInstantOrNull(),
 ): DrawerConversationDisplayData {
     val convId = conversationId ?: ""
     return DrawerConversationDisplayData(
@@ -29,7 +35,7 @@ internal fun Conversation.toDrawerDisplayData(
         title = title ?: "New Chat",
         model = model,
         endpoint = endpoint,
-        updatedAt = updatedAt?.toInstantOrNull(),
+        updatedAt = parsedUpdatedAt,
         isActive = convId == activeConversationId,
         isFavorite = SAVED_TAG in tags,
         isPinned = pinned == true,

--- a/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/drawer/DrawerUiModels.kt
+++ b/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/drawer/DrawerUiModels.kt
@@ -2,6 +2,7 @@ package com.garfiec.librechat.feature.conversations.drawer
 
 import androidx.compose.runtime.Immutable
 import com.garfiec.librechat.core.model.ConversationTag
+import kotlin.time.Instant
 
 /**
  * Lightweight snapshot of fields DrawerConversationItem actually renders.
@@ -13,7 +14,11 @@ data class DrawerConversationDisplayData(
     val title: String,
     val model: String?,
     val endpoint: String?,
-    val relativeTime: String,
+    // Parsed timestamp, formatted at render time by the row (see DrawerConversationItem).
+    // Deliberately NOT a pre-formatted "5m ago": that depends on the clock, so baking it into this
+    // immutable snapshot leaves it stale until an unrelated Room emission re-runs the mapping.
+    // Parsing, by contrast, is clock-independent and so stays upstream in the mapping.
+    val updatedAt: Instant?,
     val isActive: Boolean,
     val isFavorite: Boolean,
     val isPinned: Boolean,

--- a/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/drawer/DrawerViewModel.kt
+++ b/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/drawer/DrawerViewModel.kt
@@ -28,6 +28,7 @@ import com.garfiec.librechat.feature.conversations.export.ExportFormat
 import com.garfiec.librechat.feature.conversations.viewmodel.ConversationListActionsDelegate
 import com.garfiec.librechat.feature.conversations.viewmodel.ConversationListEvent
 import com.garfiec.librechat.feature.conversations.viewmodel.ProjectActionsDelegate
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -179,16 +180,34 @@ class DrawerViewModel(
             }
             .stateIn(viewModelScope, SharingStarted.Eagerly, DrawerPermissionFlags())
 
+    /**
+     * All three conversation sections, mapped to row data.
+     *
+     * Kept deliberately upstream of `searchQuery`: that flow changes on every keystroke, and folding
+     * it into this combine would re-map all three lists per character — including the grouped list,
+     * which ConversationListStateHolder debounces at 300ms and which is therefore usually identical
+     * to the previous keystroke's. Splitting it out means a keystroke only re-assembles
+     * [DrawerUiState] from rows that were already mapped.
+     */
+    private val displayConversations: Flow<DrawerDisplaySnapshot> = combine(
+        conversationListStateHolder.groupedConversations,
+        favoriteConversations,
+        pinnedConversations,
+        conversationListStateHolder.activeConversationId,
+        configRepository.endpointConfigs,
+    ) { grouped, favConvos, pinnedConvos, activeId, endpointConfigs ->
+        DrawerDisplaySnapshot(
+            grouped = grouped.map { (group, convos) ->
+                group to convos.map { it.toDrawerDisplayData(activeId, endpointConfigs) }
+            },
+            favorites = favConvos.map { it.toDrawerDisplayData(activeId, endpointConfigs) },
+            pinned = pinnedConvos.map { it.toDrawerDisplayData(activeId, endpointConfigs) },
+        )
+    }
+
     val drawerUiState: StateFlow<DrawerUiState> = combine(
-        combine(
-            conversationListStateHolder.groupedConversations,
-            conversationListStateHolder.activeConversationId,
-            favoriteConversations,
-            pinnedConversations,
-            conversationListStateHolder.searchQuery,
-        ) { grouped, activeId, favConvos, pinnedConvos, query ->
-            DrawerDataSnapshot(grouped, activeId, favConvos, pinnedConvos, query)
-        },
+        displayConversations,
+        conversationListStateHolder.searchQuery,
         combine(
             conversationListStateHolder.isRefreshing,
             conversationListStateHolder.isLoadingMore,
@@ -197,21 +216,14 @@ class DrawerViewModel(
             Triple(refreshing, loadingMore, hasMore)
         },
         drawerPermissionFlags,
-        configRepository.endpointConfigs,
         drawerActionMenuState,
-    ) { data, refreshState, perms, endpointConfigs, actionMenu ->
+    ) { display, query, refreshState, perms, actionMenu ->
         val (refreshing, loadingMore, hasMore) = refreshState
         DrawerUiState(
-            groupedConversations = data.grouped.map { (group, convos) ->
-                group to convos.map { it.toDrawerDisplayData(data.activeId, endpointConfigs) }
-            },
-            favoriteConversations = data.favConvos.map {
-                it.toDrawerDisplayData(data.activeId, endpointConfigs)
-            },
-            pinnedConversations = data.pinnedConvos.map {
-                it.toDrawerDisplayData(data.activeId, endpointConfigs)
-            },
-            searchQuery = data.query,
+            groupedConversations = display.grouped,
+            favoriteConversations = display.favorites,
+            pinnedConversations = display.pinned,
+            searchQuery = query,
             isRefreshing = refreshing,
             isLoadingMore = loadingMore,
             hasMore = hasMore,

--- a/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/drawer/DrawerViewModel.kt
+++ b/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/drawer/DrawerViewModel.kt
@@ -198,7 +198,11 @@ class DrawerViewModel(
     ) { grouped, favConvos, pinnedConvos, activeId, endpointConfigs ->
         DrawerDisplaySnapshot(
             grouped = grouped.map { (group, convos) ->
-                group to convos.map { it.toDrawerDisplayData(activeId, endpointConfigs) }
+                // Grouping already parsed updatedAt to pick the bucket — reuse it rather than
+                // parsing the same string again per row.
+                group to convos.map {
+                    it.conversation.toDrawerDisplayData(activeId, endpointConfigs, it.updatedAt)
+                }
             },
             favorites = favConvos.map { it.toDrawerDisplayData(activeId, endpointConfigs) },
             pinned = pinnedConvos.map { it.toDrawerDisplayData(activeId, endpointConfigs) },

--- a/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/screen/ConversationListScreen.kt
+++ b/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/screen/ConversationListScreen.kt
@@ -48,6 +48,7 @@ import com.garfiec.librechat.feature.conversations.components.ConversationAction
 import com.garfiec.librechat.feature.conversations.components.ConversationItem
 import com.garfiec.librechat.feature.conversations.components.ConversationSearchBar
 import com.garfiec.librechat.feature.conversations.components.DateGroupHeader
+import com.garfiec.librechat.feature.conversations.components.ProvideRelativeTimeReference
 import com.garfiec.librechat.feature.conversations.components.TagFilterBar
 import com.garfiec.librechat.feature.conversations.components.TagPicker
 import com.garfiec.librechat.feature.conversations.export.ExportFormat
@@ -258,66 +259,69 @@ fun ConversationListScreen(
 
                     // Content state
                     else -> {
-                        LazyColumn(
-                            state = listState,
-                            modifier = Modifier.fillMaxSize(),
-                            contentPadding = PaddingValues(bottom = 80.dp),
-                        ) {
-                            // Error banner at top if present
-                            if (uiState.error != null) {
-                                item(key = "error") {
-                                    ErrorBanner(
-                                        message = uiState.error ?: stringResource(Res.string.unknown_error),
-                                        onRetry = {
-                                            viewModel.dismissError()
-                                            viewModel.loadConversations()
-                                        },
-                                    )
-                                }
-                            }
-
-                            groupedConversations.forEach { (dateGroup, displayItems) ->
-                                stickyHeader(key = "header_$dateGroup") {
-                                    DateGroupHeader(label = dateGroup)
-                                }
-
-                                // Conversation items in this group
-                                items(
-                                    items = displayItems,
-                                    key = { it.conversationId },
-                                    contentType = { "conversation" },
-                                ) { displayData ->
-                                    ConversationItem(
-                                        data = displayData,
-                                        onClick = {
-                                            onConversationClick(displayData.conversationId)
-                                        },
-                                        onActionsClick = {
-                                            selectedConversation = viewModel.getConversation(
-                                                displayData.conversationId,
-                                            )
-                                        },
-                                        bookmarksEnabled = uiState.bookmarksEnabled,
-                                    )
-                                    HorizontalDivider(
-                                        modifier = Modifier.padding(start = 52.dp),
-                                        color = MaterialTheme.colorScheme.outlineVariant,
-                                    )
-                                }
-                            }
-
-                            // Loading indicator at bottom when loading more
-                            if (uiState.isLoading && uiState.conversationCount > 0) {
-                                item(key = "loading_more") {
-                                    Box(
-                                        modifier = Modifier
-                                            .fillMaxWidth()
-                                            .padding(16.dp),
-                                        contentAlignment = Alignment.Center,
-                                    ) {
-                                        CircularProgressIndicator(
-                                            color = MaterialTheme.colorScheme.primary,
+                        // One ticker for the whole list, so relative-time labels advance while it is open.
+                        ProvideRelativeTimeReference {
+                            LazyColumn(
+                                state = listState,
+                                modifier = Modifier.fillMaxSize(),
+                                contentPadding = PaddingValues(bottom = 80.dp),
+                            ) {
+                                // Error banner at top if present
+                                if (uiState.error != null) {
+                                    item(key = "error") {
+                                        ErrorBanner(
+                                            message = uiState.error ?: stringResource(Res.string.unknown_error),
+                                            onRetry = {
+                                                viewModel.dismissError()
+                                                viewModel.loadConversations()
+                                            },
                                         )
+                                    }
+                                }
+
+                                groupedConversations.forEach { (dateGroup, displayItems) ->
+                                    stickyHeader(key = "header_$dateGroup") {
+                                        DateGroupHeader(label = dateGroup)
+                                    }
+
+                                    // Conversation items in this group
+                                    items(
+                                        items = displayItems,
+                                        key = { it.conversationId },
+                                        contentType = { "conversation" },
+                                    ) { displayData ->
+                                        ConversationItem(
+                                            data = displayData,
+                                            onClick = {
+                                                onConversationClick(displayData.conversationId)
+                                            },
+                                            onActionsClick = {
+                                                selectedConversation = viewModel.getConversation(
+                                                    displayData.conversationId,
+                                                )
+                                            },
+                                            bookmarksEnabled = uiState.bookmarksEnabled,
+                                        )
+                                        HorizontalDivider(
+                                            modifier = Modifier.padding(start = 52.dp),
+                                            color = MaterialTheme.colorScheme.outlineVariant,
+                                        )
+                                    }
+                                }
+
+                                // Loading indicator at bottom when loading more
+                                if (uiState.isLoading && uiState.conversationCount > 0) {
+                                    item(key = "loading_more") {
+                                        Box(
+                                            modifier = Modifier
+                                                .fillMaxWidth()
+                                                .padding(16.dp),
+                                            contentAlignment = Alignment.Center,
+                                        ) {
+                                            CircularProgressIndicator(
+                                                color = MaterialTheme.colorScheme.primary,
+                                            )
+                                        }
                                     }
                                 }
                             }

--- a/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/screen/ProjectChatsScreen.kt
+++ b/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/screen/ProjectChatsScreen.kt
@@ -47,6 +47,7 @@ import com.garfiec.librechat.core.ui.components.LoadingIndicator
 import com.garfiec.librechat.feature.conversations.components.ConversationActions
 import com.garfiec.librechat.feature.conversations.components.ConversationItem
 import com.garfiec.librechat.feature.conversations.components.DateGroupHeader
+import com.garfiec.librechat.feature.conversations.components.ProvideRelativeTimeReference
 import com.garfiec.librechat.feature.conversations.components.TagPicker
 import com.garfiec.librechat.feature.conversations.export.ExportFormat
 import com.garfiec.librechat.feature.conversations.export.ExportFormatPicker
@@ -193,35 +194,38 @@ fun ProjectChatsScreen(
                     icon = Icons.Default.Forum,
                 )
                 else -> {
-                    LazyColumn(state = listState, modifier = Modifier.fillMaxSize()) {
-                        uiState.groupedConversations.forEach { (dateGroup, displayItems) ->
-                            stickyHeader(key = "header_$dateGroup") { DateGroupHeader(label = dateGroup) }
-                            items(
-                                items = displayItems,
-                                key = { it.conversationId },
-                                contentType = { "conversation" },
-                            ) { displayData ->
-                                ConversationItem(
-                                    data = displayData,
-                                    onClick = { onConversationClick(displayData.conversationId) },
-                                    onActionsClick = {
-                                        selectedConversation = viewModel.getConversation(displayData.conversationId)
-                                    },
-                                    bookmarksEnabled = uiState.bookmarksEnabled,
-                                )
-                                HorizontalDivider(
-                                    modifier = Modifier.padding(start = 52.dp),
-                                    color = MaterialTheme.colorScheme.outlineVariant,
-                                )
+                    // One ticker for the whole list, so relative-time labels advance while it is open.
+                    ProvideRelativeTimeReference {
+                        LazyColumn(state = listState, modifier = Modifier.fillMaxSize()) {
+                            uiState.groupedConversations.forEach { (dateGroup, displayItems) ->
+                                stickyHeader(key = "header_$dateGroup") { DateGroupHeader(label = dateGroup) }
+                                items(
+                                    items = displayItems,
+                                    key = { it.conversationId },
+                                    contentType = { "conversation" },
+                                ) { displayData ->
+                                    ConversationItem(
+                                        data = displayData,
+                                        onClick = { onConversationClick(displayData.conversationId) },
+                                        onActionsClick = {
+                                            selectedConversation = viewModel.getConversation(displayData.conversationId)
+                                        },
+                                        bookmarksEnabled = uiState.bookmarksEnabled,
+                                    )
+                                    HorizontalDivider(
+                                        modifier = Modifier.padding(start = 52.dp),
+                                        color = MaterialTheme.colorScheme.outlineVariant,
+                                    )
+                                }
                             }
-                        }
-                        if (uiState.isLoading && uiState.conversationCount > 0) {
-                            item(key = "loading_more") {
-                                Box(
-                                    modifier = Modifier.fillMaxWidth().padding(16.dp),
-                                    contentAlignment = Alignment.Center,
-                                ) {
-                                    CircularProgressIndicator(color = MaterialTheme.colorScheme.primary)
+                            if (uiState.isLoading && uiState.conversationCount > 0) {
+                                item(key = "loading_more") {
+                                    Box(
+                                        modifier = Modifier.fillMaxWidth().padding(16.dp),
+                                        contentAlignment = Alignment.Center,
+                                    ) {
+                                        CircularProgressIndicator(color = MaterialTheme.colorScheme.primary)
+                                    }
                                 }
                             }
                         }

--- a/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/viewmodel/ConversationGrouping.kt
+++ b/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/viewmodel/ConversationGrouping.kt
@@ -1,5 +1,6 @@
 package com.garfiec.librechat.feature.conversations.viewmodel
 
+import com.garfiec.librechat.core.common.extensions.RelativeTimeReference
 import com.garfiec.librechat.core.common.extensions.toInstantOrNull
 import com.garfiec.librechat.core.common.extensions.toRelativeDateGroup
 import com.garfiec.librechat.core.model.Conversation
@@ -8,23 +9,32 @@ import com.garfiec.librechat.feature.conversations.components.ConversationDispla
 import com.garfiec.librechat.feature.conversations.components.toDisplayData
 
 /**
- * Flattens conversations into date-grouped display rows (Today / Yesterday /
- * Previous 7 Days / … / month-year). Shared by the all-conversations list and
+ * Buckets conversations by date label (Today / Yesterday / Previous 7 Days / … / month-year),
+ * preserving order within each bucket.
+ *
+ * The drawer keeps the raw [Conversation]s and the full-screen list maps them to display rows, so
+ * the two differ only in that trailing map — the bucketing itself lives here once. Resolves the
+ * clock and timezone a single time for the whole list rather than once per row.
+ */
+internal fun List<Conversation>.groupedByDateBucket(): List<Pair<String, List<Conversation>>> {
+    if (isEmpty()) return emptyList()
+    val reference = RelativeTimeReference.current()
+    return groupBy { conversation ->
+        conversation.updatedAt
+            ?.toInstantOrNull()
+            ?.toRelativeDateGroup(reference)
+            ?: "Unknown"
+    }.toList()
+}
+
+/**
+ * Flattens conversations into date-grouped display rows. Shared by the all-conversations list and
  * the project-filtered browse screen so the grouping logic isn't forked.
  */
 internal fun groupConversationsByDate(
     conversations: List<Conversation>,
     endpointConfigs: Map<String, EndpointConfig>,
-): List<Pair<String, List<ConversationDisplayData>>> {
-    if (conversations.isEmpty()) return emptyList()
-    return conversations
-        .groupBy { conversation ->
-            conversation.updatedAt
-                ?.toInstantOrNull()
-                ?.toRelativeDateGroup()
-                ?: "Unknown"
-        }
-        .map { (group, convos) ->
-            group to convos.map { it.toDisplayData(endpointConfigs) }
-        }
-}
+): List<Pair<String, List<ConversationDisplayData>>> =
+    conversations.groupedByDateBucket().map { (group, convos) ->
+        group to convos.map { it.toDisplayData(endpointConfigs) }
+    }

--- a/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/viewmodel/ConversationGrouping.kt
+++ b/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/viewmodel/ConversationGrouping.kt
@@ -7,24 +7,39 @@ import com.garfiec.librechat.core.model.Conversation
 import com.garfiec.librechat.core.model.EndpointConfig
 import com.garfiec.librechat.feature.conversations.components.ConversationDisplayData
 import com.garfiec.librechat.feature.conversations.components.toDisplayData
+import kotlin.time.Instant
+
+/**
+ * A conversation paired with its parsed `updatedAt`.
+ *
+ * Exists so the timestamp is parsed exactly once per conversation per emission. Bucketing needs the
+ * `Instant` to pick a date group and the display mapping needs it for the row, and without carrying
+ * it between the two, both ends call `Instant.parse` on the same string — on the main thread, for
+ * every conversation, on every Room emission.
+ */
+data class DatedConversation(
+    val conversation: Conversation,
+    val updatedAt: Instant?,
+)
 
 /**
  * Buckets conversations by date label (Today / Yesterday / Previous 7 Days / … / month-year),
  * preserving order within each bucket.
  *
- * The drawer keeps the raw [Conversation]s and the full-screen list maps them to display rows, so
- * the two differ only in that trailing map — the bucketing itself lives here once. Resolves the
- * clock and timezone a single time for the whole list rather than once per row.
+ * The drawer keeps the raw conversations and the full-screen list maps them to display rows, so the
+ * two differ only in that trailing map — the bucketing itself lives here once.
+ *
+ * [reference] is a parameter rather than a `Clock.System.now()` read so that (a) the whole list
+ * buckets against one instant instead of one per row, and (b) callers can re-run grouping from
+ * `dayBoundaryReferences()` when the date changes underneath an open list.
  */
-internal fun List<Conversation>.groupedByDateBucket(): List<Pair<String, List<Conversation>>> {
+internal fun List<Conversation>.groupedByDateBucket(
+    reference: RelativeTimeReference = RelativeTimeReference.current(),
+): List<Pair<String, List<DatedConversation>>> {
     if (isEmpty()) return emptyList()
-    val reference = RelativeTimeReference.current()
-    return groupBy { conversation ->
-        conversation.updatedAt
-            ?.toInstantOrNull()
-            ?.toRelativeDateGroup(reference)
-            ?: "Unknown"
-    }.toList()
+    return map { DatedConversation(it, it.updatedAt?.toInstantOrNull()) }
+        .groupBy { it.updatedAt?.toRelativeDateGroup(reference) ?: "Unknown" }
+        .toList()
 }
 
 /**
@@ -34,7 +49,8 @@ internal fun List<Conversation>.groupedByDateBucket(): List<Pair<String, List<Co
 internal fun groupConversationsByDate(
     conversations: List<Conversation>,
     endpointConfigs: Map<String, EndpointConfig>,
+    reference: RelativeTimeReference = RelativeTimeReference.current(),
 ): List<Pair<String, List<ConversationDisplayData>>> =
-    conversations.groupedByDateBucket().map { (group, convos) ->
-        group to convos.map { it.toDisplayData(endpointConfigs) }
+    conversations.groupedByDateBucket(reference).map { (group, dated) ->
+        group to dated.map { it.conversation.toDisplayData(endpointConfigs, it.updatedAt) }
     }

--- a/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/viewmodel/ConversationListViewModel.kt
+++ b/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/viewmodel/ConversationListViewModel.kt
@@ -3,6 +3,7 @@ package com.garfiec.librechat.feature.conversations.viewmodel
 import androidx.compose.runtime.Immutable
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.garfiec.librechat.core.common.extensions.RelativeTimeReference
 import com.garfiec.librechat.core.common.extensions.toInstantOrNull
 import com.garfiec.librechat.core.common.result.Result
 import com.garfiec.librechat.core.data.repository.ConfigRepository
@@ -24,6 +25,7 @@ import com.garfiec.librechat.feature.conversations.export.ExportFormat
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -71,6 +73,10 @@ class ConversationListViewModel(
     private val conversationImporter: ConversationImporter,
     private val roleRepository: RoleRepository,
     private val configRepository: ConfigRepository,
+    // Koin-provided rather than defaulted, so `viewModelOf` (and the static `verify()` coverage it
+    // buys) still applies. Tests inject a finite flow: the production one never completes, and a
+    // repeating delay makes `advanceUntilIdle()` advance virtual time forever.
+    private val dayBoundaries: Flow<RelativeTimeReference>,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(ConversationListUiState())
@@ -188,8 +194,14 @@ class ConversationListViewModel(
 
     private fun observeGroupedConversations() {
         viewModelScope.launch {
-            combine(_conversations, configRepository.endpointConfigs) { convos, configs ->
-                groupConversationsByDate(convos, configs) to convos.size
+            // dayBoundaryReferences() re-groups at local midnight: date sections are clock-dependent
+            // and membership (not just the label) changes when the date rolls over.
+            combine(
+                _conversations,
+                configRepository.endpointConfigs,
+                dayBoundaries,
+            ) { convos, configs, reference ->
+                groupConversationsByDate(convos, configs, reference) to convos.size
             }.collect { (grouped, count) ->
                 _uiState.value = _uiState.value.copy(
                     groupedConversations = grouped,

--- a/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/viewmodel/ProjectChatsViewModel.kt
+++ b/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/viewmodel/ProjectChatsViewModel.kt
@@ -3,6 +3,8 @@ package com.garfiec.librechat.feature.conversations.viewmodel
 import androidx.compose.runtime.Immutable
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.garfiec.librechat.core.common.extensions.RelativeTimeReference
+import com.garfiec.librechat.core.common.extensions.dayBoundaryReferences
 import com.garfiec.librechat.core.common.result.Result
 import com.garfiec.librechat.core.data.repository.ConfigRepository
 import com.garfiec.librechat.core.data.repository.ConversationRepository
@@ -18,6 +20,7 @@ import com.garfiec.librechat.core.model.permissions.hasAccessOrPermissive
 import com.garfiec.librechat.feature.conversations.components.ConversationDisplayData
 import com.garfiec.librechat.feature.conversations.export.ConversationExporter
 import com.garfiec.librechat.feature.conversations.export.ExportFormat
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -61,6 +64,10 @@ class ProjectChatsViewModel(
     private val conversationExporter: ConversationExporter,
     private val roleRepository: RoleRepository,
     private val configRepository: ConfigRepository,
+    // Defaulted rather than Koin-provided: this one is built by an explicit `viewModel { }` block
+    // (projectId arrives via parametersOf), so a default costs no DI wiring. Tests override it —
+    // the production flow never completes, which would hang `advanceUntilIdle()`.
+    private val dayBoundaries: Flow<RelativeTimeReference> = dayBoundaryReferences(),
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(ProjectChatsUiState())
@@ -91,8 +98,14 @@ class ProjectChatsViewModel(
 
     private fun observeGrouped() {
         viewModelScope.launch {
-            combine(_conversations, configRepository.endpointConfigs) { convos, configs ->
-                groupConversationsByDate(convos, configs) to convos.size
+            // dayBoundaryReferences() re-groups at local midnight: date sections are clock-dependent
+            // and membership (not just the label) changes when the date rolls over.
+            combine(
+                _conversations,
+                configRepository.endpointConfigs,
+                dayBoundaries,
+            ) { convos, configs, reference ->
+                groupConversationsByDate(convos, configs, reference) to convos.size
             }.collect { (grouped, count) ->
                 _uiState.value = _uiState.value.copy(groupedConversations = grouped, conversationCount = count)
             }


### PR DESCRIPTION
## Problem

Two problems, one of them a correctness bug the perf audit missed.

**Stale labels.** `DrawerConversationDisplayData.relativeTime` held a pre-formatted `"5m ago"` — a
clock-dependent value frozen into an `@Immutable` snapshot. There is no ticker anywhere in
`feature/conversations`, so a drawer row reading "Just now" stayed "Just now" until some unrelated
Room emission re-ran the mapping, potentially for the rest of the session.

`ConversationItem.kt` in the full-screen list looked like it avoided this by formatting under
`remember(data.updatedAt)`, but it has **the same bug in a different disguise**: `remember` caches
until its *keys* change, and `updatedAt` does not change as time passes. Both surfaces were frozen;
only one of them looked frozen.

**Redundant mapping.** `DrawerViewModel.drawerUiState` mapped every cached conversation inside a
`combine` collected on `viewModelScope` (`Dispatchers.Main.immediate`, no `flowOn`), and
`ConversationListStateHolder.observeConversations` grouped them on the same dispatcher. Each row's
ISO-8601 `updatedAt` was parsed twice per Room emission — once in `groupConversationsByDate`, once
in `toDrawerDisplayData` — and three times for a favorited, unpinned conversation, which appears in
both `grouped` and `favConvos`. `searchQuery` sat inside that same `combine`, so every keystroke
re-mapped all three lists; the grouped list is debounced at 300ms, so on most keystrokes it was
re-mapped **unchanged**. Both formatters also resolved `Clock.System.now()` and
`TimeZone.currentSystemDefault()` per row rather than per list.

## Fix

The two halves of "format a relative time" have opposite requirements, and the fix is to stop
treating them as one step:

- **Parsing** the ISO string is clock-independent → do it once, upstream, in the mapping.
- **Formatting** the elapsed label is clock-dependent → do it at render time, against a reference
  that *moves*.

1. **`LocalRelativeTimeReference` + `ProvideRelativeTimeReference`** (new). One coroutine per list
   surface ticks a `RelativeTimeReference` every 60s. Rows read the local and key their `remember`
   on it, so the memo invalidates when the clock advances — which is the part that was missing.
   Non-static local, so a tick invalidates only the composables that read it. Provided at the drawer
   and at both full-screen lists.
2. **`relativeTime: String` → `updatedAt: Instant?`** on both display models, parsed in the mappers.
   `ConversationDisplayData` gets the same treatment as the drawer's model.
3. **One shared `toRelativeTimeString`** in `core/common`; the two behaviourally-identical
   feature-local copies are deleted.
4. **A `displayConversations` projection upstream of `searchQuery`**, so a keystroke re-assembles
   `DrawerUiState` from already-mapped rows instead of re-running the mapping. Memoization achieved
   structurally rather than with a cache.
5. **One `groupedByDateBucket`** shared by the drawer and the full-screen list, which had forked
   copies of the same bucketing (they differ only in a trailing `map` to display rows). Hoists the
   clock/timezone lookup out of the loop.

## Measurements

Benchmarked against the real functions (throwaway JUnit, blackhole sink, since deleted) — full
per-emission cost, one grouping pass plus two display passes:

| n | JVM median |
|---|---|
| 50 | ~0.30 ms |
| 200 | ~1.08 ms |
| 500 | ~0.69 ms |

Read these skeptically: n=500 landing below n=200 means JIT warmup dominates, so only the order of
magnitude survives — sub-millisecond to ~1ms on a warm desktop JVM. **This is not a jank fix.** The
audit rated this item medium severity; on these numbers it is low. The correctness fix and the
de-duplication are the value here; the reduced work is a side effect.

I have no before/after device numbers.

## What I got wrong first

The first version of this PR moved formatting into `remember(data.model, data.updatedAt)` and
claimed that fixed the staleness. It does not — neither key is clock-dependent, so the memo never
invalidates, and it is *worse* than the ViewModel mapping it replaced, which at least recomputed on
every combine emission. A code review caught it. The ticker is what actually closes the bug; the
claim is only true now because `reference` is in the key.

## Second round: adversarial review

Four independent reviewers went at the first implementation. What they found and what changed:

- **Date-group headers.** They don't refresh at midnight, and unlike a subtitle they can't be fixed
  at render time — crossing midnight changes a conversation's *section*, not just its label. Fixed
  by giving grouping a clock input: `dayBoundaryReferences()` emits at each local midnight and is
  combined into all three grouping paths.
- **A parse regression this PR introduced.** Bucketing parsed `updatedAt` to pick a section, threw
  the `Instant` away, and the display mapping parsed the same string again — 2N parses per emission
  on the main thread, against N before, undercutting #269 which had just moved that work off Main.
  Grouping now carries the parsed value through (`DatedConversation`), so it is parsed once.
- **`LocalRelativeTimeReference` had an unsafe default.** Compose memoizes a local's default in a
  `LazyValueHolder` for the *process* lifetime, so the first provider-less read anywhere would
  freeze one `now` that every later one reuses — a row composed hours later could render a future
  timestamp as "Just now". It now has no default and fails loudly.
- **The ticker ran unconditionally.** A closed `ModalNavigationDrawer` is offset off-screen, not
  removed from the tree, so the drawer's ticker recomposed invisible rows for the whole session.
  It is now gated on RESUMED — which also fixes device sleep: `delay` runs on a monotonic clock that
  stops during deep sleep, so resuming after eight hours would otherwise still read "2m ago".
- **`today` goes back to an eager `val`.** Making it `lazy` was right when every row built its own
  reference from the default argument; after the redesign no production call site does, so `lazy`
  only added a volatile read to the per-row date-group path.
- **One test could not fail.** `explicitReferenceMatchesDefaultForBothFormatters` compared a default
  argument against an explicit one — the same code path — so it asserted
  `f(x, current()) == f(x, current())`. A reviewer proved it by mutating the function to ignore its
  reference entirely: that test still passed. Deleted; the other tests caught the mutation.

Reviewers confirmed, with mechanism-level detail, the claim I could not verify myself: a tick
invalidates only the composables that read the local, not the provided subtree.

## Deliberately not done

- **Grouping still parses once per row on the main thread.** Moving it off requires an injected
  dispatcher, which would force `viewModelOf(::DrawerViewModel)` into an explicit `viewModel { }`
  block and cost Koin `verify()` static coverage of its 10 bindings (the tradeoff #269 made). Not
  worth it at the measured cost.
- **`String?` ISO timestamps on the domain models are untouched.** Room stores epoch millis,
  `ConversationMapper.formatTimestamp` converts them to an ISO string on read, and consumers parse
  them back. Fixing that properly means typed `Instant` at the boundary across 15+ models and ~21
  read sites in five feature modules; `ArtifactShortcut.createdAt: Long` is the one model that
  already does it right. Its own convention project, not smuggled in under a perf PR. The two
  display models here now hold `Instant`, which is a small down payment on it.

## Verification

Local CI set, all green:

- `./gradlew detekt detektMetadataCommonMain :app:lint --continue`
- `./gradlew test`
- `./gradlew :app:assembleDebug`

The `ios` job was not run — no Xcode on the dev machine. All touched code is commonMain with no
`expect`/`actual`, so `assembleDebug` compiles the same sources, but the `xcodebuild` step is
genuinely unverified here.

`DateExtTest` covers both formatters' bucket **edges** (7/8 days, 30/31 days — an interior sample
would let a `<=`→`<` slip through), pins that an explicitly-passed reference matches the default,
and pins that advancing the reference advances the label — the property the ticker depends on.
Month names are derived from `formatMonthAbbrev`/`formatMonthYear` rather than hardcoded, since
those delegate to a `Locale.getDefault()` formatter and English literals would flake on a non-English
runner. `DrawerDisplayMappingTest` pins that the mapper parses but does not format, so
reintroducing formatting there fails the build.

**Worth a look before merge:**

1. Leave the drawer open past a minute boundary and watch a "Just now" row become "1m ago" on its
   own. This is the point of the change and exactly what an earlier revision claimed without
   checking.
2. Background the app for a while and reopen it — labels should be right immediately, not a minute
   later.
3. Timestamps and date-group headers render as before; drawer search still filters through the
   300ms debounce; a favorited unpinned conversation still appears in both Favorites and its date
   group; project chats and the full-screen list still show timestamps.

Note that on a non-English device the full-screen list's absolute labels are now localized
("Mär 14" rather than "Mar 14"). The deleted private helper hardcoded English month names; it now
shares `formatMonthAbbrev` with the drawer, which always localized. Convergence, but a visible
change.

**Still untested:** there is no Compose UI test source set in this module, so nothing pins that
`reference` stays in the rows' `remember` keys. Drop it and the labels silently freeze again with a
green build.
