### PR TITLE
refactor(model): type Conversation timestamps as Instant at the deserialization boundary

### DIFF
--- a/core/common/src/commonMain/kotlin/com/garfiec/librechat/core/common/extensions/DateExt.kt
+++ b/core/common/src/commonMain/kotlin/com/garfiec/librechat/core/common/extensions/DateExt.kt
@@ -7,9 +7,6 @@ import kotlinx.datetime.toLocalDateTime
 import kotlin.time.Clock
 import kotlin.time.Instant
 
-fun String.toInstantOrNull(): Instant? =
-    try { Instant.parse(this) } catch (_: Exception) { null }
-
 /**
  * "Now", as the relative formatters below see it.
  *

--- a/core/common/src/commonTest/kotlin/com/garfiec/librechat/core/common/extensions/DateExtTest.kt
+++ b/core/common/src/commonTest/kotlin/com/garfiec/librechat/core/common/extensions/DateExtTest.kt
@@ -73,10 +73,4 @@ class DateExtTest {
         )
     }
 
-    @Test
-    fun toInstantOrNullRejectsMalformedInput() {
-        assertEquals(null, "not-a-timestamp".toInstantOrNull())
-        assertEquals(null, "".toInstantOrNull())
-        assertEquals(Instant.parse("2026-07-19T12:00:00Z"), "2026-07-19T12:00:00Z".toInstantOrNull())
-    }
 }

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/mapper/ConversationMapper.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/mapper/ConversationMapper.kt
@@ -25,8 +25,10 @@ fun Conversation.toEntity(): ConversationEntity = ConversationEntity(
     iconURL = iconURL,
     greeting = greeting,
     modelParams = null,
-    createdAt = parseTimestamp(createdAt),
-    updatedAt = parseTimestamp(updatedAt),
+    // The entity columns are non-null and drive `ORDER BY updatedAt DESC` — a null timestamp
+    // must stamp "now" rather than 0L, or the row sinks to the bottom of the list.
+    createdAt = createdAt?.toEpochMilliseconds() ?: Clock.System.now().toEpochMilliseconds(),
+    updatedAt = updatedAt?.toEpochMilliseconds() ?: Clock.System.now().toEpochMilliseconds(),
 )
 
 fun ConversationEntity.toModel(): Conversation = Conversation(
@@ -47,21 +49,8 @@ fun ConversationEntity.toModel(): Conversation = Conversation(
     },
     iconURL = iconURL,
     greeting = greeting,
-    createdAt = formatTimestamp(createdAt),
-    updatedAt = formatTimestamp(updatedAt),
+    createdAt = Instant.fromEpochMilliseconds(createdAt),
+    updatedAt = Instant.fromEpochMilliseconds(updatedAt),
 )
 
 fun List<ConversationEntity>.toModels(): List<Conversation> = map { it.toModel() }
-
-private fun parseTimestamp(dateString: String?): Long {
-    if (dateString == null) return Clock.System.now().toEpochMilliseconds()
-    return try {
-        Instant.parse(dateString).toEpochMilliseconds()
-    } catch (_: Exception) {
-        Clock.System.now().toEpochMilliseconds()
-    }
-}
-
-private fun formatTimestamp(epochMillis: Long): String {
-    return Instant.fromEpochMilliseconds(epochMillis).toString()
-}

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/mapper/ConversationMapper.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/mapper/ConversationMapper.kt
@@ -10,26 +10,30 @@ import kotlin.time.Instant
 
 private val json = Json { ignoreUnknownKeys = true }
 
-fun Conversation.toEntity(): ConversationEntity = ConversationEntity(
-    conversationId = conversationId ?: "",
-    title = title ?: "New Chat",
-    user = user ?: "",
-    endpoint = endpoint,
-    endpointType = endpointType,
-    model = model,
-    agentId = agentId,
-    isArchived = isArchived,
-    pinned = pinned ?: false,
-    chatProjectId = chatProjectId,
-    tags = json.encodeToString(ListSerializer(serializer<String>()), tags),
-    iconURL = iconURL,
-    greeting = greeting,
-    modelParams = null,
+fun Conversation.toEntity(): ConversationEntity {
     // The entity columns are non-null and drive `ORDER BY updatedAt DESC` — a null timestamp
-    // must stamp "now" rather than 0L, or the row sinks to the bottom of the list.
-    createdAt = createdAt?.toEpochMilliseconds() ?: Clock.System.now().toEpochMilliseconds(),
-    updatedAt = updatedAt?.toEpochMilliseconds() ?: Clock.System.now().toEpochMilliseconds(),
-)
+    // must stamp "now" rather than 0L, or the row sinks to the bottom of the list. One shared
+    // read so a conversation missing both timestamps gets a consistent pair.
+    val now = Clock.System.now().toEpochMilliseconds()
+    return ConversationEntity(
+        conversationId = conversationId ?: "",
+        title = title ?: "New Chat",
+        user = user ?: "",
+        endpoint = endpoint,
+        endpointType = endpointType,
+        model = model,
+        agentId = agentId,
+        isArchived = isArchived,
+        pinned = pinned ?: false,
+        chatProjectId = chatProjectId,
+        tags = json.encodeToString(ListSerializer(serializer<String>()), tags),
+        iconURL = iconURL,
+        greeting = greeting,
+        modelParams = null,
+        createdAt = createdAt?.toEpochMilliseconds() ?: now,
+        updatedAt = updatedAt?.toEpochMilliseconds() ?: now,
+    )
+}
 
 fun ConversationEntity.toModel(): Conversation = Conversation(
     conversationId = conversationId,

--- a/core/model/src/commonMain/kotlin/com/garfiec/librechat/core/model/Conversation.kt
+++ b/core/model/src/commonMain/kotlin/com/garfiec/librechat/core/model/Conversation.kt
@@ -1,7 +1,9 @@
 package com.garfiec.librechat.core.model
 
+import com.garfiec.librechat.core.model.serializer.LenientInstantSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlin.time.Instant
 
 @Serializable
 data class Conversation(
@@ -45,11 +47,14 @@ data class Conversation(
     /** True for a temporary chat (v0.8.6): not persisted to normal history and
      *  expired/cleaned up server-side after [expiredAt]. Server-derived. */
     val isTemporary: Boolean? = null,
-    /** ISO-8601 expiry for a temporary chat, computed server-side from the
-     *  interface `temporaryChatRetention` setting. Null for permanent chats. */
-    val expiredAt: String? = null,
-    val createdAt: String? = null,
-    val updatedAt: String? = null,
+    /** Expiry for a temporary chat, computed server-side from the interface
+     *  `temporaryChatRetention` setting. Null for permanent chats. */
+    @Serializable(with = LenientInstantSerializer::class)
+    val expiredAt: Instant? = null,
+    @Serializable(with = LenientInstantSerializer::class)
+    val createdAt: Instant? = null,
+    @Serializable(with = LenientInstantSerializer::class)
+    val updatedAt: Instant? = null,
 )
 
 /**

--- a/core/model/src/commonMain/kotlin/com/garfiec/librechat/core/model/serializer/LenientInstantSerializer.kt
+++ b/core/model/src/commonMain/kotlin/com/garfiec/librechat/core/model/serializer/LenientInstantSerializer.kt
@@ -1,0 +1,52 @@
+package com.garfiec.librechat.core.model.serializer
+
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.descriptors.nullable
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlin.time.Instant
+
+/**
+ * ISO-8601 timestamp serializer that degrades unparseable input to `null` instead of throwing.
+ *
+ * Leniency is load-bearing, not tolerance for its own sake: a `Conversation` rides inside larger
+ * decoded payloads (conversation-list pages, SSE `Final` events), where a strict serializer would
+ * let one garbage timestamp fail the *entire* payload decode. A missing timestamp degrades to the
+ * "Unknown" date bucket; a dropped conversation is data loss.
+ *
+ * Encoding must stay an ISO-8601 string: exported conversation files embed these fields, and
+ * exports written by this version must remain readable by app versions that still model the field
+ * as a `String`.
+ */
+@OptIn(ExperimentalSerializationApi::class)
+internal object LenientInstantSerializer : KSerializer<Instant?> {
+
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("LenientInstant", PrimitiveKind.STRING).nullable
+
+    override fun deserialize(decoder: Decoder): Instant? {
+        // With a nullable descriptor this serializer receives explicit JSON nulls itself, so the
+        // null mark must be consumed here — decodeString() on a null crashes.
+        if (!decoder.decodeNotNullMark()) {
+            decoder.decodeNull()
+            return null
+        }
+        return try {
+            Instant.parse(decoder.decodeString())
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    override fun serialize(encoder: Encoder, value: Instant?) {
+        if (value == null) {
+            encoder.encodeNull()
+        } else {
+            encoder.encodeString(value.toString())
+        }
+    }
+}

--- a/core/model/src/commonMain/kotlin/com/garfiec/librechat/core/model/serializer/LenientInstantSerializer.kt
+++ b/core/model/src/commonMain/kotlin/com/garfiec/librechat/core/model/serializer/LenientInstantSerializer.kt
@@ -8,6 +8,9 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.descriptors.nullable
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonPrimitive
 import kotlin.time.Instant
 
 /**
@@ -29,8 +32,21 @@ internal object LenientInstantSerializer : KSerializer<Instant?> {
         PrimitiveSerialDescriptor("LenientInstant", PrimitiveKind.STRING).nullable
 
     override fun deserialize(decoder: Decoder): Instant? {
-        // With a nullable descriptor this serializer receives explicit JSON nulls itself, so the
-        // null mark must be consumed here — decodeString() on a null crashes.
+        // decodeString() cannot degrade a structured value ({"$date": …}, an array): it throws with
+        // the lexer left mid-value, so the exception fails the *enclosing* payload decode — the
+        // exact loss this serializer exists to prevent. decodeJsonElement() consumes whatever token
+        // is present, letting any non-string shape degrade to null.
+        if (decoder is JsonDecoder) {
+            val primitive = decoder.decodeJsonElement() as? JsonPrimitive ?: return null
+            if (primitive is JsonNull) return null
+            return try {
+                Instant.parse(primitive.content)
+            } catch (_: Exception) {
+                null
+            }
+        }
+        // Non-JSON formats: with a nullable descriptor this serializer receives explicit nulls
+        // itself, so the null mark must be consumed here — decodeString() on a null crashes.
         if (!decoder.decodeNotNullMark()) {
             decoder.decodeNull()
             return null

--- a/core/model/src/commonTest/kotlin/com/garfiec/librechat/core/model/ConversationSerializationTest.kt
+++ b/core/model/src/commonTest/kotlin/com/garfiec/librechat/core/model/ConversationSerializationTest.kt
@@ -3,6 +3,7 @@ package com.garfiec.librechat.core.model
 import kotlinx.serialization.json.Json
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.time.Instant
 
 class ConversationSerializationTest {
 
@@ -50,8 +51,8 @@ class ConversationSerializationTest {
             spec = "openAI",
             tools = listOf("web_search", "code_interpreter"),
             webSearch = true,
-            createdAt = "2026-03-28T10:00:00Z",
-            updatedAt = "2026-03-28T11:00:00Z",
+            createdAt = Instant.parse("2026-03-28T10:00:00Z"),
+            updatedAt = Instant.parse("2026-03-28T11:00:00Z"),
         )
         val encoded = json.encodeToString(Conversation.serializer(), original)
         val decoded = json.decodeFromString(Conversation.serializer(), encoded)

--- a/core/model/src/commonTest/kotlin/com/garfiec/librechat/core/model/serializer/LenientInstantSerializerTest.kt
+++ b/core/model/src/commonTest/kotlin/com/garfiec/librechat/core/model/serializer/LenientInstantSerializerTest.kt
@@ -1,0 +1,100 @@
+package com.garfiec.librechat.core.model.serializer
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.time.Instant
+
+class LenientInstantSerializerTest {
+
+    @Serializable
+    private data class Host(
+        @Serializable(with = LenientInstantSerializer::class)
+        val at: Instant? = null,
+    )
+
+    /** Mirrors the NetworkModule client Json — the config every server payload decodes under. */
+    private val networkJson = Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+        encodeDefaults = false
+        explicitNulls = false
+        coerceInputValues = true
+    }
+
+    /** Mirrors the ConversationExporter Json (explicitNulls stays at its default of true). */
+    private val exportJson = Json { encodeDefaults = true }
+
+    @Test
+    fun decodesIsoTimestamps() {
+        // The backend (Mongoose toISOString) always emits the fractional-ms Z form; the other
+        // forms pin that any spec-valid ISO-8601 string keeps working.
+        assertEquals(
+            Instant.parse("2026-03-28T10:00:00Z"),
+            networkJson.decodeFromString<Host>("""{"at":"2026-03-28T10:00:00.000Z"}""").at,
+        )
+        assertEquals(
+            Instant.parse("2026-03-28T10:00:00.123Z"),
+            networkJson.decodeFromString<Host>("""{"at":"2026-03-28T10:00:00.123Z"}""").at,
+        )
+        assertEquals(
+            Instant.parse("2026-03-28T10:00:00Z"),
+            networkJson.decodeFromString<Host>("""{"at":"2026-03-28T10:00:00+00:00"}""").at,
+        )
+    }
+
+    /**
+     * Unparseable input degrades to null instead of throwing. A Conversation rides inside larger
+     * payloads (list pages, SSE Final events) — a strict serializer would fail the whole decode
+     * over one bad field.
+     */
+    @Test
+    fun malformedTimestampDecodesToNull() {
+        assertNull(networkJson.decodeFromString<Host>("""{"at":"not-a-timestamp"}""").at)
+    }
+
+    /** Exports written by older app versions contain explicit `"updatedAt": null`. */
+    @Test
+    fun explicitJsonNullDecodesToNull() {
+        assertNull(networkJson.decodeFromString<Host>("""{"at":null}""").at)
+        assertNull(exportJson.decodeFromString<Host>("""{"at":null}""").at)
+    }
+
+    @Test
+    fun absentKeyDecodesToNull() {
+        assertNull(networkJson.decodeFromString<Host>("""{}""").at)
+    }
+
+    /** ISO string on the wire — an epoch encoding would break old-app import of new exports. */
+    @Test
+    fun encodesAsIsoString() {
+        assertEquals(
+            """{"at":"2026-03-28T10:00:00Z"}""",
+            exportJson.encodeToString(Host(Instant.parse("2026-03-28T10:00:00Z"))),
+        )
+        assertEquals(
+            """{"at":"2026-03-28T10:00:00.123Z"}""",
+            exportJson.encodeToString(Host(Instant.parse("2026-03-28T10:00:00.123Z"))),
+        )
+    }
+
+    /** Under the exporter's config a null still emits as an explicit JSON null, as it does today. */
+    @Test
+    fun exportConfigEncodesNullExplicitly() {
+        assertEquals("""{"at":null}""", exportJson.encodeToString(Host(null)))
+    }
+
+    /** Under the network config a null field is omitted — request wire shapes stay unchanged. */
+    @Test
+    fun networkConfigOmitsNull() {
+        assertEquals("""{}""", networkJson.encodeToString(Host(null)))
+    }
+
+    @Test
+    fun roundTripPreservesValue() {
+        val original = Host(Instant.parse("2026-03-28T10:00:00.500Z"))
+        assertEquals(original, exportJson.decodeFromString<Host>(exportJson.encodeToString(original)))
+    }
+}

--- a/core/model/src/commonTest/kotlin/com/garfiec/librechat/core/model/serializer/LenientInstantSerializerTest.kt
+++ b/core/model/src/commonTest/kotlin/com/garfiec/librechat/core/model/serializer/LenientInstantSerializerTest.kt
@@ -55,6 +55,23 @@ class LenientInstantSerializerTest {
         assertNull(networkJson.decodeFromString<Host>("""{"at":"not-a-timestamp"}""").at)
     }
 
+    /**
+     * Non-string tokens must degrade too, not just garbage strings: a decodeString-based
+     * implementation throws on a structured value with the lexer mid-value, failing the whole
+     * enclosing payload. The object form is what a Mongo-extended-JSON export would carry.
+     */
+    @Test
+    fun structuredOrNumericTimestampDecodesToNull() {
+        assertNull(
+            networkJson.decodeFromString<Host>("""{"at":{"${'$'}date":"2026-03-28T10:00:00.000Z"}}""").at,
+        )
+        assertNull(networkJson.decodeFromString<Host>("""{"at":["2026-03-28T10:00:00.000Z"]}""").at)
+        // Bare number under both configs — isLenient only rescues this for the network Json.
+        assertNull(networkJson.decodeFromString<Host>("""{"at":1745000000000}""").at)
+        assertNull(exportJson.decodeFromString<Host>("""{"at":1745000000000}""").at)
+        assertNull(exportJson.decodeFromString<Host>("""{"at":{"nested":true}}""").at)
+    }
+
     /** Exports written by older app versions contain explicit `"updatedAt": null`. */
     @Test
     fun explicitJsonNullDecodesToNull() {

--- a/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/di/NetworkModule.kt
+++ b/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/di/NetworkModule.kt
@@ -58,6 +58,8 @@ val networkModule = module {
     includes(networkPlatformModule)
 
     single {
+        // Hand-mirrored by LenientInstantSerializerTest in core/model (which cannot depend on this
+        // module) — a settings change here must be copied into that test's `networkJson`.
         Json {
             ignoreUnknownKeys = true
             isLenient = true

--- a/feature/conversations/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/conversations/drawer/ConversationListStateHolderTest.kt
+++ b/feature/conversations/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/conversations/drawer/ConversationListStateHolderTest.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
+import kotlin.time.Instant
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class ConversationListStateHolderTest {
@@ -30,8 +31,8 @@ class ConversationListStateHolderTest {
     private val conversationRepository = mockk<ConversationRepository>(relaxed = true)
 
     private val convos = listOf(
-        Conversation(conversationId = "c1", title = "Alpha One", updatedAt = "2026-02-19T10:00:00.000Z"),
-        Conversation(conversationId = "c2", title = "Alpha Two", updatedAt = "2026-02-19T09:00:00.000Z"),
+        Conversation(conversationId = "c1", title = "Alpha One", updatedAt = Instant.parse("2026-02-19T10:00:00.000Z")),
+        Conversation(conversationId = "c2", title = "Alpha Two", updatedAt = Instant.parse("2026-02-19T09:00:00.000Z")),
     )
 
     @Before
@@ -49,7 +50,7 @@ class ConversationListStateHolderTest {
     private fun visibleIds(holder: ConversationListStateHolder) =
         holder.groupedConversations.value
             .flatMap { it.second }
-            .mapNotNull { it.conversation.conversationId }
+            .mapNotNull { it.conversationId }
 
     @Test
     fun `delete during active drawer search removes the row without a query change`() = runTest {
@@ -90,7 +91,7 @@ class ConversationListStateHolderTest {
         advanceUntilIdle()
 
         val titles = holder.groupedConversations.value.flatMap { it.second }
-            .associate { it.conversation.conversationId to it.conversation.title }
+            .associate { it.conversationId to it.title }
         assertThat(titles["c1"]).isEqualTo("Alpha One Renamed")
         assertThat(titles.keys).containsExactly("c1", "c2")
     }

--- a/feature/conversations/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/conversations/drawer/DrawerDisplayMappingTest.kt
+++ b/feature/conversations/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/conversations/drawer/DrawerDisplayMappingTest.kt
@@ -73,15 +73,16 @@ class DrawerDisplayMappingTest {
     }
 
     /**
-     * The mapping parses the timestamp but must NOT format it. Parsing is clock-independent, so
-     * doing it once here beats doing it per row; formatting is clock-dependent, so doing it here
-     * would freeze the label at whenever the mapping last ran — the stale-"Just now" bug.
+     * The mapping carries the timestamp through untouched — it must NOT format it. Formatting is
+     * clock-dependent, so doing it here would freeze the label at whenever the mapping last ran —
+     * the stale-"Just now" bug. (Malformed wire timestamps are handled upstream, at
+     * deserialization: see LenientInstantSerializerTest.)
      */
     @Test
-    fun updatedAtIsParsedNotFormatted() {
+    fun updatedAtIsCopiedNotFormatted() {
         val convo = Conversation(
             conversationId = "c1",
-            updatedAt = "2026-07-19T12:00:00Z",
+            updatedAt = Instant.parse("2026-07-19T12:00:00Z"),
         )
 
         val data = convo.toDrawerDisplayData(activeConversationId = null, endpointConfigs = emptyMap())
@@ -92,16 +93,6 @@ class DrawerDisplayMappingTest {
     @Test
     fun updatedAtNullSurvivesMapping() {
         val convo = Conversation(conversationId = "c1", updatedAt = null)
-
-        val data = convo.toDrawerDisplayData(activeConversationId = null, endpointConfigs = emptyMap())
-
-        assertThat(data.updatedAt).isNull()
-    }
-
-    /** Malformed timestamps must not throw in the mapping — they degrade to a blank label. */
-    @Test
-    fun malformedUpdatedAtBecomesNull() {
-        val convo = Conversation(conversationId = "c1", updatedAt = "not-a-timestamp")
 
         val data = convo.toDrawerDisplayData(activeConversationId = null, endpointConfigs = emptyMap())
 

--- a/feature/conversations/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/conversations/export/ConversationExporterGoldenTest.kt
+++ b/feature/conversations/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/conversations/export/ConversationExporterGoldenTest.kt
@@ -1,0 +1,92 @@
+package com.garfiec.librechat.feature.conversations.export
+
+import com.garfiec.librechat.core.common.result.Result
+import com.garfiec.librechat.core.data.repository.ConversationRepository
+import com.garfiec.librechat.core.data.repository.MessageRepository
+import com.garfiec.librechat.core.model.Conversation
+import com.garfiec.librechat.core.model.Message
+import com.google.common.truth.Truth.assertThat
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import kotlin.time.Instant
+
+/**
+ * Pins the exported JSON's timestamp bytes across the String→Instant model change. Exports are
+ * files on user disks: values must stay ISO-8601 strings (so old app versions can import new
+ * exports) and a missing timestamp must stay an explicit `null` (as the pre-Instant exporter
+ * emitted). Everything else in the export is free to evolve; these bytes are compatibility surface.
+ */
+class ConversationExporterGoldenTest {
+
+    private val conversationRepository = mockk<ConversationRepository>()
+    private val messageRepository = mockk<MessageRepository>()
+
+    private val conversation = Conversation(
+        conversationId = "c1",
+        title = "Golden",
+        // The backend's Mongoose toISOString form; whole seconds normalize to the plain-Z form.
+        updatedAt = Instant.parse("2026-03-28T10:00:00.000Z"),
+        createdAt = null,
+    )
+
+    private fun exporter(dispatcher: CoroutineDispatcher) =
+        ConversationExporter(conversationRepository, messageRepository, dispatcher)
+
+    @Test
+    fun timestampsExportAsIsoStringAndExplicitNull() = runTest {
+        coEvery { conversationRepository.getConversation("c1", null) } returns Result.Success(conversation)
+        coEvery { messageRepository.getMessages("c1") } returns
+            Result.Success(listOf(Message(messageId = "m1", conversationId = "c1", text = "hi")))
+
+        val result = exporter(UnconfinedTestDispatcher(testScheduler)).exportAsJson("c1")
+
+        val encoded = (result as Result.Success).data
+        assertThat(encoded).contains("\"updatedAt\": \"2026-03-28T10:00:00Z\"")
+        assertThat(encoded).contains("\"createdAt\": null")
+    }
+
+    @Test
+    fun exportRoundTripsThroughTheImporter() = runTest {
+        coEvery { conversationRepository.getConversation("c1", null) } returns Result.Success(conversation)
+        coEvery { messageRepository.getMessages("c1") } returns
+            Result.Success(listOf(Message(messageId = "m1", conversationId = "c1", text = "hi")))
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+
+        val encoded = (exporter(dispatcher).exportAsJson("c1") as Result.Success).data
+        val imported = ConversationImporter(dispatcher).parseJson(encoded)
+
+        val roundTripped = (imported as Result.Success).data.conversation
+        assertThat(roundTripped.updatedAt).isEqualTo(Instant.parse("2026-03-28T10:00:00Z"))
+        assertThat(roundTripped.createdAt).isNull()
+    }
+
+    /** Exports written by pre-Instant app versions must keep importing. */
+    @Test
+    fun legacyExportWithStringTimestampsImports() = runTest {
+        val legacyJson = """
+            {
+                "conversation": {
+                    "conversationId": "c-legacy",
+                    "title": "Old",
+                    "createdAt": "2026-02-19T10:00:00.000Z",
+                    "updatedAt": null
+                },
+                "messages": [
+                    {"messageId": "m1", "conversationId": "c-legacy", "text": "hi"}
+                ],
+                "exportedAt": 1745000000000,
+                "version": 1
+            }
+        """.trimIndent()
+
+        val imported = ConversationImporter(UnconfinedTestDispatcher(testScheduler)).parseJson(legacyJson)
+
+        val conversation = (imported as Result.Success).data.conversation
+        assertThat(conversation.createdAt).isEqualTo(Instant.parse("2026-02-19T10:00:00Z"))
+        assertThat(conversation.updatedAt).isNull()
+    }
+}

--- a/feature/conversations/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/conversations/viewmodel/ConversationListViewModelTest.kt
+++ b/feature/conversations/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/conversations/viewmodel/ConversationListViewModelTest.kt
@@ -32,6 +32,7 @@ import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
+import kotlin.time.Instant
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class ConversationListViewModelTest {
@@ -56,12 +57,12 @@ class ConversationListViewModelTest {
         Conversation(
             conversationId = "convo-1",
             title = "First Conversation",
-            updatedAt = "2026-02-19T10:00:00.000Z",
+            updatedAt = Instant.parse("2026-02-19T10:00:00.000Z"),
         ),
         Conversation(
             conversationId = "convo-2",
             title = "Second Conversation",
-            updatedAt = "2026-02-19T09:00:00.000Z",
+            updatedAt = Instant.parse("2026-02-19T09:00:00.000Z"),
         ),
     )
 
@@ -613,12 +614,12 @@ class ConversationListViewModelTest {
         val freshHit = Conversation(
             conversationId = "convo-1",
             title = "Fresh Title",
-            updatedAt = "2026-02-19T12:00:00.000Z",
+            updatedAt = Instant.parse("2026-02-19T12:00:00.000Z"),
         )
         val staleRoom = Conversation(
             conversationId = "convo-1",
             title = "Stale Title",
-            updatedAt = "2026-02-19T10:00:00.000Z",
+            updatedAt = Instant.parse("2026-02-19T10:00:00.000Z"),
         )
         val roomFlow = MutableStateFlow<Result<List<Conversation>>>(Result.Success(listOf(staleRoom)))
         every { conversationRepository.observeConversations(any()) } returns roomFlow
@@ -669,7 +670,7 @@ class ConversationListViewModelTest {
             title = "OpenRouter chat",
             endpoint = "OpenRouter",
             iconURL = null,
-            updatedAt = "2026-02-19T10:00:00.000Z",
+            updatedAt = Instant.parse("2026-02-19T10:00:00.000Z"),
         )
         every { conversationRepository.observeConversations(any()) } returns flowOf(
             Result.Success(listOf(convo)),

--- a/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/ArchivedConversationDisplayData.kt
+++ b/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/ArchivedConversationDisplayData.kt
@@ -9,7 +9,6 @@ data class ArchivedConversationDisplayData(
     val title: String,
     val endpoint: String,
     val model: String?,
-    val archivedAt: String?,
 )
 
 fun Conversation.toArchivedDisplayData() = ArchivedConversationDisplayData(
@@ -17,5 +16,4 @@ fun Conversation.toArchivedDisplayData() = ArchivedConversationDisplayData(
     title = title ?: "New Chat",
     endpoint = endpoint ?: "chat",
     model = model,
-    archivedAt = updatedAt,
 )

--- a/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/components/ConversationDisplayData.kt
+++ b/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/components/ConversationDisplayData.kt
@@ -1,7 +1,6 @@
 package com.garfiec.librechat.feature.conversations.components
 
 import androidx.compose.runtime.Immutable
-import com.garfiec.librechat.core.common.extensions.toInstantOrNull
 import com.garfiec.librechat.core.model.Conversation
 import com.garfiec.librechat.core.model.EndpointConfig
 import com.garfiec.librechat.core.model.SAVED_TAG
@@ -14,27 +13,20 @@ data class ConversationDisplayData(
     val title: String,
     val endpoint: String?,
     val model: String?,
-    // Parsed here rather than in the row: the ISO-8601 wire string is clock-independent, so parsing
-    // it belongs upstream where it happens once per conversation. Only the *formatting* has to
-    // happen at render time — see LocalRelativeTimeReference.
+    // Only the *formatting* of this happens at render time — see LocalRelativeTimeReference.
     val updatedAt: Instant?,
     val isBookmarked: Boolean,
     val endpointIconUrl: String? = null,
 )
 
-/**
- * [parsedUpdatedAt] lets a caller that has already parsed the timestamp (grouping does, to pick a
- * date bucket) hand it in rather than making this parse the same string a second time.
- */
 fun Conversation.toDisplayData(
     endpointConfigs: Map<String, EndpointConfig>,
-    parsedUpdatedAt: Instant? = updatedAt?.toInstantOrNull(),
 ): ConversationDisplayData = ConversationDisplayData(
     conversationId = conversationId ?: "",
     title = title ?: "New Chat",
     endpoint = endpoint,
     model = model,
-    updatedAt = parsedUpdatedAt,
+    updatedAt = updatedAt,
     isBookmarked = SAVED_TAG in tags,
     endpointIconUrl = resolveEndpointIconUrl(endpointConfigs),
 )

--- a/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/drawer/ConversationListStateHolder.kt
+++ b/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/drawer/ConversationListStateHolder.kt
@@ -6,7 +6,6 @@ import com.garfiec.librechat.core.common.extensions.dayBoundaryReferences
 import com.garfiec.librechat.core.common.result.Result
 import com.garfiec.librechat.core.data.repository.ConversationRepository
 import com.garfiec.librechat.core.model.Conversation
-import com.garfiec.librechat.feature.conversations.viewmodel.DatedConversation
 import com.garfiec.librechat.feature.conversations.viewmodel.groupedByDateBucket
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.FlowPreview
@@ -36,8 +35,8 @@ class ConversationListStateHolder(
     private val _recentConversations = MutableStateFlow<List<Conversation>>(emptyList())
     val recentConversations: StateFlow<List<Conversation>> = _recentConversations.asStateFlow()
 
-    private val _groupedConversations = MutableStateFlow<List<Pair<String, List<DatedConversation>>>>(emptyList())
-    val groupedConversations: StateFlow<List<Pair<String, List<DatedConversation>>>> = _groupedConversations.asStateFlow()
+    private val _groupedConversations = MutableStateFlow<List<Pair<String, List<Conversation>>>>(emptyList())
+    val groupedConversations: StateFlow<List<Pair<String, List<Conversation>>>> = _groupedConversations.asStateFlow()
 
     private val _activeConversationId = MutableStateFlow<String?>(null)
     val activeConversationId: StateFlow<String?> = _activeConversationId.asStateFlow()
@@ -203,5 +202,5 @@ class ConversationListStateHolder(
 
     private fun groupConversationsByDate(
         conversations: List<Conversation>,
-    ): List<Pair<String, List<DatedConversation>>> = conversations.groupedByDateBucket()
+    ): List<Pair<String, List<Conversation>>> = conversations.groupedByDateBucket()
 }

--- a/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/drawer/ConversationListStateHolder.kt
+++ b/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/drawer/ConversationListStateHolder.kt
@@ -100,9 +100,9 @@ class ConversationListStateHolder(
         val conversations = _recentConversations.value
         val query = _searchQuery.value
         _groupedConversations.value = if (query.isBlank()) {
-            groupConversationsByDate(conversations.withoutPinned())
+            conversations.withoutPinned().groupedByDateBucket()
         } else {
-            groupConversationsByDate(filterByQuery(conversations, query))
+            filterByQuery(conversations, query).groupedByDateBucket()
         }
     }
 
@@ -171,7 +171,7 @@ class ConversationListStateHolder(
                 .debounce(SEARCH_DEBOUNCE_MS)
                 .collectLatest { query ->
                     _groupedConversations.value =
-                        groupConversationsByDate(filterByQuery(_recentConversations.value, query))
+                        filterByQuery(_recentConversations.value, query).groupedByDateBucket()
                 }
         }
     }
@@ -199,8 +199,4 @@ class ConversationListStateHolder(
      * so this is only applied on the non-search grouping paths.
      */
     private fun List<Conversation>.withoutPinned(): List<Conversation> = filterNot { it.pinned == true }
-
-    private fun groupConversationsByDate(
-        conversations: List<Conversation>,
-    ): List<Pair<String, List<Conversation>>> = conversations.groupedByDateBucket()
 }

--- a/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/drawer/DrawerDisplayMapping.kt
+++ b/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/drawer/DrawerDisplayMapping.kt
@@ -1,11 +1,9 @@
 package com.garfiec.librechat.feature.conversations.drawer
 
-import com.garfiec.librechat.core.common.extensions.toInstantOrNull
 import com.garfiec.librechat.core.model.Conversation
 import com.garfiec.librechat.core.model.EndpointConfig
 import com.garfiec.librechat.core.model.SAVED_TAG
 import com.garfiec.librechat.core.model.resolveEndpointIconUrl
-import kotlin.time.Instant
 
 /**
  * The drawer's conversation sections, already mapped to row data.
@@ -20,14 +18,9 @@ internal data class DrawerDisplaySnapshot(
     val pinned: List<DrawerConversationDisplayData> = emptyList(),
 )
 
-/**
- * [parsedUpdatedAt] lets a caller that has already parsed the timestamp (grouping does, to pick a
- * date bucket) hand it in rather than making this parse the same string a second time.
- */
 internal fun Conversation.toDrawerDisplayData(
     activeConversationId: String?,
     endpointConfigs: Map<String, EndpointConfig>,
-    parsedUpdatedAt: Instant? = updatedAt?.toInstantOrNull(),
 ): DrawerConversationDisplayData {
     val convId = conversationId ?: ""
     return DrawerConversationDisplayData(
@@ -35,7 +28,7 @@ internal fun Conversation.toDrawerDisplayData(
         title = title ?: "New Chat",
         model = model,
         endpoint = endpoint,
-        updatedAt = parsedUpdatedAt,
+        updatedAt = updatedAt,
         isActive = convId == activeConversationId,
         isFavorite = SAVED_TAG in tags,
         isPinned = pinned == true,

--- a/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/drawer/DrawerViewModel.kt
+++ b/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/drawer/DrawerViewModel.kt
@@ -198,11 +198,7 @@ class DrawerViewModel(
     ) { grouped, favConvos, pinnedConvos, activeId, endpointConfigs ->
         DrawerDisplaySnapshot(
             grouped = grouped.map { (group, convos) ->
-                // Grouping already parsed updatedAt to pick the bucket — reuse it rather than
-                // parsing the same string again per row.
-                group to convos.map {
-                    it.conversation.toDrawerDisplayData(activeId, endpointConfigs, it.updatedAt)
-                }
+                group to convos.map { it.toDrawerDisplayData(activeId, endpointConfigs) }
             },
             favorites = favConvos.map { it.toDrawerDisplayData(activeId, endpointConfigs) },
             pinned = pinnedConvos.map { it.toDrawerDisplayData(activeId, endpointConfigs) },

--- a/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/viewmodel/ConversationGrouping.kt
+++ b/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/viewmodel/ConversationGrouping.kt
@@ -1,26 +1,11 @@
 package com.garfiec.librechat.feature.conversations.viewmodel
 
 import com.garfiec.librechat.core.common.extensions.RelativeTimeReference
-import com.garfiec.librechat.core.common.extensions.toInstantOrNull
 import com.garfiec.librechat.core.common.extensions.toRelativeDateGroup
 import com.garfiec.librechat.core.model.Conversation
 import com.garfiec.librechat.core.model.EndpointConfig
 import com.garfiec.librechat.feature.conversations.components.ConversationDisplayData
 import com.garfiec.librechat.feature.conversations.components.toDisplayData
-import kotlin.time.Instant
-
-/**
- * A conversation paired with its parsed `updatedAt`.
- *
- * Exists so the timestamp is parsed exactly once per conversation per emission. Bucketing needs the
- * `Instant` to pick a date group and the display mapping needs it for the row, and without carrying
- * it between the two, both ends call `Instant.parse` on the same string — on the main thread, for
- * every conversation, on every Room emission.
- */
-data class DatedConversation(
-    val conversation: Conversation,
-    val updatedAt: Instant?,
-)
 
 /**
  * Buckets conversations by date label (Today / Yesterday / Previous 7 Days / … / month-year),
@@ -35,10 +20,9 @@ data class DatedConversation(
  */
 internal fun List<Conversation>.groupedByDateBucket(
     reference: RelativeTimeReference = RelativeTimeReference.current(),
-): List<Pair<String, List<DatedConversation>>> {
+): List<Pair<String, List<Conversation>>> {
     if (isEmpty()) return emptyList()
-    return map { DatedConversation(it, it.updatedAt?.toInstantOrNull()) }
-        .groupBy { it.updatedAt?.toRelativeDateGroup(reference) ?: "Unknown" }
+    return groupBy { it.updatedAt?.toRelativeDateGroup(reference) ?: "Unknown" }
         .toList()
 }
 
@@ -51,6 +35,6 @@ internal fun groupConversationsByDate(
     endpointConfigs: Map<String, EndpointConfig>,
     reference: RelativeTimeReference = RelativeTimeReference.current(),
 ): List<Pair<String, List<ConversationDisplayData>>> =
-    conversations.groupedByDateBucket(reference).map { (group, dated) ->
-        group to dated.map { it.conversation.toDisplayData(endpointConfigs, it.updatedAt) }
+    conversations.groupedByDateBucket(reference).map { (group, convos) ->
+        group to convos.map { it.toDisplayData(endpointConfigs) }
     }

--- a/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/viewmodel/ConversationGrouping.kt
+++ b/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/viewmodel/ConversationGrouping.kt
@@ -20,11 +20,8 @@ import com.garfiec.librechat.feature.conversations.components.toDisplayData
  */
 internal fun List<Conversation>.groupedByDateBucket(
     reference: RelativeTimeReference = RelativeTimeReference.current(),
-): List<Pair<String, List<Conversation>>> {
-    if (isEmpty()) return emptyList()
-    return groupBy { it.updatedAt?.toRelativeDateGroup(reference) ?: "Unknown" }
-        .toList()
-}
+): List<Pair<String, List<Conversation>>> =
+    groupBy { it.updatedAt?.toRelativeDateGroup(reference) ?: "Unknown" }.toList()
 
 /**
  * Flattens conversations into date-grouped display rows. Shared by the all-conversations list and

--- a/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/viewmodel/ConversationListViewModel.kt
+++ b/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/viewmodel/ConversationListViewModel.kt
@@ -4,7 +4,6 @@ import androidx.compose.runtime.Immutable
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.garfiec.librechat.core.common.extensions.RelativeTimeReference
-import com.garfiec.librechat.core.common.extensions.toInstantOrNull
 import com.garfiec.librechat.core.common.result.Result
 import com.garfiec.librechat.core.data.repository.ConfigRepository
 import com.garfiec.librechat.core.data.repository.ConversationRepository
@@ -174,11 +173,11 @@ class ConversationListViewModel(
      * True when `this` (a Room row) is at least as fresh as [other] (a server search hit), by
      * `updatedAt`. Local edits stamp `updatedAt = now`, so they compare newer and are reflected;
      * a cross-device change not yet synced leaves Room strictly older, so it is not swapped in.
-     * Falls back to `false` (keep the server hit) when either timestamp is missing/unparseable.
+     * Falls back to `false` (keep the server hit) when either timestamp is missing.
      */
     private fun Conversation.isNotOlderThan(other: Conversation): Boolean {
-        val mine = updatedAt?.toInstantOrNull() ?: return false
-        val theirs = other.updatedAt?.toInstantOrNull() ?: return false
+        val mine = updatedAt ?: return false
+        val theirs = other.updatedAt ?: return false
         return mine >= theirs
     }
 


### PR DESCRIPTION
## Problem

`Conversation` doubles as wire DTO and domain model, and carried `createdAt/updatedAt/expiredAt`
as `String?` ISO-8601 — a wire format leaked into the domain. Room already stores epoch millis, so
the actual pipeline was: server ISO string → parse to millis (Room) → **format back to an ISO
string** (`ConversationMapper.toModel`) → re-parse in every consumer. The DB layer was typed all
along; the domain un-typed it on the way out.

Because the wire string survives into the domain, every consumer has to decide where to parse it —
a free variable with no principled answer, because every placement is a workaround. This PR removes
the variable. The timestamp is typed `Instant?` at the deserialization boundary, so no downstream
parse exists to place.

It also kills a silent data fabrication: `ConversationMapper.parseTimestamp` substituted
`Clock.System.now()` for a *malformed* server date, so corrupt data rendered as "Just now". A
malformed date now decodes to `null` and lands in the "Unknown" bucket. (The null-case `now()`
fallback on the Room columns deliberately stays — they are non-null `Long` driving
`ORDER BY updatedAt DESC`, and a `0L` would sink rows to the bottom of the list.)

## Change

- **`LenientInstantSerializer`** (new, core/model): encodes `Instant?` as an ISO-8601 string,
  decodes unparseable input to `null` instead of throwing. Leniency is load-bearing, not
  gold-plating: a `Conversation` rides inside larger decoded payloads (list pages, SSE `Final`
  events), where a strict serializer would fail the whole decode over one bad field.
- **`Conversation.createdAt/updatedAt/expiredAt`** → `Instant?` with that serializer.
- **`ConversationMapper`**: millis ↔ `Instant` directly; `parseTimestamp`/`formatTimestamp`
  deleted.
- **Downstream, mostly deletions** — this intentionally removes ~7 hunks #270 added, whose only
  purpose was compensating for the string: `DatedConversation` and its threading through
  `groupedByDateBucket`/`ConversationListStateHolder`/`DrawerViewModel`, and the `parsedUpdatedAt`
  parameters on both display mappers. `isNotOlderThan` compares `Instant`s directly.
  `String.toInstantOrNull` lost its last caller and is deleted.
- **`ArchivedConversationDisplayData.archivedAt`** deleted — it was never rendered anywhere.

Untouched: everything else #270 added (the ticker, `LocalRelativeTimeReference`,
`dayBoundaryReferences`, the screen wraps, the combine split, their tests). The formatting side —
clock-dependent, at render time against a ticking reference — is unaffected by where the parse
lives; only the parse question is dissolved.

## Scope rule

**Conversation's three fields only** — a strict subset of the deferred typed-timestamps convention
project (15+ models, ~21 read sites). `Message` and the rest deliberately stay `String?` for now;
`Conversation` becomes the template for converting them.

## Compatibility (audited before implementation)

Four independent adversarial audits ran against this design before a line was written. Key facts:

- `Conversation` is **never encoded into a request** — every mutation endpoint uses a dedicated
  arg-wrapper body. The serializer's encode side is only reachable via export.
- **Import cannot break the server**: `POST /api/convos/import` uploads the original file bytes,
  not a re-encoded model.
- **Old exports import cleanly** (string timestamps parse; explicit `"updatedAt": null` is
  handled), and **new exports remain readable by old app versions** (values are still ISO strings).
  Pinned by `ConversationExporterGoldenTest`, including a legacy-format fixture.
- The backend (Mongoose `toISOString()`) emits exactly one format; the serializer uses the same
  `Instant.parse` the deleted helpers used, so tolerance is behavior-identical.
- No Room schema change; no lexicographic comparison or map key anywhere used these strings.
- Byte-level delta in exports: whole-second timestamps normalize `.000Z` → `Z`. The pre-change
  export path already normalized identically for any conversation that had passed through Room.

## Verification

Local CI set, all green:

- `./gradlew detekt detektMetadataCommonMain :app:lint --continue`
- `./gradlew test`
- `./gradlew :app:assembleDebug`

The `ios` job was not run (no Xcode locally). All touched code is commonMain with no
`expect`/`actual`; `assembleDebug` compiles the same sources.

New tests: `LenientInstantSerializerTest` (decode forms, malformed→null, explicit null, absent
key, encode shape under both the network and exporter Json configs) and
`ConversationExporterGoldenTest` (export bytes for ISO + null, exporter→importer round trip,
legacy string-timestamp import). The mapper-level malformed-timestamp test moved to the serializer
level, where the behavior now lives.

## Post-review hardening (second commit)

A high-effort adversarial review of the branch confirmed one correctness gap and four cleanups,
all addressed:

- **Non-string timestamp tokens no longer abort the payload decode.** `decodeString()` on a
  structured value (`{"$date": …}`, an array) throws with the lexer mid-value, failing the entire
  enclosing decode — the exact loss the lenient serializer exists to prevent. The JSON path now
  decodes via `decodeJsonElement()`, so any non-string shape degrades to `null`. Tested for
  object/array/bare-number forms under both Json configs.
- `ConversationMapper.toEntity` stamps one shared `now` for both fallback columns instead of two
  clock reads that could disagree by a millisecond.
- Inlined a pass-through grouping wrapper in `ConversationListStateHolder` that shadowed a
  different top-level function of the same name; dropped a dead empty-list guard in
  `groupedByDateBucket`.
- The NetworkModule Json config and its hand-mirrored copy in `LenientInstantSerializerTest`
  now cross-reference each other (module boundaries prevent a direct dependency).

The review also confirmed the export normalization (`.000Z` → `Z`) as the one observable byte
change; it is intentional, matches what the pre-change export path already did for Room-cached
data, and is pinned by the golden test.

**Worth a device check before merge:** export a conversation and re-import it; browse the drawer
and full-screen list (timestamps and date groups render as before); send a message and confirm the
conversation jumps to the top.
