### PR TITLE
fix(chat): close the resume/stop lifecycle races that could still drop a partial reply

### DIFF
--- a/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/StreamingManagerLifecycleTest.kt
+++ b/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/StreamingManagerLifecycleTest.kt
@@ -328,4 +328,55 @@ class StreamingManagerLifecycleTest {
             events2.close()
             advanceUntilIdle()
         }
+
+    /**
+     * A transient checkStreamStatus failure on foreground (a network blip, not an actual expiry)
+     * must NOT be treated as ResumeExpired — that would wipe the in-progress reply and reload,
+     * racing the server's persist. Preserve the partial and do not reload.
+     */
+    @Test
+    fun `a transient resume-check failure preserves the partial instead of wiping`() =
+        runTest(StandardTestDispatcher()) {
+            coEvery { chatRepository.checkStreamStatus("conv-1") } throws RuntimeException("network blip")
+            val events = Channel<StreamEvent>(Channel.UNLIMITED)
+            val (delegate, flow) = delegateWith(this)
+            delegate.launchStream(events.receiveAsFlow())
+            events.send(StreamEvent.ContentDelta(chunk = "half a reply"))
+            runCurrent()
+
+            delegate.onPause() // detaches the collector; isStreaming stays true
+            delegate.onResume() // checkStreamStatus throws
+            advanceUntilIdle()
+
+            assertThat(flow.value.isStreaming).isFalse()
+            assertThat(flow.value.streamingContent).isEqualTo("half a reply")
+            verify(exactly = 0) { reloadConversation(any()) }
+            events.close()
+            advanceUntilIdle()
+        }
+
+    /**
+     * resumeActiveStreamIfNeeded (conversation-open sibling of onResume) must defer while a Stop
+     * is pending — otherwise it can restart a stream the user just stopped.
+     */
+    @Test
+    fun `resumeActiveStreamIfNeeded defers while a stop is pending`() =
+        runTest(StandardTestDispatcher()) {
+            val gate = CompletableDeferred<Result<Unit>>()
+            coEvery { chatRepository.abortChat("conv-1") } coAnswers { gate.await() }
+            val events = Channel<StreamEvent>(Channel.UNLIMITED)
+            val (delegate, _) = delegateWith(this)
+            delegate.launchStream(events.receiveAsFlow())
+            runCurrent()
+            delegate.stopGeneration() // abortRequested = true, ack still gated
+            runCurrent()
+
+            delegate.resumeActiveStreamIfNeeded("conv-1")
+            runCurrent()
+
+            coVerify(exactly = 0) { chatRepository.checkStreamStatus(any()) }
+            gate.complete(Result.Success(Unit))
+            events.close()
+            advanceUntilIdle()
+        }
 }

--- a/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/StreamingManagerLifecycleTest.kt
+++ b/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/StreamingManagerLifecycleTest.kt
@@ -19,6 +19,7 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -200,4 +201,131 @@ class StreamingManagerLifecycleTest {
         events.close()
         advanceUntilIdle()
     }
+
+    /**
+     * Stop tapped DURING the resume reattach window. onPause detaches the collector but leaves
+     * isStreaming true, so a Stop here POSTs an abort with nothing left to receive the aborted
+     * final. The onResume path must NOT run ResumeExpired (which wipes streamingContent and
+     * reloads) — a pending abort owns teardown, and its AbortFallback preserves the partial.
+     * Regression guard for the reintroduced vanishing-partial bug.
+     */
+    @Test
+    fun `a stop during the resume reattach window preserves the partial`() =
+        runTest(StandardTestDispatcher()) {
+            coEvery { chatRepository.abortChat("conv-1") } returns Result.Success(Unit)
+            val statusGate = CompletableDeferred<ChatStatusResponse>()
+            coEvery { chatRepository.checkStreamStatus("conv-1") } coAnswers { statusGate.await() }
+            val events = Channel<StreamEvent>(Channel.UNLIMITED)
+            val (delegate, flow) = delegateWith(this)
+            delegate.launchStream(events.receiveAsFlow())
+
+            events.send(StreamEvent.ContentDelta(chunk = "partial answer"))
+            runCurrent()
+            // Background (detaches the collector; isStreaming stays true), then foreground: the
+            // reattach check parks on the gate.
+            delegate.onPause()
+            delegate.onResume()
+            runCurrent()
+            // Stop lands while the status check is still in flight.
+            delegate.stopGeneration()
+            runCurrent()
+            // Server says the job is already gone — the old code would ResumeExpired-wipe here.
+            statusGate.complete(ChatStatusResponse(active = false))
+            runCurrent()
+
+            // The wipe/reload must NOT have happened; the pending abort owns teardown.
+            verify(exactly = 0) { reloadConversation(any()) }
+
+            // The abort's watchdog fires and finalizes locally with the partial intact.
+            advanceUntilIdle()
+            assertThat(flow.value.isStreaming).isFalse()
+            assertThat(flow.value.streamingContent).isEqualTo("partial answer")
+            events.close()
+            advanceUntilIdle()
+        }
+
+    /**
+     * Overlapping pause/resume: a resume parks on the status check while a newer stream starts
+     * (bumping the session). The stale resume's ResumeExpired must bail on the advanced session
+     * instead of wiping the now-current stream's content — the unpinned-session defect (1a).
+     */
+    @Test
+    fun `an overlapping resume does not wipe a newer session`() = runTest(StandardTestDispatcher()) {
+        val statusGate = CompletableDeferred<ChatStatusResponse>()
+        coEvery { chatRepository.checkStreamStatus("conv-1") } coAnswers { statusGate.await() }
+        val events = Channel<StreamEvent>(Channel.UNLIMITED)
+        val (delegate, flow) = delegateWith(this)
+        delegate.launchStream(events.receiveAsFlow())
+        runCurrent()
+
+        // Park a resume on the status check (pins the current, soon-to-be-stale session).
+        delegate.onPause()
+        delegate.onResume()
+        runCurrent()
+
+        // A newer stream starts while the resume is parked — this advances the session.
+        val events2 = Channel<StreamEvent>(Channel.UNLIMITED)
+        delegate.beginStreaming(isEdit = false)
+        delegate.launchStream(events2.receiveAsFlow())
+        events2.send(StreamEvent.ContentDelta(chunk = "newer session content"))
+        runCurrent()
+
+        // The stale resume finally sees an expired status: it must bail, not wipe/reload the
+        // newer live session.
+        statusGate.complete(ChatStatusResponse(active = false))
+        runCurrent()
+
+        assertThat(flow.value.isStreaming).isTrue()
+        verify(exactly = 0) { reloadConversation(any()) }
+        events.close()
+        events2.close()
+        delegate.reset()
+        advanceUntilIdle()
+    }
+
+    /**
+     * A delayed abort ack from an old session must not cancel a newer session's watchdog. Without
+     * the guard, the stale ack clobbers the live watchdog and binds a new one to the dead session,
+     * so the newer stream — whose final never arrives — stays wedged (isStreaming stuck true).
+     */
+    @Test
+    fun `a stale abort ack does not cancel the current session's watchdog`() =
+        runTest(StandardTestDispatcher()) {
+            val staleAck = CompletableDeferred<Result<Unit>>()
+            var abortCalls = 0
+            coEvery { chatRepository.abortChat("conv-1") } coAnswers {
+                abortCalls++
+                if (abortCalls == 1) staleAck.await() else Result.Success(Unit)
+            }
+            val events1 = Channel<StreamEvent>(Channel.UNLIMITED)
+            val (delegate, flow) = delegateWith(this)
+            delegate.beginStreaming(isEdit = false)
+            delegate.launchStream(events1.receiveAsFlow())
+            runCurrent()
+
+            // Stop the first stream; its ack is delayed (parks on staleAck).
+            delegate.stopGeneration()
+            runCurrent()
+
+            // A newer stream starts and is itself stopped — its ack is immediate, arming its watchdog.
+            val events2 = Channel<StreamEvent>(Channel.UNLIMITED)
+            delegate.beginStreaming(isEdit = false)
+            delegate.launchStream(events2.receiveAsFlow())
+            events2.send(StreamEvent.ContentDelta(chunk = "second partial"))
+            runCurrent()
+            delegate.stopGeneration()
+            runCurrent()
+
+            // The first stream's delayed ack lands now — it must NOT cancel the newer watchdog.
+            staleAck.complete(Result.Success(Unit))
+            runCurrent()
+
+            // The newer session's watchdog still fires and finalizes it with its partial intact.
+            advanceUntilIdle()
+            assertThat(flow.value.isStreaming).isFalse()
+            assertThat(flow.value.streamingContent).isEqualTo("second partial")
+            events1.close()
+            events2.close()
+            advanceUntilIdle()
+        }
 }

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/StreamingManagerDelegate.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/StreamingManagerDelegate.kt
@@ -620,6 +620,10 @@ class StreamingManagerDelegate(
      * stall timeout. See [abortWatchdogJob].
      */
     private fun armAbortWatchdog(session: Int) {
+        // A delayed abort ack can arrive after its stream ended or after a newer stream started
+        // (its own boundary already re-armed). Arming here would cancel the newer stream's live
+        // watchdog and bind this one to a dead session — leaving the newer stream unguarded.
+        if (session != streamSession || endedSession == session) return
         abortWatchdogJob?.cancel()
         abortWatchdogJob = scope.launch {
             delay(ABORT_FINAL_TIMEOUT_MS)
@@ -752,22 +756,35 @@ class StreamingManagerDelegate(
         // The session ended while backgrounded (the aborted final landed in the still-live
         // collector, or an error tore down): state is already finalized — touch nothing.
         if (isSessionEnded()) return
-        // Abort pending with a live collector: the final is still coming and the watchdog
-        // guards against it never arriving. Leave the stream alone.
-        if (abortRequested && streamJob?.isActive == true) return
+        // A Stop is pending: defer to the abort machinery (watchdog → AbortFallback), which
+        // preserves the partial. Never drive resume/expire here — ResumeExpired would wipe it.
+        // (Broader than a live-collector check: after onPause the collector may be dead, but the
+        // abort still owns teardown.)
+        if (abortRequested) return
         val conversationId = handle.state.conversationId ?: return
+        // Pin the session across the status suspension, exactly as stopGeneration does: a
+        // concurrent resume/stop can bump or end the session while checkStreamStatus is in flight,
+        // and a stale ResumeExpired must not wipe the newer stream's partial.
+        val session = streamSession
         scope.launch {
             try {
                 val status = chatRepository.checkStreamStatus(conversationId)
+                // A concurrent resume advanced the session (or it ended) while we were suspended:
+                // bail rather than redundantly restart or wipe the now-current stream.
+                if (streamSession != session || isSessionEnded()) return@launch
+                // A Stop landed during the check: hand off to the abort machinery as above.
+                if (abortRequested) return@launch
                 if (status.active) {
                     handle.update { content = content.copy(isStreaming = true) }
                     resumeStream(conversationId)
                 } else {
-                    endStream(StreamEndReason.ResumeExpired)
+                    endStream(StreamEndReason.ResumeExpired, session)
                 }
             } catch (e: Exception) {
                 Logger.e(e) { "Could not resume stream" }
-                endStream(StreamEndReason.ResumeExpired)
+                if (streamSession != session || isSessionEnded()) return@launch
+                if (abortRequested) return@launch
+                endStream(StreamEndReason.ResumeExpired, session)
                 handle.update { error = "Could not resume stream" }
             }
         }

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/StreamingManagerDelegate.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/StreamingManagerDelegate.kt
@@ -121,6 +121,14 @@ class StreamingManagerDelegate(
 
         /** onResume found the server-side job gone after a detached (backgrounded) stream. */
         data object ResumeExpired : StreamEndReason
+
+        /**
+         * The foreground resume's `checkStreamStatus` threw. Unlike [ResumeExpired], a transient
+         * failure is NOT proof the stream ended, so preserve the partial and do NOT reload (a
+         * refetch could race the server's still-in-flight persistence and drop it) — same teardown
+         * as [AbortFallback].
+         */
+        data object ResumeFailed : StreamEndReason
     }
 
     /**
@@ -698,7 +706,7 @@ class StreamingManagerDelegate(
                 // If the server already created a conversation, fetch whatever it persisted.
                 handle.state.conversationId?.let(reloadConversation)
             }
-            is StreamEndReason.AbortFallback -> {
+            is StreamEndReason.AbortFallback, is StreamEndReason.ResumeFailed -> {
                 streamJob?.cancel()
                 stopStreamingUpdater()
                 if (handle.state.isStreaming) {
@@ -771,24 +779,30 @@ class StreamingManagerDelegate(
                 val status = chatRepository.checkStreamStatus(conversationId)
                 // A concurrent resume advanced the session (or it ended) while we were suspended:
                 // bail rather than redundantly restart or wipe the now-current stream.
-                if (streamSession != session || isSessionEnded()) return@launch
+                if (isResumeStale(session)) return@launch
                 // A Stop landed during the check: hand off to the abort machinery as above.
                 if (abortRequested) return@launch
                 if (status.active) {
                     handle.update { content = content.copy(isStreaming = true) }
                     resumeStream(conversationId)
                 } else {
+                    // Server confirms the job is gone: safe to wipe and reload (past the persist race).
                     endStream(StreamEndReason.ResumeExpired, session)
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 Logger.e(e) { "Could not resume stream" }
-                if (streamSession != session || isSessionEnded()) return@launch
-                if (abortRequested) return@launch
-                endStream(StreamEndReason.ResumeExpired, session)
-                handle.update { error = "Could not resume stream" }
+                if (isResumeStale(session) || abortRequested) return@launch
+                // A transient status-check failure is NOT proof the stream ended — preserve the
+                // partial and do not reload (contrast the status==inactive branch above).
+                endStream(StreamEndReason.ResumeFailed, session)
             }
         }
     }
+
+    /** A launched resume decision is stale once a newer stream started or this session ended. */
+    private fun isResumeStale(session: Int) = streamSession != session || isSessionEnded()
 
     /**
      * Shared resume logic: clears the buffer, starts the updater, and launches
@@ -810,9 +824,14 @@ class StreamingManagerDelegate(
     }
 
     fun resumeActiveStreamIfNeeded(conversationId: String) {
+        // Sibling of onResume (runs on conversation open); apply the same hardening so the two
+        // can't race into two resumes, and a pending Stop is never overridden by a restart.
+        if (abortRequested) return
+        val session = streamSession
         scope.launch {
             try {
                 val status = chatRepository.checkStreamStatus(conversationId)
+                if (isResumeStale(session) || abortRequested) return@launch
                 if (status.active) {
                     handle.update {
                         content = content.copy(
@@ -822,6 +841,8 @@ class StreamingManagerDelegate(
                     }
                     resumeStream(conversationId)
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 Logger.d(e) { "No active stream to resume for $conversationId" }
             }


### PR DESCRIPTION
## Problem

Follow-up to #272, which fixed the headline bug (stopping a streaming reply no longer discards the partial). A refute-mode adversarial review of that fix confirmed its merge/abort-contract/caching stages are sound but found **residual races in the foreground-resume / stop lifecycle** that could still reintroduce the vanishing-partial bug or wedge the composer. A subsequent code review of this branch surfaced three more issues in the same resume path. Defects 1–5 are **Android-only** — the `onPause`/`onResume` handlers that reach them aren't wired on iOS — and narrow-timing, which is why on-device testing hadn't surfaced them. Defect 6 (`resumeActiveStreamIfNeeded`) is the exception: it runs on conversation open in shared code, so it and its guard apply on both platforms.

The common thread: the server emits the aborted/final SSE frame **before** persisting, so any `reloadConversation` near stream-end races the server's disk — and several resume/teardown paths could still trigger that reload (or an outright `streamingContent` wipe) at the wrong moment.

## Defects fixed

1. **`onResume` ran `endStream(ResumeExpired)` with an unpinned session** — the `session` arg was read *after* the `checkStreamStatus` suspension, so an overlapping pause→resume could wipe a newer, live session.
2. **A Stop tapped during the reattach window wiped the partial.** `onPause` cancels `streamJob` but leaves `isStreaming == true`; a Stop there POSTs an abort with no collector alive to receive the aborted final, and the following inactive status ran `ResumeExpired` → wipe.
3. **Watchdog clobber.** `armAbortWatchdog` cancelled the existing watchdog before checking its own session was current, so a delayed abort ack from an old session could cancel the *current* session's watchdog, leaving it unguarded until the 120s SSE timeout.
4. **A transient `checkStreamStatus` failure was treated as an expiry.** The `onResume` catch ran `ResumeExpired` (wipe + reload) on *any* exception — so a network blip on foreground destroyed an in-progress reply. This is the most common trigger of the set.
5. **`CancellationException` was swallowed** by the `onResume` catch (unlike `collectStreamSafely`, which rethrows it), so a ViewModel cancelled mid-resume fired a spurious `endStream` + reload during teardown.
6. **The sibling `resumeActiveStreamIfNeeded`** (runs on conversation open) had none of the session-pin / pending-Stop / stale-recheck guards, so it could race `onResume` into a double restart or override a pending Stop.

## Fix

- **`onResume`**: pin `val session = streamSession` before the status check (mirroring `stopGeneration`); after the suspension, bail if the session advanced or ended (`isResumeStale`) or a Stop is pending (`abortRequested`); pass the pinned session to `endStream(..., session)`. On a *thrown* status check, rethrow `CancellationException`, else end via a new **`ResumeFailed`** reason that preserves the partial and does **not** reload — only a *confirmed* inactive status still wipes/reloads via `ResumeExpired`.
- **`armAbortWatchdog`**: skip arming for a stale or already-ended session (`session != streamSession || endedSession == session`).
- **`resumeActiveStreamIfNeeded`**: same session-pin / `abortRequested` / stale-recheck / `CancellationException` hardening; shared staleness check extracted to `isResumeStale()`.
- **`onPause` is deliberately unchanged** — clearing `isStreaming` there is broad and risky (it gates the stop button, queue drain, and new-send). When a Stop is pending, teardown is handed to the abort machinery, whose `AbortFallback` **preserves** the partial rather than wiping it, exactly like `ResumeFailed`.

## Tests

Five new lifecycle tests in `StreamingManagerLifecycleTest`, each failing against the pre-fix code and passing after:
- `a stop during the resume reattach window preserves the partial`
- `an overlapping resume does not wipe a newer session`
- `a stale abort ack does not cancel the current session's watchdog`
- `a transient resume-check failure preserves the partial instead of wiping`
- `resumeActiveStreamIfNeeded defers while a stop is pending`

Full `:feature:chat` unit suite, detekt, and `:app:assembleDebug` all green.

## Verification

The fix design was pressure-tested by an independent planning pass (no interleaving strands `isStreaming` true; happy stop/resume paths unaffected), and the review findings re-verified against source. The build is deployed to a Pixel 9 Pro Fold for on-device manual verification of stop-during-reattach, rapid stop→send→stop, foreground-under-flaky-network, and the plain stop-then-background regression.

## Out of scope

`attemptNetworkRecovery`'s post-suspension `reloadConversation` is the same defect class (an unrechecked action after a suspension) but a different trigger (offline→online) and symptom (reload-clobber, not partial-wipe). Tracked as a separate follow-up.
