### PR TITLE
fix(chat): re-pin the pull-up sheet's anchors in layout so it stops flashing

### DIFF
--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatScreen.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatScreen.kt
@@ -268,16 +268,11 @@ actual fun ChatScreen(
                 positionalThreshold = { distance -> distance * 0.4f },
                 animationSpec = tween(),
             )
-            LaunchedEffect(pullUpSheetHeightPx) {
-                if (pullUpSheetHeightPx > 0) {
-                    pullUpState.updateAnchors(
-                        DraggableAnchors {
-                            PullUpAnchor.Hidden at pullUpSheetHeightPx.toFloat()
-                            PullUpAnchor.Revealed at 0f
-                        },
-                    )
-                }
-            }
+            // Anchors are re-pinned synchronously in the sheet's onSizeChanged (below), not here in a
+            // LaunchedEffect: the Hidden anchor equals the measured height, and a frame-late re-pin left
+            // `offset` (old height) briefly < the new height whenever the hidden sheet's content grew —
+            // tripping the `offset < height` visibility/dim into a one-frame scrim+sheet flash (e.g. the
+            // context gauge appearing mid-stream, or the sheet's rows differing on a chat switch).
             // Dismiss the IME the moment the sheet starts to reveal (the Scaffold uses imePadding()).
             LaunchedEffect(pullUpState, pullUpSheetHeightPx) {
                 snapshotFlow {
@@ -585,7 +580,23 @@ actual fun ChatScreen(
                     // measured height is still 0, so without this the sheet would place at offset 0
                     // (fully revealed) and flash the whole menu open on every chat entry.
                     .graphicsLayer { alpha = if (pullUpSheetHeightPx > 0) 1f else 0f }
-                    .onSizeChanged { pullUpSheetHeightPx = it.height }
+                    // Re-pin the anchors in the SAME layout pass that changes the height, so a settled
+                    // Hidden sheet snaps its offset to the new bottom in lockstep — never a frame where
+                    // the stale offset reads as "revealed". updateAnchors snaps a settled state to the
+                    // closest anchor synchronously (Hidden stays hidden; an open sheet stays open).
+                    .onSizeChanged { size ->
+                        if (size.height != pullUpSheetHeightPx) {
+                            pullUpSheetHeightPx = size.height
+                            if (size.height > 0) {
+                                pullUpState.updateAnchors(
+                                    DraggableAnchors {
+                                        PullUpAnchor.Hidden at size.height.toFloat()
+                                        PullUpAnchor.Revealed at 0f
+                                    },
+                                )
+                            }
+                        }
+                    }
                     .offset {
                         val o = pullUpState.offset
                         IntOffset(0, if (o.isNaN()) pullUpSheetHeightPx else o.roundToInt())

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatScreen.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatScreen.kt
@@ -268,11 +268,6 @@ actual fun ChatScreen(
                 positionalThreshold = { distance -> distance * 0.4f },
                 animationSpec = tween(),
             )
-            // Anchors are re-pinned synchronously in the sheet's onSizeChanged (below), not here in a
-            // LaunchedEffect: the Hidden anchor equals the measured height, and a frame-late re-pin left
-            // `offset` (old height) briefly < the new height whenever the hidden sheet's content grew —
-            // tripping the `offset < height` visibility/dim into a one-frame scrim+sheet flash (e.g. the
-            // context gauge appearing mid-stream, or the sheet's rows differing on a chat switch).
             // Dismiss the IME the moment the sheet starts to reveal (the Scaffold uses imePadding()).
             LaunchedEffect(pullUpState, pullUpSheetHeightPx) {
                 snapshotFlow {
@@ -580,10 +575,6 @@ actual fun ChatScreen(
                     // measured height is still 0, so without this the sheet would place at offset 0
                     // (fully revealed) and flash the whole menu open on every chat entry.
                     .graphicsLayer { alpha = if (pullUpSheetHeightPx > 0) 1f else 0f }
-                    // Re-pin the anchors in the SAME layout pass that changes the height, so a settled
-                    // Hidden sheet snaps its offset to the new bottom in lockstep — never a frame where
-                    // the stale offset reads as "revealed". updateAnchors snaps a settled state to the
-                    // closest anchor synchronously (Hidden stays hidden; an open sheet stays open).
                     .onSizeChanged { size ->
                         if (size.height != pullUpSheetHeightPx) {
                             pullUpSheetHeightPx = size.height


### PR DESCRIPTION
### What

The pull-up tools sheet added in #258 briefly flashed a dimmed scrim and a sliver of the sheet in two cases: switching conversations from the drawer ("flash, then gone"), and when the context gauge first appeared during a streaming response. This re-pins the sheet's drag anchors synchronously when its measured height changes, removing the flash.

### Root cause

The sheet is an always-composed `Surface` at `BottomCenter`, driven by an `AnchoredDraggableState` with `Hidden at <measured sheet height>` and `Revealed at 0f`. Its visibility and dim derive from `offset < height`. The offset was re-pinned to a new height **one frame late**, in `LaunchedEffect(pullUpSheetHeightPx)`. So whenever the hidden sheet's content **grew**:

1. `onSizeChanged` set the new (larger) height that frame,
2. `offset` was still parked at the old (smaller) height,
3. `offset < height` was briefly true → scrim + sheet sliver flashed, until the effect re-pinned next frame.

Only growth flashes (a shrink leaves `offset ≥ height`). The existing `graphicsLayer { alpha }` guard only covered the first `0 → H` measurement.

Two triggers, same root cause:

- **Chat switch** — opening another conversation builds a fresh `ChatViewModel` (view models are scoped per nav entry), so the sheet's context gauge and rows start empty and grow as state projects in; that growth trips the frame-late anchor. Default `contextBarPlacement` is `OPTIONS_SHEET`, so the gauge lives in this sheet (on backends that expose context usage).
- **Streaming** — on a new chat, the context-gauge block appears the first time an `on_context_usage` event lands mid-stream, growing the sheet once. (An existing chat that already shows the gauge does not change height mid-stream — the collapsed gauge row is fixed height, so value updates don't reflow.)

Not the scroll-to-bottom: the auto-scroll uses `scrollToItem`/`animateScrollToItem`, which run through `LazyListState.scroll` and do **not** dispatch through the parent `NestedScrollConnection` bridge, so streaming auto-scroll cannot move the sheet.

### Fix

Move `updateAnchors` into the Surface's `onSizeChanged` so height and offset update in the same layout pass, and delete the frame-late `LaunchedEffect`. This is the call site `AnchoredDraggableState`'s own docs recommend for size-dependent anchors ("ensures the state is set up within the same frame"). A settled sheet snaps to the closest anchor synchronously (Hidden stays hidden, an open sheet stays open), so `offset < height` is never transiently true and the scrim/dim never trip. First-frame hidden placement is unchanged (still guarded by the `alpha`/NaN-offset parking).

### Scope

Android only — iOS has no pull-up gesture (it opens tools via `ChatOptionsSheetHost`), and no shared/`commonMain` code carries the gesture.

### Testing

- Built and deployed to a Pixel 9 Pro Fold.
- **Chat switch** — switch conversations from the drawer repeatedly: sheet stays fully hidden, no scrim flash or sliver.
- **Streaming** — new chat with a long response: no flash when the context gauge first appears.
- **Gesture regression** — pull-up from the thread bottom and from the new-chat landing still finger-tracks, dims progressively, and settles open/closed on release/flick; scrim-tap and back-button still dismiss.
- `:feature:chat:compileDebugKotlin` → `BUILD SUCCESSFUL`.
