### PR TITLE
fix(i18n): drop redundant Android-style quote escaping in string resources

### DIFF
--- a/core/ui/src/commonMain/composeResources/values/strings.xml
+++ b/core/ui/src/commonMain/composeResources/values/strings.xml
@@ -3,5 +3,5 @@
     <!-- Accessibility label for the bottom-sheet drag handle -->
     <string name="cd_drag_handle">Drag handle</string>
     <!-- Inline indicator for a PDF page that failed to render -->
-    <string name="pdf_page_failed">Couldn\'t render this page</string>
+    <string name="pdf_page_failed">Couldn't render this page</string>
 </resources>

--- a/feature/agents/src/commonMain/composeResources/values-ar/strings.xml
+++ b/feature/agents/src/commonMain/composeResources/values-ar/strings.xml
@@ -45,7 +45,7 @@
     <!-- Detail screen -->
     <string name="agent_title">وكيل</string>
     <string name="delete_agent">حذف الوكيل</string>
-    <string name="delete_agent_confirm">هل أنت متأكد أنك تريد حذف \"%1$s\"؟ لا يمكن التراجع عن ذلك.</string>
+    <string name="delete_agent_confirm">هل أنت متأكد أنك تريد حذف "%1$s"؟ لا يمكن التراجع عن ذلك.</string>
     <string name="delete_this_agent">هذا الوكيل</string>
     <string name="by_author">بواسطة %1$s</string>
     <string name="label_description">الوصف</string>
@@ -252,7 +252,7 @@
     <string name="agent_tools_title">أدوات الوكيل</string>
     <string name="select_tools_description">اختر الأدوات التي سيستخدمها وكيلك</string>
     <string name="search_tools_hint">البحث في الأدوات…</string>
-    <string name="no_tools_matching">لا توجد أدوات تطابق \"%1$s\"</string>
+    <string name="no_tools_matching">لا توجد أدوات تطابق "%1$s"</string>
     <string name="no_tools_available">لا توجد أدوات متاحة</string>
 
     <!-- Per-capability file attachments -->
@@ -271,7 +271,7 @@
     <string name="add_skills">إضافة مهارات</string>
     <string name="select_skills">اختيار المهارات</string>
     <string name="search_skills_hint">البحث في المهارات…</string>
-    <string name="no_skills_matching">لا توجد مهارات تطابق \"%1$s\"</string>
+    <string name="no_skills_matching">لا توجد مهارات تطابق "%1$s"</string>
     <string name="no_skills_available">لا توجد مهارات متاحة</string>
     <string name="skills_done">تم</string>
 

--- a/feature/agents/src/commonMain/composeResources/values-de/strings.xml
+++ b/feature/agents/src/commonMain/composeResources/values-de/strings.xml
@@ -45,7 +45,7 @@
     <!-- Detail screen -->
     <string name="agent_title">Agent</string>
     <string name="delete_agent">Agent löschen</string>
-    <string name="delete_agent_confirm">Möchtest du \"%1$s\" wirklich löschen? Dies kann nicht rückgängig gemacht werden.</string>
+    <string name="delete_agent_confirm">Möchtest du "%1$s" wirklich löschen? Dies kann nicht rückgängig gemacht werden.</string>
     <string name="delete_this_agent">diesen Agenten</string>
     <string name="by_author">von %1$s</string>
     <string name="label_description">Beschreibung</string>
@@ -252,7 +252,7 @@
     <string name="agent_tools_title">Agent-Tools</string>
     <string name="select_tools_description">Wähle Tools aus, die dein Agent verwenden soll</string>
     <string name="search_tools_hint">Tools suchen…</string>
-    <string name="no_tools_matching">Keine Tools passend zu \"%1$s\"</string>
+    <string name="no_tools_matching">Keine Tools passend zu "%1$s"</string>
     <string name="no_tools_available">Keine Tools verfügbar</string>
 
     <!-- Per-capability file attachments -->
@@ -271,7 +271,7 @@
     <string name="add_skills">Skills hinzufügen</string>
     <string name="select_skills">Skills auswählen</string>
     <string name="search_skills_hint">Skills suchen…</string>
-    <string name="no_skills_matching">Keine Skills passend zu \"%1$s\"</string>
+    <string name="no_skills_matching">Keine Skills passend zu "%1$s"</string>
     <string name="no_skills_available">Keine Skills verfügbar</string>
     <string name="skills_done">Fertig</string>
 

--- a/feature/agents/src/commonMain/composeResources/values-es/strings.xml
+++ b/feature/agents/src/commonMain/composeResources/values-es/strings.xml
@@ -45,7 +45,7 @@
     <!-- Detail screen -->
     <string name="agent_title">Agente</string>
     <string name="delete_agent">Eliminar agente</string>
-    <string name="delete_agent_confirm">¿Seguro que quieres eliminar \"%1$s\"? Esta acción no se puede deshacer.</string>
+    <string name="delete_agent_confirm">¿Seguro que quieres eliminar "%1$s"? Esta acción no se puede deshacer.</string>
     <string name="delete_this_agent">este agente</string>
     <string name="by_author">por %1$s</string>
     <string name="label_description">Descripción</string>
@@ -252,7 +252,7 @@
     <string name="agent_tools_title">Herramientas del agente</string>
     <string name="select_tools_description">Selecciona las herramientas que usará tu agente</string>
     <string name="search_tools_hint">Buscar herramientas…</string>
-    <string name="no_tools_matching">No hay herramientas que coincidan con \"%1$s\"</string>
+    <string name="no_tools_matching">No hay herramientas que coincidan con "%1$s"</string>
     <string name="no_tools_available">No hay herramientas disponibles</string>
 
     <!-- Per-capability file attachments -->
@@ -271,7 +271,7 @@
     <string name="add_skills">Añadir habilidades</string>
     <string name="select_skills">Seleccionar habilidades</string>
     <string name="search_skills_hint">Buscar habilidades…</string>
-    <string name="no_skills_matching">No hay habilidades que coincidan con \"%1$s\"</string>
+    <string name="no_skills_matching">No hay habilidades que coincidan con "%1$s"</string>
     <string name="no_skills_available">No hay habilidades disponibles</string>
     <string name="skills_done">Hecho</string>
 

--- a/feature/agents/src/commonMain/composeResources/values-fr/strings.xml
+++ b/feature/agents/src/commonMain/composeResources/values-fr/strings.xml
@@ -19,15 +19,15 @@
     <string name="cd_create_agent">Créer un agent</string>
     <string name="cd_search">Rechercher</string>
     <string name="cd_back">Retour</string>
-    <string name="cd_more_actions">Plus d\'actions</string>
-    <string name="cd_more_options">Plus d\'options</string>
+    <string name="cd_more_actions">Plus d'actions</string>
+    <string name="cd_more_options">Plus d'options</string>
     <string name="cd_collapse">Réduire</string>
     <string name="cd_expand">Développer</string>
     <string name="cd_remove_item">Supprimer %1$s</string>
-    <string name="cd_edit_action">Modifier l\'action</string>
-    <string name="cd_delete_action">Supprimer l\'action</string>
+    <string name="cd_edit_action">Modifier l'action</string>
+    <string name="cd_delete_action">Supprimer l'action</string>
     <string name="cd_add_starter">Ajouter une amorce</string>
-    <string name="cd_agent_avatar_tap">Avatar de l\'agent. Appuyez pour le changer.</string>
+    <string name="cd_agent_avatar_tap">Avatar de l'agent. Appuyez pour le changer.</string>
     <string name="cd_agent_avatar_name">Avatar de %1$s</string>
     <string name="cd_tool_icon">Icône %1$s</string>
 
@@ -36,16 +36,16 @@
     <string name="no_agents_found">Aucun agent trouvé</string>
     <string name="no_agents_available">Aucun agent disponible</string>
     <string name="agents_not_available_title">Agents non disponibles</string>
-    <string name="agents_not_available_description">L\'administrateur de votre serveur a désactivé les agents pour votre compte.</string>
+    <string name="agents_not_available_description">L'administrateur de votre serveur a désactivé les agents pour votre compte.</string>
     <string name="try_different_search">Essayez un autre terme de recherche</string>
     <string name="check_back_later">Revenez plus tard pour de nouveaux agents</string>
-    <string name="error_unknown">Une erreur inconnue s\'est produite</string>
+    <string name="error_unknown">Une erreur inconnue s'est produite</string>
     <string name="unknown_author">Inconnu</string>
 
     <!-- Detail screen -->
     <string name="agent_title">Agent</string>
-    <string name="delete_agent">Supprimer l\'agent</string>
-    <string name="delete_agent_confirm">Voulez-vous vraiment supprimer \"%1$s\" ? Cette action est irréversible.</string>
+    <string name="delete_agent">Supprimer l'agent</string>
+    <string name="delete_agent_confirm">Voulez-vous vraiment supprimer "%1$s" ? Cette action est irréversible.</string>
     <string name="delete_this_agent">cet agent</string>
     <string name="by_author">par %1$s</string>
     <string name="label_description">Description</string>
@@ -57,20 +57,20 @@
     <string name="label_conversation_starters">Amorces de conversation</string>
 
     <!-- Editor screen -->
-    <string name="edit_agent">Modifier l\'agent</string>
+    <string name="edit_agent">Modifier l'agent</string>
     <string name="create_agent">Créer un agent</string>
-    <string name="duplicate_agent">Dupliquer l\'agent</string>
+    <string name="duplicate_agent">Dupliquer l'agent</string>
     <string name="delete_agent_editor_confirm">Voulez-vous vraiment supprimer cet agent ? Cette action est irréversible.</string>
     <string name="duplicate_agent_confirm">Créer une copie de cet agent ?</string>
     <string name="version_history">Historique des versions</string>
-    <string name="tap_to_change_avatar">Appuyez pour changer l\'avatar</string>
-    <string name="remove_avatar">Supprimer l\'avatar</string>
+    <string name="tap_to_change_avatar">Appuyez pour changer l'avatar</string>
+    <string name="remove_avatar">Supprimer l'avatar</string>
     <string name="agent_name_label">Nom *</string>
-    <string name="agent_name_placeholder">Facultatif : le nom de l\'agent</string>
+    <string name="agent_name_placeholder">Facultatif : le nom de l'agent</string>
     <string name="agent_description_label">Description</string>
     <string name="agent_description_placeholder">Facultatif : décrivez votre agent ici</string>
     <string name="agent_instructions_label">Instructions</string>
-    <string name="agent_instructions_placeholder">Les instructions système que l\'agent utilise</string>
+    <string name="agent_instructions_placeholder">Les instructions système que l'agent utilise</string>
     <string name="insert_variable">Insérer une variable</string>
     <string name="cd_insert_variable">Insérer une variable</string>
     <string name="special_var_current_date">Date actuelle</string>
@@ -87,7 +87,7 @@
     <string name="openapi_actions_count">Actions OpenAPI (%1$d)</string>
     <string name="no_actions_configured">Aucune action configurée. Ajoutez une action OpenAPI pour connecter des API externes.</string>
     <string name="add_action">Ajouter une action</string>
-    <string name="edit_action">Modifier l\'action</string>
+    <string name="edit_action">Modifier l'action</string>
     <string name="auth_api_key">Clé API</string>
     <string name="auth_oauth">OAuth</string>
     <string name="auth_none">Aucune</string>
@@ -107,21 +107,21 @@
     <string name="available_actions_count">Actions disponibles (%1$d)</string>
     <string name="label_privacy_policy_url">URL de la politique de confidentialité</string>
     <!-- Auth config dialog -->
-    <string name="label_authentication_type">Type d\'authentification</string>
+    <string name="label_authentication_type">Type d'authentification</string>
     <string name="label_api_key_settings">Paramètres de la clé API</string>
     <string name="label_api_key">Clé API</string>
-    <string name="label_authorization_type">Type d\'autorisation</string>
+    <string name="label_authorization_type">Type d'autorisation</string>
     <string name="auth_basic">Basic</string>
     <string name="auth_bearer">Bearer</string>
     <string name="auth_custom">Personnalisé</string>
-    <string name="label_custom_auth_header">En-tête d\'authentification personnalisé</string>
+    <string name="label_custom_auth_header">En-tête d'authentification personnalisé</string>
     <string name="label_oauth_settings">Paramètres OAuth</string>
     <string name="label_client_id">ID client</string>
     <string name="label_client_secret">Secret client</string>
-    <string name="label_authorization_url">URL d\'autorisation</string>
+    <string name="label_authorization_url">URL d'autorisation</string>
     <string name="label_token_url">URL du jeton</string>
     <string name="label_scope">Portée</string>
-    <string name="label_token_exchange_method">Méthode d\'échange de jeton</string>
+    <string name="label_token_exchange_method">Méthode d'échange de jeton</string>
     <string name="token_default_post">Par défaut (POST)</string>
     <string name="token_basic_auth_header">En-tête Basic Auth</string>
 
@@ -135,33 +135,33 @@
 
     <!-- Capabilities section -->
     <string name="label_artifacts">Artefacts</string>
-    <string name="artifacts_description">Activer la génération d\'artefacts</string>
+    <string name="artifacts_description">Activer la génération d'artefacts</string>
     <string name="artifacts_mode_off">Désactivé</string>
     <string name="artifacts_mode_default">Par défaut</string>
     <string name="artifacts_mode_shadcnui">shadcn/ui</string>
     <string name="artifacts_mode_custom">Personnalisé</string>
     <string name="label_end_after_tools">Terminer après les outils</string>
-    <string name="end_after_tools_description">S\'arrêter une fois l\'exécution des outils terminée</string>
+    <string name="end_after_tools_description">S'arrêter une fois l'exécution des outils terminée</string>
     <string name="label_hide_sequential_outputs">Masquer les sorties séquentielles</string>
     <string name="hide_sequential_description">Masquer les sorties intermédiaires des outils</string>
     <string name="label_recursion_limit">Limite de récursivité</string>
-    <string name="recursion_limit_description">Nombre maximal d\'appels d\'outils récursifs</string>
+    <string name="recursion_limit_description">Nombre maximal d'appels d'outils récursifs</string>
 
     <!-- Category selector -->
     <string name="general">Général</string>
 
     <!-- Code Interpreter section -->
     <string name="label_code_interpreter">Interpréteur de code</string>
-    <string name="code_interpreter_description">Permettre à l\'agent d\'écrire et d\'exécuter du code pour résoudre des problèmes</string>
+    <string name="code_interpreter_description">Permettre à l'agent d'écrire et d'exécuter du code pour résoudre des problèmes</string>
 
     <!-- Web Search section -->
     <string name="label_web_search">Recherche web</string>
-    <string name="web_search_description">Permettre à l\'agent de rechercher sur le web des informations actuelles</string>
+    <string name="web_search_description">Permettre à l'agent de rechercher sur le web des informations actuelles</string>
 
     <!-- Tool auth dialog -->
     <string name="tool_auth_revoke">Révoquer</string>
-    <string name="tool_auth_code_title">Clé API de l\'interpréteur de code</string>
-    <string name="tool_auth_code_description">Saisissez la clé API que le serveur doit utiliser pour exécuter du code en votre nom. Stockée sur votre compte, pas dans l\'agent.</string>
+    <string name="tool_auth_code_title">Clé API de l'interpréteur de code</string>
+    <string name="tool_auth_code_description">Saisissez la clé API que le serveur doit utiliser pour exécuter du code en votre nom. Stockée sur votre compte, pas dans l'agent.</string>
     <string name="tool_auth_code_field">Clé API LibreChat Code</string>
     <!-- File Context section -->
     <string name="label_file_context">Contexte de fichier</string>
@@ -169,14 +169,14 @@
 
     <!-- File Search section -->
     <string name="label_file_search">Recherche de fichiers</string>
-    <string name="file_search_description">Permettre à l\'agent de rechercher dans les fichiers et documents téléversés</string>
+    <string name="file_search_description">Permettre à l'agent de rechercher dans les fichiers et documents téléversés</string>
 
     <!-- Chain (sequential multi-agent) -->
     <string name="chain_agents_count">Agents en chaîne (%1$d)</string>
-    <string name="chain_description">Agents qui s\'exécutent en séquence après celui-ci. La limite est de %1$d.</string>
+    <string name="chain_description">Agents qui s'exécutent en séquence après celui-ci. La limite est de %1$d.</string>
     <string name="no_chain_agents">Aucun agent en chaîne configuré.</string>
     <string name="add_chain_agent">Ajouter un agent en chaîne</string>
-    <string name="chain_full">Nombre maximal d\'agents en chaîne atteint.</string>
+    <string name="chain_full">Nombre maximal d'agents en chaîne atteint.</string>
     <!-- Handoffs (graph edges) -->
     <string name="handoff_edges_count">Arêtes de passation (%1$d)</string>
     <string name="handoff_edges_description">Arêtes de routage du graphe pour la passation multi-agent dynamique.</string>
@@ -186,7 +186,7 @@
     <string name="handoff_edge_to">À</string>
     <string name="handoff_edge_description">Description (facultatif)</string>
     <string name="handoff_edge_prompt">Invite de transfert (facultatif)</string>
-    <string name="handoff_edge_prompt_key">Nom du paramètre d\'invite (facultatif)</string>
+    <string name="handoff_edge_prompt_key">Nom du paramètre d'invite (facultatif)</string>
     <string name="handoff_edge_exclude_results">Exclure les messages précédents</string>
     <string name="handoff_edge_arrow">%1$s → %2$s</string>
     <string name="handoff_edge_multi">%1$d agents → %2$d agents</string>
@@ -207,17 +207,17 @@
     <string name="sharing_and_permissions">Partage &amp; autorisations</string>
     <string name="label_visibility">Visibilité</string>
     <string name="label_collaborative">Collaboratif</string>
-    <string name="collaborative_description">Permettre à d\'autres utilisateurs de modifier cet agent</string>
-    <string name="collaborative_managed_server_side">Les autorisations d\'accès sont gérées côté serveur dans cette version.</string>
+    <string name="collaborative_description">Permettre à d'autres utilisateurs de modifier cet agent</string>
+    <string name="collaborative_managed_server_side">Les autorisations d'accès sont gérées côté serveur dans cette version.</string>
 
     <!-- Visibility labels -->
     <string name="visibility_private">Privé</string>
     <string name="visibility_public">Public</string>
 
     <!-- Support contact section -->
-    <string name="label_support_contact">Contact d\'assistance</string>
+    <string name="label_support_contact">Contact d'assistance</string>
     <string name="label_name">Nom</string>
-    <string name="support_contact_placeholder">Nom du contact d\'assistance</string>
+    <string name="support_contact_placeholder">Nom du contact d'assistance</string>
     <string name="label_email">E-mail</string>
 
     <!-- Version history -->
@@ -235,7 +235,7 @@
     <!-- ACL sharing (v0.8.5+) -->
     <string name="acl_sharing_title">Partage &amp; accès</string>
     <string name="acl_add_principal">Ajouter un utilisateur ou un groupe</string>
-    <string name="acl_no_grants">Personne n\'a encore reçu d\'accès.</string>
+    <string name="acl_no_grants">Personne n'a encore reçu d'accès.</string>
     <string name="acl_public_label">Public</string>
     <string name="acl_public_description">Autoriser toute personne ayant accès au serveur</string>
     <string name="acl_role">Rôle</string>
@@ -246,18 +246,18 @@
     <string name="acl_principal_user">Utilisateur</string>
     <string name="acl_principal_group">Groupe</string>
     <string name="acl_principal_role">Rôle</string>
-    <string name="acl_create_mode_notice">Les contrôles de partage &amp; d\'accès sont disponibles après l\'enregistrement de l\'agent.</string>
+    <string name="acl_create_mode_notice">Les contrôles de partage &amp; d'accès sont disponibles après l'enregistrement de l'agent.</string>
 
     <!-- Tool select dialog -->
-    <string name="agent_tools_title">Outils de l\'agent</string>
+    <string name="agent_tools_title">Outils de l'agent</string>
     <string name="select_tools_description">Sélectionnez les outils que votre agent peut utiliser</string>
     <string name="search_tools_hint">Rechercher des outils…</string>
-    <string name="no_tools_matching">Aucun outil correspondant à \"%1$s\"</string>
+    <string name="no_tools_matching">Aucun outil correspondant à "%1$s"</string>
     <string name="no_tools_available">Aucun outil disponible</string>
 
     <!-- Per-capability file attachments -->
     <string name="add_file">Ajouter un fichier</string>
-    <string name="agent_files_save_first">Enregistrez l\'agent avant de joindre des fichiers</string>
+    <string name="agent_files_save_first">Enregistrez l'agent avant de joindre des fichiers</string>
     <string name="agent_file_too_large">Le fichier doit faire %1$d Mo ou moins</string>
     <string name="agent_file_upload_failed">Échec du téléversement du fichier</string>
     <string name="agent_file_remove_failed">Échec de la suppression du fichier</string>
@@ -271,13 +271,13 @@
     <string name="add_skills">Ajouter des compétences</string>
     <string name="select_skills">Sélectionner des compétences</string>
     <string name="search_skills_hint">Rechercher des compétences…</string>
-    <string name="no_skills_matching">Aucune compétence correspondant à \"%1$s\"</string>
+    <string name="no_skills_matching">Aucune compétence correspondant à "%1$s"</string>
     <string name="no_skills_available">Aucune compétence disponible</string>
     <string name="skills_done">Terminé</string>
 
     <!-- Subagents config (v0.8.6) -->
     <string name="label_subagents">Sous-agents</string>
-    <string name="subagents_description">Permettre à cet agent de déléguer du travail à d\'autres agents dans des contextes isolés.</string>
+    <string name="subagents_description">Permettre à cet agent de déléguer du travail à d'autres agents dans des contextes isolés.</string>
     <string name="subagents_allow_self">Autoriser à se générer lui-même</string>
     <string name="add_subagent">Ajouter un sous-agent</string>
     <string name="subagents_full">Nombre maximal de sous-agents atteint.</string>

--- a/feature/agents/src/commonMain/composeResources/values-ko/strings.xml
+++ b/feature/agents/src/commonMain/composeResources/values-ko/strings.xml
@@ -45,7 +45,7 @@
     <!-- Detail screen -->
     <string name="agent_title">에이전트</string>
     <string name="delete_agent">에이전트 삭제</string>
-    <string name="delete_agent_confirm">\"%1$s\"을(를) 삭제하시겠습니까? 되돌릴 수 없습니다.</string>
+    <string name="delete_agent_confirm">"%1$s"을(를) 삭제하시겠습니까? 되돌릴 수 없습니다.</string>
     <string name="delete_this_agent">이 에이전트</string>
     <string name="by_author">작성자: %1$s</string>
     <string name="label_description">설명</string>
@@ -252,7 +252,7 @@
     <string name="agent_tools_title">에이전트 도구</string>
     <string name="select_tools_description">에이전트가 사용할 도구를 선택하세요</string>
     <string name="search_tools_hint">도구 검색…</string>
-    <string name="no_tools_matching">\"%1$s\"과(와) 일치하는 도구가 없습니다</string>
+    <string name="no_tools_matching">"%1$s"과(와) 일치하는 도구가 없습니다</string>
     <string name="no_tools_available">사용 가능한 도구가 없습니다</string>
 
     <!-- Per-capability file attachments -->
@@ -271,7 +271,7 @@
     <string name="add_skills">스킬 추가</string>
     <string name="select_skills">스킬 선택</string>
     <string name="search_skills_hint">스킬 검색…</string>
-    <string name="no_skills_matching">\"%1$s\"과(와) 일치하는 스킬이 없습니다</string>
+    <string name="no_skills_matching">"%1$s"과(와) 일치하는 스킬이 없습니다</string>
     <string name="no_skills_available">사용 가능한 스킬이 없습니다</string>
     <string name="skills_done">완료</string>
 

--- a/feature/agents/src/commonMain/composeResources/values-pt/strings.xml
+++ b/feature/agents/src/commonMain/composeResources/values-pt/strings.xml
@@ -45,7 +45,7 @@
     <!-- Detail screen -->
     <string name="agent_title">Agente</string>
     <string name="delete_agent">Excluir agente</string>
-    <string name="delete_agent_confirm">Tem certeza de que deseja excluir \"%1$s\"? Esta ação não pode ser desfeita.</string>
+    <string name="delete_agent_confirm">Tem certeza de que deseja excluir "%1$s"? Esta ação não pode ser desfeita.</string>
     <string name="delete_this_agent">este agente</string>
     <string name="by_author">por %1$s</string>
     <string name="label_description">Descrição</string>
@@ -252,7 +252,7 @@
     <string name="agent_tools_title">Ferramentas do agente</string>
     <string name="select_tools_description">Selecione as ferramentas que seu agente vai usar</string>
     <string name="search_tools_hint">Buscar ferramentas…</string>
-    <string name="no_tools_matching">Nenhuma ferramenta corresponde a \"%1$s\"</string>
+    <string name="no_tools_matching">Nenhuma ferramenta corresponde a "%1$s"</string>
     <string name="no_tools_available">Nenhuma ferramenta disponível</string>
 
     <!-- Per-capability file attachments -->
@@ -271,7 +271,7 @@
     <string name="add_skills">Adicionar habilidades</string>
     <string name="select_skills">Selecionar habilidades</string>
     <string name="search_skills_hint">Buscar habilidades…</string>
-    <string name="no_skills_matching">Nenhuma habilidade corresponde a \"%1$s\"</string>
+    <string name="no_skills_matching">Nenhuma habilidade corresponde a "%1$s"</string>
     <string name="no_skills_available">Nenhuma habilidade disponível</string>
     <string name="skills_done">Concluído</string>
 

--- a/feature/agents/src/commonMain/composeResources/values-ru/strings.xml
+++ b/feature/agents/src/commonMain/composeResources/values-ru/strings.xml
@@ -45,7 +45,7 @@
     <!-- Detail screen -->
     <string name="agent_title">Агент</string>
     <string name="delete_agent">Удалить агента</string>
-    <string name="delete_agent_confirm">Вы уверены, что хотите удалить \"%1$s\"? Это нельзя отменить.</string>
+    <string name="delete_agent_confirm">Вы уверены, что хотите удалить "%1$s"? Это нельзя отменить.</string>
     <string name="delete_this_agent">этого агента</string>
     <string name="by_author">автор: %1$s</string>
     <string name="label_description">Описание</string>
@@ -252,7 +252,7 @@
     <string name="agent_tools_title">Инструменты агента</string>
     <string name="select_tools_description">Выберите инструменты, которые сможет использовать ваш агент</string>
     <string name="search_tools_hint">Поиск инструментов…</string>
-    <string name="no_tools_matching">Нет инструментов, соответствующих \"%1$s\"</string>
+    <string name="no_tools_matching">Нет инструментов, соответствующих "%1$s"</string>
     <string name="no_tools_available">Нет доступных инструментов</string>
 
     <!-- Per-capability file attachments -->
@@ -271,7 +271,7 @@
     <string name="add_skills">Добавить навыки</string>
     <string name="select_skills">Выбрать навыки</string>
     <string name="search_skills_hint">Поиск навыков…</string>
-    <string name="no_skills_matching">Нет навыков, соответствующих \"%1$s\"</string>
+    <string name="no_skills_matching">Нет навыков, соответствующих "%1$s"</string>
     <string name="no_skills_available">Нет доступных навыков</string>
     <string name="skills_done">Готово</string>
 

--- a/feature/agents/src/commonMain/composeResources/values-zh/strings.xml
+++ b/feature/agents/src/commonMain/composeResources/values-zh/strings.xml
@@ -45,7 +45,7 @@
     <!-- Detail screen -->
     <string name="agent_title">智能体</string>
     <string name="delete_agent">删除智能体</string>
-    <string name="delete_agent_confirm">确定要删除 \"%1$s\" 吗？此操作无法撤销。</string>
+    <string name="delete_agent_confirm">确定要删除 "%1$s" 吗？此操作无法撤销。</string>
     <string name="delete_this_agent">此智能体</string>
     <string name="by_author">作者：%1$s</string>
     <string name="label_description">描述</string>
@@ -252,7 +252,7 @@
     <string name="agent_tools_title">智能体工具</string>
     <string name="select_tools_description">为你的智能体选择要使用的工具</string>
     <string name="search_tools_hint">搜索工具…</string>
-    <string name="no_tools_matching">没有与 \"%1$s\" 匹配的工具</string>
+    <string name="no_tools_matching">没有与 "%1$s" 匹配的工具</string>
     <string name="no_tools_available">没有可用的工具</string>
 
     <!-- Per-capability file attachments -->
@@ -271,7 +271,7 @@
     <string name="add_skills">添加技能</string>
     <string name="select_skills">选择技能</string>
     <string name="search_skills_hint">搜索技能…</string>
-    <string name="no_skills_matching">没有与 \"%1$s\" 匹配的技能</string>
+    <string name="no_skills_matching">没有与 "%1$s" 匹配的技能</string>
     <string name="no_skills_available">没有可用的技能</string>
     <string name="skills_done">完成</string>
 

--- a/feature/agents/src/commonMain/composeResources/values/strings.xml
+++ b/feature/agents/src/commonMain/composeResources/values/strings.xml
@@ -45,7 +45,7 @@
     <!-- Detail screen -->
     <string name="agent_title">Agent</string>
     <string name="delete_agent">Delete Agent</string>
-    <string name="delete_agent_confirm">Are you sure you want to delete \"%1$s\"? This cannot be undone.</string>
+    <string name="delete_agent_confirm">Are you sure you want to delete "%1$s"? This cannot be undone.</string>
     <string name="delete_this_agent">this agent</string>
     <string name="by_author">by %1$s</string>
     <string name="label_description">Description</string>
@@ -252,7 +252,7 @@
     <string name="agent_tools_title">Agent Tools</string>
     <string name="select_tools_description">Select tools for your agent to use</string>
     <string name="search_tools_hint">Search tools\u2026</string>
-    <string name="no_tools_matching">No tools matching \"%1$s\"</string>
+    <string name="no_tools_matching">No tools matching "%1$s"</string>
     <string name="no_tools_available">No tools available</string>
 
     <!-- Per-capability file attachments -->
@@ -271,7 +271,7 @@
     <string name="add_skills">Add skills</string>
     <string name="select_skills">Select Skills</string>
     <string name="search_skills_hint">Search skills…</string>
-    <string name="no_skills_matching">No skills matching \"%1$s\"</string>
+    <string name="no_skills_matching">No skills matching "%1$s"</string>
     <string name="no_skills_available">No skills available</string>
     <string name="skills_done">Done</string>
 

--- a/feature/auth/src/commonMain/composeResources/values-fr/strings.xml
+++ b/feature/auth/src/commonMain/composeResources/values-fr/strings.xml
@@ -5,9 +5,9 @@
     <string name="server_url_placeholder">https://votre-serveur.com</string>
     <string name="server_url_connect">Se connecter</string>
     <string name="connect_to_librechat">Se connecter à LibreChat</string>
-    <string name="enter_server_url_hint">Saisissez l\'URL de votre serveur pour commencer</string>
+    <string name="enter_server_url_hint">Saisissez l'URL de votre serveur pour commencer</string>
     <string name="insecure_connection_title">Connexion non sécurisée</string>
-    <string name="insecure_connection_message">Vous vous connectez via HTTP. Vos identifiants de connexion et vos messages seront envoyés sans chiffrement et pourraient être interceptés par d\'autres personnes sur le réseau.\n\nN\'utilisez HTTP que pour les serveurs de développement local.</string>
+    <string name="insecure_connection_message">Vous vous connectez via HTTP. Vos identifiants de connexion et vos messages seront envoyés sans chiffrement et pourraient être interceptés par d'autres personnes sur le réseau.\n\nN'utilisez HTTP que pour les serveurs de développement local.</string>
     <string name="connect_anyway">Se connecter quand même</string>
     <string name="cancel">Annuler</string>
 
@@ -17,15 +17,15 @@
     <string name="password_label">Mot de passe</string>
     <string name="continue_button">Continuer</string>
     <string name="forgot_password">Mot de passe oublié ?</string>
-    <string name="no_account_sign_up">Vous n\'avez pas de compte ? Inscrivez-vous</string>
+    <string name="no_account_sign_up">Vous n'avez pas de compte ? Inscrivez-vous</string>
     <string name="or_continue_with">Ou continuer avec</string>
 
     <!-- Register -->
     <string name="register_title">Créer un compte</string>
     <string name="full_name_label">Nom complet</string>
-    <string name="username_label">Nom d\'utilisateur</string>
+    <string name="username_label">Nom d'utilisateur</string>
     <string name="confirm_password_label">Confirmer le mot de passe</string>
-    <string name="sign_up">S\'inscrire</string>
+    <string name="sign_up">S'inscrire</string>
     <string name="have_account_sign_in">Vous avez déjà un compte ? Connectez-vous</string>
 
     <!-- Forgot Password -->
@@ -51,24 +51,24 @@
     <string name="two_factor_title">Authentification à deux facteurs</string>
     <string name="enter_verification_code">Saisissez le code de vérification</string>
     <string name="enter_backup_code">Saisissez le code de secours</string>
-    <string name="authenticator_prompt">Saisissez le code à 6 chiffres de votre application d\'authentification</string>
-    <string name="backup_code_prompt">Saisissez l\'un de vos codes de secours</string>
+    <string name="authenticator_prompt">Saisissez le code à 6 chiffres de votre application d'authentification</string>
+    <string name="backup_code_prompt">Saisissez l'un de vos codes de secours</string>
     <string name="verify">Vérifier</string>
-    <string name="use_authenticator_code">Utiliser le code de l\'application d\'authentification</string>
+    <string name="use_authenticator_code">Utiliser le code de l'application d'authentification</string>
     <string name="use_backup_code">Utiliser un code de secours</string>
     <string name="backup_code_label">Code de secours</string>
 
     <!-- Verify Email -->
-    <string name="verify_email_title">Vérifier l\'e-mail</string>
+    <string name="verify_email_title">Vérifier l'e-mail</string>
     <string name="verification_link_sent">Nous avons envoyé un lien de vérification à</string>
-    <string name="click_link_to_verify">Cliquez sur le lien dans l\'e-mail pour vérifier votre compte.</string>
+    <string name="click_link_to_verify">Cliquez sur le lien dans l'e-mail pour vérifier votre compte.</string>
     <string name="verification_email_sent">E-mail de vérification envoyé !</string>
-    <string name="resend_verification_email">Renvoyer l\'e-mail de vérification</string>
+    <string name="resend_verification_email">Renvoyer l'e-mail de vérification</string>
     <string name="resend_in_seconds">Renvoyer dans %1$ds</string>
 
     <!-- Terms -->
-    <string name="terms_title">Conditions d\'utilisation</string>
-    <string name="i_accept">J\'accepte</string>
+    <string name="terms_title">Conditions d'utilisation</string>
+    <string name="i_accept">J'accepte</string>
     <string name="retry">Réessayer</string>
 
     <!-- Common -->

--- a/feature/auth/src/commonMain/composeResources/values/strings.xml
+++ b/feature/auth/src/commonMain/composeResources/values/strings.xml
@@ -17,7 +17,7 @@
     <string name="password_label">Password</string>
     <string name="continue_button">Continue</string>
     <string name="forgot_password">Forgot password?</string>
-    <string name="no_account_sign_up">Don\'t have an account? Sign up</string>
+    <string name="no_account_sign_up">Don't have an account? Sign up</string>
     <string name="or_continue_with">Or continue with</string>
 
     <!-- Register -->
@@ -34,7 +34,7 @@
     <string name="enter_email_for_reset">Enter your email to receive a reset link</string>
     <string name="send_reset_link">Send reset link</string>
     <string name="check_your_email">Check your email</string>
-    <string name="reset_link_sent">We\'ve sent a password reset link to %1$s</string>
+    <string name="reset_link_sent">We've sent a password reset link to %1$s</string>
     <string name="back_to_sign_in">Back to sign in</string>
 
     <!-- Reset Password -->
@@ -60,7 +60,7 @@
 
     <!-- Verify Email -->
     <string name="verify_email_title">Verify Email</string>
-    <string name="verification_link_sent">We\'ve sent a verification link to</string>
+    <string name="verification_link_sent">We've sent a verification link to</string>
     <string name="click_link_to_verify">Click the link in the email to verify your account.</string>
     <string name="verification_email_sent">Verification email sent!</string>
     <string name="resend_verification_email">Resend verification email</string>

--- a/feature/chat/src/commonMain/composeResources/values-fr/strings.xml
+++ b/feature/chat/src/commonMain/composeResources/values-fr/strings.xml
@@ -29,7 +29,7 @@
     <!-- Neutral label for the active agent when its name hasn't resolved yet (never a model string). -->
     <string name="chat_agent_fallback_label">Agent</string>
     <string name="compare_models">Comparer les modèles</string>
-    <string name="how_can_i_help">Comment puis-je vous aider aujourd\'hui ?</string>
+    <string name="how_can_i_help">Comment puis-je vous aider aujourd'hui ?</string>
     <string name="recording">Enregistrement…</string>
     <string name="hint_message_model">Message à %1$s</string>
     <string name="hint_message">Message…</string>
@@ -38,13 +38,13 @@
     <string name="cd_open_tools_menu">Ouvrir le menu des outils</string>
     <string name="cd_paste_image">Coller une image depuis le presse-papiers</string>
     <string name="cd_message_input">Champ de saisie de message</string>
-    <string name="cd_stop_voice_recording">Arrêter l\'enregistrement vocal</string>
-    <string name="cd_start_voice_recording">Démarrer l\'enregistrement vocal</string>
+    <string name="cd_stop_voice_recording">Arrêter l'enregistrement vocal</string>
+    <string name="cd_start_voice_recording">Démarrer l'enregistrement vocal</string>
     <string name="cd_stop_generation">Arrêter la génération</string>
     <string name="cd_send_message">Envoyer le message</string>
     <string name="cd_open_drawer">Ouvrir le tiroir de navigation</string>
     <string name="cd_edit_title">Modifier le titre</string>
-    <string name="cd_more_options">Plus d\'options</string>
+    <string name="cd_more_options">Plus d'options</string>
     <string name="cd_scroll_to_bottom">Défiler vers le bas</string>
     <string name="cd_select_model">Sélectionner un modèle</string>
     <string name="cd_librechat">LibreChat</string>
@@ -58,7 +58,7 @@
     <string name="cd_regenerate_response">Régénérer la réponse</string>
     <string name="cd_stop_reading">Arrêter la lecture</string>
     <string name="cd_read_aloud">Lire à voix haute</string>
-    <string name="cd_fork_conversation">Bifurquer la conversation à partir d\'ici</string>
+    <string name="cd_fork_conversation">Bifurquer la conversation à partir d'ici</string>
     <string name="cd_previous_response">Réponse précédente</string>
     <string name="cd_next_response">Réponse suivante</string>
     <string name="cd_generating_response">Génération de la réponse</string>
@@ -66,10 +66,10 @@
     <!-- Content descriptions - Images -->
     <string name="cd_fullscreen_image">Image en plein écran</string>
     <string name="cd_close">Fermer</string>
-    <string name="cd_save_to_device">Enregistrer sur l\'appareil</string>
-    <string name="cd_share_image">Partager l\'image</string>
-    <string name="cd_failed_to_load_image">Échec du chargement de l\'image</string>
-    <string name="cd_failed_to_load_generated_image">Échec du chargement de l\'image générée</string>
+    <string name="cd_save_to_device">Enregistrer sur l'appareil</string>
+    <string name="cd_share_image">Partager l'image</string>
+    <string name="cd_failed_to_load_image">Échec du chargement de l'image</string>
+    <string name="cd_failed_to_load_generated_image">Échec du chargement de l'image générée</string>
     <string name="cd_embedded_image">Image intégrée dans le message</string>
 
     <!-- Content descriptions - Search -->
@@ -83,7 +83,7 @@
     <!-- Content descriptions - Code -->
     <string name="cd_copy_code">Copier le code</string>
     <string name="cd_copied">Copié</string>
-    <string name="cd_code_execution_result">Résultat de l\'exécution du code</string>
+    <string name="cd_code_execution_result">Résultat de l'exécution du code</string>
     <string name="cd_exit_code_success">Code de sortie 0 (succès)</string>
     <string name="cd_exit_code_failure">Code de sortie %1$d (échec)</string>
     <string name="exit_code">sortie %1$d</string>
@@ -114,14 +114,14 @@
     <string name="cd_expand_subagent">Développer le sous-agent %1$s</string>
 
     <!-- Office-doc preview attachments (deferred preview, v0.8.6+) -->
-    <string name="office_preview_preparing">Préparation de l\'aperçu de %1$s…</string>
-    <string name="office_preview_failed">Impossible d\'afficher l\'aperçu de %1$s (%2$s)</string>
+    <string name="office_preview_preparing">Préparation de l'aperçu de %1$s…</string>
+    <string name="office_preview_failed">Impossible d'afficher l'aperçu de %1$s (%2$s)</string>
     <string name="office_preview_unavailable">%1$s — aperçu non disponible</string>
 
     <!-- Content descriptions - Tool calls -->
-    <string name="cd_tool_call">Appel d\'outil</string>
-    <string name="cd_collapse_tool_call">Réduire l\'appel d\'outil %1$s</string>
-    <string name="cd_expand_tool_call">Développer l\'appel d\'outil %1$s</string>
+    <string name="cd_tool_call">Appel d'outil</string>
+    <string name="cd_collapse_tool_call">Réduire l'appel d'outil %1$s</string>
+    <string name="cd_expand_tool_call">Développer l'appel d'outil %1$s</string>
     <string name="cd_tool_complete">Terminé</string>
     <string name="video_not_supported">Contenu vidéo non pris en charge</string>
 
@@ -152,7 +152,7 @@
     <string name="cd_remove_file">Supprimer %1$s</string>
 
     <!-- Agent handoff -->
-    <string name="cd_agent_handoff">Passation d\'agent de %1$s à %2$s</string>
+    <string name="cd_agent_handoff">Passation d'agent de %1$s à %2$s</string>
     <string name="cd_handed_off_to">a transmis à</string>
     <string name="agent_unknown">inconnu</string>
     <string name="agent_previous">Agent précédent</string>
@@ -163,11 +163,11 @@
     <string name="cd_play">Lecture</string>
     <string name="cd_play_video">Lire la vidéo</string>
     <string name="audio_no_data">Aucune donnée audio</string>
-    <string name="audio_decode_failed">Échec du décodage de l\'audio</string>
+    <string name="audio_decode_failed">Échec du décodage de l'audio</string>
 
     <!-- Citation -->
     <string name="citation_number">Citation %1$d</string>
-    <string name="cd_open_citation_url">Ouvrir l\'URL de la citation</string>
+    <string name="cd_open_citation_url">Ouvrir l'URL de la citation</string>
 
     <!-- Fork options -->
     <string name="fork_conversation">Bifurquer la conversation</string>
@@ -175,13 +175,13 @@
     <string name="fork_visible_messages_desc">Uniquement le chemin direct des messages</string>
     <string name="fork_include_branches">Inclure les branches</string>
     <string name="fork_include_branches_desc">Chemin direct plus les messages frères</string>
-    <string name="fork_all_to_target">Tout jusqu\'au niveau cible</string>
-    <string name="fork_all_to_target_desc">Tous les messages et branches jusqu\'à ce niveau</string>
+    <string name="fork_all_to_target">Tout jusqu'au niveau cible</string>
+    <string name="fork_all_to_target_desc">Tous les messages et branches jusqu'à ce niveau</string>
     <string name="fork_start_new">Démarrer une nouvelle conversation à partir de la cible</string>
     <string name="fork_start_new_desc">Commencer la bifurcation à partir du message sélectionné au lieu de la racine</string>
 
     <!-- Image generation -->
-    <string name="generating_image">Génération de l\'image…</string>
+    <string name="generating_image">Génération de l'image…</string>
     <string name="image_generated">Image générée</string>
     <string name="cd_generated_image">Image générée</string>
 
@@ -229,7 +229,7 @@
 
     <!-- Preset picker -->
     <string name="select_preset">Sélectionner un préréglage</string>
-    <string name="no_presets_saved">Aucun préréglage enregistré pour l\'instant</string>
+    <string name="no_presets_saved">Aucun préréglage enregistré pour l'instant</string>
     <string name="cd_edit_preset">Modifier %1$s</string>
     <string name="cd_delete_preset">Supprimer %1$s</string>
     <string name="preset_endpoint">Point de terminaison : %1$s</string>
@@ -255,23 +255,23 @@
     <string name="dialog_delete_conversation_message">Ceci supprimera définitivement cette conversation. Cette action est irréversible.</string>
 
     <!-- Artifacts -->
-    <string name="cd_open_artifact">Ouvrir l\'artefact</string>
-    <string name="cd_share_artifact">Partager l\'artefact</string>
+    <string name="cd_open_artifact">Ouvrir l'artefact</string>
+    <string name="cd_share_artifact">Partager l'artefact</string>
     <string name="cd_previous_version">Version précédente</string>
     <string name="cd_next_version">Version suivante</string>
     <string name="artifact_version">v%1$d/%2$d</string>
     <!-- Prompts -->
-    <string name="prompts_library">Bibliothèque d\'invites</string>
+    <string name="prompts_library">Bibliothèque d'invites</string>
     <string name="use_in_chat">Utiliser dans la discussion</string>
     <string name="set_production">Définir comme production</string>
     <string name="prompt_name_label">Nom</string>
     <string name="prompt_description_label">Description</string>
     <string name="prompt_command_label">Commande</string>
-    <string name="prompt_text_label">Texte de l\'invite</string>
-    <string name="prompt_content">Contenu de l\'invite</string>
-    <string name="cd_share_prompt">Partager l\'invite</string>
-    <string name="cd_edit_prompt">Modifier l\'invite</string>
-    <string name="cd_delete_prompt">Supprimer l\'invite</string>
+    <string name="prompt_text_label">Texte de l'invite</string>
+    <string name="prompt_content">Contenu de l'invite</string>
+    <string name="cd_share_prompt">Partager l'invite</string>
+    <string name="cd_edit_prompt">Modifier l'invite</string>
+    <string name="cd_delete_prompt">Supprimer l'invite</string>
     <string name="cd_back">Retour</string>
     <string name="cd_version_history">Historique des versions</string>
     <string name="cd_filter_sort">Filtrer et trier</string>
@@ -297,7 +297,7 @@
     <string name="label_sort_by">Trier par</string>
 
     <!-- Prompt share dialog -->
-    <string name="dialog_title_share_prompt">Partager l\'invite</string>
+    <string name="dialog_title_share_prompt">Partager l'invite</string>
     <string name="label_permission">Autorisation</string>
 
     <!-- Variable input dialog -->
@@ -305,7 +305,7 @@
 
     <!-- Comparison mode -->
     <string name="continue_with_response">Continuer avec cette réponse</string>
-    <string name="waiting_for_response">En attente d\'une réponse…</string>
+    <string name="waiting_for_response">En attente d'une réponse…</string>
 
     <!-- Provider Keys chat-time errors. -->
     <string name="provider_keys_chat_error_no_key">Aucune clé trouvée. Veuillez fournir une clé et réessayer.</string>
@@ -316,10 +316,10 @@
     <string name="provider_keys_chat_error_cta">Ouvrir les paramètres des clés</string>
 
     <!-- Send block reasons (shown in error snackbar when send can't proceed) -->
-    <string name="send_block_select_agent">Sélectionnez un agent avant d\'envoyer votre message.</string>
-    <string name="send_block_select_model">Sélectionnez un modèle avant d\'envoyer votre message.</string>
+    <string name="send_block_select_agent">Sélectionnez un agent avant d'envoyer votre message.</string>
+    <string name="send_block_select_model">Sélectionnez un modèle avant d'envoyer votre message.</string>
     <string name="send_block_agents_unavailable">Les agents ne sont pas disponibles sur ce serveur. Veuillez choisir un autre modèle.</string>
-    <string name="send_block_agent_not_available">L\'agent sélectionné n\'est pas disponible sur ce serveur. Veuillez choisir un autre agent.</string>
-    <string name="send_block_model_not_available">Le modèle sélectionné n\'est pas disponible sur ce serveur. Veuillez choisir un autre modèle.</string>
-    <string name="send_block_model_load_failed">Impossible de charger le modèle sélectionné pour l\'instant. Veuillez réessayer ou choisir un autre modèle.</string>
+    <string name="send_block_agent_not_available">L'agent sélectionné n'est pas disponible sur ce serveur. Veuillez choisir un autre agent.</string>
+    <string name="send_block_model_not_available">Le modèle sélectionné n'est pas disponible sur ce serveur. Veuillez choisir un autre modèle.</string>
+    <string name="send_block_model_load_failed">Impossible de charger le modèle sélectionné pour l'instant. Veuillez réessayer ou choisir un autre modèle.</string>
 </resources>

--- a/feature/chat/src/commonMain/composeResources/values/strings.xml
+++ b/feature/chat/src/commonMain/composeResources/values/strings.xml
@@ -124,7 +124,7 @@
 
     <!-- Office-doc preview attachments (deferred preview, v0.8.6+) -->
     <string name="office_preview_preparing">Preparing preview of %1$s…</string>
-    <string name="office_preview_failed">Couldn\'t preview %1$s (%2$s)</string>
+    <string name="office_preview_failed">Couldn't preview %1$s (%2$s)</string>
     <string name="office_preview_unavailable">%1$s — preview not available</string>
 
     <!-- Content descriptions - Tool calls -->
@@ -234,7 +234,7 @@
     <!-- Tool-call generated-file attachments -->
     <string name="attachment_fallback">Attachment</string>
     <string name="pdf_document">PDF Document</string>
-    <string name="pdf_load_failed">Couldn\'t load PDF</string>
+    <string name="pdf_load_failed">Couldn't load PDF</string>
     <string name="cd_share_pdf">Share PDF</string>
     <string name="cd_open_pdf">Open PDF</string>
     <string name="retry">Retry</string>
@@ -357,10 +357,10 @@
     <!-- Send block reasons (shown in error snackbar when send can't proceed) -->
     <string name="send_block_select_agent">Select an agent before sending your message.</string>
     <string name="send_block_select_model">Select a model before sending your message.</string>
-    <string name="send_block_agents_unavailable">Agents aren\'t available on this server. Please pick a different model.</string>
-    <string name="send_block_agent_not_available">The selected agent isn\'t available on this server. Please pick a different agent.</string>
-    <string name="send_block_model_not_available">The selected model isn\'t available on this server. Please pick a different model.</string>
-    <string name="send_block_model_load_failed">Couldn\'t load the selected model yet. Please try again or pick a different model.</string>
+    <string name="send_block_agents_unavailable">Agents aren't available on this server. Please pick a different model.</string>
+    <string name="send_block_agent_not_available">The selected agent isn't available on this server. Please pick a different agent.</string>
+    <string name="send_block_model_not_available">The selected model isn't available on this server. Please pick a different model.</string>
+    <string name="send_block_model_load_failed">Couldn't load the selected model yet. Please try again or pick a different model.</string>
 
     <!-- Conversation media gallery ("Show all media") -->
     <string name="action_show_all_media">Show all media</string>

--- a/feature/conversations/src/commonMain/composeResources/values-ar/strings.xml
+++ b/feature/conversations/src/commonMain/composeResources/values-ar/strings.xml
@@ -47,7 +47,7 @@
     <string name="rename_dialog_message">أدخل عنوانًا جديدًا لهذه المحادثة.</string>
     <string name="title_label">العنوان</string>
     <string name="delete_conversation">حذف المحادثة</string>
-    <string name="delete_confirmation_message">هل أنت متأكد أنك تريد حذف \"%1$s\"؟ لا يمكن التراجع عن هذا الإجراء.</string>
+    <string name="delete_confirmation_message">هل أنت متأكد أنك تريد حذف "%1$s"؟ لا يمكن التراجع عن هذا الإجراء.</string>
     <string name="this_conversation">هذه المحادثة</string>
 
     <!-- Tag picker -->

--- a/feature/conversations/src/commonMain/composeResources/values-de/strings.xml
+++ b/feature/conversations/src/commonMain/composeResources/values-de/strings.xml
@@ -47,7 +47,7 @@
     <string name="rename_dialog_message">Gib einen neuen Titel für diese Unterhaltung ein.</string>
     <string name="title_label">Titel</string>
     <string name="delete_conversation">Unterhaltung löschen</string>
-    <string name="delete_confirmation_message">Möchtest du \"%1$s\" wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden.</string>
+    <string name="delete_confirmation_message">Möchtest du "%1$s" wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden.</string>
     <string name="this_conversation">diese Unterhaltung</string>
 
     <!-- Tag picker -->

--- a/feature/conversations/src/commonMain/composeResources/values-es/strings.xml
+++ b/feature/conversations/src/commonMain/composeResources/values-es/strings.xml
@@ -47,7 +47,7 @@
     <string name="rename_dialog_message">Introduce un nuevo título para esta conversación.</string>
     <string name="title_label">Título</string>
     <string name="delete_conversation">Eliminar conversación</string>
-    <string name="delete_confirmation_message">¿Seguro que quieres eliminar \"%1$s\"? Esta acción no se puede deshacer.</string>
+    <string name="delete_confirmation_message">¿Seguro que quieres eliminar "%1$s"? Esta acción no se puede deshacer.</string>
     <string name="this_conversation">esta conversación</string>
 
     <!-- Tag picker -->

--- a/feature/conversations/src/commonMain/composeResources/values-fr/strings.xml
+++ b/feature/conversations/src/commonMain/composeResources/values-fr/strings.xml
@@ -17,7 +17,7 @@
     <string name="cd_archived_conversations">Conversations archivées</string>
     <string name="cd_search">Rechercher</string>
     <string name="cd_clear_search">Effacer la recherche</string>
-    <string name="cd_bookmarked">Marqué d\'un signet</string>
+    <string name="cd_bookmarked">Marqué d'un signet</string>
     <string name="cd_conversation_actions">Actions de conversation</string>
     <string name="cd_add_tag">Ajouter une étiquette</string>
     <string name="cd_hide_tags">Masquer les étiquettes</string>
@@ -30,10 +30,10 @@
     <string name="search_conversations">Rechercher des conversations…</string>
     <string name="could_not_load_conversations">Impossible de charger les conversations</string>
     <string name="no_results_found">Aucun résultat trouvé</string>
-    <string name="no_conversations_yet">Aucune conversation pour l\'instant</string>
+    <string name="no_conversations_yet">Aucune conversation pour l'instant</string>
     <string name="try_different_search">Essayez un autre terme de recherche</string>
     <string name="start_new_chat">Démarrez une nouvelle discussion pour commencer</string>
-    <string name="unknown_error">Une erreur inconnue s\'est produite</string>
+    <string name="unknown_error">Une erreur inconnue s'est produite</string>
     <string name="conversation_exported">Conversation exportée</string>
     <string name="link_copied">Lien copié !</string>
     <string name="imported_title">Importée : %1$s</string>
@@ -47,18 +47,18 @@
     <string name="rename_dialog_message">Saisissez un nouveau titre pour cette conversation.</string>
     <string name="title_label">Titre</string>
     <string name="delete_conversation">Supprimer la conversation</string>
-    <string name="delete_confirmation_message">Voulez-vous vraiment supprimer \"%1$s\" ? Cette action est irréversible.</string>
+    <string name="delete_confirmation_message">Voulez-vous vraiment supprimer "%1$s" ? Cette action est irréversible.</string>
     <string name="this_conversation">cette conversation</string>
 
     <!-- Tag picker -->
-    <string name="no_tags_yet">Aucune étiquette pour l\'instant. Ajoutez-en une ci-dessous.</string>
+    <string name="no_tags_yet">Aucune étiquette pour l'instant. Ajoutez-en une ci-dessous.</string>
     <string name="add_new_tag">Ajouter une nouvelle étiquette</string>
 
     <!-- Tag filter bar -->
     <string name="tags_active_count">%1$d étiquette%2$s active(s)</string>
 
     <!-- Export format picker -->
-    <string name="export_format">Format d\'exportation</string>
+    <string name="export_format">Format d'exportation</string>
     <string name="format_json">JSON</string>
     <string name="format_json_description">Exportation complète des données, réimportable</string>
     <string name="format_markdown">Markdown</string>

--- a/feature/conversations/src/commonMain/composeResources/values-ko/strings.xml
+++ b/feature/conversations/src/commonMain/composeResources/values-ko/strings.xml
@@ -47,7 +47,7 @@
     <string name="rename_dialog_message">이 대화의 새 제목을 입력하세요.</string>
     <string name="title_label">제목</string>
     <string name="delete_conversation">대화 삭제</string>
-    <string name="delete_confirmation_message">\"%1$s\"을(를) 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.</string>
+    <string name="delete_confirmation_message">"%1$s"을(를) 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.</string>
     <string name="this_conversation">이 대화</string>
 
     <!-- Tag picker -->

--- a/feature/conversations/src/commonMain/composeResources/values-pt/strings.xml
+++ b/feature/conversations/src/commonMain/composeResources/values-pt/strings.xml
@@ -47,7 +47,7 @@
     <string name="rename_dialog_message">Digite um novo título para esta conversa.</string>
     <string name="title_label">Título</string>
     <string name="delete_conversation">Excluir conversa</string>
-    <string name="delete_confirmation_message">Tem certeza de que deseja excluir \"%1$s\"? Esta ação não pode ser desfeita.</string>
+    <string name="delete_confirmation_message">Tem certeza de que deseja excluir "%1$s"? Esta ação não pode ser desfeita.</string>
     <string name="this_conversation">esta conversa</string>
 
     <!-- Tag picker -->

--- a/feature/conversations/src/commonMain/composeResources/values-ru/strings.xml
+++ b/feature/conversations/src/commonMain/composeResources/values-ru/strings.xml
@@ -47,7 +47,7 @@
     <string name="rename_dialog_message">Введите новое название для этой беседы.</string>
     <string name="title_label">Название</string>
     <string name="delete_conversation">Удалить беседу</string>
-    <string name="delete_confirmation_message">Вы уверены, что хотите удалить \"%1$s\"? Это действие нельзя отменить.</string>
+    <string name="delete_confirmation_message">Вы уверены, что хотите удалить "%1$s"? Это действие нельзя отменить.</string>
     <string name="this_conversation">эту беседу</string>
 
     <!-- Tag picker -->

--- a/feature/conversations/src/commonMain/composeResources/values-zh/strings.xml
+++ b/feature/conversations/src/commonMain/composeResources/values-zh/strings.xml
@@ -47,7 +47,7 @@
     <string name="rename_dialog_message">为此对话输入新标题。</string>
     <string name="title_label">标题</string>
     <string name="delete_conversation">删除对话</string>
-    <string name="delete_confirmation_message">确定要删除 \"%1$s\" 吗？此操作无法撤销。</string>
+    <string name="delete_confirmation_message">确定要删除 "%1$s" 吗？此操作无法撤销。</string>
     <string name="this_conversation">此对话</string>
 
     <!-- Tag picker -->

--- a/feature/conversations/src/commonMain/composeResources/values/strings.xml
+++ b/feature/conversations/src/commonMain/composeResources/values/strings.xml
@@ -70,7 +70,7 @@
     <string name="rename_dialog_message">Enter a new title for this conversation.</string>
     <string name="title_label">Title</string>
     <string name="delete_conversation">Delete conversation</string>
-    <string name="delete_confirmation_message">Are you sure you want to delete \"%1$s\"? This action cannot be undone.</string>
+    <string name="delete_confirmation_message">Are you sure you want to delete "%1$s"? This action cannot be undone.</string>
     <string name="this_conversation">this conversation</string>
 
     <!-- Tag picker -->

--- a/feature/files/src/commonMain/composeResources/values-de/strings.xml
+++ b/feature/files/src/commonMain/composeResources/values-de/strings.xml
@@ -37,7 +37,7 @@
     <string name="delete_count_files">%1$d Datei%2$s löschen?</string>
     <string name="action_cannot_be_undone">Diese Aktion kann nicht rückgängig gemacht werden.</string>
     <string name="delete_file_question">Datei löschen?</string>
-    <string name="delete_file_message">\"%1$s\" löschen? Diese Aktion kann nicht rückgängig gemacht werden.</string>
+    <string name="delete_file_message">"%1$s" löschen? Diese Aktion kann nicht rückgängig gemacht werden.</string>
     <string name="this_file">diese Datei</string>
 
     <!-- File preview -->

--- a/feature/files/src/commonMain/composeResources/values-es/strings.xml
+++ b/feature/files/src/commonMain/composeResources/values-es/strings.xml
@@ -37,7 +37,7 @@
     <string name="delete_count_files">¿Eliminar %1$d archivo%2$s?</string>
     <string name="action_cannot_be_undone">Esta acción no se puede deshacer.</string>
     <string name="delete_file_question">¿Eliminar archivo?</string>
-    <string name="delete_file_message">¿Eliminar \"%1$s\"? Esta acción no se puede deshacer.</string>
+    <string name="delete_file_message">¿Eliminar "%1$s"? Esta acción no se puede deshacer.</string>
     <string name="this_file">este archivo</string>
 
     <!-- File preview -->

--- a/feature/files/src/commonMain/composeResources/values-fr/strings.xml
+++ b/feature/files/src/commonMain/composeResources/values-fr/strings.xml
@@ -17,7 +17,7 @@
     <string name="cd_upload_file">Téléverser un fichier</string>
     <string name="cd_delete_file">Supprimer %1$s</string>
     <string name="cd_thumbnail">Miniature de %1$s</string>
-    <string name="cd_close_preview">Fermer l\'aperçu</string>
+    <string name="cd_close_preview">Fermer l'aperçu</string>
     <string name="cd_cancel_upload">Annuler le téléversement</string>
     <string name="cd_ascending">Croissant</string>
     <string name="cd_descending">Décroissant</string>
@@ -41,12 +41,12 @@
     <string name="this_file">ce fichier</string>
 
     <!-- File preview -->
-    <string name="image_preview_unavailable">Aperçu de l\'image non disponible</string>
+    <string name="image_preview_unavailable">Aperçu de l'image non disponible</string>
     <string name="preview_of">Aperçu de %1$s</string>
     <string name="loading_pdf">Chargement du PDF…</string>
     <string name="page_of">Page %1$d sur %2$d</string>
     <string name="page_cd">Page %1$d sur %2$s</string>
-    <string name="could_not_render_pdf">Impossible d\'afficher l\'aperçu du PDF</string>
+    <string name="could_not_render_pdf">Impossible d'afficher l'aperçu du PDF</string>
     <string name="loading_file_content">Chargement du contenu du fichier…</string>
     <string name="could_not_load_file_content">Impossible de charger le contenu du fichier</string>
     <!-- Info row labels -->
@@ -58,5 +58,5 @@
     <!-- Upload progress -->
     <string name="uploading">Téléversement…</string>
     <string name="failed_to_download_pdf">Échec du téléchargement du PDF</string>
-    <string name="failed_to_render_pdf">Échec de l\'affichage du PDF</string>
+    <string name="failed_to_render_pdf">Échec de l'affichage du PDF</string>
 </resources>

--- a/feature/files/src/commonMain/composeResources/values-pt/strings.xml
+++ b/feature/files/src/commonMain/composeResources/values-pt/strings.xml
@@ -37,7 +37,7 @@
     <string name="delete_count_files">Excluir %1$d arquivo%2$s?</string>
     <string name="action_cannot_be_undone">Esta ação não pode ser desfeita.</string>
     <string name="delete_file_question">Excluir arquivo?</string>
-    <string name="delete_file_message">Excluir \"%1$s\"? Esta ação não pode ser desfeita.</string>
+    <string name="delete_file_message">Excluir "%1$s"? Esta ação não pode ser desfeita.</string>
     <string name="this_file">este arquivo</string>
 
     <!-- File preview -->

--- a/feature/settings/src/commonMain/composeResources/values-ar/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-ar/strings.xml
@@ -309,7 +309,7 @@
     <string name="add_memory">إضافة ذاكرة</string>
     <string name="edit_memory">تعديل الذاكرة</string>
     <string name="dialog_title_delete_memory">حذف الذاكرة</string>
-    <string name="dialog_delete_memory_message">هل أنت متأكد أنك تريد حذف الذاكرة \"%1$s\"؟</string>
+    <string name="dialog_delete_memory_message">هل أنت متأكد أنك تريد حذف الذاكرة "%1$s"؟</string>
     <string name="memory_key_label">المفتاح</string>
     <string name="memory_value_label">القيمة</string>
 
@@ -344,7 +344,7 @@
     <string name="mcp_oauth_scope">النطاق</string>
     <string name="mcp_oauth_scope_placeholder">read execute</string>
     <string name="dialog_title_delete_server">حذف الخادم</string>
-    <string name="dialog_delete_server_message">هل أنت متأكد أنك تريد حذف \"%1$s\"؟</string>
+    <string name="dialog_delete_server_message">هل أنت متأكد أنك تريد حذف "%1$s"؟</string>
     <string name="error_failed_to_load_servers">فشل تحميل الخوادم</string>
     <string name="mcp_tools_count">%1$d أداة%2$s</string>
     <string name="no_tools_available">لا توجد أدوات متاحة</string>
@@ -379,7 +379,7 @@
     <string name="no_api_keys">لا توجد مفاتيح API</string>
     <string name="no_api_keys_desc">أنشئ مفتاح API للوصول إلى API برمجيًا.</string>
     <string name="dialog_title_delete_api_key">حذف مفتاح API</string>
-    <string name="dialog_delete_api_key_message">هل أنت متأكد أنك تريد حذف مفتاح API \"%1$s\"؟ لا يمكن التراجع عن هذا الإجراء.</string>
+    <string name="dialog_delete_api_key_message">هل أنت متأكد أنك تريد حذف مفتاح API "%1$s"؟ لا يمكن التراجع عن هذا الإجراء.</string>
     <string name="created_prefix">تم الإنشاء: %1$s</string>
 
     <!-- API Key create dialog -->
@@ -395,13 +395,13 @@
     <string name="no_presets">لا توجد إعدادات مسبقة</string>
     <string name="no_presets_desc">احفظ الإعدادات المسبقة من شاشة المحادثة لإدارتها هنا</string>
     <string name="dialog_title_delete_preset">حذف الإعداد المسبق</string>
-    <string name="dialog_delete_preset_message">هل أنت متأكد أنك تريد حذف \"%1$s\"؟</string>
+    <string name="dialog_delete_preset_message">هل أنت متأكد أنك تريد حذف "%1$s"؟</string>
 
     <!-- Shared links -->
     <string name="no_shared_links">لا توجد روابط مشتركة</string>
     <string name="no_shared_links_desc">شارك محادثة لرؤيتها هنا</string>
     <string name="dialog_title_delete_shared_link">حذف الرابط المشترك</string>
-    <string name="dialog_delete_shared_link_message">سيؤدي هذا إلى إزالة الرابط المشترك لـ \"%1$s\". لن يتمكن أي شخص لديه الرابط من الوصول إليه بعد الآن.</string>
+    <string name="dialog_delete_shared_link_message">سيؤدي هذا إلى إزالة الرابط المشترك لـ "%1$s". لن يتمكن أي شخص لديه الرابط من الوصول إليه بعد الآن.</string>
     <string name="visibility_public">عام</string>
     <string name="visibility_private">خاص</string>
     <string name="error_failed_to_load_memories">فشل تحميل الذكريات</string>

--- a/feature/settings/src/commonMain/composeResources/values-de/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-de/strings.xml
@@ -309,7 +309,7 @@
     <string name="add_memory">Erinnerung hinzufügen</string>
     <string name="edit_memory">Erinnerung bearbeiten</string>
     <string name="dialog_title_delete_memory">Erinnerung löschen</string>
-    <string name="dialog_delete_memory_message">Möchtest du die Erinnerung \"%1$s\" wirklich löschen?</string>
+    <string name="dialog_delete_memory_message">Möchtest du die Erinnerung "%1$s" wirklich löschen?</string>
     <string name="memory_key_label">Schlüssel</string>
     <string name="memory_value_label">Wert</string>
 
@@ -344,7 +344,7 @@
     <string name="mcp_oauth_scope">Scope</string>
     <string name="mcp_oauth_scope_placeholder">read execute</string>
     <string name="dialog_title_delete_server">Server löschen</string>
-    <string name="dialog_delete_server_message">Möchtest du \"%1$s\" wirklich löschen?</string>
+    <string name="dialog_delete_server_message">Möchtest du "%1$s" wirklich löschen?</string>
     <string name="error_failed_to_load_servers">Server konnten nicht geladen werden</string>
     <string name="mcp_tools_count">%1$d Tool%2$s</string>
     <string name="no_tools_available">Keine Tools verfügbar</string>
@@ -379,7 +379,7 @@
     <string name="no_api_keys">Keine API-Schlüssel</string>
     <string name="no_api_keys_desc">Erstelle einen API-Schlüssel, um programmatisch auf die API zuzugreifen.</string>
     <string name="dialog_title_delete_api_key">API-Schlüssel löschen</string>
-    <string name="dialog_delete_api_key_message">Möchtest du den API-Schlüssel \"%1$s\" wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden.</string>
+    <string name="dialog_delete_api_key_message">Möchtest du den API-Schlüssel "%1$s" wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden.</string>
     <string name="created_prefix">Erstellt: %1$s</string>
 
     <!-- API Key create dialog -->
@@ -395,13 +395,13 @@
     <string name="no_presets">Keine Vorlagen</string>
     <string name="no_presets_desc">Speichere Vorlagen über den Chat-Bildschirm, um sie hier zu verwalten</string>
     <string name="dialog_title_delete_preset">Vorlage löschen</string>
-    <string name="dialog_delete_preset_message">Möchtest du \"%1$s\" wirklich löschen?</string>
+    <string name="dialog_delete_preset_message">Möchtest du "%1$s" wirklich löschen?</string>
 
     <!-- Shared links -->
     <string name="no_shared_links">Keine geteilten Links</string>
     <string name="no_shared_links_desc">Teile eine Unterhaltung, um sie hier zu sehen</string>
     <string name="dialog_title_delete_shared_link">Geteilten Link löschen</string>
-    <string name="dialog_delete_shared_link_message">Dies entfernt den geteilten Link für \"%1$s\". Niemand mit dem Link kann mehr darauf zugreifen.</string>
+    <string name="dialog_delete_shared_link_message">Dies entfernt den geteilten Link für "%1$s". Niemand mit dem Link kann mehr darauf zugreifen.</string>
     <string name="visibility_public">Öffentlich</string>
     <string name="visibility_private">Privat</string>
     <string name="error_failed_to_load_memories">Erinnerungen konnten nicht geladen werden</string>

--- a/feature/settings/src/commonMain/composeResources/values-es/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-es/strings.xml
@@ -309,7 +309,7 @@
     <string name="add_memory">Añadir recuerdo</string>
     <string name="edit_memory">Editar recuerdo</string>
     <string name="dialog_title_delete_memory">Eliminar recuerdo</string>
-    <string name="dialog_delete_memory_message">¿Seguro que quieres eliminar el recuerdo \"%1$s\"?</string>
+    <string name="dialog_delete_memory_message">¿Seguro que quieres eliminar el recuerdo "%1$s"?</string>
     <string name="memory_key_label">Clave</string>
     <string name="memory_value_label">Valor</string>
 
@@ -344,7 +344,7 @@
     <string name="mcp_oauth_scope">Ámbito</string>
     <string name="mcp_oauth_scope_placeholder">read execute</string>
     <string name="dialog_title_delete_server">Eliminar servidor</string>
-    <string name="dialog_delete_server_message">¿Seguro que quieres eliminar \"%1$s\"?</string>
+    <string name="dialog_delete_server_message">¿Seguro que quieres eliminar "%1$s"?</string>
     <string name="error_failed_to_load_servers">Error al cargar los servidores</string>
     <string name="mcp_tools_count">%1$d herramienta%2$s</string>
     <string name="no_tools_available">No hay herramientas disponibles</string>
@@ -379,7 +379,7 @@
     <string name="no_api_keys">No hay claves de API</string>
     <string name="no_api_keys_desc">Crea una clave de API para acceder a la API de forma programática.</string>
     <string name="dialog_title_delete_api_key">Eliminar clave de API</string>
-    <string name="dialog_delete_api_key_message">¿Seguro que quieres eliminar la clave de API \"%1$s\"? Esta acción no se puede deshacer.</string>
+    <string name="dialog_delete_api_key_message">¿Seguro que quieres eliminar la clave de API "%1$s"? Esta acción no se puede deshacer.</string>
     <string name="created_prefix">Creada: %1$s</string>
 
     <!-- API Key create dialog -->
@@ -395,13 +395,13 @@
     <string name="no_presets">No hay preajustes</string>
     <string name="no_presets_desc">Guarda preajustes desde la pantalla de chat para gestionarlos aquí</string>
     <string name="dialog_title_delete_preset">Eliminar preajuste</string>
-    <string name="dialog_delete_preset_message">¿Seguro que quieres eliminar \"%1$s\"?</string>
+    <string name="dialog_delete_preset_message">¿Seguro que quieres eliminar "%1$s"?</string>
 
     <!-- Shared links -->
     <string name="no_shared_links">No hay enlaces compartidos</string>
     <string name="no_shared_links_desc">Comparte una conversación para verla aquí</string>
     <string name="dialog_title_delete_shared_link">Eliminar enlace compartido</string>
-    <string name="dialog_delete_shared_link_message">Esto eliminará el enlace compartido de \"%1$s\". Las personas que tengan el enlace ya no podrán acceder a él.</string>
+    <string name="dialog_delete_shared_link_message">Esto eliminará el enlace compartido de "%1$s". Las personas que tengan el enlace ya no podrán acceder a él.</string>
     <string name="visibility_public">Público</string>
     <string name="visibility_private">Privado</string>
     <string name="error_failed_to_load_memories">Error al cargar los recuerdos</string>

--- a/feature/settings/src/commonMain/composeResources/values-fr/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-fr/strings.xml
@@ -22,7 +22,7 @@
     <string name="cd_add_memory">Ajouter une mémoire</string>
     <string name="cd_add_server">Ajouter un serveur</string>
     <string name="cd_back">Retour</string>
-    <string name="cd_change_avatar">Changer l\'avatar</string>
+    <string name="cd_change_avatar">Changer l'avatar</string>
     <string name="cd_choose_image">Choisir une image</string>
     <string name="cd_collapse_tools">Réduire les outils</string>
     <string name="cd_copy_api_key">Copier la clé API</string>
@@ -44,16 +44,16 @@
     <string name="cd_make_public">Rendre public</string>
     <string name="cd_preview_voice">Aperçu de la voix</string>
     <string name="cd_reinitialize">Réinitialiser</string>
-    <string name="cd_avatar_preview">Aperçu de l\'avatar</string>
+    <string name="cd_avatar_preview">Aperçu de l'avatar</string>
     <string name="cd_selected">Sélectionné</string>
     <string name="cd_selected_avatar">Avatar sélectionné</string>
-    <string name="cd_stop_voice_preview">Arrêter l\'aperçu de la voix</string>
+    <string name="cd_stop_voice_preview">Arrêter l'aperçu de la voix</string>
     <string name="cd_test_tts_voice">Tester la voix TTS sélectionnée</string>
     <string name="cd_toggle_auto_read">Activer/désactiver la lecture automatique des réponses</string>
-    <string name="cd_toggle_auto_send_stt">Activer/désactiver l\'envoi automatique après la dictée</string>
+    <string name="cd_toggle_auto_send_stt">Activer/désactiver l'envoi automatique après la dictée</string>
     <string name="cd_toggle_memories">Activer/désactiver les mémoires</string>
     <string name="cd_tts_voice_selector">Sélectionner la voix TTS. Actuellement %1$s</string>
-    <string name="cd_user_avatar">Avatar de l\'utilisateur</string>
+    <string name="cd_user_avatar">Avatar de l'utilisateur</string>
     <string name="cd_view_all_tools">Voir tous les outils</string>
     <string name="cd_view_tools">Voir les outils</string>
 
@@ -99,11 +99,11 @@
     <string name="theme_dark">Sombre</string>
 
     <!-- Accent color -->
-    <string name="accent_color">Couleur d\'accentuation</string>
+    <string name="accent_color">Couleur d'accentuation</string>
     <string name="accent_color_custom">Personnalisée</string>
     <string name="accent_color_hex">Hex</string>
-    <string name="use_wallpaper_colors">Utiliser les couleurs du fond d\'écran</string>
-    <string name="use_wallpaper_colors_desc">Adapter l\'accentuation de l\'application au fond d\'écran du système (Material You)</string>
+    <string name="use_wallpaper_colors">Utiliser les couleurs du fond d'écran</string>
+    <string name="use_wallpaper_colors_desc">Adapter l'accentuation de l'application au fond d'écran du système (Material You)</string>
 
     <!-- Settings rows -->
     <string name="language">Langue</string>
@@ -115,19 +115,19 @@
     <string name="commands">Commandes</string>
     <string name="commands_enabled_count">%1$d activée(s)</string>
     <string name="api_keys">Clés API</string>
-    <string name="api_keys_subtitle">Gérer les clés API pour l\'accès programmatique</string>
+    <string name="api_keys_subtitle">Gérer les clés API pour l'accès programmatique</string>
     <string name="presets">Préréglages</string>
     <string name="presets_subtitle">Gérer les préréglages de conversation</string>
     <string name="favorites">Favoris</string>
     <string name="favorites_subtitle">Gérer les agents et modèles épinglés</string>
     <string name="favorites_title">Favoris</string>
-    <string name="favorites_empty_title">Aucun favori pour l\'instant</string>
+    <string name="favorites_empty_title">Aucun favori pour l'instant</string>
     <string name="favorites_empty_message">Épinglez des agents ou des modèles depuis le sélecteur de modèle pour les voir ici.</string>
     <string name="favorites_count_of">%1$d sur %2$d</string>
     <string name="favorites_unpin_cd">Désépingler le favori</string>
 
     <!-- About info -->
-    <string name="app_version_label">Version de l\'application</string>
+    <string name="app_version_label">Version de l'application</string>
     <string name="app_build_label">Build</string>
     <string name="server_label">Serveur</string>
     <string name="server_not_configured">Non configuré</string>
@@ -149,11 +149,11 @@
     <string name="chat_layout_thread">Fil</string>
     <string name="chat_layout_two_sided">Discussion à deux côtés</string>
     <string name="chat_layout_thread_desc">Tous les messages alignés à gauche avec avatar et nom</string>
-    <string name="chat_layout_two_sided_desc">Messages de l\'utilisateur à droite, agent à gauche</string>
+    <string name="chat_layout_two_sided_desc">Messages de l'utilisateur à droite, agent à gauche</string>
     <string name="show_bubbles">Afficher les bulles</string>
     <string name="show_bubbles_desc">Ajouter des arrière-plans en bulles arrondies aux messages</string>
     <string name="show_avatars">Afficher les avatars</string>
-    <string name="show_avatars_desc">Afficher les avatars de l\'utilisateur et de l\'agent à côté des messages</string>
+    <string name="show_avatars_desc">Afficher les avatars de l'utilisateur et de l'agent à côté des messages</string>
     <string name="starred_models_title">Modèles favoris</string>
     <string name="starred_models_desc">Afficher vos modèles et agents épinglés en haut du sélecteur de modèle</string>
     <string name="starred_models_off">Désactivé</string>
@@ -175,17 +175,17 @@
     <string name="latex_native">Texte brut (rapide)</string>
     <string name="latex_native_desc">Affiche la source LaTeX brute pour de meilleures performances de défilement</string>
     <string name="auto_scroll">Défilement automatique pendant le streaming</string>
-    <string name="auto_scroll_desc">Faire défiler automatiquement vers le nouveau contenu pendant la génération d\'une réponse</string>
+    <string name="auto_scroll_desc">Faire défiler automatiquement vers le nouveau contenu pendant la génération d'une réponse</string>
     <string name="show_thinking_blocks">Afficher les blocs de réflexion</string>
-    <string name="show_thinking_blocks_desc">Afficher les étapes de raisonnement du modèle lorsqu\'elles sont disponibles</string>
-    <string name="show_image_descriptions">Afficher les descriptions d\'images</string>
-    <string name="show_image_descriptions_desc">Afficher les invites d\'image générées par l\'IA sous les images</string>
-    <string name="dismiss_keyboard_on_send">Masquer le clavier après l\'envoi</string>
-    <string name="dismiss_keyboard_on_send_desc">Masquer automatiquement le clavier après l\'envoi d\'un message</string>
+    <string name="show_thinking_blocks_desc">Afficher les étapes de raisonnement du modèle lorsqu'elles sont disponibles</string>
+    <string name="show_image_descriptions">Afficher les descriptions d'images</string>
+    <string name="show_image_descriptions_desc">Afficher les invites d'image générées par l'IA sous les images</string>
+    <string name="dismiss_keyboard_on_send">Masquer le clavier après l'envoi</string>
+    <string name="dismiss_keyboard_on_send_desc">Masquer automatiquement le clavier après l'envoi d'un message</string>
 
     <!-- Artifacts -->
     <string name="section_artifacts">Artefacts</string>
-    <string name="artifacts_section_desc">Afficher les artefacts directement dans la discussion au lieu d\'une carte à ouvrir d\'une pression. Appuyez sur un artefact intégré pour ouvrir l\'affichage plein écran.</string>
+    <string name="artifacts_section_desc">Afficher les artefacts directement dans la discussion au lieu d'une carte à ouvrir d'une pression. Appuyez sur un artefact intégré pour ouvrir l'affichage plein écran.</string>
     <string name="inline_artifact_mermaid">Diagrammes Mermaid</string>
     <string name="inline_artifact_mermaid_desc">Afficher les organigrammes et diagrammes Mermaid en ligne</string>
     <string name="inline_artifact_svg">Images SVG</string>
@@ -199,19 +199,19 @@
 
     <!-- Security -->
     <string name="two_factor_auth">Authentification à deux facteurs</string>
-    <string name="enable_two_factor">Activer l\'authentification à deux facteurs</string>
-    <string name="disable_two_factor">Désactiver l\'authentification à deux facteurs</string>
+    <string name="enable_two_factor">Activer l'authentification à deux facteurs</string>
+    <string name="disable_two_factor">Désactiver l'authentification à deux facteurs</string>
     <string name="view_backup_codes">Voir les codes de secours</string>
 
     <!-- 2FA setup dialog -->
-    <string name="dialog_title_enable_2fa">Activer l\'authentification à deux facteurs</string>
-    <string name="dialog_title_disable_2fa">Désactiver l\'authentification à deux facteurs</string>
-    <string name="twofa_scan_instructions">Copiez l\'URI ci-dessous et collez-le dans votre application d\'authentification (par ex. Google Authenticator, Authy), puis saisissez le code de vérification.</string>
-    <string name="twofa_disable_instructions">Saisissez le code de votre application d\'authentification pour désactiver la 2FA.</string>
+    <string name="dialog_title_enable_2fa">Activer l'authentification à deux facteurs</string>
+    <string name="dialog_title_disable_2fa">Désactiver l'authentification à deux facteurs</string>
+    <string name="twofa_scan_instructions">Copiez l'URI ci-dessous et collez-le dans votre application d'authentification (par ex. Google Authenticator, Authy), puis saisissez le code de vérification.</string>
+    <string name="twofa_disable_instructions">Saisissez le code de votre application d'authentification pour désactiver la 2FA.</string>
     <string name="hint_verification_code">Code de vérification</string>
 
     <!-- OTP verification dialogs -->
-    <string name="otp_title_verify_identity">Vérifier l\'identité</string>
+    <string name="otp_title_verify_identity">Vérifier l'identité</string>
     <string name="otp_desc_delete_account">Saisissez votre code 2FA pour supprimer votre compte.</string>
     <string name="otp_desc_reenroll_2fa">Saisissez votre code 2FA actuel pour vous réinscrire.</string>
     <string name="otp_desc_regenerate_backup_codes">Saisissez votre code 2FA pour régénérer les codes de secours.</string>
@@ -223,7 +223,7 @@
 
     <!-- Backup codes dialog -->
     <string name="dialog_title_backup_codes">Codes de secours</string>
-    <string name="backup_codes_instructions">Conservez ces codes de secours en lieu sûr. Chaque code ne peut être utilisé qu\'une seule fois.</string>
+    <string name="backup_codes_instructions">Conservez ces codes de secours en lieu sûr. Chaque code ne peut être utilisé qu'une seule fois.</string>
 
     <!-- Danger zone -->
     <string name="delete_account">Supprimer le compte</string>
@@ -266,11 +266,11 @@
     <string name="auto_send_after_speech">Envoi automatique après la dictée</string>
     <string name="auto_send_after_speech_desc">Envoyer automatiquement le message après la fin de la reconnaissance vocale</string>
     <string name="auto_read_responses">Lecture automatique des réponses</string>
-    <string name="auto_read_responses_desc">Lire automatiquement les réponses de l\'IA à voix haute via la synthèse vocale</string>
+    <string name="auto_read_responses_desc">Lire automatiquement les réponses de l'IA à voix haute via la synthèse vocale</string>
     <string name="tts_voice">Voix TTS</string>
     <string name="test_voice">Tester la voix</string>
     <string name="no_server_tts_voices">Aucune voix TTS de serveur disponible. Les fonctions vocales ne sont peut-être pas configurées sur le serveur.</string>
-    <string name="using_device_tts">Utilisation du moteur de synthèse vocale de l\'appareil. Configurez la voix et la vitesse dans les Paramètres de synthèse vocale ci-dessous.</string>
+    <string name="using_device_tts">Utilisation du moteur de synthèse vocale de l'appareil. Configurez la voix et la vitesse dans les Paramètres de synthèse vocale ci-dessous.</string>
     <string name="speech_to_text_settings">Paramètres de reconnaissance vocale</string>
     <string name="text_to_speech_settings">Paramètres de synthèse vocale</string>
 
@@ -281,11 +281,11 @@
     <string name="stt_engine_browser">Intégré</string>
     <string name="stt_engine_external">Serveur</string>
     <string name="stt_hint_browser">Utilise le moteur de reconnaissance vocale intégré de votre appareil pour la transcription en direct.</string>
-    <string name="stt_hint_external">Envoie l\'audio à votre serveur pour la reconnaissance vocale (Whisper). La reconnaissance vocale doit être activée sur votre serveur.</string>
-    <string name="stt_on_device_toggle">Reconnaissance sur l\'appareil</string>
+    <string name="stt_hint_external">Envoie l'audio à votre serveur pour la reconnaissance vocale (Whisper). La reconnaissance vocale doit être activée sur votre serveur.</string>
+    <string name="stt_on_device_toggle">Reconnaissance sur l'appareil</string>
     <string name="stt_on_device_toggle_desc">Transcrit sur cet appareil plutôt que dans le cloud. Bascule sur la reconnaissance cloud si indisponible.</string>
     <string name="stt_end_of_speech_toggle">Arrêter quand je fais une pause</string>
-    <string name="stt_end_of_speech_toggle_desc">Termine la dictée automatiquement dès que vous arrêtez de parler, au lieu de continuer jusqu\'à ce que vous touchiez arrêter. Avec l\'envoi automatique après la parole activé, le message est envoyé en mode mains libres.</string>
+    <string name="stt_end_of_speech_toggle_desc">Termine la dictée automatiquement dès que vous arrêtez de parler, au lieu de continuer jusqu'à ce que vous touchiez arrêter. Avec l'envoi automatique après la parole activé, le message est envoyé en mode mains libres.</string>
     <string name="stt_auto_detect">Détection automatique</string>
 
     <!-- TTS detail dialog -->
@@ -296,27 +296,27 @@
     <string name="tts_system_default">Par défaut du système</string>
     <string name="tts_speech_rate">Débit de parole : %1$.1fx</string>
     <string name="tts_pitch">Hauteur : %1$.1f</string>
-    <string name="tts_cache_audio">Mettre l\'audio en cache</string>
+    <string name="tts_cache_audio">Mettre l'audio en cache</string>
     <string name="tts_preview_text">Ceci est un aperçu de la voix sélectionnée.</string>
-    <string name="tts_stop_preview">Arrêter l\'aperçu</string>
+    <string name="tts_stop_preview">Arrêter l'aperçu</string>
     <string name="tts_preview_voice">Aperçu de la voix</string>
 
     <!-- Memories -->
     <string name="enable_memories">Activer les mémoires</string>
-    <string name="enable_memories_desc">Permettre à l\'IA de mémoriser des informations entre les conversations</string>
-    <string name="no_memories_saved">Aucune mémoire enregistrée pour l\'instant</string>
+    <string name="enable_memories_desc">Permettre à l'IA de mémoriser des informations entre les conversations</string>
+    <string name="no_memories_saved">Aucune mémoire enregistrée pour l'instant</string>
     <string name="memories_add_hint">Appuyez sur le bouton + pour ajouter une mémoire</string>
     <string name="add_memory">Ajouter une mémoire</string>
     <string name="edit_memory">Modifier la mémoire</string>
     <string name="dialog_title_delete_memory">Supprimer la mémoire</string>
-    <string name="dialog_delete_memory_message">Voulez-vous vraiment supprimer la mémoire \"%1$s\" ?</string>
+    <string name="dialog_delete_memory_message">Voulez-vous vraiment supprimer la mémoire "%1$s" ?</string>
     <string name="memory_key_label">Clé</string>
     <string name="memory_value_label">Valeur</string>
 
     <!-- MCP -->
     <string name="add_mcp_server">Ajouter un serveur MCP</string>
     <string name="edit_mcp_server">Modifier le serveur MCP</string>
-    <string name="mcp_not_available">MCP n\'est pas disponible sur ce serveur</string>
+    <string name="mcp_not_available">MCP n'est pas disponible sur ce serveur</string>
     <string name="no_mcp_servers">Aucun serveur MCP configuré</string>
     <string name="mcp_add_hint">Appuyez sur le bouton + pour ajouter un serveur</string>
     <string name="mcp_name_label">Nom</string>
@@ -334,27 +334,27 @@
     <string name="mcp_auth_bearer">Bearer</string>
     <string name="mcp_auth_basic">Basic</string>
     <string name="mcp_auth_custom">Personnalisé</string>
-    <string name="mcp_header_name_label">Nom de l\'en-tête</string>
+    <string name="mcp_header_name_label">Nom de l'en-tête</string>
     <string name="mcp_header_name_placeholder">X-API-Key</string>
     <string name="mcp_api_key_label">Clé API</string>
     <string name="mcp_oauth_client_id">ID client</string>
     <string name="mcp_oauth_client_secret">Secret client</string>
-    <string name="mcp_oauth_auth_url">URL d\'autorisation</string>
+    <string name="mcp_oauth_auth_url">URL d'autorisation</string>
     <string name="mcp_oauth_token_url">URL du jeton</string>
     <string name="mcp_oauth_scope">Portée</string>
     <string name="mcp_oauth_scope_placeholder">read execute</string>
     <string name="dialog_title_delete_server">Supprimer le serveur</string>
-    <string name="dialog_delete_server_message">Voulez-vous vraiment supprimer \"%1$s\" ?</string>
+    <string name="dialog_delete_server_message">Voulez-vous vraiment supprimer "%1$s" ?</string>
     <string name="error_failed_to_load_servers">Échec du chargement des serveurs</string>
     <string name="mcp_tools_count">%1$d outil%2$s</string>
     <string name="no_tools_available">Aucun outil disponible</string>
     <!-- Fork settings -->
     <string name="fork_mode_direct_path">Messages visibles</string>
-    <string name="fork_mode_direct_path_desc">Uniquement le chemin direct des messages jusqu\'au message sélectionné</string>
+    <string name="fork_mode_direct_path_desc">Uniquement le chemin direct des messages jusqu'au message sélectionné</string>
     <string name="fork_mode_include_branches">Inclure les branches</string>
     <string name="fork_mode_include_branches_desc">Chemin direct plus les messages frères à chaque niveau</string>
-    <string name="fork_mode_target_level">Tout jusqu\'au niveau cible</string>
-    <string name="fork_mode_target_level_desc">Tous les messages et branches jusqu\'au niveau du message cible (par défaut)</string>
+    <string name="fork_mode_target_level">Tout jusqu'au niveau cible</string>
+    <string name="fork_mode_target_level_desc">Tous les messages et branches jusqu'au niveau du message cible (par défaut)</string>
 
     <!-- Language selector -->
     <string name="hint_search_languages">Rechercher des langues</string>
@@ -362,24 +362,24 @@
     <!-- Personalization dialog -->
     <string name="enable_personalization">Activer la personnalisation</string>
     <string name="about_you_label">À propos de vous</string>
-    <string name="about_you_hint">Que doit savoir l\'IA à votre sujet pour le contexte ?</string>
-    <string name="response_style_label">Comment l\'IA doit-elle répondre ?</string>
+    <string name="about_you_hint">Que doit savoir l'IA à votre sujet pour le contexte ?</string>
+    <string name="response_style_label">Comment l'IA doit-elle répondre ?</string>
     <string name="response_style_hint">Ton, format ou style préféré pour les réponses</string>
 
     <!-- Commands screen -->
     <string name="no_commands_available">Aucune commande disponible</string>
 
     <!-- Avatar upload dialog -->
-    <string name="dialog_title_update_avatar">Mettre à jour l\'avatar</string>
-    <string name="avatar_choose_hint">Appuyez sur l\'icône de l\'appareil photo pour choisir une image</string>
+    <string name="dialog_title_update_avatar">Mettre à jour l'avatar</string>
+    <string name="avatar_choose_hint">Appuyez sur l'icône de l'appareil photo pour choisir une image</string>
 
     <!-- API Keys screen -->
     <string name="api_keys_not_available">Clés API non disponibles</string>
-    <string name="api_keys_not_supported">Cette fonctionnalité n\'est pas prise en charge sur la version de votre serveur.</string>
+    <string name="api_keys_not_supported">Cette fonctionnalité n'est pas prise en charge sur la version de votre serveur.</string>
     <string name="no_api_keys">Aucune clé API</string>
-    <string name="no_api_keys_desc">Créez une clé API pour accéder à l\'API de manière programmatique.</string>
+    <string name="no_api_keys_desc">Créez une clé API pour accéder à l'API de manière programmatique.</string>
     <string name="dialog_title_delete_api_key">Supprimer la clé API</string>
-    <string name="dialog_delete_api_key_message">Voulez-vous vraiment supprimer la clé API \"%1$s\" ? Cette action est irréversible.</string>
+    <string name="dialog_delete_api_key_message">Voulez-vous vraiment supprimer la clé API "%1$s" ? Cette action est irréversible.</string>
     <string name="created_prefix">Créée le : %1$s</string>
 
     <!-- API Key create dialog -->
@@ -393,15 +393,15 @@
 
     <!-- Preset manager -->
     <string name="no_presets">Aucun préréglage</string>
-    <string name="no_presets_desc">Enregistrez des préréglages depuis l\'écran de discussion pour les gérer ici</string>
+    <string name="no_presets_desc">Enregistrez des préréglages depuis l'écran de discussion pour les gérer ici</string>
     <string name="dialog_title_delete_preset">Supprimer le préréglage</string>
-    <string name="dialog_delete_preset_message">Voulez-vous vraiment supprimer \"%1$s\" ?</string>
+    <string name="dialog_delete_preset_message">Voulez-vous vraiment supprimer "%1$s" ?</string>
 
     <!-- Shared links -->
     <string name="no_shared_links">Aucun lien partagé</string>
     <string name="no_shared_links_desc">Partagez une conversation pour la voir ici</string>
     <string name="dialog_title_delete_shared_link">Supprimer le lien partagé</string>
-    <string name="dialog_delete_shared_link_message">Ceci supprimera le lien partagé pour \"%1$s\". Quiconque possède le lien ne pourra plus y accéder.</string>
+    <string name="dialog_delete_shared_link_message">Ceci supprimera le lien partagé pour "%1$s". Quiconque possède le lien ne pourra plus y accéder.</string>
     <string name="visibility_public">Public</string>
     <string name="visibility_private">Privé</string>
     <string name="error_failed_to_load_memories">Échec du chargement des mémoires</string>
@@ -411,7 +411,7 @@
     <string name="provider_keys_subtitle">Définissez vos propres clés pour les points de terminaison qui les nécessitent</string>
     <string name="provider_keys_dialog_title">Définir la clé API pour %1$s</string>
     <string name="provider_keys_status_set_expires">Expire dans %1$s</string>
-    <string name="provider_keys_status_set_never">Votre clé n\'expirera jamais</string>
+    <string name="provider_keys_status_set_never">Votre clé n'expirera jamais</string>
     <string name="provider_keys_status_unset">Non définie</string>
     <string name="provider_keys_status_expired">Expirée</string>
     <string name="provider_keys_status_loading">Vérification du statut de la clé…</string>
@@ -419,12 +419,12 @@
     <string name="provider_keys_field_base_url_label">URL de base</string>
     <string name="provider_keys_field_base_url_optional_suffix">(Facultatif)</string>
     <string name="provider_keys_field_api_key_for_endpoint">Clé API %1$s</string>
-    <string name="provider_keys_field_api_url_for_endpoint">URL de l\'API %1$s</string>
+    <string name="provider_keys_field_api_url_for_endpoint">URL de l'API %1$s</string>
 
     <string name="provider_keys_field_azure_api_key">Clé API Azure OpenAI</string>
-    <string name="provider_keys_field_azure_instance">Nom de l\'instance Azure</string>
+    <string name="provider_keys_field_azure_instance">Nom de l'instance Azure</string>
     <string name="provider_keys_field_azure_deployment">Nom du déploiement Azure</string>
-    <string name="provider_keys_field_azure_api_version">Version de l\'API Azure</string>
+    <string name="provider_keys_field_azure_api_version">Version de l'API Azure</string>
 
     <string name="provider_keys_field_google_api_key">Clé API Google</string>
     <string name="provider_keys_field_google_gemini_api">(API Gemini)</string>
@@ -436,8 +436,8 @@
     <string name="provider_keys_field_google_paste_only_hint">Collez le JSON du compte de service ci-dessous.</string>
     <string name="provider_keys_field_google_service_key_or_gemini">Clé de service Google ou clé API Gemini</string>
 
-    <string name="provider_keys_field_bedrock_access_key_id">ID de clé d\'accès</string>
-    <string name="provider_keys_field_bedrock_secret_access_key">Clé d\'accès secrète</string>
+    <string name="provider_keys_field_bedrock_access_key_id">ID de clé d'accès</string>
+    <string name="provider_keys_field_bedrock_secret_access_key">Clé d'accès secrète</string>
     <string name="provider_keys_field_bedrock_session_token">Jeton de session</string>
     <string name="provider_keys_field_bedrock_session_token_optional_suffix">(Facultatif)</string>
 
@@ -448,7 +448,7 @@
     <string name="provider_keys_revoke_all">Révoquer les clés</string>
     <string name="provider_keys_revoke_all_confirm">Voulez-vous vraiment révoquer toutes les clés ?</string>
     <string name="provider_keys_revoke_all_failed">Échec de la révocation de toutes les clés</string>
-    <string name="provider_keys_save_failed">Échec de l\'enregistrement de la clé API. Veuillez réessayer.</string>
+    <string name="provider_keys_save_failed">Échec de l'enregistrement de la clé API. Veuillez réessayer.</string>
     <string name="provider_keys_save_success">Clé API enregistrée avec succès</string>
 
     <string name="provider_keys_expiry_label">Expire</string>
@@ -460,7 +460,7 @@
     <string name="provider_keys_expiry_30d">dans 30 jours</string>
     <string name="provider_keys_expiry_never">jamais</string>
 
-    <string name="provider_keys_empty_title">Aucun point de terminaison ne nécessite de clés fournies par l\'utilisateur</string>
+    <string name="provider_keys_empty_title">Aucun point de terminaison ne nécessite de clés fournies par l'utilisateur</string>
     <string name="provider_keys_empty_desc">Les points de terminaison qui nécessitent votre propre clé API apparaîtront ici.</string>
     <string name="provider_keys_revoke_all_action">Tout révoquer</string>
 
@@ -468,7 +468,7 @@
     <string name="role_skills_settings_row">Accès aux compétences (admin)</string>
     <string name="role_skills_title">Accès aux compétences</string>
     <string name="role_skills_back">Retour</string>
-    <string name="role_skills_description">Contrôlez les capacités de compétences dont dispose chaque rôle. Les modifications s\'appliquent à tous les utilisateurs ayant le rôle sélectionné.</string>
+    <string name="role_skills_description">Contrôlez les capacités de compétences dont dispose chaque rôle. Les modifications s'appliquent à tous les utilisateurs ayant le rôle sélectionné.</string>
     <string name="role_skills_role_label">Rôle</string>
     <string name="role_skills_use">Utiliser les compétences</string>
     <string name="role_skills_create">Créer &amp; modifier des compétences</string>

--- a/feature/settings/src/commonMain/composeResources/values-ko/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-ko/strings.xml
@@ -309,7 +309,7 @@
     <string name="add_memory">메모리 추가</string>
     <string name="edit_memory">메모리 편집</string>
     <string name="dialog_title_delete_memory">메모리 삭제</string>
-    <string name="dialog_delete_memory_message">메모리 \"%1$s\"을(를) 삭제하시겠습니까?</string>
+    <string name="dialog_delete_memory_message">메모리 "%1$s"을(를) 삭제하시겠습니까?</string>
     <string name="memory_key_label">키</string>
     <string name="memory_value_label">값</string>
 
@@ -344,7 +344,7 @@
     <string name="mcp_oauth_scope">Scope</string>
     <string name="mcp_oauth_scope_placeholder">read execute</string>
     <string name="dialog_title_delete_server">서버 삭제</string>
-    <string name="dialog_delete_server_message">\"%1$s\"을(를) 삭제하시겠습니까?</string>
+    <string name="dialog_delete_server_message">"%1$s"을(를) 삭제하시겠습니까?</string>
     <string name="error_failed_to_load_servers">서버를 불러오지 못했습니다</string>
     <string name="mcp_tools_count">도구 %1$d개%2$s</string>
     <string name="no_tools_available">사용 가능한 도구가 없습니다</string>
@@ -379,7 +379,7 @@
     <string name="no_api_keys">API 키 없음</string>
     <string name="no_api_keys_desc">프로그래밍 방식으로 API에 접근하려면 API 키를 생성하세요.</string>
     <string name="dialog_title_delete_api_key">API 키 삭제</string>
-    <string name="dialog_delete_api_key_message">API 키 \"%1$s\"을(를) 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.</string>
+    <string name="dialog_delete_api_key_message">API 키 "%1$s"을(를) 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.</string>
     <string name="created_prefix">생성: %1$s</string>
 
     <!-- API Key create dialog -->
@@ -395,13 +395,13 @@
     <string name="no_presets">프리셋 없음</string>
     <string name="no_presets_desc">채팅 화면에서 프리셋을 저장하면 여기에서 관리할 수 있습니다</string>
     <string name="dialog_title_delete_preset">프리셋 삭제</string>
-    <string name="dialog_delete_preset_message">\"%1$s\"을(를) 삭제하시겠습니까?</string>
+    <string name="dialog_delete_preset_message">"%1$s"을(를) 삭제하시겠습니까?</string>
 
     <!-- Shared links -->
     <string name="no_shared_links">공유 링크 없음</string>
     <string name="no_shared_links_desc">대화를 공유하면 여기에 표시됩니다</string>
     <string name="dialog_title_delete_shared_link">공유 링크 삭제</string>
-    <string name="dialog_delete_shared_link_message">\"%1$s\"의 공유 링크를 제거합니다. 링크를 가진 사람은 더 이상 접근할 수 없습니다.</string>
+    <string name="dialog_delete_shared_link_message">"%1$s"의 공유 링크를 제거합니다. 링크를 가진 사람은 더 이상 접근할 수 없습니다.</string>
     <string name="visibility_public">공개</string>
     <string name="visibility_private">비공개</string>
     <string name="error_failed_to_load_memories">메모리를 불러오지 못했습니다</string>

--- a/feature/settings/src/commonMain/composeResources/values-pt/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-pt/strings.xml
@@ -309,7 +309,7 @@
     <string name="add_memory">Adicionar memória</string>
     <string name="edit_memory">Editar memória</string>
     <string name="dialog_title_delete_memory">Excluir memória</string>
-    <string name="dialog_delete_memory_message">Tem certeza de que deseja excluir a memória \"%1$s\"?</string>
+    <string name="dialog_delete_memory_message">Tem certeza de que deseja excluir a memória "%1$s"?</string>
     <string name="memory_key_label">Chave</string>
     <string name="memory_value_label">Valor</string>
 
@@ -344,7 +344,7 @@
     <string name="mcp_oauth_scope">Escopo</string>
     <string name="mcp_oauth_scope_placeholder">read execute</string>
     <string name="dialog_title_delete_server">Excluir servidor</string>
-    <string name="dialog_delete_server_message">Tem certeza de que deseja excluir \"%1$s\"?</string>
+    <string name="dialog_delete_server_message">Tem certeza de que deseja excluir "%1$s"?</string>
     <string name="error_failed_to_load_servers">Falha ao carregar os servidores</string>
     <string name="mcp_tools_count">%1$d ferramenta%2$s</string>
     <string name="no_tools_available">Nenhuma ferramenta disponível</string>
@@ -379,7 +379,7 @@
     <string name="no_api_keys">Nenhuma chave de API</string>
     <string name="no_api_keys_desc">Crie uma chave de API para acessar a API de forma programática.</string>
     <string name="dialog_title_delete_api_key">Excluir chave de API</string>
-    <string name="dialog_delete_api_key_message">Tem certeza de que deseja excluir a chave de API \"%1$s\"? Esta ação não pode ser desfeita.</string>
+    <string name="dialog_delete_api_key_message">Tem certeza de que deseja excluir a chave de API "%1$s"? Esta ação não pode ser desfeita.</string>
     <string name="created_prefix">Criada: %1$s</string>
 
     <!-- API Key create dialog -->
@@ -395,13 +395,13 @@
     <string name="no_presets">Nenhuma predefinição</string>
     <string name="no_presets_desc">Salve predefinições na tela de conversa para gerenciá-las aqui</string>
     <string name="dialog_title_delete_preset">Excluir predefinição</string>
-    <string name="dialog_delete_preset_message">Tem certeza de que deseja excluir \"%1$s\"?</string>
+    <string name="dialog_delete_preset_message">Tem certeza de que deseja excluir "%1$s"?</string>
 
     <!-- Shared links -->
     <string name="no_shared_links">Nenhum link compartilhado</string>
     <string name="no_shared_links_desc">Compartilhe uma conversa para vê-la aqui</string>
     <string name="dialog_title_delete_shared_link">Excluir link compartilhado</string>
-    <string name="dialog_delete_shared_link_message">Isso removerá o link compartilhado de \"%1$s\". Quem tiver o link não conseguirá mais acessá-lo.</string>
+    <string name="dialog_delete_shared_link_message">Isso removerá o link compartilhado de "%1$s". Quem tiver o link não conseguirá mais acessá-lo.</string>
     <string name="visibility_public">Público</string>
     <string name="visibility_private">Privado</string>
     <string name="error_failed_to_load_memories">Falha ao carregar as memórias</string>

--- a/feature/settings/src/commonMain/composeResources/values-ru/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-ru/strings.xml
@@ -309,7 +309,7 @@
     <string name="add_memory">Добавить запись памяти</string>
     <string name="edit_memory">Изменить запись памяти</string>
     <string name="dialog_title_delete_memory">Удалить запись памяти</string>
-    <string name="dialog_delete_memory_message">Вы уверены, что хотите удалить запись памяти \"%1$s\"?</string>
+    <string name="dialog_delete_memory_message">Вы уверены, что хотите удалить запись памяти "%1$s"?</string>
     <string name="memory_key_label">Ключ</string>
     <string name="memory_value_label">Значение</string>
 
@@ -344,7 +344,7 @@
     <string name="mcp_oauth_scope">Область</string>
     <string name="mcp_oauth_scope_placeholder">read execute</string>
     <string name="dialog_title_delete_server">Удалить сервер</string>
-    <string name="dialog_delete_server_message">Вы уверены, что хотите удалить \"%1$s\"?</string>
+    <string name="dialog_delete_server_message">Вы уверены, что хотите удалить "%1$s"?</string>
     <string name="error_failed_to_load_servers">Не удалось загрузить серверы</string>
     <string name="mcp_tools_count">%1$d инструмент%2$s</string>
     <string name="no_tools_available">Нет доступных инструментов</string>
@@ -379,7 +379,7 @@
     <string name="no_api_keys">Нет API-ключей</string>
     <string name="no_api_keys_desc">Создайте API-ключ для программного доступа к API.</string>
     <string name="dialog_title_delete_api_key">Удалить API-ключ</string>
-    <string name="dialog_delete_api_key_message">Вы уверены, что хотите удалить API-ключ \"%1$s\"? Это действие нельзя отменить.</string>
+    <string name="dialog_delete_api_key_message">Вы уверены, что хотите удалить API-ключ "%1$s"? Это действие нельзя отменить.</string>
     <string name="created_prefix">Создан: %1$s</string>
 
     <!-- API Key create dialog -->
@@ -395,13 +395,13 @@
     <string name="no_presets">Нет пресетов</string>
     <string name="no_presets_desc">Сохраняйте пресеты на экране чата, чтобы управлять ими здесь</string>
     <string name="dialog_title_delete_preset">Удалить пресет</string>
-    <string name="dialog_delete_preset_message">Вы уверены, что хотите удалить \"%1$s\"?</string>
+    <string name="dialog_delete_preset_message">Вы уверены, что хотите удалить "%1$s"?</string>
 
     <!-- Shared links -->
     <string name="no_shared_links">Нет общих ссылок</string>
     <string name="no_shared_links_desc">Поделитесь беседой, чтобы увидеть её здесь</string>
     <string name="dialog_title_delete_shared_link">Удалить общую ссылку</string>
-    <string name="dialog_delete_shared_link_message">Это удалит общую ссылку для \"%1$s\". Никто из тех, у кого есть ссылка, больше не сможет получить к ней доступ.</string>
+    <string name="dialog_delete_shared_link_message">Это удалит общую ссылку для "%1$s". Никто из тех, у кого есть ссылка, больше не сможет получить к ней доступ.</string>
     <string name="visibility_public">Публичная</string>
     <string name="visibility_private">Приватная</string>
     <string name="error_failed_to_load_memories">Не удалось загрузить записи памяти</string>

--- a/feature/settings/src/commonMain/composeResources/values-zh/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-zh/strings.xml
@@ -309,7 +309,7 @@
     <string name="add_memory">添加记忆</string>
     <string name="edit_memory">编辑记忆</string>
     <string name="dialog_title_delete_memory">删除记忆</string>
-    <string name="dialog_delete_memory_message">确定要删除记忆 \"%1$s\" 吗？</string>
+    <string name="dialog_delete_memory_message">确定要删除记忆 "%1$s" 吗？</string>
     <string name="memory_key_label">键</string>
     <string name="memory_value_label">值</string>
 
@@ -344,7 +344,7 @@
     <string name="mcp_oauth_scope">作用域</string>
     <string name="mcp_oauth_scope_placeholder">read execute</string>
     <string name="dialog_title_delete_server">删除服务器</string>
-    <string name="dialog_delete_server_message">确定要删除 \"%1$s\" 吗？</string>
+    <string name="dialog_delete_server_message">确定要删除 "%1$s" 吗？</string>
     <string name="error_failed_to_load_servers">加载服务器失败</string>
     <string name="mcp_tools_count">%1$d 个工具%2$s</string>
     <string name="no_tools_available">没有可用的工具</string>
@@ -379,7 +379,7 @@
     <string name="no_api_keys">没有 API 密钥</string>
     <string name="no_api_keys_desc">创建一个 API 密钥以程序化访问 API。</string>
     <string name="dialog_title_delete_api_key">删除 API 密钥</string>
-    <string name="dialog_delete_api_key_message">确定要删除 API 密钥 \"%1$s\" 吗？此操作无法撤销。</string>
+    <string name="dialog_delete_api_key_message">确定要删除 API 密钥 "%1$s" 吗？此操作无法撤销。</string>
     <string name="created_prefix">创建于：%1$s</string>
 
     <!-- API Key create dialog -->
@@ -395,13 +395,13 @@
     <string name="no_presets">没有预设</string>
     <string name="no_presets_desc">从聊天界面保存预设，即可在此管理</string>
     <string name="dialog_title_delete_preset">删除预设</string>
-    <string name="dialog_delete_preset_message">确定要删除 \"%1$s\" 吗？</string>
+    <string name="dialog_delete_preset_message">确定要删除 "%1$s" 吗？</string>
 
     <!-- Shared links -->
     <string name="no_shared_links">没有分享链接</string>
     <string name="no_shared_links_desc">分享一个对话即可在此查看</string>
     <string name="dialog_title_delete_shared_link">删除分享链接</string>
-    <string name="dialog_delete_shared_link_message">这将移除 \"%1$s\" 的分享链接。拥有该链接的人将无法再访问它。</string>
+    <string name="dialog_delete_shared_link_message">这将移除 "%1$s" 的分享链接。拥有该链接的人将无法再访问它。</string>
     <string name="visibility_public">公开</string>
     <string name="visibility_private">私有</string>
     <string name="error_failed_to_load_memories">加载记忆失败</string>

--- a/feature/settings/src/commonMain/composeResources/values/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values/strings.xml
@@ -303,7 +303,7 @@
     <string name="stt_default">Default</string>
     <string name="stt_engine_browser">Built-in</string>
     <string name="stt_engine_external">Server</string>
-    <string name="stt_hint_browser">Uses your device\'s built-in speech recognizer for live transcription.</string>
+    <string name="stt_hint_browser">Uses your device's built-in speech recognizer for live transcription.</string>
     <string name="stt_hint_external">Uploads audio to your server for speech-to-text (Whisper). Your server must have STT enabled.</string>
     <string name="stt_on_device_toggle">On-device recognition</string>
     <string name="stt_on_device_toggle_desc">Transcribe on this device instead of the cloud. Falls back to the cloud recognizer if unavailable.</string>
@@ -332,7 +332,7 @@
     <string name="add_memory">Add Memory</string>
     <string name="edit_memory">Edit Memory</string>
     <string name="dialog_title_delete_memory">Delete Memory</string>
-    <string name="dialog_delete_memory_message">Are you sure you want to delete the memory \"%1$s\"?</string>
+    <string name="dialog_delete_memory_message">Are you sure you want to delete the memory "%1$s"?</string>
     <string name="memory_key_label">Key</string>
     <string name="memory_value_label">Value</string>
 
@@ -367,7 +367,7 @@
     <string name="mcp_oauth_scope">Scope</string>
     <string name="mcp_oauth_scope_placeholder">read execute</string>
     <string name="dialog_title_delete_server">Delete Server</string>
-    <string name="dialog_delete_server_message">Are you sure you want to delete \"%1$s\"?</string>
+    <string name="dialog_delete_server_message">Are you sure you want to delete "%1$s"?</string>
     <string name="error_failed_to_load_servers">Failed to load servers</string>
     <string name="mcp_tools_count">%1$d tool%2$s</string>
     <string name="no_tools_available">No tools available</string>
@@ -402,7 +402,7 @@
     <string name="no_api_keys">No API keys</string>
     <string name="no_api_keys_desc">Create an API key to access the API programmatically.</string>
     <string name="dialog_title_delete_api_key">Delete API Key</string>
-    <string name="dialog_delete_api_key_message">Are you sure you want to delete the API key \"%1$s\"? This action cannot be undone.</string>
+    <string name="dialog_delete_api_key_message">Are you sure you want to delete the API key "%1$s"? This action cannot be undone.</string>
     <string name="created_prefix">Created: %1$s</string>
 
     <!-- API Key create dialog -->
@@ -411,20 +411,20 @@
     <string name="hint_key_name">Key name</string>
     <string name="hint_key_name_placeholder">e.g. My App</string>
     <string name="dialog_title_api_key_created">API Key Created</string>
-    <string name="api_key_created_warning">Your API key has been created. Copy it now — you won\'t be able to see it again.</string>
+    <string name="api_key_created_warning">Your API key has been created. Copy it now — you won't be able to see it again.</string>
     <string name="copied_to_clipboard">Copied to clipboard</string>
 
     <!-- Preset manager -->
     <string name="no_presets">No presets</string>
     <string name="no_presets_desc">Save presets from the chat screen to manage them here</string>
     <string name="dialog_title_delete_preset">Delete preset</string>
-    <string name="dialog_delete_preset_message">Are you sure you want to delete \"%1$s\"?</string>
+    <string name="dialog_delete_preset_message">Are you sure you want to delete "%1$s"?</string>
 
     <!-- Shared links -->
     <string name="no_shared_links">No shared links</string>
     <string name="no_shared_links_desc">Share a conversation to see it here</string>
     <string name="dialog_title_delete_shared_link">Delete Shared Link</string>
-    <string name="dialog_delete_shared_link_message">This will remove the shared link for \"%1$s\". Anyone with the link will no longer be able to access it.</string>
+    <string name="dialog_delete_shared_link_message">This will remove the shared link for "%1$s". Anyone with the link will no longer be able to access it.</string>
     <string name="visibility_public">Public</string>
     <string name="visibility_private">Private</string>
     <string name="error_failed_to_load_memories">Failed to load memories</string>

--- a/feature/skills/src/commonMain/composeResources/values-ar/strings.xml
+++ b/feature/skills/src/commonMain/composeResources/values-ar/strings.xml
@@ -20,7 +20,7 @@
     <string name="skill_category_label">الفئة: %1$s</string>
     <string name="skill_version_label">الإصدار %1$d</string>
     <string name="skill_delete_confirm_title">حذف المهارة؟</string>
-    <string name="skill_delete_confirm_message">سيؤدي هذا إلى حذف \"%1$s\" نهائيًا. لا يمكن التراجع عن ذلك.</string>
+    <string name="skill_delete_confirm_message">سيؤدي هذا إلى حذف "%1$s" نهائيًا. لا يمكن التراجع عن ذلك.</string>
     <string name="skill_empty_body">لا تحتوي هذه المهارة على محتوى.</string>
     <string name="skill_active_label">نشط</string>
     <string name="skill_active_description">اجعل هذه المهارة متاحة للاستخدام في المحادثات.</string>

--- a/feature/skills/src/commonMain/composeResources/values-de/strings.xml
+++ b/feature/skills/src/commonMain/composeResources/values-de/strings.xml
@@ -20,7 +20,7 @@
     <string name="skill_category_label">Kategorie: %1$s</string>
     <string name="skill_version_label">Version %1$d</string>
     <string name="skill_delete_confirm_title">Skill löschen?</string>
-    <string name="skill_delete_confirm_message">Dies löscht \"%1$s\" dauerhaft. Dies kann nicht rückgängig gemacht werden.</string>
+    <string name="skill_delete_confirm_message">Dies löscht "%1$s" dauerhaft. Dies kann nicht rückgängig gemacht werden.</string>
     <string name="skill_empty_body">Dieser Skill hat keinen Inhalt.</string>
     <string name="skill_active_label">Aktiv</string>
     <string name="skill_active_description">Diesen Skill zur Verwendung in Chats verfügbar machen.</string>

--- a/feature/skills/src/commonMain/composeResources/values-es/strings.xml
+++ b/feature/skills/src/commonMain/composeResources/values-es/strings.xml
@@ -20,7 +20,7 @@
     <string name="skill_category_label">Categoría: %1$s</string>
     <string name="skill_version_label">Versión %1$d</string>
     <string name="skill_delete_confirm_title">¿Eliminar habilidad?</string>
-    <string name="skill_delete_confirm_message">Esto elimina permanentemente \"%1$s\". Esta acción no se puede deshacer.</string>
+    <string name="skill_delete_confirm_message">Esto elimina permanentemente "%1$s". Esta acción no se puede deshacer.</string>
     <string name="skill_empty_body">Esta habilidad no tiene contenido.</string>
     <string name="skill_active_label">Activa</string>
     <string name="skill_active_description">Hacer que esta habilidad esté disponible para usar en los chats.</string>

--- a/feature/skills/src/commonMain/composeResources/values-fr/strings.xml
+++ b/feature/skills/src/commonMain/composeResources/values-fr/strings.xml
@@ -6,7 +6,7 @@
     <string name="skills_create">Créer une compétence</string>
     <string name="skills_import">Importer une compétence</string>
     <string name="skills_search_hint">Rechercher des compétences…</string>
-    <string name="skills_empty">Aucune compétence pour l\'instant.</string>
+    <string name="skills_empty">Aucune compétence pour l'instant.</string>
 
     <!-- Files -->
     <string name="skill_files_title">Fichiers</string>
@@ -20,8 +20,8 @@
     <string name="skill_category_label">Catégorie : %1$s</string>
     <string name="skill_version_label">Version %1$d</string>
     <string name="skill_delete_confirm_title">Supprimer la compétence ?</string>
-    <string name="skill_delete_confirm_message">Ceci supprime définitivement \"%1$s\". Cette action est irréversible.</string>
-    <string name="skill_empty_body">Cette compétence n\'a aucun contenu.</string>
+    <string name="skill_delete_confirm_message">Ceci supprime définitivement "%1$s". Cette action est irréversible.</string>
+    <string name="skill_empty_body">Cette compétence n'a aucun contenu.</string>
     <string name="skill_active_label">Active</string>
     <string name="skill_active_description">Rendre cette compétence disponible dans les discussions.</string>
 
@@ -31,7 +31,7 @@
     <string name="skill_field_name">Nom</string>
     <string name="skill_field_name_hint">minuscules-en-kebab-case</string>
     <string name="skill_field_name_error">Utilisez des lettres minuscules, des chiffres et des tirets (max 64).</string>
-    <string name="skill_field_display_title">Titre d\'affichage</string>
+    <string name="skill_field_display_title">Titre d'affichage</string>
     <string name="skill_field_description">Description</string>
     <string name="skill_field_description_error">La description est requise (max 1024 caractères).</string>
     <string name="skill_field_body">Contenu (markdown)</string>
@@ -50,7 +50,7 @@
     <string name="skill_acl_search_hint">Rechercher des utilisateurs, des groupes ou des rôles</string>
     <string name="skill_acl_search_empty">Aucune correspondance</string>
     <string name="skill_acl_role">Rôle</string>
-    <string name="skill_acl_revoke">Retirer l\'accès</string>
+    <string name="skill_acl_revoke">Retirer l'accès</string>
     <string name="skill_acl_public_label">Public</string>
     <string name="skill_acl_public_description">Toute personne sur ce serveur peut utiliser cette compétence.</string>
     <string name="skill_acl_principal_user">Utilisateur</string>

--- a/feature/skills/src/commonMain/composeResources/values-ko/strings.xml
+++ b/feature/skills/src/commonMain/composeResources/values-ko/strings.xml
@@ -20,7 +20,7 @@
     <string name="skill_category_label">카테고리: %1$s</string>
     <string name="skill_version_label">버전 %1$d</string>
     <string name="skill_delete_confirm_title">스킬을 삭제하시겠습니까?</string>
-    <string name="skill_delete_confirm_message">\"%1$s\"이(가) 영구적으로 삭제됩니다. 되돌릴 수 없습니다.</string>
+    <string name="skill_delete_confirm_message">"%1$s"이(가) 영구적으로 삭제됩니다. 되돌릴 수 없습니다.</string>
     <string name="skill_empty_body">이 스킬에는 내용이 없습니다.</string>
     <string name="skill_active_label">활성</string>
     <string name="skill_active_description">이 스킬을 채팅에서 사용할 수 있도록 합니다.</string>

--- a/feature/skills/src/commonMain/composeResources/values-pt/strings.xml
+++ b/feature/skills/src/commonMain/composeResources/values-pt/strings.xml
@@ -20,7 +20,7 @@
     <string name="skill_category_label">Categoria: %1$s</string>
     <string name="skill_version_label">Versão %1$d</string>
     <string name="skill_delete_confirm_title">Excluir habilidade?</string>
-    <string name="skill_delete_confirm_message">Isso exclui permanentemente \"%1$s\". Esta ação não pode ser desfeita.</string>
+    <string name="skill_delete_confirm_message">Isso exclui permanentemente "%1$s". Esta ação não pode ser desfeita.</string>
     <string name="skill_empty_body">Esta habilidade não tem conteúdo.</string>
     <string name="skill_active_label">Ativa</string>
     <string name="skill_active_description">Tornar esta habilidade disponível para uso nas conversas.</string>

--- a/feature/skills/src/commonMain/composeResources/values-ru/strings.xml
+++ b/feature/skills/src/commonMain/composeResources/values-ru/strings.xml
@@ -20,7 +20,7 @@
     <string name="skill_category_label">Категория: %1$s</string>
     <string name="skill_version_label">Версия %1$d</string>
     <string name="skill_delete_confirm_title">Удалить навык?</string>
-    <string name="skill_delete_confirm_message">Это безвозвратно удалит \"%1$s\". Это нельзя отменить.</string>
+    <string name="skill_delete_confirm_message">Это безвозвратно удалит "%1$s". Это нельзя отменить.</string>
     <string name="skill_empty_body">У этого навыка нет содержимого.</string>
     <string name="skill_active_label">Активен</string>
     <string name="skill_active_description">Сделать этот навык доступным для использования в чатах.</string>

--- a/feature/skills/src/commonMain/composeResources/values-zh/strings.xml
+++ b/feature/skills/src/commonMain/composeResources/values-zh/strings.xml
@@ -20,7 +20,7 @@
     <string name="skill_category_label">类别：%1$s</string>
     <string name="skill_version_label">版本 %1$d</string>
     <string name="skill_delete_confirm_title">删除技能？</string>
-    <string name="skill_delete_confirm_message">这将永久删除 \"%1$s\"。此操作无法撤销。</string>
+    <string name="skill_delete_confirm_message">这将永久删除 "%1$s"。此操作无法撤销。</string>
     <string name="skill_empty_body">此技能没有内容。</string>
     <string name="skill_active_label">已启用</string>
     <string name="skill_active_description">让此技能可在聊天中使用。</string>

--- a/feature/skills/src/commonMain/composeResources/values/strings.xml
+++ b/feature/skills/src/commonMain/composeResources/values/strings.xml
@@ -20,7 +20,7 @@
     <string name="skill_category_label">Category: %1$s</string>
     <string name="skill_version_label">Version %1$d</string>
     <string name="skill_delete_confirm_title">Delete skill?</string>
-    <string name="skill_delete_confirm_message">This permanently deletes \"%1$s\". This cannot be undone.</string>
+    <string name="skill_delete_confirm_message">This permanently deletes "%1$s". This cannot be undone.</string>
     <string name="skill_empty_body">This skill has no content.</string>
     <string name="skill_active_label">Active</string>
     <string name="skill_active_description">Make this skill available for use in chats.</string>


### PR DESCRIPTION
## Summary
Delete-confirmation dialogs (and many other strings) rendered a literal backslash — e.g. `delete \"New Chat\"?` instead of `delete "New Chat"?`. The resources used Android/aapt-style escaping (`\"`, `\'`), which is not XML escaping. Compose Multiplatform Resources is a faithful XML processor and does not strip those backslashes, so they leaked into the UI.

This replaces the redundant escapes with plain `"`/`'` — both are legal literal characters in XML text content — across every `composeResources/**/strings.xml`, all locales.

## Root cause
- The CMP resource generator (`handleSpecialCharacters` in `PrepareComposeResources.kt`) converts genuine escape sequences `\n`, `\t`, `\uXXXX` (and `\\`) to real characters at build time.
- It does not touch `\'` / `\"`, because those are not XML escapes — it stores them verbatim (backslash included) in the compiled `.cvr`.
- The runtime does no escape processing: `StringResourcesUtils.decodeAsString` only base64-decodes, and `replaceWithArgs` only substitutes `%N$s` / `%N$d`.
- Net: `\"` / `\'` reach the UI with the backslash intact. The inconsistency — some Android escapes honored, others not — is what made this easy to miss.

This is not a CMP correctness bug; the defect was redundant escaping in our source that XML never required.

## Changes
- Removed 384 redundant escapes (`\"` ×186, `\'` ×198) across 45 `strings.xml` files in 8 modules (agents, auth, chat, conversations, files, settings, skills, core/ui), all locales.
- Left `\n` (×20) and `\uXXXX` (×13) untouched — these are handled correctly by the generator (verified: `\n\n` stores as real newline bytes `0a 0a`, `…` as `e2 80 a6`).

## Verification
- No `\'` or `\"` remain in any `composeResources/**/strings.xml`; `\n`/`\u` counts unchanged.
- All 45 files re-validate as well-formed XML (`xmllint`).
- Regenerated the `.cvr` artifacts and decoded them: stored values are now `Are you sure you want to delete "%1$s"?` (en) / `... supprimer "%1$s" ?` (fr), with `%1$s` tokens byte-intact — no backslashes.