### PR TITLE
fix(agents): make Prompt Caching and Prompt Cache Duration controls usable in the agent editor

### DIFF
--- a/core/ui/src/commonMain/kotlin/com/garfiec/librechat/core/ui/components/DynamicEnumSlider.kt
+++ b/core/ui/src/commonMain/kotlin/com/garfiec/librechat/core/ui/components/DynamicEnumSlider.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import kotlin.math.roundToInt
 
 /**
  * Discrete slider that maps a list of string [options] to slider positions.
@@ -69,7 +70,7 @@ fun DynamicEnumSlider(
         Slider(
             value = index.toFloat(),
             onValueChange = { newPos ->
-                val newIndex = newPos.toInt().coerceIn(0, options.lastIndex)
+                val newIndex = newPos.roundToInt().coerceIn(0, options.lastIndex)
                 onValueChange(options[newIndex])
             },
             valueRange = 0f..options.lastIndex.toFloat(),

--- a/core/ui/src/commonMain/kotlin/com/garfiec/librechat/core/ui/components/ModelParameterContent.kt
+++ b/core/ui/src/commonMain/kotlin/com/garfiec/librechat/core/ui/components/ModelParameterContent.kt
@@ -70,7 +70,6 @@ data class ModelParameters(
         "fileTokenLimit" -> fileTokenLimit?.toString() ?: ""
         "stop" -> dynamicValues["stop"] ?: ""
         "reasoning_effort", "effort" -> dynamicValues[key] ?: ""
-        "promptCache" -> dynamicValues["promptCache"] ?: "false"
         else -> dynamicValues[key] ?: ""
     }
 


### PR DESCRIPTION
## Summary

Two related bugs made the Anthropic/Bedrock model-parameter controls in the **Edit Agent** screen unusable:

1. **Prompt Caching toggle wouldn't turn on.** On a fresh agent, toggling it ON and saving reverted to OFF; it only worked after enabling caching on the web.
2. **Prompt Cache Duration could only be set to 5m.** The 1h option was practically unreachable.

## Prompt Caching toggle

`ModelParameters.getValueForKey` returned a hardcoded `"false"` for an unset `promptCache`, but the registry default is **provider-dependent**: `"true"` for Anthropic and Bedrock-Anthropic, `"false"` for Bedrock-general (Meta/AI21/Amazon/DeepSeek). The save mapper (`toAgentAdvancedSettings`) only writes a key when `wasInExtras || !isDefault`, treating an absent key as "use the default."

- Toggling ON produced `"true"`, which equals the Anthropic default, so with `wasInExtras=false` it was **skipped** — never written — and read back as OFF.
- Worse, an *untouched* default-`true` (Anthropic) agent read `"false"`, which differs from the `"true"` default, so `promptCache=false` was **silently written**, overriding the backend default and disabling caching on every mobile-created Anthropic agent. (Bedrock-general, default `"false"`, was unaffected.)

Fix: remove the `promptCache` special case so it falls through to the generic `else -> dynamicValues[key] ?: ""` branch. The SWITCH renderer then supplies the correct per-provider default via `definition.default`, restoring the read/write symmetry the save mapper assumes.

## Prompt Cache Duration slider

`promptCacheTtl` is the only 2-option enum slider (`["5m", "1h"]`). For two options, `steps = options.size - 2 = 0`, which makes the Compose `Slider` **continuous** rather than snapping; the change handler then truncated the position with `toInt()`, so anything short of the exact far end floored to index 0 (`5m`). Fix: use `roundToInt()` so the nearest option wins — a no-op for the 3+ option sliders, whose thumb already lands on integer positions.

## Testing

Manually verified on a Pixel 9 Pro Fold against a live LibreChat backend:
- Anthropic agent: Prompt Caching defaults ON; OFF and ON both persist across save/reopen. Prompt Cache Duration now selects and persists `1h`.

Both fixes are contained to `core/ui` — no changes to the model, ViewModel, save mapper, or repository.