### PR TITLE
fix(auth): make 2FA login work end to end

### DIFF
--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/CommonTokenDataStore.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/CommonTokenDataStore.kt
@@ -94,13 +94,6 @@ abstract class CommonTokenDataStore(
         return cachedAccessToken.nonBlankOrNull()
     }
 
-    /**
-     * A blank token is not a session. Nothing should persist one, but builds before the issue #277 fix
-     * staged `""` when a login response arrived without a token, and that empty string reads as
-     * "authenticated" everywhere the bearer is null-checked — cold-starting those installs into the
-     * app proper, where every request 401s until the session-expired path throws them out. Coercing at
-     * the read boundary lets them start logged out instead. (The refresh path already blank-checks.)
-     */
     private fun String?.nonBlankOrNull(): String? = this?.takeUnless { it.isBlank() }
 
     // The bare key (null account) is the logged-out / legacy / mid-auth-staging fallback; a resolved
@@ -186,7 +179,7 @@ abstract class CommonTokenDataStore(
         // restore of already-keyed tokens whose mirror diverged), leave the keyed slot intact.
         // Crash-safe ordering: write the keyed slot, THEN the mirror, and only then drop the staging
         // keys — an interruption before the mirror write re-stages on the next resolve.
-        val stagedAccess = readValue(KEY_ACCESS_TOKEN)
+        val stagedAccess = readValue(KEY_ACCESS_TOKEN).nonBlankOrNull()
         val stagedRefresh = readValue(KEY_REFRESH_TOKEN)
         val rehomed = stagedAccess != null && stagedRefresh != null
         if (rehomed) {

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/CommonTokenDataStore.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/CommonTokenDataStore.kt
@@ -91,8 +91,17 @@ abstract class CommonTokenDataStore(
 
     private fun ensureTokenLoaded(): String? {
         if (!tokenInitialized) loadCacheFromStorage()
-        return cachedAccessToken
+        return cachedAccessToken.nonBlankOrNull()
     }
+
+    /**
+     * A blank token is not a session. Nothing should persist one, but builds before the issue #277 fix
+     * staged `""` when a login response arrived without a token, and that empty string reads as
+     * "authenticated" everywhere the bearer is null-checked — cold-starting those installs into the
+     * app proper, where every request 401s until the session-expired path throws them out. Coercing at
+     * the read boundary lets them start logged out instead. (The refresh path already blank-checks.)
+     */
+    private fun String?.nonBlankOrNull(): String? = this?.takeUnless { it.isBlank() }
 
     // The bare key (null account) is the logged-out / legacy / mid-auth-staging fallback; a resolved
     // account namespaces to `acct:<id>:<base>`. One helper so both token bases scope identically.
@@ -227,11 +236,12 @@ abstract class CommonTokenDataStore(
         // Serve the active account from the in-memory cache (the per-request hot path via the switch
         // barrier's keyed bearer read); fall to storage only for a non-active account's slot. Under
         // stateMutex so the account check and the cache read can't interleave with a select/teardown.
-        if (accountId == activeAccountKey) cachedAccessToken else readValue(accessKey(accountId))
+        val token = if (accountId == activeAccountKey) cachedAccessToken else readValue(accessKey(accountId))
+        token.nonBlankOrNull()
     }
 
     override suspend fun getStagedAccessToken(): String? = stateMutex.withLock {
-        readValue(KEY_ACCESS_TOKEN)
+        readValue(KEY_ACCESS_TOKEN).nonBlankOrNull()
     }
 
     override suspend fun clearStagedTokens() = stateMutex.withLock {

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/AuthRepository.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/AuthRepository.kt
@@ -8,7 +8,13 @@ import com.garfiec.librechat.core.model.response.TwoFactorSetupResponse
 interface AuthRepository {
     suspend fun login(email: String, password: String): Result<LoginOutcome>
     suspend fun loginWithOAuthToken(refreshToken: String): Result<User>
-    suspend fun verifyTwoFactor(tempToken: String, code: String): Result<User>
+
+    /**
+     * Completes a 2FA-pending login. [code] is a TOTP code by default; set [isBackupCode] to send it
+     * as a recovery code instead — the backend verifies the two by different fields and TOTP-verifies
+     * whatever arrives as `token`, so the distinction has to be carried this far.
+     */
+    suspend fun verifyTwoFactor(tempToken: String, code: String, isBackupCode: Boolean = false): Result<User>
     suspend fun register(name: String, email: String, username: String, password: String): Result<Unit>
     suspend fun logout(): Result<Unit>
     suspend fun isLoggedIn(): Boolean

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/AuthRepository.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/AuthRepository.kt
@@ -8,12 +8,6 @@ import com.garfiec.librechat.core.model.response.TwoFactorSetupResponse
 interface AuthRepository {
     suspend fun login(email: String, password: String): Result<LoginOutcome>
     suspend fun loginWithOAuthToken(refreshToken: String): Result<User>
-
-    /**
-     * Completes a 2FA-pending login. [code] is a TOTP code by default; set [isBackupCode] to send it
-     * as a recovery code instead — the backend verifies the two by different fields and TOTP-verifies
-     * whatever arrives as `token`, so the distinction has to be carried this far.
-     */
     suspend fun verifyTwoFactor(tempToken: String, code: String, isBackupCode: Boolean = false): Result<User>
     suspend fun register(name: String, email: String, username: String, password: String): Result<Unit>
     suspend fun logout(): Result<Unit>

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/AuthRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/AuthRepositoryImpl.kt
@@ -106,18 +106,24 @@ class AuthRepositoryImpl(
         return safeApiCall {
             withAuthIdentity(pending) {
                 val result = authApi.login(email, password)
-                if (result.response.twoFactorRequired && result.response.tempToken != null) {
+                if (result.response.twoFAPending) {
                     LoginOutcome.TwoFactorRequired(
                         result.response.tempToken
                             ?: throw IllegalStateException("Server indicated 2FA required but tempToken was null"),
                     )
                 } else {
-                    tokenManager.setTokens(
-                        accessToken = result.response.token ?: "",
-                        refreshToken = result.refreshToken ?: "",
-                    )
+                    // Validate BEFORE staging: a response missing either half is not a session, and
+                    // staging an empty pair would persist a blank token that reads as logged-in on the
+                    // next cold start and 401-storms until the user is bounced back to sign-in.
                     val user = result.response.user
                         ?: throw IllegalStateException("Login succeeded but user was null in response")
+                    val token = result.response.token
+                        ?: throw IllegalStateException("Login succeeded but token was null in response")
+                    tokenManager.setTokens(
+                        accessToken = token,
+                        // Absent is legitimate: the refresh token rides a Set-Cookie the server may omit.
+                        refreshToken = result.refreshToken ?: "",
+                    )
                     // Establish identity (+ run the legacy claim) before session tasks fire, so their
                     // tenant writes are stamped to this account and reads filter to it.
                     establishSession(pending, user)
@@ -150,17 +156,25 @@ class AuthRepositoryImpl(
         }.fireSessionTasksIfLoggedIn(previousAccountId)
     }
 
-    override suspend fun verifyTwoFactor(tempToken: String, code: String): Result<User> {
+    override suspend fun verifyTwoFactor(tempToken: String, code: String, isBackupCode: Boolean): Result<User> {
         val pending = accountSwitcher.pendingAdd
         val previousAccountId = activeAccountProvider.currentAccountId()
         return safeApiCall {
             withAuthIdentity(pending) {
-                val result = authApi.verifyTempToken(tempToken = tempToken, totpCode = code)
+                // The backend TOTP-verifies whenever `token` is present, so a backup code has to
+                // travel in its own field or it can never match.
+                val result = authApi.verifyTempToken(
+                    tempToken = tempToken,
+                    totpCode = code.takeUnless { isBackupCode },
+                    backupCode = code.takeIf { isBackupCode },
+                )
+                // Validate before staging — see login().
+                val user = result.response.user ?: throw IllegalStateException("No user in 2FA response")
+                val token = result.response.token ?: throw IllegalStateException("No token in 2FA response")
                 tokenManager.setTokens(
-                    accessToken = result.response.token ?: "",
+                    accessToken = token,
                     refreshToken = result.refreshToken ?: "",
                 )
-                val user = result.response.user ?: throw IllegalStateException("No user in 2FA response")
                 establishSession(pending, user)
                 user
             }

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/AuthRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/AuthRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package com.garfiec.librechat.core.data.repository
 
+import co.touchlab.kermit.Logger
 import com.garfiec.librechat.core.common.identity.AccountId
 import com.garfiec.librechat.core.common.identity.AccountState
 import com.garfiec.librechat.core.common.identity.ActiveAccountProvider
@@ -14,6 +15,7 @@ import com.garfiec.librechat.core.model.User
 import com.garfiec.librechat.core.model.response.TwoFactorSetupResponse
 import com.garfiec.librechat.core.network.api.AuthApi
 import com.garfiec.librechat.core.network.api.UserApi
+import com.garfiec.librechat.core.network.api.dto.LoginResult
 import com.garfiec.librechat.core.network.client.PendingRequestIdentity
 import com.garfiec.librechat.core.network.client.SwitchGate
 import com.garfiec.librechat.core.network.client.TokenManager
@@ -100,6 +102,21 @@ class AuthRepositoryImpl(
         ) { userApi.getUser() }
     }
 
+    private suspend fun stageAuthenticatedSession(result: LoginResult): User {
+        val user = result.response.user ?: throw incompleteAuthResponse("user")
+        val token = result.response.token ?: throw incompleteAuthResponse("token")
+        if (result.refreshToken == null) {
+            Logger.w { "Auth response carried no refresh token; this session cannot be renewed" }
+        }
+        tokenManager.setTokens(accessToken = token, refreshToken = result.refreshToken ?: "")
+        return user
+    }
+
+    private fun incompleteAuthResponse(missingField: String): IllegalStateException {
+        Logger.w { "Auth response was missing '$missingField'" }
+        return IllegalStateException("The server's sign-in response was incomplete. Please try again.")
+    }
+
     override suspend fun login(email: String, password: String): Result<LoginOutcome> {
         val pending = accountSwitcher.pendingAdd
         val previousAccountId = activeAccountProvider.currentAccountId()
@@ -112,18 +129,7 @@ class AuthRepositoryImpl(
                             ?: throw IllegalStateException("Server indicated 2FA required but tempToken was null"),
                     )
                 } else {
-                    // Validate BEFORE staging: a response missing either half is not a session, and
-                    // staging an empty pair would persist a blank token that reads as logged-in on the
-                    // next cold start and 401-storms until the user is bounced back to sign-in.
-                    val user = result.response.user
-                        ?: throw IllegalStateException("Login succeeded but user was null in response")
-                    val token = result.response.token
-                        ?: throw IllegalStateException("Login succeeded but token was null in response")
-                    tokenManager.setTokens(
-                        accessToken = token,
-                        // Absent is legitimate: the refresh token rides a Set-Cookie the server may omit.
-                        refreshToken = result.refreshToken ?: "",
-                    )
+                    val user = stageAuthenticatedSession(result)
                     // Establish identity (+ run the legacy claim) before session tasks fire, so their
                     // tenant writes are stamped to this account and reads filter to it.
                     establishSession(pending, user)
@@ -161,20 +167,12 @@ class AuthRepositoryImpl(
         val previousAccountId = activeAccountProvider.currentAccountId()
         return safeApiCall {
             withAuthIdentity(pending) {
-                // The backend TOTP-verifies whenever `token` is present, so a backup code has to
-                // travel in its own field or it can never match.
                 val result = authApi.verifyTempToken(
                     tempToken = tempToken,
                     totpCode = code.takeUnless { isBackupCode },
                     backupCode = code.takeIf { isBackupCode },
                 )
-                // Validate before staging — see login().
-                val user = result.response.user ?: throw IllegalStateException("No user in 2FA response")
-                val token = result.response.token ?: throw IllegalStateException("No token in 2FA response")
-                tokenManager.setTokens(
-                    accessToken = token,
-                    refreshToken = result.refreshToken ?: "",
-                )
+                val user = stageAuthenticatedSession(result)
                 establishSession(pending, user)
                 user
             }

--- a/core/model/src/commonMain/kotlin/com/garfiec/librechat/core/model/request/TwoFactorVerifyRequest.kt
+++ b/core/model/src/commonMain/kotlin/com/garfiec/librechat/core/model/request/TwoFactorVerifyRequest.kt
@@ -16,10 +16,15 @@ data class TwoFactorVerifyRequest(
  * Request body for POST /api/auth/2fa/verify-temp.
  * Backend reads { tempToken, token, backupCode } where tempToken is the
  * temporary auth token from login and token is the TOTP code.
+ *
+ * Exactly one of [token] / [backupCode] must be set: the backend branches
+ * `if (token) verifyTOTP else if (backupCode) verifyBackupCode`, so a backup
+ * code sent in [token] is TOTP-verified and always fails. The client `Json` is
+ * configured with `explicitNulls = false`, so the unused field is omitted.
  */
 @Serializable
 data class TwoFactorVerifyTempRequest(
     val tempToken: String,
-    val token: String,
+    val token: String? = null,
     val backupCode: String? = null,
 )

--- a/core/model/src/commonMain/kotlin/com/garfiec/librechat/core/model/request/TwoFactorVerifyRequest.kt
+++ b/core/model/src/commonMain/kotlin/com/garfiec/librechat/core/model/request/TwoFactorVerifyRequest.kt
@@ -16,11 +16,6 @@ data class TwoFactorVerifyRequest(
  * Request body for POST /api/auth/2fa/verify-temp.
  * Backend reads { tempToken, token, backupCode } where tempToken is the
  * temporary auth token from login and token is the TOTP code.
- *
- * Exactly one of [token] / [backupCode] must be set: the backend branches
- * `if (token) verifyTOTP else if (backupCode) verifyBackupCode`, so a backup
- * code sent in [token] is TOTP-verified and always fails. The client `Json` is
- * configured with `explicitNulls = false`, so the unused field is omitted.
  */
 @Serializable
 data class TwoFactorVerifyTempRequest(

--- a/core/model/src/commonMain/kotlin/com/garfiec/librechat/core/model/response/LoginResponse.kt
+++ b/core/model/src/commonMain/kotlin/com/garfiec/librechat/core/model/response/LoginResponse.kt
@@ -3,10 +3,18 @@ package com.garfiec.librechat.core.model.response
 import com.garfiec.librechat.core.model.User
 import kotlinx.serialization.Serializable
 
+/**
+ * Response body for POST /api/auth/login and the 2FA verify endpoints.
+ *
+ * Mirrors upstream's `TLoginResponse` (packages/data-provider/src/types.ts). A password-valid login
+ * against a 2FA-enabled account answers HTTP 200 with `{ twoFAPending: true, tempToken }` and no
+ * user/token — the field is named `twoFAPending` on the wire, not `twoFactorRequired`; the latter
+ * name never existed upstream and `ignoreUnknownKeys` silently dropped it (issue #277).
+ */
 @Serializable
 data class LoginResponse(
     val token: String? = null,
     val user: User? = null,
-    val twoFactorRequired: Boolean = false,
+    val twoFAPending: Boolean = false,
     val tempToken: String? = null,
 )

--- a/core/model/src/commonMain/kotlin/com/garfiec/librechat/core/model/response/LoginResponse.kt
+++ b/core/model/src/commonMain/kotlin/com/garfiec/librechat/core/model/response/LoginResponse.kt
@@ -4,12 +4,8 @@ import com.garfiec.librechat.core.model.User
 import kotlinx.serialization.Serializable
 
 /**
- * Response body for POST /api/auth/login and the 2FA verify endpoints.
- *
- * Mirrors upstream's `TLoginResponse` (packages/data-provider/src/types.ts). A password-valid login
- * against a 2FA-enabled account answers HTTP 200 with `{ twoFAPending: true, tempToken }` and no
- * user/token — the field is named `twoFAPending` on the wire, not `twoFactorRequired`; the latter
- * name never existed upstream and `ignoreUnknownKeys` silently dropped it (issue #277).
+ * Response body for POST /api/auth/login and the 2FA verify endpoints. The field is `twoFAPending`
+ * on the wire (not `twoFactorRequired`).
  */
 @Serializable
 data class LoginResponse(

--- a/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/api/AuthApiLoginTest.kt
+++ b/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/api/AuthApiLoginTest.kt
@@ -1,0 +1,139 @@
+package com.garfiec.librechat.core.network.api
+
+import com.google.common.truth.Truth.assertThat
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.engine.mock.toByteArray
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.defaultRequest
+import io.ktor.client.request.url
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Test
+
+/**
+ * Wire-shape tests for the login + 2FA endpoints, against payloads copied from the upstream
+ * controllers (`api/server/controllers/auth/LoginController.js`,
+ * `api/server/controllers/auth/TwoFactorAuthController.js`).
+ *
+ * These exist because issue #277 was a pure naming mismatch — the client modelled the 2FA flag as
+ * `twoFactorRequired`, a name that never existed upstream, and `ignoreUnknownKeys` dropped it
+ * silently. Nothing in the suite deserialized a real backend body, so no test could see it.
+ */
+class AuthApiLoginTest {
+
+    /** Mirrors the client Json in `NetworkModule.kt` — `explicitNulls = false` matters here. */
+    private val json = Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+        encodeDefaults = false
+        explicitNulls = false
+        coerceInputValues = true
+    }
+
+    private fun api(engine: MockEngine): AuthApi = AuthApi(
+        HttpClient(engine) {
+            install(ContentNegotiation) { json(json) }
+            // AuthApi builds relative paths and sets no Content-Type; the real graph supplies both
+            // via defaultRequest (LibreChatHttpClient.kt).
+            defaultRequest {
+                url("https://chat.example.com")
+                contentType(ContentType.Application.Json)
+            }
+        },
+    )
+
+    private fun jsonHeaders() = headersOf(HttpHeaders.ContentType, "application/json")
+
+    @Test
+    fun `login parses the twoFAPending challenge`() = runTest {
+        // Verbatim upstream: LoginController returns 200 with no token and no user.
+        val engine = MockEngine {
+            respond(
+                content = """{"twoFAPending":true,"tempToken":"temp-abc"}""",
+                status = HttpStatusCode.OK,
+                headers = jsonHeaders(),
+            )
+        }
+
+        val result = api(engine).login("a@b.com", "pw")
+
+        assertThat(result.response.twoFAPending).isTrue()
+        assertThat(result.response.tempToken).isEqualTo("temp-abc")
+        assertThat(result.response.token).isNull()
+        assertThat(result.response.user).isNull()
+    }
+
+    @Test
+    fun `login parses a normal success with the refresh cookie`() = runTest {
+        val engine = MockEngine {
+            respond(
+                content = """{"token":"jwt-1","user":{"_id":"u1","email":"a@b.com","name":"A","role":"USER"}}""",
+                status = HttpStatusCode.OK,
+                headers = headersOf(
+                    HttpHeaders.ContentType to listOf("application/json"),
+                    HttpHeaders.SetCookie to listOf("refreshToken=rt-1; Path=/; HttpOnly; SameSite=Lax"),
+                ),
+            )
+        }
+
+        val result = api(engine).login("a@b.com", "pw")
+
+        assertThat(result.response.twoFAPending).isFalse()
+        assertThat(result.response.token).isEqualTo("jwt-1")
+        assertThat(result.response.user?.email).isEqualTo("a@b.com")
+        assertThat(result.response.user?.mongoId).isEqualTo("u1")
+        assertThat(result.refreshToken).isEqualTo("rt-1")
+    }
+
+    @Test
+    fun `verifyTempToken sends a TOTP code as token with no backupCode`() = runTest {
+        var body: String? = null
+        val engine = MockEngine { request ->
+            body = String(request.body.toByteArray())
+            respond(
+                content = """{"token":"jwt-1","user":{"_id":"u1","email":"a@b.com"}}""",
+                status = HttpStatusCode.OK,
+                headers = jsonHeaders(),
+            )
+        }
+
+        api(engine).verifyTempToken(tempToken = "temp-abc", totpCode = "123456")
+
+        val sent = json.parseToJsonElement(body!!).jsonObject
+        assertThat(sent["tempToken"]?.jsonPrimitive?.content).isEqualTo("temp-abc")
+        assertThat(sent["token"]?.jsonPrimitive?.content).isEqualTo("123456")
+        assertThat(sent).doesNotContainKey("backupCode")
+    }
+
+    @Test
+    fun `verifyTempToken sends a backup code as backupCode and omits token`() = runTest {
+        // The backend branches `if (token) verifyTOTP else if (backupCode) verifyBackupCode`, so a
+        // backup code that travels in `token` is TOTP-verified and can only ever 401.
+        var body: String? = null
+        val engine = MockEngine { request ->
+            body = String(request.body.toByteArray())
+            respond(
+                content = """{"token":"jwt-1","user":{"_id":"u1","email":"a@b.com"}}""",
+                status = HttpStatusCode.OK,
+                headers = jsonHeaders(),
+            )
+        }
+
+        api(engine).verifyTempToken(tempToken = "temp-abc", backupCode = "abcd1234")
+
+        val sent = json.parseToJsonElement(body!!).jsonObject
+        assertThat(sent["tempToken"]?.jsonPrimitive?.content).isEqualTo("temp-abc")
+        assertThat(sent["backupCode"]?.jsonPrimitive?.content).isEqualTo("abcd1234")
+        assertThat(sent).doesNotContainKey("token")
+    }
+}

--- a/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/api/AuthApiLoginTest.kt
+++ b/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/api/AuthApiLoginTest.kt
@@ -1,5 +1,6 @@
 package com.garfiec.librechat.core.network.api
 
+import com.garfiec.librechat.core.network.di.librechatJson
 import com.google.common.truth.Truth.assertThat
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
@@ -20,31 +21,14 @@ import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import org.junit.Test
 
-/**
- * Wire-shape tests for the login + 2FA endpoints, against payloads copied from the upstream
- * controllers (`api/server/controllers/auth/LoginController.js`,
- * `api/server/controllers/auth/TwoFactorAuthController.js`).
- *
- * These exist because issue #277 was a pure naming mismatch — the client modelled the 2FA flag as
- * `twoFactorRequired`, a name that never existed upstream, and `ignoreUnknownKeys` dropped it
- * silently. Nothing in the suite deserialized a real backend body, so no test could see it.
- */
+/** Wire-shape tests for the login + 2FA endpoints, against payloads from the upstream controllers. */
 class AuthApiLoginTest {
 
-    /** Mirrors the client Json in `NetworkModule.kt` — `explicitNulls = false` matters here. */
-    private val json = Json {
-        ignoreUnknownKeys = true
-        isLenient = true
-        encodeDefaults = false
-        explicitNulls = false
-        coerceInputValues = true
-    }
+    private val json = librechatJson
 
     private fun api(engine: MockEngine): AuthApi = AuthApi(
         HttpClient(engine) {
             install(ContentNegotiation) { json(json) }
-            // AuthApi builds relative paths and sets no Content-Type; the real graph supplies both
-            // via defaultRequest (LibreChatHttpClient.kt).
             defaultRequest {
                 url("https://chat.example.com")
                 contentType(ContentType.Application.Json)
@@ -56,7 +40,6 @@ class AuthApiLoginTest {
 
     @Test
     fun `login parses the twoFAPending challenge`() = runTest {
-        // Verbatim upstream: LoginController returns 200 with no token and no user.
         val engine = MockEngine {
             respond(
                 content = """{"twoFAPending":true,"tempToken":"temp-abc"}""",
@@ -117,8 +100,6 @@ class AuthApiLoginTest {
 
     @Test
     fun `verifyTempToken sends a backup code as backupCode and omits token`() = runTest {
-        // The backend branches `if (token) verifyTOTP else if (backupCode) verifyBackupCode`, so a
-        // backup code that travels in `token` is TOTP-verified and can only ever 401.
         var body: String? = null
         val engine = MockEngine { request ->
             body = String(request.body.toByteArray())

--- a/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/client/AuthInterceptorTest.kt
+++ b/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/client/AuthInterceptorTest.kt
@@ -139,9 +139,6 @@ class AuthInterceptorTest {
 
     @Test
     fun `401 from verify-temp passes through without refresh or session expiry`() = runTest {
-        // A wrong 2FA code (or an expired tempToken) answers 401. There is no session to refresh
-        // mid-login, so refreshing would fail and eject the user from the flow they are still in —
-        // the 401 has to reach the 2FA screen as an ordinary error instead.
         val tokenManager = FakeTokenManager(accessToken = null, refreshOutcome = RefreshResult.HardExpired)
         var requestCount = 0
 
@@ -161,8 +158,6 @@ class AuthInterceptorTest {
 
     @Test
     fun `401 from the authenticated verify endpoint still refreshes`() = runTest {
-        // Contrast case: `auth/2fa/verify` (post-login, from Settings) is an authenticated call, and
-        // the skip-path prefix must not swallow it along with `verify-temp`.
         val tokenManager = FakeTokenManager(accessToken = "expired-token", refreshOutcome = RefreshResult.HardExpired)
 
         val engine = MockEngine { respond("Unauthorized", HttpStatusCode.Unauthorized) }
@@ -171,6 +166,56 @@ class AuthInterceptorTest {
         client.get("https://example.com/api/auth/2fa/verify")
         assertThat(tokenManager.refreshCallCount).isEqualTo(1)
         assertThat(tokenManager.sessionExpiredCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `a base path containing a skip token does not exempt the whole deployment`() = runTest {
+        val tokenManager = FakeTokenManager(accessToken = "expired-token", refreshOutcome = RefreshResult.HardExpired)
+        var capturedAuth: String? = null
+
+        val engine = MockEngine { request ->
+            capturedAuth = request.headers[HttpHeaders.Authorization]
+            respond("Unauthorized", HttpStatusCode.Unauthorized)
+        }
+        val client = createClient(tokenManager, engine)
+
+        client.get("https://example.com/apps/auth/login-portal/api/conversations")
+        assertThat(capturedAuth).isEqualTo("Bearer expired-token")
+        assertThat(tokenManager.refreshCallCount).isEqualTo(1)
+        assertThat(tokenManager.sessionExpiredCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `a skip endpoint under a mounted base path is still exempt`() = runTest {
+        val tokenManager = FakeTokenManager(accessToken = null, refreshOutcome = RefreshResult.HardExpired)
+
+        val engine = MockEngine { respond("Unauthorized", HttpStatusCode.Unauthorized) }
+        val client = createClient(tokenManager, engine)
+
+        client.get("https://example.com/librechat/api/auth/2fa/verify-temp")
+        assertThat(tokenManager.refreshCallCount).isEqualTo(0)
+        assertThat(tokenManager.sessionExpiredCount).isEqualTo(0)
+    }
+
+    @Test
+    fun `a query string containing a skip token does not exempt the request`() = runTest {
+        val tokenManager = FakeTokenManager(
+            accessToken = "expired-token",
+            refreshOutcome = RefreshResult.Refreshed,
+            refreshedToken = "new-token",
+        )
+        var requestCount = 0
+
+        val engine = MockEngine {
+            requestCount++
+            if (requestCount == 1) respond("Unauthorized", HttpStatusCode.Unauthorized)
+            else respond("OK", HttpStatusCode.OK)
+        }
+        val client = createClient(tokenManager, engine)
+
+        val response = client.get("https://example.com/api/search?q=auth/login")
+        assertThat(response.status).isEqualTo(HttpStatusCode.OK)
+        assertThat(tokenManager.refreshCallCount).isEqualTo(1)
     }
 
     @Test
@@ -222,8 +267,6 @@ class AuthInterceptorTest {
 
     @Test
     fun `transient refresh failure does not emit session expired`() = runTest {
-        // A recoverable refresh failure (network/5xx/malformed/server false-negative) must NOT log the
-        // user out — the request fails but the session is kept so a later attempt can recover.
         val tokenManager = FakeTokenManager(
             accessToken = "expired-token",
             refreshOutcome = RefreshResult.Transient,
@@ -255,8 +298,6 @@ class AuthInterceptorTest {
 
         val response = client.get("https://example.com/api/data")
         assertThat(response.status).isEqualTo(HttpStatusCode.Unauthorized)
-        // Refresh was attempted once, then the retry 401 is returned as-is
-        // (execute() inside interceptor doesn't re-enter the same interceptor)
         assertThat(tokenManager.refreshCallCount).isEqualTo(1)
     }
 
@@ -328,8 +369,6 @@ class AuthInterceptorTest {
             serverUrlProvider = FakeServerUrlProvider("https://chat.example.com"),
         )
 
-        // Insidious case: a CDN on a SUBDOMAIN of the base host must NOT get the
-        // token — host-matching is exact-equals, not suffix.
         client.get("https://cdn.example.com/file/abc?sig=xyz")
         assertThat(capturedAuth).isNull()
     }
@@ -350,7 +389,6 @@ class AuthInterceptorTest {
         )
 
         val response = client.get("https://cdn.example.com/file/abc?sig=xyz")
-        // Foreign-host 401 passes straight through — no refresh, no retry.
         assertThat(response.status).isEqualTo(HttpStatusCode.Unauthorized)
         assertThat(tokenManager.refreshCallCount).isEqualTo(0)
         assertThat(requestCount).isEqualTo(1)
@@ -372,8 +410,6 @@ class AuthInterceptorTest {
             if (requestCount == 1) respond("Unauthorized", HttpStatusCode.Unauthorized)
             else respond("OK", HttpStatusCode.OK)
         }
-        // Cold-start: provider returns empty base → attach-always fallback, and the
-        // 401-retry path stays active (host-scope helper returns true on empty base).
         val client = createClient(
             tokenManager,
             engine,
@@ -396,7 +432,6 @@ class AuthInterceptorTest {
             capturedAuth = request.headers[HttpHeaders.Authorization]
             respond("OK", HttpStatusCode.OK)
         }
-        // No serverUrlProvider → legacy behavior, token attached regardless of host.
         val client = createClient(tokenManager, engine)
 
         client.get("https://anyhost.example.org/api/data")
@@ -405,8 +440,6 @@ class AuthInterceptorTest {
 
     @Test
     fun `pending-identity request carries the staged bearer and its 401 passes through untouched`() = runTest {
-        // Add-account flow: the pending snapshot routes URL + bearer; a 401 must neither refresh any
-        // account nor emit the global session-expired signal (which would tear down the live account).
         val tokenManager = FakeTokenManager(accessToken = "live-a-token", refreshOutcome = RefreshResult.Refreshed)
         var requestCount = 0
         var capturedAuth: String? = null
@@ -443,9 +476,6 @@ class AuthInterceptorTest {
 
     @Test
     fun `refresh failure on a snapshot request scopes the expiry signal to the snapshot account`() = runTest {
-        // The store decides whether a scoped expiry still matters (it suppresses non-active
-        // accounts); the plugin's contract is to pass the snapshot's account along, never a blanket
-        // global signal.
         val tokenManager = FakeTokenManager(accessToken = "a-token", refreshOutcome = RefreshResult.HardExpired)
         val engine = MockEngine { respond("Unauthorized", HttpStatusCode.Unauthorized) }
         val gate = SwitchGate(

--- a/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/client/AuthInterceptorTest.kt
+++ b/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/client/AuthInterceptorTest.kt
@@ -138,6 +138,42 @@ class AuthInterceptorTest {
     }
 
     @Test
+    fun `401 from verify-temp passes through without refresh or session expiry`() = runTest {
+        // A wrong 2FA code (or an expired tempToken) answers 401. There is no session to refresh
+        // mid-login, so refreshing would fail and eject the user from the flow they are still in —
+        // the 401 has to reach the 2FA screen as an ordinary error instead.
+        val tokenManager = FakeTokenManager(accessToken = null, refreshOutcome = RefreshResult.HardExpired)
+        var requestCount = 0
+
+        val engine = MockEngine {
+            requestCount++
+            respond("""{"message":"Invalid 2FA code."}""", HttpStatusCode.Unauthorized)
+        }
+        val client = createClient(tokenManager, engine)
+
+        val response = client.get("https://example.com/api/auth/2fa/verify-temp")
+        assertThat(response.status).isEqualTo(HttpStatusCode.Unauthorized)
+        assertThat(response.bodyAsText()).contains("Invalid 2FA code.")
+        assertThat(requestCount).isEqualTo(1)
+        assertThat(tokenManager.refreshCallCount).isEqualTo(0)
+        assertThat(tokenManager.sessionExpiredCount).isEqualTo(0)
+    }
+
+    @Test
+    fun `401 from the authenticated verify endpoint still refreshes`() = runTest {
+        // Contrast case: `auth/2fa/verify` (post-login, from Settings) is an authenticated call, and
+        // the skip-path prefix must not swallow it along with `verify-temp`.
+        val tokenManager = FakeTokenManager(accessToken = "expired-token", refreshOutcome = RefreshResult.HardExpired)
+
+        val engine = MockEngine { respond("Unauthorized", HttpStatusCode.Unauthorized) }
+        val client = createClient(tokenManager, engine)
+
+        client.get("https://example.com/api/auth/2fa/verify")
+        assertThat(tokenManager.refreshCallCount).isEqualTo(1)
+        assertThat(tokenManager.sessionExpiredCount).isEqualTo(1)
+    }
+
+    @Test
     fun `refreshes token on 401 and retries`() = runTest {
         val tokenManager = FakeTokenManager(
             accessToken = "expired-token",

--- a/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/api/AuthApi.kt
+++ b/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/api/AuthApi.kt
@@ -125,11 +125,7 @@ class AuthApi constructor(
         }.body()
 
     /**
-     * Verify 2FA during login using a temporary token.
      * POST /api/auth/2fa/verify-temp with { tempToken, token: totpCode } or { tempToken, backupCode }.
-     *
-     * Pass exactly one of [totpCode] / [backupCode] — the backend TOTP-verifies whenever `token` is
-     * present and only falls through to the backup-code check when it is absent.
      */
     suspend fun verifyTempToken(
         tempToken: String,

--- a/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/api/AuthApi.kt
+++ b/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/api/AuthApi.kt
@@ -126,9 +126,16 @@ class AuthApi constructor(
 
     /**
      * Verify 2FA during login using a temporary token.
-     * POST /api/auth/2fa/verify-temp with { tempToken, token: totpCode, backupCode? }
+     * POST /api/auth/2fa/verify-temp with { tempToken, token: totpCode } or { tempToken, backupCode }.
+     *
+     * Pass exactly one of [totpCode] / [backupCode] — the backend TOTP-verifies whenever `token` is
+     * present and only falls through to the backup-code check when it is absent.
      */
-    suspend fun verifyTempToken(tempToken: String, totpCode: String, backupCode: String? = null): LoginResult {
+    suspend fun verifyTempToken(
+        tempToken: String,
+        totpCode: String? = null,
+        backupCode: String? = null,
+    ): LoginResult {
         val httpResponse = client.post {
             url { path("api/auth/2fa/verify-temp") }
             setBody(

--- a/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/AuthInterceptorPlugin.kt
+++ b/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/AuthInterceptorPlugin.kt
@@ -9,6 +9,7 @@ import io.ktor.client.request.HttpRequestPipeline
 import io.ktor.client.request.headers
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
+import io.ktor.http.URLBuilder
 import io.ktor.http.Url
 import io.ktor.util.AttributeKey
 
@@ -58,18 +59,20 @@ class AuthInterceptorPlugin private constructor(
         }
 
         override fun install(plugin: AuthInterceptorPlugin, scope: HttpClient) {
-            // Unauthenticated endpoints: no bearer is attached to them, and — just as importantly —
-            // a 401 from one is the endpoint's own answer (bad credentials, wrong 2FA code, expired
-            // tempToken), never an expired session. They must stay out of the refresh/session-expiry
-            // leg below, or a mistyped 2FA code would trigger a doomed refresh (there is no refresh
-            // token yet mid-login) and eject the user from the flow. `auth/2fa/verify-temp` does not
-            // collide with the authenticated `auth/2fa/verify`, which must keep refreshing.
+            // Endpoints that take no bearer and whose 401 is the endpoint's own verdict, not an
+            // expired session — kept out of the refresh/session-expiry leg below.
             val skipPaths = setOf(
                 "auth/login", "auth/register", "auth/refresh",
                 "auth/requestPasswordReset", "auth/resetPassword",
                 "auth/2fa/verify-temp",
             )
-            fun isSkipPath(url: String): Boolean = skipPaths.any { url.contains(it) }
+
+            // Matched on whole path segments, not as a substring of the URL, so a path-prefixed
+            // deployment (e.g. /apps/auth/login-x) doesn't match every request it serves.
+            fun isSkipPath(url: URLBuilder): Boolean {
+                val path = url.encodedPathSegments.filter { it.isNotEmpty() }.joinToString("/")
+                return skipPaths.any { path == it || path.endsWith("/$it") }
+            }
 
             // Attach token to outgoing requests. Runs at State, which is after
             // the SwitchBarrier/defaultRequest phases have applied the base URL —
@@ -86,7 +89,7 @@ class AuthInterceptorPlugin private constructor(
             scope.requestPipeline.intercept(HttpRequestPipeline.State) {
                 val snapshot = context.attributes.getOrNull(RequestIdentityKey)
                 val serverBaseUrl = snapshot?.baseUrl ?: plugin.serverUrlProvider?.getBaseUrl()
-                if (!isSkipPath(context.url.buildString()) && plugin.isSameHostAsServer(context.url.host, serverBaseUrl)) {
+                if (!isSkipPath(context.url) && plugin.isSameHostAsServer(context.url.host, serverBaseUrl)) {
                     // Explicit branch (not `?:`): a snapshot whose bearer is null must attach
                     // nothing — a pending add-account probe before sign-in has no token yet, and
                     // falling through to the live cache would send the ACTIVE account's bearer to
@@ -106,11 +109,7 @@ class AuthInterceptorPlugin private constructor(
                     return@intercept originalCall
                 }
 
-                // An unauthenticated endpoint's 401 is its own verdict on the credentials just
-                // submitted, not an expired session: pass it through so the caller's UI can show it,
-                // without refreshing (there may be no session at all yet) and without the global
-                // session-expired signal that would tear the user out of the sign-in flow.
-                if (isSkipPath(request.url.buildString())) {
+                if (isSkipPath(request.url)) {
                     return@intercept originalCall
                 }
 

--- a/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/AuthInterceptorPlugin.kt
+++ b/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/AuthInterceptorPlugin.kt
@@ -58,10 +58,18 @@ class AuthInterceptorPlugin private constructor(
         }
 
         override fun install(plugin: AuthInterceptorPlugin, scope: HttpClient) {
+            // Unauthenticated endpoints: no bearer is attached to them, and — just as importantly —
+            // a 401 from one is the endpoint's own answer (bad credentials, wrong 2FA code, expired
+            // tempToken), never an expired session. They must stay out of the refresh/session-expiry
+            // leg below, or a mistyped 2FA code would trigger a doomed refresh (there is no refresh
+            // token yet mid-login) and eject the user from the flow. `auth/2fa/verify-temp` does not
+            // collide with the authenticated `auth/2fa/verify`, which must keep refreshing.
             val skipPaths = setOf(
                 "auth/login", "auth/register", "auth/refresh",
                 "auth/requestPasswordReset", "auth/resetPassword",
+                "auth/2fa/verify-temp",
             )
+            fun isSkipPath(url: String): Boolean = skipPaths.any { url.contains(it) }
 
             // Attach token to outgoing requests. Runs at State, which is after
             // the SwitchBarrier/defaultRequest phases have applied the base URL —
@@ -76,11 +84,9 @@ class AuthInterceptorPlugin private constructor(
             // pair. Without the barrier (refresh client / tests) fall back to the
             // live active account, preserving legacy behavior.
             scope.requestPipeline.intercept(HttpRequestPipeline.State) {
-                val path = context.url.buildString()
-                val isSkipPath = skipPaths.any { path.contains(it) }
                 val snapshot = context.attributes.getOrNull(RequestIdentityKey)
                 val serverBaseUrl = snapshot?.baseUrl ?: plugin.serverUrlProvider?.getBaseUrl()
-                if (!isSkipPath && plugin.isSameHostAsServer(context.url.host, serverBaseUrl)) {
+                if (!isSkipPath(context.url.buildString()) && plugin.isSameHostAsServer(context.url.host, serverBaseUrl)) {
                     // Explicit branch (not `?:`): a snapshot whose bearer is null must attach
                     // nothing — a pending add-account probe before sign-in has no token yet, and
                     // falling through to the live cache would send the ACTIVE account's bearer to
@@ -97,6 +103,14 @@ class AuthInterceptorPlugin private constructor(
                 val originalCall = execute(request)
 
                 if (originalCall.response.status != HttpStatusCode.Unauthorized) {
+                    return@intercept originalCall
+                }
+
+                // An unauthenticated endpoint's 401 is its own verdict on the credentials just
+                // submitted, not an expired session: pass it through so the caller's UI can show it,
+                // without refreshing (there may be no session at all yet) and without the global
+                // session-expired signal that would tear the user out of the sign-in flow.
+                if (isSkipPath(request.url.buildString())) {
                     return@intercept originalCall
                 }
 

--- a/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/di/NetworkModule.kt
+++ b/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/di/NetworkModule.kt
@@ -54,20 +54,22 @@ import org.koin.dsl.module
 
 expect val networkPlatformModule: Module
 
+/**
+ * Top-level (not inline in the Koin block) so wire-shape tests decode against the shipped instance.
+ * LenientInstantSerializerTest in core/model hand-mirrors these settings — update both together.
+ */
+val librechatJson: Json = Json {
+    ignoreUnknownKeys = true
+    isLenient = true
+    encodeDefaults = false
+    explicitNulls = false
+    coerceInputValues = true
+}
+
 val networkModule = module {
     includes(networkPlatformModule)
 
-    single {
-        // Hand-mirrored by LenientInstantSerializerTest in core/model (which cannot depend on this
-        // module) — a settings change here must be copied into that test's `networkJson`.
-        Json {
-            ignoreUnknownKeys = true
-            isLenient = true
-            encodeDefaults = false
-            explicitNulls = false
-            coerceInputValues = true
-        }
-    }
+    single { librechatJson }
 
     // The switch barrier: one gate shared by both HTTP clients and (on iOS) the SSE transport, so a
     // single account switch flips URL + token key + identity atomically for all transports at once.

--- a/feature/auth/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/auth/viewmodel/LoginViewModelTest.kt
+++ b/feature/auth/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/auth/viewmodel/LoginViewModelTest.kt
@@ -162,8 +162,6 @@ class LoginViewModelTest {
 
     @Test
     fun `consumeTwoFactorNavigation clears the temp token`() = runTest {
-        // The Login entry's ViewModel is retained, so an unconsumed token would re-fire the screen's
-        // navigation effect the moment the user backs out of the 2FA screen.
         coEvery { authRepository.login("user@example.com", "password123") } returns
             Result.Success(LoginOutcome.TwoFactorRequired("temp-token-123"))
 

--- a/feature/auth/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/auth/viewmodel/LoginViewModelTest.kt
+++ b/feature/auth/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/auth/viewmodel/LoginViewModelTest.kt
@@ -161,6 +161,26 @@ class LoginViewModelTest {
     }
 
     @Test
+    fun `consumeTwoFactorNavigation clears the temp token`() = runTest {
+        // The Login entry's ViewModel is retained, so an unconsumed token would re-fire the screen's
+        // navigation effect the moment the user backs out of the 2FA screen.
+        coEvery { authRepository.login("user@example.com", "password123") } returns
+            Result.Success(LoginOutcome.TwoFactorRequired("temp-token-123"))
+
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.onEmailChanged("user@example.com")
+        viewModel.onPasswordChanged("password123")
+        viewModel.login()
+        advanceUntilIdle()
+
+        viewModel.consumeTwoFactorNavigation()
+
+        assertThat(viewModel.uiState.value.twoFactorTempToken).isNull()
+    }
+
+    @Test
     fun `login failure shows error message`() = runTest {
         coEvery { authRepository.login("user@example.com", "wrong") } returns
             Result.Error(message = "Invalid credentials")

--- a/feature/auth/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/auth/viewmodel/TwoFactorViewModelTest.kt
+++ b/feature/auth/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/auth/viewmodel/TwoFactorViewModelTest.kt
@@ -1,0 +1,100 @@
+package com.garfiec.librechat.feature.auth.viewmodel
+
+import com.garfiec.librechat.core.common.result.ApiException
+import com.garfiec.librechat.core.common.result.Result
+import com.garfiec.librechat.core.data.repository.AuthRepository
+import com.garfiec.librechat.core.model.User
+import com.google.common.truth.Truth.assertThat
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class TwoFactorViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private val authRepository = mockk<AuthRepository>(relaxed = true)
+
+    @Before
+    fun setup() = Dispatchers.setMain(testDispatcher)
+
+    @After
+    fun tearDown() = Dispatchers.resetMain()
+
+    private fun createViewModel() = TwoFactorViewModel(authRepository, initialTempToken = TEMP_TOKEN)
+
+    private fun TwoFactorViewModel.enterDigits(code: String) =
+        code.forEachIndexed { index, digit -> onDigitChanged(index, digit.toString()) }
+
+    @Test
+    fun `entering six digits verifies the code as TOTP`() = runTest {
+        coEvery { authRepository.verifyTwoFactor(any(), any(), any()) } returns Result.Success(USER)
+
+        val viewModel = createViewModel()
+        viewModel.enterDigits("123456")
+        advanceUntilIdle()
+
+        coVerify { authRepository.verifyTwoFactor(TEMP_TOKEN, "123456", false) }
+        assertThat(viewModel.uiState.value.isVerified).isTrue()
+        assertThat(viewModel.uiState.value.isLoading).isFalse()
+    }
+
+    @Test
+    fun `backup mode submits the code as a backup code`() = runTest {
+        // The backend verifies TOTP and backup codes by different fields, so the mode has to travel
+        // with the code — a backup code sent as a TOTP token can only ever fail.
+        coEvery { authRepository.verifyTwoFactor(any(), any(), any()) } returns Result.Success(USER)
+
+        val viewModel = createViewModel()
+        viewModel.toggleBackupMode()
+        viewModel.onBackupCodeChanged("  abcd1234  ")
+        viewModel.submit()
+        advanceUntilIdle()
+
+        coVerify { authRepository.verifyTwoFactor(TEMP_TOKEN, "abcd1234", true) }
+        assertThat(viewModel.uiState.value.isVerified).isTrue()
+    }
+
+    @Test
+    fun `surfaces the server's message on a rejected code`() = runTest {
+        coEvery { authRepository.verifyTwoFactor(any(), any(), any()) } returns
+            Result.Error(ApiException(401, "Your temporary session has expired. Please sign in again."))
+
+        val viewModel = createViewModel()
+        viewModel.enterDigits("000000")
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertThat(state.error).isEqualTo("Your temporary session has expired. Please sign in again.")
+        assertThat(state.isVerified).isFalse()
+        // The entry is cleared so the user retypes rather than resubmitting the rejected code.
+        assertThat(state.digits).containsExactlyElementsIn(List(6) { "" })
+    }
+
+    @Test
+    fun `falls back to a generic message when the failure carries no server message`() = runTest {
+        coEvery { authRepository.verifyTwoFactor(any(), any(), any()) } returns
+            Result.Error(java.io.IOException("connection reset"), "connection reset")
+
+        val viewModel = createViewModel()
+        viewModel.enterDigits("000000")
+        advanceUntilIdle()
+
+        assertThat(viewModel.uiState.value.error).isEqualTo("Invalid code. Please try again.")
+    }
+
+    private companion object {
+        const val TEMP_TOKEN = "temp-abc"
+        val USER = User(mongoId = "u1", email = "a@b.com")
+    }
+}

--- a/feature/auth/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/auth/viewmodel/TwoFactorViewModelTest.kt
+++ b/feature/auth/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/auth/viewmodel/TwoFactorViewModelTest.kt
@@ -51,8 +51,6 @@ class TwoFactorViewModelTest {
 
     @Test
     fun `backup mode submits the code as a backup code`() = runTest {
-        // The backend verifies TOTP and backup codes by different fields, so the mode has to travel
-        // with the code — a backup code sent as a TOTP token can only ever fail.
         coEvery { authRepository.verifyTwoFactor(any(), any(), any()) } returns Result.Success(USER)
 
         val viewModel = createViewModel()
@@ -77,20 +75,40 @@ class TwoFactorViewModelTest {
         val state = viewModel.uiState.value
         assertThat(state.error).isEqualTo("Your temporary session has expired. Please sign in again.")
         assertThat(state.isVerified).isFalse()
-        // The entry is cleared so the user retypes rather than resubmitting the rejected code.
         assertThat(state.digits).containsExactlyElementsIn(List(6) { "" })
+        assertThat(state.codeAttempt).isEqualTo(1)
     }
 
     @Test
-    fun `falls back to a generic message when the failure carries no server message`() = runTest {
+    fun `a network failure is not reported as a bad code and keeps the entry`() = runTest {
         coEvery { authRepository.verifyTwoFactor(any(), any(), any()) } returns
             Result.Error(java.io.IOException("connection reset"), "connection reset")
 
         val viewModel = createViewModel()
-        viewModel.enterDigits("000000")
+        viewModel.enterDigits("123456")
         advanceUntilIdle()
 
-        assertThat(viewModel.uiState.value.error).isEqualTo("Invalid code. Please try again.")
+        val state = viewModel.uiState.value
+        assertThat(state.error).isEqualTo("Couldn't reach the server. Check your connection and try again.")
+        assertThat(state.digits.joinToString("")).isEqualTo("123456")
+        assertThat(state.codeAttempt).isEqualTo(0)
+    }
+
+    @Test
+    fun `retrying after a network failure resubmits the retained code`() = runTest {
+        coEvery { authRepository.verifyTwoFactor(any(), any(), any()) } returns
+            Result.Error(java.io.IOException("connection reset"), "connection reset")
+
+        val viewModel = createViewModel()
+        viewModel.enterDigits("123456")
+        advanceUntilIdle()
+
+        coEvery { authRepository.verifyTwoFactor(any(), any(), any()) } returns Result.Success(USER)
+        viewModel.submit()
+        advanceUntilIdle()
+
+        coVerify(exactly = 2) { authRepository.verifyTwoFactor(TEMP_TOKEN, "123456", false) }
+        assertThat(viewModel.uiState.value.isVerified).isTrue()
     }
 
     private companion object {

--- a/feature/auth/src/commonMain/kotlin/com/garfiec/librechat/feature/auth/screen/LoginScreen.kt
+++ b/feature/auth/src/commonMain/kotlin/com/garfiec/librechat/feature/auth/screen/LoginScreen.kt
@@ -70,6 +70,9 @@ fun LoginScreen(
         val tempToken = uiState.twoFactorTempToken
         if (tempToken != null) {
             currentOnNavigateToTwoFactor(tempToken)
+            // Consume the signal so backing out of the 2FA screen returns here instead of
+            // re-triggering this effect against the retained ViewModel's stale token.
+            viewModel.consumeTwoFactorNavigation()
         }
     }
 

--- a/feature/auth/src/commonMain/kotlin/com/garfiec/librechat/feature/auth/screen/TwoFactorScreen.kt
+++ b/feature/auth/src/commonMain/kotlin/com/garfiec/librechat/feature/auth/screen/TwoFactorScreen.kt
@@ -126,6 +126,7 @@ fun TwoFactorScreen(
                     digits = uiState.digits,
                     onDigitChange = viewModel::onDigitChanged,
                     enabled = !uiState.isLoading,
+                    focusResetKey = uiState.codeAttempt,
                 )
             }
 
@@ -140,21 +141,25 @@ fun TwoFactorScreen(
 
             Spacer(modifier = Modifier.height(24.dp))
 
-            if (uiState.isBackupMode) {
-                Button(
-                    onClick = viewModel::submit,
-                    modifier = Modifier.fillMaxWidth(),
-                    enabled = !uiState.isLoading && uiState.backupCode.isNotBlank(),
-                ) {
-                    if (uiState.isLoading) {
-                        CircularProgressIndicator(
-                            modifier = Modifier.height(20.dp),
-                            color = MaterialTheme.colorScheme.onPrimary,
-                            strokeWidth = 2.dp,
-                        )
-                    } else {
-                        Text(stringResource(Res.string.verify))
-                    }
+            // A full row normally auto-submits, but a kept entry (network error) needs an explicit
+            // button to move forward.
+            Button(
+                onClick = viewModel::submit,
+                modifier = Modifier.fillMaxWidth(),
+                enabled = !uiState.isLoading && if (uiState.isBackupMode) {
+                    uiState.backupCode.isNotBlank()
+                } else {
+                    uiState.digits.all { it.isNotEmpty() }
+                },
+            ) {
+                if (uiState.isLoading) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.height(20.dp),
+                        color = MaterialTheme.colorScheme.onPrimary,
+                        strokeWidth = 2.dp,
+                    )
+                } else {
+                    Text(stringResource(Res.string.verify))
                 }
             }
 
@@ -178,6 +183,7 @@ private fun DigitBoxes(
     digits: List<String>,
     onDigitChange: (Int, String) -> Unit,
     enabled: Boolean,
+    focusResetKey: Int,
     modifier: Modifier = Modifier,
 ) {
     val focusRequesters = remember { List(6) { FocusRequester() } }
@@ -210,8 +216,8 @@ private fun DigitBoxes(
         }
     }
 
-    // Focus first box on initial composition
-    LaunchedEffect(Unit) {
+    // Re-focus the first box on each rejected code: disabled boxes drop focus while the request runs.
+    LaunchedEffect(focusResetKey) {
         focusRequesters[0].requestFocus()
     }
 }

--- a/feature/auth/src/commonMain/kotlin/com/garfiec/librechat/feature/auth/viewmodel/LoginViewModel.kt
+++ b/feature/auth/src/commonMain/kotlin/com/garfiec/librechat/feature/auth/viewmodel/LoginViewModel.kt
@@ -108,12 +108,6 @@ class LoginViewModel(
         }
     }
 
-    /**
-     * Clears the one-shot 2FA navigation signal once the screen has acted on it. This ViewModel is
-     * retained for the Login entry, so leaving the token set would have the navigation effect re-fire
-     * the moment the user backs out of the 2FA screen — bouncing them straight into it again with no
-     * way to return and correct the email or password.
-     */
     fun consumeTwoFactorNavigation() {
         _uiState.value = _uiState.value.copy(twoFactorTempToken = null)
     }

--- a/feature/auth/src/commonMain/kotlin/com/garfiec/librechat/feature/auth/viewmodel/LoginViewModel.kt
+++ b/feature/auth/src/commonMain/kotlin/com/garfiec/librechat/feature/auth/viewmodel/LoginViewModel.kt
@@ -108,6 +108,16 @@ class LoginViewModel(
         }
     }
 
+    /**
+     * Clears the one-shot 2FA navigation signal once the screen has acted on it. This ViewModel is
+     * retained for the Login entry, so leaving the token set would have the navigation effect re-fire
+     * the moment the user backs out of the 2FA screen — bouncing them straight into it again with no
+     * way to return and correct the email or password.
+     */
+    fun consumeTwoFactorNavigation() {
+        _uiState.value = _uiState.value.copy(twoFactorTempToken = null)
+    }
+
     /** Set once this screen launches its own OAuth round-trip; gates add-mode cookie consumption. */
     private var oAuthLaunched = false
 

--- a/feature/auth/src/commonMain/kotlin/com/garfiec/librechat/feature/auth/viewmodel/TwoFactorViewModel.kt
+++ b/feature/auth/src/commonMain/kotlin/com/garfiec/librechat/feature/auth/viewmodel/TwoFactorViewModel.kt
@@ -3,6 +3,7 @@ package com.garfiec.librechat.feature.auth.viewmodel
 import androidx.compose.runtime.Immutable
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.garfiec.librechat.core.common.result.ApiException
 import com.garfiec.librechat.core.common.result.Result
 import com.garfiec.librechat.core.data.repository.AuthRepository
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -68,7 +69,7 @@ class TwoFactorViewModel(
         viewModelScope.launch {
             _uiState.value = _uiState.value.copy(isLoading = true, error = null)
 
-            when (authRepository.verifyTwoFactor(tempToken, code)) {
+            when (val result = authRepository.verifyTwoFactor(tempToken, code, isBackupCode = state.isBackupMode)) {
                 is Result.Success -> {
                     _uiState.value = _uiState.value.copy(
                         isLoading = false,
@@ -78,7 +79,11 @@ class TwoFactorViewModel(
                 is Result.Error -> {
                     _uiState.value = _uiState.value.copy(
                         isLoading = false,
-                        error = "Invalid code. Please try again.",
+                        // Prefer the server's own wording: "invalid code" and "your session expired,
+                        // sign in again" call for different actions, and a flat retry prompt has the
+                        // user typing codes at a tempToken that can no longer succeed.
+                        error = (result.exception as? ApiException)?.message
+                            ?: "Invalid code. Please try again.",
                         digits = List(6) { "" },
                         backupCode = "",
                     )

--- a/feature/auth/src/commonMain/kotlin/com/garfiec/librechat/feature/auth/viewmodel/TwoFactorViewModel.kt
+++ b/feature/auth/src/commonMain/kotlin/com/garfiec/librechat/feature/auth/viewmodel/TwoFactorViewModel.kt
@@ -19,6 +19,8 @@ data class TwoFactorUiState(
     val isLoading: Boolean = false,
     val error: String? = null,
     val isVerified: Boolean = false,
+    // Bumped on each rejected code; the digit row keys its focus-reset effect on this.
+    val codeAttempt: Int = 0,
 )
 
 class TwoFactorViewModel(
@@ -77,15 +79,17 @@ class TwoFactorViewModel(
                     )
                 }
                 is Result.Error -> {
-                    _uiState.value = _uiState.value.copy(
+                    // Only an HTTP answer is a verdict on the code; a network/parsing failure keeps
+                    // the entry so a retry can recover instead of wiping a good code.
+                    val rejection = result.exception as? ApiException
+                    val current = _uiState.value
+                    _uiState.value = current.copy(
                         isLoading = false,
-                        // Prefer the server's own wording: "invalid code" and "your session expired,
-                        // sign in again" call for different actions, and a flat retry prompt has the
-                        // user typing codes at a tempToken that can no longer succeed.
-                        error = (result.exception as? ApiException)?.message
-                            ?: "Invalid code. Please try again.",
-                        digits = List(6) { "" },
-                        backupCode = "",
+                        error = rejection?.message
+                            ?: "Couldn't reach the server. Check your connection and try again.",
+                        digits = if (rejection != null) List(6) { "" } else current.digits,
+                        backupCode = if (rejection != null) "" else current.backupCode,
+                        codeAttempt = if (rejection != null) current.codeAttempt + 1 else current.codeAttempt,
                     )
                 }
                 is Result.Loading -> { /* no-op */ }


### PR DESCRIPTION
Logging into a 2FA-enabled account failed with "Login succeeded but user was null in response" and the 2FA prompt never appeared.

## Root cause

The backend answers a password-valid 2FA login with HTTP 200 `{ twoFAPending: true, tempToken }` (`api/server/controllers/auth/LoginController.js`, unchanged since Feb 2025). `LoginResponse` modelled that flag as `twoFactorRequired` — a name that never existed upstream — so `ignoreUnknownKeys` dropped it, login took the normal-success branch, staged an empty token pair, and threw on the absent user. The blank pair persisted, so the next cold start booted in as authenticated and 401-stormed until the session handler ejected the user (visible in the reporter's log).

## Why the PR is wider than the rename

An audit of the flow the rename unlocks found it broken on every error path, so those are fixed here too — shipping the rename alone would have traded a hard failure for a confusing one.

- **Validate before staging.** `user` and `token` are checked before `setTokens` in both `login()` and `verifyTwoFactor()`; an incomplete response is not a session. A blank cached token now reads as null, so installs already carrying the empty pair from an affected build start logged out instead of into the 401 storm.
- **Unauthenticated endpoints skip the 401-refresh leg.** `verify-temp` answers 401 for a wrong code and for an expired tempToken (5-min TTL). It wasn't exempt, so the 401 triggered a refresh that could only fail — no refresh token is minted until 2FA completes — and the hard-expiry signal cleared the back stack to the server-URL screen. One mistyped digit threw the user out of the flow. The exemption also future-proofs `auth/login`, which escapes today only because bad credentials happen not to return 401.
- **Backup codes reach the right field.** The screen fully exposes backup mode, but the code travelled in the TOTP `token` field, and the backend TOTP-verifies whatever arrives there — so a backup code could only ever 401 (and then hit the ejection above). `isBackupCode` now routes it to `backupCode`; `explicitNulls = false` omits the unused field.
- **Back-navigation no longer traps.** `twoFactorTempToken` was never consumed and the Login entry's ViewModel is retained, so backing out of the 2FA screen re-fired the navigation effect and bounced the user straight back — no way to return and fix a password.
- **The server's message survives.** Every failure showed "Invalid code. Please try again.", including an expired tempToken, which had users typing codes at a token that could no longer succeed.

## Tests

`AuthApiLoginTest` (new) deserializes verbatim upstream payloads for login and asserts the `verify-temp` request bodies for TOTP vs backup mode. No test deserialized a real backend body before, which is why a year-old field-name mismatch went unnoticed; reverting the model rename now breaks the build. `AuthInterceptorTest` gains the verify-temp 401 exemption plus a contrast case proving the authenticated `auth/2fa/verify` still refreshes. `TwoFactorViewModelTest` (new) covers backup-mode routing and error surfacing; `LoginViewModelTest` covers the consume.

`:core:network`, `:core:data`, `:feature:auth` unit tests, `detekt`, and `detektMetadataCommonMain` all pass locally.

Validated end-to-end against a live LibreChat v0.8.7 server: the pre-fix build reproduced #277 (`user was null`) and the fixed build signs in via TOTP and backup code, with the wrong-code, expired-tempToken, rate-limit, and back-navigation paths all exercised. A non-2FA control login passed on both builds.

## Out of scope

Two sibling DTO mismatches surfaced during the RCA and are tracked separately: `TwoFactorSetupResponse` maps snake_case keys the backend never sends (breaks enabling 2FA from Settings), and `RegisterResponse` requires a `user` the backend stopped returning in 2023.

Closes #277
