### PR TITLE
fix(settings): stop the diagnostic-log export from saving as .jsonl.json

### DIFF
--- a/feature/settings/src/androidMain/kotlin/com/garfiec/librechat/feature/settings/platform/LogFileSaver.android.kt
+++ b/feature/settings/src/androidMain/kotlin/com/garfiec/librechat/feature/settings/platform/LogFileSaver.android.kt
@@ -7,9 +7,11 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.platform.LocalContext
 
 /**
- * Android diagnostic-log saver. Uses the Storage Access Framework `CreateDocument` contract
- * (`application/json` MIME) and writes [content] via the resolved `OutputStream`. Mirrors the
- * `feature:conversations` `FileSaver` Android actual.
+ * Android diagnostic-log saver. Uses the Storage Access Framework `CreateDocument` contract and
+ * writes [content] via the resolved `OutputStream`. Mirrors the `feature:conversations` `FileSaver`
+ * Android actual.
+ *
+ * The MIME type must stay `application/octet-stream` or SAF appends `.json` to the `.jsonl` name.
  */
 @Composable
 actual fun LogFileSaver(
@@ -21,20 +23,22 @@ actual fun LogFileSaver(
     val context = LocalContext.current
 
     val launcher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.CreateDocument("application/json"),
+        contract = ActivityResultContracts.CreateDocument("application/octet-stream"),
     ) { uri ->
-        if (uri != null && content != null) {
-            try {
-                context.contentResolver.openOutputStream(uri)?.use { outputStream ->
-                    outputStream.write(content.toByteArray())
+        when {
+            uri == null -> onComplete(false, null)
+            content == null -> onComplete(false, "Export data was lost — please try again")
+            else -> try {
+                val outputStream = context.contentResolver.openOutputStream(uri)
+                if (outputStream == null) {
+                    onComplete(false, "Could not open the selected file for writing")
+                } else {
+                    outputStream.use { it.write(content.toByteArray()) }
+                    onComplete(true, null)
                 }
-                onComplete(true, null)
             } catch (e: Exception) {
-                onComplete(false, e.message)
+                onComplete(false, e.message ?: "Could not write export file")
             }
-        } else {
-            // User cancelled the picker.
-            onComplete(false, null)
         }
         onReset()
     }

--- a/feature/settings/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/settings/viewmodel/SettingsViewModelTest.kt
+++ b/feature/settings/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/settings/viewmodel/SettingsViewModelTest.kt
@@ -439,4 +439,22 @@ class SettingsViewModelTest {
 
         assertThat(viewModel.uiState.value.showExportComingSoon).isFalse()
     }
+
+    @Test
+    fun `exportLogs offers the buffer under a jsonl filename`() = runTest {
+        val buffer = """{"ts":1,"msg":"first"}""" + "\n" + """{"ts":2,"msg":"second"}""" + "\n"
+        coEvery { diagnosticLogRepository.exportText() } returns buffer
+
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.exportLogs()
+        advanceUntilIdle()
+
+        val payload = viewModel.uiState.value.logsExportReady
+        assertThat(payload).isNotNull()
+        assertThat(payload?.content).isEqualTo(buffer)
+        assertThat(payload?.fileName).endsWith(".jsonl")
+        assertThat(viewModel.uiState.value.isLogsExporting).isFalse()
+    }
 }


### PR DESCRIPTION
## Problem

Settings → Data → **Export logs** saved every file as `librechat-logs-<epoch>.jsonl.json` on Android. The double extension is wrong twice over: the payload is newline-delimited JSON records, so a `.json` suffix promises a document no strict parser can read.

The log pipeline was never at fault — `PersistentLogWriter` writes one `json.encodeToString(record)` per line, and `DataManagementDelegate.exportLogs()` already named the file `.jsonl`. The corruption was entirely in the Android saver, which declared an `application/json` MIME on the SAF `CreateDocument` contract.

## Why octet-stream

`DocumentsProvider.createDocument` runs the display name through [`FileUtils.splitFileName`](https://android.googlesource.com/platform/frameworks/base/+/refs/heads/main/core/java/android/os/FileUtils.java), which appends a type-derived extension unless the declared type agrees with the name's own:

```java
if (mimeTypeFromExt == null) mimeTypeFromExt = ContentResolver.MIME_TYPE_DEFAULT;  // application/octet-stream

final String extFromMimeType;
if (ContentResolver.MIME_TYPE_DEFAULT.equals(mimeType)) extFromMimeType = null;
else extFromMimeType = MimeTypeMap.getSingleton().getExtensionFromMimeType(mimeType);

if (Objects.equals(mimeType, mimeTypeFromExt) || Objects.equals(ext, extFromMimeType)) {
    // Extension maps back to requested MIME type; allow it
} else {
    name = displayName;      // the whole "librechat-logs-123.jsonl"
    ext = extFromMimeType;   // ...and append this
}
```

`MimeTypeMap` has no `jsonl` entry, so `mimeTypeFromExt` always falls back to `application/octet-stream`:

| Declared MIME | `mimeTypeFromExt` | `extFromMimeType` | Branch | Result |
|---|---|---|---|---|
| `application/json` | `application/octet-stream` | `json` | mismatch | `…​.jsonl.json` ← the bug |
| `application/octet-stream` | `application/octet-stream` | `null` (special-cased) | **match**, via the first condition | `…​.jsonl` |

Declaring the default type is what makes the provider consider the name consistent, so it leaves it alone. (`*/*` also yields the right name, but by the *mismatch* branch — it survives only because there is no extension to append, and it is a filter pattern for `getContent`/`openDocument` rather than a type to store on a document.)

`.jsonl` stays: it is the extension [JSON Lines](https://jsonlines.org) suggests, and `application/jsonl` is not standardized, so there is no registered type to declare. The tradeoff is that `.jsonl` is registered nowhere, so the saved file will not open on tap in a file manager — accepted, since the alternative is an extension that lies about the contents.

iOS was unaffected; `LogFileSaver.ios.kt` writes the exact filename to a temp file and shares that URL.

## Also in this change

Code review surfaced three silent-failure paths in the same callback, all pre-existing, all of which leave an empty file at the destination the user picked:

- `openOutputStream(uri)?.use { … }` null-short-circuited straight into `onComplete(true, null)` — a provider that cannot open the URI reported a **successful** export over a zero-byte file.
- A payload lost to activity recreation (the caller holds it in plain `remember`, `DataSettingsScreen.kt:109`) fell into the branch commented "user cancelled", and the screen only raises a snackbar when the message is non-null — so it failed invisibly.
- An exception carrying a null `message` produced no snackbar either.

Only a null `uri` — an actual cancel — now reports no message.

Not addressed here: the Export row's in-flight guard (`enabled = !isLogsExporting`) clears in the same state update that publishes the payload, while the SAF activity is still starting, so a fast double-tap can stack two pickers. That needs changes across the delegate and the screen. The same silent-success-on-null-stream bug also exists in `feature:conversations`' `FileSaver`, which additionally never calls `onComplete` on cancel.

## Testing

- `:feature:settings:testDebugUnitTest` — 77 tests, green. Added one pinning the export payload and its `.jsonl` name.
- Verified on a Pixel 9 Pro Fold: the SAF dialog prefills `librechat-logs-<epoch>.jsonl` and the file saves under exactly that name, with no `.json` appended.