### PR TITLE
test(ui): expose testTags as resource-ids for on-device automation

### DIFF
--- a/app/src/main/kotlin/com/garfiec/librechat/MainActivity.kt
+++ b/app/src/main/kotlin/com/garfiec/librechat/MainActivity.kt
@@ -32,9 +32,12 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
 import androidx.core.view.WindowCompat
@@ -77,7 +80,7 @@ class MainActivity : ComponentActivity() {
      */
     private var shareNavigationTrigger by mutableIntStateOf(0)
 
-    @OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
+    @OptIn(ExperimentalMaterial3WindowSizeClassApi::class, ExperimentalComposeUiApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
@@ -152,7 +155,11 @@ class MainActivity : ComponentActivity() {
                     accentColor = Color(accentColorArgb),
                     useDynamicColor = useDynamicColor,
                 ) {
-                    Surface(modifier = Modifier.fillMaxSize()) {
+                    Surface(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .semantics { testTagsAsResourceId = true },
+                    ) {
                         Column(modifier = Modifier.fillMaxSize()) {
                             AnimatedVisibility(
                                 visible = !isConnected,

--- a/core/ui/src/androidMain/kotlin/com/garfiec/librechat/core/ui/components/TestTagsAsResourceId.android.kt
+++ b/core/ui/src/androidMain/kotlin/com/garfiec/librechat/core/ui/components/TestTagsAsResourceId.android.kt
@@ -1,0 +1,10 @@
+package com.garfiec.librechat.core.ui.components
+
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTagsAsResourceId
+
+@OptIn(ExperimentalComposeUiApi::class)
+actual fun Modifier.testTagsAsResourceIdSubtree(): Modifier =
+    semantics { testTagsAsResourceId = true }

--- a/core/ui/src/commonMain/kotlin/com/garfiec/librechat/core/ui/components/TestTagsAsResourceId.kt
+++ b/core/ui/src/commonMain/kotlin/com/garfiec/librechat/core/ui/components/TestTagsAsResourceId.kt
@@ -1,0 +1,11 @@
+package com.garfiec.librechat.core.ui.components
+
+import androidx.compose.ui.Modifier
+
+/**
+ * Opts a Dialog/ModalBottomSheet content root into surfacing the `testTag`s in its subtree as
+ * Android `resource-id`s for on-device UiAutomator. The Activity-level flag set on the root Surface
+ * does not reach these subtrees — each renders in its own window/AndroidComposeView — so every such
+ * root must opt in itself. No-op on iOS.
+ */
+expect fun Modifier.testTagsAsResourceIdSubtree(): Modifier

--- a/core/ui/src/iosMain/kotlin/com/garfiec/librechat/core/ui/components/TestTagsAsResourceId.ios.kt
+++ b/core/ui/src/iosMain/kotlin/com/garfiec/librechat/core/ui/components/TestTagsAsResourceId.ios.kt
@@ -1,0 +1,5 @@
+package com.garfiec.librechat.core.ui.components
+
+import androidx.compose.ui.Modifier
+
+actual fun Modifier.testTagsAsResourceIdSubtree(): Modifier = this

--- a/feature/auth/src/commonMain/kotlin/com/garfiec/librechat/feature/auth/screen/LoginScreen.kt
+++ b/feature/auth/src/commonMain/kotlin/com/garfiec/librechat/feature/auth/screen/LoginScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.input.KeyboardType
@@ -103,7 +104,7 @@ fun LoginScreen(
                 value = uiState.email,
                 onValueChange = viewModel::onEmailChanged,
                 label = { Text(stringResource(Res.string.email_label)) },
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier.fillMaxWidth().testTag("login_email"),
                 singleLine = true,
                 keyboardOptions = KeyboardOptions(
                     keyboardType = KeyboardType.Email,
@@ -118,7 +119,7 @@ fun LoginScreen(
                 value = uiState.password,
                 onValueChange = viewModel::onPasswordChanged,
                 label = { Text(stringResource(Res.string.password_label)) },
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier.fillMaxWidth().testTag("login_password"),
                 singleLine = true,
                 visualTransformation = passwordMaskTransformation(),
                 keyboardOptions = KeyboardOptions(
@@ -134,6 +135,7 @@ fun LoginScreen(
                     text = uiState.error!!,
                     color = MaterialTheme.colorScheme.error,
                     style = MaterialTheme.typography.bodySmall,
+                    modifier = Modifier.testTag("login_error"),
                 )
             }
 
@@ -141,7 +143,7 @@ fun LoginScreen(
 
             Button(
                 onClick = viewModel::login,
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier.fillMaxWidth().testTag("login_submit"),
                 enabled = !uiState.isLoading,
             ) {
                 if (uiState.isLoading) {

--- a/feature/auth/src/commonMain/kotlin/com/garfiec/librechat/feature/auth/screen/ServerUrlScreen.kt
+++ b/feature/auth/src/commonMain/kotlin/com/garfiec/librechat/feature/auth/screen/ServerUrlScreen.kt
@@ -25,10 +25,12 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.garfiec.librechat.core.ui.components.testTagsAsResourceIdSubtree
 import com.garfiec.librechat.feature.auth.resources.*
 import com.garfiec.librechat.feature.auth.resources.Res
 import com.garfiec.librechat.feature.auth.viewmodel.ServerUrlViewModel
@@ -94,7 +96,7 @@ fun ServerUrlScreen(
                 onValueChange = viewModel::onUrlChanged,
                 label = { Text(stringResource(Res.string.server_url_label)) },
                 placeholder = { Text(stringResource(Res.string.server_url_placeholder)) },
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier.fillMaxWidth().testTag("server_url_field"),
                 singleLine = true,
                 isError = uiState.error != null,
                 supportingText = uiState.error?.let { error ->
@@ -107,7 +109,7 @@ fun ServerUrlScreen(
 
             Button(
                 onClick = viewModel::validateAndConnect,
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier.fillMaxWidth().testTag("server_url_connect"),
                 enabled = !uiState.isLoading && uiState.url.isNotBlank(),
             ) {
                 if (uiState.isLoading) {
@@ -138,7 +140,12 @@ private fun HttpWarningDialog(
             Text(stringResource(Res.string.insecure_connection_message))
         },
         confirmButton = {
-            TextButton(onClick = onConfirm) {
+            TextButton(
+                onClick = onConfirm,
+                modifier = Modifier
+                    .testTagsAsResourceIdSubtree()
+                    .testTag("server_url_http_confirm"),
+            ) {
                 Text(
                     text = stringResource(Res.string.connect_anyway),
                     color = MaterialTheme.colorScheme.error,

--- a/feature/auth/src/commonMain/kotlin/com/garfiec/librechat/feature/auth/screen/TwoFactorScreen.kt
+++ b/feature/auth/src/commonMain/kotlin/com/garfiec/librechat/feature/auth/screen/TwoFactorScreen.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.input.KeyboardType
@@ -136,6 +137,7 @@ fun TwoFactorScreen(
                     text = uiState.error!!,
                     color = MaterialTheme.colorScheme.error,
                     style = MaterialTheme.typography.bodySmall,
+                    modifier = Modifier.testTag("twofa_error"),
                 )
             }
 
@@ -145,7 +147,7 @@ fun TwoFactorScreen(
             // button to move forward.
             Button(
                 onClick = viewModel::submit,
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier.fillMaxWidth().testTag("twofa_verify"),
                 enabled = !uiState.isLoading && if (uiState.isBackupMode) {
                     uiState.backupCode.isNotBlank()
                 } else {
@@ -165,7 +167,10 @@ fun TwoFactorScreen(
 
             Spacer(modifier = Modifier.height(16.dp))
 
-            TextButton(onClick = viewModel::toggleBackupMode) {
+            TextButton(
+                onClick = viewModel::toggleBackupMode,
+                modifier = Modifier.testTag("twofa_toggle_mode"),
+            ) {
                 Text(
                     if (uiState.isBackupMode) {
                         stringResource(Res.string.use_authenticator_code)
@@ -205,6 +210,7 @@ private fun DigitBoxes(
                 },
                 modifier = Modifier
                     .weight(1f)
+                    .testTag("twofa_digit_$index")
                     .focusRequester(focusRequesters[index]),
                 enabled = enabled,
                 singleLine = true,
@@ -232,7 +238,7 @@ private fun BackupCodeInput(
     OutlinedTextField(
         value = code,
         onValueChange = onCodeChange,
-        modifier = modifier.fillMaxWidth(),
+        modifier = modifier.fillMaxWidth().testTag("twofa_backup_code"),
         enabled = enabled,
         singleLine = true,
         label = { Text(stringResource(Res.string.backup_code_label)) },

--- a/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/drawer/AccountSwitcherSheet.kt
+++ b/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/drawer/AccountSwitcherSheet.kt
@@ -48,11 +48,13 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.garfiec.librechat.core.ui.components.AvatarImage
 import com.garfiec.librechat.core.ui.components.LowProfileDragHandle
 import com.garfiec.librechat.core.ui.components.avatarColorForSeed
+import com.garfiec.librechat.core.ui.components.testTagsAsResourceIdSubtree
 import com.garfiec.librechat.feature.conversations.resources.Res
 import com.garfiec.librechat.feature.conversations.resources.accounts
 import com.garfiec.librechat.feature.conversations.resources.add_account
@@ -147,6 +149,7 @@ fun AccountChip(
     Surface(
         onClick = onClick,
         modifier = modifier
+            .testTag("account_chip")
             .graphicsLayer {
                 translationY = dragOffsetY.floatValue
                 // Shrink and fade toward the drag limit, tracking the spring-back on release.
@@ -222,7 +225,7 @@ fun AccountSwitcherSheet(
         dragHandle = { LowProfileDragHandle() },
         sheetState = sheetState,
     ) {
-        Column(modifier = Modifier.navigationBarsPadding()) {
+        Column(modifier = Modifier.testTagsAsResourceIdSubtree().navigationBarsPadding()) {
             Text(
                 text = stringResource(Res.string.accounts),
                 style = MaterialTheme.typography.titleMedium,
@@ -242,6 +245,7 @@ fun AccountSwitcherSheet(
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
+                    .testTag("account_add")
                     .clickable(onClick = onAddAccount)
                     .padding(horizontal = 24.dp, vertical = 14.dp),
                 verticalAlignment = Alignment.CenterVertically,


### PR DESCRIPTION
## What

Opt the root `Surface` into `testTagsAsResourceId` and add `Modifier.testTag`
ids to the auth entry points (server URL, login, 2FA) plus the drawer account
chip and add-account row.

## Why

uiautomator/adb address nodes by `resource-id`, and Compose emits none by
default. The six 2FA digit boxes, in particular, dump as identical unlabelled
`EditText` nodes with `text=""` — an on-device end-to-end run can neither tell
them apart nor read which one holds focus. These tags make the auth flow
scriptable by stable id instead of by coordinates or visible text.

Extracted from the 2FA login fix validation work, where the harness that
exercised the fix on a real server depended on them. Kept as its own change
because it's permanently useful for future UI automation and touches no runtime
behaviour.

## Scope

Semantics only — no runtime behaviour changes. `testTagsAsResourceId` is
Google's documented UiAutomator opt-in; `testTag` carries no user-visible
effect.

Ids added: `login_email`, `login_password`, `login_error`, `login_submit`,
`server_url_field`, `server_url_connect`, `server_url_http_confirm`,
`twofa_digit_0…5`, `twofa_error`, `twofa_verify`, `twofa_toggle_mode`,
`twofa_backup_code`, `account_chip`, `account_add`.

## Known limitation

The root opt-in covers the activity's own window only. `AlertDialog` (the HTTP
warning) and `ModalBottomSheet` (`AccountSwitcherSheet`) each compose into a
separate window with its own semantics owner, so their tagged nodes
(`server_url_http_confirm`, `account_add`) don't surface as resource-ids in a
dump — those are addressed by visible text instead. The tags are left in place
for when that changes upstream.

## Testing

Semantics-only change, exercised in practice: the tags drove the full on-device
E2E run of the 2FA login flow against a live LibreChat v0.8.7 server.
