### PR TITLE
fix(chat): stop over-sending default-valued model params on chat send

### DIFF
--- a/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ModelParamPayloadTest.kt
+++ b/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ModelParamPayloadTest.kt
@@ -38,18 +38,21 @@ class ModelParamPayloadTest {
     }
 
     @Test
-    fun `promptCache toggled on is transmitted as a boolean`() {
-        val params = ModelParameters.DEFAULT.copy(dynamicValues = mapOf("promptCache" to "true"))
+    fun `promptCache opt-out is transmitted as a boolean`() {
+        // Anthropic caches by default (registry default "true"), so turning it OFF is a real change and
+        // must be sent — encoded as a JSON boolean, not the string "false".
+        val params = ModelParameters.DEFAULT.copy(dynamicValues = mapOf("promptCache" to "false"))
         val result = build(params)
-        assertTrue(result["promptCache"]!!.jsonPrimitive.boolean)
+        assertEquals(false, result["promptCache"]?.jsonPrimitive?.boolean)
     }
 
     @Test
     fun `default-valued params are not over-sent`() {
-        // Regression guard: the sheet seeds default-valued entries into dynamicValues on open; those
-        // must NOT be transmitted (no promptCache=false, no topP=1.0, etc.) on an untouched chat.
+        // Regression guard: the sheet seeds default-valued entries into dynamicValues on open; a value
+        // equal to its default (the provider registry default for promptCache, the composer default for
+        // top_p/topP) must NOT be transmitted on an untouched chat.
         val seeded = ModelParameters.DEFAULT.copy(
-            dynamicValues = mapOf("promptCache" to "false", "top_p" to "1.0", "topP" to "1.0"),
+            dynamicValues = mapOf("promptCache" to "true", "top_p" to "1.0", "topP" to "1.0"),
         )
         val result = build(seeded)
         assertNull(result["promptCache"])

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ModelParamPayload.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ModelParamPayload.kt
@@ -42,13 +42,12 @@ object ModelParamPayload {
         for (definition in definitions) {
             val key = definition.key
             val raw = params.getValueForKey(key)
-            // "Changed" is measured against the default composer state (ModelParameters.DEFAULT), NOT
-            // the definition.default — the two can disagree (e.g. Anthropic promptCache's definition
-            // default is "true" but getValueForKey falls back to "false"). Comparing against the composer
-            // default keeps an untouched sheet from emitting anything (including spurious promptCache=false),
-            // while still transmitting any value the user actually changed. Mere presence in `dynamicValues`
-            // is NOT enough — the sheet seeds default-valued entries there on open, which must not be sent.
-            if (raw == ModelParameters.DEFAULT.getValueForKey(key) || raw.isBlank()) continue
+            // Skip any value the server would apply on its own: a blank (unset), the composer baseline
+            // (ModelParameters.DEFAULT), or the provider-specific registry default. The registry default
+            // must be checked too — for a dynamic-only key like promptCache the composer baseline is ""
+            // (empty dynamicValues), so a seeded default-valued entry would otherwise be over-sent. Mere
+            // presence in `dynamicValues` is not "changed": the sheet seeds default-valued entries on open.
+            if (raw.isBlank() || raw == ModelParameters.DEFAULT.getValueForKey(key) || raw == definition.default) continue
             out[key] = encode(definition.type, raw)
         }
         return JsonObject(out)


### PR DESCRIPTION
## Problem

`develop`'s CI has been red since #276 — `ModelParamPayloadTest > default-valued params are not over-sent` fails. Neither #278 nor #280 touches this code, but both inherit the red.

## Root cause

#276 removed the hardcoded `"promptCache" -> dynamicValues["promptCache"] ?: "false"` case from `ModelParameters.getValueForKey` so the agent editor reads the correct per-provider default (Anthropic caches by default). That was right for the editor.

But `ModelParamPayload.build` (the chat-send path) relied on that `"false"` fallback to recognize an untouched `promptCache` as its default and skip it. With the case gone, the key resolves to `""`, so a seeded default-valued entry no longer matches the baseline and is transmitted on every chat send.

## Fix

`build()` now skips a param whose value equals the **provider registry default** (`definition.default`) in addition to the composer baseline (`ModelParameters.DEFAULT`) and blank. A dynamic-only key like `promptCache`, whose composer baseline is `""`, is now correctly recognized as unchanged when it equals its per-provider default.

Tests updated to the post-#276 semantics:
- `default-valued params are not over-sent` seeds `promptCache=true` (Anthropic's default) and asserts it is **not** sent.
- The former `promptCache toggled on is transmitted` is repurposed to `promptCache opt-out is transmitted as a boolean`: an explicit `false` (opting out of Anthropic's on-by-default caching) **is** sent, encoded as a JSON boolean.

## Testing

`:feature:chat:testDebugUnitTest` (full suite) and `:feature:chat:detekt` pass locally. This makes `develop` green again; #278 and #280 go green once rebased on it.
