### PR TITLE
fix(auth): robust 2FA verify error handling via a sealed outcome contract

### DIFF
--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/repository/AuthRepositoryImplVerifyTest.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/repository/AuthRepositoryImplVerifyTest.kt
@@ -1,0 +1,176 @@
+package com.garfiec.librechat.core.data.repository
+
+import com.garfiec.librechat.core.common.identity.AccountState
+import com.garfiec.librechat.core.common.identity.ActiveAccountProvider
+import com.garfiec.librechat.core.common.identity.SessionManager
+import com.garfiec.librechat.core.common.result.ApiException
+import com.garfiec.librechat.core.data.datastore.AccountRegistry
+import com.garfiec.librechat.core.data.util.SessionTaskRunner
+import com.garfiec.librechat.core.model.User
+import com.garfiec.librechat.core.model.VerifyTwoFactorOutcome
+import com.garfiec.librechat.core.network.api.AuthApi
+import com.garfiec.librechat.core.network.api.UserApi
+import com.garfiec.librechat.core.network.client.SwitchGate
+import com.garfiec.librechat.core.network.client.TokenManager
+import com.garfiec.librechat.core.network.di.librechatJson
+import com.google.common.truth.Truth.assertThat
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.HttpResponseValidator
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.defaultRequest
+import io.ktor.client.request.url
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.http.headersOf
+import io.ktor.http.isSuccess
+import io.ktor.serialization.kotlinx.json.json
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * End-to-end coverage for [AuthRepositoryImpl.verifyTwoFactor] over a **real** Ktor stack (MockEngine
+ * + ContentNegotiation + a response validator that mirrors production's `throw ApiException` on
+ * non-2xx). This is the churn-stopping guard: it exercises the actual decode path rather than a
+ * hand-constructed exception, so a wrong assumption about which exception Ktor throws (as in the
+ * round-3 dead `SerializationException` branch) can no longer pass vacuously. It also pins the
+ * phase-2 split — a commit fault after the code was consumed must report `SessionIncomplete`, never a
+ * connectivity lie.
+ */
+class AuthRepositoryImplVerifyTest {
+
+    private val userApi = mockk<UserApi>(relaxed = true)
+    private val tokenManager = mockk<TokenManager>(relaxed = true)
+    private val sessionCacheCleaner = mockk<SessionCacheCleaner>(relaxed = true)
+    private val sessionTaskRunner = mockk<SessionTaskRunner>(relaxed = true)
+    private val accountSessionEstablisher = mockk<AccountSessionEstablisher>(relaxed = true)
+    private val accountRegistry = mockk<AccountRegistry>(relaxed = true)
+    private val activeAccountProvider = mockk<ActiveAccountProvider>(relaxed = true)
+    private val sessionManager = mockk<SessionManager>(relaxed = true)
+    private val accountSwitcher = mockk<AccountSwitcher>(relaxed = true)
+    private val switchGate = mockk<SwitchGate>(relaxed = true)
+
+    @Before
+    fun setUp() {
+        // currentAccountId() reads state.value; give it a real flow so the sealed AccountState isn't
+        // mocked. Warming resolves to a null account id (logged-out / not-yet-resolved), which is the
+        // realistic pre-verify state.
+        every { activeAccountProvider.state } returns MutableStateFlow(AccountState.Warming)
+        // No add-account flow in these tests: the plain sign-in path commits via
+        // accountSessionEstablisher.establish(), not accountSwitcher.completeAdd().
+        every { accountSwitcher.pendingAdd } returns null
+    }
+
+    private fun repo(engine: MockEngine): AuthRepositoryImpl {
+        val client = HttpClient(engine) {
+            install(ContentNegotiation) { json(librechatJson) }
+            // Mirror LibreChatHttpClient: every non-2xx becomes an ApiException before body parsing,
+            // so the classifier only ever sees a decode exception on a genuine 2xx.
+            HttpResponseValidator {
+                validateResponse { response ->
+                    if (!response.status.isSuccess()) {
+                        throw ApiException(response.status.value, response.bodyAsText().ifBlank { "error" })
+                    }
+                }
+            }
+            defaultRequest {
+                url("https://chat.example.com")
+                contentType(ContentType.Application.Json)
+            }
+        }
+        return AuthRepositoryImpl(
+            authApi = AuthApi(client),
+            userApi = userApi,
+            tokenManager = tokenManager,
+            sessionCacheCleaner = sessionCacheCleaner,
+            sessionTaskRunner = sessionTaskRunner,
+            accountSessionEstablisher = accountSessionEstablisher,
+            accountRegistry = accountRegistry,
+            activeAccountProvider = activeAccountProvider,
+            sessionManager = sessionManager,
+            accountSwitcher = accountSwitcher,
+            switchGate = switchGate,
+        )
+    }
+
+    private fun jsonHeaders() = headersOf(HttpHeaders.ContentType, "application/json")
+
+    private fun engineReturning(content: String, status: HttpStatusCode) = MockEngine {
+        respond(content = content, status = status, headers = jsonHeaders())
+    }
+
+    @Test
+    fun `an undecodable 2xx body reports SessionIncomplete, not a connectivity failure`() = runTest {
+        // Truncated + wrong-typed body: a real ContentConvertException flows out of body<LoginResponse>(),
+        // through safeApiCall, into the classifier — no hand-built exception, so it can't go vacuous.
+        val outcome = repo(engineReturning("""{"token":"jwt-1","user":{"_id":123}""", HttpStatusCode.OK))
+            .verifyTwoFactor(tempToken = "temp-abc", code = "123456")
+
+        assertThat(outcome).isInstanceOf(VerifyTwoFactorOutcome.SessionIncomplete::class.java)
+    }
+
+    @Test
+    fun `a 2xx missing the user field reports SessionIncomplete`() = runTest {
+        val outcome = repo(engineReturning("""{"token":"jwt-1"}""", HttpStatusCode.OK))
+            .verifyTwoFactor(tempToken = "temp-abc", code = "123456")
+
+        assertThat(outcome).isInstanceOf(VerifyTwoFactorOutcome.SessionIncomplete::class.java)
+    }
+
+    @Test
+    fun `a commit fault after the code was consumed reports SessionIncomplete, not ConnectionFailure`() = runTest {
+        // Valid session body, so the code is consumed server-side, but establishing the local session
+        // throws. This must NOT be misread as a wire/connectivity failure (finding #2 regression).
+        coEvery { accountSessionEstablisher.establish(any()) } throws IllegalStateException("registry write failed")
+
+        val outcome = repo(engineReturning(VALID_SESSION_BODY, HttpStatusCode.OK))
+            .verifyTwoFactor(tempToken = "temp-abc", code = "123456")
+
+        assertThat(outcome).isInstanceOf(VerifyTwoFactorOutcome.SessionIncomplete::class.java)
+    }
+
+    @Test
+    fun `a commit fault rolls back the staged tokens so no orphaned session lingers`() = runTest {
+        // stageAuthenticatedSession has already staged the pair (tokenManager.setTokens) by the time
+        // establish throws. On the fresh sign-in path (pending == null) the rollback must fully tear
+        // the staged session down via clearTokens, so a later onAccountResolved can't silently re-home
+        // a session the user was told had failed. This is the finding #1 (round 5) regression guard.
+        coEvery { accountSessionEstablisher.establish(any()) } throws IllegalStateException("registry write failed")
+
+        repo(engineReturning(VALID_SESSION_BODY, HttpStatusCode.OK))
+            .verifyTwoFactor(tempToken = "temp-abc", code = "123456")
+
+        coVerify { tokenManager.clearTokens() }
+        coVerify(exactly = 0) { tokenManager.clearStagedTokens() }
+    }
+
+    @Test
+    fun `a 401 reports CodeRejected`() = runTest {
+        val outcome = repo(engineReturning("""{"message":"Invalid 2FA code or backup code"}""", HttpStatusCode.Unauthorized))
+            .verifyTwoFactor(tempToken = "temp-abc", code = "000000")
+
+        assertThat(outcome).isInstanceOf(VerifyTwoFactorOutcome.CodeRejected::class.java)
+    }
+
+    @Test
+    fun `a healthy 2xx that commits cleanly reports Success`() = runTest {
+        val outcome = repo(engineReturning(VALID_SESSION_BODY, HttpStatusCode.OK))
+            .verifyTwoFactor(tempToken = "temp-abc", code = "123456")
+
+        assertThat(outcome).isEqualTo(VerifyTwoFactorOutcome.Success(User(mongoId = "u1", email = "a@b.com")))
+    }
+
+    private companion object {
+        const val VALID_SESSION_BODY = """{"token":"jwt-1","user":{"_id":"u1","email":"a@b.com"}}"""
+    }
+}

--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/repository/VerifyFailureClassificationTest.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/repository/VerifyFailureClassificationTest.kt
@@ -1,0 +1,70 @@
+package com.garfiec.librechat.core.data.repository
+
+import com.garfiec.librechat.core.common.result.ApiException
+import com.garfiec.librechat.core.model.VerifyTwoFactorOutcome
+import com.google.common.truth.Truth.assertThat
+import io.ktor.serialization.JsonConvertException
+import org.junit.Test
+import java.io.IOException
+
+/**
+ * Pins [classifyVerifyFailure] to the backend's 2FA verify contract
+ * (`upstream/api/server/controllers/auth/TwoFactorAuthController.js`): only a 401 means the
+ * server evaluated the submitted code, and only an undecodable 2xx means it consumed the code
+ * without yielding a session — everything else never judged the code at all. Only wire exceptions
+ * reach the classifier; commit-path faults are covered by [AuthRepositoryImplVerifyTest].
+ */
+class VerifyFailureClassificationTest {
+
+    @Test
+    fun `a 401 is the server's verdict on the code`() {
+        // Backend: wrong code and expired temp session both answer 401 — the entry is spent.
+        val outcome = classifyVerifyFailure(ApiException(401, "Invalid 2FA code or backup code"))
+
+        assertThat(outcome).isEqualTo(VerifyTwoFactorOutcome.CodeRejected("Invalid 2FA code or backup code"))
+    }
+
+    @Test
+    fun `a 400 refused the request before evaluating the code`() {
+        // Backend: missing tempToken / 2FA-not-enabled answer 400 without touching the code.
+        val outcome = classifyVerifyFailure(ApiException(400, "2FA is not enabled for this user"))
+
+        assertThat(outcome).isEqualTo(VerifyTwoFactorOutcome.NotEvaluated("2FA is not enabled for this user"))
+    }
+
+    @Test
+    fun `a 429 rate limit never judged the code`() {
+        val message = "Too many verification attempts, please try again after 5 minutes."
+        val outcome = classifyVerifyFailure(ApiException(429, message))
+
+        assertThat(outcome).isEqualTo(VerifyTwoFactorOutcome.NotEvaluated(message))
+    }
+
+    @Test
+    fun `a 5xx is a server fault, not a verdict`() {
+        val outcome = classifyVerifyFailure(ApiException(500, "Something went wrong"))
+
+        assertThat(outcome).isEqualTo(VerifyTwoFactorOutcome.NotEvaluated("Something went wrong"))
+    }
+
+    @Test
+    fun `an undecodable 2xx body consumed the code without a session`() {
+        // Ktor's ContentNegotiation wraps every 2xx body decode failure in JsonConvertException
+        // (a ContentConvertException) — this is the actual runtime type, not a bare kotlinx
+        // SerializationException. AuthApiLoginTest pins that this is what the wire really throws.
+        val outcome = classifyVerifyFailure(JsonConvertException("Illegal input: Unexpected JSON token"))
+
+        assertThat(outcome).isEqualTo(VerifyTwoFactorOutcome.SessionIncomplete(INCOMPLETE_AUTH_MESSAGE))
+    }
+
+    @Test
+    fun `a transport failure maps to ConnectionFailure`() {
+        assertThat(classifyVerifyFailure(IOException("connection reset")))
+            .isEqualTo(VerifyTwoFactorOutcome.ConnectionFailure)
+    }
+
+    @Test
+    fun `a missing exception maps to ConnectionFailure`() {
+        assertThat(classifyVerifyFailure(null)).isEqualTo(VerifyTwoFactorOutcome.ConnectionFailure)
+    }
+}

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/AuthRepository.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/AuthRepository.kt
@@ -3,12 +3,20 @@ package com.garfiec.librechat.core.data.repository
 import com.garfiec.librechat.core.common.result.Result
 import com.garfiec.librechat.core.model.LoginOutcome
 import com.garfiec.librechat.core.model.User
+import com.garfiec.librechat.core.model.VerifyTwoFactorOutcome
 import com.garfiec.librechat.core.model.response.TwoFactorSetupResponse
 
 interface AuthRepository {
     suspend fun login(email: String, password: String): Result<LoginOutcome>
     suspend fun loginWithOAuthToken(refreshToken: String): Result<User>
-    suspend fun verifyTwoFactor(tempToken: String, code: String, isBackupCode: Boolean = false): Result<User>
+
+    /**
+     * Verifies a 2FA temp-token session. Returns a closed [VerifyTwoFactorOutcome] (not a
+     * [Result]) — this repository owns the backend's error contract and classifies every
+     * failure exactly once, so callers get an exhaustive `when` instead of re-deriving
+     * semantics from status codes and exception types.
+     */
+    suspend fun verifyTwoFactor(tempToken: String, code: String, isBackupCode: Boolean = false): VerifyTwoFactorOutcome
     suspend fun register(name: String, email: String, username: String, password: String): Result<Unit>
     suspend fun logout(): Result<Unit>
     suspend fun isLoggedIn(): Boolean

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/AuthRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/AuthRepositoryImpl.kt
@@ -6,12 +6,14 @@ import com.garfiec.librechat.core.common.identity.AccountState
 import com.garfiec.librechat.core.common.identity.ActiveAccountProvider
 import com.garfiec.librechat.core.common.identity.SessionManager
 import com.garfiec.librechat.core.common.identity.currentAccountId
+import com.garfiec.librechat.core.common.result.ApiException
 import com.garfiec.librechat.core.common.result.Result
 import com.garfiec.librechat.core.common.result.safeApiCall
 import com.garfiec.librechat.core.data.datastore.AccountRegistry
 import com.garfiec.librechat.core.data.util.SessionTaskRunner
 import com.garfiec.librechat.core.model.LoginOutcome
 import com.garfiec.librechat.core.model.User
+import com.garfiec.librechat.core.model.VerifyTwoFactorOutcome
 import com.garfiec.librechat.core.model.response.TwoFactorSetupResponse
 import com.garfiec.librechat.core.network.api.AuthApi
 import com.garfiec.librechat.core.network.api.UserApi
@@ -19,8 +21,13 @@ import com.garfiec.librechat.core.network.api.dto.LoginResult
 import com.garfiec.librechat.core.network.client.PendingRequestIdentity
 import com.garfiec.librechat.core.network.client.SwitchGate
 import com.garfiec.librechat.core.network.client.TokenManager
+import io.ktor.serialization.ContentConvertException
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.withContext
+
+/** Surfaced when a 2xx auth response yields no usable session (missing fields or unparseable). */
+internal const val INCOMPLETE_AUTH_MESSAGE = "The server's sign-in response was incomplete. Please try again."
 
 class AuthRepositoryImpl(
     private val authApi: AuthApi,
@@ -112,9 +119,12 @@ class AuthRepositoryImpl(
         return user
     }
 
+    // A missing user/token on a 2xx is caught by phase 2's `catch (e: Exception)` (verify) or by
+    // safeApiCall (login/OAuth) exactly as any other Exception — no caller ever discriminates the
+    // type, so a plain IllegalStateException carries the same behaviour with no bespoke class to trace.
     private fun incompleteAuthResponse(missingField: String): IllegalStateException {
         Logger.w { "Auth response was missing '$missingField'" }
-        return IllegalStateException("The server's sign-in response was incomplete. Please try again.")
+        return IllegalStateException(INCOMPLETE_AUTH_MESSAGE)
     }
 
     override suspend fun login(email: String, password: String): Result<LoginOutcome> {
@@ -162,21 +172,74 @@ class AuthRepositoryImpl(
         }.fireSessionTasksIfLoggedIn(previousAccountId)
     }
 
-    override suspend fun verifyTwoFactor(tempToken: String, code: String, isBackupCode: Boolean): Result<User> {
+    override suspend fun verifyTwoFactor(tempToken: String, code: String, isBackupCode: Boolean): VerifyTwoFactorOutcome {
         val pending = accountSwitcher.pendingAdd
         val previousAccountId = activeAccountProvider.currentAccountId()
-        return safeApiCall {
+
+        // Phase 1 — the wire exchange only. safeApiCall captures its exceptions and
+        // classifyVerifyFailure reads the backend's verdict off them. Nothing local mutates here,
+        // so every exception the classifier sees is genuinely about the request — not a commit fault
+        // misreported as a wire outcome.
+        val wire = safeApiCall {
             withAuthIdentity(pending) {
-                val result = authApi.verifyTempToken(
+                authApi.verifyTempToken(
                     tempToken = tempToken,
                     totpCode = code.takeUnless { isBackupCode },
                     backupCode = code.takeIf { isBackupCode },
                 )
-                val user = stageAuthenticatedSession(result)
+            }
+        }
+        val loginResult = when (wire) {
+            is Result.Success -> wire.data
+            is Result.Error -> return classifyVerifyFailure(wire.exception)
+            is Result.Loading -> error("safeApiCall never returns Loading")
+        }
+
+        // Phase 2 — the server accepted (consumed) the single-use code. Commit atomically under
+        // NonCancellable so a scope death mid-commit can't leave tokens staged without the account
+        // established. A fault here is NOT a wire verdict: the code is already spent, so it maps to
+        // SessionIncomplete (clear the entry, honest message) — never a connectivity lie or a doomed
+        // retry of a consumed code.
+        return try {
+            val user = withContext(NonCancellable) {
+                val user = stageAuthenticatedSession(loginResult)
                 establishSession(pending, user)
                 user
             }
-        }.fireSessionTasksIfLoggedIn(previousAccountId)
+            Result.Success(user).fireSessionTasksIfLoggedIn(previousAccountId)
+            VerifyTwoFactorOutcome.Success(user)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Logger.w(e) { "2FA code accepted but session commit failed" }
+            // stageAuthenticatedSession already wrote the token pair; roll it back so a failed commit
+            // can't leave an orphaned session behind (see rollbackStagedSession).
+            rollbackStagedSession(pending)
+            VerifyTwoFactorOutcome.SessionIncomplete(INCOMPLETE_AUTH_MESSAGE)
+        }
+    }
+
+    /**
+     * Undoes the credentials staged in phase 2 when the session commit faults *after* the server has
+     * already consumed the code. Without this the access/refresh pair set by [stageAuthenticatedSession]
+     * lingers in the store with no established account, and a later [TokenManager.onAccountResolved]
+     * could silently re-home a session the user was just told had failed. Best-effort and
+     * NonCancellable so a scope death mid-rollback can't strand the leak.
+     *
+     * The primitive depends on the flow:
+     * - Fresh sign-in ([pending] == null, logged-out target): the staged bare pair — or a keyed slot a
+     *   partly-completed [establishSession] already re-homed via `onAccountResolved` — is the only
+     *   session, so a full [TokenManager.clearTokens] teardown is both safe and complete.
+     * - Add-account ([pending] != null): [AccountSwitcher.completeAdd] already restored the outgoing
+     *   account's binding on its own failure, so only the staged bare pair needs dropping;
+     *   [TokenManager.clearTokens] would tear down the still-live outgoing account.
+     */
+    private suspend fun rollbackStagedSession(pending: PendingAddSession?) {
+        withContext(NonCancellable) {
+            runCatching {
+                if (pending == null) tokenManager.clearTokens() else tokenManager.clearStagedTokens()
+            }.onFailure { Logger.w(it) { "2FA rollback: staged-session clear failed" } }
+        }
     }
 
     override suspend fun register(
@@ -311,4 +374,37 @@ class AuthRepositoryImpl(
             authApi.resetPassword(userId, token, password, confirmPassword)
         }
     }
+}
+
+/**
+ * Classifies a failed 2FA verify **wire exchange** against the backend's contract
+ * (`upstream/api/server/controllers/auth/TwoFactorAuthController.js`):
+ * - 401 is the only status where the server evaluated the submission (wrong/expired code, or
+ *   expired temp session) — the entered code is spent.
+ * - Every other HTTP answer (400 malformed, 429 rate-limited, 5xx fault) refused or failed the
+ *   request *before* judging the code.
+ * - A 2xx whose body couldn't be decoded means the server accepted (consumed) the single-use code
+ *   without yielding a usable session.
+ *
+ * Only wire exceptions reach here (the session commit is classified separately, in phase 2 of
+ * [verifyTwoFactor]). Top-level and internal so unit tests exercise the mapping directly.
+ */
+internal fun classifyVerifyFailure(e: Throwable?): VerifyTwoFactorOutcome = when {
+    // A 2xx the client couldn't decode into a session. Ktor's ContentNegotiation wraps every
+    // response-body decode failure in ContentConvertException (JsonConvertException) — which does
+    // NOT extend kotlinx SerializationException, so we key on the Ktor type. The single-use code was
+    // consumed server-side, so the entry must clear, not invite a doomed retry.
+    //
+    // Deliberate boundary: this treats EVERY undecodable JSON-typed 2xx as "code consumed", including
+    // the rarer case where a proxy/gateway truncates a response that never reached the 2FA controller
+    // (so the code was NOT actually consumed). Clearing is still safe there because the temp token is a
+    // reusable JWT — only the TOTP/backup code is single-use — so the user just enters a fresh code and
+    // the same tempToken re-verifies within seconds. Keeping the entry instead would reintroduce the
+    // spent-code retry this PR set out to remove for the (more likely) genuine backend-consumed case.
+    // A `200 text/html` from a proxy throws NoTransformationFoundException, not a ContentConvertException,
+    // and falls to ConnectionFailure — an HTML 200 usually means the request never reached the backend.
+    e is ContentConvertException -> VerifyTwoFactorOutcome.SessionIncomplete(INCOMPLETE_AUTH_MESSAGE)
+    e is ApiException && e.statusCode == 401 -> VerifyTwoFactorOutcome.CodeRejected(e.message)
+    e is ApiException -> VerifyTwoFactorOutcome.NotEvaluated(e.message)
+    else -> VerifyTwoFactorOutcome.ConnectionFailure
 }

--- a/core/model/src/commonMain/kotlin/com/garfiec/librechat/core/model/VerifyTwoFactorOutcome.kt
+++ b/core/model/src/commonMain/kotlin/com/garfiec/librechat/core/model/VerifyTwoFactorOutcome.kt
@@ -1,0 +1,46 @@
+package com.garfiec.librechat.core.model
+
+/**
+ * The total outcome of a 2FA verify attempt, classified once at the repository against the
+ * backend's wire contract. The UI's clear-or-keep decision for the entered code follows from
+ * the case alone: a [CodeConsumed] case clears the entry for a fresh code; every other failure
+ * keeps it intact for a plain retry.
+ */
+sealed interface VerifyTwoFactorOutcome {
+    /** Session committed (tokens stored, account established). Must always complete sign-in. */
+    data class Success(val user: User) : VerifyTwoFactorOutcome
+
+    /**
+     * The server consumed the single-use code, so the entered code is spent and the entry must
+     * clear. The sub-cases differ only in *why* no session resulted; grouping them here lets the
+     * one consumer route both with a single branch while keeping the distinction for future UI.
+     */
+    sealed interface CodeConsumed : VerifyTwoFactorOutcome {
+        val message: String
+    }
+
+    /**
+     * 401 — the server evaluated the submission: wrong/expired code, or expired temp session.
+     * The entered code is spent; clear the entry for a fresh one.
+     */
+    data class CodeRejected(override val message: String) : CodeConsumed
+
+    /**
+     * 2xx — the server accepted (consumed) the single-use code but no usable session came back
+     * (missing user/token, or an unparseable body). Clear the entry; retrying the same code
+     * would be rejected as reused.
+     */
+    data class SessionIncomplete(override val message: String) : CodeConsumed
+
+    /**
+     * The server answered without judging the code: 400 malformed, 429 rate-limited, any other
+     * non-401 4xx, or a 5xx fault. Keep the entry intact for a plain retry.
+     */
+    data class NotEvaluated(val message: String) : VerifyTwoFactorOutcome
+
+    /**
+     * No usable response at all (IO/timeout). Keep the entry; the UI supplies its own
+     * connectivity wording.
+     */
+    data object ConnectionFailure : VerifyTwoFactorOutcome
+}

--- a/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/api/AuthApiLoginTest.kt
+++ b/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/api/AuthApiLoginTest.kt
@@ -14,6 +14,7 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
 import io.ktor.http.headersOf
+import io.ktor.serialization.ContentConvertException
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
@@ -116,5 +117,26 @@ class AuthApiLoginTest {
         assertThat(sent["tempToken"]?.jsonPrimitive?.content).isEqualTo("temp-abc")
         assertThat(sent["backupCode"]?.jsonPrimitive?.content).isEqualTo("abcd1234")
         assertThat(sent).doesNotContainKey("token")
+    }
+
+    @Test
+    fun `verifyTempToken wraps an undecodable 2xx body as ContentConvertException`() = runTest {
+        // Pins the exact type the repository's classifier keys on: Ktor's ContentNegotiation wraps
+        // every 2xx body decode failure in JsonConvertException (a ContentConvertException), NOT a
+        // bare kotlinx SerializationException. A malformed success body must surface as this type so
+        // the repository can report "code consumed, session incomplete" instead of a connectivity lie.
+        val engine = MockEngine {
+            respond(
+                content = """{"token":"jwt-1","user":{"_id":123}""", // truncated + wrong-typed: undecodable
+                status = HttpStatusCode.OK,
+                headers = jsonHeaders(),
+            )
+        }
+
+        val error = runCatching {
+            api(engine).verifyTempToken(tempToken = "temp-abc", totpCode = "123456")
+        }.exceptionOrNull()
+
+        assertThat(error).isInstanceOf(ContentConvertException::class.java)
     }
 }

--- a/feature/auth/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/auth/viewmodel/TwoFactorViewModelTest.kt
+++ b/feature/auth/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/auth/viewmodel/TwoFactorViewModelTest.kt
@@ -1,18 +1,19 @@
 package com.garfiec.librechat.feature.auth.viewmodel
 
-import com.garfiec.librechat.core.common.result.ApiException
-import com.garfiec.librechat.core.common.result.Result
 import com.garfiec.librechat.core.data.repository.AuthRepository
 import com.garfiec.librechat.core.model.User
+import com.garfiec.librechat.core.model.VerifyTwoFactorOutcome
 import com.google.common.truth.Truth.assertThat
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
@@ -38,7 +39,8 @@ class TwoFactorViewModelTest {
 
     @Test
     fun `entering six digits verifies the code as TOTP`() = runTest {
-        coEvery { authRepository.verifyTwoFactor(any(), any(), any()) } returns Result.Success(USER)
+        coEvery { authRepository.verifyTwoFactor(any(), any(), any()) } returns
+            VerifyTwoFactorOutcome.Success(USER)
 
         val viewModel = createViewModel()
         viewModel.enterDigits("123456")
@@ -51,7 +53,8 @@ class TwoFactorViewModelTest {
 
     @Test
     fun `backup mode submits the code as a backup code`() = runTest {
-        coEvery { authRepository.verifyTwoFactor(any(), any(), any()) } returns Result.Success(USER)
+        coEvery { authRepository.verifyTwoFactor(any(), any(), any()) } returns
+            VerifyTwoFactorOutcome.Success(USER)
 
         val viewModel = createViewModel()
         viewModel.toggleBackupMode()
@@ -64,25 +67,25 @@ class TwoFactorViewModelTest {
     }
 
     @Test
-    fun `surfaces the server's message on a rejected code`() = runTest {
+    fun `a rejected code surfaces the server's message and clears the spent entry`() = runTest {
         coEvery { authRepository.verifyTwoFactor(any(), any(), any()) } returns
-            Result.Error(ApiException(401, "Your temporary session has expired. Please sign in again."))
+            VerifyTwoFactorOutcome.CodeRejected("Invalid 2FA code or backup code")
 
         val viewModel = createViewModel()
         viewModel.enterDigits("000000")
         advanceUntilIdle()
 
         val state = viewModel.uiState.value
-        assertThat(state.error).isEqualTo("Your temporary session has expired. Please sign in again.")
+        assertThat(state.error).isEqualTo("Invalid 2FA code or backup code")
         assertThat(state.isVerified).isFalse()
         assertThat(state.digits).containsExactlyElementsIn(List(6) { "" })
         assertThat(state.codeAttempt).isEqualTo(1)
     }
 
     @Test
-    fun `a network failure is not reported as a bad code and keeps the entry`() = runTest {
+    fun `a connection failure is not reported as a bad code and keeps the entry`() = runTest {
         coEvery { authRepository.verifyTwoFactor(any(), any(), any()) } returns
-            Result.Error(java.io.IOException("connection reset"), "connection reset")
+            VerifyTwoFactorOutcome.ConnectionFailure
 
         val viewModel = createViewModel()
         viewModel.enterDigits("123456")
@@ -95,20 +98,122 @@ class TwoFactorViewModelTest {
     }
 
     @Test
-    fun `retrying after a network failure resubmits the retained code`() = runTest {
+    fun `retrying after a connection failure resubmits the retained code`() = runTest {
         coEvery { authRepository.verifyTwoFactor(any(), any(), any()) } returns
-            Result.Error(java.io.IOException("connection reset"), "connection reset")
+            VerifyTwoFactorOutcome.ConnectionFailure
 
         val viewModel = createViewModel()
         viewModel.enterDigits("123456")
         advanceUntilIdle()
 
-        coEvery { authRepository.verifyTwoFactor(any(), any(), any()) } returns Result.Success(USER)
+        coEvery { authRepository.verifyTwoFactor(any(), any(), any()) } returns
+            VerifyTwoFactorOutcome.Success(USER)
         viewModel.submit()
         advanceUntilIdle()
 
         coVerify(exactly = 2) { authRepository.verifyTwoFactor(TEMP_TOKEN, "123456", false) }
         assertThat(viewModel.uiState.value.isVerified).isTrue()
+    }
+
+    @Test
+    fun `an incomplete session clears the spent code and surfaces its own message`() = runTest {
+        // A 2xx that accepted the code (single-use) but returned no session: the code is spent, so
+        // the boxes clear for a fresh one — but the message must be honest, not a connectivity lie.
+        val message = "The server's sign-in response was incomplete. Please try again."
+        coEvery { authRepository.verifyTwoFactor(any(), any(), any()) } returns
+            VerifyTwoFactorOutcome.SessionIncomplete(message)
+
+        val viewModel = createViewModel()
+        viewModel.enterDigits("123456")
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertThat(state.error).isEqualTo(message)
+        assertThat(state.digits).containsExactlyElementsIn(List(6) { "" })
+        assertThat(state.codeAttempt).isEqualTo(1)
+        assertThat(state.isVerified).isFalse()
+    }
+
+    @Test
+    fun `a server error keeps the entry and is not reported as a bad code`() = runTest {
+        // A 5xx never evaluated the code, so the entry stays intact for a plain retry.
+        coEvery { authRepository.verifyTwoFactor(any(), any(), any()) } returns
+            VerifyTwoFactorOutcome.NotEvaluated("Server error. Please try again.")
+
+        val viewModel = createViewModel()
+        viewModel.enterDigits("123456")
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertThat(state.error).isEqualTo("Server error. Please try again.")
+        assertThat(state.digits.joinToString("")).isEqualTo("123456")
+        assertThat(state.codeAttempt).isEqualTo(0)
+        assertThat(state.isVerified).isFalse()
+    }
+
+    @Test
+    fun `a rate limit keeps the entry so the unevaluated code can be retried`() = runTest {
+        // A 429 refuses the request before verification — the code was never judged, so wiping
+        // it would force a pointless re-type of a still-valid code.
+        coEvery { authRepository.verifyTwoFactor(any(), any(), any()) } returns
+            VerifyTwoFactorOutcome.NotEvaluated("Too many verification attempts, please try again after 5 minutes.")
+
+        val viewModel = createViewModel()
+        viewModel.enterDigits("123456")
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertThat(state.error).isEqualTo("Too many verification attempts, please try again after 5 minutes.")
+        assertThat(state.digits.joinToString("")).isEqualTo("123456")
+        assertThat(state.codeAttempt).isEqualTo(0)
+    }
+
+    @Test
+    fun `a verify that succeeds after a mode switch still completes sign-in`() = runTest {
+        // By the time Success surfaces, the session is already committed in the token store —
+        // suppressing it would strand an authenticated user on the backup-code screen.
+        coEvery { authRepository.verifyTwoFactor(any(), any(), any()) } coAnswers {
+            delay(10_000)
+            VerifyTwoFactorOutcome.Success(USER)
+        }
+
+        val viewModel = createViewModel()
+        viewModel.enterDigits("123456")
+        runCurrent() // let submit() set isLoading before the repo call suspends
+
+        viewModel.toggleBackupMode()
+
+        val switched = viewModel.uiState.value
+        assertThat(switched.isBackupMode).isTrue()
+        assertThat(switched.isLoading).isFalse()
+        assertThat(switched.digits).containsExactlyElementsIn(List(6) { "" })
+
+        advanceUntilIdle()
+        assertThat(viewModel.uiState.value.isVerified).isTrue()
+    }
+
+    @Test
+    fun `a verify that fails after a mode switch is dropped, not repainted`() = runTest {
+        coEvery { authRepository.verifyTwoFactor(any(), any(), any()) } coAnswers {
+            delay(10_000)
+            VerifyTwoFactorOutcome.ConnectionFailure
+        }
+
+        val viewModel = createViewModel()
+        viewModel.enterDigits("123456")
+        runCurrent()
+
+        viewModel.toggleBackupMode()
+        advanceUntilIdle()
+
+        // The superseded failure must not resurface on the switched screen: no error, no
+        // restored entry, no loading spinner.
+        val settled = viewModel.uiState.value
+        assertThat(settled.isVerified).isFalse()
+        assertThat(settled.isBackupMode).isTrue()
+        assertThat(settled.error).isNull()
+        assertThat(settled.digits).containsExactlyElementsIn(List(6) { "" })
+        assertThat(settled.isLoading).isFalse()
     }
 
     private companion object {

--- a/feature/auth/src/commonMain/kotlin/com/garfiec/librechat/feature/auth/viewmodel/TwoFactorViewModel.kt
+++ b/feature/auth/src/commonMain/kotlin/com/garfiec/librechat/feature/auth/viewmodel/TwoFactorViewModel.kt
@@ -3,9 +3,8 @@ package com.garfiec.librechat.feature.auth.viewmodel
 import androidx.compose.runtime.Immutable
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.garfiec.librechat.core.common.result.ApiException
-import com.garfiec.librechat.core.common.result.Result
 import com.garfiec.librechat.core.data.repository.AuthRepository
+import com.garfiec.librechat.core.model.VerifyTwoFactorOutcome
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -19,7 +18,8 @@ data class TwoFactorUiState(
     val isLoading: Boolean = false,
     val error: String? = null,
     val isVerified: Boolean = false,
-    // Bumped on each rejected code; the digit row keys its focus-reset effect on this.
+    // Bumped whenever the entered code is cleared as spent (evaluated-and-rejected, or accepted
+    // with an unusable session); the digit row keys its focus-reset effect on this.
     val codeAttempt: Int = 0,
 )
 
@@ -32,6 +32,13 @@ class TwoFactorViewModel(
 
     private val _uiState = MutableStateFlow(TwoFactorUiState())
     val uiState: StateFlow<TwoFactorUiState> = _uiState.asStateFlow()
+
+    // Bumped by toggleBackupMode() to supersede any in-flight verify. Superseding only ever
+    // suppresses a stale verify's FAILURE (it must not repaint the freshly-switched screen);
+    // a Success is always honored, because it reflects a session already committed in the
+    // token store — the store, not this coroutine, is the source of truth for sign-in, and
+    // suppressing it would strand an authenticated user on this screen.
+    private var submitGeneration = 0
 
     fun onDigitChanged(index: Int, value: String) {
         if (value.length > 1) return
@@ -50,7 +57,13 @@ class TwoFactorViewModel(
     }
 
     fun toggleBackupMode() {
+        // Supersede any in-flight verify so its eventual failure can't repaint this freshly-
+        // switched screen. The verify itself keeps running — a late Success still completes
+        // sign-in — and the toggle stays responsive even while a verify is stalled, keeping
+        // the backup-code fallback reachable.
+        submitGeneration++
         _uiState.value = _uiState.value.copy(
+            isLoading = false,
             isBackupMode = !_uiState.value.isBackupMode,
             error = null,
             digits = List(6) { "" },
@@ -68,32 +81,53 @@ class TwoFactorViewModel(
 
         if (code.isBlank()) return
 
+        val generation = submitGeneration
         viewModelScope.launch {
             _uiState.value = _uiState.value.copy(isLoading = true, error = null)
 
-            when (val result = authRepository.verifyTwoFactor(tempToken, code, isBackupCode = state.isBackupMode)) {
-                is Result.Success -> {
+            when (val outcome = authRepository.verifyTwoFactor(tempToken, code, isBackupCode = state.isBackupMode)) {
+                // Always honored, even when superseded by a mode toggle: the session is already
+                // committed in the token store, so anything but completing sign-in would strand
+                // an authenticated user here.
+                is VerifyTwoFactorOutcome.Success -> {
                     _uiState.value = _uiState.value.copy(
                         isLoading = false,
                         isVerified = true,
                     )
                 }
-                is Result.Error -> {
-                    // Only an HTTP answer is a verdict on the code; a network/parsing failure keeps
-                    // the entry so a retry can recover instead of wiping a good code.
-                    val rejection = result.exception as? ApiException
-                    val current = _uiState.value
-                    _uiState.value = current.copy(
-                        isLoading = false,
-                        error = rejection?.message
-                            ?: "Couldn't reach the server. Check your connection and try again.",
-                        digits = if (rejection != null) List(6) { "" } else current.digits,
-                        backupCode = if (rejection != null) "" else current.backupCode,
-                        codeAttempt = if (rejection != null) current.codeAttempt + 1 else current.codeAttempt,
-                    )
-                }
-                is Result.Loading -> { /* no-op */ }
+                // Failure outcomes are dropped when superseded — the toggle already reset the
+                // entry, and a stale error must not repaint the switched screen. Whether the entry
+                // clears or is kept follows the outcome's contract: the server consumed the
+                // single-use code (rejected it, or accepted it without a usable session) → clear for
+                // a fresh one; it never evaluated the code → keep it for a plain retry. Focus resets
+                // (via codeAttempt) precisely when the boxes are cleared.
+                is VerifyTwoFactorOutcome.CodeConsumed -> applyVerifyFailure(generation, outcome.message, clearEntry = true)
+                is VerifyTwoFactorOutcome.NotEvaluated -> applyVerifyFailure(generation, outcome.message, clearEntry = false)
+                is VerifyTwoFactorOutcome.ConnectionFailure -> applyVerifyFailure(
+                    generation,
+                    "Couldn't reach the server. Check your connection and try again.",
+                    clearEntry = false,
+                )
             }
         }
+    }
+
+    /**
+     * Applies a superseded-aware verify failure. When [clearEntry] the server consumed the entered
+     * code, so the boxes clear for a fresh one and [TwoFactorUiState.codeAttempt] bumps to reset
+     * focus; otherwise the code was never evaluated and stays intact for a plain retry. The
+     * supersession guard lives here alone: a failure whose generation was superseded by a mode
+     * toggle is dropped so it can't repaint the freshly-switched screen.
+     */
+    private fun applyVerifyFailure(generation: Int, message: String, clearEntry: Boolean) {
+        if (generation != submitGeneration) return
+        val state = _uiState.value
+        _uiState.value = state.copy(
+            isLoading = false,
+            error = message,
+            digits = if (clearEntry) List(6) { "" } else state.digits,
+            backupCode = if (clearEntry) "" else state.backupCode,
+            codeAttempt = if (clearEntry) state.codeAttempt + 1 else state.codeAttempt,
+        )
     }
 }


### PR DESCRIPTION
Correctness fixes on the 2FA verify screen (`TwoFactorScreen` / `TwoFactorViewModel`), hardened across four review passes. The final shape moves each decision to the layer that owns it, after earlier rounds of local patches each invalidated the previous round's fix.

## Error classification — a sealed outcome at the repository

The backend's error semantics were previously re-derived in the ViewModel from status-code ranges and exception `instanceof` chains — an open-ended classification that misfiled a new member every review pass (first 5xx, then 429). `AuthRepository.verifyTwoFactor` now returns a closed **`VerifyTwoFactorOutcome`** (mirroring the existing `LoginOutcome` precedent), classified once at the repository against the wire contract in `upstream/`:

| Outcome | Wire meaning | Entry | Focus |
|---|---|---|---|
| `Success` | session committed | — | — |
| `CodeRejected` (401) | server evaluated the code — a verdict (wrong/expired code or expired temp session) | **cleared** | reset to box 0 |
| `SessionIncomplete` (consumed 2xx) | server accepted (consumed) the single-use code but returned no usable session — missing fields, an **undecodable body**, or a fault while committing the session locally | **cleared** | reset to box 0 |
| `NotEvaluated` (400 / 429 / other 4xx / 5xx) | request refused or failed **before** the code was judged | **kept** | unchanged |
| `ConnectionFailure` (IO/timeout) | no response at all | **kept** | unchanged |

`CodeRejected` and `SessionIncomplete` share a `CodeConsumed` marker, so the ViewModel routes both with a single exhaustive branch; an unhandled case is a compile error, not a next-round review finding.

## Round 4 — the real Ktor exception type, and phase-separating the commit

The round-3 classifier keyed the undecodable-2xx case on `kotlinx.serialization.SerializationException`. Verified against the resolved Ktor 3.4.3 source: `KotlinxSerializationConverter.deserialize` wraps **every** 2xx body decode failure in `JsonConvertException` — a `ContentConvertException`, which does **not** extend `SerializationException`. So that branch was dead in production and an unparseable 2xx fell through to `ConnectionFailure`: the UI showed "couldn't reach the server" and kept the entered code, and retrying the already-consumed single-use code got "Invalid 2FA code". The classifier now keys on `ContentConvertException`, the type Ktor actually throws.

The `NonCancellable` commit also used to run *inside* the `safeApiCall` block, so a commit fault **after** the server consumed the code flowed through the wire-contract classifier and likewise became `ConnectionFailure`. `verifyTwoFactor` is now split into an explicit **wire phase** (classified against the backend contract) and a **commit phase** (a fault there is `SessionIncomplete`, since the code is already spent) — never a connectivity lie or a doomed retry.

## Mode toggle — supersede failures, always honor success

The toggle bumps a **submit generation** instead of touching the job, with one invariant: superseding only suppresses a stale verify's *failure* (it must not repaint the freshly-switched screen); a `Success` is **always honored**, because the token store — not the coroutine — is the source of truth for sign-in. The two failure handlers are now one `applyVerifyFailure(generation, message, clearEntry)`, so the supersession guard lives in exactly one place.

## Round 5 — token rollback, dead-type removal, documented boundary

High-effort round-5 review found nothing that refutes the round-4 core (the wire-vs-commit split and `ContentConvertException` keying both held). It surfaced three safe fixes, applied here:

- **Token leak on a commit fault (the one correctness fix).** When the server has consumed the code but `establishSession` throws, `stageAuthenticatedSession` has already written the access/refresh pair. The catch returned `SessionIncomplete` without undoing that, leaving an orphaned session a later `onAccountResolved` could silently re-home *after* the user was told sign-in failed. Added `rollbackStagedSession`: `clearTokens()` on the fresh sign-in path (logged-out target — full teardown is safe and complete) and `clearStagedTokens()` in add mode (`completeAdd` already restored the outgoing account; `clearTokens` would tear it down). Best-effort under `NonCancellable`; guarded by a new `AuthRepositoryImplVerifyTest` case.
- **Removed `IncompleteAuthResponseException`.** It was introduced on this branch but no caller ever discriminates on the type — in verify it is swallowed by the phase-2 `catch (e: Exception)`, in login/OAuth it flows through `safeApiCall` as a generic `Result.Error` exactly as a plain `IllegalStateException` does. `incompleteAuthResponse()` now throws `IllegalStateException`, which `safeApiCall` catches identically.
- **Documented the classifier boundary.** An undecodable JSON-typed 2xx is treated as "code consumed" even in the rarer proxy-truncation case where it wasn't. Clearing is still safe there — the temp token is a reusable JWT, so a fresh code re-verifies within seconds — whereas keeping the entry would reintroduce the spent-code retry this PR removed for the genuine backend-consumed case.

## Tests

- `TwoFactorViewModelTest` (10): clear/keep behavior per outcome incl. 429-keeps-entry; a verify that *succeeds* after a mode switch completes sign-in; one that *fails* after a switch is dropped without repainting; happy paths and retained-code retry.
- `AuthApiLoginTest`: pins that a malformed 2xx body really surfaces as `ContentConvertException` — the exact type the classifier depends on, asserted at the layer that produces it.
- New `AuthRepositoryImplVerifyTest`: drives malformed bodies, missing fields, a commit fault, a 401, and a healthy sign-in through a **real Ktor stack** (MockEngine + ContentNegotiation + validator), end-to-end — so the exception-type assumption can't pass vacuously again.
- `VerifyFailureClassificationTest`: pins `classifyVerifyFailure` per status/exception, now using the real `JsonConvertException`.

## Deferred to a dedicated observable-session-state PR

These three share one root: navigation/sign-in is derived from the verify **coroutine's** return value, when the token store is the real source of truth. The fix is a session-established signal (symmetric to `emitSessionExpired`) that navigation observes, applied uniformly across login / OAuth / verify — a cross-cutting change that belongs on its own, not wedged into this bugfix PR under review pressure.

- **Observable session-establishment state** — closes the window where a `NonCancellable` commit completing after a back-press signs the user in silently.
- **Backup-code race (round-5 #2)** — because the mode toggle supersedes but does not cancel the in-flight verify, a slow-but-valid TOTP can win the honor-success race while a submitted backup code is also consumed server-side. A naive cancel-on-toggle reintroduces the silent-sign-in strand above; the observable-state signal is what makes cancelling safe, so the two are fixed together.
- **A shared `commitSession` helper** across login / OAuth / verify (login and OAuth commit cancellably today).

Verified locally: `:core:data:testDebugUnitTest`, `:core:network:testDebugUnitTest`, `:feature:auth:testDebugUnitTest`, `:app:assembleDebug`, and the CI lint command (`detekt detektMetadataCommonMain :app:lint`) all pass.
