### PR TITLE
fix(files): confirm before discarding multi-select on back/close

### DIFF
--- a/feature/files/src/commonMain/composeResources/values-ar/strings.xml
+++ b/feature/files/src/commonMain/composeResources/values-ar/strings.xml
@@ -5,6 +5,10 @@
     <string name="delete">حذف</string>
     <string name="cancel">إلغاء</string>
     <string name="done">تم</string>
+    <string name="discard">تجاهل</string>
+    <string name="keep_selecting">متابعة التحديد</string>
+    <string name="discard_selection_title">تجاهل التحديد؟</string>
+    <string name="discard_selection_message">سيتم إلغاء تحديد الملفات المحددة.</string>
 
     <!-- Content descriptions -->
     <string name="cd_exit_edit_mode">الخروج من وضع التعديل</string>

--- a/feature/files/src/commonMain/composeResources/values-de/strings.xml
+++ b/feature/files/src/commonMain/composeResources/values-de/strings.xml
@@ -5,6 +5,10 @@
     <string name="delete">Löschen</string>
     <string name="cancel">Abbrechen</string>
     <string name="done">Fertig</string>
+    <string name="discard">Verwerfen</string>
+    <string name="keep_selecting">Weiter auswählen</string>
+    <string name="discard_selection_title">Auswahl verwerfen?</string>
+    <string name="discard_selection_message">Die Auswahl der markierten Dateien wird aufgehoben.</string>
 
     <!-- Content descriptions -->
     <string name="cd_exit_edit_mode">Bearbeitungsmodus verlassen</string>

--- a/feature/files/src/commonMain/composeResources/values-es/strings.xml
+++ b/feature/files/src/commonMain/composeResources/values-es/strings.xml
@@ -5,6 +5,10 @@
     <string name="delete">Eliminar</string>
     <string name="cancel">Cancelar</string>
     <string name="done">Hecho</string>
+    <string name="discard">Descartar</string>
+    <string name="keep_selecting">Seguir seleccionando</string>
+    <string name="discard_selection_title">¿Descartar selección?</string>
+    <string name="discard_selection_message">Se anulará la selección de los archivos elegidos.</string>
 
     <!-- Content descriptions -->
     <string name="cd_exit_edit_mode">Salir del modo de edición</string>

--- a/feature/files/src/commonMain/composeResources/values-fr/strings.xml
+++ b/feature/files/src/commonMain/composeResources/values-fr/strings.xml
@@ -5,6 +5,10 @@
     <string name="delete">Supprimer</string>
     <string name="cancel">Annuler</string>
     <string name="done">Terminé</string>
+    <string name="discard">Abandonner</string>
+    <string name="keep_selecting">Continuer la sélection</string>
+    <string name="discard_selection_title">Abandonner la sélection ?</string>
+    <string name="discard_selection_message">Vos fichiers sélectionnés seront désélectionnés.</string>
 
     <!-- Content descriptions -->
     <string name="cd_exit_edit_mode">Quitter le mode édition</string>

--- a/feature/files/src/commonMain/composeResources/values-ja/strings.xml
+++ b/feature/files/src/commonMain/composeResources/values-ja/strings.xml
@@ -5,6 +5,10 @@
     <string name="delete">削除</string>
     <string name="cancel">キャンセル</string>
     <string name="done">完了</string>
+    <string name="discard">破棄</string>
+    <string name="keep_selecting">選択を続ける</string>
+    <string name="discard_selection_title">選択を破棄しますか？</string>
+    <string name="discard_selection_message">選択したファイルの選択が解除されます。</string>
 
     <!-- Content descriptions -->
     <string name="cd_exit_edit_mode">編集モードを終了</string>

--- a/feature/files/src/commonMain/composeResources/values-ko/strings.xml
+++ b/feature/files/src/commonMain/composeResources/values-ko/strings.xml
@@ -5,6 +5,10 @@
     <string name="delete">삭제</string>
     <string name="cancel">취소</string>
     <string name="done">완료</string>
+    <string name="discard">선택 취소</string>
+    <string name="keep_selecting">계속 선택</string>
+    <string name="discard_selection_title">선택을 취소하시겠어요?</string>
+    <string name="discard_selection_message">선택한 파일이 선택 해제됩니다.</string>
 
     <!-- Content descriptions -->
     <string name="cd_exit_edit_mode">편집 모드 종료</string>

--- a/feature/files/src/commonMain/composeResources/values-pt/strings.xml
+++ b/feature/files/src/commonMain/composeResources/values-pt/strings.xml
@@ -5,6 +5,10 @@
     <string name="delete">Excluir</string>
     <string name="cancel">Cancelar</string>
     <string name="done">Concluído</string>
+    <string name="discard">Descartar</string>
+    <string name="keep_selecting">Continuar selecionando</string>
+    <string name="discard_selection_title">Descartar seleção?</string>
+    <string name="discard_selection_message">Os arquivos selecionados serão desmarcados.</string>
 
     <!-- Content descriptions -->
     <string name="cd_exit_edit_mode">Sair do modo de edição</string>

--- a/feature/files/src/commonMain/composeResources/values-ru/strings.xml
+++ b/feature/files/src/commonMain/composeResources/values-ru/strings.xml
@@ -5,6 +5,10 @@
     <string name="delete">Удалить</string>
     <string name="cancel">Отмена</string>
     <string name="done">Готово</string>
+    <string name="discard">Сбросить</string>
+    <string name="keep_selecting">Продолжить выбор</string>
+    <string name="discard_selection_title">Сбросить выбор?</string>
+    <string name="discard_selection_message">Выбранные файлы будут сняты с выделения.</string>
 
     <!-- Content descriptions -->
     <string name="cd_exit_edit_mode">Выйти из режима редактирования</string>

--- a/feature/files/src/commonMain/composeResources/values-zh/strings.xml
+++ b/feature/files/src/commonMain/composeResources/values-zh/strings.xml
@@ -5,6 +5,10 @@
     <string name="delete">删除</string>
     <string name="cancel">取消</string>
     <string name="done">完成</string>
+    <string name="discard">放弃</string>
+    <string name="keep_selecting">继续选择</string>
+    <string name="discard_selection_title">放弃选择？</string>
+    <string name="discard_selection_message">已选择的文件将被取消选择。</string>
 
     <!-- Content descriptions -->
     <string name="cd_exit_edit_mode">退出编辑模式</string>

--- a/feature/files/src/commonMain/composeResources/values/strings.xml
+++ b/feature/files/src/commonMain/composeResources/values/strings.xml
@@ -5,6 +5,12 @@
     <string name="delete">Delete</string>
     <string name="cancel">Cancel</string>
     <string name="done">Done</string>
+    <string name="discard">Discard</string>
+    <string name="keep_selecting">Keep selecting</string>
+
+    <!-- Discard-selection confirmation -->
+    <string name="discard_selection_title">Discard selection?</string>
+    <string name="discard_selection_message">Your selected files will be deselected.</string>
 
     <!-- Content descriptions -->
     <string name="cd_exit_edit_mode">Exit edit mode</string>

--- a/feature/files/src/commonMain/kotlin/com/garfiec/librechat/feature/files/screen/FilesScreen.kt
+++ b/feature/files/src/commonMain/kotlin/com/garfiec/librechat/feature/files/screen/FilesScreen.kt
@@ -77,6 +77,7 @@ import coil3.compose.AsyncImage
 import com.garfiec.librechat.core.model.FileObject
 import com.garfiec.librechat.core.ui.components.EmptyState
 import com.garfiec.librechat.core.ui.components.ErrorBanner
+import com.garfiec.librechat.core.ui.components.PlatformBackHandler
 import com.garfiec.librechat.core.ui.media.MediaActionBar
 import com.garfiec.librechat.core.ui.media.ZoomableMediaPager
 import com.garfiec.librechat.core.ui.media.rememberSaveImageToGallery
@@ -119,6 +120,20 @@ fun FilesScreen(
     var showDeleteConfirmation by remember { mutableStateOf(false) }
     var singleDeleteFileId by remember { mutableStateOf<String?>(null) }
     var showSortMenu by remember { mutableStateOf(false) }
+    var showCancelSelectionConfirmation by remember { mutableStateOf(false) }
+
+    val requestExitSelection = {
+        if (uiState.selectedFileIds.isEmpty()) {
+            viewModel.exitSelectionMode()
+        } else {
+            showCancelSelectionConfirmation = true
+        }
+    }
+
+    // Gated so it never arms in picker mode (back should close the picker) or outside selection mode.
+    PlatformBackHandler(enabled = uiState.isSelectionMode && !pickerMode) {
+        requestExitSelection()
+    }
 
     val filePickerLauncher = rememberFilePickerLauncher(
         onFilePick = { fileRef -> viewModel.uploadFile(fileRef) },
@@ -165,7 +180,7 @@ fun FilesScreen(
                 TopAppBar(
                     title = { SelectionCountTitle(uiState.selectedFileIds.size) },
                     navigationIcon = {
-                        IconButton(onClick = { viewModel.exitSelectionMode() }) {
+                        IconButton(onClick = requestExitSelection) {
                             Icon(
                                 imageVector = Icons.Default.Close,
                                 contentDescription = stringResource(Res.string.cd_exit_edit_mode),
@@ -421,6 +436,36 @@ fun FilesScreen(
             dismissButton = {
                 TextButton(onClick = { showDeleteConfirmation = false }) {
                     Text(stringResource(Res.string.cancel))
+                }
+            },
+        )
+    }
+
+    // Cancel-selection confirmation (back gesture / close with files selected)
+    if (showCancelSelectionConfirmation) {
+        AlertDialog(
+            onDismissRequest = { showCancelSelectionConfirmation = false },
+            title = { Text(stringResource(Res.string.discard_selection_title)) },
+            text = {
+                Text(
+                    text = stringResource(Res.string.discard_selection_message),
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    viewModel.exitSelectionMode()
+                    showCancelSelectionConfirmation = false
+                }) {
+                    Text(
+                        text = stringResource(Res.string.discard),
+                        color = MaterialTheme.colorScheme.error,
+                    )
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showCancelSelectionConfirmation = false }) {
+                    Text(stringResource(Res.string.keep_selecting))
                 }
             },
         )


### PR DESCRIPTION
## Summary

In the Files browser, multi-select mode had no handling for the system
back button — pressing Back popped the entire Files screen off the back
stack instead of leaving selection mode, which is easy to trigger by
accident after selecting files. This intercepts back (and the top-bar
close) so a selection isn't lost unexpectedly.

## Changes

- Add a `PlatformBackHandler` and route the selection-mode close (X) icon
  through a shared exit path, so both leave selection mode instead of
  exiting the Files screen. The handler is gated to selection mode and
  excluded from picker mode (where back should still close the picker).
- Prompt for confirmation when files are selected, guarding against
  accidental loss; when nothing is selected, exit selection mode silently.
- The "Done" button is unchanged (deliberate finish action).
- Add discard-selection strings (`discard`, `keep_selecting`,
  `discard_selection_title`, `discard_selection_message`) across all
  locales.

## Testing

- `:feature:files` unit tests pass.
- Built and installed the debug APK on a Pixel 9 Pro Fold.
