### PR TITLE
fix(agents): gate agent editing on edit permission

### DIFF
--- a/feature/agents/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/agents/viewmodel/AgentDetailViewModelTest.kt
+++ b/feature/agents/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/agents/viewmodel/AgentDetailViewModelTest.kt
@@ -1,0 +1,102 @@
+package com.garfiec.librechat.feature.agents.viewmodel
+
+import com.garfiec.librechat.core.common.result.ApiException
+import com.garfiec.librechat.core.common.result.Result
+import com.garfiec.librechat.core.data.datastore.ServerDataStore
+import com.garfiec.librechat.core.data.repository.AgentRepository
+import com.garfiec.librechat.core.model.Agent
+import com.google.common.truth.Truth.assertThat
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AgentDetailViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    private val agentRepository = mockk<AgentRepository>(relaxed = true)
+    private val serverDataStore = mockk<ServerDataStore>(relaxed = true)
+
+    private val agent = Agent(id = "agent-1", name = "Coding Assistant")
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun forbidden() = Result.Error(exception = ApiException(statusCode = 403, message = "Forbidden"))
+
+    private fun createViewModel() = AgentDetailViewModel(
+        agentRepository = agentRepository,
+        serverDataStore = serverDataStore,
+        initialAgentId = "agent-1",
+    )
+
+    @Test
+    fun `canEdit is true when the edit-gated expanded fetch succeeds`() = runTest(testDispatcher) {
+        coEvery { agentRepository.getAgentForEditing("agent-1") } returns Result.Success(agent)
+
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertThat(state.agent).isNotNull()
+        assertThat(state.canEdit).isTrue()
+    }
+
+    @Test
+    fun `canEdit is false when the edit endpoint returns a 403 and view fetch succeeds`() = runTest(testDispatcher) {
+        coEvery { agentRepository.getAgentForEditing("agent-1") } returns forbidden()
+        coEvery { agentRepository.getAgent("agent-1") } returns Result.Success(agent)
+
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertThat(state.agent).isNotNull()
+        assertThat(state.canEdit).isFalse()
+    }
+
+    @Test
+    fun `canEdit stays true when the edit endpoint fails transiently but view fetch succeeds`() = runTest(testDispatcher) {
+        coEvery { agentRepository.getAgentForEditing("agent-1") } returns
+            Result.Error(exception = ApiException(statusCode = 500, message = "Server error"))
+        coEvery { agentRepository.getAgent("agent-1") } returns Result.Success(agent)
+
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertThat(state.agent).isNotNull()
+        assertThat(state.canEdit).isTrue()
+    }
+
+    @Test
+    fun `canEdit is false when the agent fails to load entirely`() = runTest(testDispatcher) {
+        coEvery { agentRepository.getAgentForEditing("agent-1") } returns forbidden()
+        coEvery { agentRepository.getAgent("agent-1") } returns Result.Error(message = "Not found")
+
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertThat(state.agent).isNull()
+        assertThat(state.error).isNotNull()
+        assertThat(state.canEdit).isFalse()
+    }
+}

--- a/feature/agents/src/commonMain/kotlin/com/garfiec/librechat/feature/agents/screen/AgentDetailScreen.kt
+++ b/feature/agents/src/commonMain/kotlin/com/garfiec/librechat/feature/agents/screen/AgentDetailScreen.kt
@@ -136,19 +136,21 @@ fun AgentDetailScreen(
                             expanded = menuExpanded,
                             onDismissRequest = { menuExpanded = false },
                         ) {
-                            DropdownMenuItem(
-                                text = { Text(stringResource(Res.string.edit)) },
-                                onClick = {
-                                    menuExpanded = false
-                                    uiState.agent?.let { onEdit(it.id) }
-                                },
-                                leadingIcon = {
-                                    Icon(
-                                        imageVector = Icons.Default.Edit,
-                                        contentDescription = null,
-                                    )
-                                },
-                            )
+                            if (uiState.canEdit) {
+                                DropdownMenuItem(
+                                    text = { Text(stringResource(Res.string.edit)) },
+                                    onClick = {
+                                        menuExpanded = false
+                                        uiState.agent?.let { onEdit(it.id) }
+                                    },
+                                    leadingIcon = {
+                                        Icon(
+                                            imageVector = Icons.Default.Edit,
+                                            contentDescription = null,
+                                        )
+                                    },
+                                )
+                            }
                             DropdownMenuItem(
                                 text = { Text(stringResource(Res.string.duplicate)) },
                                 onClick = {
@@ -163,26 +165,28 @@ fun AgentDetailScreen(
                                     )
                                 },
                             )
-                            DropdownMenuItem(
-                                text = {
-                                    Text(
-                                        stringResource(Res.string.delete),
-                                        color = MaterialTheme.colorScheme.error,
-                                    )
-                                },
-                                onClick = {
-                                    menuExpanded = false
-                                    viewModel.showDeleteConfirmation()
-                                },
-                                enabled = !uiState.isDeleting,
-                                leadingIcon = {
-                                    Icon(
-                                        imageVector = Icons.Default.Delete,
-                                        contentDescription = null,
-                                        tint = MaterialTheme.colorScheme.error,
-                                    )
-                                },
-                            )
+                            if (uiState.canEdit) {
+                                DropdownMenuItem(
+                                    text = {
+                                        Text(
+                                            stringResource(Res.string.delete),
+                                            color = MaterialTheme.colorScheme.error,
+                                        )
+                                    },
+                                    onClick = {
+                                        menuExpanded = false
+                                        viewModel.showDeleteConfirmation()
+                                    },
+                                    enabled = !uiState.isDeleting,
+                                    leadingIcon = {
+                                        Icon(
+                                            imageVector = Icons.Default.Delete,
+                                            contentDescription = null,
+                                            tint = MaterialTheme.colorScheme.error,
+                                        )
+                                    },
+                                )
+                            }
                         }
                     }
                 },

--- a/feature/agents/src/commonMain/kotlin/com/garfiec/librechat/feature/agents/viewmodel/AgentDetailViewModel.kt
+++ b/feature/agents/src/commonMain/kotlin/com/garfiec/librechat/feature/agents/viewmodel/AgentDetailViewModel.kt
@@ -3,6 +3,7 @@ package com.garfiec.librechat.feature.agents.viewmodel
 import androidx.compose.runtime.Immutable
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.garfiec.librechat.core.common.result.ApiException
 import com.garfiec.librechat.core.common.result.Result
 import com.garfiec.librechat.core.data.datastore.ServerDataStore
 import com.garfiec.librechat.core.data.repository.AgentRepository
@@ -21,6 +22,7 @@ data class AgentDetailUiState(
     val agent: AgentDetailDisplayData? = null,
     val isLoading: Boolean = false,
     val error: String? = null,
+    val canEdit: Boolean = false,
     val showDeleteDialog: Boolean = false,
     val isDeleting: Boolean = false,
     val isDuplicating: Boolean = false,
@@ -53,9 +55,15 @@ class AgentDetailViewModel(
         viewModelScope.launch {
             _uiState.value = _uiState.value.copy(isLoading = true, error = null)
             // Try the expanded endpoint first (returns full agent data including
-            // description, category, tools, conversation_starters). Falls back to
-            // the standard endpoint if the user lacks edit permission (403).
-            val result = when (val expanded = agentRepository.getAgentForEditing(agentId)) {
+            // description, category, tools, conversation_starters). It requires
+            // EDIT permission server-side, so a 403 there means the user may view
+            // but not edit this agent. Any other failure is transient/unknown, so
+            // stay optimistic rather than hiding Edit from an owner during a flaky
+            // request — the editor re-checks permission on entry. Fall back to the
+            // standard view-only endpoint for the displayed data.
+            val expanded = agentRepository.getAgentForEditing(agentId)
+            val canEdit = expanded !is Result.Error || !expanded.isPermissionDenied()
+            val result = when (expanded) {
                 is Result.Success -> expanded
                 else -> agentRepository.getAgent(agentId)
             }
@@ -63,12 +71,14 @@ class AgentDetailViewModel(
                 is Result.Success -> {
                     _uiState.value = _uiState.value.copy(
                         agent = result.data.toDetailDisplayData(),
+                        canEdit = canEdit,
                         isLoading = false,
                     )
                 }
                 is Result.Error -> {
                     _uiState.value = _uiState.value.copy(
                         isLoading = false,
+                        canEdit = false,
                         error = result.message ?: "Failed to load agent",
                     )
                 }
@@ -127,6 +137,9 @@ class AgentDetailViewModel(
         }
     }
 
+    private fun Result.Error.isPermissionDenied(): Boolean =
+        (exception as? ApiException)?.statusCode == HTTP_FORBIDDEN
+
     private fun Agent.toDetailDisplayData(): AgentDetailDisplayData {
         val resolvedUrl = avatarUrl?.let { url ->
             if (url.startsWith("http")) {
@@ -147,5 +160,9 @@ class AgentDetailViewModel(
             tools = tools,
             conversationStarters = conversationStarters,
         )
+    }
+
+    private companion object {
+        const val HTTP_FORBIDDEN = 403
     }
 }


### PR DESCRIPTION
## Summary

A user without permission to edit an agent could still open the agent editor
from the detail screen. The editor would load, fail the edit-gated fetch, and
show an error banner over default/empty settings. This blocks that path up
front by hiding the Edit and Delete actions when the user can't edit, instead
of letting them in to discover it.

## Changes

- Add a `canEdit` flag to `AgentDetailUiState`, derived when the detail screen
  loads the agent. The `/expanded` endpoint requires EDIT permission
  server-side, so its result is used as the signal: success ⇒ can edit, a
  `403` ⇒ view-only. Any other failure (timeout, 5xx, network) stays optimistic
  so a flaky request doesn't hide Edit from an owner — the editor re-checks
  permission on entry.
- Gate the Edit and Delete menu items in `AgentDetailScreen` on `canEdit`.
  Duplicate stays available, since duplicating creates a new agent the user
  owns.

## Testing

- Unit tests added for `AgentDetailViewModel` covering four cases: edit-allowed,
  a `403` denial (view-only), a transient non-403 failure (stays editable), and
  full load failure. `:feature:agents` unit tests pass.

## Notes

- The client can't distinguish DELETE permission from EDIT: the server never
  populates a per-user permission bitmask on any agent read endpoint, and
  DELETE-ability is only discoverable by attempting the delete. Gating Delete on
  `canEdit` is the closest non-destructive signal; a user with EDIT but not
  DELETE would still see Delete and get a server 403 on that rare combination.
