### PR TITLE
feat(skill): rebuild sync-upstream as a coordinator + two dynamic workflows

### DIFF
--- a/.claude/skills/sync-upstream/SKILL.md
+++ b/.claude/skills/sync-upstream/SKILL.md
@@ -1,533 +1,218 @@
 ---
 name: sync-upstream
 description: >
-  Sync the LibreChat Mobile client with a newer official LibreChat server release.
-  Diffs upstream tags, identifies gaps in the mobile app, proposes changes with
-  user approval, then implements them. Use when a new LibreChat version is released.
-allowed-tools: Bash, Read, Glob, Grep, Write, Edit, WebFetch, WebSearch, Agent, TeamCreate, SendMessage, TaskCreate, TaskUpdate, TaskGet, TaskList
-argument-hint: "[target-tag] (optional, defaults to latest stable)"
+  Sync the LibreChat Mobile client with a newer official LibreChat server version —
+  a stable release, a release candidate, or a PARTIAL sync up to an untagged upstream
+  commit (e.g. current dev HEAD). If the client is ALREADY at the target commit, runs
+  an AUDIT of the last synced delta to catch anything that was missed. Coordinates two
+  dynamic workflows (discovery, implementation) around human decision gates.
+allowed-tools: Bash, Read, Glob, Grep, Write, Edit, WebFetch, WebSearch, Workflow, AskUserQuestion
+argument-hint: "[target] (stable tag | rc tag | branch dev/main | commit SHA; add 'audit' or '--full' to force/ widen an audit; defaults to latest stable)"
 ---
 
 # Sync Upstream
 
 Synchronize the LibreChat Mobile app with a newer version of the official LibreChat server.
-This is a multi-phase, team-based workflow.
 
-You are the **team lead**. You orchestrate at a high level. You NEVER read code, write code,
-or grep the codebase yourself. All heavy lifting is delegated to teammates.
+**You are the coordinator.** You run the lightweight deterministic work yourself with `Bash`
+(prereqs, target/mode resolution, final consistency asserts) and own the three human decision
+points. All heavy parallel work is delegated to **two dynamic workflows** — you never read or
+write app code yourself.
 
-## Team Setup
-
-Create an Agent Team with 5 teammates at the start:
-
-| Teammate | Role | Prompt Summary |
-|----------|------|----------------|
-| **investigator** | Reads upstream diffs, analyzes API/type/UI changes, cross-references with mobile codebase | "You are the investigator for a LibreChat Mobile upstream sync. Your job is to analyze diffs between upstream tags and identify gaps in the mobile client. You have read-only responsibilities — never write code. You have WebFetch and WebSearch access so you can read GitHub release notes and changelogs in addition to local diffs." |
-| **android-expert** | Technical advisor on Android architecture and best practices. Cross-checks all guidance with online research before advising. | "You are the Android tech lead for a LibreChat Mobile upstream sync. You provide guidance on Android best practices, Jetpack Compose patterns, Kotlin idioms, and architectural decisions. CRITICAL: You MUST cross-check your knowledge by researching online (WebSearch/WebFetch) before giving advice. Never rely solely on training data — always verify current best practices, especially for Compose, Ktor, Koin, and Material 3. Return researched guidance to teammates who ask." |
-| **ios-kmp-expert** | Technical advisor on iOS and Kotlin Multiplatform architecture. Ensures KMP shared code and iOS-specific implementations follow platform conventions. | "You are the iOS/KMP tech lead for a LibreChat Mobile upstream sync. You provide guidance on Compose Multiplatform patterns, KMP expect/actual declarations, iOS platform APIs (UIKit, Foundation, Keychain, Network.framework), SKIE interop, and ensuring shared code compiles correctly for both targets. CRITICAL: You MUST cross-check your knowledge by researching online (WebSearch/WebFetch) before giving advice. Never rely solely on training data — always verify current best practices for CMP, KMP, and iOS platform conventions. Return researched guidance to teammates who ask." |
-| **implementer** | Writes code changes to mobile app following existing patterns and conventions | "You are the implementer for a LibreChat Mobile upstream sync. Your job is to write code changes following existing architecture patterns. Always read the module's CLAUDE.md before touching it. This project uses **Koin** for DI (NOT Hilt) — use `koinViewModel()`, `viewModelOf(::X)`, `singleOf(::X)`, and Koin modules in `feature/*/di/`. Follow safeApiCall, UDF, Ktor, @Serializable patterns. Whenever you touch a KMP module, check BOTH commonMain AND iosMain source sets — expect declarations in commonMain need actual implementations in both androidMain and iosMain. Before making significant architectural decisions, consult the android-expert or ios-kmp-expert teammate." |
-| **verifier** | Checks implementation correctness, runs builds, validates changes match proposal | "You are the verifier for a LibreChat Mobile upstream sync. Your job is to independently validate that implementation matches the approved proposal. Run Android build, iOS framework link, detekt, and tests. Review changes file-by-file. Flag issues. Message the implementer directly if fixes are needed — they retain context of what they changed." |
-
-**Teammate interaction pattern:**
-- **investigator** works independently on Phase A and B (diff + gap analysis)
-- **android-expert** is consulted for Android-specific architecture, Compose, and Material 3 decisions.
-  The android-expert MUST search online to verify recommendations — do not accept advice that
-  hasn't been cross-checked against current documentation.
-- **ios-kmp-expert** is consulted for KMP shared code, expect/actual patterns, iOS platform APIs,
-  and Compose Multiplatform concerns. Same online-verification requirement as android-expert.
-- **implementer** does all code changes, consulting android-expert or ios-kmp-expert for non-trivial patterns
-- **verifier** validates after implementer finishes, messages implementer for fixes
-
-**Important:** Teammates retain context across messages. Reuse them for follow-ups — do NOT
-spawn new sub-agents (sub-agents lose context). Sub-agents are a last resort fallback only.
-
-## Prerequisites
-
-Run these checks yourself (lightweight, no codebase reading). The working directory is already
-the mobile repo root — do **not** `cd` into a different directory. The local checkout directory
-name can vary, so rely on relative paths from CWD rather than any hardcoded repo-dir name.
-
-### 1. Submodule check
-```bash
-git submodule status
 ```
-If `upstream/` is missing:
-```bash
-git submodule add https://github.com/danny-avila/LibreChat.git upstream
-git submodule update --init
+[you]  0. Prereqs + resolve target + detect mode          (Bash — fail loud on ambiguity)
+  │
+[WF1]  1. sync-upstream-discovery   — parallel multi-angle sweep → converged findings
+  │
+[you]  2. HITL INTERVIEW            — the one real gate: target + scope + direction   (AskUserQuestion)
+  │
+[WF2]  3. sync-upstream-implement   — implement → build+consistency gates → ≥2 independent review passes
+  │
+[you]  4. TEST + PUSH TAIL          — present test plan, facilitate device testing, hold the push gate
 ```
 
-### 2. Version file check
-```bash
-cat UPSTREAM_VERSION
-```
-If missing, create from current state:
-```bash
-VERSION=$(grep '^backendTargetVersion=' version.properties | cut -d= -f2 | tr -d '[:space:]')
-COMMIT=$(cd upstream && git rev-parse HEAD)
-echo "# Upstream LibreChat version this mobile build tracks." > UPSTREAM_VERSION
-echo "# Updated by the sync-upstream skill. Do not edit manually." >> UPSTREAM_VERSION
-echo "tag=v${VERSION}" >> UPSTREAM_VERSION
-echo "commit=${COMMIT}" >> UPSTREAM_VERSION
-echo "date=$(date +%Y-%m-%d)" >> UPSTREAM_VERSION
-```
+Two workflows do the work; you hold the seams. **A workflow cannot pause to ask the user** — that
+is exactly why the target choice, the proposal approval, and the no-push/device-test boundary live
+in your main loop *between* invocations, never inside a script.
 
-### 3. Clean working tree
-```bash
-git status --porcelain
-```
-If dirty, ask the user to commit or stash before proceeding.
+## Two modes
 
-### 4. Context recovery (new session detection)
+Resolve these before anything else (Phase 0), because they change the whole run:
 
-Check if a prior sync was partially done in another session:
-```bash
-TRACKED_TAG=$(grep '^tag=' UPSTREAM_VERSION | cut -d= -f2)
-CODE_VERSION=$(grep '^backendTargetVersion=' version.properties | cut -d= -f2 | tr -d '[:space:]')
-SUBMODULE_HEAD=$(cd upstream && git rev-parse HEAD)
-TRACKED_COMMIT=$(grep '^commit=' UPSTREAM_VERSION | cut -d= -f2)
-```
+| Mode | Trigger | Goal | Version bookkeeping |
+|------|---------|------|---------------------|
+| **sync** | resolved target commit ≠ current pin | absorb new upstream changes | advances (version.properties, UPSTREAM_VERSION, submodule, commit map) |
+| **audit** | resolved target commit **==** current pin (or `audit` in `$ARGUMENTS`) | re-check that the LAST synced delta was fully/correctly absorbed — find misses | **none — the pin does not move** |
 
-If `TRACKED_TAG` (without `v` prefix) != `CODE_VERSION`, or `SUBMODULE_HEAD` != `TRACKED_COMMIT`:
-> "It looks like a sync may have been partially done. UPSTREAM_VERSION says {TRACKED_TAG}
-> but version.properties (backendTargetVersion) says {CODE_VERSION}. Should I treat the
-> higher version as the current baseline, or would you like to investigate?"
+Audit's default range is the **last synced delta** (`previous pin → current pin`), recovered from
+`UPSTREAM_VERSION`'s own git history. `--full` widens it to full-pin reconciliation.
 
-Wait for user response before continuing.
+## Target Modes (sync)
 
-Also check for existing artifacts from a previous partial run:
-```bash
-ls -la .claude/sync-upstream/artifacts/ 2>/dev/null
-```
-If a previous proposal or phase report exists, offer to resume from that state.
+| Mode | Target looks like | `backendTargetVersion` | UPSTREAM_VERSION | Gating strategy |
+|------|-------------------|------------------------|------------------|-----------------|
+| **release** | `v0.8.8` (default: latest stable tag) | `0.8.8` | `tag=v0.8.8`, `commit=<tag commit>` | `isCompatibleOrNewer(version, "0.8.8-rc1")` |
+| **rc** | `v0.8.8-rc1` | `0.8.8-rc1` | `tag=v0.8.8-rc1`, `commit=<tag commit>` | `isCompatibleOrNewer(version, "0.8.8-rc1")` |
+| **partial** | `dev`, `main`, or a SHA | `<base>+dev.<sha8>` | `tag=<last v-tag at/before commit>`, `commit=<target SHA>` | `supportsFeature(detected, "<next-rc-line>", landedDate)` |
 
-### 5. Prepare artifact directory
-
-```bash
-mkdir -p .claude/sync-upstream/artifacts
-```
-All phase outputs (diff summaries, gap reports, proposals) are persisted here so the skill
-is resumable if the session is compacted or dies mid-run.
+Shared invariants: the **diff base is always `commit=` from `UPSTREAM_VERSION`** (never `tag=`);
+`BackendVersion.parse()` handles all three forms; a later sync from a partial baseline is normal.
 
 ---
 
-## Phase A: Diff Analysis
+## Phase 0 — Prereqs, target & mode (you, with Bash)
 
-**Delegate to: investigator**
+Working directory is already the mobile repo root — do **not** `cd` elsewhere; rely on relative paths.
+Fail LOUD on any ambiguity below — never guess a baseline or target for the user.
 
-### A1. Assign investigation task
+1. **Submodule.** `git submodule status`. If `upstream/` missing:
+   `git submodule add https://github.com/danny-avila/LibreChat.git upstream && git submodule update --init`.
+2. **Version file.** `cat UPSTREAM_VERSION`. If missing, create from `version.properties`
+   `backendTargetVersion` + submodule HEAD (`tag=v<version>`, `commit=<HEAD>`, `date=$(date +%Y-%m-%d)`).
+3. **Clean tree.** `git status --porcelain`. If dirty → **ask the user** to commit/stash; wait.
+4. **Baseline consistency** (compute, then apply — a partial/rc baseline is NOT an inconsistency):
+   - `X.Y.Z+dev.<sha8>` → `<sha8>` must be a prefix of `commit=`; verify the sha, not tag equality.
+   - `X.Y.Z-rcN` / plain `X.Y.Z` → must equal `tag=` without `v`.
+   - Always: submodule HEAD must equal `commit=`.
+   - On failure → **ask the user** which state is the true baseline; wait. Never auto-pick.
+5. **Fetch + resolve target.** `cd upstream && git fetch origin --tags && git fetch origin dev main`.
+   Resolve `$ARGUMENTS` (see Target Modes) to a full `{target_commit}`:
+   - none → newest stable tag (exclude `-rc/-beta/-alpha`), but still enumerate newer rc tags and how
+     far `dev`/`main` are ahead (`git rev-list --count {base_commit}..origin/dev`) for the interview.
+   - tag (stable or rc) → that tag; never silently drop an rc the user named.
+   - branch/SHA → **partial**; `{base_version}` from `git show {sha}:package.json`,
+     `{anchor_tag}` = `git describe --tags --abbrev=0 --match "v[0-9]*" {sha}`
+     (`--match` is required — upstream also tags Helm charts like `chart-2.0.7`).
+6. **Detect mode.** If `{target_commit}` == `commit=` (submodule HEAD) **or** `$ARGUMENTS` contains
+   `audit` → **audit mode**; the audit base is the previous `commit=` from
+   `git log -p --format=%H -- UPSTREAM_VERSION` (or full-pin if `--full`). Else **sync mode**.
+   If sync mode and no newer tags AND branch heads == base → tell the user "already up to date" and
+   offer an audit instead of stopping.
+7. **Artifacts dir.** `mkdir -p .claude/sync-upstream/artifacts`.
 
-Create a task for the investigator with this prompt:
-
-> Analyze upstream changes for a version sync. **Persist all outputs to files under
-> `.claude/sync-upstream/artifacts/` as you go** so the team lead can recover state if
-> the session is compacted.
->
-> 1. Read `UPSTREAM_VERSION` at the repo root to get the current tracked tag and commit.
-> 2. Fetch latest tags: `cd upstream && git fetch --tags origin`
-> 3. List all tags newer than the current tracked tag:
->    `cd upstream && git tag --sort=-v:refname`
->    Filter OUT any tags containing `-rc`, `-beta`, `-alpha`.
-> 4. **Read GitHub release notes for every stable tag** between the current tracked tag and
->    the target tag (inclusive). Release notes almost always flag breaking changes that
->    diffs hide. For each tag:
->    ```bash
->    gh api repos/danny-avila/LibreChat/releases/tags/{tag} --jq .body
->    ```
->    Fall back to `WebFetch` on `https://github.com/danny-avila/LibreChat/releases/tag/{tag}`
->    if `gh` is unavailable. Also scan commit messages:
->    `cd upstream && git log --oneline {current_tag}..{target_tag}` — commit subjects
->    from upstream maintainers are often the most candid description of what broke.
-> 5. Generate diffs between the current tag and {target_tag} for all paths listed in
->    `${CLAUDE_SKILL_DIR}/reference/upstream-paths.md`. Use `--stat` for an overview,
->    then request per-path file-level diffs for anything non-trivial. Paths include:
->    - `api/server/routes/` (including `routes/agents/`, `routes/files/`, `routes/admin/`)
->    - `api/server/controllers/`, `api/server/middleware/`, `api/server/services/`
->    - `api/models/` (Mongoose models that shape API responses)
->    - `packages/data-provider/src/` — especially `api-endpoints.ts`, `config.ts`,
->      `data-service.ts`, `parsers.ts`, `permissions.ts`, `types/`, `react-query/`
->    - `packages/data-schemas/src/`
->    - `packages/api/src/` (newer workspace introduced recently)
->    - `client/src/components/`, `client/src/hooks/`, `client/src/data-provider/`,
->      `client/src/store/`, `client/src/Providers/`
->    - `librechat.example.yaml`, `.env.example` (server config schema — affects `/api/config` surface)
-> 6. Categorize every change into exactly one of:
->    - **API changes**: New or modified routes, controller logic
->    - **Removed/deprecated endpoints**: Routes or fields that were removed or deprecated (BREAK mobile hard — cannot be deferred)
->    - **Type/schema changes**: New or modified data types, request/response shapes
->    - **New config / feature flags**: New keys in `/api/config` response that gate UI
->    - **UI changes**: New components, modified user flows
->    - **Security fixes**: CVEs, auth changes, token handling — cannot be deferred
->    - **Bug fixes**: Non-security fixes that may need mobile equivalents
->    - **Infrastructure**: Build, config, deps (usually not relevant)
-> 7. Write the categorized summary to
->    `.claude/sync-upstream/artifacts/phase-a-diff-summary.md` and report a short
->    version back. Include representative file paths and release-note excerpts.
-
-If `$ARGUMENTS` was provided, use it as the target tag.
-
-### A2. Present results to user
-
-Once investigator reports back:
-- If no newer tags exist, tell user "Already up to date with {current_tag}" and stop.
-- If no `$ARGUMENTS`, present the list of available tags and ask user to pick one (default: latest stable).
-- Show the investigator's categorized summary.
-
-**Done when:** User has seen the diff summary and confirmed the target tag. The file
-`.claude/sync-upstream/artifacts/phase-a-diff-summary.md` exists.
+If a prior run's artifacts exist (`ls .claude/sync-upstream/artifacts/`), offer to resume from them.
 
 ---
 
-## Phase B: Gap Analysis
+## Phase 1 — Discovery (WF1)
 
-**Delegate to: investigator** (reuses context from Phase A — do NOT spawn a new agent)
+Invoke the discovery workflow. It runs the parallel multi-angle sweep, converges + cross-references
+the mobile codebase, and runs a completeness critic. Watch its phase tree live via `/workflows`.
 
-### B1. Send follow-up to investigator
+```
+Workflow({ name: "sync-upstream-discovery", args: {
+  mode, baseCommit, targetCommit, targetMode, baseVersion, anchorTag,
+  skillDir: "<abs path to .claude/skills/sync-upstream>",
+  artifactsDir: "<abs path to .claude/sync-upstream/artifacts>",
+} })
+```
 
-> Now cross-reference the upstream changes you found with the mobile codebase.
-> Persist the gap report to `.claude/sync-upstream/artifacts/phase-b-gap-report.md`.
->
-> 1. Read these mapping files from `${CLAUDE_SKILL_DIR}/reference/`:
->    - `api-mapping.md` — official routes to mobile `*Api.kt` files
->    - `model-mapping.md` — official TS types to Kotlin data classes
->    - `ui-mapping.md` — web components to mobile feature modules
->    - `upstream-backend-gaps.md` — features that exist in the upstream **client** but
->      have **no real backend** (client-only stubs / unmounted routes). For any gap that
->      matches an entry, mark it **backend-blocked — do not build** (don't re-investigate
->      from scratch). RE-CHECK each open entry: has the backend route shipped since the
->      recorded version? If yes, remove the entry and scope the mobile feature normally.
->      If you discover a NEW vapor feature this sync, ADD it to that file with evidence.
-> 2. Read `DISCOVERY.md` at the repo root — it catalogs already-discovered backend
->    endpoints and their quirks. Any new endpoints must be appended there by the
->    implementer in Phase D.
-> 3. For each **API change**:
->    - Grep `core/network/src/commonMain/` for the corresponding endpoint (`*Api.kt` files)
->    - Also grep `core/data/src/commonMain/` — some repositories inline endpoint paths
->    - Note: exists / needs updating / missing
-> 4. For each **removed / deprecated endpoint**:
->    - Find every mobile call site and flag it as a Breaking gap
-> 5. For each **type / schema change**:
->    - Check `core/model/src/commonMain/` for the matching Kotlin data class
->    - Note new, removed, or type-changed fields
->    - **SSE-specific**: when upstream modifies streaming payloads or run events, also
->      check `core/model/src/.../StreamEvent.kt`, `SseContentEvent.kt`, `ToolCallRecord.kt`,
->      `ToolCallResult.kt`, `ToolAuthStatus.kt`. SSE shape drift is a frequent source of
->      silent breakage that compiles but produces wrong UI at runtime.
-> 6. For each **UI change**:
->    - Check the corresponding `feature/*/` module (commonMain + platform sources)
->    - Note if the feature exists, needs updating, or is missing
-> 7. For each **new feature flag in `/api/config`**:
->    - Check `core/model/src/commonMain/.../StartupConfig.kt` — new keys must be added
->      for the mobile app to detect the flag and gate UI accordingly
-> 8. **Version-gating check.** Read `core/common/src/commonMain/.../BackendVersion.kt`.
->    It exposes `parse()`, `isCompatible()`, and `extractVersionFromFooter()`. For any
->    new upstream feature that requires the target tag or higher, flag it so the
->    implementer adds a `BackendVersion.isCompatible(...)` check on the mobile side.
-> 9. **iosMain coverage check.** For every touched module under `core/*` or `feature/*`,
->    confirm whether `src/iosMain/kotlin/...` sources exist. If they do, the implementer
->    must update both commonMain AND iosMain (expect/actual pairs, platform-specific
->    bridges like `NWConnection` SSE transport, Keychain, etc.). Flag modules where
->    iosMain parity is easily missed.
-> 10. Categorize all gaps:
->     - **Breaking** (must fix): Changed or removed request/response shapes, removed/renamed
->       endpoints, auth changes, security fixes
->     - **Additive** (new feature): New endpoints, new UI features, new optional fields,
->       new feature flags
->     - **Cosmetic** (polish): UI improvements, a11y, i18n
-> 11. Report the categorized gap list with specific file paths for both upstream and mobile.
-
-### B2. Receive gap report
-
-The investigator now has full context of both the upstream diff AND the mobile gaps.
-Keep the investigator alive for follow-up questions during Phase C.
-
-**Done when:** You have the categorized gap list, and
-`.claude/sync-upstream/artifacts/phase-b-gap-report.md` exists on disk.
+It returns `{ mode, range, findings[], counts, criticComplete, reportPath }` and writes
+`artifacts/discovery-report.md`. Each finding is machine-complete: category, severity, mobile-gap
+status, iosMain coverage, **landing commit + UTC `landedDate`**, first-target-line, gate form. Do not
+paraphrase-and-lose those — thread the structured objects straight into WF2.
 
 ---
 
-## Phase C: Proposal
+## Phase 2 — HITL interview (you)
 
-**Lead presents to user — no delegation needed.**
+This is the single human gate. Present the converged report, then use `AskUserQuestion` to settle:
 
-Take the investigator's gap report and produce a structured proposal.
-**Persist the proposal to `.claude/sync-upstream/artifacts/proposal-{target_tag}.md`
-before presenting it** so the user has a reviewable artifact and the skill can
-resume if the session dies.
+- **Target / scope** (sync): confirm the resolved target or switch (stable / rc / partial — the findings
+  are already tagged by target-line, so switching just filters). If the user switches, you have the
+  data; no re-run needed unless they name a target outside the swept superset (then re-invoke WF1).
+- **Which items** to implement now vs defer (Breaking + Security cannot be deferred — say so).
+- **Direction** on UI items that don't map cleanly to Compose (surface the 2-3 options per item).
+- **Audit**: which surfaced misses to fix now.
+- Items marked `backend-blocked` are shown as knowingly-skipped, never built.
 
-```
-## Sync Proposal: {current_tag} → {target_tag}
-
-### Breaking Changes ({count}) — must fix before updating version
-For each: what changed upstream (file reference), mobile file(s) needing updates, proposed change.
-
-### Security Fixes ({count}) — must fix, cannot be deferred
-For each: CVE / patch description, mobile-side impact (if any), proposed change.
-
-### Removed / Deprecated Endpoints ({count}) — mobile call sites must migrate
-For each: removed/deprecated route, mobile call sites (file paths), replacement route and migration plan.
-
-### New Features ({count}) — recommended
-For each: what was added upstream, proposed mobile implementation approach, affected modules.
-
-### New Config / Feature Flags ({count})
-For each: new key in `/api/config`, proposed `StartupConfig.kt` update, whether a `BackendVersion` gate is needed.
-
-### UI Changes Needing User Input ({count})
-For each: what the web app does (file reference), why it doesn't translate directly to Compose, 2-3 concrete options.
-
-### Deferred Items ({count}) — can wait for a future sync
-Items that are low priority or require significant new infrastructure.
-
-### Upstream-Incomplete (backend not shipped) — NOT built, by design
-Features whose upstream backend is missing (client-only stubs / unmounted routes), per
-`${CLAUDE_SKILL_DIR}/reference/upstream-backend-gaps.md`. List the still-open entries so
-the user sees they're knowingly skipped, not missed. Building these would wire mobile UI
-to a nonexistent endpoint.
-```
-
-### Consult experts on non-trivial items
-
-Before presenting to the user, for any proposed change that involves:
-- New architectural patterns (new module, new DI scope, new navigation key)
-- UI patterns without an existing equivalent in the codebase
-- Performance-sensitive changes (list rendering, image loading, SSE throughput)
-- KMP shared code or expect/actual patterns
-- iOS-specific bridges (Network.framework, Keychain, WKWebView)
-
-Send Android-specific items to **android-expert** and KMP/iOS items to **ios-kmp-expert**:
-
-> Review these proposed mobile changes for best practices. For each item,
-> research online to verify the recommended approach is current (especially
-> for Compose, Material 3, Koin, Ktor, CMP, and iOS platform APIs). Flag any
-> items where modern best practices differ from what we're proposing.
-> {list of non-trivial items}
-
-Incorporate the experts' feedback into the proposal **and update the artifact file** before showing the user.
-
-### Approval gate
-
-Ask the user:
-
-> Review the proposal above (also saved at `.claude/sync-upstream/artifacts/proposal-{target_tag}.md`).
-> Reply with:
-> - **approve all** — proceed with full implementation
-> - **approve with changes** — tell me what to modify in the proposal
-> - **approve partial** — list which items to implement now (rest deferred)
-> - **cancel** — abort, no changes made
-
-**Do NOT proceed to Phase D until the user explicitly approves.**
-
-If the user requests changes, update the proposal file AND re-present.
+Persist the approved, scoped list to `artifacts/approved-{target}.md`. If the user cancels, archive the
+report and stop cleanly. **Do not invoke WF2 until the user approves.**
 
 ---
 
-## Phase D: Implementation
+## Phase 3 — Implementation (WF2)
 
-**Delegate to: implementer, then verifier**
-
-> **HARD RULE — Phase D ends at local commits. DO NOT push. DO NOT open a PR.**
->
-> The verifier's gates (build + detekt + tests) confirm scaffolding correctness,
-> not feature correctness. A sync touches dozens of files across endpoints, SSE
-> shapes, UI wires, and backward-compat gates — it must be device-tested against
-> a real backend on BOTH Android and iOS (including older-server compat cases)
-> before a PR is offered for review.
->
-> The implementer works on a feature branch named `chore/sync-upstream-{target_tag}`
-> and commits per P/D group. After the verifier greenlights, the team-lead
-> presents the test plan to the user. The user drives device testing, asks for
-> follow-up fixes as more commits on the same local branch, and decides when
-> (if ever) to open the PR. The team does NOT run `git push`, `git push -u`,
-> or `gh pr create` at any point during `/sync-upstream`.
-
-### D1. Assign implementation task
-
-Create a task for the implementer with the approved change list:
-
-> Implement the following approved changes for the upstream sync from {current_tag} to {target_tag}.
->
-> **Before touching any module:**
-> 1. Read the root `CLAUDE.md` for architecture rules
-> 2. Read `${CLAUDE_SKILL_DIR}/reference/android-architecture.md` for patterns
-> 3. Read the specific module's `CLAUDE.md` (e.g., `core/network/CLAUDE.md`)
-> 4. Read existing similar code as a pattern reference
->
-> **Conventions (THIS PROJECT USES KOIN, NOT HILT):**
-> - `safeApiCall` for all network calls in repositories
-> - **Koin** for DI — use `viewModelOf(::X)`, `singleOf(::X)`, `factoryOf(::X)` in Koin modules at `feature/*/di/` and `core/*/di/`. Register the module in `LibreChatApplication.kt`'s `startKoin { modules(...) }` when creating a new one.
-> - Use `koinViewModel()` in Composables — never `hiltViewModel()` or `@HiltViewModel`.
-> - Unidirectional data flow: UI → ViewModel → Repository → API/Room
-> - `@Serializable` data classes in `core/model/`
-> - Ktor client patterns in `core/network/`
-> - For KMP modules, update BOTH `src/commonMain/` AND `src/iosMain/` (and `src/androidMain/` when relevant). `expect` declarations in commonMain REQUIRE matching `actual` implementations in every target's source set.
->
-> **Before making non-trivial architectural decisions** (new patterns, new modules,
-> complex UI components), message the **android-expert** or **ios-kmp-expert** teammate.
-> They will research current best practices online and advise.
->
-> **Approved changes:**
-> {paste the approved change list here}
->
-> **Branching:** Create a feature branch `chore/sync-upstream-{target_tag}` at the
-> start. Commit per P/D group (one commit per must-ship item, one per deferred
-> item). Use conventional-commit subjects (e.g. `feat(chat): render SUMMARY
-> content blocks (D2)`).
->
-> **After all code changes:**
-> 1. Update `backendTargetVersion` in the root `version.properties` to `{new_version}` (without `v` prefix). This is the single source of truth — a Gradle task code-generates `BackendVersion.SUPPORTED_BACKEND_VERSION` from it, and `release.yml` reads the same key. Do **not** edit the `BackendVersion.kt` literal (it no longer exists).
-> 2. Advance submodule: `cd upstream && git checkout {target_tag}`
-> 3. Update `UPSTREAM_VERSION` at repo root:
->    ```
->    tag={target_tag}
->    commit={full SHA of target_tag}
->    date={today's date YYYY-MM-DD}
->    ```
-> 4. Update `README.md` at repo root: bump the compatibility badge and the
->    "Backend compatibility" note's upper bound to the new `{target_tag}` (badge
->    link target too). Leave the lower bound unless the floor was deliberately
->    raised. Easy to forget — it's the only user-facing version surface not
->    driven by `version.properties`. (Missed in the v0.8.6 sync; fixed in PR #125.)
-> 5. Update `DISCOVERY.md` at the repo root: append newly-discovered endpoints, removed
->    endpoints, and revised response shapes. Keep it accurate — future syncs depend on it.
-> 6. Create/update `VERSION_GATES.md` at repo root: add a row for any code path
->    that branches on `BackendVersion.isCompatible()` / `isCompatibleOrNewer()`.
->    Keep backward-compat gates auditable so future floor-raises are mechanical.
-> 7. Report back the full list of files created or modified, grouped by module.
->
-> **DO NOT** run `git push`, `git push -u origin ...`, or `gh pr create`.
-> The branch stays local-only until the user device-tests and explicitly
-> authorizes the push.
-
-### D2. Assign verification task
-
-After implementer reports done, create a task for the verifier:
-
-> Verify the upstream sync implementation from {current_tag} to {target_tag}.
->
-> **Build verification (run all four):**
-> 1. `./gradlew assembleDebug` — Android app compiles
-> 2. `./gradlew detekt` — static analysis passes on ALL source sets (commonMain,
->    androidMain, iosMain). The CI gate currently only covers commonMain, so do
->    not rely on CI here. If failures are found in iosMain/androidMain, report them.
-> 3. `./gradlew :shared:linkDebugFrameworkIosSimulatorArm64` — iOS framework links.
->    This catches iosMain compile errors that `assembleDebug` silently skips.
-> 4. `./gradlew check` — unit tests pass for touched modules
->
-> **Correctness review:**
-> 5. Read the approved proposal at `.claude/sync-upstream/artifacts/proposal-{target_tag}.md`.
-> 6. Review every file the implementer changed:
->    - All approved items implemented?
->    - Any unapproved changes (scope creep)?
->    - Koin DI used (not Hilt / `@Inject`)?
->    - `safeApiCall` wrapping new network calls?
->    - For KMP modules: did the implementer touch iosMain where needed, not just commonMain?
->    - For new endpoints: was `DISCOVERY.md` updated?
->
-> **Version consistency:**
-> 7. `backendTargetVersion` in the root `version.properties` matches target (this drives the generated `SUPPORTED_BACKEND_VERSION`)
-> 8. `UPSTREAM_VERSION` file has correct tag, commit, date
-> 9. `README.md` compatibility badge + note upper bound matches the new target tag
-> 10. Submodule is at the correct tag: `cd upstream && git describe --tags`
-> 11. `DISCOVERY.md` reflects endpoint additions/removals
->
-> **If you find issues**, message the **implementer** directly to fix them.
-> The implementer retains context of what it changed.
->
-> **Report back:**
-> - Pass/fail for each of the four build commands + any errors
-> - Issues found (if any) and who fixed them
-> - List of user-testable behaviors to verify on device — separate lists for Android and iOS where applicable
-
-### D3. Independent reviewer pass
-
-After the verifier signs off, spawn a fresh `reviewer` teammate (independence is
-the point — do not reuse the verifier):
-
-> Review `chore/sync-upstream-{target_tag}` against the approved proposal at
-> `.claude/sync-upstream/artifacts/proposal-{target_tag}.md`. You have not seen
-> the verifier's report; that is intentional.
->
-> Look for:
-> - Scope creep beyond approved items
-> - Backward-compat regressions on older-server paths
-> - iOS-vs-Android SSE shape divergence
-> - Missing version gates around new endpoints
-> - Koin DI wiring gaps
->
-> Report clean or a numbered issue list. Do NOT fix — the implementer fixes.
-
-Once the reviewer's pass is clean, spawn a second independent `auditor` for a
-final pass. Two independent passes are mandatory — thoroughness is imperative.
-Iterate (auditor → implementer fix → re-audit) until clean.
-
-### D4. Present results to user
-
-Once verifier confirms everything passes:
+Invoke the implementation workflow with the approved list. It implements per group, runs build +
+consistency gates, then ≥2 mandatory independent review passes (stateless ⇒ independent by
+construction; CONFIRMED vs PLAUSIBLE; iteration-capped). **It ends at local commits — it never pushes.**
 
 ```
-## Sync Ready for Device Testing: {current_tag} → {target_tag}
-
-**Branch `chore/sync-upstream-{target_tag}` is local-only. Not pushed. No PR opened.**
-This is a first pass. Device testing comes next.
-
-### Files Changed
-{grouped by module}
-
-### Test plan (run on device — Android and iOS)
-{verifier's user-testable behaviors list, split Android / iOS / v0.8.x-compat}
-
-### How to build and run
-1. Android: `./gradlew assembleDebug`, install to device/emulator.
-2. iOS: `./gradlew :shared:linkDebugFrameworkIosSimulatorArm64`, open the Xcode project, run.
-3. Connect to a v{target_tag} server + at least one older supported server and walk the test plan.
-
-### Version Updates (on this branch, not yet shipped)
-- backendTargetVersion (version.properties): {old} → {new}
-- UPSTREAM_VERSION tag: {old_tag} → {new_tag}
-- Submodule: pinned to {target_tag}
-- DISCOVERY.md: {brief summary of what was appended}
-- VERSION_GATES.md: {new gate rows added, if any}
-
-### Artifacts
-Proposal and phase reports saved under `.claude/sync-upstream/artifacts/`.
-
-### When ready, the user will:
-- Report bugs → team lead dispatches follow-up fixes as additional commits on the same local branch.
-- Explicitly authorize pushing the branch and opening a PR. Until then, the team does not push.
+Workflow({ name: "sync-upstream-implement", args: {
+  approvedItems, mode, targetMode, targetCommit, baseVersion, anchorTag,
+  targetTag,               // release/rc only; null for partial
+  sha8,                    // partial only
+  bumpVersion,             // FALSE in audit mode
+  branchName,              // chore/sync-upstream-{tag} | -dev-{sha8} | -audit-{sha8}
+  skillDir, artifactsDir,
+  reportPath,              // artifacts/discovery-report.md
+} })
 ```
 
-**Do NOT push or open a PR in this phase.** Even if the user says "looks good" in chat, wait for explicit "push it" / "open the PR" before running `git push` or `gh pr create`. Sync PRs are offered to reviewers only after the user has walked the full test plan on real devices.
+Returns `{ branchName, buildResults, buildGreen, consistency, reviewPasses, reviewClean,
+unresolvedConfirmed, testPlan }`.
 
-### D5. Dispatch test runners
+**Then re-assert independently (you, with Bash)** — do not trust the workflow's self-report blindly:
+- sync: `sha8` is a prefix of `commit=`; `cd upstream && git rev-parse HEAD` == `commit=`;
+  `BackendCommitMap.kt` contains the 12-char prefix of `commit=` (same check `release.yml` runs);
+  README upper bound matches; each `supportsFeature` row's `landedDate` ≤ synced commit's UTC date.
+- audit: the pin did **not** move — `commit=`, `backendTargetVersion`, submodule HEAD, and
+  `BackendCommitMap.kt` are all unchanged from before the audit.
 
-After presenting the report, split the Test plan and dispatch one teammate
-per section. Each walks the user through their section, captures blockers,
-and reports back to team-lead for triage and routing to the implementer.
-
-Section split scales with sync size:
-- Small sync (no new feature areas, <10 files): one teammate per platform
-  (Android, iOS).
-- Medium / large: split by feature area as well (e.g. Auth / Chat / Files /
-  Conversations × Android+iOS).
-
-Spawn teammates in parallel (single message, multiple Agent calls).
+If `buildGreen` is false or `unresolvedConfirmed` is true, report it and route back into WF2 (scoped
+to the failures) rather than proceeding.
 
 ---
 
-## Error Recovery
+## Phase 4 — Test & push tail (you) — HARD STOP
+
+> **Phase 3 ends at local commits. DO NOT push. DO NOT open a PR.** Build + detekt + tests confirm
+> scaffolding, not feature correctness. A sync must be device-tested against a real backend on BOTH
+> Android and iOS (incl. older-server compat) before a PR is offered. The branch stays local-only
+> until the user walks the test plan and **explicitly** says "push it" / "open the PR".
+
+Present:
+
+```
+## Sync Ready for Device Testing: {baseline} → {target}   [{mode}]
+Branch `{branchName}` is local-only. Not pushed. No PR opened.
+
+### Files changed        {grouped by module}
+### Test plan            {WF2 testPlan — Android / iOS / compat}
+### How to build & run   Android: assembleDebug + install. iOS: linkDebugFrameworkIosSimulatorArm64, run in Xcode.
+                         Connect to a target-version server + an older supported server; walk the plan.
+                         Partial: verify new features HIDDEN on the older server, visible on a server the
+                         regenerated BackendCommitMap COVERS (between landing and the pin). A server NEWER
+                         than the pin resolves to no-version → features fail closed by design (not a bug),
+                         and your own dev server drifts past the pin within days.
+### Version updates      {sync: the bumps; audit: "none — pin unchanged"}
+```
+
+Then:
+- User reports bugs → re-invoke **WF2** scoped to just those fixes (same branch), loop until they're happy.
+- User explicitly authorizes the push → only then run `git push` / `gh pr create`. Not before.
+
+Dispatch on-device test facilitation as needed (split by platform, or platform × feature area for large
+syncs). Device testing is the human's; you facilitate and route blockers back into WF2.
+
+---
+
+## Reference files (read by the workflows' agents, not by you)
+
+`${CLAUDE_SKILL_DIR}/reference/`: `upstream-paths.md` (diff surface), `api-mapping.md`,
+`model-mapping.md`, `ui-mapping.md`, `upstream-backend-gaps.md` (client-only vapor features — do not
+build), `android-architecture.md` (implementer patterns). Root: `DISCOVERY.md`, `VERSION_GATES.md`,
+`BackendVersion.kt`.
+
+## Error recovery
 
 | Situation | Recovery |
 |-----------|----------|
-| Submodule missing | `git submodule add https://github.com/danny-avila/LibreChat.git upstream` |
-| `UPSTREAM_VERSION` missing | Create from `version.properties` `backendTargetVersion` + submodule HEAD |
-| No newer tags | Report "up to date" and stop |
-| Dirty working tree | Ask user to commit/stash |
-| Git fetch fails | Show `git remote -v`, check network |
-| Android build fails after changes | Verifier messages implementer to fix (both retain context) |
-| iOS framework link fails (but Android passes) | Implementer likely forgot iosMain updates — message them to audit iosMain source sets for affected modules |
-| Detekt fails (any source set) | Implementer fixes findings. Do not use `--ignore-failures`. |
-| User cancels at Phase C | Delete or archive the proposal artifact, tear down the team (`TeamDelete`), stop cleanly |
-| Version mismatch (tracked tag ≠ version.properties backendTargetVersion) | Ask user which is the true baseline |
-| Session compacted mid-run | List `.claude/sync-upstream/artifacts/` — newest file indicates phase reached; resume from there |
-| Teammate unresponsive | Check task status, re-send message; sub-agent as last resort |
+| Submodule / UPSTREAM_VERSION missing | Recreate (Phase 0 steps 1–2) |
+| Dirty tree / baseline inconsistency / SHA not found | **Ask the user** — never auto-resolve |
+| Already up to date | Offer an **audit** (don't just stop) |
+| No newer tags but dev/main ahead | Offer a **partial** sync |
+| WF1/WF2 returns partial (agent died) | Re-invoke with `resumeFromRunId` (cached agents replay); artifacts under `artifacts/` show the phase reached |
+| BackendCommitMap missing the pin (release.yml net) | WF2's regen step runs AFTER submodule checkout; re-run if needed |
+| Build/consistency/review fail | Reported in WF2's return; re-invoke WF2 scoped to the failures |
+| Session compacted mid-run | Artifacts dir is the resume authority; `resumeFromRunId` only within a single workflow invocation |

--- a/.claude/skills/sync-upstream/reference/upstream-paths.md
+++ b/.claude/skills/sync-upstream/reference/upstream-paths.md
@@ -1,7 +1,7 @@
 # Upstream Paths to Watch
 
 These are the directories and files in the `upstream/` submodule that matter for mobile parity.
-Use these paths when generating focused diffs between tags.
+Use these paths when generating focused diffs between the current baseline commit (UPSTREAM_VERSION commit=) and the target ref (tag, rc tag, or untagged commit for partial syncs).
 
 ## Server: Routes, Controllers, Middleware, Services
 
@@ -64,7 +64,7 @@ Use these paths when generating focused diffs between tags.
 ## Release Notes (authoritative)
 
 GitHub Releases often explicitly flag breaking changes and migrations that diffs hide.
-For every stable tag between current and target (inclusive):
+For every stable or rc tag between current baseline and target (inclusive; untagged partial targets have no release notes — scan merged PRs and commit subjects instead):
 ```bash
 gh api repos/danny-avila/LibreChat/releases/tags/{tag} --jq .body
 ```
@@ -76,7 +76,7 @@ Upstream has no repo-root `CHANGELOG.md` — release notes on GitHub are the can
 
 Overview:
 ```bash
-cd upstream && git diff {old_tag}..{new_tag} --stat -- \
+cd upstream && git diff {base_commit}..{target_commit} --stat -- \
   api/server/routes/ \
   api/server/controllers/ \
   api/server/middleware/ \
@@ -96,12 +96,12 @@ cd upstream && git diff {old_tag}..{new_tag} --stat -- \
 
 For detailed diffs, run each path separately to keep output manageable:
 ```bash
-cd upstream && git diff {old_tag}..{new_tag} -- packages/data-provider/src/api-endpoints.ts
+cd upstream && git diff {base_commit}..{target_commit} -- packages/data-provider/src/api-endpoints.ts
 ```
 
 ## Commit-message scan (complements the diff)
 
 ```bash
-cd upstream && git log --oneline {old_tag}..{new_tag}
+cd upstream && git log --oneline {base_commit}..{target_commit}
 ```
 Breaking changes are frequently summarized in subject lines (e.g., `BREAKING CHANGE:`, `refactor!:`).

--- a/.claude/workflows/sync-upstream-discovery.js
+++ b/.claude/workflows/sync-upstream-discovery.js
@@ -1,0 +1,240 @@
+export const meta = {
+  name: 'sync-upstream-discovery',
+  description: 'Parallel multi-angle discovery of upstream LibreChat changes + mobile-gap mapping, converged into one findings report (sync or audit lens)',
+  phases: [
+    { title: 'Multi-angle sweep', detail: 'parallel readers, each a different lens over base..target' },
+    { title: 'Converge', detail: 'dedup + cross-reference mobile codebase + tag landing commit/date' },
+    { title: 'Completeness critic', detail: 'what modality/claim did we miss?' },
+  ],
+}
+
+// ---------------------------------------------------------------------------
+// WF1 — DISCOVERY.  Invoked by the sync-upstream skill AFTER it has (in the main
+// loop, with direct Bash) run prereqs, resolved the target, and detected the mode.
+// The script body has NO shell/fs access — every git/grep/read action happens
+// INSIDE an agent(). Determinism comes from control flow + schema-forced output.
+//
+// args = {
+//   mode:         'sync' | 'audit'
+//   baseCommit:   diff base (sync: current pin; audit: previous pin from UPSTREAM_VERSION history)
+//   targetCommit: diff ceiling (sync: new target SHA; audit: current pin)
+//   targetMode:   'release' | 'rc' | 'partial'
+//   baseVersion:  version the target commit's package.json reports (e.g. "0.8.7")
+//   anchorTag:    last v-tag at/before targetCommit (e.g. "v0.8.7")
+//   skillDir:     absolute path to .claude/skills/sync-upstream
+//   artifactsDir: absolute path to .claude/sync-upstream/artifacts
+// }
+// ---------------------------------------------------------------------------
+
+const A = args || {}
+const RANGE = `${A.baseCommit}..${A.targetCommit}`
+const IS_AUDIT = A.mode === 'audit'
+
+// The lens flips the whole run — the same range, read with opposite intent.
+const LENS = IS_AUDIT
+  ? `AUDIT LENS: the mobile pin is ALREADY at ${A.targetCommit}. You are NOT finding new
+     work — you are checking whether the upstream changes in ${RANGE} (the last synced delta)
+     were FULLY and CORRECTLY absorbed into the mobile client. Report ONLY misses: upstream
+     changes with no mobile equivalent, partial ports, wrong field/shape mappings, missing
+     version gates, or iosMain parity that was skipped. A change that mobile handled correctly
+     is NOT a finding.`
+  : `SYNC LENS: report every upstream change in ${RANGE} that the mobile client may need to
+     absorb — new/changed/removed endpoints, type & SSE shape drift, new config flags, new UI
+     flows, security fixes. This is the superset diff; each finding is tagged with the target
+     line it first lands in so the human can filter scope at the interview.`
+
+// Six blind angles. Each reads only its slice, categorizes only its kind of change.
+// Blindness is the point (multi-modal sweep): no angle sees the others' output.
+const ANGLES = [
+  { key: 'routes-api', label: 'Routes / API',
+    focus: 'HTTP endpoints added, removed, deprecated, or changed (path, method, request/response contract).',
+    paths: 'api/server/routes/ (incl. routes/agents, routes/files, routes/admin), api/server/controllers/, api/server/middleware/' },
+  { key: 'types-sse', label: 'Types / schemas / SSE shapes',
+    focus: 'Data-type / response-shape drift AND streaming payload changes. SSE shape drift is the top source of silent runtime breakage.',
+    paths: 'api/models/, packages/data-schemas/src/, packages/data-provider/src/types/, and SSE/run-event emitters. Cross-check mobile core/model StreamEvent.kt, SseContentEvent.kt, ToolCallRecord.kt, ToolCallResult.kt, ToolAuthStatus.kt.' },
+  { key: 'config-flags', label: 'Config / feature flags',
+    focus: 'New or changed keys in the /api/config surface that gate UI availability.',
+    paths: 'packages/data-provider/src/config.ts, librechat.example.yaml, .env.example. Mobile counterpart: core/model StartupConfig.kt.' },
+  { key: 'ui-flows', label: 'UI / user flows',
+    focus: 'New components, changed user flows, new screens — mapped to mobile feature modules.',
+    paths: 'client/src/components/, client/src/hooks/, client/src/store/, client/src/Providers/, client/src/data-provider/.' },
+  { key: 'security-auth', label: 'Security / auth',
+    focus: 'CVEs, auth/token-handling changes, permission changes. CANNOT be deferred.',
+    paths: 'api/server/middleware/, packages/data-provider/src/permissions.ts, auth controllers/services, token handling.' },
+  { key: 'release-narrative', label: 'Release notes / PR narrative',
+    focus: 'The candid "what broke" source that diffs hide: release-note bodies, merged-PR titles/bodies, rc-prep PR body, and raw commit subjects.',
+    paths: 'gh api releases + gh pr list (merged, base dev) + `git log --oneline` over the range. Flag anything a maintainer described as breaking/removed/migration.' },
+]
+
+const RAW_FINDING = {
+  type: 'object',
+  properties: {
+    id: { type: 'string' },
+    title: { type: 'string' },
+    category: { type: 'string', enum: ['api', 'removed-endpoint', 'type-schema', 'config-flag', 'ui', 'security', 'bugfix', 'infra'] },
+    upstreamPaths: { type: 'array', items: { type: 'string' } },
+    landingCommit: { type: 'string', description: '12-char upstream commit SHA that introduced this change (best effort from the range)' },
+    breaking: { type: 'boolean' },
+    evidence: { type: 'string', description: 'commit subject / release-note excerpt / diff summary supporting the finding' },
+  },
+  required: ['id', 'title', 'category', 'breaking', 'evidence'],
+}
+
+phase('Multi-angle sweep')
+
+const angleResults = await parallel(ANGLES.map((angle) => () => agent(
+  `You are the "${angle.label}" discovery angle for a LibreChat Mobile upstream ${A.mode}.
+Repo root is the current working directory. Upstream submodule is at ./upstream (read-only).
+
+${LENS}
+
+YOUR ANGLE — ${angle.label}: ${angle.focus}
+Upstream area to read/diff: ${angle.paths}
+Reference the full path inventory at ${A.skillDir}/reference/upstream-paths.md but stay in YOUR lane —
+other angles cover routes/types/config/ui/security/narrative separately. Do not duplicate them.
+
+Method:
+- Diff the range with: cd upstream && git diff ${RANGE} -- <your paths>   (use --stat first, then per-file).
+- For the release-narrative angle, use: gh api repos/danny-avila/LibreChat/releases/tags/{tag} --jq .body
+  for any tag in range, gh pr list --repo danny-avila/LibreChat --state merged --base dev --limit 200
+  --json number,title,mergedAt,url, and cd upstream && git log --oneline ${RANGE}.
+- For each real change, capture the introducing commit's 12-char SHA when identifiable
+  (git log ${RANGE} -- <path> for the relevant file).
+- Persist your raw notes to ${A.artifactsDir}/discovery-angle-${angle.key}.md as you go.
+
+Return ONLY findings in your lane. In audit mode, remember: report misses, not correctly-absorbed changes.`,
+  { label: `angle:${angle.key}`, phase: 'Multi-angle sweep', schema: {
+    type: 'object',
+    properties: { findings: { type: 'array', items: RAW_FINDING } },
+    required: ['findings'],
+  } }
+)))
+
+const rawFindings = (angleResults || []).filter(Boolean).flatMap((r) => r.findings || [])
+log(`Swept ${ANGLES.length} angles → ${rawFindings.length} raw findings`)
+
+phase('Converge')
+
+// Machine-COMPLETE converged schema. Landing commit + UTC date per feature is the
+// tax that keeps downstream version gates correct — WF2's stateless implementer
+// must never re-derive these from prose.
+const CONVERGED_FINDING = {
+  type: 'object',
+  properties: {
+    id: { type: 'string' },
+    title: { type: 'string' },
+    category: { type: 'string', enum: ['api', 'removed-endpoint', 'type-schema', 'config-flag', 'ui', 'security', 'bugfix', 'infra'] },
+    severity: { type: 'string', enum: ['breaking', 'additive', 'cosmetic'] },
+    upstreamPaths: { type: 'array', items: { type: 'string' } },
+    mobilePaths: { type: 'array', items: { type: 'string' }, description: 'mobile files that need to change (or that already handle it)' },
+    mobileGapStatus: { type: 'string', enum: ['missing', 'needs-update', 'exists', 'backend-blocked'] },
+    iosMainCoverage: { type: 'string', enum: ['common-only', 'needs-iosmain', 'na'], description: 'needs-iosmain = touched module has iosMain sources that must be updated too' },
+    landingCommit: { type: 'string', description: '12-char upstream SHA that introduced the change' },
+    landedDate: { type: 'string', description: 'UTC committer date YYYY-MM-DD of landingCommit, from: cd upstream && TZ=UTC git log -1 --date=format-local:%Y-%m-%d --format=%cd <sha>' },
+    firstTargetLine: { type: 'string', description: 'version the feature first ships under, e.g. "0.8.8-rc1" (even before that tag exists)' },
+    gateForm: { type: 'string', description: 'recommended gate: isCompatibleOrNewer(v,"X") or supportsFeature(detected,"X",landedDate=...) or none' },
+    proposedApproach: { type: 'string' },
+  },
+  required: ['id', 'title', 'category', 'severity', 'mobileGapStatus', 'landingCommit', 'landedDate'],
+}
+
+const converged = await agent(
+  `Converge the raw discovery findings for a LibreChat Mobile upstream ${A.mode}
+(${A.baseVersion}, targetMode=${A.targetMode}, anchor=${A.anchorTag}). Repo root is CWD.
+
+${LENS}
+
+RAW FINDINGS (from ${ANGLES.length} blind angles — expect duplicates across angles):
+${JSON.stringify(rawFindings)}
+
+Do ALL of the following, then return the converged report:
+1. Dedup: merge findings that describe the same upstream change (routes & types angles often overlap).
+2. Cross-reference each finding against the mobile codebase to set mobileGapStatus + mobilePaths:
+   - api:            grep core/network/src/commonMain (*Api.kt) AND core/data/src/commonMain (inlined paths).
+   - type-schema:    check core/model/src/commonMain data classes; for SSE, the StreamEvent/SseContentEvent/
+                     ToolCall* files. Note added/removed/type-changed fields precisely.
+   - config-flag:    check core/model StartupConfig.kt for the key.
+   - ui:             check the matching feature/* module (commonMain + platform sources).
+3. Read ${A.skillDir}/reference/{api-mapping.md,model-mapping.md,ui-mapping.md} to resolve upstream→mobile,
+   and DISCOVERY.md at repo root for already-catalogued endpoints/quirks.
+4. Read ${A.skillDir}/reference/upstream-backend-gaps.md. Any finding matching an OPEN entry → mobileGapStatus
+   "backend-blocked" (do not build). RE-CHECK each entry: if the backend route has since shipped, say so.
+5. iosMainCoverage: for each touched core/* or feature/* module, check whether src/iosMain/ sources exist →
+   "needs-iosmain" if they do, else "common-only".
+6. Landing commit + date (REQUIRED, machine-complete): for each finding set landingCommit (12-char) and
+   landedDate via: cd upstream && TZ=UTC git log -1 --date=format-local:%Y-%m-%d --format=%cd <sha>
+   (UTC is mandatory — it must match how BackendCommitMap bakes dates; %cs mis-orders).
+7. Version gating: read core/common/src/commonMain/.../BackendVersion.kt and VERSION_GATES.md. For each
+   feature needing a gate set firstTargetLine + gateForm:
+   - release/rc target → isCompatibleOrNewer(version, "{first line carrying it, usually the rc1}")
+   - partial target    → supportsFeature(detected, "{next-rc-line}", landedDate="{the UTC date above}")
+8. severity: breaking (changed/removed shapes, removed endpoints, auth/security) / additive / cosmetic.
+9. Write the full converged report to ${A.artifactsDir}/discovery-report.md (human-reviewable: grouped by
+   severity, each finding with upstream+mobile paths, landing commit/date, gap status, gate form).
+
+Return the structured report.`,
+  { label: 'converge', phase: 'Converge', schema: {
+    type: 'object',
+    properties: {
+      findings: { type: 'array', items: CONVERGED_FINDING },
+      counts: {
+        type: 'object',
+        properties: {
+          breaking: { type: 'integer' }, additive: { type: 'integer' }, cosmetic: { type: 'integer' },
+          missing: { type: 'integer' }, backendBlocked: { type: 'integer' },
+        },
+      },
+      reportPath: { type: 'string' },
+    },
+    required: ['findings', 'reportPath'],
+  } }
+)
+
+phase('Completeness critic')
+
+const critic = await agent(
+  `You are the completeness critic for a LibreChat Mobile upstream ${A.mode}. Repo root is CWD.
+The converged discovery report is at ${converged.reportPath}. Read it.
+
+Your ONLY job is to find what the sweep MISSED. Check, concretely:
+- Any path group in ${A.skillDir}/reference/upstream-paths.md that no angle actually diffed over ${RANGE}?
+  (Verify with: cd upstream && git diff --stat ${RANGE} -- <path> ; a non-empty diff with no matching
+  finding is a miss.)
+- Any finding missing landingCommit or landedDate (would break version gating downstream)?
+- Any claim asserted without diff/commit/release-note evidence?
+- Any NEW client-only "vapor" feature (upstream UI with no shipped backend) not yet in
+  ${A.skillDir}/reference/upstream-backend-gaps.md?
+- ${IS_AUDIT ? 'Audit-specific: any upstream change in range that was silently assumed absorbed without checking the mobile side?' : 'Sync-specific: any removed/renamed endpoint whose mobile call sites were not enumerated?'}
+
+Return addenda findings (same shape as the report's findings) plus a short note per gap on what to verify.
+If the report is complete, return an empty findings array and say so. Do NOT fix — just surface.`,
+  { label: 'critic', phase: 'Completeness critic', schema: {
+    type: 'object',
+    properties: {
+      addenda: { type: 'array', items: CONVERGED_FINDING },
+      notes: { type: 'string' },
+      complete: { type: 'boolean' },
+    },
+    required: ['addenda', 'complete'],
+  } }
+)
+
+const allFindings = converged.findings.concat(critic.addenda || [])
+if ((critic.addenda || []).length) {
+  log(`Critic surfaced ${critic.addenda.length} additional finding(s) — merging into report`)
+  await agent(
+    `Append these critic addenda to the discovery report at ${converged.reportPath}, keeping the same
+grouping/format, and mark them "(added by completeness critic)". ADDENDA:\n${JSON.stringify(critic.addenda)}`,
+    { label: 'merge-addenda', phase: 'Completeness critic' }
+  )
+}
+
+return {
+  mode: A.mode,
+  targetMode: A.targetMode,
+  range: RANGE,
+  findings: allFindings,
+  counts: converged.counts || null,
+  criticComplete: critic.complete,
+  reportPath: converged.reportPath,
+}

--- a/.claude/workflows/sync-upstream-implement.js
+++ b/.claude/workflows/sync-upstream-implement.js
@@ -1,0 +1,278 @@
+export const meta = {
+  name: 'sync-upstream-implement',
+  description: 'Implement approved upstream-sync changes, run deterministic build + consistency gates, then >=2 mandatory independent review passes. Ends at local commits — never pushes.',
+  phases: [
+    { title: 'Implement', detail: 'one implementer, commits per group, shared working tree' },
+    { title: 'Version bookkeeping', detail: 'checkout submodule then regen commit map (ordering as code)' },
+    { title: 'Build gates', detail: 'assembleDebug, detekt, iOS link, check' },
+    { title: 'Consistency asserts', detail: 'sha-prefix, HEAD==commit, map-has-pin, landedDate<=synced' },
+    { title: 'Independent review', detail: '>=2 stateless passes, CONFIRMED vs PLAUSIBLE, iteration-capped' },
+    { title: 'Test plan', detail: 'user-testable behaviors, split Android / iOS / compat' },
+  ],
+}
+
+// ---------------------------------------------------------------------------
+// WF2 — IMPLEMENT + VERIFY + REVIEW.  Invoked by the sync-upstream skill AFTER the
+// human approval gate. Runs in the SHARED working tree (no worktree isolation) so
+// implement -> verify -> fix operate on the same branch; mutation is sequential,
+// only the read-only review agents fan out.
+//
+// HARD RULE: this script contains NO `git push` / `gh pr create`, and its agents
+// are told never to run them. It ends at local commits. Device testing + push
+// authorization live in the skill's main loop, never here.
+//
+// args = {
+//   approvedItems: [...]   // human-approved, scoped change list (findings + any direction notes)
+//   mode:          'sync' | 'audit'
+//   targetMode:    'release' | 'rc' | 'partial'
+//   targetCommit:  full SHA
+//   baseVersion:   e.g. "0.8.7"
+//   anchorTag:     e.g. "v0.8.7"   (UPSTREAM_VERSION tag= for partial; the target tag for release/rc)
+//   targetTag:     e.g. "v0.8.8" or "v0.8.8-rc1" (release/rc only; null for partial)
+//   sha8:          first 8 chars of targetCommit (partial only)
+//   bumpVersion:   boolean  // FALSE in audit mode — the pin does not move
+//   branchName:    e.g. "chore/sync-upstream-v0.8.8" | "chore/sync-upstream-dev-6c97a7f4"
+//                  |     "chore/sync-upstream-audit-6c97a7f4"
+//   skillDir, artifactsDir, reportPath
+// }
+// ---------------------------------------------------------------------------
+
+const A = args || {}
+const MAX_BUILD_FIX_ROUNDS = 3
+const MAX_REVIEW_ROUNDS = 4
+const REVIEW_ROLES = ['reviewer', 'auditor']
+
+const BUILD_SCHEMA = {
+  type: 'object',
+  properties: {
+    assembleDebug: { type: 'boolean' }, detekt: { type: 'boolean' },
+    iosLink: { type: 'boolean' }, check: { type: 'boolean' },
+    errors: { type: 'string', description: 'concatenated failing output, empty if all pass' },
+  },
+  required: ['assembleDebug', 'detekt', 'iosLink', 'check'],
+}
+
+async function runBuildGates(round) {
+  return agent(
+    `Run the four build gates for the LibreChat Mobile sync branch, IN ORDER, and report each pass/fail.
+Do NOT use --ignore-failures. Repo root is CWD.
+1. ./gradlew assembleDebug                                    (Android compiles)
+2. ./gradlew detekt                                           (static analysis, ALL source sets)
+3. ./gradlew :shared:linkDebugFrameworkIosSimulatorArm64      (catches iosMain compile errors assembleDebug skips)
+4. ./gradlew check                                            (unit tests for touched modules)
+Capture the failing output for any gate that fails into "errors". Do not fix anything — just report.`,
+    { label: `build-gates:${round}`, phase: 'Build gates', schema: BUILD_SCHEMA }
+  )
+}
+
+function gatesGreen(b) {
+  return b && b.assembleDebug && b.detekt && b.iosLink && b.check
+}
+
+phase('Implement')
+
+await agent(
+  `You are the implementer for a LibreChat Mobile upstream ${A.mode}. Repo root is CWD. Read the root
+CLAUDE.md, ${A.skillDir}/reference/android-architecture.md, and each touched module's CLAUDE.md before editing.
+
+Create the branch first:  git checkout -b ${A.branchName}   (off current HEAD).
+
+CONVENTIONS (this project uses KOIN, not Hilt):
+- safeApiCall for all repository network calls; UDF: UI -> ViewModel -> Repository -> API/Room.
+- Koin DI: viewModelOf(::X)/singleOf(::X)/factoryOf(::X) in feature/*/di and core/*/di; koinViewModel() in
+  Composables; register new modules in the shared Koin module list. Never hiltViewModel()/@HiltViewModel.
+- @Serializable data classes in core/model; Ktor client patterns in core/network.
+- KMP: for every touched module, update BOTH src/commonMain AND src/iosMain (and androidMain when relevant).
+  expect in commonMain REQUIRES actual in every target. The approved items carry an iosMainCoverage flag —
+  honor it.
+- Apply the version gate exactly as each item specifies (isCompatibleOrNewer vs supportsFeature+landedDate).
+
+APPROVED ITEMS (implement each; do not add unapproved scope):
+${JSON.stringify(A.approvedItems)}
+
+Commit per logical group with conventional-commit subjects (e.g. "feat(chat): render SUMMARY blocks").
+Commit locally only.
+
+HARD RULE: do NOT run git push, git push -u, or gh pr create. Ever. The branch stays local.
+
+Report the full list of files created/modified grouped by module.`,
+  { label: 'implement', phase: 'Implement' }
+)
+
+if (A.bumpVersion) {
+  // Ordering-as-code: submodule checkout MUST precede commit-map regen (the map is
+  // keyed off the new pin). Two sequential agents make the order structural.
+  phase('Version bookkeeping')
+  await agent(
+    `Version bookkeeping for the LibreChat Mobile ${A.targetMode} sync (base ${A.baseVersion},
+target commit ${A.targetCommit}). Repo root is CWD. Do these IN ORDER:
+1. Set backendTargetVersion in version.properties to the mode-correct form:
+   release -> "${A.baseVersion}"   rc -> "${A.targetTag ? A.targetTag.replace(/^v/, '') : A.baseVersion}"
+   partial -> "${A.baseVersion}+dev.${A.sha8}"
+2. Advance the submodule:  cd upstream && git checkout ${A.targetCommit}   (detached HEAD).
+3. Rewrite UPSTREAM_VERSION (keep its comment block):
+     tag=${A.targetMode === 'partial' ? A.anchorTag : (A.targetTag || A.anchorTag)}
+     commit=${A.targetCommit}
+     date=$(date +%Y-%m-%d)
+4. Update README.md compatibility badge + note upper bound (badge link target too):
+   release/rc -> the tag; partial -> "${A.anchorTag} +dev" phrasing. Leave the lower bound.
+5. Append to DISCOVERY.md: newly-discovered endpoints, removed endpoints, revised response shapes.
+6. Update VERSION_GATES.md: a row per gated code path. For supportsFeature gates the row MUST cite the
+   landing commit + landedDate (from the approved item) and the rc/final version at which the date can be
+   dropped for a plain version gate.
+Commit these as a "chore(sync): advance backend target to ..." commit. Do NOT regenerate the commit map yet
+(next step). Do NOT push.`,
+    { label: 'bookkeeping', phase: 'Version bookkeeping' }
+  )
+  await agent(
+    `Regenerate the baked commit->version table AFTER the submodule checkout (it is keyed off the new pin):
+  ./gradlew :core:common:generateBackendCommitMap
+Then commit the regenerated core/common/src/commonMain/.../generated/BackendCommitMap.kt as
+"chore(sync): regenerate BackendCommitMap at new pin". Verify it now contains the first 12 chars of
+${A.targetCommit}. Do NOT push.`,
+    { label: 'regen-commitmap', phase: 'Version bookkeeping' }
+  )
+} else {
+  log('Audit mode: pin does not move — skipping version bookkeeping (version.properties / UPSTREAM_VERSION / submodule / commit map unchanged)')
+}
+
+phase('Build gates')
+let build = await runBuildGates(0)
+
+phase('Consistency asserts')
+const consistency = await agent(
+  `Run version-consistency checks for the LibreChat Mobile ${A.mode} and report each as a pass/fail boolean.
+Repo root is CWD. ${A.bumpVersion
+    ? `This was a version-advancing ${A.targetMode} sync — assert:
+  - sha8Prefix:   ${A.targetMode === 'partial' ? `version.properties backendTargetVersion ends with "+dev.${A.sha8}" and ${A.sha8} is a prefix of UPSTREAM_VERSION commit=` : 'backendTargetVersion matches the tag form (no +dev)'}
+  - headEqualsCommit:  (cd upstream && git rev-parse HEAD) equals UPSTREAM_VERSION commit= (== ${A.targetCommit})
+  - mapHasPin:    BackendCommitMap.kt contains the first 12 chars of ${A.targetCommit} (same check release.yml runs)
+  - readmeMatches: README badge/note upper bound matches ${A.targetMode === 'partial' ? `"${A.anchorTag} +dev"` : (A.targetTag || A.anchorTag)}
+  - gatesDated:   every supportsFeature row in VERSION_GATES.md cites a landedDate <= the synced commit's UTC date`
+    : `This was an AUDIT (pin must NOT have moved) — assert the pin is UNCHANGED:
+  - pinUnchanged: UPSTREAM_VERSION commit= still equals ${A.targetCommit} AND (cd upstream && git rev-parse HEAD) equals it
+  - versionUnchanged: version.properties backendTargetVersion is unchanged from before the audit
+  - mapUnchanged: BackendCommitMap.kt was not regenerated (git diff shows no change to it)
+  - gatesDated:   any NEW supportsFeature row added by an audit fix cites a landedDate <= the pin's UTC date`}
+Return one boolean per named check plus a "failures" string describing any that failed.`,
+  { label: 'consistency', phase: 'Consistency asserts', schema: {
+    type: 'object',
+    properties: {
+      ok: { type: 'boolean' },
+      failures: { type: 'string' },
+    },
+    required: ['ok'],
+  } }
+)
+
+let buildRound = 0
+while ((!gatesGreen(build) || !consistency.ok) && buildRound < MAX_BUILD_FIX_ROUNDS) {
+  buildRound++
+  await agent(
+    `Fix these failures on the sync branch, then stop (do not push). Repo root is CWD.
+BUILD: ${JSON.stringify(build)}
+CONSISTENCY: ${JSON.stringify(consistency)}
+For an iOS-link failure with Android passing, audit the iosMain source sets of the affected modules
+(missing actual for a commonMain expect is the usual cause). Commit the fixes.`,
+    { label: `build-fix:${buildRound}`, phase: 'Build gates' }
+  )
+  build = await runBuildGates(buildRound)
+}
+
+phase('Independent review')
+// >=2 mandatory passes. Every agent() is stateless, so independence is structural
+// (a reviewer literally cannot have seen the prior pass). Only CONFIRMED issues force
+// another round; PLAUSIBLE are surfaced but don't block. Capped to avoid the flip-flop
+// loop documented in project memory (the 9-round STT A->B->A RCA).
+const REVIEW_SCHEMA = {
+  type: 'object',
+  properties: {
+    clean: { type: 'boolean' },
+    issues: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+          verdict: { type: 'string', enum: ['CONFIRMED', 'PLAUSIBLE'] },
+          category: { type: 'string' },
+          description: { type: 'string' },
+          file: { type: 'string' },
+          suggestedFix: { type: 'string' },
+        },
+        required: ['verdict', 'description'],
+      },
+    },
+  },
+  required: ['clean', 'issues'],
+}
+
+const reviewPasses = []
+let reviewRound = 0
+let confirmedOpen = true
+while (reviewRound < MAX_REVIEW_ROUNDS && (reviewRound < REVIEW_ROLES.length || confirmedOpen)) {
+  const role = REVIEW_ROLES[reviewRound % REVIEW_ROLES.length]
+  const r = await agent(
+    `You are an INDEPENDENT ${role} for a LibreChat Mobile upstream ${A.mode}. You have NOT seen any prior
+review pass — that independence is the point. Repo root is CWD; branch is ${A.branchName}.
+Read the approved discovery report at ${A.reportPath} and compare it against the actual changes on the branch
+(git diff/log against the branch point).
+
+Hunt for:
+- Scope creep beyond approved items.
+- Backward-compat regressions on older-server paths (a bare final-version gate that should be rc1/supportsFeature).
+- iOS-vs-Android SSE shape divergence; missing iosMain actuals for touched commonMain expects.
+- Missing/incorrect version gates around new endpoints (wrong landedDate, wrong first-line).
+- Koin DI wiring gaps; missing safeApiCall; DISCOVERY.md not updated for new endpoints.
+${A.bumpVersion ? '' : '- AUDIT: any change that moved the pin / version (it must not have).'}
+
+Classify each issue: CONFIRMED (you verified it is real and wrong) vs PLAUSIBLE (suspected, not proven).
+Do NOT fix anything. Return clean=true only if there are zero CONFIRMED issues.`,
+    { label: `${role}:${reviewRound}`, phase: 'Independent review', schema: REVIEW_SCHEMA }
+  )
+  reviewPasses.push({ role, round: reviewRound, clean: r.clean, issues: r.issues || [] })
+  const confirmed = (r.issues || []).filter((i) => i.verdict === 'CONFIRMED')
+  confirmedOpen = confirmed.length > 0
+  if (confirmedOpen) {
+    log(`${role} pass ${reviewRound}: ${confirmed.length} CONFIRMED issue(s) → dispatching fix`)
+    await agent(
+      `Fix these CONFIRMED review issues on branch ${A.branchName}, then stop (do not push). Repo root is CWD.
+Commit the fixes with a clear subject. CONFIRMED ISSUES:\n${JSON.stringify(confirmed)}`,
+      { label: `review-fix:${reviewRound}`, phase: 'Independent review' }
+    )
+    build = await runBuildGates(`r${reviewRound}`)
+  }
+  reviewRound++
+}
+
+const reviewClean = reviewPasses.length >= REVIEW_ROLES.length && !confirmedOpen
+
+phase('Test plan')
+const testPlan = await agent(
+  `Author the on-device test plan for this LibreChat Mobile ${A.mode} on branch ${A.branchName}. Repo root is CWD.
+Read the approved report at ${A.reportPath} and the branch diff. Produce concrete user-testable behaviors,
+split into three lists: android, ios, and compat (older-server / version-gate behavior — e.g. "feature X is
+HIDDEN on a v0.8.6 server, visible on the target"). Be specific enough to walk without re-reading the diff.`,
+  { label: 'test-plan', phase: 'Test plan', schema: {
+    type: 'object',
+    properties: {
+      android: { type: 'array', items: { type: 'string' } },
+      ios: { type: 'array', items: { type: 'string' } },
+      compat: { type: 'array', items: { type: 'string' } },
+    },
+    required: ['android', 'ios', 'compat'],
+  } }
+)
+
+return {
+  branchName: A.branchName,
+  mode: A.mode,
+  bumpVersion: !!A.bumpVersion,
+  buildResults: build,
+  buildGreen: gatesGreen(build),
+  consistency,
+  reviewPasses,
+  reviewClean,
+  unresolvedConfirmed: confirmedOpen,
+  testPlan,
+}


### PR DESCRIPTION
## Summary
Reworks the `/sync-upstream` skill from a single Agent-Teams flow into a lightweight coordinator that delegates the heavy parallel work to two dynamic workflows, keeping the human decision points in the coordinator rather than inside the workflows. Adds an audit mode (used automatically when the client is already at the target commit, or forced via an `audit` argument). Tooling/process only — no app code.

## Changes
- **`SKILL.md`** rewritten as a coordinator: runs prereqs, target + mode resolution, and final consistency asserts itself; owns the human decision points (the target/scope/direction interview and the no-push/device-test boundary); invokes the two workflows by name.
- **New `sync-upstream-discovery.js`** — parallel multi-angle upstream sweep (routes, types/SSE, config, UI, security, release narrative) → converge + mobile-gap cross-reference (landing commit + UTC date per finding) → completeness critic. Sync/audit lens.
- **New `sync-upstream-implement.js`** — implement approved changes → version bookkeeping → build + consistency gates → ≥2 iteration-capped independent review passes (CONFIRMED vs PLAUSIBLE) → test-plan generation. Ends at local commits; contains no push/PR step.
- **Two modes:** sync (release / rc / partial untagged-commit) and audit (re-check the last synced delta; the pin does not move).
- **`upstream-paths.md`** — diff-range wording clarified to `{base_commit}..{target_commit}`.

## Verification
- ES-module syntax-checked both workflow scripts. Not otherwise exercised — skills/workflows aren't run by CI, and no full `/sync-upstream` run has been performed on this branch.

## Notes
- The workflows apply version gates via the existing `BackendVersion` helpers (`isCompatibleOrNewer`, `supportsFeature` + `landedDate`, `BackendCommitMap`). Those runtime helpers are **not** in this branch — they land in the separate rc/partial gating change (`chore/partial-sync-rc-gates`); sequence that before any real partial/rc/audit run that relies on date gating.
- Drops the old android/ios-kmp expert advisory roles; architectural guidance is folded into the implementer/reviewer prompts.
- Workflow scripts live under `.claude/workflows/` and are invoked by name, so a branch must have them present to run `/sync-upstream`.