### PR TITLE
fix(auth): correct 2FA-setup and register response wire shapes

### DIFF
--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/AuthRepository.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/AuthRepository.kt
@@ -4,6 +4,7 @@ import com.garfiec.librechat.core.common.result.Result
 import com.garfiec.librechat.core.model.LoginOutcome
 import com.garfiec.librechat.core.model.User
 import com.garfiec.librechat.core.model.VerifyTwoFactorOutcome
+import com.garfiec.librechat.core.model.response.BackupCodesResponse
 import com.garfiec.librechat.core.model.response.TwoFactorSetupResponse
 
 interface AuthRepository {
@@ -34,9 +35,9 @@ interface AuthRepository {
      */
     suspend fun restoreAccountIfNeeded(): Boolean
     suspend fun enableTwoFactor(token: String? = null, backupCode: String? = null): Result<TwoFactorSetupResponse>
-    suspend fun confirmTwoFactor(code: String): Result<TwoFactorSetupResponse>
+    suspend fun confirmTwoFactor(code: String): Result<Unit>
     suspend fun disableTwoFactor(code: String): Result<Unit>
-    suspend fun regenerateBackupCodes(token: String? = null, backupCode: String? = null): Result<TwoFactorSetupResponse>
+    suspend fun regenerateBackupCodes(token: String? = null, backupCode: String? = null): Result<BackupCodesResponse>
     suspend fun requestPasswordReset(email: String): Result<Unit>
     suspend fun resetPassword(userId: String, token: String, password: String, confirmPassword: String): Result<Unit>
 }

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/AuthRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/AuthRepositoryImpl.kt
@@ -14,6 +14,7 @@ import com.garfiec.librechat.core.data.util.SessionTaskRunner
 import com.garfiec.librechat.core.model.LoginOutcome
 import com.garfiec.librechat.core.model.User
 import com.garfiec.librechat.core.model.VerifyTwoFactorOutcome
+import com.garfiec.librechat.core.model.response.BackupCodesResponse
 import com.garfiec.librechat.core.model.response.TwoFactorSetupResponse
 import com.garfiec.librechat.core.network.api.AuthApi
 import com.garfiec.librechat.core.network.api.UserApi
@@ -337,7 +338,7 @@ class AuthRepositoryImpl(
         }
     }
 
-    override suspend fun confirmTwoFactor(code: String): Result<TwoFactorSetupResponse> {
+    override suspend fun confirmTwoFactor(code: String): Result<Unit> {
         return safeApiCall {
             authApi.confirmTwoFactor(code)
         }
@@ -349,7 +350,7 @@ class AuthRepositoryImpl(
         }
     }
 
-    override suspend fun regenerateBackupCodes(token: String?, backupCode: String?): Result<TwoFactorSetupResponse> {
+    override suspend fun regenerateBackupCodes(token: String?, backupCode: String?): Result<BackupCodesResponse> {
         return safeApiCall {
             authApi.regenerateBackupCodes(token = token, backupCode = backupCode)
         }

--- a/core/model/src/commonMain/kotlin/com/garfiec/librechat/core/model/response/BackupCodesResponse.kt
+++ b/core/model/src/commonMain/kotlin/com/garfiec/librechat/core/model/response/BackupCodesResponse.kt
@@ -1,0 +1,17 @@
+package com.garfiec.librechat.core.model.response
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Response of `POST /api/auth/2fa/backup/regenerate` — the backend returns
+ * `{ backupCodes, backupCodesHash }` (`upstream/api/server/controllers/TwoFactorController.js`
+ * `regenerateBackupCodes`). Only the plain [backupCodes] are surfaced; the `backupCodesHash`
+ * (server-side hashed objects) is unmodeled and dropped via `ignoreUnknownKeys`.
+ *
+ * This is deliberately distinct from [TwoFactorSetupResponse]: regenerate does NOT return an
+ * `otpauthUrl`, so reusing the setup shape (which requires it) fails to decode.
+ */
+@Serializable
+data class BackupCodesResponse(
+    val backupCodes: List<String>,
+)

--- a/core/model/src/commonMain/kotlin/com/garfiec/librechat/core/model/response/RegisterResponse.kt
+++ b/core/model/src/commonMain/kotlin/com/garfiec/librechat/core/model/response/RegisterResponse.kt
@@ -1,9 +1,14 @@
 package com.garfiec.librechat.core.model.response
 
-import com.garfiec.librechat.core.model.User
 import kotlinx.serialization.Serializable
 
+/**
+ * Response of `POST /api/auth/register`. The backend returns only `{ message }`
+ * (`upstream/api/server/controllers/AuthController.js` `registrationController` →
+ * `res.status(status).send({ message })`) — it has never returned a `user` object. The field is
+ * nullable so a successful registration decodes even if the backend omits the message.
+ */
 @Serializable
 data class RegisterResponse(
-    val user: User,
+    val message: String? = null,
 )

--- a/core/model/src/commonMain/kotlin/com/garfiec/librechat/core/model/response/TwoFactorSetupResponse.kt
+++ b/core/model/src/commonMain/kotlin/com/garfiec/librechat/core/model/response/TwoFactorSetupResponse.kt
@@ -1,10 +1,18 @@
 package com.garfiec.librechat.core.model.response
 
-import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
+/**
+ * Response of `POST /api/auth/2fa/enable` — the initial enrolment step that returns the TOTP
+ * provisioning URI (for the QR code) and the freshly generated backup codes.
+ *
+ * The backend sends camelCase `{ otpauthUrl, backupCodes }`
+ * (`upstream/api/server/controllers/TwoFactorController.js` `enable2FA`); the Kotlin property names
+ * match the wire keys, so no `@SerialName` is needed. This response shape is unique to `enable` —
+ * `confirm` returns an empty body and `regenerate` returns [BackupCodesResponse].
+ */
 @Serializable
 data class TwoFactorSetupResponse(
-    @SerialName("otpauth_url") val otpauthUrl: String,
-    @SerialName("backup_codes") val backupCodes: List<String>,
+    val otpauthUrl: String,
+    val backupCodes: List<String>,
 )

--- a/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/api/AuthApiLoginTest.kt
+++ b/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/api/AuthApiLoginTest.kt
@@ -139,4 +139,66 @@ class AuthApiLoginTest {
 
         assertThat(error).isInstanceOf(ContentConvertException::class.java)
     }
+
+    // --- 2FA setup wire shapes (upstream TwoFactorController.js) --------------------------------
+
+    @Test
+    fun `enableTwoFactor parses the camelCase otpauthUrl and backupCodes`() = runTest {
+        // enable2FA: `res.status(200).json({ otpauthUrl, backupCodes: plainCodes })` — camelCase.
+        val engine = MockEngine {
+            respond(
+                content = """{"otpauthUrl":"otpauth://totp/LibreChat:a@b.com?secret=S&issuer=LibreChat","backupCodes":["aaaa1111","bbbb2222"]}""",
+                status = HttpStatusCode.OK,
+                headers = jsonHeaders(),
+            )
+        }
+
+        val response = api(engine).enableTwoFactor()
+
+        assertThat(response.otpauthUrl).contains("secret=S")
+        assertThat(response.backupCodes).containsExactly("aaaa1111", "bbbb2222").inOrder()
+    }
+
+    @Test
+    fun `confirmTwoFactor tolerates the empty 200 body`() = runTest {
+        // confirm2FA: `res.status(200).json()` — an empty body. Must NOT be decoded into an object.
+        val engine = MockEngine {
+            respond(content = "", status = HttpStatusCode.OK, headers = jsonHeaders())
+        }
+
+        api(engine).confirmTwoFactor("123456") // returns Unit; the assertion is that it does not throw
+    }
+
+    @Test
+    fun `regenerateBackupCodes parses backupCodes and ignores backupCodesHash`() = runTest {
+        // regenerateBackupCodes: `res.status(200).json({ backupCodes, backupCodesHash })` — no
+        // otpauthUrl. The hashed objects are unmodeled and dropped via ignoreUnknownKeys.
+        val engine = MockEngine {
+            respond(
+                content = """{"backupCodes":["cccc3333","dddd4444"],"backupCodesHash":[{"codeHash":"x","used":false}]}""",
+                status = HttpStatusCode.OK,
+                headers = jsonHeaders(),
+            )
+        }
+
+        val response = api(engine).regenerateBackupCodes()
+
+        assertThat(response.backupCodes).containsExactly("cccc3333", "dddd4444").inOrder()
+    }
+
+    @Test
+    fun `register parses the message-only body`() = runTest {
+        // registrationController: `res.status(status).send({ message })` — no user object.
+        val engine = MockEngine {
+            respond(
+                content = """{"message":"User registered successfully"}""",
+                status = HttpStatusCode.OK,
+                headers = jsonHeaders(),
+            )
+        }
+
+        val response = api(engine).register("A", "a@b.com", "auser", "pw", "pw")
+
+        assertThat(response.message).isEqualTo("User registered successfully")
+    }
 }

--- a/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/api/AuthApi.kt
+++ b/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/api/AuthApi.kt
@@ -8,6 +8,7 @@ import com.garfiec.librechat.core.model.request.ResetPasswordRequest
 import com.garfiec.librechat.core.model.request.TwoFactorDisableRequest
 import com.garfiec.librechat.core.model.request.TwoFactorVerifyRequest
 import com.garfiec.librechat.core.model.request.TwoFactorVerifyTempRequest
+import com.garfiec.librechat.core.model.response.BackupCodesResponse
 import com.garfiec.librechat.core.model.response.LoginResponse
 import com.garfiec.librechat.core.model.response.RefreshResponse
 import com.garfiec.librechat.core.model.response.RegisterResponse
@@ -118,11 +119,13 @@ class AuthApi constructor(
             }
         }.body()
 
-    suspend fun confirmTwoFactor(code: String): TwoFactorSetupResponse =
+    // confirm2FA returns an empty 200 body (`res.status(200).json()`); there is nothing to decode.
+    suspend fun confirmTwoFactor(code: String) {
         client.post {
             url { path("api/auth/2fa/confirm") }
             setBody(TwoFactorConfirmRequest(token = code))
-        }.body()
+        }
+    }
 
     /**
      * POST /api/auth/2fa/verify-temp with { tempToken, token: totpCode } or { tempToken, backupCode }.
@@ -147,7 +150,7 @@ class AuthApi constructor(
         return LoginResult(body, refreshToken)
     }
 
-    suspend fun regenerateBackupCodes(token: String? = null, backupCode: String? = null): TwoFactorSetupResponse =
+    suspend fun regenerateBackupCodes(token: String? = null, backupCode: String? = null): BackupCodesResponse =
         client.post {
             url { path("api/auth/2fa/backup/regenerate") }
             if (token != null || backupCode != null) {

--- a/core/ui/src/commonMain/kotlin/com/garfiec/librechat/core/ui/components/OtpCodeInput.kt
+++ b/core/ui/src/commonMain/kotlin/com/garfiec/librechat/core/ui/components/OtpCodeInput.kt
@@ -1,0 +1,90 @@
+package com.garfiec.librechat.core.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+
+/**
+ * Six-box numeric OTP entry: one [BasicTextField] behind a row of digit boxes.
+ *
+ * A single field (rather than six) is what makes the whole code pasteable in one action and keeps
+ * focus handling trivial; the boxes are only a decoration.
+ *
+ * [onValueChange] is filtered to digits and capped at [length], so callers can auto-submit on
+ * `value.length == length` without re-validating. Callers that auto-submit must guard against a
+ * second submit, since composition can deliver the terminal value more than once.
+ */
+@Composable
+fun OtpCodeInput(
+    value: String,
+    onValueChange: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    length: Int = OTP_LENGTH,
+) {
+    BasicTextField(
+        value = value,
+        onValueChange = { new ->
+            if (new.length <= length && new.all { it.isDigit() }) onValueChange(new)
+        },
+        enabled = enabled,
+        keyboardOptions = KeyboardOptions(
+            keyboardType = KeyboardType.Number,
+            imeAction = ImeAction.Done,
+        ),
+        modifier = modifier.fillMaxWidth(),
+        decorationBox = {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally),
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                repeat(length) { index ->
+                    val char = value.getOrNull(index)?.toString() ?: ""
+                    val isFocused = index == value.length
+                    Box(
+                        contentAlignment = Alignment.Center,
+                        modifier = Modifier
+                            .weight(1f)
+                            .aspectRatio(1f)
+                            .border(
+                                width = if (isFocused) 2.dp else 1.dp,
+                                color = if (isFocused) {
+                                    MaterialTheme.colorScheme.primary
+                                } else {
+                                    MaterialTheme.colorScheme.outline
+                                },
+                                shape = DIGIT_BOX_SHAPE,
+                            )
+                            .background(MaterialTheme.colorScheme.surface, DIGIT_BOX_SHAPE),
+                    ) {
+                        Text(
+                            text = char,
+                            style = MaterialTheme.typography.titleLarge,
+                            textAlign = TextAlign.Center,
+                        )
+                    }
+                }
+            }
+        },
+    )
+}
+
+const val OTP_LENGTH = 6
+
+private val DIGIT_BOX_SHAPE = RoundedCornerShape(8.dp)

--- a/core/ui/src/commonMain/kotlin/com/garfiec/librechat/core/ui/components/OtpVerificationDialog.kt
+++ b/core/ui/src/commonMain/kotlin/com/garfiec/librechat/core/ui/components/OtpVerificationDialog.kt
@@ -1,19 +1,10 @@
 package com.garfiec.librechat.core.ui.components
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.border
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.AlertDialog
@@ -27,13 +18,10 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.text.input.ImeAction
-import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 
 /**
@@ -121,15 +109,13 @@ fun OtpVerificationDialog(
                         ),
                     )
                 } else {
-                    OtpInput(
+                    OtpCodeInput(
                         value = otpValue,
                         onValueChange = { newValue ->
-                            if (newValue.length <= 6 && newValue.all { it.isDigit() }) {
-                                otpValue = newValue
-                                if (newValue.length == 6 && !submitted) {
-                                    submitted = true
-                                    onVerify(newValue, null)
-                                }
+                            otpValue = newValue
+                            if (newValue.length == OTP_LENGTH && !submitted) {
+                                submitted = true
+                                onVerify(newValue, null)
                             }
                         },
                         enabled = !isLoading,
@@ -171,60 +157,3 @@ fun OtpVerificationDialog(
         },
     )
 }
-
-@Composable
-private fun OtpInput(
-    value: String,
-    onValueChange: (String) -> Unit,
-    enabled: Boolean,
-    modifier: Modifier = Modifier,
-) {
-    BasicTextField(
-        value = value,
-        onValueChange = onValueChange,
-        enabled = enabled,
-        keyboardOptions = KeyboardOptions(
-            keyboardType = KeyboardType.Number,
-            imeAction = ImeAction.Done,
-        ),
-        modifier = modifier.fillMaxWidth(),
-        decorationBox = {
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally),
-                modifier = Modifier.fillMaxWidth(),
-            ) {
-                repeat(6) { index ->
-                    val char = value.getOrNull(index)?.toString() ?: ""
-                    val isFocused = index == value.length
-                    Box(
-                        contentAlignment = Alignment.Center,
-                        modifier = Modifier
-                            .weight(1f)
-                            .aspectRatio(1f)
-                            .border(
-                                width = if (isFocused) 2.dp else 1.dp,
-                                color = if (isFocused) {
-                                    MaterialTheme.colorScheme.primary
-                                } else {
-                                    MaterialTheme.colorScheme.outline
-                                },
-                                shape = DIGIT_BOX_SHAPE,
-                            )
-                            .background(
-                                MaterialTheme.colorScheme.surface,
-                                DIGIT_BOX_SHAPE,
-                            ),
-                    ) {
-                        Text(
-                            text = char,
-                            style = MaterialTheme.typography.titleLarge,
-                            textAlign = TextAlign.Center,
-                        )
-                    }
-                }
-            }
-        },
-    )
-}
-
-private val DIGIT_BOX_SHAPE = RoundedCornerShape(8.dp)

--- a/feature/settings/build.gradle.kts
+++ b/feature/settings/build.gradle.kts
@@ -14,6 +14,7 @@ kotlin {
             implementation(libs.coil3.compose)
             implementation(libs.coil3.network.ktor)
             implementation(libs.kermit)
+            implementation(libs.qrose)
         }
         androidMain.dependencies {
             implementation(libs.koin.android)

--- a/feature/settings/src/androidMain/kotlin/com/garfiec/librechat/feature/settings/util/PlatformUri.android.kt
+++ b/feature/settings/src/androidMain/kotlin/com/garfiec/librechat/feature/settings/util/PlatformUri.android.kt
@@ -1,0 +1,22 @@
+package com.garfiec.librechat.feature.settings.util
+
+import android.content.ActivityNotFoundException
+import android.content.Context
+import android.content.Intent
+import androidx.core.net.toUri
+import org.koin.mp.KoinPlatformTools
+
+actual fun openUri(uri: String): Boolean {
+    val context = KoinPlatformTools.defaultContext().get().get<Context>()
+    // Android 11+ package visibility hides other apps from resolveActivity(), but startActivity()
+    // is still resolved by the system, so catching ActivityNotFoundException -- not pre-checking --
+    // is the way to detect "no authenticator installed" without a <queries> manifest entry.
+    return try {
+        context.startActivity(
+            Intent(Intent.ACTION_VIEW, uri.toUri()).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
+        )
+        true
+    } catch (_: ActivityNotFoundException) {
+        false
+    }
+}

--- a/feature/settings/src/commonMain/composeResources/values-ar/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-ar/strings.xml
@@ -206,7 +206,6 @@
     <!-- 2FA setup dialog -->
     <string name="dialog_title_enable_2fa">تفعيل المصادقة الثنائية</string>
     <string name="dialog_title_disable_2fa">تعطيل المصادقة الثنائية</string>
-    <string name="twofa_scan_instructions">انسخ الرابط أدناه والصقه في تطبيق المصادقة الخاص بك (مثل Google Authenticator أو Authy)، ثم أدخل رمز التحقق.</string>
     <string name="twofa_disable_instructions">أدخل رمز المصادقة لتعطيل المصادقة الثنائية.</string>
     <string name="hint_verification_code">رمز التحقق</string>
 

--- a/feature/settings/src/commonMain/composeResources/values-de/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-de/strings.xml
@@ -206,7 +206,6 @@
     <!-- 2FA setup dialog -->
     <string name="dialog_title_enable_2fa">Zwei-Faktor-Authentifizierung aktivieren</string>
     <string name="dialog_title_disable_2fa">Zwei-Faktor-Authentifizierung deaktivieren</string>
-    <string name="twofa_scan_instructions">Kopiere die untenstehende URI und füge sie in deine Authenticator-App ein (z. B. Google Authenticator, Authy), und gib dann den Bestätigungscode ein.</string>
     <string name="twofa_disable_instructions">Gib deinen Authenticator-Code ein, um 2FA zu deaktivieren.</string>
     <string name="hint_verification_code">Bestätigungscode</string>
 

--- a/feature/settings/src/commonMain/composeResources/values-es/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-es/strings.xml
@@ -206,7 +206,6 @@
     <!-- 2FA setup dialog -->
     <string name="dialog_title_enable_2fa">Activar la autenticación de dos factores</string>
     <string name="dialog_title_disable_2fa">Desactivar la autenticación de dos factores</string>
-    <string name="twofa_scan_instructions">Copia el URI de abajo y pégalo en tu app de autenticación (p. ej. Google Authenticator, Authy), luego introduce el código de verificación.</string>
     <string name="twofa_disable_instructions">Introduce el código de tu autenticador para desactivar la 2FA.</string>
     <string name="hint_verification_code">Código de verificación</string>
 

--- a/feature/settings/src/commonMain/composeResources/values-fr/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-fr/strings.xml
@@ -206,7 +206,6 @@
     <!-- 2FA setup dialog -->
     <string name="dialog_title_enable_2fa">Activer l'authentification à deux facteurs</string>
     <string name="dialog_title_disable_2fa">Désactiver l'authentification à deux facteurs</string>
-    <string name="twofa_scan_instructions">Copiez l'URI ci-dessous et collez-le dans votre application d'authentification (par ex. Google Authenticator, Authy), puis saisissez le code de vérification.</string>
     <string name="twofa_disable_instructions">Saisissez le code de votre application d'authentification pour désactiver la 2FA.</string>
     <string name="hint_verification_code">Code de vérification</string>
 

--- a/feature/settings/src/commonMain/composeResources/values-ja/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-ja/strings.xml
@@ -206,7 +206,6 @@
     <!-- 2FA setup dialog -->
     <string name="dialog_title_enable_2fa">二要素認証を有効にする</string>
     <string name="dialog_title_disable_2fa">二要素認証を無効にする</string>
-    <string name="twofa_scan_instructions">以下のURIをコピーして認証アプリ（例: Google Authenticator、Authy）に貼り付け、確認コードを入力してください。</string>
     <string name="twofa_disable_instructions">2FAを無効にするには認証アプリのコードを入力してください。</string>
     <string name="hint_verification_code">確認コード</string>
 

--- a/feature/settings/src/commonMain/composeResources/values-ko/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-ko/strings.xml
@@ -206,7 +206,6 @@
     <!-- 2FA setup dialog -->
     <string name="dialog_title_enable_2fa">2단계 인증 사용</string>
     <string name="dialog_title_disable_2fa">2단계 인증 사용 안 함</string>
-    <string name="twofa_scan_instructions">아래 URI를 복사하여 인증 앱(예: Google Authenticator, Authy)에 붙여넣은 후 인증 코드를 입력하세요.</string>
     <string name="twofa_disable_instructions">2FA를 사용 중지하려면 인증 앱 코드를 입력하세요.</string>
     <string name="hint_verification_code">인증 코드</string>
 

--- a/feature/settings/src/commonMain/composeResources/values-pt/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-pt/strings.xml
@@ -206,7 +206,6 @@
     <!-- 2FA setup dialog -->
     <string name="dialog_title_enable_2fa">Ativar autenticação de dois fatores</string>
     <string name="dialog_title_disable_2fa">Desativar autenticação de dois fatores</string>
-    <string name="twofa_scan_instructions">Copie a URI abaixo e cole-a no seu app autenticador (por exemplo, Google Authenticator, Authy) e depois digite o código de verificação.</string>
     <string name="twofa_disable_instructions">Digite o código do seu autenticador para desativar o 2FA.</string>
     <string name="hint_verification_code">Código de verificação</string>
 

--- a/feature/settings/src/commonMain/composeResources/values-ru/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-ru/strings.xml
@@ -206,7 +206,6 @@
     <!-- 2FA setup dialog -->
     <string name="dialog_title_enable_2fa">Включить двухфакторную аутентификацию</string>
     <string name="dialog_title_disable_2fa">Отключить двухфакторную аутентификацию</string>
-    <string name="twofa_scan_instructions">Скопируйте URI ниже и вставьте его в приложение-аутентификатор (например, Google Authenticator, Authy), затем введите код подтверждения.</string>
     <string name="twofa_disable_instructions">Введите код из аутентификатора, чтобы отключить 2FA.</string>
     <string name="hint_verification_code">Код подтверждения</string>
 

--- a/feature/settings/src/commonMain/composeResources/values-zh/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-zh/strings.xml
@@ -206,7 +206,6 @@
     <!-- 2FA setup dialog -->
     <string name="dialog_title_enable_2fa">启用两步验证</string>
     <string name="dialog_title_disable_2fa">禁用两步验证</string>
-    <string name="twofa_scan_instructions">复制下方的 URI 并粘贴到你的身份验证器应用中（例如 Google Authenticator、Authy），然后输入验证码。</string>
     <string name="twofa_disable_instructions">输入身份验证器验证码以禁用两步验证。</string>
     <string name="hint_verification_code">验证码</string>
 

--- a/feature/settings/src/commonMain/composeResources/values/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values/strings.xml
@@ -230,7 +230,14 @@
     <!-- 2FA setup dialog -->
     <string name="dialog_title_enable_2fa">Enable Two-Factor Authentication</string>
     <string name="dialog_title_disable_2fa">Disable Two-Factor Authentication</string>
-    <string name="twofa_scan_instructions">Copy the URI below and paste it into your authenticator app (e.g. Google Authenticator, Authy), then enter the verification code.</string>
+    <string name="twofa_enroll_instructions">Add this account to your authenticator app, then enter the 6-digit code it shows.</string>
+    <string name="action_open_authenticator">Open in authenticator app</string>
+    <string name="twofa_no_authenticator">No authenticator app found. Add the setup key below manually, or scan the QR code from another device.</string>
+    <string name="twofa_setup_key">Setup key</string>
+    <string name="cd_copy_setup_key">Copy setup key</string>
+    <string name="action_show_qr">Show QR code</string>
+    <string name="action_hide_qr">Hide QR code</string>
+    <string name="cd_twofa_qr">QR code for enrolling on another device</string>
     <string name="twofa_disable_instructions">Enter your authenticator code to disable 2FA.</string>
     <string name="hint_verification_code">Verification code</string>
 

--- a/feature/settings/src/commonMain/composeResources/values/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values/strings.xml
@@ -5,6 +5,7 @@
     <string name="action_cancel">Cancel</string>
     <string name="action_clear">Clear</string>
     <string name="action_confirm">Confirm</string>
+    <string name="action_copy">Copy</string>
     <string name="action_creating">Creating…</string>
     <string name="action_create">Create</string>
     <string name="action_delete">Delete</string>

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/sections/SecuritySection.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/sections/SecuritySection.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import com.garfiec.librechat.feature.settings.resources.*
 import com.garfiec.librechat.feature.settings.resources.Res
+import com.garfiec.librechat.feature.settings.util.copyToClipboard
 import org.jetbrains.compose.resources.stringResource
 
 @Composable
@@ -144,6 +145,11 @@ internal fun BackupCodesDialog(
     backupCodes: List<String>,
     onDismiss: () -> Unit,
 ) {
+    // These are single-use recovery codes shown exactly once. Without a copy action the only way
+    // to keep them is a screenshot or transcribing ten hex strings by hand, so offer the same
+    // copy-then-confirm affordance ApiKeyCreateDialog uses for its equally one-shot secret.
+    var copied by remember { mutableStateOf(false) }
+
     AlertDialog(
         onDismissRequest = onDismiss,
         title = { Text(stringResource(Res.string.dialog_title_backup_codes)) },
@@ -161,24 +167,43 @@ internal fun BackupCodesDialog(
                     color = MaterialTheme.colorScheme.surfaceVariant,
                     shape = MaterialTheme.shapes.small,
                 ) {
-                    Column(
-                        modifier = Modifier.padding(12.dp),
-                        verticalArrangement = Arrangement.spacedBy(4.dp),
-                    ) {
-                        backupCodes.forEach { code ->
-                            Text(
-                                text = code,
-                                style = MaterialTheme.typography.bodyMedium,
-                                fontFamily = FontFamily.Monospace,
-                            )
+                    SelectionContainer {
+                        Column(
+                            modifier = Modifier.padding(12.dp),
+                            verticalArrangement = Arrangement.spacedBy(4.dp),
+                        ) {
+                            backupCodes.forEach { code ->
+                                Text(
+                                    text = code,
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    fontFamily = FontFamily.Monospace,
+                                )
+                            }
                         }
                     }
+                }
+                if (copied) {
+                    Text(
+                        text = stringResource(Res.string.copied_to_clipboard),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.primary,
+                    )
                 }
             }
         },
         confirmButton = {
             TextButton(onClick = onDismiss) {
                 Text(stringResource(Res.string.action_done))
+            }
+        },
+        dismissButton = {
+            TextButton(
+                onClick = {
+                    copyToClipboard(backupCodes.joinToString("\n"), "Backup Codes")
+                    copied = true
+                },
+            ) {
+                Text(stringResource(Res.string.action_copy))
             }
         },
     )

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/sections/SecuritySection.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/sections/SecuritySection.kt
@@ -1,33 +1,55 @@
 package com.garfiec.librechat.feature.settings.screen.sections
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
+import com.garfiec.librechat.core.ui.components.OTP_LENGTH
+import com.garfiec.librechat.core.ui.components.OtpCodeInput
 import com.garfiec.librechat.feature.settings.resources.*
 import com.garfiec.librechat.feature.settings.resources.Res
 import com.garfiec.librechat.feature.settings.util.copyToClipboard
+import com.garfiec.librechat.feature.settings.util.openUri
+import io.github.alexzhirkevich.qrose.rememberQrCodePainter
 import org.jetbrains.compose.resources.stringResource
+
+/**
+ * The `secret` query parameter of an `otpauth://` URI -- what an authenticator's "enter a setup
+ * key" screen asks for. The full URI is not accepted there, so manual enrollment needs this alone.
+ */
+private fun otpauthSecret(uri: String): String? =
+    uri.substringAfter("secret=", "").substringBefore("&").takeIf { it.isNotEmpty() }
 
 @Composable
 internal fun TwoFactorSetupDialog(
@@ -37,6 +59,14 @@ internal fun TwoFactorSetupDialog(
     onDismiss: () -> Unit,
 ) {
     var code by remember { mutableStateOf("") }
+    var submitted by remember { mutableStateOf(false) }
+    var noAuthenticator by remember { mutableStateOf(false) }
+    var copied by remember { mutableStateOf(false) }
+    var showQr by remember { mutableStateOf(false) }
+    val secret = otpauthUrl?.let(::otpauthSecret)
+
+    // A rejected code leaves six digits in the boxes; re-arm so editing (or Verify) can submit again.
+    LaunchedEffect(isLoading) { if (!isLoading) submitted = false }
 
     AlertDialog(
         onDismissRequest = onDismiss,
@@ -49,39 +79,89 @@ internal fun TwoFactorSetupDialog(
                 verticalArrangement = Arrangement.spacedBy(12.dp),
             ) {
                 Text(
-                    text = stringResource(Res.string.twofa_scan_instructions),
+                    text = stringResource(Res.string.twofa_enroll_instructions),
                     style = MaterialTheme.typography.bodyMedium,
                 )
                 if (otpauthUrl != null) {
-                    Surface(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(vertical = 4.dp),
-                        color = MaterialTheme.colorScheme.surfaceVariant,
-                        shape = MaterialTheme.shapes.small,
+                    // The phone IS the second device, so it cannot scan its own screen -- handing
+                    // the otpauth:// URI to the authenticator is the enrollment path that works
+                    // here. QR and the setup key are the fallbacks, not the default.
+                    FilledTonalButton(
+                        onClick = { noAuthenticator = !openUri(otpauthUrl) },
+                        modifier = Modifier.fillMaxWidth(),
                     ) {
-                        SelectionContainer {
-                            Text(
-                                text = otpauthUrl,
-                                style = MaterialTheme.typography.bodySmall,
-                                modifier = Modifier.padding(12.dp),
+                        Text(stringResource(Res.string.action_open_authenticator))
+                    }
+                    if (noAuthenticator) {
+                        Text(
+                            text = stringResource(Res.string.twofa_no_authenticator),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.error,
+                        )
+                    }
+                    if (secret != null) {
+                        SetupKeyRow(
+                            secret = secret,
+                            onCopy = {
+                                copyToClipboard(secret, "2FA setup key")
+                                copied = true
+                            },
+                        )
+                    }
+                    TextButton(onClick = { showQr = !showQr }) {
+                        Text(
+                            stringResource(
+                                if (showQr) Res.string.action_hide_qr else Res.string.action_show_qr,
+                            ),
+                            style = MaterialTheme.typography.bodySmall,
+                        )
+                    }
+                    if (showQr) {
+                        // Black-on-transparent by default, which is unscannable on a dark surface.
+                        Surface(
+                            modifier = Modifier.fillMaxWidth(),
+                            color = Color.White,
+                            shape = MaterialTheme.shapes.small,
+                        ) {
+                            Image(
+                                painter = rememberQrCodePainter(otpauthUrl),
+                                contentDescription = stringResource(Res.string.cd_twofa_qr),
+                                modifier = Modifier
+                                    .padding(16.dp)
+                                    .size(QR_SIZE),
                             )
                         }
                     }
+                    if (copied) {
+                        Text(
+                            text = stringResource(Res.string.copied_to_clipboard),
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.primary,
+                        )
+                    }
                 }
-                OutlinedTextField(
+                OtpCodeInput(
                     value = code,
-                    onValueChange = { code = it.filter { ch -> ch.isDigit() }.take(6) },
-                    label = { Text(stringResource(Res.string.hint_verification_code)) },
-                    singleLine = true,
-                    modifier = Modifier.fillMaxWidth(),
+                    onValueChange = {
+                        code = it
+                        if (it.length == OTP_LENGTH && !submitted) {
+                            submitted = true
+                            onConfirm(it)
+                        }
+                    },
+                    enabled = !isLoading,
                 )
             }
         },
         confirmButton = {
+            // Auto-submit covers the happy path; the button is what lets a user retry the same
+            // code after a failure without having to delete a digit first.
             TextButton(
-                onClick = { onConfirm(code) },
-                enabled = code.length == 6 && !isLoading,
+                onClick = {
+                    submitted = true
+                    onConfirm(code)
+                },
+                enabled = code.length == OTP_LENGTH && !isLoading,
             ) {
                 Text(stringResource(if (isLoading) Res.string.action_verifying else Res.string.action_verify))
             }
@@ -93,6 +173,43 @@ internal fun TwoFactorSetupDialog(
         },
     )
 }
+
+@Composable
+private fun SetupKeyRow(secret: String, onCopy: () -> Unit) {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        color = MaterialTheme.colorScheme.surfaceVariant,
+        shape = MaterialTheme.shapes.small,
+    ) {
+        Row(
+            modifier = Modifier.padding(start = 12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = stringResource(Res.string.twofa_setup_key),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                SelectionContainer {
+                    Text(
+                        text = secret,
+                        style = MaterialTheme.typography.bodyMedium,
+                        fontFamily = FontFamily.Monospace,
+                    )
+                }
+            }
+            IconButton(onClick = onCopy) {
+                Icon(
+                    imageVector = Icons.Default.ContentCopy,
+                    contentDescription = stringResource(Res.string.cd_copy_setup_key),
+                )
+            }
+        }
+    }
+}
+
+private val QR_SIZE = 200.dp
 
 @Composable
 internal fun TwoFactorCodeDialog(

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/util/PlatformUri.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/util/PlatformUri.kt
@@ -1,0 +1,11 @@
+package com.garfiec.librechat.feature.settings.util
+
+/**
+ * Hands [uri] to whatever app registered its scheme, returning false when nothing can handle it.
+ *
+ * Used for `otpauth://` enrollment links: every major authenticator (Google Authenticator, Authy,
+ * 1Password, Bitwarden, Microsoft Authenticator, Aegis) registers the scheme, so one tap adds the
+ * account with issuer and label pre-filled. The false return is the contract that matters -- the
+ * caller must fall back to manual entry rather than leaving the user on a dead button.
+ */
+expect fun openUri(uri: String): Boolean

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/delegate/TwoFactorSecurityDelegate.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/delegate/TwoFactorSecurityDelegate.kt
@@ -65,6 +65,8 @@ class TwoFactorSecurityDelegate(
             stateHandle.update { copy(isTwoFactorLoading = true) }
             when (val result = authRepository.confirmTwoFactor(code)) {
                 is Result.Success -> {
+                    // confirm returns an empty body — the backup codes to display were already
+                    // returned by enable and are held in state; keep them rather than re-reading.
                     stateHandle.update {
                         copy(
                             isTwoFactorLoading = false,
@@ -72,7 +74,6 @@ class TwoFactorSecurityDelegate(
                             showTwoFactorSetupDialog = false,
                             twoFactorOtpauthUrl = null,
                             showBackupCodesDialog = true,
-                            backupCodes = result.data.backupCodes,
                         )
                     }
                 }

--- a/feature/settings/src/iosMain/kotlin/com/garfiec/librechat/feature/settings/util/PlatformUri.ios.kt
+++ b/feature/settings/src/iosMain/kotlin/com/garfiec/librechat/feature/settings/util/PlatformUri.ios.kt
@@ -1,0 +1,12 @@
+package com.garfiec.librechat.feature.settings.util
+
+import platform.Foundation.NSURL
+import platform.UIKit.UIApplication
+
+actual fun openUri(uri: String): Boolean {
+    val url = NSURL.URLWithString(uri) ?: return false
+    val app = UIApplication.sharedApplication
+    if (!app.canOpenURL(url)) return false
+    app.openURL(url)
+    return true
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -55,6 +55,9 @@ zoomimage = "1.4.0"
 # Color theming (seed -> Material 3 ColorScheme, KMP)
 material-kolor = "4.1.1"
 
+# QR rendering (KMP: Android + iOS) -- 2FA enrollment on a second device
+qrose = "1.1.2"
+
 # Logging
 kermit = "2.1.0"
 
@@ -178,6 +181,9 @@ zoomimage-compose-coil3-core = { group = "io.github.panpf.zoomimage", name = "zo
 
 # Color theming
 material-kolor = { group = "com.materialkolor", name = "material-kolor", version.ref = "material-kolor" }
+
+# QR rendering
+qrose = { group = "io.github.alexzhirkevich", name = "qrose", version.ref = "qrose" }
 
 # Logging
 kermit = { group = "co.touchlab", name = "kermit", version.ref = "kermit" }

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -70,5 +70,11 @@
 			</array>
 		</dict>
 	</array>
+	<!-- canOpenURL() answers false for any scheme not listed here, so 2FA enrollment could not
+	     detect an installed authenticator without this entry. -->
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>otpauth</string>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary

Follow-up to #278 ("make 2FA login work end to end"). Both come out of the same issue-#277 RCA, which found that three auth DTOs had been authored from assumption instead of from upstream `types.ts`: #278 fixed the *login* half (`twoFAPending`), and this PR clears the *setup* half it left on the backlog — including the `Settings → enable 2FA` scenario #278's device run had to skip as "known-broken".

The auth response DTOs for 2FA setup and registration were authored from assumption rather than from the upstream controllers, and no test deserialized a real backend payload. The result: the **entire 2FA-enablement surface in Settings fails to decode**, plus a latent registration parse failure. Discovered during the issue-#277 RCA and verified here against `upstream/api/server/controllers/`.

## The bugs

`TwoFactorSetupResponse` (`otpauth_url` / `backup_codes`, both **required**, snake_case) was the return type of all three 2FA setup calls — and is wrong for each:

| Endpoint | Backend returns (upstream) | Old model expected | Result |
|---|---|---|---|
| `enable2FA` | `{ otpauthUrl, backupCodes }` (camelCase) | `otpauth_url` + `backup_codes` | both missing → `MissingFieldException` → **enabling 2FA fails** |
| `confirm2FA` | `res.status(200).json()` — **empty body** | two required fields | decode fails → **confirming 2FA fails** |
| `regenerateBackupCodes` | `{ backupCodes, backupCodesHash }` — no `otpauthUrl` | requires `otpauthUrl` | missing → decode fails → **view/regenerate backup codes fails** |

The delegate compounded confirm: `confirmEnableTwoFactor` read backup codes from the (empty) confirm response, when they actually come from `enable` and are already held in state.

Sibling bug found in the same RCA: `registrationController` returns `{ message }`, but `RegisterResponse` required a `user` object → parse threw even on a **successful** registration (masked because `register()` discards the body into `Result<Unit>`).

## Fixes

- **`TwoFactorSetupResponse`** — camelCase `otpauthUrl` / `backupCodes` (matches the wire; `enable` only).
- **`confirmTwoFactor`** — returns `Unit` (empty body); delegate keeps the codes already returned by `enable` instead of re-reading a non-existent body.
- **New `BackupCodesResponse`** — for `regenerate`; `backupCodesHash` dropped via `ignoreUnknownKeys`.
- **`RegisterResponse`** — models `{ message }` (nullable), no `user`.

## Tests

Wire-shape tests in `AuthApiLoginTest`, driven through a **real Ktor `MockEngine`** with the exact payloads from `TwoFactorController.js` / `AuthController.js` — camelCase enable, empty confirm body, regenerate's `{ backupCodes, backupCodesHash }`, and register's `{ message }` — so a wrong shape assumption can no longer pass vacuously.

Verified locally: `:core:network`, `:feature:settings`, `:feature:auth`, `:core:data` unit tests, `:app:assembleDebug`, `detekt detektMetadataCommonMain`, `:app:lint` — all green.

## Live verification (device + real v0.8.7 server)

Validated on a Pixel 9 Pro Fold against the LibreChat v0.8.7 Docker stack, mirroring the PR #278 methodology (control build reproduces the failure, fixed build passes). This is the `Settings → enable 2FA` flow that the #278 run had to skip as "known-broken".

| Flow | control (`develop`) | fix (this branch) |
|---|---|---|
| Settings → Enable 2FA | FAIL — no setup dialog (enable body fails to decode) | PASS — setup dialog with the `otpauth://` URI |
| Enter TOTP → Confirm | unreachable | PASS — Backup Codes dialog (10 codes); status → Enabled |
| Regenerate backup codes | unreachable | PASS — 10 new codes displayed, disjoint from the first set, server-side `codeHash` set rotated |

Server-side after the fixed run: `db.users` shows `twoFactorEnabled: true` for the test user and `login` returns `twoFAPending` — 2FA genuinely enabled. All four wire shapes (`enable` camelCase, `confirm` empty body, `regenerate` `{backupCodes,backupCodesHash}`, `register` `{message}`) confirmed by `curl` against the live container.

## Follow-on: the 2FA surface people actually touch

Live-testing the fix surfaced two usability defects in the same dialogs, folded in here rather than
left for later — both are about not losing access to your own account.

**Backup codes were unrecoverable.** Ten single-use recovery codes, shown exactly once, rendered as
bare `Text`: no copy action, and not even inside a `SelectionContainer` (that wrapped only the
otpauth URI). A screenshot or hand-transcription was the only way to keep them. Now there is a
`Copy` action (newline-joined, with the copied confirmation) and the codes are selectable — the same
affordance `ApiKeyCreateDialog` already uses for its equally one-shot secret.

**Enrollment was the web flow on a phone.** The dialog printed the raw `otpauth://` URI and said to
"copy the URI and paste it into your authenticator app" — but the device cannot scan its own screen,
and an authenticator's manual-entry screen takes the setup *key*, not the URI. The only way through
was transcribing a base32 secret. It now leads with **Open in authenticator app** (`otpauth://` is
the de-facto Key URI Format scheme that major authenticators register), falling back to the setup key on its own
(selectable + copy) and a collapsed QR for enrolling a second device. `openUri()` returns false when
nothing handles the scheme, which is what makes the fallback message honest instead of a dead button.
`otpauth` is added to `LSApplicationQueriesSchemes` — without it iOS `canOpenURL` answers false for
every authenticator and the primary action would look unavailable.

The code field is now the shared six-box `OtpCodeInput`, extracted from `OtpVerificationDialog` so
the setup dialog and the three settings OTP prompts (delete account, re-enroll, regenerate codes)
share one component — numeric, auto-submitting on the sixth digit, with Verify kept as the retry path
after a rejected code. The disable-2FA dialog and the login 2FA screen still carry their own inputs;
converting those is deliberately out of scope here.

Verified on the same device + server:

| | Evidence |
|---|---|
| Copy backup codes | tapped Copy, pasted into the composer, read back all 10 codes matching the dialog |
| Deep link | `otpauth://` → chooser → Google Authenticator "Add token — LibreChat: b-plain@e2e.test" (issuer + account pre-filled) |
| Full human loop | code read back out of Google Authenticator, typed into the app → 2FA enabled, `twoFactorEnabled: true`, 10 backup codes |
| QR | renders on a white surface (black-on-transparent is unscannable in dark theme) |

New dependency: `qrose 1.1.2` (KMP, ships iosArm64/iosSimulatorArm64/iosX64, built on Kotlin 2.3.0).

## Screenshots

<img width="451" height="1015" alt="image" src="https://github.com/user-attachments/assets/c1f68367-0dd9-41a2-b040-9e9def221f58" />
