### PR TITLE
feat(skill): add deterministic i18n coverage audit

### DIFF
--- a/.claude/skills/audit-i18n/SKILL.md
+++ b/.claude/skills/audit-i18n/SKILL.md
@@ -1,0 +1,506 @@
+---
+name: audit-i18n
+description: >
+  Audit localization / i18n coverage across the compose-resources surface (9 modules
+  x 9 locales). Finds strings that exist in English but not in some or all languages,
+  keys left as untranslated English stubs inside a translated file, stale keys the base
+  dropped, and English literals that never reached a strings.xml at all. Use when
+  asking "which features shipped English-only?", after landing a feature that added
+  user-facing strings, before a release that claims multi-language support, or when a
+  translator asks what still needs doing. Audit-only — produces a report, never writes
+  translations.
+allowed-tools: Bash, Read, Glob, Grep, Write, Workflow, AskUserQuestion
+argument-hint: "[exact-only] (optional; default runs the full fan-out including heuristic triage)"
+---
+
+# Audit i18n Coverage
+
+Audit the localization surface and report what is missing, in a form the user can act on
+and re-run later.
+
+You are the **lead**. You do Phase 0 yourself with direct Bash, then hand the analysis to the
+`audit-i18n` workflow, then independently re-assert what it claims. You do not attribute keys to
+features, triage candidates, or write the report yourself — the workflow fans that out.
+
+**The deterministic checker is the source of truth.** `scripts/i18n-coverage.py` is the only
+thing that produces findings. The workflow explains findings that already exist; it never
+discovers them.
+
+The skill is **audit-only**. It ends at findings + a recommended fix order. It never writes a
+translation, never edits a `strings.xml`, never adds a Gradle task or CI gate, never commits,
+never opens a PR.
+
+## The two layers, and why they are separate
+
+| Layer | Produces | Property |
+| --- | --- | --- |
+| `scripts/i18n-coverage.py` | *What* the findings are | Exact, byte-deterministic, diffable across months |
+| `audit-i18n` workflow | *Why / when / whether it matters* | Judgment, parallelised, not reproducible |
+
+Keep the seam clean. The instant an agent re-derives findings by grepping, the audit stops being
+comparable to the last one and the determinism you paid for is gone. Every number in the final
+report traces to the JSON; the workflow's contribution is feature names, dates, verdicts and
+priority.
+
+## Hard rule — do not re-derive findings by hand
+
+**Never grep for missing strings, diff `strings.xml` files with shell tools, or count keys
+yourself.** Every number in your report must come out of the script.
+
+The reason is not politeness, it is that a hand-rolled pass is *not comparable to the next one*.
+The script is byte-deterministic — identical input produces identical stdout on every run and
+every machine (no timestamps, no absolute paths, no set-iteration order). That is what makes a
+report diffable against the report from six weeks ago, and what lets the user prove a fix
+actually shrank the debt. An ad-hoc grep produces a number nobody can reproduce, and it
+systematically misses the things the script handles carefully: both directions of parity drift
+(a module with extras that cancel against its missing keys looks fine to a count comparison),
+`values-night` being a theme qualifier and not a locale, and the Android `res/` surface being a
+separate thing that must not be folded into the parity math.
+
+You may read source files to *explain* a finding the script already reported — naming the
+feature a key cluster belongs to, or triaging a heuristic candidate. You may not use reading to
+*discover* findings.
+
+## Phase 0 — Sanity-check the tool
+
+Run this first, always:
+
+```bash
+python3 scripts/i18n-coverage.py --summary; echo "exit=$?"
+```
+
+Confirm three things before trusting anything downstream:
+
+1. The header line reads `allowlist: config/l10n/i18n-allowlist.txt`. If it reads
+   `allowlist: (none)` you are running unsuppressed — see the blind spot below, this failure is
+   silent.
+2. The module table lists **9 modules** and `loc` is **9** on every row. Fewer means discovery
+   broke or a locale was dropped wholesale.
+3. The exit code is **below 16**. `16` and above is a hard failure — the script could not find or
+   parse the surface. It shares no bits with the finding mask (`1|2|4|8`) so that "the check
+   broke" can never be misread as "the code is clean". If you see it, read the failure line, fix
+   the invocation, and re-run. Do not report anything from a hard-failed run.
+
+   An **advisory** (bit `8`) is not a failure and must not be treated as one. It means the tool
+   measured something it wants a human to see — a locale directory missing wholesale, a new
+   `<plurals>`, a module added since `EXPECTED_MODULES` was last updated. Those are findings.
+   Carry them into the report; do not abort on them.
+
+Phase 0 is yours and is not delegated: if the tool is broken, fanning out ten agents over its
+output just multiplies the wrong answer.
+
+## Phase 1 — Run the workflow
+
+Resolve these yourself first, with Bash. **The date matters**: workflow scripts have no clock
+(`Date.now()` throws inside one by design, so runs stay resumable), so the report date must be
+computed here and passed in.
+
+```bash
+REPO="$(git rev-parse --show-toplevel)"
+DATE="$(date -u +%F)"
+SKILL_DIR="$REPO/.claude/skills/audit-i18n"
+
+# Never overwrite an existing dated report. Two audits on the same UTC day collide on one
+# filename, and the earlier report is the baseline the later one is meant to be diffed
+# against — it is uncommitted at that moment, and artifacts/ is gitignored, so an overwrite
+# is unrecoverable. Pick the first free suffix instead.
+REPORT_PATH="$SKILL_DIR/REPORT-$DATE.md"
+n=2
+while [ -e "$REPORT_PATH" ]; do
+  REPORT_PATH="$SKILL_DIR/REPORT-$DATE.$n.md"
+  n=$((n + 1))
+done
+echo "$REPO" "$DATE" "$REPORT_PATH"
+```
+
+Pass `REPORT_PATH` through verbatim — the workflow derives its artifact filenames from it, so
+the raw JSON behind an earlier report is preserved too. Then:
+
+```
+Workflow({ name: "audit-i18n", args: {
+  repoRoot:     "<REPO>",
+  skillDir:     "<REPO>/.claude/skills/audit-i18n",
+  artifactsDir: "<REPO>/.claude/skills/audit-i18n/artifacts",
+  reportPath:   "<REPORT_PATH from the snippet above — do not re-derive it>",
+  reportDate:   "<DATE>",
+  scope:        "full",     // or "exact-only" to skip heuristic triage
+  attributeStale: true,
+} })
+```
+
+Pass `scope: "exact-only"` when the user wants a fast parity-and-stubs answer, or when the
+heuristic candidates were triaged recently and have not moved. It drops the triage agents and
+leaves `[H]` reported as raw counts.
+
+What it does: measures (1 agent, writes the JSON), then fans out one attribution agent per module
+with drift plus a stub adjudicator plus up to three heuristic triagers — all concurrently — then
+synthesizes one report, then reconciles that report against the raw JSON with two independent
+agents that did not write it. Typically 10–13 agents.
+
+It returns `{ reportPath, jsonPath, totals, featureClusters, modulesAttributed,
+modulesNotAttributed, unreconciledModules, stubVerdictCounts, heuristicSampled, advisories,
+reconcileVerdicts, confirmedDiscrepanciesFixed, reconcileFailedLenses,
+unconfirmedDiscrepancies, clean, summary }`.
+
+**If it returns `{ halted: true }`, stop.** That means the checker hard-failed (exit ≥ 16) — it
+did not run at all. Report the reason to the user and fix the tool before auditing anything. A
+report generated over a broken measurement reads as a clean bill of health, which is the worst
+possible output. Advisories alone never halt the run; they are carried into the report.
+
+## Phase 2 — Re-assert independently
+
+Do not relay the workflow's self-report unchecked. It already reconciles itself, but it graded its
+own homework. Run these yourself:
+
+Use the `jsonPath` the workflow returned — it is keyed to this run's report, not a fixed name.
+
+```bash
+# 1. The report's headline total must equal the JSON's — the single most load-bearing number.
+python3 -c "import json,sys;d=json.load(open(sys.argv[1]));print('missing',d['parity']['missing_total'],'stale',d['parity']['stale_total'],'struct',d['parity']['structural_total'],'stubs',d['stubs']['counts']['errors'],'heuristic',d['hardcoded']['total'])" <jsonPath>
+grep -nE "^\| \*\*total\*\*|debt|missing" <reportPath> | head
+
+# 2. The audit is reproducible: re-running the checker reproduces the same JSON.
+python3 scripts/i18n-coverage.py --format json | shasum -a 256
+shasum -a 256 <jsonPath>
+
+# 3. Spot-check one feature attribution against git yourself. --reverse|head -1 gives the
+#    commit that INTRODUCED the key; `-1` alone gives the last commit that touched it, which
+#    is a different (and usually wrong) answer. The name="…" anchor stops a prefix-nested
+#    sibling key from matching.
+git log --format='%h %ad %s' --date=short --reverse -S'name="<a key named in the report>"' \
+  -- <module>/src/commonMain/composeResources/values/strings.xml | head -1
+```
+
+Then check the returned fields. **`clean: true` is the only state you may summarize without
+caveats.** When it is false, one of these is non-empty, and each means something specific:
+
+| Field | If non-empty |
+| --- | --- |
+| `modulesNotAttributed` | an attribution cap bit — those modules' findings are in the report but unexplained |
+| `unreconciledModules` | a module's feature clusters do not account for all its keys |
+| `reconcileFailedLenses` | a reconcile lens returned `FAIL` — the report is not trustworthy as written |
+| `unconfirmedDiscrepancies` | a lens suspected a fabricated or dropped finding but did not mechanically reproduce it. **Not auto-fixed.** Verify each by hand against the JSON before you summarize |
+| `advisories` | the checker's own findings about the surface — these belong in your summary too |
+
+Say so to the user in your summary. Those are the parts of the surface the audit did **not**
+fully cover, and they must not be presented as if they were.
+
+If `confirmedDiscrepanciesFixed` is non-zero, mention it: the report needed correcting against
+its own source data, which is worth knowing about the run.
+
+## Invocations
+
+All paths are repo-relative; run from the repo root.
+
+```bash
+# Full report, human-readable. The default.
+python3 scripts/i18n-coverage.py
+
+# Totals only — good for a before/after comparison or a quick status line.
+python3 scripts/i18n-coverage.py --summary
+
+# One detector at a time. Useful because the exit code then isolates that detector.
+python3 scripts/i18n-coverage.py --detector parity
+python3 scripts/i18n-coverage.py --detector stubs
+python3 scripts/i18n-coverage.py --detector hardcoded
+python3 scripts/i18n-coverage.py --detector all        # same as omitting it
+
+# Machine-readable. Use this when you need to group, sort, or cross-tabulate findings.
+python3 scripts/i18n-coverage.py --json                # shorthand for --format json
+python3 scripts/i18n-coverage.py --format json
+python3 scripts/i18n-coverage.py --format text         # the default
+
+# Show the raw, unsuppressed finding set — what the allowlist is currently hiding.
+python3 scripts/i18n-coverage.py --no-allowlist
+
+# Point at a different allowlist (must resolve INSIDE the repo).
+python3 scripts/i18n-coverage.py --allowlist config/l10n/i18n-allowlist.txt
+
+# Two opt-in low-precision stub tiers, both INFO, both off by default.
+python3 scripts/i18n-coverage.py --include-latin       # Latin-locale values identical to base
+python3 scripts/i18n-coverage.py --near-identical      # case/punctuation-only differences
+
+# Override repo-root detection (normally found by walking up for settings.gradle.kts).
+python3 scripts/i18n-coverage.py --repo-root .
+```
+
+A useful pattern for grouping missing keys by feature — the highest-value analysis step — is to
+pull the distinct key lists out of the JSON rather than the text report:
+
+```bash
+python3 scripts/i18n-coverage.py --json > /tmp/i18n.json
+python3 -c "
+import json
+d = json.load(open('/tmp/i18n.json'))
+for m in d['parity']['per_module']:
+    if m['missing_total']:
+        print('===', m['module'], 'base', m['base_keys'], 'rows', m['missing_total'])
+        for k in m['distinct_missing_keys']: print('  ', k)
+"
+```
+
+### Exit codes
+
+A bitmask, so a caller can tell exact findings from heuristic ones:
+
+| Code | Meaning | Trust |
+| --- | --- | --- |
+| `0` | clean | — |
+| `1` | parity findings | exact |
+| `2` | stub findings, ERROR tier | exact |
+| `4` | hardcoded candidates | heuristic |
+| `8` | advisories (stale allowlist directives, module/locale-set drift, parser disagreement with `StringResourceParityTest`'s regex) | exact |
+| `16` | **hard failure** — layout unrecognized, 0 modules, a module with 0 base keys, an unreadable/non-UTF-8/unparseable resource file, bad CLI argument, a missing explicitly-passed `--allowlist`, unexpected exception | the run did not happen |
+
+Codes combine: `7` = parity + stubs + hardcoded, which is the current state of `develop`.
+
+**Test hard failure with `exit & ~15` (equivalently `exit >= 16`), never with a narrower mask.**
+The hard-failure code shares no bits with the finding mask, and that is the whole point — the
+conventional `70` (`0b1000110`) sets both the stub bit and the hardcoded bit, so `exit & 3` would
+report a crashed run as "2 — exact stub findings". Anything at or above 16 means the check did
+not run; anything below is a finding set.
+
+A caller wanting *proven* defects only would check `exit & 3` **after** ruling out hard failure.
+Do not treat that as an invitation to add a gate — that is explicitly out of scope for this
+skill.
+
+## Reading the three detectors
+
+The single most important thing you do is keep these three straight in the report. Two are exact
+set operations. One is a regex heuristic over a language with no type-level marking of
+user-facing strings. Blurring them destroys the report's credibility.
+
+### [P] parity — EXACT. Report as fact.
+
+Set difference between each module's base `values/strings.xml` and each of its `values-<loc>/`
+files, computed in **both** directions:
+
+- **missing** — in base, not in the locale. The user sees English in a translated app.
+- **stale** — in the locale, not in base. Dead weight; usually a key the base renamed or
+  removed, which the locale files were never updated to follow.
+- **structural** — an entirely absent locale file (scored as 100% missing, not skipped),
+  duplicate keys within one file, unknown locale qualifiers.
+
+Also reported: `uniform`, meaning every locale in the module shares one identical missing set and
+one identical stale set. When `uniform` is `yes`, the per-module distinct key list is lossless
+and you can quote it directly. When it is `no`, per-locale sets diverge and you must go to the
+JSON `parity.findings` rows before making per-locale claims.
+
+Note that `missing_total` is a **row count summed over locales**, not a key count. 504 missing
+rows in a 9-locale module is 56 distinct keys. State both in the report; the user sizes work in
+keys and sizes debt in rows.
+
+Parity is never allowlist-suppressible. A missing or stale key is not a judgment call.
+
+### [S] stubs — EXACT. Report as fact.
+
+A key that *is* present in a non-Latin-script locale but whose value is byte-identical to the
+English base and pure ASCII was never actually translated. The file passes parity and still ships
+English.
+
+Two classes are exempted mechanically, with no allowlist entry needed: **shared literals** (no
+locale anywhere translated them — `Bearer`, `OAuth`, `JSON`, `MCP`, `SSE`, `Markdown`,
+`LibreChat`, `mermaid`, `shadcn/ui`) and **letterless values** (arrows, em dashes, pure format
+strings).
+
+What survives is tiered by cross-locale corroboration:
+
+- **ERROR** — at least 4 other locales translated this key. The holdout is a genuine miss.
+- **REVIEW** — only 1–3 others did, so English may be the local convention. Report these
+  separately and say so.
+- **INFO** (`--include-latin`, `--near-identical`) — off by default and near-100% /
+  1-in-3 precision respectively. Only surface these if the user asks for exhaustive output, and
+  label them INFO.
+
+Also reported: **contiguous runs** of ≥3 adjacent untranslated keys in one file. These are the
+cheapest fixes in the whole report — one localized block of a file, usually a whole form that a
+translator skipped in one go. Call them out by `file:first_line-last_line`.
+
+### [H] hardcoded — HEURISTIC CANDIDATES. Never report as proven.
+
+Sink-anchored regex matching for English literals in `.kt` that never reached a `strings.xml` —
+`Text("…")`, `contentDescription = "…"`, `?: "…"` error fallbacks, `when` branches returning
+display strings, and so on, bucketed into rule families.
+
+**Language rules for this section, non-negotiable:**
+
+- Call them **candidates**. Never "missing strings", never "confirmed gaps", never fold their
+  count into the translation-debt total.
+- Print the script's own precision estimate and its enumerated false-positive class verbatim
+  rather than paraphrasing it. The script knows which of its rows are wrong; you don't.
+- Say explicitly that each one needs a human to decide whether it is user-facing at all.
+
+Triage priority, best-value first:
+
+1. `content_desc` and `text_call` — unambiguously on screen, and `content_desc` is also an
+   accessibility defect. Smallest families, highest hit rate.
+2. `ui_param` — labels/descriptions passed to UI builders. Large, but usually dominated by a few
+   registry-shaped files where one file is one fix.
+3. `when_branch` and `continuation` — display-string mappings and multi-line concatenations.
+4. `state_error` and `elvis_error` — error fallbacks. Mixed: real user-facing error copy sits
+   next to developer diagnostics that merely leak.
+5. `enum_label` and `sink_call` — mostly wire tokens and non-UI helpers. Verify before touching.
+
+Sort candidates by module and by file, not by rule, when recommending work: a single file with 100
+rows is one PR, and 100 rows spread over 40 files is not.
+
+## The allowlist
+
+`config/l10n/i18n-allowlist.txt`. Suppresses individual `[S]` and `[H]` findings. It does **not**
+touch `[P]`.
+
+Format is TAB-separated, exact string equality — no regex, no globs, no prefix matching. Read the
+header comment in the file for the five directive forms (`literal`, `key`, `pair`, `site`,
+`file`). It is **shrink-only**: a directive that suppresses nothing is surfaced as a stale
+advisory (exit bit `8`) and must be deleted, so debt can only go down.
+
+**Every entry needs a written justification comment above it.** "The check was noisy" is not one.
+
+Legitimate reasons to add an entry:
+
+- The value is a protocol or wire token displayed verbatim (`Basic` as an HTTP auth scheme).
+- The value is a proper noun or product name (`Streamable HTTP` as the MCP transport's name).
+- The value is an input-format spec the user must literally type (`lowercase-kebab-case`).
+- The value is an example inside a placeholder, where translating it would make it *wrong*.
+- A `[H]` site is genuinely not user-facing — a wire constant, an internal exception default.
+
+Illegitimate — this is hiding a real gap:
+
+- Other locales translated the same key. If `ar`, `ja` and `zh` rendered it as prose, `ko`
+  leaving it English is a miss, not a convention. The script's REVIEW/ERROR tiering exists
+  precisely to make this visible; do not suppress across it.
+- You could not decide, so you suppressed. Leave it as REVIEW and say it needs a native reader.
+- A whole `file` directive used to quiet a noisy module. Prefer `site`.
+- Anything to make the exit code smaller.
+
+When the audit surfaces a suppression that looks wrong, report it as a finding against the
+allowlist. Do not edit the allowlist inside this skill — proposing an entry is in scope, writing
+it is a separate authorized change.
+
+## Report artifact
+
+**The workflow writes this, not you** — its synthesize phase produces
+`.claude/skills/audit-i18n/REPORT-<YYYY-MM-DD>.md` and its reconcile phase checks it against the
+raw JSON. This section documents the contract that report must satisfy, so you can tell whether
+what came back is right; the shell snippets below are what the workflow's attribution agents run.
+
+Never overwrite a prior dated report — the whole point of determinism is that two dated reports
+diff cleanly. The raw JSON lands in `artifacts/` (gitignored, regenerable); the dated report is
+the durable artifact.
+
+Required sections:
+
+1. **Headline number** — total translation debt as a single figure (missing rows + stale rows +
+   ERROR stub rows), so the user can size the work in one glance. Exclude `[H]` candidates from
+   it and say that you did.
+2. **Per-module × per-locale parity table** — real numbers from the script, base key count
+   included so percentages are checkable.
+3. **Missing keys grouped by feature.** This is the highest-value section. Key names are
+   prefix-clustered by design (`project_*`, `context_usage_*`, `media_*`), so group them and
+   **name the feature**. Then date a representative key per cluster:
+
+   ```bash
+   git log -S'"context_usage_label"' --format='%h|%ad|%s' --date=short --reverse \
+     -- feature/chat/src/commonMain/composeResources/values/strings.xml | head -1
+   ```
+
+   and establish when localization itself landed:
+
+   ```bash
+   git log --oneline --reverse --diff-filter=A -- '*/values-de/strings.xml'
+   ```
+
+   Cite the commit and PR for each cluster. A cluster whose keys postdate the i18n introduction
+   is a feature that **shipped English-only** — that is the user's actual question, and counts
+   alone do not answer it.
+4. **Stub findings** — ERROR and REVIEW separated, per-locale counts, contiguous runs called out
+   as the cheap wins.
+5. **Hardcoded candidates** — labeled heuristic, with the triage ordering above.
+6. **Recommended fix order** — biggest coverage win per unit of effort first, with rough entry
+   counts per step so each step is schedulable. Deletions of stale keys and single-file registry
+   extractions go early; they are near-zero-risk and shrink the number visibly.
+
+## Known blind spots
+
+State these in the report. A tool whose limits are undocumented gets over-trusted.
+
+- **No placeholder or format-specifier checking.** A locale that writes `%2$s` where base has
+  `%1$s`, or drops a `%s` entirely, passes every detector. This is a deliberate scope decision,
+  not an oversight, and it is the most likely source of a runtime crash in translated copy.
+- **Translation quality is entirely invisible.** Non-ASCII text is accepted as translated. A
+  machine-translated or wrong-register string is indistinguishable from a good one. The stub
+  detector only catches *English left in place*.
+- **The default allowlist can be absent.** An explicitly-passed `--allowlist` that does not
+  exist is a hard failure, but if the DEFAULT `config/l10n/i18n-allowlist.txt` is simply
+  missing, the run continues unsuppressed with an `ALLOWLIST_ABSENT` advisory. That is a real
+  state to notice: totals from such a run are not comparable with a run that had it. Always
+  verify the header line reads the path, not `(none)`.
+- **`--summary` hides the INFO tiers.** `--summary --include-latin` prints the same bytes as
+  `--summary` alone. Use the full text or JSON output when you want those counts.
+- **`[H]` scans `.kt` only, and not inside raw strings.** English inside `"""…"""` HTML/JS
+  templates is not scanned (there is no sink pattern inside an inline web document), and
+  `android:label` in `AndroidManifest.xml` is out of scope.
+- **`[H]` recall limits, per the script's own notes:** concatenation fragments beyond a 4-line
+  window are reported once at the head line; a `val message = "…"` bound far from its sink is
+  missed; a spaceless all-lowercase word is dropped by the prose gate (admitting them measured
+  2 true positives against 48 false, so that recall is given up on purpose).
+- **The Android `res/` surface is reported but not scored.** `app/src/main/res/values/strings.xml`
+  holds the platform strings and has no locale directories. Folding it into parity math would
+  fabricate phantom "entire locale missing" failures, so it is listed separately. Its gap is
+  real; it is just not part of the compose-resources numbers.
+- **No iOS `.strings` / `.stringsdict` / `.xcstrings` exist**, so there is nothing to compare
+  against on that side. If any are ever added, this tool will not see them.
+- **Nothing checks that a declared key is actually *used*.** An orphaned base key that no
+  composable references counts as real work for all 9 locales.
+
+## Relationship to StringResourceParityTest
+
+There is an overlapping JUnit test — `StringResourceParityTest` plus
+`config/l10n/strings-parity-baseline.txt` (~1269 frozen entries, shrink-only) — on the **unmerged
+local branch `chore/review-loop-protocol`** (commit `7f4f66e8`). Read it with
+`git show chore/review-loop-protocol:<path>`.
+
+It is **not on `develop`**, so nothing currently enforces parity in CI. Do not assume its baseline
+reflects the present state; the checker deliberately does not read or regenerate it.
+
+Where the two differ:
+
+- The test walks only `shared` + `feature/*`, so **`core/ui` drift is invisible to it.** This
+  checker discovers modules by sorted glob and includes `core/ui`.
+- The test `continue`s past a missing locale file, so a **wholly absent locale is silently OK**.
+  This checker scores an absent locale file as 100% missing and reports it as a structural defect.
+- The test only checks key presence. It has no stub detection and no hardcoded-literal detection.
+- The checker emits an advisory (exit bit `8`) if its parser disagrees with the test's regex, so
+  the two can be reconciled rather than silently diverging.
+
+Treat the checker as the superset. If the test later lands on `develop`, that is a CI gate
+decision for the user, not something this skill performs.
+
+## Anti-patterns to avoid
+
+- **Don't grep to find findings.** Re-deriving by hand produces numbers nobody can reproduce and
+  misses both-direction drift, the `values-night` trap, and the `res/` separation.
+- **Don't merge `[H]` into the debt total.** Heuristic candidates and exact defects are different
+  kinds of claim. Keeping one number honest is worth more than a bigger number.
+- **Don't report `missing_total` as a key count.** It is rows summed over 9 locales. Divide, and
+  show both.
+- **Don't skip the feature attribution.** "feature/chat is missing 56 keys" is not actionable.
+  "Media gallery (#145), message queue (#167), artifact home-screen shortcuts (#241) and context
+  usage (#204) all shipped English-only" is.
+- **Don't suppress a REVIEW row to get a cleaner exit code.** REVIEW exists to be escalated to a
+  native reader, not resolved by fiat.
+- **Don't write translations, edit a `strings.xml`, touch Gradle, or add a CI gate.** All four are
+  out of scope. The skill stops at the report.
+- **Don't run Gradle or an iOS build.** The deliverable is Python output and Markdown.
+- **Don't report anything from a hard-failed run (exit ≥ 16).** It is not a clean bill of
+  health; the check did not run. Conversely, don't abort on an advisory (bit `8`) — that is a
+  finding, and refusing to report it is its own kind of silence.
+- **Don't do the analysis yourself instead of running the workflow.** Attribution across five
+  modules is the slow part and it parallelises perfectly. Doing it inline is both slower and
+  worse, because nothing then reconciles the report against the JSON.
+- **Don't let the workflow's numbers into the summary unchecked.** It reconciles itself, which is
+  necessary but not sufficient — it graded its own homework. Phase 2 exists for that reason.
+- **Don't hide a partial run.** If `modulesNotAttributed` or `unreconciledModules` came back
+  non-empty, the audit covered less than it appears to. Say which parts, plainly.
+- **Don't pass a stale `reportDate`.** The workflow cannot read a clock; whatever you pass becomes
+  the filename and the in-report date. Compute it fresh with `date -u +%F` each run.

--- a/.claude/workflows/audit-i18n.js
+++ b/.claude/workflows/audit-i18n.js
@@ -1,0 +1,737 @@
+export const meta = {
+  name: 'audit-i18n',
+  description: 'Fan out over the deterministic i18n-coverage findings: attribute missing keys to the features that shipped them, adjudicate untranslated stubs, triage heuristic literal candidates, then reconcile the report against the raw JSON',
+  phases: [
+    { title: 'Measure', detail: 'run scripts/i18n-coverage.py, persist JSON, derive fan-out shape' },
+    { title: 'Attribute', detail: 'one agent per module with drift: git archaeology -> feature clusters' },
+    { title: 'Adjudicate', detail: 'stub verdicts + heuristic candidate triage, in parallel with attribution' },
+    { title: 'Synthesize', detail: 'single report from the structured returns' },
+    { title: 'Reconcile', detail: 'adversarial: report claims vs raw JSON, and coverage of what was dropped' },
+  ],
+}
+
+// ---------------------------------------------------------------------------
+// Invoked by the audit-i18n skill. The skill (main loop, direct Bash) resolves
+// paths and the report date FIRST, because this script body has no shell, no fs
+// and no clock — Date.now()/new Date() throw here by design, so `reportDate`
+// MUST arrive via args.
+//
+// THE LOAD-BEARING INVARIANT, repeated into every prompt below:
+//   scripts/i18n-coverage.py is the sole authority on WHAT the findings are.
+//   Agents supply WHY / WHEN / WHETHER-IT-MATTERS. No agent may add a finding
+//   the JSON does not contain, or drop one it does. That separation is what
+//   keeps a re-run diffable — the moment an agent re-derives findings by
+//   grepping, the output stops being reproducible and the whole point is lost.
+//
+// args = {
+//   repoRoot:         absolute path to the checkout (worktree-safe)
+//   skillDir:         absolute path to .claude/skills/audit-i18n
+//   artifactsDir:     absolute path for the raw JSON + intermediate artifacts
+//   reportPath:       absolute path the final report is written to
+//   reportDate:       YYYY-MM-DD, computed by the skill (no clock in here)
+//   scope:            'full' | 'exact-only'   (exact-only skips heuristic triage)
+//   attributeStale:   boolean, archaeology on stale keys too (default true)
+// }
+// ---------------------------------------------------------------------------
+
+// The harness has been observed delivering `args` JSON-stringified; parse defensively
+// or every field silently reads as undefined and the run proceeds against nonsense.
+let A = args
+if (typeof A === 'string') {
+  try { A = JSON.parse(A) } catch (e) { A = {} }
+}
+A = A || {}
+
+const REPO = A.repoRoot
+const SKILL_DIR = A.skillDir
+const ARTIFACTS = A.artifactsDir || `${SKILL_DIR}/artifacts`
+const REPORT_DATE = A.reportDate
+// The skill is responsible for handing in a path that does not already exist (it has a
+// shell and a clock; this script has neither). Two audits on the same UTC day would
+// otherwise resolve to one filename and the second would destroy the first — and since
+// the report is uncommitted at that moment and artifacts/ is gitignored, there is no copy
+// to recover. The synthesize agent refuses to overwrite as a second line of defence.
+const REPORT_PATH = A.reportPath || `${SKILL_DIR}/REPORT-${REPORT_DATE}.md`
+// Keyed to the report it belongs to, so the raw JSON behind an earlier report is not
+// clobbered either — diffing two reports is useless if both point at one JSON.
+const RUN_STEM = REPORT_PATH.split('/').pop().replace(/^REPORT-/, '').replace(/\.md$/, '')
+const JSON_PATH = `${ARTIFACTS}/i18n-coverage-${RUN_STEM}.json`
+const TEXT_PATH = `${ARTIFACTS}/i18n-coverage-${RUN_STEM}.txt`
+const EXACT_ONLY = A.scope === 'exact-only'
+const ATTRIBUTE_STALE = A.attributeStale !== false
+
+if (!REPO || !SKILL_DIR || !REPORT_DATE) {
+  return {
+    error: 'audit-i18n workflow requires args.repoRoot, args.skillDir and args.reportDate. ' +
+      `Received: repoRoot=${REPO} skillDir=${SKILL_DIR} reportDate=${REPORT_DATE}. ` +
+      'The skill computes these in the main loop — Date.now() is unavailable inside a workflow.',
+  }
+}
+
+// Caps exist so a pathological corpus cannot fan out unboundedly. When one bites we
+// log it — a silently truncated audit reads as "covered everything" when it did not.
+const MAX_ATTRIBUTION_AGENTS = 6
+const MAX_HEURISTIC_AGENTS = 3
+
+const GROUND_RULES = `
+REPO ROOT (a git worktree — never cd to the original checkout): ${REPO}
+RAW FINDINGS JSON (already written, read it, do not regenerate it): ${JSON_PATH}
+
+THE INVARIANT — read this twice:
+  \`scripts/i18n-coverage.py\` is the SOLE authority on WHAT the findings are. It is exact and
+  deterministic, and a caller re-runs it to diff audits over time. Your job is to explain
+  findings that already exist: WHY a gap happened, WHEN it landed, WHETHER it matters.
+  - You may NOT introduce a finding absent from the JSON.
+  - You may NOT drop, merge away, or silently re-scope a finding present in the JSON.
+  - You may NOT re-derive findings by grepping strings.xml yourself. If your reading of the
+    repo disagrees with the JSON, that is a BUG REPORT about the script — say so explicitly
+    and loudly in your return, with the exact command and the discrepancy. Do not quietly
+    "correct" the numbers in your output; a silent correction destroys reproducibility.
+  Git history, source files and PR metadata ARE yours to read freely — that is the whole point
+  of this phase. The restriction is on inventing or discarding FINDINGS, not on investigation.
+
+NON-GOALS: do not write translations, do not edit any strings.xml, do not edit the checker or
+the allowlist, do not commit, do not push, do not open a PR. Do not run Gradle or any iOS build.
+`
+
+// ---------------------------------------------------------------------------
+// Phase 1 — Measure.  Barrier: the entire fan-out shape is derived from this.
+// ---------------------------------------------------------------------------
+
+phase('Measure')
+
+const SHAPE_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['exit_code', 'json_written', 'totals', 'modules_with_drift', 'stub_locales', 'hardcoded_modules', 'advisories', 'trustworthy'],
+  properties: {
+    exit_code: { type: 'integer' },
+    json_written: { type: 'boolean' },
+    trustworthy: {
+      type: 'boolean',
+      description:
+        'false ONLY if the checker hard-failed (exit & ~15, i.e. >= 16) or exit was 0 over an ' +
+        'implausibly empty corpus. Advisories do NOT make a run untrustworthy — they are ' +
+        'findings about the surface, and the report must carry them.',
+    },
+    advisories: { type: 'array', items: { type: 'string' } },
+    totals: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['parity_missing', 'parity_stale', 'parity_structural', 'stub_errors', 'stub_review', 'hardcoded_candidates', 'base_keys'],
+      properties: {
+        parity_missing: { type: 'integer' },
+        parity_stale: { type: 'integer' },
+        parity_structural: { type: 'integer' },
+        stub_errors: { type: 'integer' },
+        stub_review: { type: 'integer' },
+        hardcoded_candidates: { type: 'integer' },
+        base_keys: { type: 'integer' },
+      },
+    },
+    modules_with_drift: {
+      type: 'array',
+      description: 'Every module whose missing_total or stale_total is non-zero, from parity.per_module',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['module', 'missing_total', 'stale_total', 'distinct_missing_keys', 'distinct_stale_keys', 'uniform'],
+        properties: {
+          module: { type: 'string' },
+          missing_total: { type: 'integer' },
+          stale_total: { type: 'integer' },
+          distinct_missing_keys: { type: 'integer' },
+          distinct_stale_keys: { type: 'integer' },
+          uniform: { type: 'boolean' },
+        },
+      },
+    },
+    stub_locales: { type: 'array', items: { type: 'string' } },
+    hardcoded_modules: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['module', 'count'],
+        properties: { module: { type: 'string' }, count: { type: 'integer' } },
+      },
+    },
+  },
+}
+
+const shape = await agent(`${GROUND_RULES}
+
+PHASE: measure. You produce the ground truth every later agent consumes.
+
+1. mkdir -p ${ARTIFACTS}
+2. Run, from ${REPO}:
+     python3 scripts/i18n-coverage.py --format json > ${JSON_PATH}
+   Capture the exit code. Then ALSO run the human-readable form and keep it for the report:
+     python3 scripts/i18n-coverage.py > ${TEXT_PATH}
+   (Both write files; neither mutates the repo.)
+3. INTERPRET THE EXIT CODE BEFORE ANYTHING ELSE. The low nibble is the finding mask
+   (1=parity 2=stubs 4=hardcoded 8=advisories); anything at or above 16 is a hard failure.
+   - exit & ~15 (>= 16) = HARD FAILURE. The check did not run. Set trustworthy=false,
+     explain, and stop — do not report zeros as a clean result.
+   - Any other non-zero = findings exist. Normal. This INCLUDES the advisory bit.
+   - 0 = genuinely no findings. Verify that is plausible (base_keys should be >1000); if the
+     corpus looks empty, set trustworthy=false.
+4. Read the JSON's \`advisories\`, \`stale_allowlist_directives\`, and each detector's own
+   \`advisories\` array. Report every one VERBATIM in the advisories field.
+   Advisories do NOT set trustworthy=false. The checker already draws the fatal /
+   non-fatal line itself, deterministically: what it cannot measure it hard-fails on,
+   what it CAN measure but wants a human to see it reports as an advisory. Treating
+   advisories as fatal makes a dropped locale, a new <plurals>, or a newly added module —
+   all ordinary, all things the audit exists to surface — produce no report at all.
+   Do not re-litigate that boundary with your own judgement; carry the advisories into
+   the report as a prominent section instead.
+5. Populate the schema from the JSON. Read the real fields, do not estimate:
+   parity.missing_total / stale_total / structural_total / per_module[]
+   stubs.counts.errors / .review / stubs.counts.errors_per_locale
+   hardcoded.total / hardcoded.by_module
+   base_keys = sum of parity.per_module[].base_keys
+   modules_with_drift comes from per_module entries with missing_total>0 OR stale_total>0.
+   stub_locales = the keys of stubs.counts.errors_per_locale.
+
+Return the shape. Do not analyze anything yet — later agents do that.`, {
+  label: 'measure',
+  phase: 'Measure',
+  schema: SHAPE_SCHEMA,
+})
+
+if (!shape) {
+  return { error: 'Measure phase returned nothing — the checker could not be run. No report written.' }
+}
+
+// Halt ONLY on a genuine hard failure. The exit code is checked here as well as in the
+// prompt, so an agent that misreads its own instruction cannot start a fan-out over a
+// run that never happened — and, symmetrically, cannot halt a run that merely had
+// advisories. `exit & ~15` is the checker's own documented hard-failure test.
+const HARD_FAILED = typeof shape.exit_code === 'number' && (shape.exit_code & ~15) !== 0
+
+if (HARD_FAILED || !shape.trustworthy) {
+  log(`HALTED: the checker did not produce a usable measurement (exit ${shape.exit_code}).`)
+  return {
+    halted: true,
+    reason: HARD_FAILED
+      ? `Checker hard-failed (exit ${shape.exit_code}, outside the finding mask) — it did not run. ` +
+        'Refusing to emit a report that would read as a clean bill of health.'
+      : 'Measure agent judged the corpus implausible (e.g. exit 0 over an empty corpus).',
+    exit_code: shape.exit_code,
+    advisories: shape.advisories || [],
+    jsonPath: JSON_PATH,
+  }
+}
+
+const ADVISORIES = shape.advisories || []
+if (ADVISORIES.length) {
+  log(`${ADVISORIES.length} advisory/advisories — carried into the report, NOT fatal.`)
+}
+
+const T = shape.totals
+log(`Measured: ${T.parity_missing} missing + ${T.parity_stale} stale over ${T.base_keys} base keys; ${T.stub_errors} stub errors; ${T.hardcoded_candidates} heuristic candidates`)
+
+// ---------------------------------------------------------------------------
+// Fan-out shape, derived deterministically from the JSON.
+// ---------------------------------------------------------------------------
+
+const driftModules = (shape.modules_with_drift || [])
+  .slice()
+  .sort((a, b) => (b.missing_total + b.stale_total) - (a.missing_total + a.stale_total) || a.module.localeCompare(b.module))
+
+const attributionTargets = driftModules.slice(0, MAX_ATTRIBUTION_AGENTS)
+const attributionDropped = driftModules.slice(MAX_ATTRIBUTION_AGENTS)
+if (attributionDropped.length) {
+  log(`CAP HIT: ${attributionDropped.length} module(s) will not get a dedicated attribution agent: ${attributionDropped.map((m) => m.module).join(', ')}. Their findings still appear in the report, unattributed.`)
+}
+
+// Greedy balance of heuristic candidates across a small fixed pool, largest first,
+// so one huge module does not serialize the phase behind eight trivial ones.
+const hModules = (shape.hardcoded_modules || []).slice().sort((a, b) => b.count - a.count || a.module.localeCompare(b.module))
+const hBuckets = []
+if (!EXACT_ONLY && hModules.length) {
+  const n = Math.min(MAX_HEURISTIC_AGENTS, hModules.length)
+  for (let i = 0; i < n; i++) hBuckets.push({ modules: [], count: 0 })
+  for (const m of hModules) {
+    let lightest = 0
+    for (let i = 1; i < hBuckets.length; i++) {
+      if (hBuckets[i].count < hBuckets[lightest].count) lightest = i
+    }
+    hBuckets[lightest].modules.push(m.module)
+    hBuckets[lightest].count += m.count
+  }
+}
+
+log(`Fan-out: ${attributionTargets.length} attribution agent(s), ${T.stub_errors > 0 || T.stub_review > 0 ? 1 : 0} stub adjudicator, ${hBuckets.length} heuristic triager(s)${EXACT_ONLY ? ' (exact-only scope — heuristic triage skipped)' : ''}`)
+
+// ---------------------------------------------------------------------------
+// Phases 2+3 — Attribute and Adjudicate.  Independent tracks, run concurrently.
+// ---------------------------------------------------------------------------
+
+phase('Attribute')
+
+const ATTRIBUTION_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['module', 'clusters', 'unattributed_keys', 'key_count_reconciles'],
+  properties: {
+    module: { type: 'string' },
+    key_count_reconciles: {
+      type: 'boolean',
+      description: 'true iff (sum of cluster key counts + unattributed) equals distinct_missing_keys + distinct_stale_keys from the JSON',
+    },
+    reconciliation_note: { type: 'string' },
+    clusters: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['feature', 'keys', 'landed_commit', 'landed_date', 'kind'],
+        properties: {
+          feature: { type: 'string', description: 'Human feature name, e.g. "Chat Projects"' },
+          pr: { type: 'string', description: 'PR number like #204, or "" if none found' },
+          landed_commit: { type: 'string' },
+          landed_date: { type: 'string', description: 'YYYY-MM-DD, UTC, author date of the commit that added the key to the base file' },
+          kind: { type: 'string', enum: ['missing', 'stale', 'mixed'] },
+          keys: { type: 'array', items: { type: 'string' } },
+          evidence: { type: 'string', description: 'The exact git command whose output backs the attribution' },
+        },
+      },
+    },
+    unattributed_keys: {
+      type: 'array',
+      description: 'Keys you could not tie to a commit. Listing them honestly beats a tidy table.',
+      items: { type: 'string' },
+    },
+  },
+}
+
+const attributionTrack = () => parallel(attributionTargets.map((m) => () => agent(`${GROUND_RULES}
+
+PHASE: attribute — module \`${m.module}\`.
+
+The JSON says this module has ${m.distinct_missing_keys} distinct missing key(s) across
+${m.missing_total} rows, and ${m.distinct_stale_keys} distinct stale key(s) across ${m.stale_total} rows.
+${m.uniform ? 'Drift is UNIFORM across locales, so the distinct key lists are lossless.' : 'Drift is NON-UNIFORM across locales — different locales are missing different keys. Read parity.per_module[].missing_by_locale for the per-locale breakdown and preserve that distinction; do not flatten it into a union.'}
+
+Read the distinct key lists for \`${m.module}\` out of ${JSON_PATH}. For EACH key, date it:
+
+  git log --format='%h|%ad|%s' --date=short --reverse -S'name="<key>"' \\
+      -- ${m.module}/src/commonMain/composeResources/values/strings.xml | head -1
+
+Three details are load-bearing, do not "simplify" them:
+  --reverse | head -1  takes the OLDEST matching commit, i.e. the one that INTRODUCED the
+      key. \`-1\` alone takes the newest, which is the most recent time anyone touched the
+      key — usually a later edit, and for a re-touched key that names the wrong PR and a
+      landing date that can be months off.
+  -S'name="<key>"'  the pickaxe string includes the XML attribute syntax, so it matches the
+      key exactly. A bare -S'<key>' also matches every prefix-nested sibling
+      (\`skill_field_name\` matches commits that only added \`skill_field_name_hint\`).
+  --date=short  NOT --date=short-local: a local-timezone date makes the report
+      machine-dependent, and this report is meant to diff cleanly across runs.
+
+Batch this — one shell loop over the key list, not one tool call per key.
+
+Then CLUSTER the keys into the user-facing features that shipped them. Cluster by the commit
+that added them first, then by key-name prefix within a commit (a single PR often ships two
+unrelated groups, e.g. a feature plus its settings page). Name each cluster the way a human
+would describe the feature in a changelog — "Chat Projects", "context-usage bar" — not by key
+prefix. Pull the PR number from the commit subject when it has one.
+
+${ATTRIBUTE_STALE ? `STALE keys get archaeology too, and a different question: find the commit that REMOVED
+the key from the base file (\`git log --format='%h|%ad|%s' --date=short -S'name="<key>"' --\` on
+the base file; here you DO want the newest commit, since removal is the last event — confirm
+with \`git show\` that it is a deletion and not an edit). A stale key means the base dropped a string but the locale files kept
+it — the interesting fact is which change orphaned it, because that is a cleanup others may
+have missed too. Mark those clusters kind="stale".` : 'Skip stale-key archaeology this run.'}
+
+RECONCILE BEFORE RETURNING: the sum of your clusters' key counts plus unattributed_keys MUST
+equal the JSON's distinct missing + distinct stale count for this module. Set
+key_count_reconciles accordingly and explain any shortfall in reconciliation_note. A key you
+cannot date goes in unattributed_keys — never drop it to make the arithmetic work.`, {
+  label: `attribute:${m.module}`,
+  phase: 'Attribute',
+  schema: ATTRIBUTION_SCHEMA,
+})))
+
+const STUB_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['verdicts', 'locale_summary', 'recommended_allowlist_additions'],
+  properties: {
+    locale_summary: { type: 'string' },
+    verdicts: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['module', 'key', 'locale', 'verdict'],
+        properties: {
+          module: { type: 'string' },
+          key: { type: 'string' },
+          locale: { type: 'string' },
+          verdict: { type: 'string', enum: ['GENUINE_MISS', 'ACCEPTABLE_AS_IS', 'UNCERTAIN'] },
+          reason: { type: 'string' },
+        },
+      },
+    },
+    recommended_allowlist_additions: {
+      type: 'array',
+      description: 'Only for ACCEPTABLE_AS_IS rows. Each needs a written justification — the allowlist is not a mute button.',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['entry', 'justification'],
+        properties: { entry: { type: 'string' }, justification: { type: 'string' } },
+      },
+    },
+  },
+}
+
+const stubTrack = () => agent(`${GROUND_RULES}
+
+PHASE: adjudicate stubs.
+
+Read \`stubs.errors\` (${T.stub_errors} rows) and \`stubs.review\` (${T.stub_review} rows) from ${JSON_PATH}.
+Each row is a key whose value in a non-Latin-script locale (${(shape.stub_locales || []).join(', ')}) is
+byte-identical to English and pure ASCII — the detector's evidence that it was never translated.
+Each row carries \`translated_by\`: the other locales that DID translate that key, which is the
+corroboration the ERROR tier is built on.
+
+For every row, decide:
+  GENUINE_MISS      — should be translated; the term has a normal rendering in that language.
+  ACCEPTABLE_AS_IS  — correctly left in English: a brand, a protocol token, a header name, a
+                      unit, or a term that is genuinely used untranslated in that locale's
+                      technical register.
+  UNCERTAIN         — you cannot tell without a native speaker. Use this rather than guessing;
+                      an honest UNCERTAIN is more useful than a confident wrong verdict.
+
+Weigh \`translated_by\` heavily: if 8 locales translated a key and one did not, that one is
+almost certainly a miss. If a term is English in every locale that has it, the detector already
+auto-exempted it (see stubs.auto_exempt) and it will not be in your list.
+
+Also read \`stubs.runs\` — contiguous untranslated regions by source line. A run of adjacent
+untranslated keys is evidence a translator skipped a block wholesale rather than making N
+independent judgments, which usually promotes every row in that run to GENUINE_MISS. Say so
+where it applies.
+
+Recommend allowlist entries ONLY for ACCEPTABLE_AS_IS, each with a real justification. Do not
+recommend allowlisting anything merely to reduce the count.`, {
+  label: 'adjudicate:stubs',
+  phase: 'Adjudicate',
+  schema: STUB_SCHEMA,
+})
+
+const HEURISTIC_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['bucket', 'sampled', 'true_positives', 'false_positives', 'precision_estimate', 'priority_examples'],
+  properties: {
+    bucket: { type: 'string' },
+    sampled: { type: 'integer' },
+    true_positives: { type: 'integer' },
+    false_positives: { type: 'integer' },
+    precision_estimate: { type: 'string' },
+    fp_classes: {
+      type: 'array',
+      description: 'Recurring false-positive shapes worth a rule tightening or an allowlist entry',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['shape', 'example', 'count'],
+        properties: { shape: { type: 'string' }, example: { type: 'string' }, count: { type: 'integer' } },
+      },
+    },
+    priority_examples: {
+      type: 'array',
+      description: 'Highest-value TRUE positives: user-visible English that clearly should be a resource',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['file', 'line', 'literal', 'why_it_matters'],
+        properties: {
+          file: { type: 'string' },
+          line: { type: 'integer' },
+          literal: { type: 'string' },
+          why_it_matters: { type: 'string' },
+        },
+      },
+    },
+  },
+}
+
+const heuristicTracks = hBuckets.map((b, i) => () => agent(`${GROUND_RULES}
+
+PHASE: triage heuristic candidates — bucket ${i + 1} of ${hBuckets.length}: ${b.modules.join(', ')} (~${b.count} candidates).
+
+These come from \`hardcoded.candidates\` in ${JSON_PATH}, filtered to your modules. Unlike parity
+and stubs, this detector is HEURISTIC: sink-anchored regex over a language with no type-level
+marking of user-facing text. It is expected to be wrong sometimes. Your job is to measure HOW
+wrong, and to surface the ones that genuinely matter.
+
+Each candidate has: file, line, rule (the sink family that matched), literal, source (the matched
+source line), module.
+
+1. SAMPLE at least 25 candidates across your bucket, spread over every \`rule\` family present —
+   not 25 from the easiest family. If your bucket has fewer than 25, take all of them.
+2. OPEN each at its file:line and read enough surrounding code to judge it. Do not classify from
+   the \`source\` snippet alone; the snippet is one line and the answer is usually in the caller.
+3. Classify TRUE POSITIVE (user-visible English that should be a string resource) vs FALSE
+   POSITIVE (log/Timber message, exception text never surfaced, test fixture, wire/JSON key, DI
+   or Koin name, DataStore key, testTag, MIME type, HTTP header, regex, SQL, @Preview sample data).
+   The decisive question is: can a user of the shipped app read this text on screen?
+4. Group recurring false positives into CLASSES with counts — a class is actionable (tighten a
+   rule, add an allowlist entry), a one-off is not.
+5. Return the highest-value true positives with file:line and why each matters. Prioritize text
+   on a primary user path (empty states, error banners, buttons, content descriptions) over
+   text a user reaches only in an edge case.
+
+Report your real precision honestly. If this bucket's precision is poor, say so plainly and name
+the rule that is misfiring — rubber-stamping a noisy detector is how it stops being read.`, {
+  label: `triage:h${i + 1}`,
+  phase: 'Adjudicate',
+  schema: HEURISTIC_SCHEMA,
+}))
+
+const [attributions, stubVerdicts, heuristicResults] = await parallel([
+  attributionTrack,
+  () => ((T.stub_errors > 0 || T.stub_review > 0) ? stubTrack() : Promise.resolve(null)),
+  () => (heuristicTracks.length ? parallel(heuristicTracks) : Promise.resolve([])),
+])
+
+const attrOk = (attributions || []).filter(Boolean)
+const hOk = (heuristicResults || []).filter(Boolean)
+const unreconciled = attrOk.filter((a) => !a.key_count_reconciles)
+if (unreconciled.length) {
+  log(`WARNING: ${unreconciled.length} module(s) failed key-count reconciliation: ${unreconciled.map((a) => a.module).join(', ')} — the report must flag this, not paper over it`)
+}
+log(`Attributed ${attrOk.reduce((n, a) => n + (a.clusters || []).length, 0)} feature cluster(s) across ${attrOk.length} module(s); triaged ${hOk.reduce((n, h) => n + (h.sampled || 0), 0)} heuristic candidate(s)`)
+
+// ---------------------------------------------------------------------------
+// Phase 4 — Synthesize.
+// ---------------------------------------------------------------------------
+
+phase('Synthesize')
+
+const report = await agent(`${GROUND_RULES}
+
+PHASE: synthesize. Write the audit report to ${REPORT_PATH} (date ${REPORT_DATE}).
+
+BEFORE YOU WRITE ANYTHING: check whether ${REPORT_PATH} already exists
+(\`test -e ${REPORT_PATH} && echo EXISTS\`). If it does, STOP — do not write, do not
+overwrite, do not append. Return an explanation that the path collided. Dated reports are
+the durable artifact this whole tool exists to diff across time; silently replacing one
+destroys the baseline a reader was about to compare against, and it is not in git yet.
+The caller is expected to hand in a fresh path, so a collision means something is wrong
+upstream and is worth surfacing rather than papering over.
+
+${ADVISORIES.length ? `ADVISORIES from the checker — these are FINDINGS, not failures. Give them their own
+section in the report, verbatim, and say what each one means for the numbers:
+${ADVISORIES.map((a) => `  - ${a}`).join('\n')}` : 'The checker raised no advisories.'}
+
+You have the raw JSON at ${JSON_PATH}, the human-readable run at ${TEXT_PATH},
+and these structured returns from the fan-out:
+
+ATTRIBUTION (per module, feature clusters with landing commits):
+${JSON.stringify(attrOk)}
+
+STUB VERDICTS:
+${JSON.stringify(stubVerdicts)}
+
+HEURISTIC TRIAGE:
+${JSON.stringify(hOk)}
+
+${unreconciled.length ? `RECONCILIATION FAILURES — these modules' clusters do not account for every key.
+State this in the report explicitly, per module, rather than presenting a complete-looking table:
+${unreconciled.map((a) => `  ${a.module}: ${a.reconciliation_note || 'no note given'}`).join('\n')}` : 'All modules reconciled their key counts.'}
+
+Structure the report:
+
+1. **Headline** — total translation debt as ONE number a human can act on, coverage %, and the
+   single most important sentence: which shipped features are English-only.
+2. **Parity, exact** — per-module x per-locale table with real numbers from the JSON. Include a
+   short note that count-only comparison understates drift wherever stale keys cancel missing
+   ones, and show the modules where that actually happens, with the specific stale keys.
+3. **The English-only features** — the centerpiece. A table ordered newest first: feature, PR,
+   landing date, distinct keys, rows (keys x locales), modules. This is the direct answer to
+   "which features shipped English-only?", so it leads on feature names, not key prefixes.
+4. **Stale keys** — with the commit that orphaned each.
+5. **Untranslated stubs** — per-locale counts, the GENUINE_MISS rows, and any recommended
+   allowlist additions WITH their justifications.
+6. **Unextracted literals — heuristic** — measured precision, false-positive classes, and a
+   prioritized list of true positives. Label this section unmistakably as candidates requiring
+   triage. A reader skimming must never mistake it for the exact sections.
+7. **Recommended fix order** — biggest coverage win per unit of effort first, with entry counts
+   so the user can size each step.
+8. **Limits** — what this audit cannot see. Carry the checker's documented blind spots forward
+   (no placeholder/format-specifier checking; translation quality invisible; \`[H]\` scans .kt
+   only) plus anything the fan-out could not attribute.
+
+Rules for the writing:
+- Every number traces to the JSON. If a fan-out agent's count disagrees with the JSON, the JSON
+  wins and you FLAG the disagreement in the report rather than silently picking one.
+- Mark exact sections and heuristic sections distinctly and consistently.
+- No invented findings. No dropped findings.
+- Keep the reproduction line at the top: the exact command that regenerates the JSON, so the next
+  run diffs cleanly against this one.
+
+Return the absolute path you wrote plus a 3-sentence summary of what it says.`, {
+  label: 'synthesize',
+  phase: 'Synthesize',
+})
+
+// ---------------------------------------------------------------------------
+// Phase 5 — Reconcile.  The guard that makes the fan-out safe: a workflow that
+// interprets findings can hallucinate them, so the report is checked back
+// against the raw JSON by agents that did not write it.
+// ---------------------------------------------------------------------------
+
+phase('Reconcile')
+
+const RECONCILE_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['lens', 'verdict', 'discrepancies'],
+  properties: {
+    lens: { type: 'string' },
+    verdict: { type: 'string', enum: ['PASS', 'FAIL'] },
+    discrepancies: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['severity', 'claim_in_report', 'what_json_says', 'confirmed'],
+        properties: {
+          severity: { type: 'string', enum: ['HIGH', 'MEDIUM', 'LOW'] },
+          claim_in_report: { type: 'string' },
+          what_json_says: { type: 'string' },
+          confirmed: { type: 'boolean', description: 'true only if you actually diffed the two and saw it' },
+          location: { type: 'string' },
+        },
+      },
+    },
+  },
+}
+
+const checks = (await parallel([
+  () => agent(`${GROUND_RULES}
+
+PHASE: reconcile — LENS: numeric fidelity. You did not write the report; do not defend it.
+
+Compare ${REPORT_PATH} against ${JSON_PATH} mechanically. Prefer computing over reading: use
+python3/jq to pull the JSON's numbers, then check each against the report's tables.
+
+1. Every per-module missing/stale figure in the report matches parity.per_module.
+2. The headline total matches parity.missing_total (and the row/key distinction is not conflated
+   — "keys" and "rows = keys x locales" are different numbers and the report must not mix them).
+3. Stub counts match stubs.counts, per locale.
+4. The heuristic total matches hardcoded.total, and the report does not present sampled-subset
+   precision as if the whole set were triaged.
+5. The feature-attribution table's key counts sum to the distinct missing keys the JSON reports.
+   A shortfall is only acceptable if the report explicitly flags it as unattributed.
+6. INVENTED FINDINGS: take a sample of at least 12 specific keys named in the report and confirm
+   each exists in the JSON with the same module and locale(s). Any key in the report but not the
+   JSON is a HIGH severity fabrication.
+7. DROPPED FINDINGS: confirm no module with drift in the JSON is missing from the report.
+
+Report only discrepancies you actually reproduced, with the command you ran.`, { label: 'reconcile:numeric', phase: 'Reconcile', schema: RECONCILE_SCHEMA }),
+
+  () => agent(`${GROUND_RULES}
+
+PHASE: reconcile — LENS: honesty and usability. You did not write the report; be skeptical.
+
+1. EXACT vs HEURISTIC separation: can a reader skimming the report mistake a heuristic candidate
+   for a proven gap? Check headings, the summary, and any combined totals. Any place the
+   ${T.hardcoded_candidates} heuristic candidates are added into the exact debt figure
+   (${T.parity_missing} missing + ${T.stub_errors} stub rows) is a HIGH severity finding.
+2. Attribution soundness: spot-check at least 5 feature clusters. Re-run the pickaxe yourself,
+   and use the INTRODUCING commit, not the newest one:
+     git log --format='%h|%ad|%s' --date=short --reverse -S'name="<key>"' \\
+         -- <module>/src/commonMain/composeResources/values/strings.xml | head -1
+   \`--reverse | head -1\` and the \`name="…"\` anchor are both required — with \`-1\` and a bare
+   key you would re-derive the same wrong answer the attribution agent might have made and
+   "confirm" it. A confidently wrong attribution is worse than an honest "unattributed".
+3. Silent caps: if the workflow dropped modules from attribution or sampled only a subset of
+   heuristic candidates, does the report SAY so? An audit that quietly covers 80% while reading
+   as complete is the failure mode here.
+4. Are the documented blind spots carried forward — especially that placeholder/format-specifier
+   mismatches are not checked at all?
+5. Is the recommended fix order actually justified by the numbers, or is it asserted?
+6. Does the report state how to reproduce it exactly?
+
+Report only what you verified.`, { label: 'reconcile:honesty', phase: 'Reconcile', schema: RECONCILE_SCHEMA }),
+])).filter(Boolean)
+
+const allDiscrepancies = checks.flatMap((c) => (c.discrepancies || []).map((d) => ({ ...d, lens: c.lens })))
+const confirmedDiscrepancies = allDiscrepancies.filter((d) => d.confirmed)
+
+// A discrepancy the lens reasoned about but did not mechanically re-diff still gets
+// `confirmed:false` under the schema's own wording. Such rows are NOT auto-fixed (they are
+// unverified, and acting on them could corrupt a correct report) but they MUST stay
+// surfaced, and any FAIL verdict must block the run from reading as clean — drop them and a
+// lens can return FAIL over a HIGH-severity "this key is not in the JSON" while the workflow
+// still reports a tidy `confirmedDiscrepanciesFixed: 0` and the fabrication ships.
+const unconfirmedDiscrepancies = allDiscrepancies.filter((d) => !d.confirmed)
+const failedLenses = checks.filter((c) => c.verdict === 'FAIL').map((c) => c.lens)
+
+if (unconfirmedDiscrepancies.length) {
+  log(`${unconfirmedDiscrepancies.length} UNCONFIRMED discrepancy(ies) reported but not mechanically reproduced — surfaced for the lead, not auto-fixed.`)
+}
+if (failedLenses.length) {
+  log(`RECONCILE FAILED on lens(es): ${failedLenses.join(', ')} — the report is NOT clean.`)
+}
+
+if (confirmedDiscrepancies.length) {
+  log(`Reconcile found ${confirmedDiscrepancies.length} confirmed discrepancy(ies) — correcting the report`)
+  await agent(`${GROUND_RULES}
+
+The report at ${REPORT_PATH} was checked against the raw JSON by two independent agents. Fix every
+confirmed discrepancy below, editing the report in place.
+
+${confirmedDiscrepancies.map((d, i) => `${i + 1}. [${d.severity}] (${d.lens}) ${d.location || ''}
+   report claims: ${d.claim_in_report}
+   JSON says:     ${d.what_json_says}`).join('\n\n')}
+
+The JSON is authoritative for every number. Where a discrepancy is a missing caveat rather than a
+wrong figure, add the caveat rather than deleting the content. Do not introduce new findings while
+fixing. When done, state what you changed, line by line.`, { label: 'correct-report', phase: 'Reconcile' })
+}
+
+return {
+  reportPath: REPORT_PATH,
+  jsonPath: JSON_PATH,
+  reportDate: REPORT_DATE,
+  totals: T,
+  featureClusters: attrOk.reduce((n, a) => n + (a.clusters || []).length, 0),
+  modulesAttributed: attrOk.map((a) => a.module),
+  modulesNotAttributed: attributionDropped.map((m) => m.module),
+  unreconciledModules: unreconciled.map((a) => a.module),
+  stubVerdictCounts: stubVerdicts
+    ? {
+        genuine: (stubVerdicts.verdicts || []).filter((v) => v.verdict === 'GENUINE_MISS').length,
+        acceptable: (stubVerdicts.verdicts || []).filter((v) => v.verdict === 'ACCEPTABLE_AS_IS').length,
+        uncertain: (stubVerdicts.verdicts || []).filter((v) => v.verdict === 'UNCERTAIN').length,
+      }
+    : null,
+  heuristicSampled: hOk.reduce((n, h) => n + (h.sampled || 0), 0),
+  advisories: ADVISORIES,
+  reconcileVerdicts: checks.map((c) => ({ lens: c.lens, verdict: c.verdict, discrepancies: (c.discrepancies || []).length })),
+  confirmedDiscrepanciesFixed: confirmedDiscrepancies.length,
+  // Every one of these must be empty/false for the audit to be reportable as clean. The
+  // lead re-asserts them in Phase 2 rather than trusting this summary.
+  reconcileFailedLenses: failedLenses,
+  unconfirmedDiscrepancies: unconfirmedDiscrepancies.map((d) => ({
+    lens: d.lens,
+    severity: d.severity,
+    location: d.location,
+    claim_in_report: d.claim_in_report,
+    what_json_says: d.what_json_says,
+    note: 'NOT auto-fixed — the lens did not mechanically reproduce it. Verify by hand.',
+  })),
+  clean:
+    failedLenses.length === 0 &&
+    unconfirmedDiscrepancies.length === 0 &&
+    attributionDropped.length === 0 &&
+    unreconciled.length === 0,
+  summary: report,
+}

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,10 @@ local.properties
 keystore.properties
 *.b64
 
+# Python (scripts/)
+__pycache__/
+*.pyc
+
 # OS
 .DS_Store
 Thumbs.db
@@ -34,6 +38,9 @@ Thumbs.db
 .claude/inline-artifacts/
 .claude/worktrees/
 .claude/sync-upstream/
+# Raw i18n-coverage JSON — regenerable from scripts/i18n-coverage.py, large, and the
+# committed REPORT-*.md is the durable artifact worth diffing across audits.
+.claude/skills/audit-i18n/artifacts/
 # Ephemeral runtime state from Claude Code's scheduler (per-session lock)
 .claude/scheduled_tasks.lock
 .claude/*.lock

--- a/config/l10n/i18n-allowlist.txt
+++ b/config/l10n/i18n-allowlist.txt
@@ -1,0 +1,123 @@
+# i18n suppression allowlist — consumed by scripts/i18n-coverage.py
+#
+# Suppresses individual findings from the [S] stub detector and the [H] hardcoded-literal
+# candidate detector. It does NOT affect [P] key parity: a missing or stale key is never
+# a judgment call, so there is nothing to allowlist.
+#
+# Sibling of strings-parity-baseline.txt and it follows the same discipline: SHRINK-ONLY.
+# A directive that suppresses nothing fails the run and must be deleted. Once ko finally
+# translates a key, any line covering it goes stale and the check tells you to remove it,
+# so debt can only go down.
+#
+# FORMAT — TAB-separated fields, one directive per line. Blank lines and lines whose first
+# non-space character is '#' are ignored. Matching is exact string equality: no regex, no
+# globs, no prefix matching, no normalization. That is deliberate — a reviewer must be able
+# to verify any line here by grepping for it.
+#
+#   literal<TAB><exact English base value>
+#       Suppresses every (key, locale) whose BASE value equals this string. Use only for
+#       values with no prose reading at all; prefer 'key' or 'pair'.
+#   key<TAB><module>/<key>
+#       Suppresses this stub key in every locale.
+#   pair<TAB><module>/values-<loc><TAB><key>
+#       Suppresses exactly this (key, locale). The left field intentionally mirrors the
+#       <module>/values-<loc> token used by strings-parity-baseline.txt.
+#   site<TAB><repo-relative-path>:<line>
+#       Drops one [H] hardcoded candidate. Site-keyed, never text-keyed: the same literal
+#       legitimately recurs at many sites with different verdicts.
+#   file<TAB><repo-relative-path>
+#       Drops every [H] candidate in a file. Use sparingly.
+#
+# EVERY ENTRY NEEDS A JUSTIFICATION COMMENT above it. 'the check was noisy' is not one.
+# Note that two whole classes need no entries at all, because the detector exempts them
+# mechanically: terms no locale anywhere translated (shared literals such as Bearer,
+# OAuth, JSON, MCP, SSE, HTML, Markdown, LibreChat, mermaid, shadcn/ui, X-API-Key), and
+# values carrying no translatable prose (arrows, em dashes, pure format strings).
+
+
+# =====================================================================================
+# [S] STUBS — protocol / auth-scheme literals and version patterns
+# =====================================================================================
+# 'Basic' is the HTTP auth-scheme token, sent on the wire verbatim. Only es rendered it
+# as prose ('Básica'); leaving it in English is the defensible reading.
+key	feature/agents/auth_basic
+key	feature/settings/mcp_auth_basic
+
+# 'Streamable HTTP' is the MCP transport's proper name, not a description of it.
+key	feature/settings/mcp_type_streamable_http
+
+# 'URL' is used as the field label. ar translated it ('الرابط'); the remaining locales
+# conventionally keep the acronym.
+key	feature/settings/mcp_url_label
+
+# Version sigils: 'v%1$d' and 'v%1$d/%2$d'. The only translatable atom is the letter 'v',
+# which every locale but ar keeps.
+key	feature/chat/version_number
+key	feature/chat/artifact_version
+
+# '(Gemini API)' — a product name in parentheses; there is no prose to translate.
+key	feature/settings/provider_keys_field_google_gemini_api
+
+# 'lowercase-kebab-case' is an input-format spec the user must literally type, not prose.
+key	feature/skills/skill_field_name_hint
+
+# accent_color_hex ('Hex') is deliberately NOT suppressed: ar, ja and zh all translated it
+# ('16進数', '十六进制'), so ko and ru are genuine misses, not a convention.
+
+
+# =====================================================================================
+# [S] STUBS — locale-specific conventions
+# =====================================================================================
+# Japanese UIs conventionally label the dismiss affordance 'OK' in Latin characters.
+pair	feature/skills/values-ja	skill_conflict_dismiss
+
+# zh treats 'artifact' as a loanword and keeps it Latin inside otherwise-Chinese copy —
+# see feature/settings/.../values-zh/strings.xml artifacts_section_desc, which reads
+# '直接在聊天中渲染 artifact…'. Translating only the label would be internally inconsistent.
+pair	feature/agents/values-zh	label_artifacts
+pair	feature/agents/values-zh	version_snapshot_artifacts
+pair	feature/settings/values-zh	section_artifacts
+
+
+# =====================================================================================
+# [H] HARDCODED CANDIDATES — endpoint / provider proper nouns
+# =====================================================================================
+# Endpoint display names in one when-block. These are LibreChat endpoint identifiers
+# surfaced verbatim, matching the web client. 'Custom', 'Agents' and 'Assistants' are the
+# debatable members of the block — revisit them if endpoint labels ever get localized.
+site	feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/components/ConversationItem.kt:140
+site	feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/components/ConversationItem.kt:141
+site	feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/components/ConversationItem.kt:142
+site	feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/components/ConversationItem.kt:143
+site	feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/components/ConversationItem.kt:144
+site	feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/components/ConversationItem.kt:145
+site	feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/components/ConversationItem.kt:146
+site	feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/components/ConversationItem.kt:147
+
+
+# =====================================================================================
+# [H] HARDCODED CANDIDATES — wire values and technical placeholders
+# =====================================================================================
+# '3gp' is an audio container extension chosen for the recording request, never displayed.
+site	core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/api/SpeechApi.kt:44
+
+# An interpolated image URL assembled from baseUrl + filepath, not a message.
+site	feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ToolCallParsing.kt:325
+
+# Example values shown inside input placeholders so the user can see the expected shape:
+# a header name, an OAuth scope list, and a support-address example. Translating them
+# would make them wrong.
+site	feature/agents/src/commonMain/kotlin/com/garfiec/librechat/feature/agents/components/ActionAuthConfigDialog.kt:162
+site	feature/agents/src/commonMain/kotlin/com/garfiec/librechat/feature/agents/components/ActionAuthConfigDialog.kt:230
+site	feature/agents/src/commonMain/kotlin/com/garfiec/librechat/feature/agents/components/AgentSupportContactSection.kt:64
+
+# An OpenAPI JSON skeleton rendered as a monospace placeholder. Line 228 is already
+# dropped by the prose gate ('{' prefix); 229 is its continuation line.
+site	feature/agents/src/commonMain/kotlin/com/garfiec/librechat/feature/agents/components/ActionEditorDialog.kt:229
+
+# The default value of an Exception subclass's `message` constructor parameter. Exception
+# text is out of scope by policy (the non-UI suppression drops every line containing
+# `Exception(`), but here the class header is on an earlier line so that suppression cannot
+# see it. Not a UI slot despite the `message: String = "…"` shape.
+site	core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/sse/SseHttpTransport.kt:40
+

--- a/scripts/i18n-coverage.py
+++ b/scripts/i18n-coverage.py
@@ -1,0 +1,1841 @@
+#!/usr/bin/env python3
+"""Deterministic i18n coverage checker for LibreChat Mobile.
+
+Three independent detectors over the compose-resources localization surface:
+
+  P  parity     EXACT. Per (module, locale): keys present in the English base but
+                absent from the locale ("missing"), and keys present in the locale
+                but absent from the base ("stale"). Plus structural defects: an
+                entirely absent locale strings.xml, duplicate keys inside one file,
+                unknown locale qualifiers, and <plurals>/<string-array> advisories.
+
+  S  stubs      EXACT. Keys whose locale value was never actually translated: the
+                locale value is byte-identical to the English base, the locale uses a
+                non-Latin script, and the value is pure ASCII. Shared literals
+                (brand names / acronyms nobody translated anywhere) and letterless
+                values (symbols, pure format strings) are auto-exempted mechanically.
+                Remaining judgment calls are suppressed via the allowlist.
+
+  H  hardcoded  HEURISTIC — always reported as CANDIDATES, never as defects. English
+                literals in Kotlin/Compose that never reached any strings.xml and are
+                therefore structurally invisible to parity checking. Sink-anchored
+                regexes plus a prose gate; ~98% precision, requires human triage.
+
+Determinism is the point: this script exists so a skill can re-run it and diff the
+output. Every collection is sorted, discovery is sorted-glob based, and the output
+contains no timestamps, hostnames, absolute paths, or hash-order-dependent ordering.
+Identical input produces byte-identical stdout on every run and every machine.
+The single exception is opt-in and stderr-only: I18N_COVERAGE_TRACEBACK=1 prints a
+Python traceback (with machine-absolute paths) after an unexpected hard failure.
+
+Exit codes
+----------
+  0   no findings in the selected detectors
+  bitmask, confined to the low nibble (FINDING_MASK = 15):
+    1   parity findings          (exact)
+    2   stub findings, ERROR tier (exact)
+    4   hardcoded candidates     (heuristic — triage, not a defect count)
+    8   advisories: allowlist staleness, module/locale-set drift, parser disagreement
+  16  hard failure: repo layout not recognized, no modules discovered, a module with
+      0 base keys, an unreadable/unparseable resource file, a bad CLI argument, a
+      missing explicitly-passed --allowlist, or any unexpected exception. Never
+      silently reports "0 findings".
+
+The hard-failure code shares NO bits with the finding mask (16 & 15 == 0), so
+`exit & FINDING_MASK` is 0 on every failure path and a caller that branches on the
+bitmask can never read a crash as real findings. This is asserted at import time.
+Any future finding bit must stay inside FINDING_MASK; anything above it means "the
+check did not run". stdout/stderr are reconfigured to UTF-8 at startup so an ambient
+non-UTF-8 codec cannot truncate the report mid-write.
+
+Scope
+-----
+Read-only. This script never writes to any strings.xml, never runs Gradle, and never
+compares format specifiers / placeholder counts (deliberately out of scope).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import traceback
+import xml.etree.ElementTree as ET
+from collections import Counter
+from pathlib import Path
+
+# --------------------------------------------------------------------------------------
+# Exit-code bits
+# --------------------------------------------------------------------------------------
+
+EXIT_PARITY = 1
+EXIT_STUBS = 2
+EXIT_HARDCODED = 4
+EXIT_ADVISORY = 8
+
+# Every finding bit lives inside this mask; the hard-failure code lives outside it.
+# `exit & FINDING_MASK` is therefore the finding set, on every path, including crashes.
+FINDING_MASK = EXIT_PARITY | EXIT_STUBS | EXIT_HARDCODED | EXIT_ADVISORY
+
+# Must not be 70 (EX_SOFTWARE): 0b1000110 sets the stub bit (70 & 2) and the hardcoded bit
+# (70 & 4), so a bitmask-testing caller reads a crash as exact stub findings. 16 is the
+# first bit above the finding mask.
+EXIT_HARD_FAILURE = 16
+
+if EXIT_HARD_FAILURE & FINDING_MASK:  # pragma: no cover — structural invariant
+    raise SystemExit(
+        "i18n-coverage is misconfigured: EXIT_HARD_FAILURE shares bits with FINDING_MASK, "
+        "so callers would read a hard failure as findings."
+    )
+
+# --------------------------------------------------------------------------------------
+# Tripwire expectations.
+#
+# These are deliberate, not defensive. Pure discovery hides a module whose base file was
+# accidentally deleted; pure hardcoding hides a newly added module. Asserting the
+# discovered set against the known set catches both, and the resulting advisory is the
+# signal to update this constant on purpose.
+# --------------------------------------------------------------------------------------
+
+EXPECTED_MODULES = (
+    "core/ui",
+    "feature/agents",
+    "feature/auth",
+    "feature/chat",
+    "feature/conversations",
+    "feature/files",
+    "feature/settings",
+    "feature/skills",
+    "shared",
+)
+
+EXPECTED_LOCALES = ("ar", "de", "es", "fr", "ja", "ko", "pt", "ru", "zh")
+
+# Parity findings that are defects of SHAPE rather than of a single key. They survive
+# --summary (lowest volume, highest signal) and are counted in structural_total. Named
+# once so a new kind cannot be added to the finding stream while silently missing from
+# the totals, the renderer, or the --summary filter.
+STRUCTURAL_KINDS = ("ABSENT_LOCALE_DIR", "ABSENT_LOCALE_FILE", "DUPLICATE_KEY")
+
+# Corpus floor. Discovery tripwires catch a module disappearing; this catches the corpus
+# EVAPORATING while the file tree still looks right (a bad merge, a truncating write, a
+# resource-format migration that keeps the filenames). Without it, 90 well-formed but
+# empty strings.xml files report "0 findings / ADVISORIES: none" — a clean bill of health
+# over nothing. Shrink-only, same discipline as the allowlist: a deliberate key deletion
+# means lowering this constant on purpose.
+EXPECTED_MIN_BASE_KEYS = 1213
+
+# Script class per locale. Hardcoded on purpose: the stub detector's precision rests
+# entirely on this partition, and deriving it from Unicode ranges of the tag is fragile.
+# A locale in neither set is an advisory, forcing a human decision.
+NON_LATIN_LOCALES = frozenset({"ar", "ja", "ko", "ru", "zh"})
+LATIN_LOCALES = frozenset({"de", "es", "fr", "pt"})
+
+# --------------------------------------------------------------------------------------
+# Locale-directory predicate
+# --------------------------------------------------------------------------------------
+
+# Accepts values-<lang>, values-<lang>-r<REGION> and values-b+<bcp47>.
+LOCALE_DIR_RE = re.compile(r"^values-(?:b\+[A-Za-z0-9+]+|[a-z]{2,3}(?:-r[A-Z]{2})?)$")
+
+# Android resource qualifiers that are shape-compatible with a language code but are not
+# locales. `car` is load-bearing: three lowercase letters the regex alone would accept.
+NON_LOCALE_QUALIFIERS = frozenset(
+    {
+        "night", "notnight", "land", "port", "ldrtl", "ldltr", "round", "notround",
+        "car", "desk", "watch", "television", "appliance", "vrheadset", "long",
+        "notlong", "ldpi", "mdpi", "hdpi", "xhdpi", "xxhdpi", "xxxhdpi", "nodpi",
+        "tvdpi", "anydpi",
+    }
+)
+
+
+def locale_code_of(dirname: str) -> str | None:
+    """Return the locale code for a `values-*` directory name, or None if not a locale."""
+    if not LOCALE_DIR_RE.match(dirname):
+        return None
+    suffix = dirname[len("values-") :]
+    first_token = suffix.split("-")[0]
+    if first_token in NON_LOCALE_QUALIFIERS:
+        return None
+    return suffix
+
+
+# --------------------------------------------------------------------------------------
+# Repo discovery
+# --------------------------------------------------------------------------------------
+
+
+class HardFailure(Exception):
+    """Layout/parse problem that must never be reported as a clean bill of health."""
+
+
+def find_repo_root(start: Path) -> Path:
+    for candidate in [start, *start.parents]:
+        if (candidate / "settings.gradle.kts").is_file():
+            return candidate
+    raise HardFailure(
+        f"could not locate repo root: no settings.gradle.kts found in {start} or any parent. "
+        "Run this from inside the LibreChat-Android checkout, or pass --repo-root."
+    )
+
+
+def rel(path: Path, root: Path) -> str:
+    """Repo-relative POSIX path. Absolute paths must never reach the output."""
+    return path.relative_to(root).as_posix()
+
+
+def rel_or_str(path: Path, root: Path) -> str:
+    """rel(), degrading to the basename for a path outside the repo.
+
+    Only for stderr diagnostics about a path that failed to resolve. Never used for report
+    content: an absolute path there would be machine-specific and break determinism.
+    """
+    try:
+        return rel(path, root)
+    except ValueError:
+        return f"<outside repo>/{path.name}"
+
+
+def read_text_or_fail(path: Path, relpath: str) -> str:
+    """Read UTF-8 text, converting any read/decode error into a HARD FAILURE.
+
+    A resource file this script cannot read is not "zero findings" — it is an unmeasured
+    file. Unreadable (permissions, broken symlink) and non-UTF-8 (an `encoding=` decl
+    ElementTree honours but read_text does not) both land here.
+    """
+    try:
+        return path.read_text(encoding="utf-8")
+    except UnicodeDecodeError as exc:
+        raise HardFailure(
+            f"{relpath} is not valid UTF-8 ({exc.reason} at byte {exc.start}). "
+            "Resource files must be UTF-8; a non-UTF-8 `encoding=` declaration is the "
+            "usual cause. Refusing to report this file as clean."
+        ) from exc
+    except OSError as exc:
+        raise HardFailure(
+            f"cannot read {relpath}: {exc.strerror or exc}. Refusing to report an "
+            "unreadable file as clean."
+        ) from exc
+
+
+# --------------------------------------------------------------------------------------
+# XML parsing
+# --------------------------------------------------------------------------------------
+
+
+def _element_value(el: ET.Element) -> str:
+    """Full textual value of a <string>, including any child markup, in document order.
+
+    Today no value contains child markup, so the child branch is dead — but it keeps the
+    comparison honest if <b> or <xliff:g> is ever introduced.
+    """
+    parts = [el.text or ""]
+    for child in el:
+        parts.append(ET.tostring(child, encoding="unicode"))
+    return "".join(parts)
+
+
+class ResourceFile:
+    """One parsed strings.xml.
+
+    ElementTree is used (not a regex) so XML comments and CDATA can never be miscounted
+    as keys, and attribute order / quote style cannot cause a miss.
+    """
+
+    __slots__ = (
+        "path", "relpath", "text", "ordered_keys", "values", "duplicates",
+        "plurals", "arrays", "non_translatable",
+    )
+
+    def __init__(self, path: Path, root: Path):
+        self.path = path
+        self.relpath = rel(path, root)
+        # Read once, through the fail-loud helper, and parse the decoded text: that way a
+        # read error, a decode error and a parse error all become HardFailure, and the
+        # line-number and second-opinion passes reuse this text instead of re-reading.
+        self.text = read_text_or_fail(path, self.relpath)
+        try:
+            resources = ET.fromstring(self.text)
+        except ET.ParseError as exc:
+            raise HardFailure(
+                f"malformed XML in {self.relpath}: {exc}. "
+                "Unescaped '&' or '<' in a value is the usual cause; fix the file and re-run."
+            ) from exc
+
+        self.ordered_keys: list[str] = []
+        self.values: dict[str, str] = {}
+        self.plurals: list[str] = []
+        self.arrays: list[str] = []
+        # Android's standard marker for "this string is intentionally never translated".
+        # Tracked separately so it can be excluded from parity instead of generating a
+        # phantom missing-key finding in every locale.
+        self.non_translatable: list[str] = []
+
+        for el in list(resources):
+            name = el.get("name")
+            if el.tag == "string":
+                if name is None:
+                    raise HardFailure(f"<string> without a name attribute in {self.relpath}")
+                self.ordered_keys.append(name)
+                self.values[name] = _element_value(el)
+                if (el.get("translatable") or "").strip().lower() == "false":
+                    self.non_translatable.append(name)
+            elif el.tag == "plurals":
+                if name is not None:
+                    self.plurals.append(name)
+            elif el.tag == "string-array":
+                if name is not None:
+                    self.arrays.append(name)
+
+        # Counter over the ordered list, before collapsing to a dict: set/dict-based
+        # extraction destroys duplicate information, and a duplicated key would itself
+        # mask a missing key in any count-based reconciliation.
+        counts = Counter(self.ordered_keys)
+        self.duplicates: list[str] = sorted(k for k, n in counts.items() if n > 1)
+
+    @property
+    def keys(self) -> frozenset[str]:
+        return frozenset(self.ordered_keys)
+
+    @property
+    def translatable_keys(self) -> frozenset[str]:
+        """Keys eligible for parity/stub checking: everything not marked translatable="false"."""
+        return frozenset(self.ordered_keys) - frozenset(self.non_translatable)
+
+
+# The exact regex used by the prior-art StringResourceParityTest. Run only as a SECOND
+# opinion, to report which files that guard would miscount. Never the primary parser: it
+# misses reversed attribute order and single-quoted attrs, and falsely captures
+# commented-out and CDATA-embedded <string> tags.
+LEGACY_KEY_RE = re.compile(r'<(string|plurals)\s+name="([^"]+)"')
+
+
+def legacy_keys(rf: ResourceFile) -> frozenset[str]:
+    return frozenset(m.group(2) for m in LEGACY_KEY_RE.finditer(rf.text))
+
+
+# --------------------------------------------------------------------------------------
+# Module model
+# --------------------------------------------------------------------------------------
+
+
+class Module:
+    __slots__ = ("name", "res_dir", "base", "locales", "absent_locale_files", "unknown_dirs")
+
+    def __init__(self, name: str, res_dir: Path, root: Path):
+        self.name = name
+        self.res_dir = res_dir
+        self.base = ResourceFile(res_dir / "values" / "strings.xml", root)
+        self.locales: dict[str, ResourceFile] = {}
+        self.absent_locale_files: list[str] = []
+        self.unknown_dirs: list[str] = []
+
+        for child in sorted(res_dir.iterdir()):
+            if not child.is_dir() or child.name == "values":
+                continue
+            if not child.name.startswith("values-"):
+                continue  # drawable/, font/, ... — not a string qualifier at all
+            code = locale_code_of(child.name)
+            if code is None:
+                self.unknown_dirs.append(child.name)
+                continue
+            strings = child / "strings.xml"
+            if not strings.is_file():
+                # Never `continue` silently here: that is exactly the hole that lets a
+                # whole locale be deleted while the check stays green.
+                self.absent_locale_files.append(f"{child.name}/strings.xml")
+                continue
+            self.locales[code] = ResourceFile(strings, root)
+
+
+def discover_modules(root: Path) -> list[Module]:
+    """Discover string-resource modules by globbing, at both 1- and 2-segment depths."""
+    bases: list[Path] = []
+    for pattern in (
+        "*/src/commonMain/composeResources/values/strings.xml",
+        "*/*/src/commonMain/composeResources/values/strings.xml",
+    ):
+        bases.extend(sorted(root.glob(pattern)))
+
+    modules: list[Module] = []
+    seen: set[str] = set()
+    for base in sorted(bases):
+        relpath = rel(base, root)
+        if "/upstream/" in f"/{relpath}":
+            continue
+        module_name = relpath.split("/src/")[0]
+        if module_name in seen:
+            continue
+        seen.add(module_name)
+        modules.append(Module(module_name, base.parent.parent, root))
+
+    if not modules:
+        raise HardFailure(
+            "discovered 0 string-resource modules. Expected "
+            "<module>/src/commonMain/composeResources/values/strings.xml to exist. "
+            "The localization layout has moved — this run proves nothing."
+        )
+    for module in modules:
+        # A module with 0 usable locale directories is deliberately NOT a hard failure:
+        # "this feature shipped English-only" is the question the audit exists to answer,
+        # and hard-failing here would suppress the findings for every other module too.
+        # run_parity scores it as 100% missing in every expected locale, exactly like an
+        # absent locale file.
+        #
+        # Corpus floor. A base strings.xml that parses but declares no keys means the
+        # content evaporated while the tree still looks right. Reporting that as
+        # "0 findings" would be the worst possible outcome for a check whose whole
+        # purpose is to be re-run and diffed.
+        if not module.base.ordered_keys:
+            raise HardFailure(
+                f"module {module.name} has a base strings.xml ({module.base.relpath}) that "
+                "declares 0 <string> keys. The corpus is empty or truncated — this run "
+                "proves nothing."
+            )
+    return modules
+
+
+# --------------------------------------------------------------------------------------
+# Allowlist
+# --------------------------------------------------------------------------------------
+
+ALLOWLIST_DEFAULT = "config/l10n/i18n-allowlist.txt"
+
+
+class Allowlist:
+    """Exact-equality suppression directives for the stub and hardcoded detectors.
+
+    TAB-separated, one directive per line. Blank lines and `#` comments ignored.
+
+      literal <base value>                 suppress every stub whose BASE value equals this
+      key     <module>/<key>               suppress this stub key in every locale
+      pair    <module>/values-<loc>  <key> suppress exactly this (stub key, locale)
+      site    <path>:<line>                drop this hardcoded candidate site
+      file    <path>                       drop every hardcoded candidate in this file
+
+    No regex, no globs, no prefix matching, no normalization — a reviewer must be able to
+    verify any line by grepping for it. Suppression is matched against the RAW candidate
+    set (before the mechanical auto-exemptions), so an auto-exempted row cannot make a
+    directive look stale.
+    """
+
+    __slots__ = ("path", "relpath", "literals", "keys", "pairs", "sites", "files", "used", "lines", "errors")
+
+    def __init__(self, path: Path | None, root: Path):
+        self.path = path
+        if path is None:
+            self.relpath = None
+        else:
+            try:
+                self.relpath = rel(path, root)
+            except ValueError:
+                raise HardFailure(
+                    f"--allowlist must resolve inside the repo (got {path}); paths in the report "
+                    "are repo-relative by design."
+                ) from None
+        self.literals: dict[str, int] = {}
+        self.keys: dict[str, int] = {}
+        self.pairs: dict[tuple[str, str], int] = {}
+        self.sites: dict[str, int] = {}
+        self.files: dict[str, int] = {}
+        self.lines: dict[int, str] = {}
+        self.errors: list[str] = []
+        self.used: set[int] = set()
+
+        if path is None or not path.is_file():
+            return
+
+        for lineno, raw in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+            if not raw.strip() or raw.lstrip().startswith("#"):
+                continue
+            fields = raw.split("\t")
+            kind = fields[0].strip()
+            if kind == "literal" and len(fields) == 2:
+                self.literals[fields[1]] = lineno
+            elif kind == "key" and len(fields) == 2:
+                self.keys[fields[1].strip()] = lineno
+            elif kind == "pair" and len(fields) == 3:
+                self.pairs[(fields[1].strip(), fields[2].strip())] = lineno
+            elif kind == "site" and len(fields) == 2:
+                self.sites[fields[1].strip()] = lineno
+            elif kind == "file" and len(fields) == 2:
+                self.files[fields[1].strip()] = lineno
+            else:
+                self.errors.append(
+                    f"{self.relpath}:{lineno}: unrecognized directive (fields must be "
+                    f"TAB-separated): {raw!r}"
+                )
+                continue
+            # Only successfully parsed directives are staleness-tracked, so a malformed
+            # line is reported once (as unrecognized) rather than twice (also as stale).
+            self.lines[lineno] = raw
+
+    # Both matchers mark EVERY directive that covers the row as used, then report the
+    # first. Marking only the first makes any overlapping directive look stale — one broad
+    # `file` directive would strand every `site` directive for the same file — and the
+    # shrink-only rule ("a stale directive must be deleted") would then instruct users to
+    # delete live suppressions along with their written justifications.
+
+    def match_stub(self, module: str, locale: str, key: str, base_value: str) -> int | None:
+        matched = [
+            candidate
+            for candidate in (
+                self.literals.get(base_value),
+                self.keys.get(f"{module}/{key}"),
+                self.pairs.get((f"{module}/values-{locale}", key)),
+            )
+            if candidate is not None
+        ]
+        self.used.update(matched)
+        return matched[0] if matched else None
+
+    def match_site(self, relpath: str, line: int) -> int | None:
+        matched = [
+            candidate
+            for candidate in (self.files.get(relpath), self.sites.get(f"{relpath}:{line}"))
+            if candidate is not None
+        ]
+        self.used.update(matched)
+        return matched[0] if matched else None
+
+    def stale(self) -> list[str]:
+        """Directives that matched nothing. Shrink-only: dead lines must be deleted."""
+        return [
+            f"{self.relpath}:{lineno}: {self.lines[lineno]}"
+            for lineno in sorted(set(self.lines) - self.used)
+        ]
+
+
+# --------------------------------------------------------------------------------------
+# Detector P — parity (EXACT)
+# --------------------------------------------------------------------------------------
+
+
+def run_parity(modules: list[Module], root: Path) -> dict:
+    findings: list[dict] = []
+    advisories: list[str] = []
+    per_module: list[dict] = []
+
+    discovered = tuple(sorted(m.name for m in modules))
+    if discovered != tuple(sorted(EXPECTED_MODULES)):
+        added = sorted(set(discovered) - set(EXPECTED_MODULES))
+        removed = sorted(set(EXPECTED_MODULES) - set(discovered))
+        advisories.append(
+            "MODULE_SET_CHANGED: discovered string-resource modules differ from the expected set. "
+            f"added={added} removed={removed}. Update EXPECTED_MODULES in scripts/i18n-coverage.py "
+            "deliberately — a silently added module means its drift goes unmeasured."
+        )
+    else:
+        # Only meaningful when the module set matches; otherwise the totals are not
+        # comparable and the advisory would be noise on every fixture.
+        live_base_keys = sum(len(m.base.keys) for m in modules)
+        if live_base_keys < EXPECTED_MIN_BASE_KEYS:
+            advisories.append(
+                f"CORPUS_SHRANK: total base keys across the expected modules is {live_base_keys}, "
+                f"below the recorded floor of {EXPECTED_MIN_BASE_KEYS}. Either the corpus lost "
+                "content (truncation / bad merge) or keys were deliberately deleted — in the "
+                "latter case lower EXPECTED_MIN_BASE_KEYS in scripts/i18n-coverage.py on purpose."
+            )
+
+    for module in modules:
+        # translatable="false" declares a key is intentionally never localized, so it must
+        # not be scored as missing in every locale. Excluded from `base_keys` (missing) and
+        # tolerated in a locale file (not stale), with an advisory so the exclusion is
+        # auditable rather than invisible.
+        non_translatable = frozenset(module.base.non_translatable)
+        if non_translatable:
+            advisories.append(
+                f"NON_TRANSLATABLE_KEYS: {module.base.relpath} declares "
+                f"{len(non_translatable)} translatable=\"false\" key(s) "
+                f"{sorted(non_translatable)}, excluded from parity and from stub detection."
+            )
+        base_keys = module.base.keys - non_translatable
+
+        for dirname in sorted(module.unknown_dirs):
+            advisories.append(
+                f"UNKNOWN_LOCALE_DIR: {module.name}/{dirname} looks like a locale qualifier but is "
+                "not a recognized language code. Not scored as a locale."
+            )
+        absent_locales: list[str] = []
+        for missing_file in sorted(module.absent_locale_files):
+            absent_locale = missing_file.split("/")[0][len("values-") :]
+            absent_locales.append(absent_locale)
+            findings.append(
+                {
+                    "kind": "ABSENT_LOCALE_FILE",
+                    "module": module.name,
+                    "locale": absent_locale,
+                    "detail": f"{rel(module.res_dir, root)}/{missing_file} does not exist; "
+                    f"all {len(base_keys)} base keys are reported missing below",
+                }
+            )
+
+        locales = sorted(module.locales)
+        # An expected locale with no values-<loc>/ directory at all is scored the same as
+        # one whose strings.xml was deleted: 100% missing, as an exact structural finding.
+        # An advisory alone would be an under-report with the same shape as the count-based
+        # comparison this tool exists to replace: a deleted locale directory would produce
+        # a warning and ZERO missing rows, leaving its drift invisible in every total. This
+        # is also what makes a brand-new English-only module measurable.
+        expected_missing = sorted(set(EXPECTED_LOCALES) - set(locales) - set(absent_locales))
+        for absent_dir_locale in expected_missing:
+            absent_locales.append(absent_dir_locale)
+            findings.append(
+                {
+                    "kind": "ABSENT_LOCALE_DIR",
+                    "module": module.name,
+                    "locale": absent_dir_locale,
+                    "detail": f"{rel(module.res_dir, root)}/values-{absent_dir_locale}/ does not "
+                    f"exist; all {len(base_keys)} base keys are reported missing below",
+                }
+            )
+        if expected_missing:
+            advisories.append(
+                f"LOCALE_SET_INCOMPLETE: {module.name} is missing locale(s) {expected_missing} "
+                f"out of the expected {list(EXPECTED_LOCALES)}. Scored as 100% missing."
+            )
+        unexpected = sorted(set(locales) - set(EXPECTED_LOCALES))
+        if unexpected:
+            advisories.append(
+                f"UNEXPECTED_LOCALE: {module.name} ships locale(s) {unexpected} not in the expected "
+                f"set {list(EXPECTED_LOCALES)}. Classify them in NON_LATIN_LOCALES/LATIN_LOCALES."
+            )
+
+        for dup in module.base.duplicates:
+            findings.append(
+                {"kind": "DUPLICATE_KEY", "module": module.name, "locale": None,
+                 "key": dup, "detail": f"{module.base.relpath} declares '{dup}' more than once"}
+            )
+
+        missing_sets: dict[str, frozenset[str]] = {}
+        stale_sets: dict[str, frozenset[str]] = {}
+
+        # An absent locale file is 100% missing, not zero findings, and it is scored
+        # alongside the present locales so the per-module table and the TOTAL agree. The
+        # prior-art guard test `continue`s here instead, which is what would let a whole
+        # locale be deleted while the check stayed green.
+        for locale in sorted(absent_locales):
+            missing_sets[locale] = frozenset(base_keys)
+            stale_sets[locale] = frozenset()
+            for key in sorted(base_keys):
+                findings.append({"kind": "missing", "module": module.name, "locale": locale, "key": key})
+
+        for locale in locales:
+            lf = module.locales[locale]
+            for dup in lf.duplicates:
+                findings.append(
+                    {"kind": "DUPLICATE_KEY", "module": module.name, "locale": locale,
+                     "key": dup, "detail": f"{lf.relpath} declares '{dup}' more than once"}
+                )
+            missing = frozenset(base_keys - lf.keys)
+            # Compared against the FULL base key set, so a locale that happens to carry a
+            # translatable="false" key is not reported as stale for doing so.
+            stale = frozenset(lf.keys - module.base.keys)
+            missing_sets[locale] = missing
+            stale_sets[locale] = stale
+            for key in sorted(missing):
+                findings.append({"kind": "missing", "module": module.name, "locale": locale, "key": key})
+            for key in sorted(stale):
+                findings.append({"kind": "stale", "module": module.name, "locale": locale, "key": key})
+
+            if lf.plurals or lf.arrays:
+                advisories.append(
+                    f"NON_STRING_RESOURCE: {lf.relpath} contains "
+                    f"{len(lf.plurals)} <plurals> / {len(lf.arrays)} <string-array>. "
+                    "Parity for those forms is NOT checked, and <string-array> is invisible to "
+                    "StringResourceParityTest's regex."
+                )
+        if module.base.plurals or module.base.arrays:
+            advisories.append(
+                f"NON_STRING_RESOURCE: {module.base.relpath} contains "
+                f"{len(module.base.plurals)} <plurals> / {len(module.base.arrays)} <string-array>. "
+                "Parity for those forms is NOT checked."
+            )
+
+        # Second-opinion parse. Reports which files the prior-art guard test would
+        # miscount, without this script re-litigating parity through a regex.
+        for rf in [module.base] + [module.locales[loc] for loc in locales]:
+            regex_keys = legacy_keys(rf)
+            if regex_keys != rf.keys:
+                only_regex = sorted(regex_keys - rf.keys)
+                only_xml = sorted(rf.keys - regex_keys)
+                advisories.append(
+                    f"PARSER_DISAGREEMENT: {rf.relpath} — StringResourceParityTest's regex sees "
+                    f"keys the XML parser does not ({only_regex}) and/or misses keys it should see "
+                    f"({only_xml}). That guard would miscount this file."
+                )
+
+        scored = sorted(missing_sets)
+        distinct_missing = len({missing_sets[loc] for loc in scored})
+        distinct_stale = len({stale_sets[loc] for loc in scored})
+        uniform = distinct_missing <= 1 and distinct_stale <= 1
+        per_module.append(
+            {
+                "module": module.name,
+                "base_keys": len(base_keys),
+                "non_translatable_keys": sorted(non_translatable),
+                "locales": locales,
+                "absent_locales": sorted(absent_locales),
+                "missing_total": sum(len(missing_sets[loc]) for loc in scored),
+                "stale_total": sum(len(stale_sets[loc]) for loc in scored),
+                "distinct_missing_keys": sorted(set().union(*missing_sets.values()) if scored else set()),
+                "distinct_stale_keys": sorted(set().union(*stale_sets.values()) if scored else set()),
+                "uniform_across_locales": uniform,
+                # Populated ONLY when drift is non-uniform. When it is uniform the collapsed
+                # distinct_* lists above are lossless (that is what `uniform` asserts), so
+                # duplicating them per locale would just double the report for no signal.
+                # When it is NOT uniform the collapsed lists are a union over locales and
+                # would misstate both the scope and the affected locale, so the renderer
+                # must use these instead.
+                "missing_by_locale": (
+                    {} if uniform else {loc: sorted(missing_sets[loc]) for loc in scored if missing_sets[loc]}
+                ),
+                "stale_by_locale": (
+                    {} if uniform else {loc: sorted(stale_sets[loc]) for loc in scored if stale_sets[loc]}
+                ),
+            }
+        )
+
+    return {
+        # Self-describing for machine consumers: parity is a set operation over declared
+        # resources, so every finding is a proven defect, not a candidate.
+        "confidence": "exact",
+        "per_module": per_module,
+        "findings": findings,
+        "advisories": sorted(set(advisories)),
+        "missing_total": sum(1 for f in findings if f["kind"] == "missing"),
+        "stale_total": sum(1 for f in findings if f["kind"] == "stale"),
+        "structural_total": sum(1 for f in findings if f["kind"] in STRUCTURAL_KINDS),
+    }
+
+
+def android_res_note(root: Path) -> dict:
+    """Android platform res/ is a separate surface, deliberately outside parity math.
+
+    Folding it in would fabricate nine phantom 'entire locale missing' failures; ignoring
+    it entirely would hide that its strings are untranslated.
+    """
+    values = root / "app" / "src" / "main" / "res" / "values" / "strings.xml"
+    if not values.is_file():
+        return {"present": False}
+    rf = ResourceFile(values, root)
+    res_dir = values.parent.parent
+    locale_dirs = sorted(
+        d.name
+        for d in sorted(res_dir.iterdir())
+        if d.is_dir() and d.name.startswith("values-") and locale_code_of(d.name) and (d / "strings.xml").is_file()
+    )
+    return {
+        "present": True,
+        "path": rf.relpath,
+        "keys": sorted(rf.keys),
+        "locale_dirs_with_strings": locale_dirs,
+    }
+
+
+# --------------------------------------------------------------------------------------
+# Detector S — untranslated stubs (EXACT)
+# --------------------------------------------------------------------------------------
+
+FORMAT_SPEC_RE = re.compile(r"%(\d+\$)?[a-zA-Z]|%%")
+LETTER_RE = re.compile(r"[A-Za-z]")
+STRING_LINE_RE = re.compile(r'<string\s+name="([^"]+)"')
+NEAR_IDENTICAL_STRIP_RE = re.compile(r"[\s.:!?…]+")
+
+
+def is_ascii(value: str) -> bool:
+    return all(ord(ch) < 128 for ch in value)
+
+
+def is_letterless(base_value: str) -> bool:
+    """True when the value carries no translatable prose once format specifiers are removed.
+
+    This inspects format specifiers ONLY to decide whether prose exists. It never compares
+    specifier sets or counts between base and locale — that is explicitly out of scope.
+    """
+    return LETTER_RE.search(FORMAT_SPEC_RE.sub("", base_value)) is None
+
+
+def key_line_numbers(rf: ResourceFile) -> dict[str, int]:
+    out: dict[str, int] = {}
+    for lineno, line in enumerate(rf.text.splitlines(), start=1):
+        m = STRING_LINE_RE.search(line)
+        if m and m.group(1) not in out:
+            out[m.group(1)] = lineno
+    return out
+
+
+def run_stubs(modules: list[Module], allowlist: Allowlist, include_latin: bool, near_identical: bool) -> dict:
+    errors: list[dict] = []
+    review: list[dict] = []
+    suppressed: list[dict] = []
+    auto_exempt: list[dict] = []
+    info_latin: list[dict] = []
+    info_near: list[dict] = []
+    runs: list[dict] = []
+    advisories: list[str] = []
+
+    for module in modules:
+        base = module.base
+        locales = sorted(module.locales)
+        # translatable="false" says this value is deliberately identical everywhere, which
+        # is precisely the stub predicate — so scoring it would be a guaranteed FP.
+        non_translatable = frozenset(base.non_translatable)
+
+        unclassified = sorted(set(locales) - NON_LATIN_LOCALES - LATIN_LOCALES)
+        if unclassified:
+            advisories.append(
+                f"UNCLASSIFIED_SCRIPT: {module.name} locale(s) {unclassified} are in neither "
+                "NON_LATIN_LOCALES nor LATIN_LOCALES. Stub detection SKIPPED for them — classify "
+                "them in scripts/i18n-coverage.py before trusting this section."
+            )
+
+        for key in sorted(base.keys - non_translatable):
+            base_value = base.values[key]
+            present = [loc for loc in locales if key in module.locales[loc].values]
+            if not present:
+                continue
+            identical = [loc for loc in present if module.locales[loc].values[key] == base_value]
+            translated_by = [loc for loc in present if module.locales[loc].values[key] != base_value]
+
+            # AUTO-EXEMPT A: no locale anywhere translated this term -> shared literal.
+            shared_literal = len(identical) == len(present)
+            # AUTO-EXEMPT B: nothing translatable in the value at all.
+            letterless = is_letterless(base_value)
+
+            for locale in identical:
+                if locale not in NON_LATIN_LOCALES:
+                    if include_latin and locale in LATIN_LOCALES:
+                        info_latin.append(
+                            {"module": module.name, "locale": locale, "key": key, "value": base_value}
+                        )
+                    continue
+                value = module.locales[locale].values[key]
+                if not is_ascii(value):
+                    continue
+
+                row = {
+                    "module": module.name,
+                    "locale": locale,
+                    "key": key,
+                    "value": value,
+                    "translated_by": sorted(translated_by),
+                }
+
+                # Allowlist is matched against the RAW hit set, before the auto-exemptions,
+                # so an auto-exempted row can never make a directive look stale.
+                hit = allowlist.match_stub(module.name, locale, key, base_value)
+                if hit is not None:
+                    suppressed.append({**row, "allowlist_line": hit})
+                    continue
+                if shared_literal:
+                    auto_exempt.append({**row, "rule": "shared-literal"})
+                    continue
+                if letterless:
+                    auto_exempt.append({**row, "rule": "letterless-value"})
+                    continue
+                if len(translated_by) >= 4:
+                    errors.append(row)
+                else:
+                    review.append(row)
+
+        # CORROBORATOR: contiguous runs of >=3 untranslated keys by source line. Direct
+        # evidence a translator skipped a region. Non-Latin only — extended to Latin it is
+        # 100% false (correct French/German words that coincide with English).
+        for locale in locales:
+            if locale not in NON_LATIN_LOCALES:
+                continue
+            lf = module.locales[locale]
+            lines = key_line_numbers(lf)
+            run: list[str] = []
+            for key in lf.ordered_keys:
+                hit = (
+                    key in base.values
+                    and key not in non_translatable
+                    and lf.values[key] == base.values[key]
+                    and is_ascii(lf.values[key])
+                )
+                if hit:
+                    run.append(key)
+                    continue
+                if len(run) >= 3:
+                    runs.append(_run_record(module.name, locale, lf, run, lines))
+                run = []
+            if len(run) >= 3:
+                runs.append(_run_record(module.name, locale, lf, run, lines))
+
+        if near_identical:
+            for key in sorted(base.keys - non_translatable):
+                base_value = base.values[key]
+                norm_base = NEAR_IDENTICAL_STRIP_RE.sub("", base_value).casefold()
+                for locale in locales:
+                    lf = module.locales[locale]
+                    if key not in lf.values:
+                        continue
+                    value = lf.values[key]
+                    if value == base_value:
+                        continue
+                    if NEAR_IDENTICAL_STRIP_RE.sub("", value).casefold() == norm_base:
+                        info_near.append(
+                            {"module": module.name, "locale": locale, "key": key,
+                             "base": base_value, "locale_value": value}
+                        )
+
+    sort_key = lambda r: (r["module"], r["locale"], r["key"])  # noqa: E731
+    return {
+        # Byte-identity of a declared value is a proven fact, not a guess.
+        "confidence": "exact",
+        # Counts are stored explicitly, not derived from the lists, so --summary can drop
+        # the per-item detail without silently changing the reported totals.
+        "counts": {
+            "errors": len(errors),
+            "error_keys": len({(r["module"], r["key"]) for r in errors}),
+            "errors_per_locale": {k: v for k, v in sorted(Counter(r["locale"] for r in errors).items())},
+            "review": len(review),
+            "review_keys": len({(r["module"], r["key"]) for r in review}),
+            "suppressed": len(suppressed),
+            "auto_exempt_shared_literal": sum(1 for r in auto_exempt if r["rule"] == "shared-literal"),
+            "auto_exempt_letterless": sum(1 for r in auto_exempt if r["rule"] == "letterless-value"),
+            "runs": len(runs),
+            "info_latin": len(info_latin),
+            "info_near_identical": len(info_near),
+        },
+        "errors": sorted(errors, key=sort_key),
+        "review": sorted(review, key=sort_key),
+        "suppressed": sorted(suppressed, key=sort_key),
+        "auto_exempt": sorted(auto_exempt, key=lambda r: (r["rule"], r["module"], r["locale"], r["key"])),
+        "runs": sorted(runs, key=lambda r: (r["module"], r["locale"], r["first_line"])),
+        "info_latin": sorted(info_latin, key=sort_key),
+        "info_near_identical": sorted(info_near, key=sort_key),
+        "advisories": sorted(set(advisories)),
+    }
+
+
+def _run_record(module: str, locale: str, lf: ResourceFile, run: list[str], lines: dict[str, int]) -> dict:
+    first = min(lines.get(k, 0) for k in run)
+    last = max(lines.get(k, 0) for k in run)
+    return {
+        "module": module,
+        "locale": locale,
+        "file": lf.relpath,
+        "first_line": first,
+        "last_line": last,
+        "length": len(run),
+        "keys": list(run),
+    }
+
+
+# --------------------------------------------------------------------------------------
+# Detector H — unextracted literals (HEURISTIC, candidates only)
+# --------------------------------------------------------------------------------------
+
+H_PATH_EXCLUDE = re.compile(
+    r"(^|/)(build|upstream|\.git|\.gradle|iosApp|detekt-rules|build-logic|scripts|docs|config)(/|$)"
+    r"|/src/(androidTest|androidUnitTest|androidInstrumentedTest|commonTest|iosTest|jvmTest|test)/"
+    r"|(Test|Tests|Fake|Fakes|Preview|Previews)\.kt$"
+    r"|/generated/"
+    r"|/composeResources/"
+    r"|(^|/)core/logging/"
+    r"|(CrashReporting|ExceptionHandler|LibreChatApplication)[A-Za-z.]*\.kt$"
+)
+
+# The single most important suppression: the repo logs through core/logging's LogHelper
+# exposed as `Logger`/`log` with a trailing lambda. 263 lines. There is no Timber.
+H_SUPPRESS_LOGGING = re.compile(r"\b(Logger|log|logger)\s*\.\s*[a-z]+\s*(\([^)]*\))?\s*\{")
+
+H_SUPPRESS_NON_UI = re.compile(
+    # The lookbehind on Error( is load-bearing: unanchored, `Error\(\s*"` also matches the
+    # tail of `setError("…")` / `showError("…")` and suppresses the WHOLE line before
+    # H_SINKS runs, silently shadowing two sinks the `sink_call` rule explicitly names and
+    # hiding the user-facing error banners the detector is meant to find. Match only a bare
+    # constructor call (`throw Error("…")`), never a method whose name ends in Error.
+    r"\bthrow\b|Exception\(|(?<![A-Za-z0-9_])Error\(\s*\"|require\(|requireNotNull"
+    r"|check\(|checkNotNull|\berror\("
+    r"|testTag\(|named\(\"|[Pp]referencesKey\("
+    r"|@SerialName|@Suppress|@OptIn|@SuppressLint|@Deprecated|@Test"
+    r"|Regex\(|\.toRegex\("
+    r"|\bheader\(|headers\.|ContentType\.|\bappendPathSegments\("
+    r"|buildJsonObject|putJsonObject|\bput\(\"|jsonPrimitive"
+    r"|rememberInfiniteTransition|animate[A-Za-z]*AsState|updateTransition|\bCrossfade\("
+    r"|^\s*(//|\*|/\*)"
+)
+
+_LIT = r'"((?:[^"\\\n]|\\.)*)"'
+
+# An optional Kotlin type annotation between the slot name and `=`, so a composable's
+# rendered DEFAULT (`verifyLabel: String = "Verify"`) is caught, not just a call-site
+# argument.
+_TYPE_ANN = r"(?:\s*:\s*[A-Za-z_][A-Za-z0-9_.]*[?]?(?:<[^=>\n]*>)?[?]?)?"
+
+# camelCase-suffixed slot names (`backupCodeLabel`, `dialogTitle`, `stateDescription`) are
+# as user-facing as the bare names, and a closed bare-name list silently misses them.
+_SLOT_SUFFIX = r"[A-Za-z]*(?:Label|Title|Text|Description|Hint|Placeholder|Headline|Subtitle)"
+
+# Trial order is fixed so rule attribution is reproducible run to run. content_desc is
+# tried before ui_param so an accessibility slot keeps its own family even though the
+# relaxed ui_param name pattern would also match it.
+H_SINKS: tuple[tuple[str, re.Pattern[str], re.Pattern[str] | None], ...] = (
+    ("text_call", re.compile(r"(?<![A-Za-z0-9_.])Text\(\s*(?:text\s*=\s*)?" + _LIT), None),
+    (
+        "content_desc",
+        re.compile(
+            r"(?<![A-Za-z0-9_])(?:contentDescription|stateDescription)"
+            + _TYPE_ANN + r"\s*=\s*" + _LIT
+        ),
+        None,
+    ),
+    (
+        "ui_param",
+        re.compile(
+            r"(?<![A-Za-z0-9_])(?:" + _SLOT_SUFFIX
+            + r"|label|placeholder|title|text|description|subtitle|hint|headline)"
+            + _TYPE_ANN + r"\s*=\s*" + _LIT
+        ),
+        None,
+    ),
+    (
+        "state_error",
+        re.compile(
+            r"(?<![A-Za-z0-9_])(?:error|errorMessage|message|snackbarMessage|toastMessage)"
+            + _TYPE_ANN + r"\s*=\s*" + _LIT
+        ),
+        None,
+    ),
+    # The guard is load-bearing: unguarded, `?: "lit"` matches 334 lines of URL/path/default
+    # fallbacks; guarded it is 118 genuine `error = result.message ?: "Failed to …"` sites.
+    # `$` stands in for the newline terminator: the literal is frequently the last thing on
+    # its line, and matching is done line-by-line so no newline character is present.
+    ("elvis_error", re.compile(r"\?:\s*" + _LIT + r"\s*(?:[,)]|$)"), re.compile(r"\b(error|errorMessage|message)\b")),
+    # Project-specific user-facing sinks. A closed list is a recall hole, so every name
+    # here is a grep-verified in-repo sink: `toast()` is core/ui's Android helper,
+    # `fail()` reaches handle.setError via VoiceInputDelegate, `copyToClipboard()`'s second
+    # argument is the clipboard label the OS paste UI shows, `onComplete(ok, message)` is
+    # the export/share result channel, and `errors.add()` feeds ActionEditorDialog's
+    # validation list.
+    (
+        "sink_call",
+        re.compile(
+            r"(?<![A-Za-z0-9_])(?:setError|failStart|showError|showMessage|showToast"
+            r"|showSnackbar|makeText|toast|fail|copyToClipboard|onComplete|errors\.add)\s*\("
+            r"[^\"\n]*" + _LIT
+        ),
+        None,
+    ),
+    ("when_branch", re.compile(r"->\s*" + _LIT + r"\s*$"), None),
+)
+
+# Continuation-window openers: a line that opens a user-facing sink but whose literal is on
+# a later physical line. `->$` and `<slot> = if` are included so a `when`/`if` branch whose
+# literal wrapped onto the next line is still reported, instead of at no line at all.
+H_CONT_OPEN_TRAILING = re.compile(
+    r"(contentDescription\s*=|(?<![A-Za-z0-9_.])Text\(|showSnackbar\(|makeText\(|setError\("
+    r"|failStart\(|\btext\s*=|->)$"
+)
+H_CONT_OPEN_IF = re.compile(
+    r"(?:contentDescription|stateDescription|title|label|description|text|message|error)"
+    r"\s*=\s*if\b"
+)
+H_CONT_LITERAL = re.compile(r"^\s*" + _LIT + r"\s*,?\s*$")
+
+# Enum constructor display labels: `VIEW_ONLY("View only")`. Handled outside H_SINKS
+# because the decision needs BOTH captures — a SCREAMING_SNAKE constant whose literal is
+# byte-identical to its own name is a wire token (`USE("USE")`, `MCP_SERVERS("MCP_SERVERS")`),
+# not a label, and dropping those is what makes this rule clean.
+H_ENUM_LABEL = re.compile(r"^\s*([A-Z][A-Z0-9_]*)\s*\(\s*" + _LIT)
+
+H_INTERP_BRACE = re.compile(r"\$\{[^}]*\}")
+H_INTERP_BARE = re.compile(r"\$[A-Za-z_][A-Za-z0-9_]*")
+H_MIME = re.compile(r"^[a-z0-9]+/[a-z0-9.+\-]+$")
+# Any URI scheme, not just http(s): the deep-link scheme `librechat://` and `prompt://`
+# are addresses, never prose. Exactly 2 rows, both verified non-prose, 0 collateral.
+H_URI_SCHEME = re.compile(r"^[a-z][a-z0-9+.\-]*://")
+H_CAMEL_HUMPS = re.compile(r"^(?:[A-Z][a-z0-9]*){2,}$")
+H_DOTTED = re.compile(r"^[a-z0-9]+(?:[._\-][a-z0-9]+)+$")
+H_LOWER_CAMEL = re.compile(r"^[a-z][a-zA-Z0-9]*$")
+H_CONSTANT_CASE = re.compile(r"^[A-Z][A-Z_0-9]+$")
+
+
+def h_prose_gate(literal: str) -> bool:
+    """True when a captured literal plausibly reads as user-facing prose."""
+    text = literal.strip()
+    if len(text) < 2:
+        return False
+    if not LETTER_RE.search(text):
+        return False
+    residue = H_INTERP_BARE.sub("", H_INTERP_BRACE.sub("", text))
+    if not re.search(r"[A-Za-z]{2}", residue):
+        return False
+    if H_URI_SCHEME.match(text):
+        return False
+    if text.startswith(("/", ".", "@", "#", "<", "{")):
+        return False
+    if "::" in text:
+        return False
+    if H_MIME.match(text):
+        return False
+    if " " not in text:
+        # A spaceless multi-hump CamelCase / dotted / all-lowercase token is an identifier
+        # (animation labels, wire enum values, file extensions, persisted preference
+        # values); a single CAPITALIZED word is UI text ("Back", "OK").
+        #
+        # The all-lowercase clause is deliberately unconditional. Relaxing it to "length
+        # >= 5 or contains a digit" — so real lowercase UI words like "now" survive — was
+        # measured on this corpus: it admits 2 true positives (TimestampFormatter's "now"
+        # on both platforms) and 48 false positives (image/audio/code file extensions,
+        # MCP transport tokens, export-format tokens, DataStore enum values such as
+        # "off"/"top"/"left"/"fill"/"none"). No lexical rule separates "now" from "off",
+        # so recall here is traded away on purpose; see the declared recall limits.
+        if H_CAMEL_HUMPS.match(text) or H_DOTTED.match(text) or H_LOWER_CAMEL.match(text):
+            return False
+    if H_CONSTANT_CASE.match(text) and "_" in text:
+        return False
+    return True
+
+
+H_SCAN_ROOTS = ("shared", "core", "feature", "app")
+
+# Re-derived by triaging the CURRENT output, not carried forward from an earlier
+# calibration. Every FP class named here is enumerable — a reader can grep the stated
+# file/rule and count the rows. Classes that a gate already removes are NOT listed: naming
+# a class that contributes 0 rows makes the precision claim unauditable.
+# The denominator is the triage sample size — a fact about when the triage happened — and
+# is deliberately kept separate from the live `total`. Never inline a row count into the
+# estimate text: a later detector change leaves a precision claim about a count that no
+# longer exists, with nothing to flag the drift.
+H_PRECISION_TRIAGED_TOTAL = 536
+H_PRECISION_ESTIMATE = (
+    f"~98% (8 enumerated false positives + ~8 debatable, triaged over "
+    f"{H_PRECISION_TRIAGED_TOTAL} rows; compare against the live `total` field — if they "
+    f"differ, the detector changed and this estimate is unverified)"
+)
+
+# A @Preview composable's body is throwaway sample data, not shipped UI. The path exclusion
+# only drops files NAMED *Preview.kt; without this, every @Preview function living inside
+# its own component file is scanned — 21 false positives in core/ui alone.
+H_PREVIEW_ANNOTATION = re.compile(r"^\s*@Preview\w*\b")
+H_FUN_DECL = re.compile(r"^\s*(?:@\w+(?:\([^)]*\))?\s+)*(?:private |internal |public )?fun\b")
+H_TOP_LEVEL_DECL = re.compile(
+    r"^(?:@|(?:private |internal |public |expect |actual )*"
+    r"(?:fun|val|var|class|object|interface|enum|data|sealed|typealias)\b)"
+)
+
+
+def preview_line_ranges(lines: list[str]) -> list[tuple[int, int]]:
+    """1-based inclusive line ranges of top-level functions annotated @Preview.
+
+    Mechanical: no allowlist entry and no human judgment. A top-level Kotlin function body
+    closes with `}` in column 0; if a top-level declaration starts first (an
+    expression-bodied preview), the range ends there instead so it cannot swallow the file.
+    """
+    ranges: list[tuple[int, int]] = []
+    n = len(lines)
+    i = 0
+    while i < n:
+        if not H_PREVIEW_ANNOTATION.match(lines[i]):
+            i += 1
+            continue
+        start = i
+        # Skip the remaining annotation lines (@Composable, more @Preview*, ...).
+        fun_line = None
+        for j in range(i, min(i + 12, n)):
+            if H_FUN_DECL.match(lines[j]):
+                fun_line = j
+                break
+        if fun_line is None:
+            i += 1
+            continue
+        end = n - 1
+        for k in range(fun_line + 1, n):
+            if lines[k] == "}":
+                end = k
+                break
+            if H_TOP_LEVEL_DECL.match(lines[k]):
+                end = k - 1
+                break
+        ranges.append((start + 1, end + 1))
+        i = end + 1
+    return ranges
+
+
+def module_of(relpath: str) -> str:
+    """Gradle module id for a source path, split on the /src/ boundary.
+
+    Must agree with discover_modules (which splits base strings.xml paths the same way),
+    because [P]/[S] and [H] totals are joined per module by this string. Splitting on path
+    SEGMENTS instead yields 'shared/src' and 'app/src' for single-segment modules — ids
+    that appear in no other detector's table, so those candidates drop silently out of any
+    per-module sizing.
+    """
+    return relpath.split("/src/")[0] if "/src/" in relpath else relpath
+
+
+def run_hardcoded(root: Path, allowlist: Allowlist) -> dict:
+    candidates: list[dict] = []
+    suppressed: list[dict] = []
+    unreadable: list[str] = []
+
+    files: list[Path] = []
+    for scan_root in H_SCAN_ROOTS:
+        base = root / scan_root
+        if not base.is_dir():
+            continue
+        files.extend(sorted(base.rglob("*.kt")))
+
+    for path in sorted(files):
+        relpath = rel(path, root)
+        if H_PATH_EXCLUDE.search(relpath):
+            continue
+        try:
+            lines = path.read_text(encoding="utf-8").splitlines()
+        except (OSError, UnicodeDecodeError):
+            # Heuristic detector, so an odd source file is an advisory rather than a hard
+            # failure — but it is never silent: an unscanned file is unmeasured recall.
+            unreadable.append(relpath)
+            continue
+
+        preview_ranges = preview_line_ranges(lines)
+
+        window = 0
+        for lineno, line in enumerate(lines, start=1):
+            if H_SUPPRESS_LOGGING.search(line) or H_SUPPRESS_NON_UI.search(line):
+                window = 0
+                continue
+
+            hits: list[tuple[str, str]] = []
+            for rule, pattern, guard in H_SINKS:
+                if guard is not None and not guard.search(line):
+                    continue
+                for m in pattern.finditer(line):
+                    hits.append((rule, m.group(1)))
+
+            enum_m = H_ENUM_LABEL.match(line)
+            if enum_m is not None and enum_m.group(1) != enum_m.group(2):
+                hits.append(("enum_label", enum_m.group(2)))
+
+            if window > 0:
+                m = H_CONT_LITERAL.match(line)
+                if m:
+                    hits.append(("continuation", m.group(1)))
+
+            in_preview = any(a <= lineno <= b for a, b in preview_ranges)
+
+            seen_literals: set[str] = set()
+            for rule, literal in hits:
+                if literal in seen_literals:
+                    continue
+                seen_literals.add(literal)
+                # A nested Kotlin string template ("... ${if (x) \"a\" else \"b\"}") ends the
+                # capture at the inner quote, so the printed literal would not exist in the
+                # source and could not be grepped during triage. Show the source line and
+                # flag it rather than trying to balance nested quotes with a regex.
+                truncated = literal.count("${") > literal.count("}")
+                row = {
+                    "module": module_of(relpath),
+                    "file": relpath,
+                    "line": lineno,
+                    "rule": rule,
+                    "literal": literal,
+                    "display": line.strip()[:120] if truncated else literal,
+                    "truncated": truncated,
+                    "confidence": "heuristic",
+                    "source": line.strip()[:120],
+                }
+                hit = allowlist.match_site(relpath, lineno)
+                if hit is not None:
+                    suppressed.append({**row, "allowlist_line": hit})
+                    continue
+                if in_preview:
+                    continue
+                if not h_prose_gate(literal):
+                    continue
+                candidates.append(row)
+
+            stripped = line.rstrip()
+            if H_CONT_OPEN_TRAILING.search(stripped) or H_CONT_OPEN_IF.search(stripped):
+                window = 4
+            elif window > 0:
+                window -= 1
+
+    by_rule = Counter(c["rule"] for c in candidates)
+    by_module = Counter(c["module"] for c in candidates)
+    advisories = [
+        f"UNREADABLE_SOURCE: {p} could not be decoded as UTF-8 or could not be read, so it "
+        "was NOT scanned for unextracted literals. Recall for that file is unknown."
+        for p in sorted(unreadable)
+    ]
+    return {
+        # Sink-anchored regex over a language with no type-level marking of user-facing
+        # strings. Stamped so a machine consumer cannot mistake a candidate for a proven
+        # defect the way the exact detectors' findings can be trusted.
+        "confidence": "heuristic",
+        "precision_estimate": H_PRECISION_ESTIMATE,
+        "candidates": sorted(candidates, key=lambda c: (c["module"], c["file"], c["line"], c["rule"], c["literal"])),
+        "suppressed": sorted(suppressed, key=lambda c: (c["file"], c["line"], c["rule"], c["literal"])),
+        "by_rule": {k: by_rule[k] for k in sorted(by_rule)},
+        "by_module": {k: by_module[k] for k in sorted(by_module)},
+        "total": len(candidates),
+        "suppressed_total": len(suppressed),
+        "advisories": sorted(advisories),
+    }
+
+
+# --------------------------------------------------------------------------------------
+# Text rendering
+# --------------------------------------------------------------------------------------
+
+H_PRECISION_NOTE = (
+    "Precision re-derived from THIS output by triaging every row of the six small\n"
+    "  families and every distinct literal of the two large ones. Enumerated false\n"
+    "  positives, all in one class:\n"
+    "    sink_call  8  core/network/.../sse/HttpResponseParser.kt HTTP/1.1 wire-format\n"
+    "                  parse diagnostics ('malformed header line', 'invalid chunk size').\n"
+    "                  Matched on the function NAME `fail(`, but that `fail` is a private\n"
+    "                  parser helper, not the voice-input sink of the same name. They\n"
+    "                  reach the user only wrapped as SseStreamException(\"parser: …\").\n"
+    "  Debatable, reported on purpose because they do reach the screen:\n"
+    "    state_error ~7  developer-facing diagnostics that still surface (SseEventMapper\n"
+    "                    'Parse error: …' x2, ConversationExporter 'Unexpected loading\n"
+    "                    state' x4, RoleRepositoryImpl 'User load still in progress').\n"
+    "    elvis_error ~1  ArtifactPanel 'Unknown error' (rendered in the WebView error page).\n"
+    "  Clean families at 0 enumerated FPs: text_call, content_desc, continuation,\n"
+    "  when_branch, ui_param, and enum_label (whose SCREAMING_SNAKE-equals-its-own-\n"
+    "  literal wire tokens in core/model/permissions are dropped mechanically).\n"
+    "  Note the classes an earlier calibration attributed to ui_param — animation\n"
+    "  labels, the 'ChatGPT' brand placeholder, the OpenAPI JSON sample — contribute 0\n"
+    "  rows: the hard suppressions, the identifier gate and the allowlist already remove\n"
+    "  all of them, so they are no longer listed.\n"
+    "  Known recall limits: (a) string-concatenation fragments beyond the 4-line\n"
+    "  continuation window are reported once at the head line, not per fragment\n"
+    "  (ChatApi.kt:42 and :52); (b) a `val message = \"…\"` bound far from its sink is\n"
+    "  missed; (c) android:label in app/src/main/AndroidManifest.xml is out of scope —\n"
+    "  only .kt files are scanned; (d) user-facing English inside raw-string (\"\"\"…\"\"\")\n"
+    "  HTML/JS templates is NOT scanned — no sink pattern applies inside an inline web\n"
+    "  document. Verified live in 6 files: artifact/ArtifactPanel.kt ('Failed to load\n"
+    "  preview'), artifact/ArtifactWebContent.kt ('Component failed to render'),\n"
+    "  artifact/MermaidWebContent.kt ('Mermaid parse error'), MermaidDiagram.kt and\n"
+    "  PlatformMediaComponents.ios.kt ('Diagram error'); (e) a spaceless all-lowercase\n"
+    "  word is dropped by the prose gate, so TimestampFormatter's 'now' is missed while\n"
+    "  its four siblings are reported. Measured: admitting them yields 2 true positives\n"
+    "  and 48 false ones (file extensions, MCP transport tokens, DataStore enum values),\n"
+    "  so that recall is given up deliberately."
+)
+
+
+def render_text(report: dict, out) -> None:
+    p = report.get("parity")
+    s = report.get("stubs")
+    h = report.get("hardcoded")
+
+    w = lambda *a: print(*a, file=out)  # noqa: E731
+
+    w("=" * 78)
+    w("i18n COVERAGE REPORT — LibreChat Mobile")
+    w("=" * 78)
+    w(f"allowlist: {report['allowlist'] or '(none)'}")
+    w(f"detectors: {report['detector']}")
+    w("")
+
+    if p is not None:
+        w("-" * 78)
+        w("[P] KEY PARITY — EXACT")
+        w("-" * 78)
+        w("Per module: base key count, locales with a strings.xml, locales whose strings.xml")
+        w("is entirely gone ('gone' — scored as 100% missing), then missing (in base, not in")
+        w("locale) and stale (in locale, not in base) totals summed over every scored locale.")
+        w("Both directions are computed independently: a count-only comparison understates")
+        w("real drift wherever a module has extras that cancel against its missing keys.")
+        w("")
+        w(f"{'module':24} {'base':>5} {'loc':>4} {'gone':>5} {'missing':>8} {'stale':>6} {'uniform':>8}")
+        for row in p["per_module"]:
+            w(
+                f"{row['module']:24} {row['base_keys']:>5} {len(row['locales']):>4} "
+                f"{len(row['absent_locales']):>5} "
+                f"{row['missing_total']:>8} {row['stale_total']:>6} "
+                f"{('yes' if row['uniform_across_locales'] else 'NO'):>8}"
+            )
+        w("")
+        w(f"TOTAL missing={p['missing_total']}  stale={p['stale_total']}  "
+          f"structural={p['structural_total']}  "
+          f"sum={p['missing_total'] + p['stale_total'] + p['structural_total']}")
+        w("")
+        w("'uniform' = all locales in the module share one identical missing set and one")
+        w("identical stale set, so the per-module key list below is lossless.")
+        w("")
+        for row in p["per_module"]:
+            if not row["distinct_missing_keys"] and not row["distinct_stale_keys"]:
+                continue
+            if row["uniform_across_locales"]:
+                w(f"  {row['module']} ({len(row['locales'])} locales)")
+                if row["distinct_missing_keys"]:
+                    w(f"    missing ({len(row['distinct_missing_keys'])} keys x locale):")
+                    for key in row["distinct_missing_keys"]:
+                        w(f"      {key}")
+                if row["distinct_stale_keys"]:
+                    w(f"    stale ({len(row['distinct_stale_keys'])} keys x locale):")
+                    for key in row["distinct_stale_keys"]:
+                        w(f"      {key}")
+                w("")
+                continue
+            # NON-UNIFORM: the collapsed lists above are a union over locales, so the
+            # 'K keys x locale' phrasing would multiply the real scope and never name the
+            # affected locale — exactly the masked-key case this tool exists to catch.
+            # List per locale instead, so the printed scope matches the totals column.
+            affected = sorted(set(row["missing_by_locale"]) | set(row["stale_by_locale"]))
+            w(f"  {row['module']} — NON-UNIFORM drift, listed per locale "
+              f"({len(affected)} of {len(row['locales']) + len(row['absent_locales'])} affected)")
+            for locale in affected:
+                gone = " [strings.xml absent]" if locale in row["absent_locales"] else ""
+                missing = row["missing_by_locale"].get(locale, [])
+                stale = row["stale_by_locale"].get(locale, [])
+                w(f"    {row['module']}/values-{locale}{gone}")
+                if missing:
+                    w(f"      missing ({len(missing)}): {', '.join(missing)}")
+                if stale:
+                    w(f"      stale ({len(stale)}): {', '.join(stale)}")
+            w("")
+        if p["structural_total"]:
+            w(f"  STRUCTURAL DEFECTS ({p['structural_total']})")
+            for f in p["findings"]:
+                if f["kind"] in STRUCTURAL_KINDS:
+                    w(f"    {f['kind']}: {f['detail']}")
+            w("")
+        else:
+            w("  STRUCTURAL DEFECTS: none (0 absent locale files, 0 duplicate keys)")
+            w("")
+
+    if s is not None:
+        w("-" * 78)
+        w("[S] UNTRANSLATED STUBS — EXACT")
+        w("-" * 78)
+        w("A key present in a non-Latin-script locale whose value is byte-identical to the")
+        w("English base and pure ASCII was never translated. Shared literals (no locale")
+        w("anywhere translated them) and letterless values (symbols / pure format strings)")
+        w("are auto-exempted mechanically. ERROR tier = at least 4 other locales did")
+        w("translate the key; REVIEW tier = only 1-3 did, so it may be intentional.")
+        w("")
+        sc = s["counts"]
+        raw = (
+            sc["errors"] + sc["review"] + sc["suppressed"]
+            + sc["auto_exempt_shared_literal"] + sc["auto_exempt_letterless"]
+        )
+        w(f"raw predicate hits         {raw} rows")
+        w(f"ERROR   {sc['errors']} rows / {sc['error_keys']} distinct keys")
+        w(f"REVIEW  {sc['review']} rows / {sc['review_keys']} distinct keys")
+        w(f"suppressed by allowlist    {sc['suppressed']} rows")
+        w(f"auto-exempt shared-literal {sc['auto_exempt_shared_literal']} rows")
+        w(f"auto-exempt letterless     {sc['auto_exempt_letterless']} rows")
+        w("")
+        if sc["errors_per_locale"]:
+            w("ERROR rows per locale: " + "  ".join(f"{k}={v}" for k, v in sc["errors_per_locale"].items()))
+            w("")
+        if s["errors"]:
+            w("  ERROR — untranslated (paste-able suppression line shown for each)")
+            for r in s["errors"]:
+                w(f"    {r['module']}/values-{r['locale']}  {r['key']} = {r['value']!r}")
+                w(f"      translated by: {', '.join(r['translated_by'])}")
+                w(f"      suppress with: pair\\t{r['module']}/values-{r['locale']}\\t{r['key']}")
+            w("")
+        if s["review"]:
+            w("  REVIEW — ambiguous (few other locales translated these)")
+            for r in s["review"]:
+                w(f"    {r['module']}/values-{r['locale']}  {r['key']} = {r['value']!r} "
+                  f"(translated by: {', '.join(r['translated_by']) or 'none'})")
+            w("")
+        if s["runs"]:
+            w("  CONTIGUOUS RUNS — >=3 adjacent untranslated keys (non-Latin locales only).")
+            w("  A block shape is direct evidence a translator skipped a region.")
+            for r in s["runs"]:
+                w(f"    {r['file']}:{r['first_line']}-{r['last_line']}  ({r['length']} keys) "
+                  f"{', '.join(r['keys'])}")
+            w("")
+        if s["info_latin"]:
+            w(f"  INFO (--include-latin) — {sc['info_latin']} Latin-locale rows identical to base.")
+            w("  Never an error: Latin identity is overwhelmingly legitimate coincidence")
+            w("  ('Description' in French, 'Name' in German).")
+            for r in s["info_latin"]:
+                w(f"    {r['module']}/values-{r['locale']}  {r['key']} = {r['value']!r}")
+            w("")
+        if s["info_near_identical"]:
+            w(f"  INFO (--near-identical) — {sc['info_near_identical']} rows differing only by")
+            w("  case/punctuation. Low precision (German noun capitalization is correct).")
+            for r in s["info_near_identical"]:
+                w(f"    {r['module']}/values-{r['locale']}  {r['key']}: "
+                  f"base={r['base']!r} locale={r['locale_value']!r}")
+            w("")
+
+    if h is not None:
+        w("-" * 78)
+        w("[H] UNEXTRACTED LITERALS — CANDIDATES, HEURISTIC, REQUIRES HUMAN TRIAGE")
+        w("-" * 78)
+        w("These are NOT confirmed defects. Unlike [P] and [S], which are exact set")
+        w("operations over declared resources, this detector is sink-anchored regex")
+        w("matching over a language with no type-level marking of user-facing strings.")
+        w("")
+        w(f"  {H_PRECISION_NOTE}")
+        w("")
+        w(f"TOTAL CANDIDATES {h['total']}   (suppressed by allowlist: {h['suppressed_total']})")
+        w("")
+        w("  by rule family:")
+        for rule in sorted(h["by_rule"]):
+            w(f"    {rule:14} {h['by_rule'][rule]:>5}")
+        w("")
+        w("  by module:")
+        for module in sorted(h["by_module"], key=lambda m: (-h["by_module"][m], m)):
+            w(f"    {module:20} {h['by_module'][module]:>5}")
+        w("")
+        current_file = None
+        for c in h["candidates"]:
+            if c["file"] != current_file:
+                current_file = c["file"]
+                w(f"  {current_file}")
+            if c["truncated"]:
+                # The capture stopped at a nested template quote; print the source line so
+                # the row is greppable, and say so.
+                w(f"    :{c['line']:<5} {c['rule']:14} [nested template, source line] {c['display']}")
+            else:
+                w(f"    :{c['line']:<5} {c['rule']:14} {c['literal']!r}")
+        w("")
+
+    adv = report["advisories"]
+    w("-" * 78)
+    w("ADVISORIES")
+    w("-" * 78)
+    if adv:
+        for a in adv:
+            w(f"  {a}")
+    else:
+        w("  none")
+    w("")
+
+    note = report["android_res"]
+    if note.get("present"):
+        w("-" * 78)
+        w("ANDROID PLATFORM res/ (separate surface, excluded from parity math)")
+        w("-" * 78)
+        w(f"  {note['path']} holds {len(note['keys'])} string(s): {', '.join(note['keys'])}")
+        w(f"  locale directories with strings.xml: {note['locale_dirs_with_strings'] or 'NONE'}")
+        w("  Folding this into parity math would fabricate phantom 'entire locale missing'")
+        w("  failures; it is reported here so the gap is still visible.")
+        w("")
+
+    w("-" * 78)
+    w(f"EXIT CODE {report['exit_code']}  "
+      f"(bits: 1=parity 2=stubs 4=hardcoded-candidates 8=advisories; "
+      f"{EXIT_HARD_FAILURE}=hard failure, shares no bit with the finding mask {FINDING_MASK})")
+    w("-" * 78)
+
+
+# --------------------------------------------------------------------------------------
+# CLI
+# --------------------------------------------------------------------------------------
+
+
+class HardFailArgumentParser(argparse.ArgumentParser):
+    """argparse exits 2 on a bad argument, which collides with EXIT_STUBS.
+
+    A caller branching on the bitmask would read `--typo` as "2 stub findings". Every
+    failure path in this script must land on EXIT_HARD_FAILURE, which shares no bits
+    with FINDING_MASK.
+    """
+
+    def error(self, message: str) -> None:  # type: ignore[override]
+        self.print_usage(sys.stderr)
+        print(f"i18n-coverage: HARD FAILURE: {message}", file=sys.stderr)
+        print(
+            f"i18n-coverage: exiting {EXIT_HARD_FAILURE}. This is NOT a clean bill of health — the check did "
+            "not run.",
+            file=sys.stderr,
+        )
+        raise SystemExit(EXIT_HARD_FAILURE)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = HardFailArgumentParser(
+        prog="i18n-coverage.py",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description=(
+            "Deterministic i18n coverage checker for the LibreChat Mobile compose-resources\n"
+            "localization surface (9 modules x 9 locales)."
+        ),
+        epilog="""
+DETECTORS
+  parity     [P] EXACT. Missing / stale keys per (module, locale); absent locale files;
+                 duplicate keys within one file; unknown locale qualifiers.
+  stubs      [S] EXACT. Locale values byte-identical to English in a non-Latin-script
+                 locale (ASCII-only), minus mechanically auto-exempted shared literals
+                 and letterless values. Tiered ERROR / REVIEW by cross-locale
+                 corroboration; allowlist-suppressible.
+  hardcoded  [H] HEURISTIC CANDIDATES. English literals in Kotlin/Compose that never
+                 reached a strings.xml. Always labeled as candidates; ~98% precision.
+
+EXIT CODES (bitmask, so a caller can distinguish exact findings from heuristics)
+  0   clean
+  1   parity findings              exact
+  2   stub findings, ERROR tier    exact
+  4   hardcoded candidates         heuristic
+  8   advisories (stale allowlist directives, module/locale-set drift,
+      parser disagreement with StringResourceParityTest's regex)
+  16  HARD FAILURE — repo layout unrecognized, 0 modules discovered, a module with
+      0 base keys, an unreadable/non-UTF-8/unparseable resource file, a bad CLI
+      argument, a missing explicitly-passed --allowlist, or any unexpected exception.
+
+  Test findings with `exit & 15`, and hard failure with `exit & ~15` (equivalently
+  `exit >= 16`). Do NOT mask with a smaller value: `exit & 3` cannot distinguish a
+  crash from findings for any hard-failure code that overlaps the low bits, which is
+  exactly why the hard-failure code is 16 and not 70.
+
+DETERMINISM
+  Identical input produces byte-identical stdout on every run and every machine. No
+  timestamps, hostnames, absolute paths, wall-clock, randomness, or reliance on
+  set/dict iteration order. Discovery is sorted-glob based.
+
+OUT OF SCOPE (deliberate)
+  Format-specifier / placeholder-count comparison. Writing translations. Modifying any
+  strings.xml. Running Gradle. Reading or regenerating
+  config/l10n/strings-parity-baseline.txt (that baseline lives on the unmerged branch
+  chore/review-loop-protocol and is stale).
+
+EXAMPLES
+  scripts/i18n-coverage.py                             full report, text
+  scripts/i18n-coverage.py --detector parity           exact key parity only
+  scripts/i18n-coverage.py --detector stubs --json     machine-readable stub findings
+  scripts/i18n-coverage.py --include-latin             add Latin-locale identity INFO
+  scripts/i18n-coverage.py --summary                   totals only, no per-item detail
+""",
+    )
+    parser.add_argument(
+        "--detector",
+        choices=("all", "parity", "stubs", "hardcoded"),
+        default="all",
+        help="which detector(s) to run (default: all)",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("text", "json"),
+        default="text",
+        help="output format (default: text)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="shorthand for --format json",
+    )
+    parser.add_argument(
+        "--allowlist",
+        default=None,
+        help=f"repo-relative allowlist path (default: {ALLOWLIST_DEFAULT}). A path passed "
+        "here that does not exist is a hard failure, never a silent fallback to "
+        "no suppression — use --no-allowlist to disable suppression on purpose",
+    )
+    parser.add_argument(
+        "--no-allowlist",
+        action="store_true",
+        help="ignore the allowlist entirely (shows the raw, unsuppressed finding set)",
+    )
+    parser.add_argument(
+        "--include-latin",
+        action="store_true",
+        help="[S] also report Latin-locale values identical to base, at INFO tier "
+        "(off by default: near-100%% false-positive rate)",
+    )
+    parser.add_argument(
+        "--near-identical",
+        action="store_true",
+        help="[S] also report case/punctuation-only differences, at INFO tier "
+        "(off by default: 1-in-3 precision)",
+    )
+    parser.add_argument(
+        "--summary",
+        action="store_true",
+        help="omit per-item detail; print totals only",
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=None,
+        help="override repo-root detection (normally found by walking up for settings.gradle.kts)",
+    )
+    return parser
+
+
+def _force_utf8_streams() -> None:
+    """Pin stdout/stderr to UTF-8.
+
+    The report chrome and several base values contain non-ASCII (em dash, ellipsis, arrow).
+    Under PYTHONUTF8=0 / PYTHONIOENCODING=ascii / an explicit non-UTF-8 locale, the writer
+    raises UnicodeEncodeError mid-report, leaving truncated (and for --json, unparseable)
+    output behind an exit code that looks like real findings.
+    """
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is not None:
+            reconfigure(encoding="utf-8", errors="backslashreplace")
+
+
+def main(argv: list[str]) -> int:
+    # Everything lives inside the try, so no code path can produce a traceback + a
+    # finding-bit exit code. argparse raises SystemExit, which is not an Exception and
+    # therefore passes through with the code HardFailArgumentParser.error already set.
+    try:
+        _force_utf8_streams()
+        args = build_parser().parse_args(argv)
+        fmt = "json" if args.json else args.format
+
+        root = Path(args.repo_root).resolve() if args.repo_root else find_repo_root(Path.cwd().resolve())
+        if not (root / "settings.gradle.kts").is_file():
+            raise HardFailure(f"{args.repo_root} is not a repo root (no settings.gradle.kts)")
+
+        # An allowlist path that does not exist must never degrade quietly into "no
+        # suppression": every suppressed row silently comes back as live debt, inflating
+        # the headline number and manufacturing a regression when two dated reports are
+        # diffed — behind an exit code identical to a good run. An explicit --allowlist is
+        # a promise the file exists, so a typo is a hard failure. The DEFAULT path is
+        # allowed to be absent (fresh checkout, or the file genuinely deleted), but says so
+        # as an advisory rather than saying nothing.
+        allowlist_path: Path | None = None
+        allowlist_advisory: str | None = None
+        if not args.no_allowlist:
+            allowlist_path = (root / (args.allowlist or ALLOWLIST_DEFAULT)).resolve()
+            if not allowlist_path.is_file():
+                if args.allowlist is not None:
+                    raise HardFailure(
+                        f"--allowlist {args.allowlist} does not exist (resolved to "
+                        f"{rel_or_str(allowlist_path, root)}). Refusing to run with "
+                        "suppression silently disabled — pass --no-allowlist if that is "
+                        "what you meant."
+                    )
+                allowlist_advisory = (
+                    f"ALLOWLIST_ABSENT: {ALLOWLIST_DEFAULT} does not exist, so NO "
+                    "suppression is in effect and previously-justified rows are reported "
+                    "as live findings. Totals are not comparable with a run that had it."
+                )
+                allowlist_path = None
+
+        allowlist = Allowlist(allowlist_path, root)
+        allowlist_in_effect = allowlist.relpath if allowlist_path else None
+        modules = discover_modules(root)
+
+        want = args.detector
+        report: dict = {
+            "detector": want,
+            "allowlist": allowlist_in_effect,
+            "modules": [m.name for m in modules],
+            "locales": sorted({loc for m in modules for loc in m.locales}),
+            "android_res": android_res_note(root),
+        }
+        advisories: list[str] = list(allowlist.errors)
+        if allowlist_advisory:
+            advisories.append(allowlist_advisory)
+
+        if want in ("all", "parity"):
+            report["parity"] = run_parity(modules, root)
+            advisories.extend(report["parity"]["advisories"])
+        if want in ("all", "stubs"):
+            report["stubs"] = run_stubs(modules, allowlist, args.include_latin, args.near_identical)
+            advisories.extend(report["stubs"]["advisories"])
+        if want in ("all", "hardcoded"):
+            report["hardcoded"] = run_hardcoded(root, allowlist)
+            advisories.extend(report["hardcoded"]["advisories"])
+
+        # Shrink-only discipline: a directive that suppresses nothing is dead weight and
+        # must be deleted, otherwise debt can silently grow back behind it. Only meaningful
+        # when every detector that consumes the allowlist actually ran.
+        stale_directives: list[str] = []
+        if want == "all" and allowlist_in_effect:
+            stale_directives = allowlist.stale()
+            for line in stale_directives:
+                advisories.append(
+                    f"STALE_ALLOWLIST_DIRECTIVE: {line} — matched nothing. Delete it "
+                    "(the allowlist is shrink-only)."
+                )
+        report["stale_allowlist_directives"] = stale_directives
+        report["advisories"] = sorted(set(advisories))
+
+        exit_code = 0
+        if "parity" in report:
+            pr = report["parity"]
+            if pr["missing_total"] or pr["stale_total"] or pr["structural_total"]:
+                exit_code |= EXIT_PARITY
+        if "stubs" in report and report["stubs"]["errors"]:
+            exit_code |= EXIT_STUBS
+        if "hardcoded" in report and report["hardcoded"]["total"]:
+            exit_code |= EXIT_HARDCODED
+        if report["advisories"]:
+            exit_code |= EXIT_ADVISORY
+        report["exit_code"] = exit_code
+
+        # --summary drops per-item detail only. Every printed total comes from a stored
+        # count, never from len() of a list that this block clears.
+        if args.summary:
+            if "parity" in report:
+                for row in report["parity"]["per_module"]:
+                    row["distinct_missing_keys"] = []
+                    row["distinct_stale_keys"] = []
+                    row["missing_by_locale"] = {}
+                    row["stale_by_locale"] = {}
+                # Structural rows survive --summary: ABSENT_LOCALE_FILE and DUPLICATE_KEY are
+                # the highest-signal, lowest-volume findings the tool produces, and clearing
+                # them leaves the renderer printing a structural count with no rows.
+                report["parity"]["findings"] = [
+                    f for f in report["parity"]["findings"]
+                    if f["kind"] in STRUCTURAL_KINDS
+                ]
+            if "stubs" in report:
+                for key in ("errors", "review", "suppressed", "auto_exempt", "runs",
+                            "info_latin", "info_near_identical"):
+                    report["stubs"][key] = []
+            if "hardcoded" in report:
+                report["hardcoded"]["candidates"] = []
+                report["hardcoded"]["suppressed"] = []
+
+        if fmt == "json":
+            json.dump(report, sys.stdout, indent=2, sort_keys=True, ensure_ascii=False)
+            sys.stdout.write("\n")
+        else:
+            render_text(report, sys.stdout)
+        return exit_code
+
+    except BrokenPipeError:
+        # `… | head` closes the pipe mid-report. The run itself succeeded and its findings
+        # were computed; reporting a HARD FAILURE for a truncated *display* would be the
+        # same lie in the opposite direction. Exit 0 is wrong too (findings existed), so
+        # report the real bit that says "output was cut off": an advisory. stdout is
+        # redirected to devnull first, or the interpreter re-raises on the final flush.
+        devnull = os.open(os.devnull, os.O_WRONLY)
+        os.dup2(devnull, sys.stdout.fileno())
+        print(
+            "i18n-coverage: stdout closed early (broken pipe). The check RAN; the report "
+            "was truncated for display only. Exiting with the advisory bit.",
+            file=sys.stderr,
+        )
+        return EXIT_ADVISORY
+    except HardFailure as exc:
+        print(f"i18n-coverage: HARD FAILURE: {exc}", file=sys.stderr)
+        print(
+            f"i18n-coverage: exiting {EXIT_HARD_FAILURE}. This is NOT a clean bill of health — the check did "
+            "not run.",
+            file=sys.stderr,
+        )
+        return EXIT_HARD_FAILURE
+    except Exception as exc:  # noqa: BLE001 — deliberate catch-all
+        # Anything unforeseen must land on EXIT_HARD_FAILURE, never on a finding bit, and
+        # must never leak a machine-absolute path via a traceback: a caller branching on the
+        # bitmask would otherwise read a crash as real findings over truncated output.
+        print(
+            f"i18n-coverage: HARD FAILURE: unexpected {type(exc).__name__}: {exc}",
+            file=sys.stderr,
+        )
+        print(
+            f"i18n-coverage: exiting {EXIT_HARD_FAILURE}. This is NOT a clean bill of health — the check did "
+            "not run. Re-run with I18N_COVERAGE_TRACEBACK=1 for a traceback.",
+            file=sys.stderr,
+        )
+        if os.environ.get("I18N_COVERAGE_TRACEBACK"):
+            traceback.print_exc()
+        return EXIT_HARD_FAILURE
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary

Adds an `/audit-i18n` skill that answers "which features shipped English-only?" across the 9-module × 9-locale compose-resources surface. The findings come from a deterministic Python checker so two dated audits diff cleanly; the skill fans out to a workflow that explains them. Audit-only — it produces a report and never writes a translation, edits a `strings.xml`, or adds a CI gate.

## Changes

**`scripts/i18n-coverage.py`** — the source of truth. Three detectors over `composeResources`:

- `[P]` **parity**, exact — missing *and* stale keys per (module, locale). Both directions matter: a count-only comparison cancels a missing key against a stale one and understates real drift. A locale with no `values-<loc>/` directory scores as 100% missing rather than passing silently.
- `[S]` **stubs**, exact — locale values byte-identical to English *and* pure ASCII, in a non-Latin-script locale, with shared literals and letterless values auto-exempted.
- `[H]` **unextracted literals**, heuristic — English in Kotlin/Compose that never reached a `strings.xml`. Labeled as *candidates* everywhere, never merged into the exact debt figure.

Determinism is the design constraint: sorted output, repo-relative paths, stdlib only, no clock or randomness. Key extraction is `ElementTree`, so a commented-out `<string>` can't be miscounted. Every file is *also* re-parsed with `StringResourceParityTest`'s regex as a second opinion, and a disagreement between the two becomes a `PARSER_DISAGREEMENT` advisory naming the file — that is how the tool reports which files the existing guard test would miscount, without re-litigating parity through a regex itself.

Exit codes are a bitmask (`1` parity, `2` stubs, `4` heuristic, `8` advisories) confined to a `FINDING_MASK`. Hard failure is `16`, deliberately **not** the conventional `70` — `70` sets bits 2 and 4, so a bitmask-testing caller reads a crashed run as exact stub findings. A module-scope tripwire refuses to start if a future edit ever makes the two overlap.

**`config/l10n/i18n-allowlist.txt`** — exact-equality suppression, no globs or regex, so any line can be verified by grepping for it. Every entry carries a written justification. The list is shrink-only: on a full run, directives that matched nothing are reported as stale so they get deleted rather than accumulating.

**`.claude/skills/audit-i18n/SKILL.md`** — the lead: sanity-check the tool with its own Bash, run the workflow, then independently re-assert what it claims.

**`.claude/workflows/audit-i18n.js`** — fan-out derived from the JSON, not hardcoded: measure → one attribution agent per module with drift (capped at six, and the cap logs which modules it dropped) plus a stub adjudicator and up to three heuristic triagers, all concurrent → synthesize → two reconcile agents that did not write the report and diff it back against the raw JSON hunting invented and dropped findings. A confirmed discrepancy triggers a final pass that edits the report in place; a discrepancy the lens could not mechanically reproduce is deliberately *not* auto-fixed, and surfaces to the caller instead.

**`.gitignore`** — ignores `__pycache__/`, `*.pyc`, and the audit's `artifacts/` directory. The raw JSON is regenerable and large; the dated report is the durable artifact worth diffing across audits.

## Testing / verification

Verified by hand during development; none of the following is committed as an automated test, so nothing in the repo re-runs it:

- Checker output is byte-identical across repeated runs under `PYTHONHASHSEED=random`, for both text and JSON.
- Exit-code contract exercised for each detector alone, every flag, a bad CLI argument, a run outside the repo, a missing allowlist path, and a truncated pipe.
- Detector behavior checked against throwaway fixtures: a module with no locale directories, and a locale directory deleted from a module.
- The workflow's control flow was exercised with a throwaway harness that runs the real script body against a fake `agent()` — fan-out shape, stringified `args`, `exact-only` scope, the hard-failure halt, the attribution cap, and report-path collision handling.
- **The workflow has not been run end to end with live agents.** Its control flow was checked; the agent prompts were not.

## Notes

- Placeholder and format-specifier comparison is deliberately out of scope, and is the likeliest source of a runtime crash in translated copy — documented as the top blind spot.
- Overlaps `StringResourceParityTest`, which currently lives on an unmerged local branch. This checker deliberately does not read or regenerate its baseline; whether to land a CI gate is left open.
- No dated report is committed. Run the skill to generate one.
