### PR TITLE
chore(l10n): drop orphaned locale keys left by the media viewer

### DIFF
--- a/feature/chat/src/commonMain/composeResources/values-ar/strings.xml
+++ b/feature/chat/src/commonMain/composeResources/values-ar/strings.xml
@@ -64,7 +64,6 @@
     <string name="cd_generating_response">جارٍ إنشاء الرد</string>
 
     <!-- Content descriptions - Images -->
-    <string name="cd_fullscreen_image">صورة بملء الشاشة</string>
     <string name="cd_close">إغلاق</string>
     <string name="cd_save_to_device">الحفظ في الجهاز</string>
     <string name="cd_share_image">مشاركة الصورة</string>

--- a/feature/chat/src/commonMain/composeResources/values-de/strings.xml
+++ b/feature/chat/src/commonMain/composeResources/values-de/strings.xml
@@ -64,7 +64,6 @@
     <string name="cd_generating_response">Antwort wird generiert</string>
 
     <!-- Content descriptions - Images -->
-    <string name="cd_fullscreen_image">Vollbild-Bild</string>
     <string name="cd_close">Schließen</string>
     <string name="cd_save_to_device">Auf Gerät speichern</string>
     <string name="cd_share_image">Bild teilen</string>

--- a/feature/chat/src/commonMain/composeResources/values-es/strings.xml
+++ b/feature/chat/src/commonMain/composeResources/values-es/strings.xml
@@ -64,7 +64,6 @@
     <string name="cd_generating_response">Generando respuesta</string>
 
     <!-- Content descriptions - Images -->
-    <string name="cd_fullscreen_image">Imagen a pantalla completa</string>
     <string name="cd_close">Cerrar</string>
     <string name="cd_save_to_device">Guardar en el dispositivo</string>
     <string name="cd_share_image">Compartir imagen</string>

--- a/feature/chat/src/commonMain/composeResources/values-fr/strings.xml
+++ b/feature/chat/src/commonMain/composeResources/values-fr/strings.xml
@@ -64,7 +64,6 @@
     <string name="cd_generating_response">Génération de la réponse</string>
 
     <!-- Content descriptions - Images -->
-    <string name="cd_fullscreen_image">Image en plein écran</string>
     <string name="cd_close">Fermer</string>
     <string name="cd_save_to_device">Enregistrer sur l'appareil</string>
     <string name="cd_share_image">Partager l'image</string>

--- a/feature/chat/src/commonMain/composeResources/values-ja/strings.xml
+++ b/feature/chat/src/commonMain/composeResources/values-ja/strings.xml
@@ -64,7 +64,6 @@
     <string name="cd_generating_response">応答を生成中</string>
 
     <!-- Content descriptions - Images -->
-    <string name="cd_fullscreen_image">全画面画像</string>
     <string name="cd_close">閉じる</string>
     <string name="cd_save_to_device">デバイスに保存</string>
     <string name="cd_share_image">画像を共有</string>

--- a/feature/chat/src/commonMain/composeResources/values-ko/strings.xml
+++ b/feature/chat/src/commonMain/composeResources/values-ko/strings.xml
@@ -64,7 +64,6 @@
     <string name="cd_generating_response">응답 생성 중</string>
 
     <!-- Content descriptions - Images -->
-    <string name="cd_fullscreen_image">전체 화면 이미지</string>
     <string name="cd_close">닫기</string>
     <string name="cd_save_to_device">기기에 저장</string>
     <string name="cd_share_image">이미지 공유</string>

--- a/feature/chat/src/commonMain/composeResources/values-pt/strings.xml
+++ b/feature/chat/src/commonMain/composeResources/values-pt/strings.xml
@@ -64,7 +64,6 @@
     <string name="cd_generating_response">Gerando resposta</string>
 
     <!-- Content descriptions - Images -->
-    <string name="cd_fullscreen_image">Imagem em tela cheia</string>
     <string name="cd_close">Fechar</string>
     <string name="cd_save_to_device">Salvar no dispositivo</string>
     <string name="cd_share_image">Compartilhar imagem</string>

--- a/feature/chat/src/commonMain/composeResources/values-ru/strings.xml
+++ b/feature/chat/src/commonMain/composeResources/values-ru/strings.xml
@@ -64,7 +64,6 @@
     <string name="cd_generating_response">Генерация ответа</string>
 
     <!-- Content descriptions - Images -->
-    <string name="cd_fullscreen_image">Изображение во весь экран</string>
     <string name="cd_close">Закрыть</string>
     <string name="cd_save_to_device">Сохранить на устройство</string>
     <string name="cd_share_image">Поделиться изображением</string>

--- a/feature/chat/src/commonMain/composeResources/values-zh/strings.xml
+++ b/feature/chat/src/commonMain/composeResources/values-zh/strings.xml
@@ -64,7 +64,6 @@
     <string name="cd_generating_response">正在生成回复</string>
 
     <!-- Content descriptions - Images -->
-    <string name="cd_fullscreen_image">全屏图片</string>
     <string name="cd_close">关闭</string>
     <string name="cd_save_to_device">保存到设备</string>
     <string name="cd_share_image">分享图片</string>

--- a/feature/files/src/commonMain/composeResources/values-ar/strings.xml
+++ b/feature/files/src/commonMain/composeResources/values-ar/strings.xml
@@ -45,8 +45,6 @@
     <string name="this_file">هذا الملف</string>
 
     <!-- File preview -->
-    <string name="image_preview_unavailable">معاينة الصورة غير متاحة</string>
-    <string name="preview_of">معاينة %1$s</string>
     <string name="loading_pdf">جارٍ تحميل PDF…</string>
     <string name="page_of">الصفحة %1$d من %2$d</string>
     <string name="page_cd">الصفحة %1$d من %2$s</string>

--- a/feature/files/src/commonMain/composeResources/values-de/strings.xml
+++ b/feature/files/src/commonMain/composeResources/values-de/strings.xml
@@ -45,8 +45,6 @@
     <string name="this_file">diese Datei</string>
 
     <!-- File preview -->
-    <string name="image_preview_unavailable">Bildvorschau nicht verfügbar</string>
-    <string name="preview_of">Vorschau von %1$s</string>
     <string name="loading_pdf">PDF wird geladen…</string>
     <string name="page_of">Seite %1$d von %2$d</string>
     <string name="page_cd">Seite %1$d von %2$s</string>

--- a/feature/files/src/commonMain/composeResources/values-es/strings.xml
+++ b/feature/files/src/commonMain/composeResources/values-es/strings.xml
@@ -45,8 +45,6 @@
     <string name="this_file">este archivo</string>
 
     <!-- File preview -->
-    <string name="image_preview_unavailable">Vista previa de imagen no disponible</string>
-    <string name="preview_of">Vista previa de %1$s</string>
     <string name="loading_pdf">Cargando PDF…</string>
     <string name="page_of">Página %1$d de %2$d</string>
     <string name="page_cd">Página %1$d de %2$s</string>

--- a/feature/files/src/commonMain/composeResources/values-fr/strings.xml
+++ b/feature/files/src/commonMain/composeResources/values-fr/strings.xml
@@ -45,8 +45,6 @@
     <string name="this_file">ce fichier</string>
 
     <!-- File preview -->
-    <string name="image_preview_unavailable">Aperçu de l'image non disponible</string>
-    <string name="preview_of">Aperçu de %1$s</string>
     <string name="loading_pdf">Chargement du PDF…</string>
     <string name="page_of">Page %1$d sur %2$d</string>
     <string name="page_cd">Page %1$d sur %2$s</string>

--- a/feature/files/src/commonMain/composeResources/values-ja/strings.xml
+++ b/feature/files/src/commonMain/composeResources/values-ja/strings.xml
@@ -45,8 +45,6 @@
     <string name="this_file">このファイル</string>
 
     <!-- File preview -->
-    <string name="image_preview_unavailable">画像のプレビューは利用できません</string>
-    <string name="preview_of">%1$s のプレビュー</string>
     <string name="loading_pdf">PDFを読み込み中…</string>
     <string name="page_of">%2$d ページ中 %1$d ページ</string>
     <string name="page_cd">%2$s ページ中 %1$d ページ</string>

--- a/feature/files/src/commonMain/composeResources/values-ko/strings.xml
+++ b/feature/files/src/commonMain/composeResources/values-ko/strings.xml
@@ -45,8 +45,6 @@
     <string name="this_file">이 파일</string>
 
     <!-- File preview -->
-    <string name="image_preview_unavailable">이미지 미리보기를 사용할 수 없습니다</string>
-    <string name="preview_of">%1$s 미리보기</string>
     <string name="loading_pdf">PDF 불러오는 중…</string>
     <string name="page_of">%2$d페이지 중 %1$d페이지</string>
     <string name="page_cd">%2$s페이지 중 %1$d페이지</string>

--- a/feature/files/src/commonMain/composeResources/values-pt/strings.xml
+++ b/feature/files/src/commonMain/composeResources/values-pt/strings.xml
@@ -45,8 +45,6 @@
     <string name="this_file">este arquivo</string>
 
     <!-- File preview -->
-    <string name="image_preview_unavailable">Visualização da imagem indisponível</string>
-    <string name="preview_of">Visualização de %1$s</string>
     <string name="loading_pdf">Carregando PDF…</string>
     <string name="page_of">Página %1$d de %2$d</string>
     <string name="page_cd">Página %1$d de %2$s</string>

--- a/feature/files/src/commonMain/composeResources/values-ru/strings.xml
+++ b/feature/files/src/commonMain/composeResources/values-ru/strings.xml
@@ -45,8 +45,6 @@
     <string name="this_file">этот файл</string>
 
     <!-- File preview -->
-    <string name="image_preview_unavailable">Предпросмотр изображения недоступен</string>
-    <string name="preview_of">Предпросмотр %1$s</string>
     <string name="loading_pdf">Загрузка PDF…</string>
     <string name="page_of">Страница %1$d из %2$d</string>
     <string name="page_cd">Страница %1$d из %2$s</string>

--- a/feature/files/src/commonMain/composeResources/values-zh/strings.xml
+++ b/feature/files/src/commonMain/composeResources/values-zh/strings.xml
@@ -45,8 +45,6 @@
     <string name="this_file">此文件</string>
 
     <!-- File preview -->
-    <string name="image_preview_unavailable">图片预览不可用</string>
-    <string name="preview_of">%1$s 的预览</string>
     <string name="loading_pdf">正在加载 PDF…</string>
     <string name="page_of">第 %1$d 页，共 %2$d 页</string>
     <string name="page_cd">第 %1$d 页，共 %2$s 页</string>


### PR DESCRIPTION
## Summary

Removes three keys from all nine locale files that no longer exist in the English base. They were dropped from `values/strings.xml` in #142 (the full-screen media viewer) but left behind in every translation.

`cd_fullscreen_image`, `image_preview_unavailable`, `preview_of` — 27 entries across `feature/chat` and `feature/files`.

## Why they're dead

compose-resources generates its Kotlin accessors from the base file. With no base entry there is no accessor, so no source file can reference these keys — confirmed by grep across `.kt`, `.swift` and `.xml`. They ship translated strings for UI that was deleted.

They also distort measurement: a per-file key count treats a stale key as offsetting a missing one, so `feature/files` reads as 3 missing when it is really 5 missing and 2 stale.

## Verification

- `:feature:files:compileDebugKotlinAndroid` and `:feature:chat:compileDebugKotlinAndroid` pass.
- `:feature:files:testDebugUnitTest` and `:feature:chat:testDebugUnitTest` pass.
- Parity stale count goes 27 → 0; missing count is unchanged at 1224, as expected — deleting a stale key must not move the missing total. (Measured with the checker from #289; independent of this change.)
- No remaining references to any of the three keys anywhere in the tree.

## Notes

No user-visible change: every removed entry was unreachable.
