### PR TITLE
docs: explain why to choose the mobile app over the web client

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -1,5 +1,20 @@
 # FAQ
 
+## Why not just add the web app to my home screen?
+
+You can — LibreChat ships a PWA manifest with `display: standalone`, so an "Add to Home Screen" install gets you an icon and a chrome-less window. That covers the cosmetics. What it doesn't cover:
+
+| | Web PWA | This app |
+|---|---|---|
+| **Receive shares from other apps** | No — the manifest declares no `share_target` | Text, images, arbitrary files, and multi-select, from any app *(Android)* |
+| **Home-screen shortcuts** | One icon; the manifest declares no `shortcuts` | Per-model launcher shortcuts / quick actions on both platforms, plus artifacts pinned as their own icons *(Android)* |
+| **Reading old chats offline** | No — the service worker precaches app assets, not conversation data | List and opened threads render from a local database |
+| **Multiple accounts / servers at once** | One session per browser profile | Switch instantly; storage scoped per account |
+| **On-device dictation** | Web Speech API is missing or vendor-hosted on mobile browsers | Platform on-device recognizers, with server STT as fallback |
+| **System back gesture** | Navigates browser history | Navigates the app, with predictive-back previews |
+
+See [Why use this instead of the web app?](README.md#why-use-this-instead-of-the-web-app) for the longer version.
+
 ## Can I use a self-signed TLS certificate?
 
 Yes on iOS (with caveats). Not effectively on Android with the current release build — see below for workarounds.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,15 @@ A third-party native mobile client for [LibreChat](https://www.librechat.ai/) (A
 
 > **Backend compatibility:** Tested against LibreChat **v0.8.4 – v0.8.7**. Older releases may work but are not guaranteed; newer releases are supported on a best-effort basis until the next sync.
 
+## Why use this instead of the web app?
+
+- **Smoother and faster** — a real native app instead of a website in a wrapper, so scrolling, typing, and watching responses stream in all feel snappier.
+- **Feels like a mobile app, not a shrunk-down website** — familiar gestures like swipe to switch accounts and swipe back, comfortable tap targets, and a layout that adapts to tablets and foldables.
+- **Plays nicely with your phone** — share text, images, and files into the app from anywhere *(Android)*, pin your favorite models or generated content to your home screen, open chat links straight into the right screen, and save or share images through your phone's normal menus.
+- **Works without a connection** — your chat list and any conversations you've opened are saved on your phone, so you can keep reading with spotty or no signal.
+- **Multiple accounts, one app** — sign in to different accounts on different LibreChat servers and switch between them instantly, no re-entering passwords.
+- **Dictation stays on your phone** — voice typing runs on-device instead of through a server.
+
 ## Features
 
 - **Multi-Account & Multi-Server** — Sign in to multiple accounts across different LibreChat servers and switch between them instantly, no re-login. Swipe the account chip to switch; storage is fully scoped per account.


### PR DESCRIPTION
## Summary
Adds a "Why use this instead of the web app?" section to the README and a matching FAQ entry, making the case for the native client over LibreChat's web/PWA client.

## Changes
- **README** — new "Why use this instead of the web app?" section: a short, user-facing bulleted list covering native performance, mobile-first feel (gestures, tablet/foldable layout), OS integration (sharing, home-screen shortcuts, deep links), offline access to chats, multi-account/multi-server switching, and on-device dictation.
- **FAQ.md** — new "Why not just add the web app to my home screen?" entry with a PWA-vs-native comparison table.
- Android-only capabilities (receiving shares from other apps, pinning artifacts to the home screen) are explicitly marked as such, rather than implied as cross-platform.

## Testing / verification
Docs-only change (README.md, FAQ.md) — no code, build, or test impact.
