### PR TITLE
feat: custom per-server request headers for access gateways (part 1) (#287)

### DIFF
--- a/app/src/test/kotlin/com/garfiec/librechat/KoinGraphVerificationTest.kt
+++ b/app/src/test/kotlin/com/garfiec/librechat/KoinGraphVerificationTest.kt
@@ -8,6 +8,7 @@ import com.garfiec.librechat.core.common.network.ConnectivityObserver
 import com.garfiec.librechat.core.data.datastore.AccountRoster
 import com.garfiec.librechat.core.data.datastore.ConfigCacheDataStore
 import com.garfiec.librechat.core.data.datastore.ServerDataStore
+import com.garfiec.librechat.core.data.datastore.ServerHeadersDataStore
 import com.garfiec.librechat.core.data.datastore.SettingsDataStore
 import com.garfiec.librechat.core.data.datastore.ThemeDataStore
 import com.garfiec.librechat.core.data.repository.AccountSwitcher
@@ -154,6 +155,7 @@ class KoinGraphVerificationTest {
             // core:data provides
             ConfigCacheDataStore::class,
             ServerDataStore::class,
+            ServerHeadersDataStore::class,
             AccountRoster::class,
             AccountSwitcher::class,
             SettingsDataStore::class,

--- a/core/common/build.gradle.kts
+++ b/core/common/build.gradle.kts
@@ -224,6 +224,10 @@ kotlin {
                 implementation(libs.coroutines.core)
                 implementation(libs.okio)
                 api(libs.kotlinx.datetime)
+                // Kermit only — :core:logging depends on this module, so `Diag` is unreachable here.
+                // Its PersistentLogWriter is a Kermit LogWriter, so plain Kermit still reaches the
+                // diagnostic export.
+                implementation(libs.kermit)
             }
         }
         commonTest.dependencies {

--- a/core/common/src/commonMain/kotlin/com/garfiec/librechat/core/common/result/ApiException.kt
+++ b/core/common/src/commonMain/kotlin/com/garfiec/librechat/core/common/result/ApiException.kt
@@ -15,4 +15,13 @@ class ApiException(
     val isBanned: Boolean = false,
     val body: String? = null,
     cause: Throwable? = null,
+    /**
+     * True when [message] came out of the response body rather than being written by this app.
+     *
+     * Server-authored text is worth showing ("Invalid credentials" beats "Something went wrong"),
+     * but it is arbitrary and unbounded — a gateway can put an HTML login page there. Only text
+     * flagged here is screened before display; the app's own wording is trusted as-is, so a long
+     * but deliberate message can never be silently swallowed by that screen.
+     */
+    val serverAuthored: Boolean = false,
 ) : Exception(message, cause)

--- a/core/common/src/commonMain/kotlin/com/garfiec/librechat/core/common/result/FailureMessages.kt
+++ b/core/common/src/commonMain/kotlin/com/garfiec/librechat/core/common/result/FailureMessages.kt
@@ -1,0 +1,131 @@
+package com.garfiec.librechat.core.common.result
+
+/**
+ * Thrown when an access gateway in front of the server answered instead of the server itself
+ * (issue #287). Distinct from a transport failure: the network is fine and the server is up — the
+ * request never got past the gateway, so the fix is a credential in Settings → Account → Server
+ * connection, not a retry.
+ */
+class AccessGatewayException(
+    val serverUrl: String? = null,
+    cause: Throwable? = null,
+) : Exception("Access gateway rejected the request", cause)
+
+/**
+ * What went wrong, coarsely. Deliberately broad: it exists so the UI can decide whether to offer a
+ * retry (and, later, localize) without ever reading an exception message.
+ */
+enum class FailureKind {
+    /** No usable connection — DNS, socket, offline. */
+    Network,
+
+    /** The request was sent but nothing came back in time. */
+    Timeout,
+
+    /** A response arrived but wasn't what the API promised: HTML, truncated JSON, wrong shape. */
+    MalformedResponse,
+
+    /** An access gateway intercepted the request. See [AccessGatewayException]. */
+    AccessGateway,
+
+    /** The server answered with an error status and (usually) an explanation of its own. */
+    Server,
+
+    /** Anything unrecognised. */
+    Unknown,
+}
+
+/**
+ * User-facing failure text.
+ *
+ * These are hardcoded English, matching the existing convention in `LibreChatHttpClient`'s status
+ * fallbacks — `:core:common` has no `composeResources`. [FailureKind] rides along on
+ * [Result.Error] so a UI layer can localize by kind later without changing any of this.
+ */
+internal object FailureMessages {
+    const val NETWORK = "Network unavailable. Check your connection."
+    const val TIMEOUT = "The server took too long to respond."
+    const val MALFORMED = "Unexpected response from the server."
+    const val GATEWAY = "Your server's access gateway rejected this request. " +
+        "Check Server connection in Settings."
+    const val UNKNOWN = "Something went wrong. Please try again."
+}
+
+/**
+ * Longest server-authored message we will render. Past this it is not a sentence aimed at a person.
+ */
+private const val MAX_SERVER_MESSAGE_LENGTH = 200
+
+/**
+ * Above this length a message with no spaces at all is a token, a hash or a blob — never prose.
+ */
+private const val MAX_UNSPACED_LENGTH = 40
+
+/**
+ * Whether server-authored text is safe to put in front of a user.
+ *
+ * The server's own wording is genuinely useful ("Invalid credentials", "Email already registered"),
+ * so it is kept — but only when it actually looks like a sentence. A gateway's HTML login page, a
+ * redirect URL with a JWT in the query string, or a raw token would otherwise be rendered verbatim
+ * in an error banner (issue #287).
+ */
+internal fun looksLikeUserMessage(message: String): Boolean {
+    val trimmed = message.trim()
+    return when {
+        trimmed.isEmpty() || trimmed.length > MAX_SERVER_MESSAGE_LENGTH -> false
+        // Markup, URLs and multi-line payloads are documents, not messages.
+        trimmed.any { it == '<' || it == '>' || it == '\n' || it == '\r' } -> false
+        trimmed.contains("://") -> false
+        // A long unbroken run with no spaces is a token/hash, not a sentence.
+        trimmed.length > MAX_UNSPACED_LENGTH && !trimmed.contains(' ') -> false
+        else -> true
+    }
+}
+
+/**
+ * Classifies a failure by walking the cause chain.
+ *
+ * Matched on exception *type names* rather than the types themselves because `:core:common` sits
+ * below `:core:network` and cannot see Ktor or kotlinx-serialization. That is a deliberate trade: a
+ * renamed upstream exception degrades one category to [FailureKind.Unknown] — still a safe,
+ * non-leaking message — whereas depending on Ktor here would invert the module graph.
+ */
+internal fun classifyFailure(throwable: Throwable): FailureKind {
+    var current: Throwable? = throwable
+    // Bounded: a malformed cause chain must not spin forever.
+    repeat(TRAVERSAL_LIMIT) {
+        val error = current ?: return FailureKind.Unknown
+        when (error) {
+            is AccessGatewayException -> return FailureKind.AccessGateway
+            is ApiException -> return FailureKind.Server
+            else -> Unit
+        }
+        val name = error::class.simpleName.orEmpty()
+        when {
+            name.contains("Timeout") -> return FailureKind.Timeout
+            name.contains("UnresolvedAddress") ||
+                name.contains("UnknownHost") ||
+                name.contains("ConnectException") ||
+                name.contains("SocketException") ||
+                name.contains("IOException") -> return FailureKind.Network
+            name.contains("NoTransformationFound") ||
+                name.contains("Serialization") ||
+                name.contains("JsonConvert") ||
+                name.contains("JsonDecoding") ||
+                name.contains("ContentConvert") -> return FailureKind.MalformedResponse
+        }
+        current = error.cause?.takeIf { it !== error }
+    }
+    return FailureKind.Unknown
+}
+
+private const val TRAVERSAL_LIMIT = 8
+
+/** The safe, user-facing text for a [FailureKind]. */
+internal fun FailureKind.defaultMessage(): String = when (this) {
+    FailureKind.Network -> FailureMessages.NETWORK
+    FailureKind.Timeout -> FailureMessages.TIMEOUT
+    FailureKind.MalformedResponse -> FailureMessages.MALFORMED
+    FailureKind.AccessGateway -> FailureMessages.GATEWAY
+    FailureKind.Server, FailureKind.Unknown -> FailureMessages.UNKNOWN
+}

--- a/core/common/src/commonMain/kotlin/com/garfiec/librechat/core/common/result/Result.kt
+++ b/core/common/src/commonMain/kotlin/com/garfiec/librechat/core/common/result/Result.kt
@@ -1,10 +1,23 @@
 package com.garfiec.librechat.core.common.result
 
+import co.touchlab.kermit.Logger
 import kotlinx.coroutines.CancellationException
 
 sealed interface Result<out T> {
     data class Success<T>(val data: T) : Result<T>
-    data class Error(val exception: Throwable? = null, val message: String? = null) : Result<Nothing>
+
+    /**
+     * [message] is safe to render: it is either app-authored or server text that passed
+     * [looksLikeUserMessage]. The untrimmed detail lives on [exception] and in the log — never put
+     * `exception.message` on screen. [kind] lets a UI layer branch (retry affordance, and localized
+     * copy later) without parsing text.
+     */
+    data class Error(
+        val exception: Throwable? = null,
+        val message: String? = null,
+        val kind: FailureKind = FailureKind.Unknown,
+    ) : Result<Nothing>
+
     data object Loading : Result<Nothing>
 }
 
@@ -27,5 +40,27 @@ suspend fun <T> safeApiCall(block: suspend () -> T): Result<T> =
         // not writing stale errors back to state (e.g. SettingsViewModel.loadUserJob).
         throw e
     } catch (e: Exception) {
-        Result.Error(e, e.message ?: "An unexpected error occurred")
+        e.toSafeError()
     }
+
+/**
+ * Turns a caught failure into a [Result.Error] whose message is fit to display, and sends the full
+ * detail to the log instead.
+ *
+ * Never hand `exception.message` to the UI: Ktor composes its messages out of the request URL, so
+ * an access gateway's redirect would render on screen complete with its `meta=` JWT (issue #287).
+ */
+fun Throwable.toSafeError(): Result.Error {
+    val kind = classifyFailure(this)
+    Logger.e(throwable = this) { "Request failed (${kind.name})" }
+    // Only response-body text is screened; the app's own wording is trusted as-is. See
+    // [ApiException.serverAuthored].
+    val apiMessage = (this as? ApiException)?.let { api ->
+        if (api.serverAuthored) api.message.takeIf(::looksLikeUserMessage) else api.message
+    }
+    return Result.Error(
+        exception = this,
+        message = apiMessage ?: kind.defaultMessage(),
+        kind = kind,
+    )
+}

--- a/core/common/src/commonTest/kotlin/com/garfiec/librechat/core/common/result/SafeApiCallTest.kt
+++ b/core/common/src/commonTest/kotlin/com/garfiec/librechat/core/common/result/SafeApiCallTest.kt
@@ -21,12 +21,19 @@ class SafeApiCallTest {
         assertEquals("hello", result.data)
     }
 
+    /**
+     * The exception is kept for logging and diagnosis, but its message is NOT the user-facing text:
+     * Ktor quotes the request URL in its own messages, so passing `e.message` through would render
+     * a gateway redirect and its `meta=` JWT in an error banner.
+     */
     @Test
     fun safeApiCallReturnsErrorOnException() = runTest {
         val result = safeApiCall<String> { throw IllegalStateException("boom") }
         assertIs<Result.Error>(result)
-        assertEquals("boom", result.message)
+        assertEquals(FailureMessages.UNKNOWN, result.message)
+        assertEquals(FailureKind.Unknown, result.kind)
         assertIs<IllegalStateException>(result.exception)
+        assertEquals("boom", result.exception?.message)
     }
 
     @Test

--- a/core/common/src/commonTest/kotlin/com/garfiec/librechat/core/common/result/SafeErrorMessageTest.kt
+++ b/core/common/src/commonTest/kotlin/com/garfiec/librechat/core/common/result/SafeErrorMessageTest.kt
@@ -1,0 +1,140 @@
+package com.garfiec.librechat.core.common.result
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * What reaches the UI when a call fails.
+ *
+ * The rule these pin down: an exception's own message is never user-facing. Ktor builds its
+ * messages out of the request URL, so passing one through renders an access gateway's redirect —
+ * query string and `meta=` JWT included — verbatim in an error banner.
+ */
+class SafeErrorMessageTest {
+
+    /** The exact shape that put a JWT on screen: Ktor's type-mismatch message quoting the URL. */
+    private class NoTransformationFoundException(message: String) : Exception(message)
+
+    private class HttpRequestTimeoutException : Exception("Request timeout has expired")
+
+    private class IOException(message: String) : Exception(message)
+
+    private val gatewayRedirectMessage =
+        "Expected response body of the type 'class com.garfiec.librechat.core.model.User' " +
+            "but was 'class io.ktor.utils.io.SourceByteReadChannel'\n" +
+            "In response from `https://team.cloudflareaccess.com/cdn-cgi/access/login/" +
+            "chat.example.com?kid=0000000000000000&meta=eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9`"
+
+    @Test
+    fun `the gateway redirect message never reaches the user`() {
+        val error = NoTransformationFoundException(gatewayRedirectMessage).toSafeError()
+
+        assertEquals(FailureMessages.MALFORMED, error.message)
+        assertEquals(FailureKind.MalformedResponse, error.kind)
+        // The specifics that must not be on screen.
+        assertFalse(error.message.orEmpty().contains("cloudflareaccess"))
+        assertFalse(error.message.orEmpty().contains("meta="))
+        assertFalse(error.message.orEmpty().contains("eyJ"))
+        // ...but they are still recoverable for a bug report.
+        assertTrue(error.exception is NoTransformationFoundException)
+    }
+
+    @Test
+    fun `transport failures map to their own category`() {
+        assertEquals(FailureKind.Timeout, HttpRequestTimeoutException().toSafeError().kind)
+        assertEquals(FailureMessages.TIMEOUT, HttpRequestTimeoutException().toSafeError().message)
+
+        assertEquals(FailureKind.Network, IOException("Connection reset").toSafeError().kind)
+        assertEquals(FailureMessages.NETWORK, IOException("Connection reset").toSafeError().message)
+    }
+
+    @Test
+    fun `an access gateway rejection is its own actionable category`() {
+        val error = AccessGatewayException(serverUrl = "https://chat-test.example.org").toSafeError()
+
+        assertEquals(FailureKind.AccessGateway, error.kind)
+        assertEquals(FailureMessages.GATEWAY, error.message)
+    }
+
+    /** The classifier walks the chain — Ktor wraps the interesting exception more often than not. */
+    @Test
+    fun `a wrapped cause is still classified`() {
+        val wrapped = IllegalStateException("outer", HttpRequestTimeoutException())
+
+        assertEquals(FailureKind.Timeout, wrapped.toSafeError().kind)
+    }
+
+    /** A self-referencing cause chain must not hang the classifier. */
+    @Test
+    fun `a cyclic cause chain terminates`() {
+        val cyclic = object : Exception("loops") {
+            override val cause: Throwable get() = this
+        }
+
+        assertEquals(FailureKind.Unknown, cyclic.toSafeError().kind)
+    }
+
+    @Test
+    fun `useful server wording survives`() {
+        listOf("Invalid credentials", "Email already registered", "Too many requests. Try later.")
+            .forEach { serverText ->
+                val error = ApiException(
+                    statusCode = 400,
+                    message = serverText,
+                    serverAuthored = true,
+                ).toSafeError()
+                assertEquals(serverText, error.message)
+                assertEquals(FailureKind.Server, error.kind)
+            }
+    }
+
+    @Test
+    fun `server text that is not a message falls back`() {
+        val hostile = listOf(
+            "<html><body>Sign in to continue</body></html>",
+            "https://gateway.example.com/login?token=eyJhbGciOiJIUzI1NiJ9",
+            "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IjQ4MmYxNTFkMTA3NzE4OGU1ODc0N2VkODl9",
+            "a".repeat(500),
+            "line one\nline two",
+        )
+        hostile.forEach { body ->
+            val error = ApiException(
+                statusCode = 500,
+                message = body,
+                serverAuthored = true,
+            ).toSafeError()
+            assertEquals(FailureMessages.UNKNOWN, error.message, "should not render: $body")
+        }
+    }
+
+    /**
+     * The app's own wording is trusted outright — several deliberate in-app messages run close to
+     * the screening length limit, and silently swallowing one would be worse than the leak this
+     * screen exists to stop.
+     */
+    @Test
+    fun `app-authored text is never screened, however long`() {
+        val longAppMessage = "Server returned an unexpected response when starting the chat. " +
+            "This usually indicates a backend version incompatibility — please check that the " +
+            "server is running a supported LibreChat release, and that no proxy is rewriting it."
+        val error = ApiException(statusCode = 200, message = longAppMessage).toSafeError()
+
+        assertEquals(longAppMessage, error.message)
+    }
+
+    @Test
+    fun `the message gate accepts prose and rejects payloads`() {
+        assertTrue(looksLikeUserMessage("Invalid credentials"))
+        assertTrue(looksLikeUserMessage("Access denied"))
+        // Exactly at the unspaced limit, still fine.
+        assertTrue(looksLikeUserMessage("a".repeat(40)))
+
+        assertFalse(looksLikeUserMessage(""))
+        assertFalse(looksLikeUserMessage("   "))
+        assertFalse(looksLikeUserMessage("a".repeat(41)))
+        assertFalse(looksLikeUserMessage("see <b>here</b>"))
+        assertFalse(looksLikeUserMessage("go to https://example.com"))
+    }
+}

--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/datastore/ServerHeadersDataStoreTest.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/datastore/ServerHeadersDataStoreTest.kt
@@ -1,0 +1,120 @@
+package com.garfiec.librechat.core.data.datastore
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+/**
+ * Persistence contract for per-server gateway headers (issue #287).
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class ServerHeadersDataStoreTest {
+
+    @get:Rule
+    val tmpFolder = TemporaryFolder()
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private val json = Json { ignoreUnknownKeys = true }
+
+    private val server = "https://chat.example.com"
+    private val other = "https://other.example.com"
+    private val headers = mapOf("CF-Access-Client-Id" to "id", "CF-Access-Client-Secret" to "secret")
+
+    private fun createDataStore(name: String): DataStore<Preferences> =
+        PreferenceDataStoreFactory.create { File(tmpFolder.root, "$name.preferences_pb") }
+
+    private fun store(ds: DataStore<Preferences>) =
+        ServerHeadersDataStore(ds, json, CoroutineScope(testDispatcher), testDispatcher)
+
+    @Test
+    fun `headers written are visible to the very next read with no restart`() = runTest(testDispatcher) {
+        // ServerUrlViewModel saves and then immediately probes the server. A snapshot cache would make
+        // the first Connect after entering a token fail and the second succeed — which reads as
+        // flakiness, not as a bug anyone can report.
+        val subject = store(createDataStore("headers-live"))
+        subject.awaitWarm()
+
+        subject.setHeaders(server, headers)
+
+        assertThat(subject.headersFor(server)).isEqualTo(headers)
+    }
+
+    @Test
+    fun `headers are scoped per server`() = runTest(testDispatcher) {
+        val subject = store(createDataStore("headers-scope"))
+        subject.setHeaders(server, headers)
+
+        assertThat(subject.headersFor(other)).isEmpty()
+    }
+
+    @Test
+    fun `url variants of the same deployment resolve to the same headers`() = runTest(testDispatcher) {
+        // beginAdd pins its URL with trimTrailingSlash(), not normalizeServerUrl — so the strings
+        // genuinely differ between call sites while the deployment is the same. Everything must derive.
+        val subject = store(createDataStore("headers-normalize"))
+        subject.setHeaders("https://chat.example.com/", headers)
+
+        assertThat(subject.headersFor("https://Chat.Example.com:443")).isEqualTo(headers)
+    }
+
+    @Test
+    fun `a blank or unparseable base URL yields empty rather than throwing`() = runTest(testDispatcher) {
+        // Routine, not exotic: cold start before warm-up, and ServerUrlViewModel setting
+        // setServerUrl("") after every failed probe. Both normalizeServerUrl and ServerId throw on
+        // these, and this runs on the request path where a throw surfaces as a network failure.
+        val subject = store(createDataStore("headers-blank"))
+        subject.setHeaders(server, headers)
+
+        assertThat(subject.headersFor("")).isEmpty()
+        assertThat(subject.headersFor("   ")).isEmpty()
+        assertThat(subject.headersFor("ftp://nope")).isEmpty()
+        assertThat(subject.headersFor("https://")).isEmpty()
+    }
+
+    @Test
+    fun `an empty map removes the entry`() = runTest(testDispatcher) {
+        val subject = store(createDataStore("headers-clear"))
+        subject.setHeaders(server, headers)
+        subject.setHeaders(server, emptyMap())
+
+        assertThat(subject.headersFor(server)).isEmpty()
+    }
+
+    @Test
+    fun `reserved and malformed pairs never survive a round trip`() = runTest(testDispatcher) {
+        val subject = store(createDataStore("headers-sanitize"))
+        subject.setHeaders(
+            server,
+            mapOf(
+                "CF-Access-Client-Id" to "keep",
+                "Authorization" to "Basic nope",
+                "User-Agent" to "curl/8",
+            ),
+        )
+
+        assertThat(subject.headersFor(server)).containsExactly("CF-Access-Client-Id", "keep")
+    }
+
+    @Test
+    fun `headers survive a new store instance over the same preferences`() = runTest(testDispatcher) {
+        // Logging out must not cost the user their gateway credential — it is what lets them log
+        // back IN. Nothing sweeps the srv: namespace, so this is really asserting that absence.
+        val ds = createDataStore("headers-persist")
+        store(ds).setHeaders(server, headers)
+
+        val reopened = store(ds)
+        reopened.awaitWarm()
+
+        assertThat(reopened.headersFor(server)).isEqualTo(headers)
+    }
+}

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/CommonTokenDataStore.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/CommonTokenDataStore.kt
@@ -6,6 +6,7 @@ import com.garfiec.librechat.core.logging.Diag
 import com.garfiec.librechat.core.logging.LogOrigin
 import com.garfiec.librechat.core.model.response.RefreshResponse
 import com.garfiec.librechat.core.network.client.CookieHelper
+import com.garfiec.librechat.core.network.client.PinnedServerBaseUrlKey
 import com.garfiec.librechat.core.network.client.RefreshResult
 import com.garfiec.librechat.core.network.client.SecureTokenStorage
 import com.garfiec.librechat.core.network.client.TokenManager
@@ -274,12 +275,18 @@ abstract class CommonTokenDataStore(
 
     override suspend fun refreshAccessToken(): RefreshResult =
         // The live active account, against the live base URL (the refresh client's defaultRequest).
-        performRefresh(accountKey = activeAccountKey, absoluteRefreshUrl = null)
+        performRefresh(accountKey = activeAccountKey, absoluteRefreshUrl = null, pinnedBaseUrl = null)
 
     override suspend fun refreshAccessTokenFor(accountId: String, baseUrl: String): RefreshResult =
         // URL-pinned: post to an absolute URL so a concurrent server switch can't redirect this
-        // account's refresh token to another server.
-        performRefresh(accountKey = accountId, absoluteRefreshUrl = "${baseUrl.trimTrailingSlash()}$REFRESH_PATH")
+        // account's refresh token to another server. [pinnedBaseUrl] carries the *server* half of that
+        // pin to ServerHeadersPlugin — the request URL alone can't serve as the key, because it is the
+        // refresh endpoint, not the deployment root, and would derive a different serverId.
+        performRefresh(
+            accountKey = accountId,
+            absoluteRefreshUrl = "${baseUrl.trimTrailingSlash()}$REFRESH_PATH",
+            pinnedBaseUrl = baseUrl.trimTrailingSlash(),
+        )
 
     /**
      * Refresh [accountKey]'s tokens with a bounded retry loop, classifying the outcome so a caller can
@@ -300,7 +307,11 @@ abstract class CommonTokenDataStore(
      * [Transient] so the session is kept. A transport failure (server unreachable) is terminal-Transient
      * rather than retried, so the flight lock is not held across repeated full request timeouts.
      */
-    private suspend fun performRefresh(accountKey: String?, absoluteRefreshUrl: String?): RefreshResult =
+    private suspend fun performRefresh(
+        accountKey: String?,
+        absoluteRefreshUrl: String?,
+        pinnedBaseUrl: String?,
+    ): RefreshResult =
         flightFor(accountKey).withLock {
             // Any auth rejection ⇒ a genuinely dead session ⇒ route to re-auth, even if a later attempt
             // hit a transient blip; a purely transient run (5xx / rate-limit / transport) keeps the
@@ -332,7 +343,10 @@ abstract class CommonTokenDataStore(
                 }
 
                 val delayMillis: Long =
-                    when (val outcome = attemptRefresh(accountKey, epochAtStart, storedRefreshToken, absoluteRefreshUrl)) {
+                    when (
+                        val outcome =
+                            attemptRefresh(accountKey, epochAtStart, storedRefreshToken, absoluteRefreshUrl, pinnedBaseUrl)
+                    ) {
                         RefreshAttempt.Success -> return@withLock RefreshResult.Refreshed
                         // A teardown/re-authentication owns the routing for this slot; never double-emit
                         // a session-expired from here and never re-persist over it.
@@ -371,10 +385,15 @@ abstract class CommonTokenDataStore(
         epochAtStart: Int,
         storedRefreshToken: String,
         absoluteRefreshUrl: String?,
+        pinnedBaseUrl: String?,
     ): RefreshAttempt =
         try {
             val httpResponse: HttpResponse = refreshClient.value
                 .post(absoluteRefreshUrl ?: REFRESH_PATH) {
+                    // Tells ServerHeadersPlugin which deployment's gateway headers this POST needs.
+                    // Without it the plugin would fall back to the *live* base URL and pair server B's
+                    // headers with server A's pinned refresh URL.
+                    pinnedBaseUrl?.let { attributes.put(PinnedServerBaseUrlKey, it) }
                     header("Cookie", "refreshToken=$storedRefreshToken")
                     setBody(mapOf("refreshToken" to storedRefreshToken))
                 }

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/ServerHeadersDataStore.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/ServerHeadersDataStore.kt
@@ -1,0 +1,157 @@
+package com.garfiec.librechat.core.data.datastore
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import co.touchlab.kermit.Logger
+import com.garfiec.librechat.core.common.identity.deriveServerId
+import com.garfiec.librechat.core.network.client.CustomHeaderRules
+import com.garfiec.librechat.core.network.client.ServerHeadersProvider
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.serialization.builtins.MapSerializer
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.json.Json
+import kotlin.concurrent.Volatile
+
+/**
+ * Per-server gateway headers (issue #287), persisted as `srv:<serverId>:custom_headers` in the shared
+ * preference store — the same server-scoped namespace as [ConfigCacheDataStore].
+ *
+ * **Server-scoped, not account-scoped**, and that is forced rather than chosen: the credential is
+ * needed on the very first request to a protected deployment, which happens before any account
+ * exists. It also means nothing sweeps it — `removeAllForAccount` is `acct:`-prefixed only, so
+ * logging out keeps the headers, which is required, since they are what lets you log back *in*.
+ *
+ * **Stored in plaintext.** The realistic exfiltration path for app-private preferences is an ADB
+ * backup, which `android:allowBackup="false"` already closes; on iOS the app container is sandboxed.
+ * Against that, `EncryptedSharedPreferences` would add a wipe-and-rebuild failure mode on OEMs with
+ * broken Keystores (see `TokenDataStore`) — and losing this particular value doesn't degrade to a
+ * re-login prompt, it degrades to a server the user can no longer reach at all.
+ *
+ * The in-memory map is **Flow-backed, not read once**: `ServerUrlViewModel` writes headers and probes
+ * the server back-to-back, so a one-shot warm read would make the first Connect after entering a
+ * token fail and the second succeed.
+ */
+class ServerHeadersDataStore(
+    private val dataStore: DataStore<Preferences>,
+    private val json: Json,
+    appScope: CoroutineScope,
+    ioDispatcher: CoroutineDispatcher,
+) : ServerHeadersProvider {
+
+    // Completes once the persisted headers have resolved (success, failure, or cancellation), so a
+    // cold-start request never builds itself against the empty pre-warm-up map. An access gateway
+    // answers a credential-less request with a redirect to its own login page, not a retryable error,
+    // so "we'll catch it on the retry" is not available to us here.
+    private val warmedUp = CompletableDeferred<Unit>()
+
+    @Volatile
+    private var byServerId: Map<String, Map<String, String>> = emptyMap()
+
+    private val writeMutex = Mutex()
+
+    init {
+        appScope.launch(ioDispatcher) {
+            try {
+                dataStore.data.collect { prefs ->
+                    byServerId = parse(prefs)
+                    warmedUp.complete(Unit)
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                // Leave the map empty: a server with no gateway in front of it still works, and one
+                // with a gateway surfaces the same actionable failure as an unconfigured server.
+                Logger.w(e) { "Failed to load custom server headers" }
+            } finally {
+                // Also on cancellation — an awaiter must never hang on a scope that went away.
+                warmedUp.complete(Unit)
+            }
+        }
+    }
+
+    override suspend fun awaitWarm() {
+        warmedUp.await()
+    }
+
+    override fun headersFor(baseUrl: String): Map<String, String> =
+        serverIdOf(baseUrl)?.let { byServerId[it] }.orEmpty()
+
+    /** Headers currently configured for [serverUrl], after the store has warmed up. For the UI. */
+    suspend fun headersForServer(serverUrl: String): Map<String, String> {
+        warmedUp.await()
+        return headersFor(serverUrl)
+    }
+
+    /**
+     * Persist [headers] for [serverUrl], replacing whatever was there. An empty map removes the entry
+     * entirely rather than storing `{}`.
+     *
+     * Refreshes the in-memory map before returning instead of waiting for the collector to see the
+     * write, so the caller's very next request carries the new headers. `ServerUrlViewModel` saves and
+     * then immediately probes the server, and that probe is the whole point of saving.
+     *
+     * @return false when [serverUrl] yields no server id and nothing was written. Callers must not
+     * report success on a false: a UI that confirms "saved" and clears its dirty flag leaves the user
+     * believing a credential is stored that never reached disk, with no way to retry.
+     */
+    suspend fun setHeaders(serverUrl: String, headers: Map<String, String>): Boolean {
+        val serverId = serverIdOf(serverUrl) ?: return false
+        val sanitized = CustomHeaderRules.sanitize(headers)
+        val key = serverScopedKey(serverId, CUSTOM_HEADERS)
+        writeMutex.withLock {
+            dataStore.edit { prefs ->
+                if (sanitized.isEmpty()) prefs.remove(key) else prefs[key] = json.encodeToString(SERIALIZER, sanitized)
+            }
+            // Re-parse the whole store rather than patching one entry: a concurrent write to a
+            // different server would otherwise be clobbered by a stale read-modify-write.
+            byServerId = parse(dataStore.data.first())
+        }
+        return true
+    }
+
+    /**
+     * The server id for [rawUrl], or null when it isn't a usable server URL.
+     *
+     * Always derived, never string-compared: `AccountSwitcher.beginAdd` pins its URL with
+     * `trimTrailingSlash()` rather than `normalizeServerUrl`, so the strings genuinely differ between
+     * call sites while the deployment is the same.
+     *
+     * Both `normalizeServerUrl` and `ServerId` reject blank/schemeless input by throwing, and blank
+     * base URLs are entirely routine on this path — cold start before warm-up, and
+     * `ServerUrlViewModel` setting `setServerUrl("")` after every failed probe. Swallow rather than
+     * propagate: this runs on the request path, where a throw would surface as a network failure.
+     */
+    private fun serverIdOf(rawUrl: String): String? {
+        if (rawUrl.isBlank()) return null
+        return runCatching { deriveServerId(rawUrl).value }.getOrNull()
+    }
+
+    private fun parse(prefs: Preferences): Map<String, Map<String, String>> =
+        prefs.asMap().entries.mapNotNull { (key, value) ->
+            val name = key.name
+            if (!name.startsWith(PREFIX) || !name.endsWith(SUFFIX)) return@mapNotNull null
+            val serverId = name.removePrefix(PREFIX).removeSuffix(SUFFIX)
+            if (serverId.isEmpty()) return@mapNotNull null
+            val raw = value as? String ?: return@mapNotNull null
+            val decoded = runCatching { json.decodeFromString(SERIALIZER, raw) }.getOrNull() ?: return@mapNotNull null
+            // Sanitise on the way out of storage too, so a pair written by an older build — or one
+            // whose name a later release added to RESERVED_NAMES — can't reach the wire.
+            val sanitized = CustomHeaderRules.sanitize(decoded)
+            if (sanitized.isEmpty()) null else serverId to sanitized
+        }.toMap()
+
+    private companion object {
+        const val CUSTOM_HEADERS = "custom_headers"
+        val PREFIX = serverScopedName("", "").removeSuffix(":")
+        val SUFFIX = ":$CUSTOM_HEADERS"
+        val SERIALIZER = MapSerializer(String.serializer(), String.serializer())
+    }
+}

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/di/DataModule.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/di/DataModule.kt
@@ -10,6 +10,7 @@ import com.garfiec.librechat.core.data.datastore.AccountScopedPrefsPurger
 import com.garfiec.librechat.core.data.datastore.ConfigCacheDataStore
 import com.garfiec.librechat.core.data.datastore.RoleCacheDataStore
 import com.garfiec.librechat.core.data.datastore.ServerDataStore
+import com.garfiec.librechat.core.data.datastore.ServerHeadersDataStore
 import com.garfiec.librechat.core.data.datastore.SettingsDataStore
 import com.garfiec.librechat.core.data.datastore.ThemeDataStore
 import com.garfiec.librechat.core.data.db.LibreChatDatabase
@@ -84,6 +85,7 @@ import com.garfiec.librechat.core.data.util.SessionTask
 import com.garfiec.librechat.core.data.util.SessionTaskRunner
 import com.garfiec.librechat.core.data.util.SyncFavoritesSessionTask
 import com.garfiec.librechat.core.network.client.AccountReadyGate
+import com.garfiec.librechat.core.network.client.ServerHeadersProvider
 import com.garfiec.librechat.core.network.client.ServerUrlProvider
 import kotlinx.coroutines.CoroutineScope
 import org.koin.core.module.Module
@@ -158,6 +160,7 @@ val dataModule = module {
             accountDataPurger = get(),
             prefsPurger = get(),
             sessionCacheCleaner = get(),
+            serverHeadersProvider = get(),
         )
     }
     single { AccountScopedPrefsPurger(dataStore = get()) }
@@ -197,6 +200,14 @@ val dataModule = module {
             ioDispatcher = get(KoinQualifiers.IO),
         )
     }
+    single {
+        ServerHeadersDataStore(
+            dataStore = get(),
+            json = get(),
+            appScope = get<CoroutineScope>(KoinQualifiers.ApplicationScope),
+            ioDispatcher = get(KoinQualifiers.IO),
+        )
+    } bind ServerHeadersProvider::class
     singleOf(::ConfigCacheDataStore)
     singleOf(::RoleCacheDataStore)
     single {

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/AccountSwitcher.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/AccountSwitcher.kt
@@ -13,7 +13,9 @@ import com.garfiec.librechat.core.data.datastore.AccountScopedPrefsPurger
 import com.garfiec.librechat.core.data.datastore.ServerDataStore
 import com.garfiec.librechat.core.model.User
 import com.garfiec.librechat.core.model.config.StartupConfig
+import com.garfiec.librechat.core.network.client.EmptyServerHeadersProvider
 import com.garfiec.librechat.core.network.client.PendingRequestIdentity
+import com.garfiec.librechat.core.network.client.ServerHeadersProvider
 import com.garfiec.librechat.core.network.client.SwitchGate
 import com.garfiec.librechat.core.network.client.TokenManager
 import kotlinx.coroutines.NonCancellable
@@ -97,6 +99,9 @@ class AccountSwitcher(
     private val accountDataPurger: AccountDataPurger,
     private val prefsPurger: AccountScopedPrefsPurger,
     private val sessionCacheCleaner: SessionCacheCleaner,
+    // Trailing + defaulted: several test harnesses construct this positionally, and an add-account
+    // flow against a server with no gateway in front of it needs nothing from here.
+    private val serverHeadersProvider: ServerHeadersProvider = EmptyServerHeadersProvider,
 ) {
 
     /** The in-progress add-account flow, or null. The auth repository reads this to route sign-in
@@ -174,6 +179,15 @@ class AccountSwitcher(
             serverUrl = normalizedUrl,
             requestIdentity = PendingRequestIdentity(
                 baseUrl = normalizedUrl,
+                // Awaits the header store itself: captureSnapshot short-circuits to the pending
+                // identity before running any of its own awaits, so this is the only place the
+                // add-account probe can be kept from racing a cold store. Keyed on the URL being
+                // added, never the live one — adding a second account on an unprotected server while
+                // signed in to a gateway-protected one must not send that gateway's secret.
+                headers = {
+                    serverHeadersProvider.awaitWarm()
+                    serverHeadersProvider.headersFor(normalizedUrl)
+                },
                 bearer = { tokenManager.getStagedAccessToken() },
             ),
         )

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/AuthRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/AuthRepositoryImpl.kt
@@ -104,9 +104,16 @@ class AuthRepositoryImpl(
      */
     private suspend fun fetchAuthenticatedUser(pending: PendingAddSession?): User {
         if (pending != null) return userApi.getUser()
-        val baseUrl = switchGate.captureSnapshot().baseUrl
+        val snapshot = switchGate.captureSnapshot()
         return withContext(
-            PendingRequestIdentity(baseUrl = baseUrl, bearer = { tokenManager.getStagedAccessToken() }),
+            PendingRequestIdentity(
+                baseUrl = snapshot.baseUrl,
+                // Carried over from the snapshot rather than re-read: this overrides the identity for
+                // a request to the *same* server, so dropping the gateway headers here would make the
+                // post-login profile fetch the one call that can't get through the gateway.
+                headers = { snapshot.customHeaders },
+                bearer = { tokenManager.getStagedAccessToken() },
+            ),
         ) { userApi.getUser() }
     }
 
@@ -271,7 +278,11 @@ class AuthRepositoryImpl(
             val account = snapshot.accountId?.let { AccountId(it) }
             try {
                 withContext(
-                    PendingRequestIdentity(baseUrl = snapshot.baseUrl, bearer = { snapshot.bearer }),
+                    PendingRequestIdentity(
+                        baseUrl = snapshot.baseUrl,
+                        headers = { snapshot.customHeaders },
+                        bearer = { snapshot.bearer },
+                    ),
                 ) { authApi.logout() }
             } finally {
                 // Teardown must finish even if this coroutine is cancelled mid-way (e.g. the Activity

--- a/core/network/CLAUDE.md
+++ b/core/network/CLAUDE.md
@@ -61,6 +61,46 @@ Legacy single-phase path (OpenAI Assistants): POST body is the SSE stream itself
 
 The Ktor SSE plugin uses the same `NSURLSessionDataTask` code path as the regular Darwin engine, so it would have the same Layer 2 bug on iOS. The custom transport is mandatory.
 
+## Custom per-server headers (issue #287)
+
+`ServerHeadersPlugin` attaches the user's static gateway headers (Cloudflare Access service tokens and
+equivalents) and is installed on **all three** clients — main, streaming, and refresh. The store lives
+in `:core:data` (`ServerHeadersDataStore`, keyed `srv:<serverId>:custom_headers`, plaintext); iOS SSE
+gets them off the `RequestIdentity` snapshot and renders them via `customHeaderLines`.
+
+Two rules that are load-bearing and easy to undo by accident:
+
+- **The headers must NOT reuse `AuthInterceptorPlugin`'s `skipPaths`.** Those exist to keep the bearer
+  off `auth/login` and `auth/refresh`; gating the gateway credential the same way leaves the app unable
+  to sign in at all.
+- **The cross-authority strip must stay in the `HttpSend` interceptor.** Ktor's `HttpRedirect` copies
+  every header to a redirect target and strips only `Authorization`, and it re-executes below the
+  request pipeline — so a `State`-phase host check cannot see the new host. `FilesApi.downloadFromUrl`
+  fetches server-supplied absolute URLs, so this is reachable. `KtorRedirectContractTest` pins the Ktor
+  behaviour; without it the guard's own test would be unfalsifiable.
+
+Host-scoping for these is stricter than for the bearer (`isSameServerAuthority` vs
+`isSameHostAsServer`, both in `HostScoping.kt`): scheme + host + port, and fail-closed. A gateway token
+is long-lived and never rotates, so an `http://` downgrade or an unknown base URL must not carry it.
+
+The editor UI is shared: `CustomHeadersEditor` in `:core:ui` backs both the pre-login server screen
+(`feature/auth`) and the post-login Settings → Account → Server connection dialog (`feature/settings`),
+and its strings live in `core/ui`'s `composeResources`. `:core:ui` deliberately does **not** depend on
+`:core:network`, so each caller maps `HeaderRejection` to the editor's own `CustomHeaderRowError` —
+three lines, versus a UI-to-network module dependency taken on just to name three cases.
+
+Values are **masked** (`PasswordVisualTransformation`) with a per-row reveal toggle, matching how MCP
+server headers and provider API keys are already treated: these end up in screenshots and
+accessibility dumps otherwise. The reveal set is keyed by row index, so adding or removing a row
+re-masks everything rather than letting a stale index alias onto a different row's credential.
+
+The editor **branches on the width it is given** (`BoxWithConstraints`, stacking below 420dp), not on
+the device or a caller flag — the same phone needs stacking inside a dialog but has room on the
+full-screen pre-login form, and a tablet's dialog is narrow despite the tablet. Side by side, each
+field gets under half the width, which rendered both `CF-Access-Client-Id` and
+`CF-Access-Client-Secret` as `CF-Access-C…`: two different headers looking identical, next to a
+masked value.
+
 ## Key Configuration
 
 - `Json { ignoreUnknownKeys = true; isLenient = true; encodeDefaults = false; explicitNulls = false; coerceInputValues = true }`

--- a/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/client/CustomHeaderRulesTest.kt
+++ b/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/client/CustomHeaderRulesTest.kt
@@ -1,0 +1,148 @@
+package com.garfiec.librechat.core.network.client
+
+import com.google.common.truth.Truth.assertThat
+import io.ktor.http.HeadersBuilder
+import io.ktor.http.HttpHeaders
+import org.junit.Test
+
+/**
+ * The validation contract for user-entered gateway headers (issue #287), plus the `Cookie`
+ * merge/unpick pair that the redirect guard depends on.
+ */
+class CustomHeaderRulesTest {
+
+    @Test
+    fun `accepts a Cloudflare Access service token pair`() {
+        assertThat(CustomHeaderRules.validate("CF-Access-Client-Id", "4cf2254e.access")).isNull()
+        assertThat(CustomHeaderRules.validate("CF-Access-Client-Secret", "efde2dc9dbfff6c4")).isNull()
+    }
+
+    @Test
+    fun `values may contain spaces and may be empty`() {
+        // Spaces are legal in a header value (`Bearer x`, `key=a b`), and some gateways treat a
+        // present-but-empty header as meaningful.
+        assertThat(CustomHeaderRules.validateValue("token with spaces")).isNull()
+        assertThat(CustomHeaderRules.validateValue("")).isNull()
+    }
+
+    @Test
+    fun `rejects control characters and non-ASCII in values`() {
+        // CR/LF are request-splitting. Non-ASCII is the subtler one: it survives Ktor's own
+        // checkHeaderValue but throws inside OkHttp's Headers.Builder, whose message quotes the
+        // offending value — so a pasted secret would fail every Android request with the secret
+        // verbatim in the exception text.
+        assertThat(CustomHeaderRules.validateValue("bad\rvalue")).isEqualTo(HeaderRejection.InvalidValue)
+        assertThat(CustomHeaderRules.validateValue("bad\nvalue")).isEqualTo(HeaderRejection.InvalidValue)
+        assertThat(CustomHeaderRules.validateValue("bad\u0000value")).isEqualTo(HeaderRejection.InvalidValue)
+        // U+2019 right single quote and U+00A0 no-break space — what a pasted token actually looks
+        // like once it has been through a dashboard's rich-text field or a chat client.
+        assertThat(CustomHeaderRules.validateValue("smart\u2019quote")).isEqualTo(HeaderRejection.InvalidValue)
+        assertThat(CustomHeaderRules.validateValue("nb\u00A0space")).isEqualTo(HeaderRejection.InvalidValue)
+        // A plain space is legal and must NOT be rejected.
+        assertThat(CustomHeaderRules.validateValue("plain space")).isNull()
+    }
+
+    @Test
+    fun `trims surrounding whitespace off pasted values`() {
+        assertThat(CustomHeaderRules.normalizeValue("  token\n")).isEqualTo("token")
+        assertThat(CustomHeaderRules.sanitize(mapOf(" X-Token " to "  secret  ")))
+            .containsExactly("X-Token", "secret")
+    }
+
+    @Test
+    fun `rejects names the transport or the app owns`() {
+        listOf("Authorization", "user-agent", "Host", "Accept", "Content-Length", "TE").forEach { name ->
+            assertThat(CustomHeaderRules.validateName(name)).isEqualTo(HeaderRejection.ReservedName)
+        }
+    }
+
+    @Test
+    fun `Cookie is not reserved`() {
+        // Authelia, Authentik and oauth2-proxy all authenticate on a session cookie; reserving it
+        // would make the "any static-header gateway" promise false for the commonest self-hosted setups.
+        assertThat(CustomHeaderRules.validateName("Cookie")).isNull()
+    }
+
+    @Test
+    fun `rejects malformed names`() {
+        listOf("", "   ", "X Token", "X:Token", "X\nToken").forEach { name ->
+            assertThat(CustomHeaderRules.validateName(name)).isEqualTo(HeaderRejection.InvalidName)
+        }
+    }
+
+    @Test
+    fun `sanitize drops rejected pairs and keeps the rest`() {
+        val result = CustomHeaderRules.sanitize(
+            mapOf(
+                "CF-Access-Client-Id" to "keep-me",
+                "Authorization" to "Basic drop-me",
+                "X Bad Name" to "drop-me",
+                "X-Bad-Value" to "drop\r\nme",
+            ),
+        )
+        assertThat(result).containsExactly("CF-Access-Client-Id", "keep-me")
+    }
+
+    @Test
+    fun `applyCustomHeaders merges into a single Cookie header`() {
+        // Ktor's append is additive and RFC 6265 allows exactly one Cookie header; two lines are
+        // handled inconsistently across servers, and the app's own refreshToken cookie is on the line
+        // that would break.
+        val builder = HeadersBuilder().apply {
+            append(HttpHeaders.Cookie, "refreshToken=rt-1")
+            applyCustomHeaders(mapOf("Cookie" to "CF_Authorization=jwt"))
+        }
+        val cookies = builder.getAll(HttpHeaders.Cookie).orEmpty()
+        assertThat(cookies).hasSize(1)
+        assertThat(cookies.single()).isEqualTo("CF_Authorization=jwt; refreshToken=rt-1")
+    }
+
+    @Test
+    fun `the app's own cookie wins over a colliding user segment`() {
+        // Pasting a whole Cookie header out of browser devtools is the likely way anyone configures a
+        // cookie-auth gateway, and it can carry a stale refreshToken. Cookie parsers keep the FIRST
+        // occurrence of a repeated name (Express's cookie.parse among them), so ordering alone would
+        // let that stale value shadow the app's real one and sign the user out at every refresh.
+        val builder = HeadersBuilder()
+        builder.append(HttpHeaders.Cookie, "refreshToken=app-token")
+        builder.applyCustomHeaders(
+            mapOf(HttpHeaders.Cookie to "authelia_session=abc; refreshToken=stale-browser-token"),
+        )
+
+        val cookies = builder.getAll(HttpHeaders.Cookie).orEmpty()
+        assertThat(cookies).hasSize(1)
+        assertThat(cookies.single()).isEqualTo("authelia_session=abc; refreshToken=app-token")
+    }
+
+    @Test
+    fun `cookie name matching is case-sensitive per RFC 6265`() {
+        // `refreshToken` and `refreshtoken` are genuinely different cookies; folding them would drop a
+        // user segment the gateway needs.
+        val builder = HeadersBuilder()
+        builder.append(HttpHeaders.Cookie, "refreshToken=app-token")
+        builder.applyCustomHeaders(mapOf(HttpHeaders.Cookie to "refreshtoken=gateway-value"))
+
+        assertThat(builder.getAll(HttpHeaders.Cookie).orEmpty().single())
+            .isEqualTo("refreshtoken=gateway-value; refreshToken=app-token")
+    }
+
+    @Test
+    fun `stripCustomHeaders unpicks the user cookie and keeps the app's`() {
+        val builder = HeadersBuilder().apply {
+            append(HttpHeaders.Cookie, "refreshToken=rt-1")
+            applyCustomHeaders(mapOf("Cookie" to "CF_Authorization=jwt", "CF-Access-Client-Id" to "id"))
+            stripCustomHeaders(mapOf("Cookie" to "CF_Authorization=jwt", "CF-Access-Client-Id" to "id"))
+        }
+        assertThat(builder["CF-Access-Client-Id"]).isNull()
+        assertThat(builder.getAll(HttpHeaders.Cookie).orEmpty().single()).isEqualTo("refreshToken=rt-1")
+    }
+
+    @Test
+    fun `customHeaderLines renders CRLF-terminated lines for the iOS SSE transport`() {
+        // The iOS transport hand-writes its request, so this is the only unit-testable seam for it —
+        // core:network has no iosTest source set.
+        val lines = customHeaderLines(mapOf("CF-Access-Client-Id" to "id", "Authorization" to "dropped"))
+        assertThat(lines).isEqualTo("CF-Access-Client-Id: id\r\n")
+        assertThat(customHeaderLines(emptyMap())).isEmpty()
+    }
+}

--- a/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/client/GatewayDetectionPluginTest.kt
+++ b/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/client/GatewayDetectionPluginTest.kt
@@ -1,0 +1,125 @@
+package com.garfiec.librechat.core.network.client
+
+import com.garfiec.librechat.core.common.result.AccessGatewayException
+import com.google.common.truth.Truth.assertThat
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import kotlin.test.assertFailsWith
+
+/**
+ * Detection of an access gateway answering instead of the server (issue #287).
+ *
+ * The case that matters is the one no status check can see: the gateway 302s, Ktor follows it, and
+ * the sign-in page comes back as a perfectly valid **200 `text/html`**. Nothing fails until a typed
+ * call tries to decode it — and Ktor's decode error quotes the request URL, so a Cloudflare Access
+ * `meta=` JWT would render in an error banner.
+ */
+class GatewayDetectionPluginTest {
+
+    private companion object {
+        const val SERVER = "https://chat.example.com"
+        const val ACCESS_LOGIN =
+            "https://team.cloudflareaccess.com/cdn-cgi/access/login/chat.example.com?meta=eyJhbGci"
+        const val CF_CHALLENGE =
+            "Cloudflare-Access resource_metadata=\"https://chat.example.com/.well-known\""
+    }
+
+    private class FakeServerUrlProvider(private val baseUrl: String) : ServerUrlProvider {
+        override fun getBaseUrl(): String = baseUrl
+    }
+
+    private fun clientWith(engine: MockEngine): HttpClient = HttpClient(engine) {
+        install(GatewayDetectionPlugin) {
+            serverUrlProvider = FakeServerUrlProvider(SERVER)
+        }
+    }
+
+    /**
+     * Ktor follows the 302 to a 200 sign-in page, so without this plugin the call "succeeds" and
+     * blows up later with a URL-quoting decode error.
+     */
+    @Test
+    fun `a Cloudflare Access rejection surfaces as a typed gateway error`() = runTest {
+        val engine = MockEngine { request ->
+            if (request.url.host == "chat.example.com") {
+                respond(
+                    content = "",
+                    status = HttpStatusCode.Found,
+                    headers = headersOf(
+                        HttpHeaders.Location to listOf(ACCESS_LOGIN),
+                        HttpHeaders.WWWAuthenticate to listOf(CF_CHALLENGE),
+                        HttpHeaders.ContentType to listOf("text/html; charset=UTF-8"),
+                    ),
+                )
+            } else {
+                respond("<html>sign in</html>", HttpStatusCode.OK)
+            }
+        }
+
+        val failure = assertFailsWith<AccessGatewayException> {
+            clientWith(engine).get("$SERVER/api/config")
+        }
+
+        assertThat(failure.serverUrl).isEqualTo(SERVER)
+        // The gateway's URL and JWT must not ride along on the exception the UI classifies.
+        assertThat(failure.message.orEmpty()).doesNotContain("cloudflareaccess")
+        assertThat(failure.message.orEmpty()).doesNotContain("meta=")
+    }
+
+    /** An ordinary successful call must be untouched — this interceptor runs on every response. */
+    @Test
+    fun `a normal response passes through`() = runTest {
+        val engine = MockEngine { respond("""{"ok":true}""", HttpStatusCode.OK) }
+
+        assertThat(clientWith(engine).get("$SERVER/api/config").bodyAsText())
+            .isEqualTo("""{"ok":true}""")
+    }
+
+    /**
+     * The server legitimately redirects downloads off-authority to object storage. Keying on the
+     * redirect alone would break every file download, which is why detection keys on the
+     * `WWW-Authenticate` scheme instead.
+     */
+    @Test
+    fun `an off-authority download redirect is not mistaken for a gateway`() = runTest {
+        val engine = MockEngine { request ->
+            if (request.url.host == "chat.example.com") {
+                respond(
+                    content = "",
+                    status = HttpStatusCode.Found,
+                    headers = headersOf(
+                        HttpHeaders.Location to listOf("https://objectstore.example.net/file.png"),
+                    ),
+                )
+            } else {
+                respond("binary-image-bytes", HttpStatusCode.OK)
+            }
+        }
+
+        assertThat(clientWith(engine).get("$SERVER/api/files/download/1").bodyAsText())
+            .isEqualTo("binary-image-bytes")
+    }
+
+    /** A 401 carrying a normal auth challenge is the app's own concern, not a gateway. */
+    @Test
+    fun `an ordinary WWW-Authenticate challenge is not a gateway`() = runTest {
+        val engine = MockEngine {
+            respond(
+                content = "unauthorized",
+                status = HttpStatusCode.Unauthorized,
+                headers = headersOf(HttpHeaders.WWWAuthenticate to listOf("Bearer realm=\"api\"")),
+            )
+        }
+
+        assertThat(clientWith(engine).get("$SERVER/api/config").status)
+            .isEqualTo(HttpStatusCode.Unauthorized)
+    }
+}

--- a/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/client/KtorRedirectContractTest.kt
+++ b/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/client/KtorRedirectContractTest.kt
@@ -1,0 +1,57 @@
+package com.garfiec.librechat.core.network.client
+
+import com.google.common.truth.Truth.assertThat
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.request.HttpRequestData
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+/**
+ * Characterization of the Ktor behaviour that [ServerHeadersPlugin]'s redirect guard exists to
+ * contain. Nothing here is our code — it pins a third-party contract.
+ *
+ * Without it, the redirect test in `ServerHeadersPluginTest` is unfalsifiable: if a future Ktor
+ * stopped forwarding custom headers across a cross-authority redirect, that test would keep passing
+ * while proving nothing, and the guard could be deleted on a green suite. This one fails instead,
+ * which is the signal to re-derive whether the guard is still needed.
+ */
+class KtorRedirectContractTest {
+
+    @Test
+    fun `ktor forwards custom headers across a cross-authority redirect and strips only Authorization`() = runTest {
+        val seen = mutableListOf<HttpRequestData>()
+        val engine = MockEngine { request ->
+            seen += request
+            if (request.url.host == "chat.example.com") {
+                respond(
+                    content = "",
+                    status = HttpStatusCode.Found,
+                    headers = headersOf(HttpHeaders.Location, "https://evil.example.net/steal"),
+                )
+            } else {
+                respond("{}", HttpStatusCode.OK)
+            }
+        }
+
+        // A bare client: none of our plugins, so this measures Ktor's stock redirect handling.
+        HttpClient(engine).get("https://chat.example.com/api/files/download/1") {
+            header("CF-Access-Client-Id", "id-value")
+            header(HttpHeaders.Authorization, "Bearer session-token")
+        }
+
+        assertThat(seen).hasSize(2)
+        val redirected = seen[1]
+        assertThat(redirected.url.host).isEqualTo("evil.example.net")
+        // Ktor's HttpRedirect strips exactly one header...
+        assertThat(redirected.headers[HttpHeaders.Authorization]).isNull()
+        // ...and forwards everything else, including a credential it has no way to recognise as one.
+        assertThat(redirected.headers["CF-Access-Client-Id"]).isEqualTo("id-value")
+    }
+}

--- a/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/client/ServerHeadersPluginTest.kt
+++ b/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/client/ServerHeadersPluginTest.kt
@@ -1,0 +1,364 @@
+package com.garfiec.librechat.core.network.client
+
+import com.google.common.truth.Truth.assertThat
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.request.HttpRequestData
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+/**
+ * Injection and containment for user-configured gateway headers (issue #287).
+ *
+ * The redirect test is the load-bearing one: a `HttpRequestPipeline.State` host check passes while the
+ * secret still escapes, because Ktor's `HttpRedirect` re-executes at the `HttpSend` level and never
+ * re-runs the request pipeline. A suite without it goes green on a build that leaks.
+ */
+class ServerHeadersPluginTest {
+
+    private companion object {
+        const val SERVER = "https://chat.example.com"
+        const val CLIENT_ID = "CF-Access-Client-Id"
+        const val SECRET = "CF-Access-Client-Secret"
+        val GATEWAY_HEADERS = mapOf(CLIENT_ID to "id-value", SECRET to "secret-value")
+    }
+
+    private class FakeHeadersProvider(
+        private val byServer: Map<String, Map<String, String>> = mapOf(SERVER to GATEWAY_HEADERS),
+    ) : ServerHeadersProvider {
+        var warmAwaited = false
+        override suspend fun awaitWarm() {
+            warmAwaited = true
+        }
+
+        override fun headersFor(baseUrl: String): Map<String, String> = byServer[baseUrl].orEmpty()
+    }
+
+    private class FakeServerUrlProvider(private val baseUrl: String) : ServerUrlProvider {
+        override fun getBaseUrl(): String = baseUrl
+    }
+
+    /** Enough of a [TokenManager] to drive one 401 → refresh → retry cycle. */
+    private class FakeTokenManager : TokenManager {
+        private var accessToken: String? = "initial-token"
+        private val _sessionExpiredFlow = MutableSharedFlow<Unit>()
+        override val sessionExpiredFlow: SharedFlow<Unit> = _sessionExpiredFlow
+        override val isAuthenticated: Boolean get() = accessToken != null
+        override suspend fun getAccessToken(): String? = accessToken
+        override suspend fun setTokens(accessToken: String, refreshToken: String) {
+            this.accessToken = accessToken
+        }
+
+        override suspend fun refreshAccessToken(): RefreshResult {
+            accessToken = "refreshed-token"
+            return RefreshResult.Refreshed
+        }
+
+        override suspend fun clearTokens() {
+            accessToken = null
+        }
+
+        override suspend fun getAccessTokenFor(accountId: String): String? = accessToken
+        override suspend fun getStagedAccessToken(): String? = null
+        override suspend fun clearStagedTokens() = Unit
+        override suspend fun selectAccount(accountId: String) = Unit
+        override suspend fun removeAccount(accountId: String) = Unit
+        override suspend fun refreshAccessTokenFor(accountId: String, baseUrl: String): RefreshResult =
+            refreshAccessToken()
+
+        override suspend fun onAccountResolved(accountId: String) = Unit
+        override fun emitSessionExpired(expiredAccountId: String?) = Unit
+    }
+
+    private fun createClient(
+        engine: MockEngine,
+        headersProvider: ServerHeadersProvider,
+        serverUrlProvider: ServerUrlProvider? = FakeServerUrlProvider(SERVER),
+    ): HttpClient = HttpClient(engine) {
+        install(ServerHeadersPlugin) {
+            this.serverHeadersProvider = headersProvider
+            this.serverUrlProvider = serverUrlProvider
+        }
+    }
+
+    /**
+     * The production install order: `AuthInterceptorPlugin` first, `ServerHeadersPlugin` second, so the
+     * header plugin's `HttpSend` hook is the INNER one and therefore runs on the auth plugin's
+     * post-refresh 401 retry as well as the first send.
+     *
+     * [createClient] installs only the header plugin, which cannot observe that ordering at all — a
+     * refactor swapping the two installs would leave every test using it green while the 401-retry
+     * path re-sent the gateway secret without passing through containment.
+     */
+    private fun createProductionOrderClient(
+        engine: MockEngine,
+        headersProvider: ServerHeadersProvider,
+        tokenManager: TokenManager,
+    ): HttpClient = HttpClient(engine) {
+        install(AuthInterceptorPlugin) {
+            this.tokenManager = tokenManager
+            this.serverUrlProvider = FakeServerUrlProvider(SERVER)
+        }
+        install(ServerHeadersPlugin) {
+            this.serverHeadersProvider = headersProvider
+            this.serverUrlProvider = FakeServerUrlProvider(SERVER)
+        }
+    }
+
+    private fun HttpRequestData.gatewayHeaders(): Map<String, String?> =
+        mapOf(CLIENT_ID to headers[CLIENT_ID], SECRET to headers[SECRET])
+
+    @Test
+    fun `attaches configured headers to a request to the server`() = runTest {
+        val seen = mutableListOf<HttpRequestData>()
+        val engine = MockEngine { request ->
+            seen += request
+            respond("{}", HttpStatusCode.OK)
+        }
+
+        createClient(engine, FakeHeadersProvider()).get("$SERVER/api/config")
+
+        assertThat(seen.single().gatewayHeaders()).containsExactly(CLIENT_ID, "id-value", SECRET, "secret-value")
+    }
+
+    @Test
+    fun `auth login and refresh still carry the gateway headers`() = runTest {
+        // AuthInterceptorPlugin's skipPaths (which include auth/login and auth/refresh) exist to keep
+        // the *bearer* off those routes. Reusing that gate for gateway headers would send the login
+        // request without the credential — leaving the feature unable to sign in at all.
+        val seen = mutableListOf<HttpRequestData>()
+        val engine = MockEngine { request ->
+            seen += request
+            respond("{}", HttpStatusCode.OK)
+        }
+        val client = createClient(engine, FakeHeadersProvider())
+
+        client.post("$SERVER/api/auth/login") { setBody("{}") }
+        client.post("$SERVER/api/auth/refresh") { setBody("{}") }
+
+        assertThat(seen).hasSize(2)
+        seen.forEach { assertThat(it.headers[CLIENT_ID]).isEqualTo("id-value") }
+    }
+
+    @Test
+    fun `a cross-authority redirect drops the gateway headers`() = runTest {
+        // FilesApi.downloadFromUrl fetches a SERVER-SUPPLIED absolute URL. A hostile or misconfigured
+        // deployment answers with a same-host URL that 302s off-domain; Ktor's HttpRedirect copies
+        // every header to the target and strips only Authorization. The secret is long-lived and never
+        // rotates, so one leak is network-level access to the whole deployment.
+        val seen = mutableListOf<HttpRequestData>()
+        val engine = MockEngine { request ->
+            seen += request
+            if (request.url.host == "chat.example.com") {
+                respond(
+                    content = "",
+                    status = HttpStatusCode.Found,
+                    headers = headersOf(HttpHeaders.Location, "https://evil.example.net/steal"),
+                )
+            } else {
+                respond("{}", HttpStatusCode.OK)
+            }
+        }
+
+        createClient(engine, FakeHeadersProvider()).get("$SERVER/api/files/download/1")
+
+        assertThat(seen).hasSize(2)
+        assertThat(seen[0].headers[CLIENT_ID]).isEqualTo("id-value")
+        val leaked = seen[1]
+        assertThat(leaked.url.host).isEqualTo("evil.example.net")
+        assertThat(leaked.gatewayHeaders()).containsExactly(CLIENT_ID, null, SECRET, null)
+    }
+
+    @Test
+    fun `an absolute cross-host URL never receives the gateway headers`() = runTest {
+        val seen = mutableListOf<HttpRequestData>()
+        val engine = MockEngine { request ->
+            seen += request
+            respond("bytes", HttpStatusCode.OK)
+        }
+
+        // A presigned S3/CloudFront download URL.
+        createClient(engine, FakeHeadersProvider()).get("https://cdn.amazonaws.example/presigned?sig=x")
+
+        assertThat(seen.single().gatewayHeaders()).containsExactly(CLIENT_ID, null, SECRET, null)
+    }
+
+    @Test
+    fun `a same-host scheme downgrade never receives the gateway headers`() = runTest {
+        // Host-only scoping (what the bearer uses) would pass this. A non-rotating secret in cleartext
+        // is a materially worse outcome than a short-lived bearer, so this gate also matches scheme.
+        val seen = mutableListOf<HttpRequestData>()
+        val engine = MockEngine { request ->
+            seen += request
+            respond("{}", HttpStatusCode.OK)
+        }
+
+        createClient(engine, FakeHeadersProvider()).get("http://chat.example.com/api/config")
+
+        assertThat(seen.single().gatewayHeaders()).containsExactly(CLIENT_ID, null, SECRET, null)
+    }
+
+    @Test
+    fun `a pinned base URL wins over the live provider`() = runTest {
+        // The URL-pinned token refresh: a switch landing mid-flight flips the live provider, and
+        // pairing server B's headers with server A's pinned refresh URL produces a 302 that
+        // performRefresh classifies as Retryable — a session that silently never recovers.
+        val seen = mutableListOf<HttpRequestData>()
+        val engine = MockEngine { request ->
+            seen += request
+            respond("{}", HttpStatusCode.OK)
+        }
+        val provider = FakeHeadersProvider(
+            byServer = mapOf(
+                SERVER to GATEWAY_HEADERS,
+                "https://other.example.com" to mapOf(CLIENT_ID to "other-id"),
+            ),
+        )
+        // Live provider points at `other`, but this request is pinned to SERVER.
+        val client = createClient(engine, provider, FakeServerUrlProvider("https://other.example.com"))
+
+        client.post("$SERVER/api/auth/refresh") {
+            attributes.put(PinnedServerBaseUrlKey, SERVER)
+            setBody("{}")
+        }
+
+        assertThat(seen.single().headers[CLIENT_ID]).isEqualTo("id-value")
+    }
+
+    @Test
+    fun `a snapshot's headers win over the live store`() = runTest {
+        val seen = mutableListOf<HttpRequestData>()
+        val engine = MockEngine { request ->
+            seen += request
+            respond("{}", HttpStatusCode.OK)
+        }
+        // Empty store: the only way headers can arrive is off the snapshot the switch barrier captured.
+        val client = createClient(engine, FakeHeadersProvider(byServer = emptyMap()))
+
+        client.get("$SERVER/api/config") {
+            attributes.put(
+                RequestIdentityKey,
+                RequestIdentity(baseUrl = SERVER, accountId = "a", bearer = null, customHeaders = GATEWAY_HEADERS),
+            )
+        }
+
+        assertThat(seen.single().headers[SECRET]).isEqualTo("secret-value")
+    }
+
+    @Test
+    fun `merges a user Cookie into the app's own rather than sending two`() = runTest {
+        val seen = mutableListOf<HttpRequestData>()
+        val engine = MockEngine { request ->
+            seen += request
+            respond("{}", HttpStatusCode.OK)
+        }
+        val provider = FakeHeadersProvider(mapOf(SERVER to mapOf("Cookie" to "CF_Authorization=jwt")))
+
+        createClient(engine, provider).post("$SERVER/api/auth/refresh") {
+            header(HttpHeaders.Cookie, "refreshToken=rt-1")
+            setBody("{}")
+        }
+
+        val cookies = seen.single().headers.getAll(HttpHeaders.Cookie).orEmpty()
+        assertThat(cookies).hasSize(1)
+        assertThat(cookies.single()).isEqualTo("CF_Authorization=jwt; refreshToken=rt-1")
+    }
+
+    @Test
+    fun `awaits the store warm-up before building a request with no snapshot`() = runTest {
+        // Missing the credential on the FIRST request is not a recoverable miss: an access gateway
+        // answers it with a redirect to its own login page, not a retryable error.
+        val provider = FakeHeadersProvider()
+        val engine = MockEngine { respond("{}", HttpStatusCode.OK) }
+
+        createClient(engine, provider).get("$SERVER/api/config")
+
+        assertThat(provider.warmAwaited).isTrue()
+    }
+
+    @Test
+    fun `sends nothing when the server has no headers configured`() = runTest {
+        val seen = mutableListOf<HttpRequestData>()
+        val engine = MockEngine { request ->
+            seen += request
+            respond("{}", HttpStatusCode.OK)
+        }
+
+        createClient(engine, FakeHeadersProvider(byServer = emptyMap())).get("$SERVER/api/config")
+
+        assertThat(seen.single().gatewayHeaders()).containsExactly(CLIENT_ID, null, SECRET, null)
+    }
+
+    @Test
+    fun `a redirect back into the server's authority re-attaches the gateway headers`() = runTest {
+        // origin -> object store -> origin is an ordinary signed-URL shape, and an Access edge bounces
+        // through its own domain by design. The `State` attach phase runs once per CALL, not per hop,
+        // so a strip that is never undone leaves the final hop hitting the gateway with no credential
+        // — which comes back as a 200 HTML login page and reads as a corrupt download, not an error.
+        val seen = mutableListOf<HttpRequestData>()
+        val engine = MockEngine { request ->
+            seen += request
+            when {
+                seen.size == 1 -> respond(
+                    content = "",
+                    status = HttpStatusCode.Found,
+                    headers = headersOf(HttpHeaders.Location, "https://objects.example.net/blob/1"),
+                )
+                seen.size == 2 -> respond(
+                    content = "",
+                    status = HttpStatusCode.Found,
+                    headers = headersOf(HttpHeaders.Location, "$SERVER/api/files/blob/1"),
+                )
+                else -> respond("bytes", HttpStatusCode.OK)
+            }
+        }
+
+        createClient(engine, FakeHeadersProvider()).get("$SERVER/api/files/download/1")
+
+        assertThat(seen).hasSize(3)
+        assertThat(seen[0].headers[CLIENT_ID]).isEqualTo("id-value")
+        // Still stripped while off-domain — the containment guarantee must not regress.
+        assertThat(seen[1].gatewayHeaders()).containsExactly(CLIENT_ID, null, SECRET, null)
+        assertThat(seen[2].url.host).isEqualTo("chat.example.com")
+        assertThat(seen[2].gatewayHeaders()).containsExactly(CLIENT_ID, "id-value", SECRET, "secret-value")
+    }
+
+    @Test
+    fun `the strip still runs on the auth plugin's post-refresh retry`() = runTest {
+        // Pins the documented install order. With ServerHeadersPlugin installed FIRST its HttpSend hook
+        // becomes the outer one and the auth plugin's 401 retry re-executes inside it — re-sending the
+        // request without passing back through containment.
+        val seen = mutableListOf<HttpRequestData>()
+        val engine = MockEngine { request ->
+            seen += request
+            when {
+                request.url.host != "chat.example.com" -> respond("{}", HttpStatusCode.OK)
+                seen.count { it.url.host == "chat.example.com" } == 1 ->
+                    respond("", HttpStatusCode.Unauthorized)
+                else -> respond(
+                    content = "",
+                    status = HttpStatusCode.Found,
+                    headers = headersOf(HttpHeaders.Location, "https://evil.example.net/steal"),
+                )
+            }
+        }
+
+        createProductionOrderClient(engine, FakeHeadersProvider(), FakeTokenManager())
+            .get("$SERVER/api/files/download/1")
+
+        val leaked = seen.last()
+        assertThat(leaked.url.host).isEqualTo("evil.example.net")
+        assertThat(leaked.gatewayHeaders()).containsExactly(CLIENT_ID, null, SECRET, null)
+        assertThat(leaked.headers[HttpHeaders.Authorization]).isNull()
+    }
+}

--- a/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/di/NetworkModuleVerificationTest.kt
+++ b/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/di/NetworkModuleVerificationTest.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import android.content.Context
 import com.garfiec.librechat.core.common.identity.ActiveAccountProvider
 import com.garfiec.librechat.core.network.client.AccountReadyGate
+import com.garfiec.librechat.core.network.client.ServerHeadersProvider
 import com.garfiec.librechat.core.network.client.ServerUrlProvider
 import com.garfiec.librechat.core.network.client.TokenManager
 import io.ktor.client.engine.HttpClientEngine
@@ -26,6 +27,8 @@ class NetworkModuleVerificationTest {
                 // ready gate (getOrNull) — cross-module, so whitelist them for the isolated verify.
                 ActiveAccountProvider::class,
                 AccountReadyGate::class,
+                // Gateway headers (issue #287) are stored in :core:data, same as the URL and tokens.
+                ServerHeadersProvider::class,
             ),
         )
     }

--- a/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/AuthInterceptorPlugin.kt
+++ b/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/AuthInterceptorPlugin.kt
@@ -10,7 +10,6 @@ import io.ktor.client.request.headers
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.URLBuilder
-import io.ktor.http.Url
 import io.ktor.util.AttributeKey
 
 class AuthInterceptorPlugin private constructor(
@@ -28,25 +27,11 @@ class AuthInterceptorPlugin private constructor(
          * bearer token to that host. Null disables host-scoping (attach to every
          * non-auth-path request), preserving legacy behavior for callers/tests
          * that don't wire a provider.
+         *
+         * The rule itself lives in `HostScoping.kt` (`isSameHostAsServer`), shared with the
+         * gateway-header plugin so the two can't drift onto different definitions of "same server".
          */
         var serverUrlProvider: ServerUrlProvider? = null
-    }
-
-    /**
-     * True when [requestHost] belongs to the server [baseUrl] (so the bearer token is safe to attach).
-     * Returns true when host-scoping is disabled ([baseUrl] null — no provider and no snapshot) or the
-     * base URL isn't resolved yet (empty host) — the latter only happens during cold-start warm-up,
-     * before any cross-host CDN fetch can occur, so it preserves same-origin auth without leaking.
-     *
-     * [baseUrl] is the request's snapshotted server URL when the [SwitchBarrierPlugin] is installed, so
-     * an account switch mid-request scopes the bearer to the account the request was snapshotted for
-     * (never the live one), keeping A's bearer off B's host.
-     */
-    private fun isSameHostAsServer(requestHost: String, baseUrl: String?): Boolean {
-        if (baseUrl.isNullOrEmpty()) return true
-        val baseHost = runCatching { Url(baseUrl).host }.getOrNull()
-        if (baseHost.isNullOrEmpty()) return true
-        return requestHost.equals(baseHost, ignoreCase = true)
     }
 
     companion object : HttpClientPlugin<Config, AuthInterceptorPlugin> {
@@ -89,7 +74,7 @@ class AuthInterceptorPlugin private constructor(
             scope.requestPipeline.intercept(HttpRequestPipeline.State) {
                 val snapshot = context.attributes.getOrNull(RequestIdentityKey)
                 val serverBaseUrl = snapshot?.baseUrl ?: plugin.serverUrlProvider?.getBaseUrl()
-                if (!isSkipPath(context.url) && plugin.isSameHostAsServer(context.url.host, serverBaseUrl)) {
+                if (!isSkipPath(context.url) && isSameHostAsServer(context.url.host, serverBaseUrl)) {
                     // Explicit branch (not `?:`): a snapshot whose bearer is null must attach
                     // nothing — a pending add-account probe before sign-in has no token yet, and
                     // falling through to the live cache would send the ACTIVE account's bearer to
@@ -119,7 +104,7 @@ class AuthInterceptorPlugin private constructor(
                 // original 401 straight through with no token on the retry.
                 val snapshot = request.attributes.getOrNull(RequestIdentityKey)
                 val serverBaseUrl = snapshot?.baseUrl ?: plugin.serverUrlProvider?.getBaseUrl()
-                if (!plugin.isSameHostAsServer(request.url.host, serverBaseUrl)) {
+                if (!isSameHostAsServer(request.url.host, serverBaseUrl)) {
                     return@intercept originalCall
                 }
 

--- a/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/GatewayDetectionPlugin.kt
+++ b/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/GatewayDetectionPlugin.kt
@@ -1,0 +1,65 @@
+package com.garfiec.librechat.core.network.client
+
+import com.garfiec.librechat.core.common.result.AccessGatewayException
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.HttpClientPlugin
+import io.ktor.client.plugins.HttpSend
+import io.ktor.client.plugins.plugin
+import io.ktor.http.HttpHeaders
+import io.ktor.util.AttributeKey
+
+/** The `WWW-Authenticate` scheme Cloudflare Access answers a rejected request with. */
+private const val CLOUDFLARE_ACCESS_SCHEME = "Cloudflare-Access"
+
+/**
+ * Turns an access gateway's interception into a typed [AccessGatewayException] (issue #287).
+ *
+ * Without this the rejection is invisible until something downstream chokes on it, and *what*
+ * chokes depends on the caller: a typed API call dies converting an HTML body, surfacing Ktor's
+ * `NoTransformationFoundException` — which quotes the request URL, and so carries the gateway's
+ * redirect, query string and `meta=` JWT into an error banner.
+ *
+ * Detection keys on the `WWW-Authenticate: Cloudflare-Access` header on the gateway's 302, which is
+ * measured against a live Access deployment. Three reasons that header and not something looser:
+ *
+ * - **No body read.** This interceptor runs for every response including streaming ones; consuming
+ *   a body here would break SSE.
+ * - **A redirect alone is not enough.** The server legitimately 302s downloads off-authority to
+ *   object storage, so "redirected somewhere else" would false-positive on file downloads.
+ * - **Status is useless.** Following the redirect yields **200** `text/html`, so nothing
+ *   status-based ever fires — which is why `HttpResponseValidator` cannot do this job.
+ *
+ * Installed on the main client only, so it covers config, auth, user and the chat POST. The SSE and
+ * refresh clients are not covered and fail differently: a hung stream, and a silently unrecoverable
+ * session.
+ *
+ * A gateway that is not Cloudflare Access (Authelia, oauth2-proxy) does not set this header; those
+ * still degrade to the generic "unexpected response from the server" rather than leaking anything.
+ */
+class GatewayDetectionPlugin private constructor(
+    private val serverUrlProvider: ServerUrlProvider?,
+) {
+    class Config {
+        var serverUrlProvider: ServerUrlProvider? = null
+    }
+
+    companion object : HttpClientPlugin<Config, GatewayDetectionPlugin> {
+        override val key = AttributeKey<GatewayDetectionPlugin>("GatewayDetection")
+
+        override fun prepare(block: Config.() -> Unit): GatewayDetectionPlugin =
+            GatewayDetectionPlugin(Config().apply(block).serverUrlProvider)
+
+        override fun install(plugin: GatewayDetectionPlugin, scope: HttpClient) {
+            scope.plugin(HttpSend).intercept { request ->
+                val call = execute(request)
+                val wwwAuthenticate = call.response.headers[HttpHeaders.WWWAuthenticate].orEmpty()
+                if (wwwAuthenticate.contains(CLOUDFLARE_ACCESS_SCHEME, ignoreCase = true)) {
+                    // Thrown from inside the redirect loop, so it surfaces instead of the sign-in
+                    // page the redirect would otherwise deliver as a perfectly valid 200.
+                    throw AccessGatewayException(serverUrl = plugin.serverUrlProvider?.getBaseUrl())
+                }
+                call
+            }
+        }
+    }
+}

--- a/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/HostScoping.kt
+++ b/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/HostScoping.kt
@@ -1,0 +1,56 @@
+package com.garfiec.librechat.core.network.client
+
+import io.ktor.http.DEFAULT_PORT
+import io.ktor.http.URLBuilder
+import io.ktor.http.Url
+
+/**
+ * True when [requestHost] belongs to the server [baseUrl], so the **session bearer** is safe to
+ * attach. Returns true when host-scoping is disabled ([baseUrl] null — no provider and no snapshot)
+ * or the base URL isn't resolved yet (empty host); the latter only happens during cold-start warm-up,
+ * before any cross-host CDN fetch can occur, so it preserves same-origin auth without leaking.
+ *
+ * [baseUrl] is the request's snapshotted server URL when the [SwitchBarrierPlugin] is installed, so an
+ * account switch mid-request scopes the bearer to the account the request was snapshotted for (never
+ * the live one), keeping A's bearer off B's host.
+ *
+ * Deliberately host-only and fail-*open*: this is the pre-existing bearer rule, kept unchanged.
+ * Custom gateway headers use [isSameServerAuthority] instead, which is stricter on both counts.
+ */
+internal fun isSameHostAsServer(requestHost: String, baseUrl: String?): Boolean {
+    if (baseUrl.isNullOrEmpty()) return true
+    val baseHost = runCatching { Url(baseUrl).host }.getOrNull()
+    if (baseHost.isNullOrEmpty()) return true
+    return requestHost.equals(baseHost, ignoreCase = true)
+}
+
+/**
+ * True when [requestUrl] addresses exactly the server [baseUrl] identifies — **scheme, host and
+ * effective port all matching**. The gate for user-configured gateway headers.
+ *
+ * Stricter than [isSameHostAsServer] in two ways, both deliberate:
+ *
+ * - **Scheme and port count.** A same-host `http://` downgrade would otherwise pass, putting a
+ *   long-lived, non-rotating secret on the wire in cleartext. The session bearer is short-lived and
+ *   rotates; a gateway service token is neither, so the blast radius of one leak is the whole
+ *   deployment rather than one session.
+ * - **Fail closed.** An unknown or unparseable base URL yields false, so a request whose server can't
+ *   be established carries no credential. [isSameHostAsServer] fails open to preserve legacy
+ *   cold-start behaviour for the bearer; there is no equivalent legacy to preserve here.
+ */
+internal fun isSameServerAuthority(requestUrl: URLBuilder, baseUrl: String?): Boolean {
+    if (baseUrl.isNullOrEmpty()) return false
+    val base = runCatching { Url(baseUrl) }.getOrNull() ?: return false
+    if (base.host.isEmpty() || requestUrl.host.isEmpty()) return false
+    return requestUrl.host.equals(base.host, ignoreCase = true) &&
+        requestUrl.protocol.name.equals(base.protocol.name, ignoreCase = true) &&
+        requestUrl.effectivePort() == base.port
+}
+
+/**
+ * The port a [URLBuilder] will actually dial. `URLBuilder.port` reports [DEFAULT_PORT] (a sentinel,
+ * not a real port) when no port was written explicitly, whereas `Url.port` already resolves to the
+ * protocol default — comparing the two raw would make `https://host` and `https://host:443` differ.
+ */
+private fun URLBuilder.effectivePort(): Int =
+    if (port == DEFAULT_PORT) protocol.defaultPort else port

--- a/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/LibreChatHttpClient.kt
+++ b/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/LibreChatHttpClient.kt
@@ -38,6 +38,7 @@ object LibreChatHttpClient {
         redactor: LogRedactor,
         accountReadyGate: AccountReadyGate? = null,
         switchGate: SwitchGate? = null,
+        serverHeadersProvider: ServerHeadersProvider = EmptyServerHeadersProvider,
         debug: Boolean = false,
     ): HttpClient = HttpClient(engineFactory) {
         install(ContentNegotiation) {
@@ -53,6 +54,20 @@ object LibreChatHttpClient {
                 }
             }
             level = if (debug) LogLevel.HEADERS else LogLevel.NONE
+            // A user-configured gateway header is a secret under a name only the user knows, so
+            // LogRedactor's pattern matching can't recognise it the way it recognises `Bearer`. Gate
+            // it here, where the name is known, instead. Pre-emptive: `level` is NONE in release
+            // builds, so nothing reaches the logger today — this keeps a future `debug = true` from
+            // silently starting to print the credential.
+            //
+            // Matched against the CONFIGURED names only. "Any name that would be a legal custom
+            // header" is every RFC-7230 token outside RESERVED_NAMES — Location, Set-Cookie,
+            // Retry-After, X-Request-Id — i.e. exactly the fields someone turns HEADERS logging on to
+            // read, and redacting them makes the log useless for the gateway problems it exists for.
+            sanitizeHeader { name ->
+                serverHeadersProvider.headersFor(serverUrlProvider.getBaseUrl())
+                    .keys.any { it.equals(name, ignoreCase = true) }
+            }
         }
 
         install(HttpTimeout) {
@@ -70,6 +85,19 @@ object LibreChatHttpClient {
             // Host-scope the bearer token so a presigned absolute-URL fetch to a
             // third-party CDN (S3/CloudFront file download-url) never leaks the
             // LibreChat session token to that host.
+            this.serverUrlProvider = serverUrlProvider
+        }
+
+        // Installed AFTER AuthInterceptorPlugin so its HttpSend interceptor is the inner one: it then
+        // runs on every actual send, including the auth plugin's post-refresh 401 retry.
+        install(ServerHeadersPlugin) {
+            this.serverHeadersProvider = serverHeadersProvider
+            this.serverUrlProvider = serverUrlProvider
+        }
+
+        // Must see the gateway's own 302, so it has to be inside the redirect loop — following that
+        // redirect yields a 200 sign-in page, which no status-based check can catch.
+        install(GatewayDetectionPlugin) {
             this.serverUrlProvider = serverUrlProvider
         }
 
@@ -93,7 +121,7 @@ object LibreChatHttpClient {
                 if (!response.status.isSuccess()) {
                     val statusCode = response.status.value
                     val bodyText = try { response.bodyAsText() } catch (_: Exception) { "" }
-                    val errorMessage = extractErrorMessage(json, bodyText, statusCode)
+                    val extracted = extractErrorMessage(json, bodyText, statusCode)
                     val isBanned = statusCode == 403 && bodyText.contains("ban", ignoreCase = true)
 
                     Diag.w(
@@ -120,9 +148,10 @@ object LibreChatHttpClient {
 
                     throw ApiException(
                         statusCode = statusCode,
-                        message = errorMessage,
+                        message = extracted.message,
                         isBanned = isBanned,
                         body = bodyText.ifBlank { null },
+                        serverAuthored = extracted.serverAuthored,
                     )
                 }
             }
@@ -138,22 +167,34 @@ object LibreChatHttpClient {
     const val BROWSER_USER_AGENT =
         "Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Mobile Safari/537.36"
 
-    private fun extractErrorMessage(json: Json, body: String, statusCode: Int): String {
+    /**
+     * The message for an error response, plus whether it came from the body.
+     *
+     * The provenance flag matters downstream: server-authored text is screened before it is
+     * rendered (a gateway can put an entire HTML login page in `message`), while this app's own
+     * wording below is shown as-is.
+     */
+    private data class ExtractedError(val message: String, val serverAuthored: Boolean)
+
+    private fun extractErrorMessage(json: Json, body: String, statusCode: Int): ExtractedError {
         if (body.isNotBlank()) {
             try {
                 val jsonObj = json.parseToJsonElement(body).jsonObject
                 val msg = (jsonObj["message"] as? JsonPrimitive)?.content
                     ?: (jsonObj["error"] as? JsonPrimitive)?.content
                     ?: (jsonObj["error_message"] as? JsonPrimitive)?.content
-                if (!msg.isNullOrBlank()) return msg
+                if (!msg.isNullOrBlank()) return ExtractedError(msg, serverAuthored = true)
             } catch (_: Exception) {
                 if (body.contains("banned", ignoreCase = true) || body.contains("forbidden", ignoreCase = true)) {
-                    return "Access denied. Your account may have been restricted."
+                    return ExtractedError(
+                        "Access denied. Your account may have been restricted.",
+                        serverAuthored = false,
+                    )
                 }
             }
         }
 
-        return when (statusCode) {
+        val fallback = when (statusCode) {
             400 -> "Bad request"
             403 -> "Access denied"
             404 -> "Not found"
@@ -161,6 +202,7 @@ object LibreChatHttpClient {
             in 500..599 -> "Server error. Please try again later."
             else -> "Request failed (HTTP $statusCode)"
         }
+        return ExtractedError(fallback, serverAuthored = false)
     }
 }
 

--- a/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/ServerHeaders.kt
+++ b/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/ServerHeaders.kt
@@ -1,0 +1,236 @@
+package com.garfiec.librechat.core.network.client
+
+import io.ktor.http.HeadersBuilder
+import io.ktor.http.HttpHeaders
+
+/**
+ * Static per-server request headers the user configures for a deployment that sits behind a reverse
+ * proxy or access gateway (issue #287). The driving case is Cloudflare Access service tokens
+ * (`CF-Access-Client-Id` / `CF-Access-Client-Secret`), but nothing here is Cloudflare-specific — any
+ * gateway that authenticates on static headers works.
+ *
+ * Keyed by **server, not account**: the credential belongs to the deployment, and it is needed on the
+ * very first request — before any account exists — so an account-scoped store could never carry it.
+ */
+interface ServerHeadersProvider {
+    /**
+     * Suspends until the persisted headers have resolved. Deliberately URL-free: the snapshot in
+     * [SwitchGate.captureSnapshot] only resolves its base URL *inside* the switch lock, so a URL-keyed
+     * await taken before that lock could be awaiting a different server than the snapshot lands on.
+     * The backing store is whole-store anyway, so one warm gate covers every server.
+     *
+     * Startup-path callers await this so a cold-start request can't be built before the store has
+     * warmed up — missing the gateway credential on the *first* request is not a recoverable miss: an
+     * access gateway answers it with a redirect to its own login page, not a retryable error.
+     */
+    suspend fun awaitWarm()
+
+    /**
+     * Headers configured for [baseUrl]'s server, or empty when none are set / the store hasn't warmed
+     * up / [baseUrl] isn't a usable server URL. Must not block and **must not throw** — a blank or
+     * partial base URL is routine on the cold-start and failed-probe paths.
+     */
+    fun headersFor(baseUrl: String): Map<String, String>
+}
+
+/** No headers for any server. The default binding when the feature is unconfigured, and for tests. */
+object EmptyServerHeadersProvider : ServerHeadersProvider {
+    override suspend fun awaitWarm() = Unit
+    override fun headersFor(baseUrl: String): Map<String, String> = emptyMap()
+}
+
+/**
+ * Why a header a user typed can't be trusted verbatim.
+ *
+ * Rejection is deliberately loud rather than silent-sanitising: a gateway credential that is *almost*
+ * right fails as an opaque redirect to a login page, so the user has to be told at entry time.
+ */
+enum class HeaderRejection {
+    /** Blank, or contains a character outside the RFC 7230 `token` set. */
+    InvalidName,
+
+    /** Contains a character outside printable US-ASCII (plus HTAB). */
+    InvalidValue,
+
+    /** A header the transport or the app itself owns; see [CustomHeaderRules.RESERVED_NAMES]. */
+    ReservedName,
+}
+
+/**
+ * Validation for user-entered header pairs. Enforced at the UI entry point *and* again at the
+ * injection sites, so a value that reached storage through an older build (or a future import path)
+ * still can't reach the wire.
+ */
+object CustomHeaderRules {
+
+    /**
+     * Headers the user must not override.
+     *
+     * - `Host`, `Content-Length`, `Transfer-Encoding`, `Connection`, `Upgrade`, `TE` — the transport
+     *   owns these; a user value corrupts framing. On iOS the SSE transport hand-writes the request
+     *   line, so a bad `Host` there is a malformed request, not a caught exception.
+     * - `Authorization` — the LibreChat session bearer. Overriding it silently breaks auth in a way
+     *   that looks like an expired session. (The cost: gateways fronted by HTTP Basic aren't
+     *   supported through this feature.)
+     * - `User-Agent` — the stock LibreChat server's `ua-parser-js` middleware soft-bans non-browser
+     *   UAs on first contact, and that ban outlives the bad config.
+     * - `Accept`, `Accept-Encoding`, `Content-Type` — the iOS SSE transport hand-writes `Accept` and
+     *   `Accept-Encoding`; a user value emits a second, ambiguous line rather than replacing them.
+     * - `Expect`, `Proxy-Authorization` — engine-level semantics the client does not model.
+     *
+     * `Cookie` is deliberately **absent**: Cloudflare Access, Authelia, Authentik and oauth2-proxy all
+     * authenticate on a session cookie, so reserving it would make the "any static-header gateway"
+     * promise false for the most common self-hosted deployments. It is merged with the app's own
+     * cookie instead — see [applyCustomHeaders].
+     */
+    val RESERVED_NAMES: Set<String> = setOf(
+        "host",
+        "content-length",
+        "transfer-encoding",
+        "connection",
+        "upgrade",
+        "te",
+        "authorization",
+        "user-agent",
+        "accept",
+        "accept-encoding",
+        "content-type",
+        "expect",
+        "proxy-authorization",
+    )
+
+    // RFC 7230 token characters. Anything else in a header name is malformed on the wire.
+    private const val TOKEN_SPECIALS = "!#$%&'*+-.^_`|~"
+
+    private fun Char.isTokenChar(): Boolean =
+        this in 'a'..'z' || this in 'A'..'Z' || this in '0'..'9' || this in TOKEN_SPECIALS
+
+    /**
+     * A header value character that is safe to put on the wire: printable US-ASCII plus HTAB.
+     *
+     * The bar is deliberately higher than "no CR/LF/NUL". A non-ASCII character (a smart quote or a
+     * non-breaking space picked up pasting a token out of a dashboard) passes Ktor's own
+     * `checkHeaderValue`, but OkHttp's `Headers.Builder` throws on it — and its message quotes the
+     * offending value for any name outside its sensitive list. A pasted secret would then fail every
+     * Android request with the secret verbatim in an exception that flows through `safeApiCall`.
+     */
+    private fun Char.isSafeValueChar(): Boolean = this == '\t' || this.code in 0x20..0x7E
+
+    /** Null when [name] is a usable header name, else why it isn't. */
+    fun validateName(name: String): HeaderRejection? = when {
+        name.isBlank() || !name.all { it.isTokenChar() } -> HeaderRejection.InvalidName
+        name.lowercase() in RESERVED_NAMES -> HeaderRejection.ReservedName
+        else -> null
+    }
+
+    /**
+     * Null when [value] is safe to send. Empty is allowed — some gateways treat a present-but-empty
+     * header as meaningful — and spaces are legal inside a value; control and non-ASCII characters
+     * never are.
+     */
+    fun validateValue(value: String): HeaderRejection? =
+        if (value.all { it.isSafeValueChar() }) null else HeaderRejection.InvalidValue
+
+    /**
+     * Canonical form of a user-entered value: surrounding whitespace stripped. Pasting a token out of
+     * a dashboard is the overwhelmingly likely entry path and it very often carries a trailing
+     * newline or space, which would otherwise be a silent authentication failure.
+     */
+    fun normalizeValue(value: String): String = value.trim()
+
+    /** Null when the pair is safe to send, else the first problem found. */
+    fun validate(name: String, value: String): HeaderRejection? =
+        validateName(name.trim()) ?: validateValue(normalizeValue(value))
+
+    /**
+     * Drop every pair that fails [validate], normalizing what survives. The last line of defence
+     * before the wire: injection sites call this rather than trusting the store, so a value persisted
+     * by an older build — or one that became reserved after a later release added it — can't reach a
+     * request.
+     */
+    fun sanitize(headers: Map<String, String>): Map<String, String> =
+        headers.mapNotNull { (name, value) ->
+            val trimmedName = name.trim()
+            val normalizedValue = normalizeValue(value)
+            if (validate(trimmedName, normalizedValue) == null) trimmedName to normalizedValue else null
+        }.toMap()
+}
+
+/**
+ * Append [custom] to an outgoing request, merging rather than duplicating `Cookie`.
+ *
+ * Ktor's `append` is additive, and RFC 6265 allows exactly one `Cookie` header — two lines are
+ * handled inconsistently across servers and proxies. The app sets its own `Cookie: refreshToken=…` on
+ * the refresh POST, so a user cookie has to be folded into that one header. The custom value goes
+ * first: a gateway sitting in front of the origin reads its own cookie without having to parse past
+ * the app's.
+ *
+ * **The app's own segments win on a name collision.** Ordering alone is not enough: cookie parsers
+ * keep the *first* occurrence of a repeated name (Express's `cookie.parse` among them), so a user who
+ * pastes a whole `Cookie` header out of browser devtools — the likely way anyone configures a
+ * cookie-auth gateway — can carry a stale `refreshToken=` that shadows the real one and signs them
+ * out at every refresh. Colliding custom segments are therefore dropped, not merely out-ordered.
+ */
+// NoGetOutsideModuleDefinition is a Koin rule that matches on the name `getAll`; here it is
+// Ktor's StringValuesBuilder.getAll, reading back a header this function just wrote. No DI involved.
+@Suppress("NoGetOutsideModuleDefinition")
+internal fun HeadersBuilder.applyCustomHeaders(custom: Map<String, String>) {
+    CustomHeaderRules.sanitize(custom).forEach { (name, value) ->
+        if (name.equals(HttpHeaders.Cookie, ignoreCase = true)) {
+            val existing = getAll(HttpHeaders.Cookie).orEmpty().flatMap(::cookieSegments)
+            // Case-SENSITIVE: RFC 6265 cookie names are case-sensitive, so `refreshToken` and
+            // `refreshtoken` are genuinely different cookies and folding them would over-drop.
+            val ownNames = existing.map { it.cookieName() }.toSet()
+            val merged = (cookieSegments(value).filterNot { it.cookieName() in ownNames } + existing)
+                .distinct()
+            remove(HttpHeaders.Cookie)
+            if (merged.isNotEmpty()) append(HttpHeaders.Cookie, merged.joinToString("; "))
+        } else {
+            append(name, value)
+        }
+    }
+}
+
+/**
+ * Undo [applyCustomHeaders] for a request that is about to leave the server's authority (a redirect
+ * off-domain). Ktor's `HttpRedirect` copies every header to the new target and strips only
+ * `Authorization`, so without this a server-supplied redirect would hand a long-lived, non-rotating
+ * gateway secret to an arbitrary host.
+ *
+ * `Cookie` is unpicked segment-wise rather than dropped wholesale, so the app's own cookie survives a
+ * strip of the user's.
+ */
+@Suppress("NoGetOutsideModuleDefinition") // Ktor's StringValuesBuilder.getAll, not Koin's — see above.
+internal fun HeadersBuilder.stripCustomHeaders(custom: Map<String, String>) {
+    CustomHeaderRules.sanitize(custom).forEach { (name, value) ->
+        if (name.equals(HttpHeaders.Cookie, ignoreCase = true)) {
+            val customSegments = cookieSegments(value).toSet()
+            val remaining = getAll(HttpHeaders.Cookie).orEmpty()
+                .flatMap(::cookieSegments)
+                .filterNot { it in customSegments }
+            remove(HttpHeaders.Cookie)
+            if (remaining.isNotEmpty()) append(HttpHeaders.Cookie, remaining.joinToString("; "))
+        } else {
+            remove(name)
+        }
+    }
+}
+
+private fun cookieSegments(value: String): List<String> =
+    value.split(';').map { it.trim() }.filter { it.isNotEmpty() }
+
+/** The name half of a `name=value` cookie segment; the whole segment when there is no `=`. */
+private fun String.cookieName(): String = substringBefore('=').trim()
+
+/**
+ * [custom] rendered as raw HTTP/1.1 header lines (each CRLF-terminated), for the iOS SSE transport,
+ * which hand-writes its request rather than going through Ktor.
+ *
+ * Lives in `commonMain` rather than inline in `SseHttpTransport.ios.kt` so it is unit-testable: the
+ * module has no `iosTest` source set, so anything written inside the iOS transport is verifiable only
+ * by inspection and on-device runs. Returns "" for an empty map so callers can append unconditionally.
+ */
+internal fun customHeaderLines(custom: Map<String, String>): String =
+    CustomHeaderRules.sanitize(custom)
+        .entries
+        .joinToString(separator = "") { (name, value) -> "$name: $value\r\n" }

--- a/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/ServerHeadersPlugin.kt
+++ b/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/ServerHeadersPlugin.kt
@@ -1,0 +1,127 @@
+package com.garfiec.librechat.core.network.client
+
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.HttpClientPlugin
+import io.ktor.client.plugins.HttpSend
+import io.ktor.client.plugins.plugin
+import io.ktor.client.request.HttpRequestPipeline
+import io.ktor.util.AttributeKey
+
+/**
+ * Records exactly which custom headers this plugin put on a request, so the redirect guard removes
+ * precisely those and nothing else (notably: not the app's own `Cookie`, which a user cookie may have
+ * been merged into).
+ */
+internal val AppliedCustomHeadersKey = AttributeKey<Map<String, String>>("AppliedCustomHeaders")
+
+/**
+ * The server base URL a request is pinned to, for clients that have no [SwitchGate] snapshot. Set by
+ * the URL-pinned token refresh so its headers key off the server the refresh token actually belongs
+ * to, rather than whichever server happens to be live when the interceptor runs.
+ */
+val PinnedServerBaseUrlKey = AttributeKey<String>("PinnedServerBaseUrl")
+
+/**
+ * Attaches the user's per-server gateway headers (issue #287) and keeps them from escaping the
+ * server's authority.
+ *
+ * Two interceptors, because one phase cannot do both jobs:
+ *
+ * 1. **`HttpRequestPipeline.State`** — attach. Runs after the base URL has been applied, so
+ *    `context.url` is the real target: a relative API call carries the server's authority, an absolute
+ *    presigned CDN fetch carries the CDN's.
+ * 2. **`HttpSend`** — strip on cross-authority redirect. Ktor's `HttpRedirect` copies every header to
+ *    the redirect target and strips only `Authorization`, and it re-executes at the `HttpSend` level
+ *    without re-running the request pipeline — so the phase-1 gate cannot see the new host at all. A
+ *    server-supplied absolute URL (`FilesApi.downloadFromUrl`) that 302s off-domain would otherwise
+ *    hand a long-lived, non-rotating gateway secret to an arbitrary host. `HttpRedirect` is installed
+ *    before user plugins and the `HttpSend` chain runs first-registered-outermost, so this interceptor
+ *    executes *inside* the redirect loop and sees every hop.
+ */
+class ServerHeadersPlugin private constructor(
+    private val serverHeadersProvider: ServerHeadersProvider,
+    private val serverUrlProvider: ServerUrlProvider?,
+) {
+    class Config {
+        lateinit var serverHeadersProvider: ServerHeadersProvider
+
+        /**
+         * Fallback source of the server base URL for requests with no [RequestIdentity] snapshot and
+         * no [PinnedServerBaseUrlKey]. Null leaves those requests headerless — fail-closed, since a
+         * request whose server can't be established must not carry a gateway credential.
+         */
+        var serverUrlProvider: ServerUrlProvider? = null
+    }
+
+    companion object : HttpClientPlugin<Config, ServerHeadersPlugin> {
+        override val key = AttributeKey<ServerHeadersPlugin>("ServerHeaders")
+
+        override fun prepare(block: Config.() -> Unit): ServerHeadersPlugin {
+            val config = Config().apply(block)
+            return ServerHeadersPlugin(config.serverHeadersProvider, config.serverUrlProvider)
+        }
+
+        override fun install(plugin: ServerHeadersPlugin, scope: HttpClient) {
+            scope.requestPipeline.intercept(HttpRequestPipeline.State) {
+                val snapshot = context.attributes.getOrNull(RequestIdentityKey)
+                val baseUrl = plugin.resolveBaseUrl(snapshot, context.attributes.getOrNull(PinnedServerBaseUrlKey))
+                val custom = if (snapshot != null) {
+                    // The barrier already awaited the warm-up and read the map under its own lock;
+                    // re-reading here could pair a *newer* header set with an older snapshot URL.
+                    snapshot.customHeaders
+                } else {
+                    plugin.serverHeadersProvider.awaitWarm()
+                    plugin.serverHeadersProvider.headersFor(baseUrl.orEmpty())
+                }
+                if (custom.isNotEmpty() && isSameServerAuthority(context.url, baseUrl)) {
+                    context.headers.applyCustomHeaders(custom)
+                    context.attributes.put(AppliedCustomHeadersKey, custom)
+                }
+            }
+
+            scope.plugin(HttpSend).intercept { request ->
+                // What this request's server *would* carry, independent of what is on it right now.
+                // A redirect rebuilds the request; if Ktor ever stops carrying attributes across that
+                // rebuild, fall back to the snapshot and then to the live store rather than silently
+                // losing the strip.
+                val custom = request.attributes.getOrNull(AppliedCustomHeadersKey)
+                    ?: request.attributes.getOrNull(RequestIdentityKey)?.customHeaders
+                    ?: plugin.serverHeadersProvider.headersFor(plugin.serverUrlProvider?.getBaseUrl().orEmpty())
+                if (custom.isNotEmpty()) {
+                    val baseUrl = plugin.resolveBaseUrl(
+                        request.attributes.getOrNull(RequestIdentityKey),
+                        request.attributes.getOrNull(PinnedServerBaseUrlKey),
+                    )
+                    // Both directions, because a redirect chain can leave the server's authority and
+                    // come back (origin → object store → origin is an ordinary signed-URL shape, and
+                    // an Access edge bounces through its own domain by design). The `State` attach
+                    // phase runs once per *call*, not per hop, so a strip that is never undone leaves
+                    // the final hop hitting the gateway with no credential — which comes back as a
+                    // 200 HTML login page and reads as a corrupt download, not as an auth error.
+                    val applied = request.attributes.contains(AppliedCustomHeadersKey)
+                    when {
+                        !isSameServerAuthority(request.url, baseUrl) && applied -> {
+                            request.headers.stripCustomHeaders(custom)
+                            request.attributes.remove(AppliedCustomHeadersKey)
+                        }
+                        isSameServerAuthority(request.url, baseUrl) && !applied -> {
+                            request.headers.applyCustomHeaders(custom)
+                            request.attributes.put(AppliedCustomHeadersKey, custom)
+                        }
+                    }
+                }
+                execute(request)
+            }
+        }
+    }
+
+    /**
+     * Which server a request belongs to, most-specific first: the switch-barrier snapshot, then an
+     * explicitly pinned URL, then the live provider. Never a mix — pairing one source's URL with
+     * another's headers is the tear this whole ordering exists to prevent.
+     */
+    private fun resolveBaseUrl(snapshot: RequestIdentity?, pinned: String?): String? =
+        snapshot?.baseUrl?.takeIf { it.isNotEmpty() }
+            ?: pinned?.takeIf { it.isNotEmpty() }
+            ?: serverUrlProvider?.getBaseUrl()
+}

--- a/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/SwitchGate.kt
+++ b/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/SwitchGate.kt
@@ -27,7 +27,20 @@ data class RequestIdentity(
     val accountId: String?,
     val bearer: String?,
     val isPending: Boolean = false,
-)
+    val customHeaders: Map<String, String> = emptyMap(),
+) {
+    /**
+     * Explicit, not the generated one: both [bearer] and [customHeaders] are credentials, and the
+     * generated `toString` would put them verbatim into any log line, exception message, or debugger
+     * frame that renders the snapshot. Header *names* are kept — they are what makes a
+     * misconfiguration diagnosable — values never are.
+     */
+    override fun toString(): String =
+        "RequestIdentity(baseUrl=$baseUrl, accountId=$accountId, bearer=${redact(bearer)}, " +
+            "isPending=$isPending, customHeaders=${customHeaders.keys})"
+
+    private fun redact(value: String?): String = if (value == null) "null" else "<redacted>"
+}
 
 /**
  * Coroutine-scoped override of the request identity, for the **add-account** flow: run the flow's
@@ -40,15 +53,29 @@ data class RequestIdentity(
  *
  * [bearer] is read per request (not captured once) because the staged token only exists after the
  * flow's sign-in call succeeds; earlier calls (config validation, the login POST itself) carry none.
+ *
+ * [headers] sits **before** [bearer] on purpose. Several call sites pass the bearer as a trailing
+ * lambda; a new parameter appended after it would silently re-bind that lambda to the new slot and
+ * compile clean while sending no token at all. It also has to resolve the warm-up itself:
+ * [SwitchGate.captureSnapshot] short-circuits to this identity *before* any of its own awaits, so the
+ * add-account probe would otherwise race the header store's first read — and losing the gateway
+ * credential on the probe is exactly the failure this feature exists to fix.
  */
 class PendingRequestIdentity(
     private val baseUrl: String,
+    private val headers: suspend () -> Map<String, String> = { emptyMap() },
     private val bearer: suspend () -> String?,
 ) : AbstractCoroutineContextElement(PendingRequestIdentity) {
     companion object Key : CoroutineContext.Key<PendingRequestIdentity>
 
     suspend fun identity(): RequestIdentity =
-        RequestIdentity(baseUrl = baseUrl, accountId = null, bearer = bearer(), isPending = true)
+        RequestIdentity(
+            baseUrl = baseUrl,
+            accountId = null,
+            bearer = bearer(),
+            isPending = true,
+            customHeaders = headers(),
+        )
 }
 
 /** Attribute carrying the per-request [RequestIdentity] snapshot from the barrier to the URL/auth phases. */
@@ -77,6 +104,9 @@ class SwitchGate(
     private val serverUrlProvider: ServerUrlProvider,
     private val tokenManager: TokenManager,
     private val accountReadyGate: AccountReadyGate?,
+    // Trailing + defaulted so the one positional construction (the account-switcher test harness)
+    // keeps compiling, and so tests that don't care about gateway headers need not wire a fake.
+    private val serverHeadersProvider: ServerHeadersProvider = EmptyServerHeadersProvider,
 ) {
     private val lock = Mutex()
     private val open = MutableStateFlow(true)
@@ -97,14 +127,21 @@ class SwitchGate(
         coroutineContext[PendingRequestIdentity]?.let { return it.identity() }
         accountReadyGate?.awaitReady()
         serverUrlProvider.awaitBaseUrl()
+        // Warm the gateway-header store here, OUTSIDE [lock]: the lock below is the same mutex
+        // [withSwitch] takes, so suspending inside it would stall every account switch behind a
+        // DataStore read. The await is URL-free precisely so it can happen out here — the base URL is
+        // only resolved inside the lock, and keying the await on a URL read before it could await the
+        // wrong server's headers.
+        serverHeadersProvider.awaitWarm()
         // The gate is open >99.9% of the time (a switch is rare and user-initiated); reading the value
         // directly avoids allocating a flow collector on every request and only suspends when a switch
         // is actually mid-flip.
         if (!open.value) open.first { it }
         return lock.withLock {
             val accountId = activeAccountProvider.currentAccountId()?.value
+            val baseUrl = serverUrlProvider.getBaseUrl()
             RequestIdentity(
-                baseUrl = serverUrlProvider.getBaseUrl(),
+                baseUrl = baseUrl,
                 accountId = accountId,
                 // Explicit branch (not `?: fallback`): a resolved account with an empty keyed slot
                 // must yield a null bearer, never fall through to the live cache — during sign-in
@@ -114,6 +151,9 @@ class SwitchGate(
                 } else {
                     tokenManager.getAccessToken()
                 },
+                // Read against the snapshot's own base URL, under the same lock, so the headers can't
+                // pair with a different server than the URL and bearer did.
+                customHeaders = serverHeadersProvider.headersFor(baseUrl),
             )
         }
     }

--- a/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/di/NetworkModule.kt
+++ b/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/di/NetworkModule.kt
@@ -31,6 +31,8 @@ import com.garfiec.librechat.core.network.api.TagsApi
 import com.garfiec.librechat.core.network.api.UserApi
 import com.garfiec.librechat.core.network.client.AuthInterceptorPlugin
 import com.garfiec.librechat.core.network.client.LibreChatHttpClient
+import com.garfiec.librechat.core.network.client.ServerHeadersPlugin
+import com.garfiec.librechat.core.network.client.ServerHeadersProvider
 import com.garfiec.librechat.core.network.client.ServerUrlProvider
 import com.garfiec.librechat.core.network.client.ServerUrlReadyPlugin
 import com.garfiec.librechat.core.network.client.SwitchBarrierPlugin
@@ -79,6 +81,7 @@ val networkModule = module {
             serverUrlProvider = get(),
             tokenManager = get(),
             accountReadyGate = getOrNull(),
+            serverHeadersProvider = get(),
         )
     }
 
@@ -91,6 +94,7 @@ val networkModule = module {
             redactor = get(),
             accountReadyGate = getOrNull(),
             switchGate = get(),
+            serverHeadersProvider = get(),
         )
     }
 
@@ -99,9 +103,14 @@ val networkModule = module {
         val serverUrlProvider = get<ServerUrlProvider>()
         val engineFactory = get<HttpClientEngineFactory<*>>()
         val switchGate = get<SwitchGate>()
+        val serverHeadersProvider = get<ServerHeadersProvider>()
         HttpClient(engineFactory) {
             install(AuthInterceptorPlugin) {
                 this.tokenManager = tokenManager
+                this.serverUrlProvider = serverUrlProvider
+            }
+            install(ServerHeadersPlugin) {
+                this.serverHeadersProvider = serverHeadersProvider
                 this.serverUrlProvider = serverUrlProvider
             }
             install(SwitchBarrierPlugin) {
@@ -122,9 +131,22 @@ val networkModule = module {
         val json = get<Json>()
         val serverUrlProvider = get<ServerUrlProvider>()
         val engineFactory = get<HttpClientEngineFactory<*>>()
+        val serverHeadersProvider = get<ServerHeadersProvider>()
         HttpClient(engineFactory) {
             install(ContentNegotiation) { json(json) }
             install(ServerUrlReadyPlugin) {
+                this.serverUrlProvider = serverUrlProvider
+            }
+            // `/api/auth/refresh` is gated by the access gateway like every other route, and this
+            // client has neither a SwitchBarrier snapshot nor an AuthInterceptor to hang an append on.
+            // Without this the session dies at the first refresh: the gateway's 302→200 HTML
+            // deserializes as garbage, which `performRefresh` classifies as Retryable — so it never
+            // routes to re-auth and never recovers, it just silently stops working.
+            //
+            // ServerUrlReadyPlugin could not host this: it intercepts before HttpRequestPipeline.Before,
+            // where `context.url.host` is still empty and no host-scoping is possible.
+            install(ServerHeadersPlugin) {
+                this.serverHeadersProvider = serverHeadersProvider
                 this.serverUrlProvider = serverUrlProvider
             }
             install(HttpTimeout) {

--- a/core/network/src/iosMain/kotlin/com/garfiec/librechat/core/network/sse/SseHttpTransport.ios.kt
+++ b/core/network/src/iosMain/kotlin/com/garfiec/librechat/core/network/sse/SseHttpTransport.ios.kt
@@ -5,6 +5,7 @@ import com.garfiec.librechat.core.network.client.BearerResult
 import com.garfiec.librechat.core.network.client.LibreChatHttpClient
 import com.garfiec.librechat.core.network.client.SwitchGate
 import com.garfiec.librechat.core.network.client.TokenManager
+import com.garfiec.librechat.core.network.client.customHeaderLines
 import com.garfiec.librechat.core.network.client.refreshBearerFor
 import kotlinx.cinterop.BetaInteropApi
 import kotlinx.cinterop.ExperimentalForeignApi
@@ -110,7 +111,7 @@ actual class SseHttpTransport(
         var triedRefresh = false
         while (true) {
             try {
-                emitAll(openConnection(streamPath, resume, snapshot.baseUrl, token))
+                emitAll(openConnection(streamPath, resume, snapshot.baseUrl, token, snapshot.customHeaders))
                 return@flow
             } catch (e: SseHttpStatusException) {
                 if (e.statusCode == 401 && !triedRefresh) {
@@ -148,6 +149,7 @@ actual class SseHttpTransport(
         resume: Boolean,
         snapshotBaseUrl: String,
         bearerToken: String?,
+        customHeaders: Map<String, String>,
     ): Flow<ByteArray> = callbackFlow {
         // Normalize base URL + stream path so there's exactly one slash between
         // them. The base URL comes from the snapshot captured before this connection
@@ -310,6 +312,7 @@ actual class SseHttpTransport(
                         path = requestPath,
                         host = host,
                         bearerToken = bearerToken,
+                        customHeaders = customHeaders,
                     )
                     val requestBytes = request.encodeToByteArray()
                     val dispatchData = byteArrayToDispatchData(requestBytes, queue)
@@ -373,6 +376,7 @@ actual class SseHttpTransport(
         path: String,
         host: String,
         bearerToken: String?,
+        customHeaders: Map<String, String>,
     ): String = buildString {
         append("GET ").append(path).append(" HTTP/1.1\r\n")
         append("Host: ").append(host).append("\r\n")
@@ -383,6 +387,12 @@ actual class SseHttpTransport(
         append("User-Agent: ").append(LibreChatHttpClient.BROWSER_USER_AGENT).append("\r\n")
         append("Accept-Encoding: identity\r\n")
         append("Connection: close\r\n")
+        // The user's gateway headers (issue #287). No host-scoping check is needed here the way the
+        // Ktor plugin needs one: this connection is dialled at the snapshot's own base URL and never
+        // follows a redirect, so it cannot arrive anywhere but the server the headers belong to.
+        // Sanitised again inside customHeaderLines — the names reserved there are exactly the ones
+        // hand-written above, so a user value can never emit a second, ambiguous copy of one.
+        append(customHeaderLines(customHeaders))
         append("\r\n")
     }
 

--- a/core/ui/src/commonMain/composeResources/values-ar/strings.xml
+++ b/core/ui/src/commonMain/composeResources/values-ar/strings.xml
@@ -2,4 +2,17 @@
 <resources>
     <!-- Accessibility label for the bottom-sheet drag handle -->
     <string name="cd_drag_handle">مقبض السحب</string>
+    <!-- Custom per-server request headers (issue #287); shared by the pre-login
+         server screen and the post-login Settings editor -->
+    <string name="server_headers_title">ترويسات طلب مخصّصة</string>
+    <string name="server_headers_description">تُرسل مع كل طلب إلى هذا الخادم. مطلوبة لبوابات الوصول مثل Cloudflare Access.</string>
+    <string name="server_headers_name">اسم الترويسة</string>
+    <string name="server_headers_value">القيمة</string>
+    <string name="server_headers_add">إضافة ترويسة</string>
+    <string name="server_headers_remove">إزالة الترويسة</string>
+    <string name="server_headers_show_value">إظهار القيمة</string>
+    <string name="server_headers_hide_value">إخفاء القيمة</string>
+    <string name="server_headers_error_name">اسم الترويسة غير صالح.</string>
+    <string name="server_headers_error_value">تحتوي هذه القيمة على أحرف لا يمكن إرسالها.</string>
+    <string name="server_headers_error_reserved">يضبط التطبيق هذه الترويسة ولا يمكن تجاوزها.</string>
 </resources>

--- a/core/ui/src/commonMain/composeResources/values-de/strings.xml
+++ b/core/ui/src/commonMain/composeResources/values-de/strings.xml
@@ -2,4 +2,17 @@
 <resources>
     <!-- Accessibility label for the bottom-sheet drag handle -->
     <string name="cd_drag_handle">Ziehpunkt</string>
+    <!-- Custom per-server request headers (issue #287); shared by the pre-login
+         server screen and the post-login Settings editor -->
+    <string name="server_headers_title">Benutzerdefinierte Anfrage-Header</string>
+    <string name="server_headers_description">Werden bei jeder Anfrage an diesen Server gesendet. Erforderlich für Zugangs-Gateways wie Cloudflare Access.</string>
+    <string name="server_headers_name">Header-Name</string>
+    <string name="server_headers_value">Wert</string>
+    <string name="server_headers_add">Header hinzufügen</string>
+    <string name="server_headers_remove">Header entfernen</string>
+    <string name="server_headers_show_value">Wert anzeigen</string>
+    <string name="server_headers_hide_value">Wert ausblenden</string>
+    <string name="server_headers_error_name">Kein gültiger Header-Name.</string>
+    <string name="server_headers_error_value">Dieser Wert enthält Zeichen, die nicht gesendet werden können.</string>
+    <string name="server_headers_error_reserved">Dieser Header wird von der App gesetzt und kann nicht überschrieben werden.</string>
 </resources>

--- a/core/ui/src/commonMain/composeResources/values-es/strings.xml
+++ b/core/ui/src/commonMain/composeResources/values-es/strings.xml
@@ -2,4 +2,17 @@
 <resources>
     <!-- Accessibility label for the bottom-sheet drag handle -->
     <string name="cd_drag_handle">Controlador para arrastrar</string>
+    <!-- Custom per-server request headers (issue #287); shared by the pre-login
+         server screen and the post-login Settings editor -->
+    <string name="server_headers_title">Encabezados de solicitud personalizados</string>
+    <string name="server_headers_description">Se envían con cada solicitud a este servidor. Necesarios para pasarelas de acceso como Cloudflare Access.</string>
+    <string name="server_headers_name">Nombre del encabezado</string>
+    <string name="server_headers_value">Valor</string>
+    <string name="server_headers_add">Añadir encabezado</string>
+    <string name="server_headers_remove">Eliminar encabezado</string>
+    <string name="server_headers_show_value">Mostrar valor</string>
+    <string name="server_headers_hide_value">Ocultar valor</string>
+    <string name="server_headers_error_name">No es un nombre de encabezado válido.</string>
+    <string name="server_headers_error_value">Este valor contiene caracteres que no se pueden enviar.</string>
+    <string name="server_headers_error_reserved">Este encabezado lo establece la aplicación y no se puede sobrescribir.</string>
 </resources>

--- a/core/ui/src/commonMain/composeResources/values-fr/strings.xml
+++ b/core/ui/src/commonMain/composeResources/values-fr/strings.xml
@@ -2,4 +2,17 @@
 <resources>
     <!-- Accessibility label for the bottom-sheet drag handle -->
     <string name="cd_drag_handle">Poignée de déplacement</string>
+    <!-- Custom per-server request headers (issue #287); shared by the pre-login
+         server screen and the post-login Settings editor -->
+    <string name="server_headers_title">En-têtes de requête personnalisés</string>
+    <string name="server_headers_description">Envoyés avec chaque requête vers ce serveur. Nécessaires pour les passerelles d'accès comme Cloudflare Access.</string>
+    <string name="server_headers_name">Nom de l'en-tête</string>
+    <string name="server_headers_value">Valeur</string>
+    <string name="server_headers_add">Ajouter un en-tête</string>
+    <string name="server_headers_remove">Supprimer l'en-tête</string>
+    <string name="server_headers_show_value">Afficher la valeur</string>
+    <string name="server_headers_hide_value">Masquer la valeur</string>
+    <string name="server_headers_error_name">Nom d'en-tête non valide.</string>
+    <string name="server_headers_error_value">Cette valeur contient des caractères qui ne peuvent pas être envoyés.</string>
+    <string name="server_headers_error_reserved">Cet en-tête est défini par l'application et ne peut pas être remplacé.</string>
 </resources>

--- a/core/ui/src/commonMain/composeResources/values-ja/strings.xml
+++ b/core/ui/src/commonMain/composeResources/values-ja/strings.xml
@@ -2,4 +2,17 @@
 <resources>
     <!-- Accessibility label for the bottom-sheet drag handle -->
     <string name="cd_drag_handle">ドラッグ ハンドル</string>
+    <!-- Custom per-server request headers (issue #287); shared by the pre-login
+         server screen and the post-login Settings editor -->
+    <string name="server_headers_title">カスタムリクエストヘッダー</string>
+    <string name="server_headers_description">このサーバーへのすべてのリクエストに送信されます。Cloudflare Access などのアクセスゲートウェイに必要です。</string>
+    <string name="server_headers_name">ヘッダー名</string>
+    <string name="server_headers_value">値</string>
+    <string name="server_headers_add">ヘッダーを追加</string>
+    <string name="server_headers_remove">ヘッダーを削除</string>
+    <string name="server_headers_show_value">値を表示</string>
+    <string name="server_headers_hide_value">値を非表示</string>
+    <string name="server_headers_error_name">ヘッダー名が正しくありません。</string>
+    <string name="server_headers_error_value">この値には送信できない文字が含まれています。</string>
+    <string name="server_headers_error_reserved">このヘッダーはアプリが設定するため、上書きできません。</string>
 </resources>

--- a/core/ui/src/commonMain/composeResources/values-ko/strings.xml
+++ b/core/ui/src/commonMain/composeResources/values-ko/strings.xml
@@ -2,4 +2,17 @@
 <resources>
     <!-- Accessibility label for the bottom-sheet drag handle -->
     <string name="cd_drag_handle">드래그 핸들</string>
+    <!-- Custom per-server request headers (issue #287); shared by the pre-login
+         server screen and the post-login Settings editor -->
+    <string name="server_headers_title">사용자 지정 요청 헤더</string>
+    <string name="server_headers_description">이 서버로 보내는 모든 요청에 포함됩니다. Cloudflare Access 같은 액세스 게이트웨이에 필요합니다.</string>
+    <string name="server_headers_name">헤더 이름</string>
+    <string name="server_headers_value">값</string>
+    <string name="server_headers_add">헤더 추가</string>
+    <string name="server_headers_remove">헤더 삭제</string>
+    <string name="server_headers_show_value">값 표시</string>
+    <string name="server_headers_hide_value">값 숨기기</string>
+    <string name="server_headers_error_name">올바른 헤더 이름이 아닙니다.</string>
+    <string name="server_headers_error_value">이 값에는 보낼 수 없는 문자가 있습니다.</string>
+    <string name="server_headers_error_reserved">이 헤더는 앱이 설정하므로 덮어쓸 수 없습니다.</string>
 </resources>

--- a/core/ui/src/commonMain/composeResources/values-pt/strings.xml
+++ b/core/ui/src/commonMain/composeResources/values-pt/strings.xml
@@ -2,4 +2,17 @@
 <resources>
     <!-- Accessibility label for the bottom-sheet drag handle -->
     <string name="cd_drag_handle">Alça de arrasto</string>
+    <!-- Custom per-server request headers (issue #287); shared by the pre-login
+         server screen and the post-login Settings editor -->
+    <string name="server_headers_title">Cabeçalhos de solicitação personalizados</string>
+    <string name="server_headers_description">Enviados em todas as solicitações a este servidor. Necessários para gateways de acesso como o Cloudflare Access.</string>
+    <string name="server_headers_name">Nome do cabeçalho</string>
+    <string name="server_headers_value">Valor</string>
+    <string name="server_headers_add">Adicionar cabeçalho</string>
+    <string name="server_headers_remove">Remover cabeçalho</string>
+    <string name="server_headers_show_value">Mostrar valor</string>
+    <string name="server_headers_hide_value">Ocultar valor</string>
+    <string name="server_headers_error_name">Nome de cabeçalho inválido.</string>
+    <string name="server_headers_error_value">Este valor contém caracteres que não podem ser enviados.</string>
+    <string name="server_headers_error_reserved">Este cabeçalho é definido pelo app e não pode ser substituído.</string>
 </resources>

--- a/core/ui/src/commonMain/composeResources/values-ru/strings.xml
+++ b/core/ui/src/commonMain/composeResources/values-ru/strings.xml
@@ -2,4 +2,17 @@
 <resources>
     <!-- Accessibility label for the bottom-sheet drag handle -->
     <string name="cd_drag_handle">Маркер перемещения</string>
+    <!-- Custom per-server request headers (issue #287); shared by the pre-login
+         server screen and the post-login Settings editor -->
+    <string name="server_headers_title">Пользовательские заголовки запроса</string>
+    <string name="server_headers_description">Отправляются с каждым запросом к этому серверу. Нужны для шлюзов доступа, таких как Cloudflare Access.</string>
+    <string name="server_headers_name">Имя заголовка</string>
+    <string name="server_headers_value">Значение</string>
+    <string name="server_headers_add">Добавить заголовок</string>
+    <string name="server_headers_remove">Удалить заголовок</string>
+    <string name="server_headers_show_value">Показать значение</string>
+    <string name="server_headers_hide_value">Скрыть значение</string>
+    <string name="server_headers_error_name">Недопустимое имя заголовка.</string>
+    <string name="server_headers_error_value">Значение содержит символы, которые нельзя отправить.</string>
+    <string name="server_headers_error_reserved">Этот заголовок задаётся приложением и не может быть изменён.</string>
 </resources>

--- a/core/ui/src/commonMain/composeResources/values-zh/strings.xml
+++ b/core/ui/src/commonMain/composeResources/values-zh/strings.xml
@@ -2,4 +2,17 @@
 <resources>
     <!-- Accessibility label for the bottom-sheet drag handle -->
     <string name="cd_drag_handle">拖动手柄</string>
+    <!-- Custom per-server request headers (issue #287); shared by the pre-login
+         server screen and the post-login Settings editor -->
+    <string name="server_headers_title">自定义请求头</string>
+    <string name="server_headers_description">发送到此服务器的每个请求都会带上。Cloudflare Access 等访问网关需要。</string>
+    <string name="server_headers_name">请求头名称</string>
+    <string name="server_headers_value">值</string>
+    <string name="server_headers_add">添加请求头</string>
+    <string name="server_headers_remove">删除请求头</string>
+    <string name="server_headers_show_value">显示值</string>
+    <string name="server_headers_hide_value">隐藏值</string>
+    <string name="server_headers_error_name">请求头名称无效。</string>
+    <string name="server_headers_error_value">此值包含无法发送的字符。</string>
+    <string name="server_headers_error_reserved">此请求头由应用设置，无法覆盖。</string>
 </resources>

--- a/core/ui/src/commonMain/composeResources/values/strings.xml
+++ b/core/ui/src/commonMain/composeResources/values/strings.xml
@@ -4,4 +4,17 @@
     <string name="cd_drag_handle">Drag handle</string>
     <!-- Inline indicator for a PDF page that failed to render -->
     <string name="pdf_page_failed">Couldn't render this page</string>
+    <!-- Custom per-server request headers (issue #287); shared by the pre-login
+         server screen and the post-login Settings editor -->
+    <string name="server_headers_title">Custom request headers</string>
+    <string name="server_headers_description">Sent with every request to this server. Needed for access gateways such as Cloudflare Access.</string>
+    <string name="server_headers_name">Header name</string>
+    <string name="server_headers_value">Value</string>
+    <string name="server_headers_add">Add header</string>
+    <string name="server_headers_remove">Remove header</string>
+    <string name="server_headers_show_value">Show value</string>
+    <string name="server_headers_hide_value">Hide value</string>
+    <string name="server_headers_error_name">Not a valid header name.</string>
+    <string name="server_headers_error_value">This value contains characters that can't be sent.</string>
+    <string name="server_headers_error_reserved">This header is set by the app and can't be overridden.</string>
 </resources>

--- a/core/ui/src/commonMain/kotlin/com/garfiec/librechat/core/ui/components/CustomHeadersEditor.kt
+++ b/core/ui/src/commonMain/kotlin/com/garfiec/librechat/core/ui/components/CustomHeadersEditor.kt
@@ -1,0 +1,360 @@
+package com.garfiec.librechat.core.ui.components
+
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.filled.VisibilityOff
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.garfiec.librechat.core.ui.resources.Res
+import com.garfiec.librechat.core.ui.resources.server_headers_add
+import com.garfiec.librechat.core.ui.resources.server_headers_description
+import com.garfiec.librechat.core.ui.resources.server_headers_error_name
+import com.garfiec.librechat.core.ui.resources.server_headers_error_reserved
+import com.garfiec.librechat.core.ui.resources.server_headers_error_value
+import com.garfiec.librechat.core.ui.resources.server_headers_hide_value
+import com.garfiec.librechat.core.ui.resources.server_headers_name
+import com.garfiec.librechat.core.ui.resources.server_headers_remove
+import com.garfiec.librechat.core.ui.resources.server_headers_show_value
+import com.garfiec.librechat.core.ui.resources.server_headers_title
+import com.garfiec.librechat.core.ui.resources.server_headers_value
+import org.jetbrains.compose.resources.StringResource
+import org.jetbrains.compose.resources.stringResource
+
+/** One editable header pair. Blank rows are ignored by callers rather than rejected. */
+@Immutable
+data class CustomHeaderRow(val name: String = "", val value: String = "")
+
+/**
+ * Why a row can't be sent, as a UI-level enum.
+ *
+ * Deliberately not `:core:network`'s `HeaderRejection`: mapping the two at each call site (three
+ * lines) is cheaper than making `:core:ui` depend on the network module just to name three cases.
+ */
+enum class CustomHeaderRowError { InvalidName, InvalidValue, ReservedName }
+
+/**
+ * Below this, name and value are stacked instead of sitting side by side.
+ *
+ * Split across two columns each field gets under half the width, which on a phone dialog left
+ * "CF-Access-Client-Id" and "CF-Access-Client-Secret" both truncated to "CF-Access-C…" — two
+ * different headers rendering identically, with a masked value beside them.
+ */
+private val STACK_BELOW_WIDTH: Dp = 420.dp
+
+/**
+ * Editor for a server's static gateway headers (issue #287), shared by the pre-login server screen
+ * and the post-login Settings dialog so the two can't drift.
+ *
+ * Stateless apart from which values are revealed: the caller owns the rows, the validation and the
+ * persistence. The two hosts differ in exactly those things — pre-login commits on Connect as part
+ * of validating the URL, Settings commits on an explicit Save against the already-active server.
+ *
+ * The layout branches on the width this is actually *given*, not on the device: the same phone that
+ * needs stacking in a dialog has plenty of room on the full-screen pre-login form, and a tablet's
+ * dialog is narrow despite the tablet.
+ *
+ * Test tags are indexed (`server_header_name_0`) rather than content-keyed because a header name is
+ * user-entered and a value is a credential; neither belongs in an automation selector.
+ */
+@Composable
+fun CustomHeadersEditor(
+    headers: List<CustomHeaderRow>,
+    onNameChange: (Int, String) -> Unit,
+    onValueChange: (Int, String) -> Unit,
+    onAdd: () -> Unit,
+    onRemove: (Int) -> Unit,
+    modifier: Modifier = Modifier,
+    errorIndex: Int? = null,
+    errorReason: CustomHeaderRowError? = null,
+    enabled: Boolean = true,
+    showHeading: Boolean = true,
+) {
+    // Indices are only valid for the current row list, so any add/remove must re-mask everything —
+    // otherwise a stale index aliases onto a different row's credential.
+    var revealed by remember { mutableStateOf(emptySet<Int>()) }
+    LaunchedEffect(headers.size) { revealed = emptySet() }
+
+    BoxWithConstraints(modifier = modifier.fillMaxWidth()) {
+        val stacked = maxWidth < STACK_BELOW_WIDTH
+
+        Column(modifier = Modifier.fillMaxWidth()) {
+            if (showHeading) {
+                Text(
+                    text = stringResource(Res.string.server_headers_title),
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.onBackground,
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+            }
+            Text(
+                text = stringResource(Res.string.server_headers_description),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+
+            headers.forEachIndexed { index, field ->
+                val rejection = errorReason?.takeIf { errorIndex == index }
+                if (stacked) {
+                    StackedHeaderRow(
+                        index = index,
+                        field = field,
+                        rejection = rejection,
+                        revealed = index in revealed,
+                        enabled = enabled,
+                        onNameChange = onNameChange,
+                        onValueChange = onValueChange,
+                        onRemove = onRemove,
+                        onToggleReveal = { revealed = revealed.toggle(index) },
+                    )
+                } else {
+                    InlineHeaderRow(
+                        index = index,
+                        field = field,
+                        rejection = rejection,
+                        revealed = index in revealed,
+                        enabled = enabled,
+                        onNameChange = onNameChange,
+                        onValueChange = onValueChange,
+                        onRemove = onRemove,
+                        onToggleReveal = { revealed = revealed.toggle(index) },
+                    )
+                }
+                if (rejection != null) {
+                    Text(
+                        text = stringResource(rejection.messageRes()),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.error,
+                    )
+                }
+                if (stacked && index != headers.lastIndex) {
+                    Spacer(modifier = Modifier.height(8.dp))
+                    HorizontalDivider()
+                }
+            }
+
+            TextButton(
+                onClick = onAdd,
+                enabled = enabled,
+                modifier = Modifier.align(Alignment.Start).testTag("server_header_add"),
+            ) {
+                Text(stringResource(Res.string.server_headers_add))
+            }
+        }
+    }
+}
+
+/** Name and value side by side. Only used when there is genuinely room for both. */
+@Composable
+private fun InlineHeaderRow(
+    index: Int,
+    field: CustomHeaderRow,
+    rejection: CustomHeaderRowError?,
+    revealed: Boolean,
+    enabled: Boolean,
+    onNameChange: (Int, String) -> Unit,
+    onValueChange: (Int, String) -> Unit,
+    onRemove: (Int) -> Unit,
+    onToggleReveal: () -> Unit,
+) {
+    Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.Top) {
+        HeaderNameField(
+            index = index,
+            name = field.name,
+            rejection = rejection,
+            enabled = enabled,
+            onNameChange = onNameChange,
+            modifier = Modifier.weight(1f),
+        )
+        Spacer(modifier = Modifier.width(8.dp))
+        HeaderValueField(
+            index = index,
+            value = field.value,
+            rejection = rejection,
+            revealed = revealed,
+            enabled = enabled,
+            onValueChange = onValueChange,
+            onToggleReveal = onToggleReveal,
+            modifier = Modifier.weight(1f),
+        )
+        RemoveHeaderButton(index = index, enabled = enabled, onRemove = onRemove)
+    }
+}
+
+/**
+ * Name above value, both the **same** full width, with remove as a text button underneath.
+ *
+ * Header names are the long part ("CF-Access-Client-Secret"), and two headers whose names truncate
+ * to the same prefix are indistinguishable — so the name gets the full width rather than sharing it.
+ *
+ * The remove control sits below rather than beside the name for the same reason the fields stack: an
+ * icon button next to one of the two fields makes that field narrower than the other, and a pair of
+ * boxes that nearly-but-don't-quite line up reads as broken. Below, both fields are identical width
+ * and the action gets a labelled tap target instead of a bare glyph.
+ */
+@Composable
+private fun StackedHeaderRow(
+    index: Int,
+    field: CustomHeaderRow,
+    rejection: CustomHeaderRowError?,
+    revealed: Boolean,
+    enabled: Boolean,
+    onNameChange: (Int, String) -> Unit,
+    onValueChange: (Int, String) -> Unit,
+    onRemove: (Int) -> Unit,
+    onToggleReveal: () -> Unit,
+) {
+    Column(modifier = Modifier.fillMaxWidth()) {
+        HeaderNameField(
+            index = index,
+            name = field.name,
+            rejection = rejection,
+            enabled = enabled,
+            onNameChange = onNameChange,
+            modifier = Modifier.fillMaxWidth(),
+        )
+        Spacer(modifier = Modifier.height(4.dp))
+        HeaderValueField(
+            index = index,
+            value = field.value,
+            rejection = rejection,
+            revealed = revealed,
+            enabled = enabled,
+            onValueChange = onValueChange,
+            onToggleReveal = onToggleReveal,
+            modifier = Modifier.fillMaxWidth(),
+        )
+        TextButton(
+            onClick = { onRemove(index) },
+            enabled = enabled,
+            // Same tag as the icon-button variant: which layout is on screen depends on width, and a
+            // test asserting "remove row 1" should not have to know which one it got.
+            modifier = Modifier.align(Alignment.End).testTag("server_header_remove_$index"),
+        ) {
+            Text(stringResource(Res.string.server_headers_remove))
+        }
+    }
+}
+
+@Composable
+private fun HeaderNameField(
+    index: Int,
+    name: String,
+    rejection: CustomHeaderRowError?,
+    enabled: Boolean,
+    onNameChange: (Int, String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    OutlinedTextField(
+        value = name,
+        onValueChange = { onNameChange(index, it) },
+        label = { Text(stringResource(Res.string.server_headers_name)) },
+        modifier = modifier.testTag("server_header_name_$index"),
+        singleLine = true,
+        enabled = enabled,
+        isError = rejection == CustomHeaderRowError.InvalidName ||
+            rejection == CustomHeaderRowError.ReservedName,
+    )
+}
+
+@Composable
+private fun HeaderValueField(
+    index: Int,
+    value: String,
+    rejection: CustomHeaderRowError?,
+    revealed: Boolean,
+    enabled: Boolean,
+    onValueChange: (Int, String) -> Unit,
+    onToggleReveal: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    OutlinedTextField(
+        value = value,
+        onValueChange = { onValueChange(index, it) },
+        label = { Text(stringResource(Res.string.server_headers_value)) },
+        modifier = modifier.testTag("server_header_value_$index"),
+        singleLine = true,
+        enabled = enabled,
+        isError = rejection == CustomHeaderRowError.InvalidValue,
+        // A gateway token is a credential — masked by default so it stays out of screenshots and
+        // accessibility dumps, as MCP server headers and provider API keys already are.
+        visualTransformation = if (revealed) {
+            VisualTransformation.None
+        } else {
+            PasswordVisualTransformation()
+        },
+        // Keeps the IME from learning, suggesting or autocorrecting the secret.
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+        trailingIcon = {
+            IconButton(
+                onClick = onToggleReveal,
+                enabled = enabled,
+                modifier = Modifier.testTag("server_header_reveal_$index"),
+            ) {
+                Icon(
+                    imageVector = if (revealed) Icons.Default.VisibilityOff else Icons.Default.Visibility,
+                    contentDescription = stringResource(
+                        if (revealed) {
+                            Res.string.server_headers_hide_value
+                        } else {
+                            Res.string.server_headers_show_value
+                        },
+                    ),
+                )
+            }
+        },
+    )
+}
+
+@Composable
+private fun RemoveHeaderButton(index: Int, enabled: Boolean, onRemove: (Int) -> Unit) {
+    IconButton(
+        onClick = { onRemove(index) },
+        enabled = enabled,
+        modifier = Modifier.testTag("server_header_remove_$index"),
+    ) {
+        Icon(
+            imageVector = Icons.Default.Close,
+            contentDescription = stringResource(Res.string.server_headers_remove),
+        )
+    }
+}
+
+/** Reveal/hide one row, keeping the set immutable so the state write is a plain replacement. */
+private fun Set<Int>.toggle(index: Int): Set<Int> =
+    if (index in this) this - index else this + index
+
+private fun CustomHeaderRowError.messageRes(): StringResource = when (this) {
+    CustomHeaderRowError.InvalidName -> Res.string.server_headers_error_name
+    CustomHeaderRowError.InvalidValue -> Res.string.server_headers_error_value
+    CustomHeaderRowError.ReservedName -> Res.string.server_headers_error_reserved
+}

--- a/feature/auth/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/auth/di/AuthModuleVerificationTest.kt
+++ b/feature/auth/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/auth/di/AuthModuleVerificationTest.kt
@@ -3,6 +3,7 @@ package com.garfiec.librechat.feature.auth.di
 import android.app.Application
 import android.content.Context
 import com.garfiec.librechat.core.data.datastore.ServerDataStore
+import com.garfiec.librechat.core.data.datastore.ServerHeadersDataStore
 import com.garfiec.librechat.core.data.repository.AccountSwitcher
 import com.garfiec.librechat.core.data.repository.AuthRepository
 import com.garfiec.librechat.core.data.repository.ConfigRepository
@@ -20,6 +21,7 @@ class AuthModuleVerificationTest {
                 Context::class,
                 Application::class,
                 ServerDataStore::class,
+                ServerHeadersDataStore::class,
                 AuthRepository::class,
                 ConfigRepository::class,
                 UserRepository::class,

--- a/feature/auth/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/auth/viewmodel/ServerUrlViewModelTest.kt
+++ b/feature/auth/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/auth/viewmodel/ServerUrlViewModelTest.kt
@@ -2,12 +2,16 @@ package com.garfiec.librechat.feature.auth.viewmodel
 
 import com.garfiec.librechat.core.common.result.Result
 import com.garfiec.librechat.core.data.datastore.ServerDataStore
+import com.garfiec.librechat.core.data.datastore.ServerHeadersDataStore
 import com.garfiec.librechat.core.data.repository.AccountSwitcher
 import com.garfiec.librechat.core.data.repository.ConfigRepository
 import com.garfiec.librechat.core.model.config.StartupConfig
+import com.garfiec.librechat.core.network.client.HeaderRejection
+import com.garfiec.librechat.core.ui.components.CustomHeaderRow
 import com.google.common.truth.Truth.assertThat
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.coVerifyOrder
 import io.mockk.mockk
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -32,11 +36,15 @@ class ServerUrlViewModelTest {
     private val testDispatcher = StandardTestDispatcher()
 
     private val serverDataStore = mockk<ServerDataStore>(relaxed = true)
+    private val serverHeadersDataStore = mockk<ServerHeadersDataStore>(relaxed = true)
     private val configRepository = mockk<ConfigRepository>(relaxed = true)
     private val accountSwitcher = mockk<AccountSwitcher>(relaxed = true)
 
     private val pendingUrl = "https://b.example.com"
     private val config = StartupConfig(serverDomain = pendingUrl)
+
+    private val liveUrl = "https://live.example.com"
+    private val liveHeaders = mapOf("CF-Access-Client-Id" to "id-value")
 
     @Before
     fun setup() {
@@ -54,6 +62,7 @@ class ServerUrlViewModelTest {
 
     private fun createViewModel(addAccount: Boolean) = ServerUrlViewModel(
         serverDataStore = serverDataStore,
+        serverHeadersDataStore = serverHeadersDataStore,
         configRepository = configRepository,
         accountSwitcher = accountSwitcher,
         addAccount = addAccount,
@@ -74,6 +83,47 @@ class ServerUrlViewModelTest {
         coVerify(exactly = 1) { accountSwitcher.attachPendingConfig(config) }
         coVerify(exactly = 0) { serverDataStore.setServerUrl(any()) }
         coVerify(exactly = 0) { configRepository.validateServerUrl(any()) }
+    }
+
+    /**
+     * `isValidated` is a one-shot navigation signal, and the screen re-fires its navigate effect
+     * whenever it re-composes with the flag still set. Since this ViewModel outlives the forward
+     * navigation (it sits in the nav back stack), a latched flag would throw the user forward again
+     * the moment they pop BACK onto the screen — in add-account mode, an inescapable loop that only
+     * force-stopping the app can break.
+     */
+    @Test
+    fun `the validated signal is consumable so back does not bounce forward`() = runTest(testDispatcher) {
+        coEvery { configRepository.probeServerUrl() } returns Result.Success(config)
+        val viewModel = createViewModel(addAccount = true)
+        advanceUntilIdle()
+
+        viewModel.onUrlChanged(pendingUrl)
+        viewModel.validateAndConnect()
+        advanceUntilIdle()
+        assertThat(viewModel.uiState.value.isValidated).isTrue()
+
+        viewModel.consumeValidated()
+
+        assertThat(viewModel.uiState.value.isValidated).isFalse()
+    }
+
+    /** Consuming must not wedge the screen: a second Connect has to navigate again. */
+    @Test
+    fun `connecting again after a consume re-raises the signal`() = runTest(testDispatcher) {
+        coEvery { configRepository.probeServerUrl() } returns Result.Success(config)
+        val viewModel = createViewModel(addAccount = true)
+        advanceUntilIdle()
+
+        viewModel.onUrlChanged(pendingUrl)
+        viewModel.validateAndConnect()
+        advanceUntilIdle()
+        viewModel.consumeValidated()
+
+        viewModel.validateAndConnect()
+        advanceUntilIdle()
+
+        assertThat(viewModel.uiState.value.isValidated).isTrue()
     }
 
     @Test
@@ -120,5 +170,185 @@ class ServerUrlViewModelTest {
         coVerify(exactly = 1) { serverDataStore.setServerUrl(pendingUrl) }
         coVerify(exactly = 1) { serverDataStore.setServerUrl("") }
         coVerify(exactly = 0) { accountSwitcher.beginAdd(any()) }
+    }
+
+    /**
+     * Add mode prefills the ACTIVE server's URL by design, and must not prefill its headers with it.
+     * A gateway header is a credential: showing it on a screen the user believes is configuring a new
+     * server invites an edit that silently rewrites the live server's credential instead.
+     */
+    @Test
+    fun `add mode prefills the active URL but never the active server's headers`() = runTest(testDispatcher) {
+        coEvery { serverDataStore.awaitBaseUrl() } returns liveUrl
+        coEvery { serverHeadersDataStore.headersForServer(any()) } returns liveHeaders
+
+        val viewModel = createViewModel(addAccount = true)
+        advanceUntilIdle()
+
+        assertThat(viewModel.uiState.value.url).isEqualTo(liveUrl)
+        assertThat(viewModel.uiState.value.customHeaders).isEmpty()
+        assertThat(viewModel.uiState.value.showAdvanced).isFalse()
+        // Not merely absent from the state — never read, so it cannot leak via a later copy() either.
+        coVerify(exactly = 0) { serverHeadersDataStore.headersForServer(any()) }
+    }
+
+    /** The same prefill in normal mode DOES restore the headers — that's what makes logout survivable. */
+    @Test
+    fun `normal mode prefills the saved headers and opens the advanced section`() = runTest(testDispatcher) {
+        coEvery { serverDataStore.awaitBaseUrl() } returns liveUrl
+        coEvery { serverHeadersDataStore.headersForServer(liveUrl) } returns liveHeaders
+
+        val viewModel = createViewModel(addAccount = false)
+        advanceUntilIdle()
+
+        assertThat(viewModel.uiState.value.customHeaders)
+            .containsExactly(CustomHeaderRow("CF-Access-Client-Id", "id-value"))
+        assertThat(viewModel.uiState.value.showAdvanced).isTrue()
+    }
+
+    /**
+     * The probe is the FIRST request to a gateway-protected server, so it is exactly the request that
+     * has to already carry the headers. Persisting them in a separate coroutine (or after the probe)
+     * would make the first Connect fail and the second succeed — indistinguishable from flakiness.
+     */
+    @Test
+    fun `normal mode persists the headers before probing the server`() = runTest(testDispatcher) {
+        coEvery { configRepository.validateServerUrl(pendingUrl) } returns Result.Success(config)
+        val viewModel = createViewModel(addAccount = false)
+        advanceUntilIdle()
+
+        viewModel.onUrlChanged(pendingUrl)
+        viewModel.addHeaderRow()
+        viewModel.onHeaderNameChanged(0, "CF-Access-Client-Id")
+        // Padded on purpose: pasting a token out of a dashboard is the likely entry path, and the
+        // trailing whitespace must be normalized away before it is persisted.
+        viewModel.onHeaderValueChanged(0, "  id-value  ")
+        viewModel.validateAndConnect()
+        advanceUntilIdle()
+
+        coVerifyOrder {
+            serverHeadersDataStore.setHeaders(pendingUrl, mapOf("CF-Access-Client-Id" to "id-value"))
+            serverDataStore.setServerUrl(pendingUrl)
+            configRepository.validateServerUrl(pendingUrl)
+        }
+    }
+
+    /**
+     * Add mode's deadline is earlier still: `beginAdd` mints the PendingRequestIdentity whose headers
+     * lambda reads the store, so a save landing after it probes with an empty header set.
+     */
+    @Test
+    fun `add mode persists the headers before beginAdd mints the pending identity`() = runTest(testDispatcher) {
+        coEvery { configRepository.probeServerUrl() } returns Result.Success(config)
+        val viewModel = createViewModel(addAccount = true)
+        advanceUntilIdle()
+
+        viewModel.onUrlChanged(pendingUrl)
+        viewModel.addHeaderRow()
+        viewModel.onHeaderNameChanged(0, "CF-Access-Client-Id")
+        viewModel.onHeaderValueChanged(0, "id-value")
+        viewModel.validateAndConnect()
+        advanceUntilIdle()
+
+        coVerifyOrder {
+            serverHeadersDataStore.setHeaders(pendingUrl, mapOf("CF-Access-Client-Id" to "id-value"))
+            accountSwitcher.beginAdd(pendingUrl)
+        }
+    }
+
+    /**
+     * The single-tap "add another account on the same server" flow the init comment advertises. Add
+     * mode prefills the ACTIVE server's URL with an empty editor, so an unconditional save writes an
+     * empty map — and an empty map means "delete this server's headers" to the store. That wipes the
+     * live session's gateway credential, which is plaintext-only and has no second copy.
+     */
+    @Test
+    fun `add mode with an untouched editor never writes over the active server's headers`() =
+        runTest(testDispatcher) {
+            coEvery { serverDataStore.awaitBaseUrl() } returns liveUrl
+            coEvery { configRepository.probeServerUrl() } returns Result.Success(config)
+
+            val viewModel = createViewModel(addAccount = true)
+            advanceUntilIdle()
+
+            // Connect on the unchanged prefill — no header row touched.
+            viewModel.validateAndConnect()
+            advanceUntilIdle()
+
+            coVerify(exactly = 0) { serverHeadersDataStore.setHeaders(any(), any()) }
+        }
+
+    /** Same guard pre-login: an editor that never loaded must not be mistaken for a cleared one. */
+    @Test
+    fun `normal mode with an untouched editor does not rewrite stored headers`() = runTest(testDispatcher) {
+        coEvery { serverDataStore.awaitBaseUrl() } returns liveUrl
+        coEvery { serverHeadersDataStore.headersForServer(liveUrl) } returns liveHeaders
+        coEvery { configRepository.validateServerUrl(any()) } returns Result.Success(config)
+
+        val viewModel = createViewModel(addAccount = false)
+        advanceUntilIdle()
+
+        viewModel.validateAndConnect()
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { serverHeadersDataStore.setHeaders(any(), any()) }
+    }
+
+    /** Clearing every row IS an edit, so it must still reach the store as an empty map. */
+    @Test
+    fun `removing the last row persists the clear`() = runTest(testDispatcher) {
+        coEvery { serverDataStore.awaitBaseUrl() } returns liveUrl
+        coEvery { serverHeadersDataStore.headersForServer(liveUrl) } returns liveHeaders
+        coEvery { configRepository.validateServerUrl(any()) } returns Result.Success(config)
+
+        val viewModel = createViewModel(addAccount = false)
+        advanceUntilIdle()
+
+        viewModel.removeHeaderRow(0)
+        viewModel.validateAndConnect()
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { serverHeadersDataStore.setHeaders(liveUrl, emptyMap()) }
+    }
+
+    /**
+     * Both init awaits can outlast the first frame, and `headersForServer` adds a second suspension on
+     * the header store's warm-up. A user typing a rotated token in that window must not have it
+     * replaced by the stale persisted set.
+     */
+    @Test
+    fun `a late prefill does not clobber rows the user already typed`() = runTest(testDispatcher) {
+        coEvery { serverDataStore.awaitBaseUrl() } returns liveUrl
+        coEvery { serverHeadersDataStore.headersForServer(liveUrl) } returns liveHeaders
+
+        val viewModel = createViewModel(addAccount = false)
+        // Deliberately NOT advancing to idle — init is still suspended.
+        viewModel.addHeaderRow()
+        viewModel.onHeaderNameChanged(0, "CF-Access-Client-Secret")
+        viewModel.onHeaderValueChanged(0, "rotated-secret")
+        advanceUntilIdle()
+
+        assertThat(viewModel.uiState.value.customHeaders)
+            .containsExactly(CustomHeaderRow("CF-Access-Client-Secret", "rotated-secret"))
+    }
+
+    /** A reserved name is rejected inline, before any network or storage write. */
+    @Test
+    fun `a reserved header name blocks the connect entirely`() = runTest(testDispatcher) {
+        val viewModel = createViewModel(addAccount = false)
+        advanceUntilIdle()
+
+        viewModel.onUrlChanged(pendingUrl)
+        viewModel.addHeaderRow()
+        viewModel.onHeaderNameChanged(0, "Authorization")
+        viewModel.onHeaderValueChanged(0, "Basic abc")
+        viewModel.validateAndConnect()
+        advanceUntilIdle()
+
+        assertThat(viewModel.uiState.value.headerError)
+            .isEqualTo(HeaderFieldError(index = 0, reason = HeaderRejection.ReservedName))
+        assertThat(viewModel.uiState.value.showAdvanced).isTrue()
+        coVerify(exactly = 0) { serverHeadersDataStore.setHeaders(any(), any()) }
+        coVerify(exactly = 0) { configRepository.validateServerUrl(any()) }
     }
 }

--- a/feature/auth/src/commonMain/composeResources/values-ar/strings.xml
+++ b/feature/auth/src/commonMain/composeResources/values-ar/strings.xml
@@ -73,4 +73,7 @@
 
     <!-- Common -->
     <string name="back">رجوع</string>
+
+    <!-- Custom server headers (issue #287) -->
+    <string name="server_headers_advanced">متقدم</string>
 </resources>

--- a/feature/auth/src/commonMain/composeResources/values-de/strings.xml
+++ b/feature/auth/src/commonMain/composeResources/values-de/strings.xml
@@ -73,4 +73,7 @@
 
     <!-- Common -->
     <string name="back">Zurück</string>
+
+    <!-- Custom server headers (issue #287) -->
+    <string name="server_headers_advanced">Erweitert</string>
 </resources>

--- a/feature/auth/src/commonMain/composeResources/values-es/strings.xml
+++ b/feature/auth/src/commonMain/composeResources/values-es/strings.xml
@@ -73,4 +73,7 @@
 
     <!-- Common -->
     <string name="back">Atrás</string>
+
+    <!-- Custom server headers (issue #287) -->
+    <string name="server_headers_advanced">Avanzado</string>
 </resources>

--- a/feature/auth/src/commonMain/composeResources/values-fr/strings.xml
+++ b/feature/auth/src/commonMain/composeResources/values-fr/strings.xml
@@ -73,4 +73,7 @@
 
     <!-- Common -->
     <string name="back">Retour</string>
+
+    <!-- Custom server headers (issue #287) -->
+    <string name="server_headers_advanced">Avancé</string>
 </resources>

--- a/feature/auth/src/commonMain/composeResources/values-ja/strings.xml
+++ b/feature/auth/src/commonMain/composeResources/values-ja/strings.xml
@@ -73,4 +73,7 @@
 
     <!-- Common -->
     <string name="back">戻る</string>
+
+    <!-- Custom server headers (issue #287) -->
+    <string name="server_headers_advanced">詳細設定</string>
 </resources>

--- a/feature/auth/src/commonMain/composeResources/values-ko/strings.xml
+++ b/feature/auth/src/commonMain/composeResources/values-ko/strings.xml
@@ -73,4 +73,7 @@
 
     <!-- Common -->
     <string name="back">뒤로</string>
+
+    <!-- Custom server headers (issue #287) -->
+    <string name="server_headers_advanced">고급</string>
 </resources>

--- a/feature/auth/src/commonMain/composeResources/values-pt/strings.xml
+++ b/feature/auth/src/commonMain/composeResources/values-pt/strings.xml
@@ -73,4 +73,7 @@
 
     <!-- Common -->
     <string name="back">Voltar</string>
+
+    <!-- Custom server headers (issue #287) -->
+    <string name="server_headers_advanced">Avançado</string>
 </resources>

--- a/feature/auth/src/commonMain/composeResources/values-ru/strings.xml
+++ b/feature/auth/src/commonMain/composeResources/values-ru/strings.xml
@@ -73,4 +73,7 @@
 
     <!-- Common -->
     <string name="back">Назад</string>
+
+    <!-- Custom server headers (issue #287) -->
+    <string name="server_headers_advanced">Дополнительно</string>
 </resources>

--- a/feature/auth/src/commonMain/composeResources/values-zh/strings.xml
+++ b/feature/auth/src/commonMain/composeResources/values-zh/strings.xml
@@ -73,4 +73,7 @@
 
     <!-- Common -->
     <string name="back">返回</string>
+
+    <!-- Custom server headers (issue #287) -->
+    <string name="server_headers_advanced">高级</string>
 </resources>

--- a/feature/auth/src/commonMain/composeResources/values/strings.xml
+++ b/feature/auth/src/commonMain/composeResources/values/strings.xml
@@ -73,4 +73,7 @@
 
     <!-- Common -->
     <string name="back">Back</string>
+
+    <!-- Custom server headers (issue #287) -->
+    <string name="server_headers_advanced">Advanced</string>
 </resources>

--- a/feature/auth/src/commonMain/kotlin/com/garfiec/librechat/feature/auth/di/AuthModule.kt
+++ b/feature/auth/src/commonMain/kotlin/com/garfiec/librechat/feature/auth/di/AuthModule.kt
@@ -23,6 +23,7 @@ val authModule = module {
     viewModel { params ->
         ServerUrlViewModel(
             serverDataStore = get(),
+            serverHeadersDataStore = get(),
             configRepository = get(),
             accountSwitcher = get(),
             addAccount = params.getOrNull() ?: false,

--- a/feature/auth/src/commonMain/kotlin/com/garfiec/librechat/feature/auth/screen/ServerUrlScreen.kt
+++ b/feature/auth/src/commonMain/kotlin/com/garfiec/librechat/feature/auth/screen/ServerUrlScreen.kt
@@ -10,11 +10,16 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
@@ -30,9 +35,14 @@ import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.garfiec.librechat.core.network.client.HeaderRejection
+import com.garfiec.librechat.core.ui.components.CustomHeaderRow
+import com.garfiec.librechat.core.ui.components.CustomHeaderRowError
+import com.garfiec.librechat.core.ui.components.CustomHeadersEditor
 import com.garfiec.librechat.core.ui.components.testTagsAsResourceIdSubtree
 import com.garfiec.librechat.feature.auth.resources.*
 import com.garfiec.librechat.feature.auth.resources.Res
+import com.garfiec.librechat.feature.auth.viewmodel.HeaderFieldError
 import com.garfiec.librechat.feature.auth.viewmodel.ServerUrlViewModel
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
@@ -50,6 +60,9 @@ fun ServerUrlScreen(
     LaunchedEffect(uiState.isValidated) {
         if (uiState.isValidated) {
             currentOnServerValidated()
+            // Consume it, or backing out of the next screen lands here and is immediately thrown
+            // forward again — this entry's ViewModel outlives the forward navigation.
+            viewModel.consumeValidated()
         }
     }
 
@@ -105,6 +118,20 @@ fun ServerUrlScreen(
                 enabled = !uiState.isLoading,
             )
 
+            Spacer(modifier = Modifier.height(8.dp))
+
+            CustomHeadersSection(
+                expanded = uiState.showAdvanced,
+                headers = uiState.customHeaders,
+                headerError = uiState.headerError,
+                enabled = !uiState.isLoading,
+                onToggle = viewModel::toggleAdvanced,
+                onNameChange = viewModel::onHeaderNameChanged,
+                onValueChange = viewModel::onHeaderValueChanged,
+                onAdd = viewModel::addHeaderRow,
+                onRemove = viewModel::removeHeaderRow,
+            )
+
             Spacer(modifier = Modifier.height(24.dp))
 
             Button(
@@ -126,6 +153,65 @@ fun ServerUrlScreen(
 
         BackAffordanceOverlay(onBack)
     }
+}
+
+/**
+ * Collapsed-by-default editor for the server's static gateway headers (issue #287).
+ *
+ * Pre-login only, and that placement is the point: a deployment behind Cloudflare Access (or
+ * Authelia, Authentik, oauth2-proxy…) can't be reached *at all* without these, so a post-login
+ * settings screen would be unreachable for exactly the users who need it.
+ */
+@Composable
+private fun CustomHeadersSection(
+    expanded: Boolean,
+    headers: List<CustomHeaderRow>,
+    headerError: HeaderFieldError?,
+    enabled: Boolean,
+    onToggle: () -> Unit,
+    onNameChange: (Int, String) -> Unit,
+    onValueChange: (Int, String) -> Unit,
+    onAdd: () -> Unit,
+    onRemove: (Int) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier.fillMaxWidth()) {
+        TextButton(
+            onClick = onToggle,
+            modifier = Modifier.align(Alignment.Start).testTag("server_url_advanced_toggle"),
+        ) {
+            Icon(
+                imageVector = if (expanded) Icons.Default.KeyboardArrowUp else Icons.Default.KeyboardArrowDown,
+                contentDescription = null,
+            )
+            Spacer(modifier = Modifier.width(4.dp))
+            Text(stringResource(Res.string.server_headers_advanced))
+        }
+
+        if (!expanded) return@Column
+
+        CustomHeadersEditor(
+            headers = headers,
+            onNameChange = onNameChange,
+            onValueChange = onValueChange,
+            onAdd = onAdd,
+            onRemove = onRemove,
+            errorIndex = headerError?.index,
+            errorReason = headerError?.reason?.toRowError(),
+            enabled = enabled,
+        )
+    }
+}
+
+/**
+ * `:core:ui` deliberately does not depend on `:core:network`, so the wire-level rejection is mapped to
+ * the editor's own enum here. Exhaustive `when` — a new [HeaderRejection] case breaks the build rather
+ * than silently rendering no message.
+ */
+private fun HeaderRejection.toRowError(): CustomHeaderRowError = when (this) {
+    HeaderRejection.InvalidName -> CustomHeaderRowError.InvalidName
+    HeaderRejection.InvalidValue -> CustomHeaderRowError.InvalidValue
+    HeaderRejection.ReservedName -> CustomHeaderRowError.ReservedName
 }
 
 @Composable

--- a/feature/auth/src/commonMain/kotlin/com/garfiec/librechat/feature/auth/viewmodel/ServerUrlViewModel.kt
+++ b/feature/auth/src/commonMain/kotlin/com/garfiec/librechat/feature/auth/viewmodel/ServerUrlViewModel.kt
@@ -5,12 +5,24 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.garfiec.librechat.core.common.result.Result
 import com.garfiec.librechat.core.data.datastore.ServerDataStore
+import com.garfiec.librechat.core.data.datastore.ServerHeadersDataStore
 import com.garfiec.librechat.core.data.repository.AccountSwitcher
 import com.garfiec.librechat.core.data.repository.ConfigRepository
+import com.garfiec.librechat.core.network.client.CustomHeaderRules
+import com.garfiec.librechat.core.network.client.HeaderRejection
+import com.garfiec.librechat.core.ui.components.CustomHeaderRow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+
+/**
+ * A rejected header row, as the row index plus the machine-readable reason. Deliberately not a
+ * message: `:core:network` has no string resources and this module's strings live in its own
+ * `composeResources`, so the mapping to text belongs in the composable.
+ */
+@Immutable
+data class HeaderFieldError(val index: Int, val reason: HeaderRejection)
 
 @Immutable
 data class ServerUrlUiState(
@@ -19,6 +31,9 @@ data class ServerUrlUiState(
     val error: String? = null,
     val isValidated: Boolean = false,
     val showHttpWarning: Boolean = false,
+    val showAdvanced: Boolean = false,
+    val customHeaders: List<CustomHeaderRow> = emptyList(),
+    val headerError: HeaderFieldError? = null,
 )
 
 /**
@@ -35,6 +50,7 @@ data class ServerUrlUiState(
  */
 class ServerUrlViewModel(
     private val serverDataStore: ServerDataStore,
+    private val serverHeadersDataStore: ServerHeadersDataStore,
     private val configRepository: ConfigRepository,
     private val accountSwitcher: AccountSwitcher,
     private val addAccount: Boolean = false,
@@ -43,6 +59,16 @@ class ServerUrlViewModel(
     private val _uiState = MutableStateFlow(ServerUrlUiState())
     val uiState: StateFlow<ServerUrlUiState> = _uiState.asStateFlow()
 
+    /**
+     * Whether the user has edited a header row. Gates the save at Connect: the editor starts empty
+     * (always in add mode, and in normal mode until the store resolves), so an unconditional write
+     * would mean "empty editor" == "delete this server's credential".
+     */
+    private var headersEdited = false
+
+    /** Whether the user has interacted at all, which makes the async prefill stale rather than late. */
+    private var userEdited = false
+
     init {
         viewModelScope.launch {
             // awaitBaseUrl (not getBaseUrl) so a cold-start relaunch doesn't read "" before
@@ -50,16 +76,88 @@ class ServerUrlViewModel(
             // In add mode this pre-fills the ACTIVE server so the common same-server-different-user
             // add is a single tap; typing a different URL adds a new server.
             val existingUrl = serverDataStore.awaitBaseUrl()
-            if (existingUrl.isNotBlank()) {
-                _uiState.value = _uiState.value.copy(
-                    url = existingUrl,
-                )
-            }
+            if (existingUrl.isBlank()) return@launch
+            // The URL prefill above deliberately shows the ACTIVE server in add mode — but its
+            // headers must NOT come along. They are a credential, and prefilling them would show the
+            // live server's secret on a screen the user believes is configuring a *new* server; an
+            // edit there would then silently rewrite the live server's credential. Add mode starts
+            // empty and the user re-enters what the new server needs.
+            val savedHeaders = if (addAccount) emptyMap() else serverHeadersDataStore.headersForServer(existingUrl)
+            // Both awaits above can outlast the first frame, and `headersForServer` adds a second
+            // suspension on the header store's own warm-up. By the time they resolve the user may
+            // already be typing — applying the prefill then overwrites a URL or a freshly rotated
+            // token with the stale persisted set, and can collapse the section back shut.
+            if (userEdited) return@launch
+            _uiState.value = _uiState.value.copy(
+                url = existingUrl,
+                customHeaders = savedHeaders.map { (name, value) -> CustomHeaderRow(name, value) },
+                // Auto-expand when headers already exist, so a saved credential is never invisible.
+                showAdvanced = savedHeaders.isNotEmpty(),
+            )
         }
     }
 
     fun onUrlChanged(url: String) {
+        // Deliberately does not re-key the saved headers: this fires per keystroke, and deriveServerId
+        // throws on partial input. The header set is committed against the final URL on Connect.
+        userEdited = true
         _uiState.value = _uiState.value.copy(url = url, error = null)
+    }
+
+    /**
+     * Retires the one-shot navigation signal once the host has acted on it.
+     *
+     * Without this the flag stays latched for the ViewModel's whole life, and the screen's
+     * `LaunchedEffect(isValidated)` re-fires the moment the entry is re-composed. Popping BACK onto
+     * this screen therefore navigated straight forward again — in add-account mode that made the
+     * flow impossible to leave by any means short of killing the app, since the ViewModel survives
+     * in the nav back stack. Same shape as `TermsViewModel.consumeAccepted`.
+     */
+    fun consumeValidated() {
+        _uiState.value = _uiState.value.copy(isValidated = false)
+    }
+
+    fun toggleAdvanced() {
+        _uiState.value = _uiState.value.copy(showAdvanced = !_uiState.value.showAdvanced)
+    }
+
+    fun addHeaderRow() {
+        markHeadersEdited()
+        _uiState.value = _uiState.value.copy(
+            customHeaders = _uiState.value.customHeaders + CustomHeaderRow(),
+            headerError = null,
+        )
+    }
+
+    fun removeHeaderRow(index: Int) {
+        val current = _uiState.value.customHeaders
+        if (index !in current.indices) return
+        markHeadersEdited()
+        _uiState.value = _uiState.value.copy(
+            customHeaders = current.filterIndexed { i, _ -> i != index },
+            headerError = null,
+        )
+    }
+
+    private fun markHeadersEdited() {
+        headersEdited = true
+        userEdited = true
+    }
+
+    fun onHeaderNameChanged(index: Int, name: String) = updateHeader(index) { it.copy(name = name) }
+
+    fun onHeaderValueChanged(index: Int, value: String) = updateHeader(index) { it.copy(value = value) }
+
+    private fun updateHeader(index: Int, transform: (CustomHeaderRow) -> CustomHeaderRow) {
+        val current = _uiState.value.customHeaders
+        if (index !in current.indices) return
+        markHeadersEdited()
+        _uiState.value = _uiState.value.copy(
+            customHeaders = current.mapIndexed { i, field -> if (i == index) transform(field) else field },
+            // Clear the rejection as soon as the user edits: leaving it pinned to a stale index would
+            // point at the wrong row after an add/remove.
+            headerError = null,
+        )
     }
 
     fun validateAndConnect() {
@@ -98,8 +196,33 @@ class ServerUrlViewModel(
     }
 
     private fun doValidateAndConnect(url: String) {
+        val headers = _uiState.value.customHeaders
+        firstInvalidHeader(headers)?.let { rejection ->
+            // Reject before touching the network: a gateway answers a malformed credential with a
+            // redirect to its own login page, which surfaces as an opaque "could not reach the
+            // server" — the user would have no way to tell a typo from a wrong URL.
+            _uiState.value = _uiState.value.copy(headerError = rejection, showAdvanced = true)
+            return
+        }
+
         viewModelScope.launch {
-            _uiState.value = _uiState.value.copy(isLoading = true, error = null)
+            _uiState.value = _uiState.value.copy(isLoading = true, error = null, headerError = null)
+
+            // Three rules here, each easy to undo:
+            // - Awaited BEFORE the probe below, which is the first request to a gateway-protected
+            //   server and must already carry the headers; in add mode also before beginAdd(),
+            //   which mints the pending identity that reads them.
+            // - Keyed on the normalized `url`, not the raw field text: `http://` and `https://`
+            //   derive different serverIds, so the credential would be filed under a server the
+            //   app never contacts.
+            // - Only when a row was actually edited. An empty map means "delete this server's
+            //   headers", and the editor is empty by default both in add mode (which prefills the
+            //   ACTIVE server's URL, so one tap on the untouched prefill would wipe the live
+            //   session's credential) and before the store resolves. Clearing is expressed by
+            //   removing rows, which sets the flag.
+            if (headersEdited) {
+                serverHeadersDataStore.setHeaders(url, headers.toHeaderMap())
+            }
 
             val result = if (addAccount) validatePendingServer(url) else validateLiveServer(url)
 
@@ -151,4 +274,22 @@ class ServerUrlViewModel(
         }
         return result
     }
+
+    /**
+     * The first row that can't be sent, or null. Fully blank rows are skipped — the list always ends
+     * with an empty row the user hasn't filled in yet, and that isn't an error.
+     */
+    private fun firstInvalidHeader(headers: List<CustomHeaderRow>): HeaderFieldError? =
+        headers.withIndex().firstNotNullOfOrNull { (index, field) ->
+            if (field.name.isBlank() && field.value.isBlank()) {
+                null
+            } else {
+                CustomHeaderRules.validate(field.name, field.value)?.let { HeaderFieldError(index, it) }
+            }
+        }
+
+    /** Drops blank rows and normalizes what's left. Later rows win on a duplicate name. */
+    private fun List<CustomHeaderRow>.toHeaderMap(): Map<String, String> =
+        filterNot { it.name.isBlank() && it.value.isBlank() }
+            .associate { it.name.trim() to CustomHeaderRules.normalizeValue(it.value) }
 }

--- a/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/StreamingManagerEndStreamTest.kt
+++ b/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/StreamingManagerEndStreamTest.kt
@@ -35,8 +35,8 @@ import org.junit.Test
 /**
  * Covers the [StreamingManagerDelegate] termination chokepoint: every stream session ends
  * through exactly one `endStream(reason)`. Pins the session latch (a session cannot end twice,
- * and a stale end from stream N cannot touch stream N+1), the abort watchdog, and the two
- * legacy error paths now producing identical teardown.
+ * and a stale end from stream N cannot touch stream N+1), the abort watchdog, and the identical
+ * teardown the two legacy error paths produce.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 class StreamingManagerEndStreamTest {
@@ -48,6 +48,13 @@ class StreamingManagerEndStreamTest {
     private val reloadConversation = mockk<(String) -> Unit>(relaxed = true)
     private val treeDelegate = mockk<MessageTreeDelegate>(relaxed = true)
     private val restoreUnsentInput = mockk<(String) -> Unit>(relaxed = true)
+
+    /**
+     * Shared so a test can assert whether the connectivity observer was started — that is the only
+     * externally visible consequence of a stream end being flagged as a network failure. JUnit4
+     * builds a fresh test instance per method, so this stays per-test state.
+     */
+    private val connectivityObserver = mockk<ConnectivityObserver>(relaxed = true)
 
     private fun message(id: String, parentId: String? = null, isUser: Boolean = false) = Message(
         messageId = id,
@@ -68,7 +75,7 @@ class StreamingManagerEndStreamTest {
     ): Pair<StreamingManagerDelegate, MutableStateFlow<ChatUiState>> {
         val flow = MutableStateFlow(state)
         val root = ChatStateHandle(flow, scope)
-        val connectivity = mockk<ConnectivityObserver>(relaxed = true)
+        val connectivity = connectivityObserver
         every { connectivity.isConnected } returns flowOf(true)
         val delegate = StreamingManagerDelegate(
             handle = StreamingHandle(root),
@@ -241,6 +248,138 @@ class StreamingManagerEndStreamTest {
         advanceUntilIdle()
     }
 
+    /**
+     * A send rejected before the server's `created` milestone persisted nothing — not even the user
+     * message — so the turn is un-sent and the text handed back, exactly as an early abort does.
+     *
+     * Without this the typed text simply vanishes: on a new chat the optimistic bubble is never even
+     * rendered (screenState stays LANDING until `created`), and on an existing conversation the
+     * reload rebuilds the path without it, leaving nothing to retry from. An access gateway
+     * rejecting the request (issue #287) arrives as an ordinary transport failure well before
+     * `created`.
+     */
+    @Test
+    fun `a send that dies before created un-sends the turn and hands the text back`() =
+        runTest(StandardTestDispatcher()) {
+            val events = Channel<StreamEvent>(Channel.UNLIMITED)
+            val (delegate, flow) = delegateWith(this)
+            delegate.beginStreaming(isEdit = false, optimisticUserMessageId = "u1")
+            delegate.launchStream(events.receiveAsFlow())
+
+            events.send(StreamEvent.Error(message = "Request failed (HTTP 302)"))
+            runCurrent()
+
+            verify(exactly = 1) { treeDelegate.unsendOptimisticTurn("u1") }
+            verify(exactly = 1) { restoreUnsentInput("text-u1") }
+            // The failure is still reported — un-sending is not the same as swallowing it.
+            assertThat(flow.value.error).isEqualTo("Request failed (HTTP 302)")
+
+            events.close()
+            delegate.reset()
+            advanceUntilIdle()
+        }
+
+    /**
+     * Past `created` the server owns the turn, so a later failure must NOT remove the user message —
+     * it is a persisted row, and un-sending it would desync the client from the server's tree.
+     */
+    @Test
+    fun `a failure after created leaves the turn in place`() = runTest(StandardTestDispatcher()) {
+        val events = Channel<StreamEvent>(Channel.UNLIMITED)
+        val (delegate, _) = delegateWith(this)
+        delegate.beginStreaming(isEdit = false, optimisticUserMessageId = "u1")
+        delegate.launchStream(events.receiveAsFlow())
+
+        events.send(
+            StreamEvent.Created(conversationId = "conv-1", messageId = "m1", parentMessageId = "u1"),
+        )
+        events.send(StreamEvent.Error(message = "boom"))
+        runCurrent()
+
+        verify(exactly = 0) { treeDelegate.unsendOptimisticTurn(any()) }
+        verify(exactly = 0) { restoreUnsentInput(any()) }
+
+        events.close()
+        delegate.reset()
+        advanceUntilIdle()
+    }
+
+    /**
+     * Regenerate / continue / edit-AI re-submit a message the server already has, so they mint no
+     * optimistic id — and a failure there must never remove the existing user turn.
+     */
+    @Test
+    fun `a resubmitted turn is never un-sent on failure`() = runTest(StandardTestDispatcher()) {
+        val events = Channel<StreamEvent>(Channel.UNLIMITED)
+        val (delegate, _) = delegateWith(this)
+        delegate.beginStreaming(isEdit = true)
+        delegate.launchStream(events.receiveAsFlow())
+
+        events.send(StreamEvent.Error(message = "boom"))
+        runCurrent()
+
+        verify(exactly = 0) { treeDelegate.unsendOptimisticTurn(any()) }
+        verify(exactly = 0) { restoreUnsentInput(any()) }
+
+        events.close()
+        delegate.reset()
+        advanceUntilIdle()
+    }
+
+    /**
+     * The chat stream is collected directly, not through `safeApiCall`, so it is the one place a
+     * raw exception message could reach the UI. Ktor composes those from the request URL, so an
+     * access gateway's redirect — query string and `meta=` JWT included — would render verbatim in
+     * the chat's own error snackbar.
+     *
+     * The in-band `StreamEvent.Error` path deliberately still shows the server's own wording: the
+     * server wrote that for a person, whereas an exception's message is written for a developer.
+     */
+    @Test
+    fun `a transport exception's raw message never reaches the error banner`() =
+        runTest(StandardTestDispatcher()) {
+            val leaky = "Expected response body of the type 'class User' but was 'class Source'\n" +
+                "In response from `https://team.cloudflareaccess.com/cdn-cgi/access/login/" +
+                "chat.example.com?meta=eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9`"
+            val (delegate, state) = delegateWith(this)
+
+            delegate.launchStream(flow { throw IllegalStateException(leaky) })
+            advanceUntilIdle()
+
+            val shown = state.value.error.orEmpty()
+            assertThat(shown).isNotEmpty() // the failure is still reported...
+            assertThat(shown).doesNotContain("cloudflareaccess") // ...just not like this
+            assertThat(shown).doesNotContain("meta=")
+            assertThat(shown).doesNotContain("eyJ")
+            assertThat(shown).doesNotContain("Expected response body")
+        }
+
+    /**
+     * Only a network-flagged end starts the connectivity observer, and that observer is what resumes
+     * the stream when the connection comes back — so the flag must be derived from the failure, not
+     * hardcoded, or a dropped connection never re-arms the one path auto-reconnect exists for.
+     */
+    @Test
+    fun `a dropped connection arms auto-reconnect`() = runTest(StandardTestDispatcher()) {
+        val (delegate, _) = delegateWith(this)
+
+        delegate.launchStream(flow { throw java.io.IOException("Connection reset by peer") })
+        advanceUntilIdle()
+
+        verify(atLeast = 1) { connectivityObserver.isConnected }
+    }
+
+    /** ...and a failure that is NOT the network must not, or every error would poll connectivity. */
+    @Test
+    fun `a non-network failure does not arm auto-reconnect`() = runTest(StandardTestDispatcher()) {
+        val (delegate, _) = delegateWith(this)
+
+        delegate.launchStream(flow { throw IllegalStateException("malformed frame") })
+        advanceUntilIdle()
+
+        verify(exactly = 0) { connectivityObserver.isConnected }
+    }
+
     @Test
     fun `a flow exception preserves the partial and reloads`() = runTest(StandardTestDispatcher()) {
         val (delegate, flow) = delegateWith(this)
@@ -254,7 +393,8 @@ class StreamingManagerEndStreamTest {
 
         assertThat(flow.value.isStreaming).isFalse()
         assertThat(flow.value.streamingContent).isEqualTo("half an answer")
-        assertThat(flow.value.error).isEqualTo("boom")
+        assertThat(flow.value.error).isNotEmpty()
+        assertThat(flow.value.error).doesNotContain("boom")
         verify(atLeast = 1) { queueDelegate.pause() }
         verify(exactly = 0) { queueDelegate.drainNext(any()) }
         verify(exactly = 1) { reloadConversation("conv-1") }

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/StreamingManagerDelegate.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/StreamingManagerDelegate.kt
@@ -6,7 +6,9 @@ import com.garfiec.librechat.core.common.identity.AccountId
 import com.garfiec.librechat.core.common.identity.ActiveAccountProvider
 import com.garfiec.librechat.core.common.identity.currentAccountId
 import com.garfiec.librechat.core.common.network.ConnectivityObserver
+import com.garfiec.librechat.core.common.result.FailureKind
 import com.garfiec.librechat.core.common.result.Result
+import com.garfiec.librechat.core.common.result.toSafeError
 import com.garfiec.librechat.core.data.repository.ChatRepository
 import com.garfiec.librechat.core.model.Attachment
 import com.garfiec.librechat.core.model.StreamEvent
@@ -169,6 +171,12 @@ class StreamingManagerDelegate(
     private var currentTurnOptimisticUserMessageId: String? = null
 
     /**
+     * Whether this turn reached the server's `created` milestone. Below that line nothing is
+     * persisted — not even the user message — which is what makes a failed send safe to un-send.
+     */
+    private var currentTurnCreated = false
+
+    /**
      * Resets the streaming-internal session state (buffer, edit flag, traces) and starts the
      * throttled updater. Does NOT touch UI state — callers that already mutate UI state
      * for their send (e.g. the optimistic-insert path) use this; [prepareForStreaming] wraps
@@ -243,6 +251,7 @@ class StreamingManagerDelegate(
         // A resumed stream re-enters without beginStreaming's assignment; never let a previous
         // turn's optimistic id leak into it (the un-send would remove the wrong message).
         currentTurnOptimisticUserMessageId = null
+        currentTurnCreated = false
     }
 
     private suspend fun collectStreamSafely(stream: Flow<StreamEvent>) {
@@ -252,7 +261,17 @@ class StreamingManagerDelegate(
             throw e // Never swallow cancellation
         } catch (e: Exception) {
             Logger.e(e) { "Stream collection failed" }
-            endStream(StreamEndReason.StreamError(e.message ?: "Chat request failed", isNetwork = false))
+            // Classify rather than surfacing `e.message`: this stream is collected directly, not
+            // through safeApiCall, and Ktor builds its messages out of the request URL — a gateway
+            // redirect would put its `meta=` JWT in the error banner. The kind also drives
+            // isNetwork, which is what arms the connectivity observer that resumes the stream.
+            val safe = e.toSafeError()
+            endStream(
+                StreamEndReason.StreamError(
+                    safe.message ?: "Chat request failed",
+                    isNetwork = safe.kind == FailureKind.Network,
+                ),
+            )
         }
     }
 
@@ -417,6 +436,8 @@ class StreamingManagerDelegate(
     }
 
     private fun handleCreated(event: StreamEvent.Created) {
+        // Past this milestone the server owns the turn, so a later failure must NOT un-send it.
+        currentTurnCreated = true
         if (lastErrorWasNetwork) {
             lastErrorWasNetwork = false
             cancelConnectivityObserver()
@@ -685,6 +706,22 @@ class StreamingManagerDelegate(
                 // A typed user-provided-key error surfaces as a snackbar with a Settings CTA
                 // instead of the generic error banner (no double-surfacing).
                 val keyError = parseUserKeyError(reason.message)
+                // The turn died before `created`, so the server persisted nothing — not even the
+                // user message. Un-send it and hand the text back to the composer, exactly as an
+                // early abort does, rather than stranding it: the optimistic bubble is invisible on
+                // a new chat anyway (screenState stays LANDING until `created`) and on an existing
+                // conversation the reload below rebuilds the path without it. Either way the user's
+                // typed text simply disappeared, with nothing to retry from. Null id means the turn
+                // re-submitted a persisted message (regenerate / continue / edit-AI) — never remove
+                // those.
+                val unsentId = currentTurnOptimisticUserMessageId?.takeUnless { currentTurnCreated }
+                if (unsentId != null) {
+                    val unsentText = handle.state.messages
+                        .firstOrNull { it.messageId == unsentId }
+                        ?.text
+                    treeDelegate.unsendOptimisticTurn(unsentId)
+                    unsentText?.takeIf { it.isNotBlank() }?.let(restoreUnsentInput)
+                }
                 // Preserve partial content so users can read/copy what was received.
                 val partialContent = streamingBuffer.toString()
                 handle.update {

--- a/feature/settings/CLAUDE.md
+++ b/feature/settings/CLAUDE.md
@@ -57,6 +57,28 @@
 - `ApiKeyCreateDialog` is two-phase: name input → show created key value with copy button
 - **Gotcha**: The key value is only available in the creation response — it cannot be retrieved again from the server. The dialog must show it immediately after creation.
 
+### Server connection (gateway headers, issue #287)
+- `ServerHeadersDialog` + `ServerHeadersViewModel` — edits the **active** server's static request
+  headers (Cloudflare Access service tokens and equivalents). Reached from **Settings → Account →
+  Server connection**, grouped with the other credentials rather than with data/diagnostics.
+- The dialog is **stateless** (the screen owns the ViewModel and passes state + callbacks down) —
+  forwarding the ViewModel into it trips detekt-compose's `ViewModelForwarding`.
+- Two things the dialog does NOT own: it closes on `saved` turning true, driven from the screen, so a
+  save the store could not persist keeps it open with the typed rows intact; and dismissing with
+  `isDirty` prompts before discarding, then calls `discardEdits()` — the ViewModel outlives the
+  dialog, so an abandoned edit would otherwise still be there on the next open.
+- **Gotcha**: `AlertDialog` clips its content rather than scrolling it, so the dialog body wraps the
+  editor in its own `verticalScroll` — otherwise a few rows plus the keyboard put the fields out of
+  reach.
+- The same headers are editable pre-login on `ServerUrlScreen`; both render `CustomHeadersEditor` from
+  `:core:ui` so the two can't drift.
+- **Why it exists post-login at all**: a gateway credential can be rotated or revoked mid-session, and
+  the pre-login editor is only reachable by signing out — not a step anyone would guess from the
+  resulting "could not reach the server."
+- Save is explicit and does **not** re-probe: `ServerHeadersDataStore` is Flow-backed, so the next
+  ordinary request picks the values up, and in-flight requests keep the headers they were snapshotted
+  with (immutable by design).
+
 ### Dialogs
 - `LanguageSelectorDialog` — 37+ locales with search, single-select radio
 - `ForkSettingsDialog` — 3 fork modes (`DIRECT_PATH`, `INCLUDE_BRANCHES`, `TARGET_LEVEL`); labels/descriptions come from `fork_mode_*` string resources via `forkModeLabel()` / `forkModeDescription()`, not from the enum

--- a/feature/settings/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/settings/di/SettingsModuleVerificationTest.kt
+++ b/feature/settings/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/settings/di/SettingsModuleVerificationTest.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import android.content.Context
 import com.garfiec.librechat.core.common.AppInfo
 import com.garfiec.librechat.core.data.datastore.ServerDataStore
+import com.garfiec.librechat.core.data.datastore.ServerHeadersDataStore
 import com.garfiec.librechat.core.data.datastore.SettingsDataStore
 import com.garfiec.librechat.core.data.datastore.ThemeDataStore
 import com.garfiec.librechat.core.data.repository.ApiKeyRepository
@@ -54,6 +55,7 @@ class SettingsModuleVerificationTest {
                 PresetRepository::class,
                 ThemeDataStore::class,
                 ServerDataStore::class,
+                ServerHeadersDataStore::class,
                 SettingsDataStore::class,
                 ContentReader::class,
                 PlatformCacheCleaner::class,

--- a/feature/settings/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/settings/viewmodel/ServerHeadersViewModelTest.kt
+++ b/feature/settings/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/settings/viewmodel/ServerHeadersViewModelTest.kt
@@ -1,0 +1,353 @@
+package com.garfiec.librechat.feature.settings.viewmodel
+
+import com.garfiec.librechat.core.data.datastore.ServerDataStore
+import com.garfiec.librechat.core.data.datastore.ServerHeadersDataStore
+import com.garfiec.librechat.core.network.client.HeaderRejection
+import com.garfiec.librechat.core.ui.components.CustomHeaderRow
+import com.google.common.truth.Truth.assertThat
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Post-login gateway-header editing (issue #287). The contract that matters here is that this edits
+ * the ACTIVE server and nothing else: it is reached while signed in, so a write keyed on the wrong
+ * URL would file the credential under a server the app never contacts while leaving the live one
+ * broken.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class ServerHeadersViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    private val serverDataStore = mockk<ServerDataStore>(relaxed = true)
+    private val serverHeadersDataStore = mockk<ServerHeadersDataStore>(relaxed = true)
+
+    private val liveUrl = "https://gateway.example.com"
+    private val otherUrl = "https://other.example.com"
+
+    /** Drives the observed server URL, so a test can switch servers under a composed screen. */
+    private val currentUrl = MutableStateFlow(liveUrl)
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        every { serverDataStore.currentUrlFlow } returns currentUrl
+        coEvery { serverDataStore.awaitBaseUrl() } returns liveUrl
+        coEvery { serverHeadersDataStore.setHeaders(any(), any()) } returns true
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun createViewModel() = ServerHeadersViewModel(
+        serverDataStore = serverDataStore,
+        serverHeadersDataStore = serverHeadersDataStore,
+    )
+
+    @Test
+    fun `loads the active server's saved headers`() = runTest(testDispatcher) {
+        coEvery { serverHeadersDataStore.headersForServer(liveUrl) } returns
+            mapOf("CF-Access-Client-Id" to "id-value")
+
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        assertThat(viewModel.uiState.value.serverUrl).isEqualTo(liveUrl)
+        assertThat(viewModel.uiState.value.headers)
+            .containsExactly(CustomHeaderRow("CF-Access-Client-Id", "id-value"))
+        // Nothing edited yet, so there is nothing to save.
+        assertThat(viewModel.uiState.value.isDirty).isFalse()
+    }
+
+    @Test
+    fun `saves against the active server URL, normalizing pasted values`() = runTest(testDispatcher) {
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.addHeaderRow()
+        viewModel.onNameChanged(0, "CF-Access-Client-Secret")
+        viewModel.onValueChanged(0, "  secret-value\t")
+        assertThat(viewModel.uiState.value.isDirty).isTrue()
+
+        viewModel.save()
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) {
+            serverHeadersDataStore.setHeaders(liveUrl, mapOf("CF-Access-Client-Secret" to "secret-value"))
+        }
+        assertThat(viewModel.uiState.value.saved).isTrue()
+        assertThat(viewModel.uiState.value.isDirty).isFalse()
+    }
+
+    @Test
+    fun `a reserved name blocks the save and points at the offending row`() = runTest(testDispatcher) {
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.addHeaderRow()
+        viewModel.onNameChanged(0, "CF-Access-Client-Id")
+        viewModel.onValueChanged(0, "id-value")
+        viewModel.addHeaderRow()
+        viewModel.onNameChanged(1, "User-Agent")
+        viewModel.onValueChanged(1, "curl/8")
+
+        viewModel.save()
+        advanceUntilIdle()
+
+        assertThat(viewModel.uiState.value.error)
+            .isEqualTo(ServerHeaderError(index = 1, reason = HeaderRejection.ReservedName))
+        coVerify(exactly = 0) { serverHeadersDataStore.setHeaders(any(), any()) }
+    }
+
+    @Test
+    fun `a non-ASCII value blocks the save`() = runTest(testDispatcher) {
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.addHeaderRow()
+        viewModel.onNameChanged(0, "CF-Access-Client-Id")
+        // A smart quote, the classic artifact of pasting a token out of a dashboard.
+        viewModel.onValueChanged(0, "id’value")
+
+        viewModel.save()
+        advanceUntilIdle()
+
+        assertThat(viewModel.uiState.value.error)
+            .isEqualTo(ServerHeaderError(index = 0, reason = HeaderRejection.InvalidValue))
+        coVerify(exactly = 0) { serverHeadersDataStore.setHeaders(any(), any()) }
+    }
+
+    @Test
+    fun `clearing every row saves an empty map rather than skipping the write`() = runTest(testDispatcher) {
+        coEvery { serverHeadersDataStore.headersForServer(liveUrl) } returns
+            mapOf("CF-Access-Client-Id" to "id-value")
+
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.removeHeaderRow(0)
+        viewModel.save()
+        advanceUntilIdle()
+
+        // Removing the last header has to reach the store — otherwise a user who deletes a stale
+        // credential keeps sending it.
+        coVerify(exactly = 1) { serverHeadersDataStore.setHeaders(liveUrl, emptyMap()) }
+    }
+
+    @Test
+    fun `editing a row clears a rejection pinned to a stale index`() = runTest(testDispatcher) {
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.addHeaderRow()
+        viewModel.onNameChanged(0, "Host")
+        viewModel.save()
+        advanceUntilIdle()
+        assertThat(viewModel.uiState.value.error).isNotNull()
+
+        viewModel.onNameChanged(0, "CF-Access-Client-Id")
+
+        assertThat(viewModel.uiState.value.error).isNull()
+    }
+
+    /** A blank editor row is the normal state after tapping Add; it must not read as an error. */
+    @Test
+    fun `a fully blank row is ignored rather than rejected`() = runTest(testDispatcher) {
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.addHeaderRow()
+        viewModel.save()
+        advanceUntilIdle()
+
+        assertThat(viewModel.uiState.value.error).isNull()
+        coVerify(exactly = 1) { serverHeadersDataStore.setHeaders(liveUrl, emptyMap()) }
+    }
+
+    /**
+     * This screen can stay composed across an account switch — a two-pane tablet layout never
+     * navigates away from it. A URL captured once would file the edited credential under the previous
+     * server's id: breaking the server being edited AND overwriting the one that was working.
+     */
+    @Test
+    fun `a server switch under a composed screen re-targets the save`() = runTest(testDispatcher) {
+        coEvery { serverHeadersDataStore.headersForServer(liveUrl) } returns
+            mapOf("CF-Access-Client-Id" to "server-a-value")
+        coEvery { serverHeadersDataStore.headersForServer(otherUrl) } returns emptyMap()
+
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        currentUrl.value = otherUrl
+        advanceUntilIdle()
+
+        assertThat(viewModel.uiState.value.serverUrl).isEqualTo(otherUrl)
+        // Server A's rows must not carry over — they belong to the server that just went away.
+        assertThat(viewModel.uiState.value.headers).isEmpty()
+
+        viewModel.addHeaderRow()
+        viewModel.onNameChanged(0, "CF-Access-Client-Id")
+        viewModel.onValueChanged(0, "server-b-value")
+        viewModel.save()
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) {
+            serverHeadersDataStore.setHeaders(otherUrl, mapOf("CF-Access-Client-Id" to "server-b-value"))
+        }
+        coVerify(exactly = 0) { serverHeadersDataStore.setHeaders(liveUrl, any()) }
+    }
+
+    /**
+     * The Save button is enabled as soon as a row is edited, which can be before ServerDataStore has
+     * warmed up. Returning silently there would drop the credential with no write, no error and no
+     * way to retry.
+     */
+    @Test
+    fun `a save before the URL resolves still lands, keeping the typed rows`() = runTest(testDispatcher) {
+        currentUrl.value = ""
+        coEvery { serverHeadersDataStore.headersForServer(any()) } returns emptyMap()
+
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+        assertThat(viewModel.uiState.value.serverUrl).isEmpty()
+
+        viewModel.addHeaderRow()
+        viewModel.onNameChanged(0, "CF-Access-Client-Id")
+        viewModel.onValueChanged(0, "id-value")
+        viewModel.save()
+        advanceUntilIdle()
+
+        // awaitBaseUrl resolves it rather than the save being dropped on the floor.
+        coVerify(exactly = 1) {
+            serverHeadersDataStore.setHeaders(liveUrl, mapOf("CF-Access-Client-Id" to "id-value"))
+        }
+        assertThat(viewModel.uiState.value.saved).isTrue()
+    }
+
+    /** The first URL resolution must not wipe rows typed while it was still pending. */
+    @Test
+    fun `the first URL resolution keeps rows typed before it landed`() = runTest(testDispatcher) {
+        currentUrl.value = ""
+        coEvery { serverHeadersDataStore.headersForServer(liveUrl) } returns
+            mapOf("CF-Access-Client-Id" to "stale-value")
+
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.addHeaderRow()
+        viewModel.onNameChanged(0, "CF-Access-Client-Secret")
+        viewModel.onValueChanged(0, "rotated-secret")
+
+        currentUrl.value = liveUrl
+        advanceUntilIdle()
+
+        assertThat(viewModel.uiState.value.serverUrl).isEqualTo(liveUrl)
+        assertThat(viewModel.uiState.value.headers)
+            .containsExactly(CustomHeaderRow("CF-Access-Client-Secret", "rotated-secret"))
+    }
+
+    /**
+     * setHeaders no-ops when the URL yields no server id. Confirming "saved" over that is a lie the
+     * user cannot see through: the token is gone, the button greys out, and every request keeps
+     * failing at the gateway with an unrelated-looking connection error.
+     */
+    @Test
+    fun `a store that could not persist reports failure, not success`() = runTest(testDispatcher) {
+        coEvery { serverHeadersDataStore.setHeaders(any(), any()) } returns false
+
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.addHeaderRow()
+        viewModel.onNameChanged(0, "CF-Access-Client-Id")
+        viewModel.onValueChanged(0, "id-value")
+        viewModel.save()
+        advanceUntilIdle()
+
+        assertThat(viewModel.uiState.value.saved).isFalse()
+        assertThat(viewModel.uiState.value.saveFailure)
+            .isEqualTo(ServerHeadersSaveFailure.NoActiveServer)
+        // Still dirty, so the user can retry rather than being told it worked.
+        assertThat(viewModel.uiState.value.isDirty).isTrue()
+    }
+
+    /**
+     * The editor lives in a dismissible dialog but this ViewModel outlives it, so an abandoned edit
+     * has to be reverted to what is actually stored. Otherwise the next open presents a half-typed
+     * credential as if it were the active one.
+     */
+    @Test
+    fun `discarding restores the persisted headers and clears the dirty flag`() = runTest(testDispatcher) {
+        coEvery { serverHeadersDataStore.headersForServer(liveUrl) } returns
+            mapOf("CF-Access-Client-Id" to "id-value")
+
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.onValueChanged(0, "half-typed-replacement")
+        viewModel.addHeaderRow()
+        assertThat(viewModel.uiState.value.isDirty).isTrue()
+
+        viewModel.discardEdits()
+        advanceUntilIdle()
+
+        assertThat(viewModel.uiState.value.headers)
+            .containsExactly(CustomHeaderRow("CF-Access-Client-Id", "id-value"))
+        assertThat(viewModel.uiState.value.isDirty).isFalse()
+        assertThat(viewModel.uiState.value.error).isNull()
+        // Discarding is a UI-level revert — it must never write.
+        coVerify(exactly = 0) { serverHeadersDataStore.setHeaders(any(), any()) }
+    }
+
+    /** A rejection must not survive the revert and pin an error to a row that no longer exists. */
+    @Test
+    fun `discarding clears a pending row rejection`() = runTest(testDispatcher) {
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.addHeaderRow()
+        viewModel.onNameChanged(0, "Host")
+        viewModel.save()
+        advanceUntilIdle()
+        assertThat(viewModel.uiState.value.error).isNotNull()
+
+        viewModel.discardEdits()
+        advanceUntilIdle()
+
+        assertThat(viewModel.uiState.value.error).isNull()
+        assertThat(viewModel.uiState.value.headers).isEmpty()
+    }
+
+    /** One-shot events: a retained ViewModel must not re-fire the confirmation on a new composition. */
+    @Test
+    fun `the saved flag is consumable`() = runTest(testDispatcher) {
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.addHeaderRow()
+        viewModel.onNameChanged(0, "CF-Access-Client-Id")
+        viewModel.onValueChanged(0, "id-value")
+        viewModel.save()
+        advanceUntilIdle()
+        assertThat(viewModel.uiState.value.saved).isTrue()
+
+        viewModel.consumeSaved()
+
+        assertThat(viewModel.uiState.value.saved).isFalse()
+    }
+}

--- a/feature/settings/src/commonMain/composeResources/values-ar/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-ar/strings.xml
@@ -474,4 +474,15 @@
     <string name="role_skills_share">مشاركة المهارات</string>
     <string name="role_skills_share_public">مشاركة المهارات علنًا</string>
     <string name="role_skills_save">حفظ</string>
+    <!-- Post-login editor for the active server's gateway headers (issue #287) -->
+    <string name="section_server_connection">اتصال الخادم</string>
+    <string name="server_headers_scope">تُرسل إلى %1$s</string>
+    <string name="server_headers_save">حفظ الترويسات</string>
+    <string name="server_headers_saved">تم حفظ الترويسات</string>
+    <string name="server_headers_no_server">تعذّر الحفظ — لم يتم إعداد أي خادم بعد.</string>
+    <string name="server_connection_subtitle">رؤوس الطلبات لبوابات الوصول</string>
+    <string name="server_headers_discard_title">تجاهل التغييرات؟</string>
+    <string name="server_headers_discard_message">سيتم فقدان تغييرات الرؤوس غير المحفوظة.</string>
+    <string name="server_headers_discard_confirm">تجاهل</string>
+    <string name="server_headers_keep_editing">متابعة التحرير</string>
 </resources>

--- a/feature/settings/src/commonMain/composeResources/values-de/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-de/strings.xml
@@ -474,4 +474,15 @@
     <string name="role_skills_share">Skills teilen</string>
     <string name="role_skills_share_public">Skills öffentlich teilen</string>
     <string name="role_skills_save">Speichern</string>
+    <!-- Post-login editor for the active server's gateway headers (issue #287) -->
+    <string name="section_server_connection">Serververbindung</string>
+    <string name="server_headers_scope">Wird an %1$s gesendet</string>
+    <string name="server_headers_save">Header speichern</string>
+    <string name="server_headers_saved">Header gespeichert</string>
+    <string name="server_headers_no_server">Speichern nicht möglich — es ist noch kein Server konfiguriert.</string>
+    <string name="server_connection_subtitle">Anfrage-Header für Zugangs-Gateways</string>
+    <string name="server_headers_discard_title">Änderungen verwerfen?</string>
+    <string name="server_headers_discard_message">Deine nicht gespeicherten Header-Änderungen gehen verloren.</string>
+    <string name="server_headers_discard_confirm">Verwerfen</string>
+    <string name="server_headers_keep_editing">Weiter bearbeiten</string>
 </resources>

--- a/feature/settings/src/commonMain/composeResources/values-es/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-es/strings.xml
@@ -474,4 +474,15 @@
     <string name="role_skills_share">Compartir habilidades</string>
     <string name="role_skills_share_public">Compartir habilidades públicamente</string>
     <string name="role_skills_save">Guardar</string>
+    <!-- Post-login editor for the active server's gateway headers (issue #287) -->
+    <string name="section_server_connection">Conexión al servidor</string>
+    <string name="server_headers_scope">Se envían a %1$s</string>
+    <string name="server_headers_save">Guardar encabezados</string>
+    <string name="server_headers_saved">Encabezados guardados</string>
+    <string name="server_headers_no_server">No se pudo guardar: aún no hay ningún servidor configurado.</string>
+    <string name="server_connection_subtitle">Encabezados de solicitud para pasarelas de acceso</string>
+    <string name="server_headers_discard_title">¿Descartar los cambios?</string>
+    <string name="server_headers_discard_message">Se perderán los cambios de encabezados sin guardar.</string>
+    <string name="server_headers_discard_confirm">Descartar</string>
+    <string name="server_headers_keep_editing">Seguir editando</string>
 </resources>

--- a/feature/settings/src/commonMain/composeResources/values-fr/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-fr/strings.xml
@@ -474,4 +474,15 @@
     <string name="role_skills_share">Partager des compétences</string>
     <string name="role_skills_share_public">Partager des compétences publiquement</string>
     <string name="role_skills_save">Enregistrer</string>
+    <!-- Post-login editor for the active server's gateway headers (issue #287) -->
+    <string name="section_server_connection">Connexion au serveur</string>
+    <string name="server_headers_scope">Envoyés à %1$s</string>
+    <string name="server_headers_save">Enregistrer les en-têtes</string>
+    <string name="server_headers_saved">En-têtes enregistrés</string>
+    <string name="server_headers_no_server">Enregistrement impossible — aucun serveur n'est encore configuré.</string>
+    <string name="server_connection_subtitle">En-têtes de requête pour les passerelles d'accès</string>
+    <string name="server_headers_discard_title">Abandonner les modifications ?</string>
+    <string name="server_headers_discard_message">Vos modifications d'en-têtes non enregistrées seront perdues.</string>
+    <string name="server_headers_discard_confirm">Abandonner</string>
+    <string name="server_headers_keep_editing">Continuer l'édition</string>
 </resources>

--- a/feature/settings/src/commonMain/composeResources/values-ja/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-ja/strings.xml
@@ -474,4 +474,15 @@
     <string name="role_skills_share">スキルを共有</string>
     <string name="role_skills_share_public">スキルを公開で共有</string>
     <string name="role_skills_save">保存</string>
+    <!-- Post-login editor for the active server's gateway headers (issue #287) -->
+    <string name="section_server_connection">サーバー接続</string>
+    <string name="server_headers_scope">%1$s に送信されます</string>
+    <string name="server_headers_save">ヘッダーを保存</string>
+    <string name="server_headers_saved">ヘッダーを保存しました</string>
+    <string name="server_headers_no_server">保存できません。サーバーがまだ設定されていません。</string>
+    <string name="server_connection_subtitle">アクセスゲートウェイ用のリクエストヘッダー</string>
+    <string name="server_headers_discard_title">変更を破棄しますか？</string>
+    <string name="server_headers_discard_message">保存していないヘッダーの変更は失われます。</string>
+    <string name="server_headers_discard_confirm">破棄</string>
+    <string name="server_headers_keep_editing">編集を続ける</string>
 </resources>

--- a/feature/settings/src/commonMain/composeResources/values-ko/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-ko/strings.xml
@@ -474,4 +474,15 @@
     <string name="role_skills_share">스킬 공유</string>
     <string name="role_skills_share_public">스킬 공개 공유</string>
     <string name="role_skills_save">저장</string>
+    <!-- Post-login editor for the active server's gateway headers (issue #287) -->
+    <string name="section_server_connection">서버 연결</string>
+    <string name="server_headers_scope">%1$s(으)로 전송됩니다</string>
+    <string name="server_headers_save">헤더 저장</string>
+    <string name="server_headers_saved">헤더가 저장되었습니다</string>
+    <string name="server_headers_no_server">저장할 수 없습니다. 아직 서버가 설정되지 않았습니다.</string>
+    <string name="server_connection_subtitle">액세스 게이트웨이용 요청 헤더</string>
+    <string name="server_headers_discard_title">변경 사항을 취소할까요?</string>
+    <string name="server_headers_discard_message">저장하지 않은 헤더 변경 사항이 사라집니다.</string>
+    <string name="server_headers_discard_confirm">취소</string>
+    <string name="server_headers_keep_editing">계속 편집</string>
 </resources>

--- a/feature/settings/src/commonMain/composeResources/values-pt/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-pt/strings.xml
@@ -474,4 +474,15 @@
     <string name="role_skills_share">Compartilhar habilidades</string>
     <string name="role_skills_share_public">Compartilhar habilidades publicamente</string>
     <string name="role_skills_save">Salvar</string>
+    <!-- Post-login editor for the active server's gateway headers (issue #287) -->
+    <string name="section_server_connection">Conexão com o servidor</string>
+    <string name="server_headers_scope">Enviados para %1$s</string>
+    <string name="server_headers_save">Salvar cabeçalhos</string>
+    <string name="server_headers_saved">Cabeçalhos salvos</string>
+    <string name="server_headers_no_server">Não foi possível salvar — nenhum servidor configurado ainda.</string>
+    <string name="server_connection_subtitle">Cabeçalhos de requisição para gateways de acesso</string>
+    <string name="server_headers_discard_title">Descartar alterações?</string>
+    <string name="server_headers_discard_message">Suas alterações de cabeçalho não salvas serão perdidas.</string>
+    <string name="server_headers_discard_confirm">Descartar</string>
+    <string name="server_headers_keep_editing">Continuar editando</string>
 </resources>

--- a/feature/settings/src/commonMain/composeResources/values-ru/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-ru/strings.xml
@@ -474,4 +474,15 @@
     <string name="role_skills_share">Делиться навыками</string>
     <string name="role_skills_share_public">Делиться навыками публично</string>
     <string name="role_skills_save">Сохранить</string>
+    <!-- Post-login editor for the active server's gateway headers (issue #287) -->
+    <string name="section_server_connection">Подключение к серверу</string>
+    <string name="server_headers_scope">Отправляются на %1$s</string>
+    <string name="server_headers_save">Сохранить заголовки</string>
+    <string name="server_headers_saved">Заголовки сохранены</string>
+    <string name="server_headers_no_server">Не удалось сохранить — сервер ещё не настроен.</string>
+    <string name="server_connection_subtitle">Заголовки запросов для шлюзов доступа</string>
+    <string name="server_headers_discard_title">Отменить изменения?</string>
+    <string name="server_headers_discard_message">Несохранённые изменения заголовков будут потеряны.</string>
+    <string name="server_headers_discard_confirm">Отменить</string>
+    <string name="server_headers_keep_editing">Продолжить правку</string>
 </resources>

--- a/feature/settings/src/commonMain/composeResources/values-zh/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-zh/strings.xml
@@ -474,4 +474,15 @@
     <string name="role_skills_share">分享技能</string>
     <string name="role_skills_share_public">公开分享技能</string>
     <string name="role_skills_save">保存</string>
+    <!-- Post-login editor for the active server's gateway headers (issue #287) -->
+    <string name="section_server_connection">服务器连接</string>
+    <string name="server_headers_scope">发送到 %1$s</string>
+    <string name="server_headers_save">保存请求头</string>
+    <string name="server_headers_saved">请求头已保存</string>
+    <string name="server_headers_no_server">无法保存：尚未配置服务器。</string>
+    <string name="server_connection_subtitle">用于访问网关的请求标头</string>
+    <string name="server_headers_discard_title">放弃更改？</string>
+    <string name="server_headers_discard_message">未保存的标头更改将会丢失。</string>
+    <string name="server_headers_discard_confirm">放弃</string>
+    <string name="server_headers_keep_editing">继续编辑</string>
 </resources>

--- a/feature/settings/src/commonMain/composeResources/values/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values/strings.xml
@@ -512,4 +512,15 @@
     <string name="artifact_shortcuts_empty">No artifacts pinned to the home screen yet.</string>
     <string name="artifact_shortcuts_disabled_message">This artifact shortcut was removed.</string>
     <string name="cd_artifact_shortcut_delete">Delete shortcut</string>
+    <!-- Post-login editor for the active server's gateway headers (issue #287) -->
+    <string name="section_server_connection">Server connection</string>
+    <string name="server_headers_scope">Sent to %1$s</string>
+    <string name="server_headers_save">Save headers</string>
+    <string name="server_headers_saved">Headers saved</string>
+    <string name="server_headers_no_server">Couldn't save — no server is configured yet.</string>
+    <string name="server_connection_subtitle">Request headers for access gateways</string>
+    <string name="server_headers_discard_title">Discard changes?</string>
+    <string name="server_headers_discard_message">Your unsaved header changes will be lost.</string>
+    <string name="server_headers_discard_confirm">Discard</string>
+    <string name="server_headers_keep_editing">Keep editing</string>
 </resources>

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/di/SettingsModule.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/di/SettingsModule.kt
@@ -7,6 +7,7 @@ import com.garfiec.librechat.feature.settings.viewmodel.McpViewModel
 import com.garfiec.librechat.feature.settings.viewmodel.MemoriesViewModel
 import com.garfiec.librechat.feature.settings.viewmodel.PresetManagerViewModel
 import com.garfiec.librechat.feature.settings.viewmodel.RoleSkillsAdminViewModel
+import com.garfiec.librechat.feature.settings.viewmodel.ServerHeadersViewModel
 import com.garfiec.librechat.feature.settings.viewmodel.SettingsViewModel
 import com.garfiec.librechat.feature.settings.viewmodel.providerkeys.ProviderKeysViewModel
 import com.garfiec.librechat.feature.settings.viewmodel.providerkeys.SetProviderKeyViewModel
@@ -53,6 +54,7 @@ val settingsModule = module {
     viewModelOf(::PresetManagerViewModel)
     viewModelOf(::ProviderKeysViewModel)
     viewModelOf(::RoleSkillsAdminViewModel)
+    viewModelOf(::ServerHeadersViewModel)
 
     // viewModelOf has no overload that accepts ParametersHolder, so the runtime
     // endpointName parameter forces the lambda DSL despite the deprecation hint.

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/AccountSettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/AccountSettingsScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.Dns
 import androidx.compose.material.icons.filled.Key
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material3.AlertDialog
@@ -52,6 +53,7 @@ import com.garfiec.librechat.feature.settings.resources.Res
 import com.garfiec.librechat.feature.settings.screen.sections.BackupCodesDialog
 import com.garfiec.librechat.feature.settings.screen.sections.TwoFactorCodeDialog
 import com.garfiec.librechat.feature.settings.screen.sections.TwoFactorSetupDialog
+import com.garfiec.librechat.feature.settings.viewmodel.ServerHeadersViewModel
 import com.garfiec.librechat.feature.settings.viewmodel.SettingsViewModel
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
@@ -114,13 +116,18 @@ fun AccountSettingsContent(
     modifier: Modifier = Modifier,
     snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
     viewModel: SettingsViewModel = koinViewModel(),
+    // Hoisted rather than resolved inside the dialog: the save confirmation has to outlive the
+    // dialog that triggered it, since the dialog closes as soon as the save lands.
+    serverHeadersViewModel: ServerHeadersViewModel = koinViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val serverHeadersState by serverHeadersViewModel.uiState.collectAsStateWithLifecycle()
     val currentOnLogout by rememberUpdatedState(onLogout)
     val retryLabel = stringResource(Res.string.action_retry)
 
     var showDeleteDialog by remember { mutableStateOf(false) }
     var showLogoutDialog by remember { mutableStateOf(false) }
+    var showServerHeadersDialog by remember { mutableStateOf(false) }
 
     LaunchedEffect(uiState.error) {
         val error = uiState.error ?: return@LaunchedEffect
@@ -137,6 +144,27 @@ fun AccountSettingsContent(
     LaunchedEffect(uiState.isLoggedOut, uiState.isAccountDeleted) {
         if (uiState.isLoggedOut || uiState.isAccountDeleted) {
             currentOnLogout()
+        }
+    }
+
+    // Consume after showing: the ViewModel outlives the composition, so a flag that merely *changes*
+    // re-fires on the next fresh composition tree (rotation, fold/unfold, theme change).
+    val headersSavedMsg = stringResource(Res.string.server_headers_saved)
+    LaunchedEffect(serverHeadersState.saved) {
+        if (serverHeadersState.saved) {
+            // Close on a save that actually landed, not on the Save tap — a save the store could not
+            // persist keeps the dialog open with the typed rows intact so it can be retried.
+            showServerHeadersDialog = false
+            snackbarHostState.showSnackbar(message = headersSavedMsg)
+            serverHeadersViewModel.consumeSaved()
+        }
+    }
+
+    val headersNoServerMsg = stringResource(Res.string.server_headers_no_server)
+    LaunchedEffect(serverHeadersState.saveFailure) {
+        if (serverHeadersState.saveFailure != null) {
+            snackbarHostState.showSnackbar(message = headersNoServerMsg)
+            serverHeadersViewModel.consumeSaveFailure()
         }
     }
 
@@ -178,6 +206,14 @@ fun AccountSettingsContent(
             // Security section
             item(key = "security_header") {
                 SectionHeader(stringResource(Res.string.section_security))
+            }
+            item(key = "server_connection_row") {
+                AccountSettingsRow(
+                    icon = Icons.Default.Dns,
+                    title = stringResource(Res.string.section_server_connection),
+                    subtitle = stringResource(Res.string.server_connection_subtitle),
+                    onClick = { showServerHeadersDialog = true },
+                )
             }
             item(key = "security_settings") {
                 SecuritySection(
@@ -276,6 +312,23 @@ fun AccountSettingsContent(
             BackupCodesDialog(
                 backupCodes = uiState.backupCodes,
                 onDismiss = viewModel::dismissBackupCodesDialog,
+            )
+        }
+
+        if (showServerHeadersDialog) {
+            ServerHeadersDialog(
+                serverUrl = serverHeadersState.serverUrl,
+                headers = serverHeadersState.headers,
+                error = serverHeadersState.error,
+                isSaving = serverHeadersState.isSaving,
+                isDirty = serverHeadersState.isDirty,
+                onNameChange = serverHeadersViewModel::onNameChanged,
+                onValueChange = serverHeadersViewModel::onValueChanged,
+                onAdd = serverHeadersViewModel::addHeaderRow,
+                onRemove = serverHeadersViewModel::removeHeaderRow,
+                onSave = serverHeadersViewModel::save,
+                onDiscard = serverHeadersViewModel::discardEdits,
+                onDismiss = { showServerHeadersDialog = false },
             )
         }
 

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/ServerHeadersDialog.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/ServerHeadersDialog.kt
@@ -1,0 +1,157 @@
+package com.garfiec.librechat.feature.settings.screen
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import com.garfiec.librechat.core.network.client.HeaderRejection
+import com.garfiec.librechat.core.ui.components.CustomHeaderRow
+import com.garfiec.librechat.core.ui.components.CustomHeaderRowError
+import com.garfiec.librechat.core.ui.components.CustomHeadersEditor
+import com.garfiec.librechat.feature.settings.resources.Res
+import com.garfiec.librechat.feature.settings.resources.action_cancel
+import com.garfiec.librechat.feature.settings.resources.section_server_connection
+import com.garfiec.librechat.feature.settings.resources.server_headers_discard_confirm
+import com.garfiec.librechat.feature.settings.resources.server_headers_discard_message
+import com.garfiec.librechat.feature.settings.resources.server_headers_discard_title
+import com.garfiec.librechat.feature.settings.resources.server_headers_keep_editing
+import com.garfiec.librechat.feature.settings.resources.server_headers_save
+import com.garfiec.librechat.feature.settings.resources.server_headers_scope
+import com.garfiec.librechat.feature.settings.viewmodel.ServerHeaderError
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * Post-login editor for the active server's gateway headers (issue #287).
+ *
+ * The pre-login server screen owns the same headers, but reaching it requires being signed out — and a
+ * gateway credential is exactly the thing that gets rotated or revoked *mid-session*. Without this the
+ * only recovery is to log out, which is not a step anyone would guess from "could not reach the
+ * server."
+ *
+ * Saving is explicit and deliberately does **not** re-probe: a wrong value fails the next ordinary
+ * request, and a probe would only duplicate that with a second, differently-worded error. Stateless
+ * apart from the discard prompt — the caller owns the rows, the save and the dismissal, and is what
+ * closes this on a save that actually landed.
+ */
+@Composable
+fun ServerHeadersDialog(
+    serverUrl: String,
+    headers: List<CustomHeaderRow>,
+    error: ServerHeaderError?,
+    isSaving: Boolean,
+    isDirty: Boolean,
+    onNameChange: (Int, String) -> Unit,
+    onValueChange: (Int, String) -> Unit,
+    onAdd: () -> Unit,
+    onRemove: (Int) -> Unit,
+    onSave: () -> Unit,
+    onDiscard: () -> Unit,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var showDiscardConfirm by remember { mutableStateOf(false) }
+
+    // Dismissing with pending edits asks first: these values are pasted secrets, and a stray tap
+    // outside the dialog is a cheap way to lose one with no way to get it back.
+    val requestClose: () -> Unit = {
+        if (isDirty) showDiscardConfirm = true else onDismiss()
+    }
+
+    AlertDialog(
+        onDismissRequest = requestClose,
+        modifier = modifier,
+        title = { Text(stringResource(Res.string.section_server_connection)) },
+        text = {
+            // AlertDialog clips its content instead of scrolling it, so a handful of header rows
+            // plus the keyboard would put the fields out of reach with no way to get at them.
+            Column(
+                modifier = Modifier.verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                if (serverUrl.isNotBlank()) {
+                    Text(
+                        text = stringResource(Res.string.server_headers_scope, serverUrl),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                CustomHeadersEditor(
+                    headers = headers,
+                    onNameChange = onNameChange,
+                    onValueChange = onValueChange,
+                    onAdd = onAdd,
+                    onRemove = onRemove,
+                    errorIndex = error?.index,
+                    errorReason = error?.reason?.toRowError(),
+                    enabled = !isSaving,
+                    // The dialog's own title already names this.
+                    showHeading = false,
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = onSave,
+                enabled = !isSaving && isDirty,
+                modifier = Modifier.testTag("server_headers_save"),
+            ) {
+                Text(stringResource(Res.string.server_headers_save))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = requestClose, enabled = !isSaving) {
+                Text(stringResource(Res.string.action_cancel))
+            }
+        },
+    )
+
+    if (showDiscardConfirm) {
+        AlertDialog(
+            onDismissRequest = { showDiscardConfirm = false },
+            title = { Text(stringResource(Res.string.server_headers_discard_title)) },
+            text = { Text(stringResource(Res.string.server_headers_discard_message)) },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        showDiscardConfirm = false
+                        // Revert, or the abandoned edit is still sitting there on the next open:
+                        // the ViewModel behind this outlives the dialog.
+                        onDiscard()
+                        onDismiss()
+                    },
+                    modifier = Modifier.testTag("server_headers_discard"),
+                ) {
+                    Text(stringResource(Res.string.server_headers_discard_confirm))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDiscardConfirm = false }) {
+                    Text(stringResource(Res.string.server_headers_keep_editing))
+                }
+            },
+        )
+    }
+}
+
+/**
+ * `:core:ui` deliberately does not depend on `:core:network`, so the wire-level rejection is mapped to
+ * the editor's own enum here. Exhaustive `when` — a new [HeaderRejection] case breaks the build rather
+ * than silently rendering no message.
+ */
+private fun HeaderRejection.toRowError(): CustomHeaderRowError = when (this) {
+    HeaderRejection.InvalidName -> CustomHeaderRowError.InvalidName
+    HeaderRejection.InvalidValue -> CustomHeaderRowError.InvalidValue
+    HeaderRejection.ReservedName -> CustomHeaderRowError.ReservedName
+}

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/ServerHeadersViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/ServerHeadersViewModel.kt
@@ -1,0 +1,204 @@
+package com.garfiec.librechat.feature.settings.viewmodel
+
+import androidx.compose.runtime.Immutable
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.garfiec.librechat.core.data.datastore.ServerDataStore
+import com.garfiec.librechat.core.data.datastore.ServerHeadersDataStore
+import com.garfiec.librechat.core.network.client.CustomHeaderRules
+import com.garfiec.librechat.core.network.client.HeaderRejection
+import com.garfiec.librechat.core.ui.components.CustomHeaderRow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.launch
+
+/** A rejected header row: the index plus the machine-readable reason, mapped to text in the UI. */
+@Immutable
+data class ServerHeaderError(val index: Int, val reason: HeaderRejection)
+
+/** Why a save didn't happen. Row-level rejections are [ServerHeaderError]; these are screen-level. */
+enum class ServerHeadersSaveFailure {
+    /** No active server URL resolved, so there is no server id to file the headers under. */
+    NoActiveServer,
+}
+
+@Immutable
+data class ServerHeadersUiState(
+    val serverUrl: String = "",
+    val headers: List<CustomHeaderRow> = emptyList(),
+    val error: ServerHeaderError? = null,
+    val isSaving: Boolean = false,
+    val isDirty: Boolean = false,
+    /** One-shot: set on a successful save, cleared by [consumeSaved] once the confirmation is shown. */
+    val saved: Boolean = false,
+    /** One-shot: set when a save could not be persisted, cleared by [consumeSaveFailure]. */
+    val saveFailure: ServerHeadersSaveFailure? = null,
+)
+
+/**
+ * Post-login editor for the active server's gateway headers (issue #287).
+ *
+ * The pre-login screen owns the same headers, but only reaching it requires being signed out — and a
+ * gateway credential is exactly the thing that can be revoked or rotated *mid-session*. Without this
+ * the only recovery is to log out, which is not a step anyone would guess from "could not reach the
+ * server."
+ *
+ * Always edits the **active** server, and follows it: the URL is *observed*, not read once, because
+ * this screen can stay composed across an account switch (a two-pane tablet layout never navigates
+ * away from it). A stale URL would file the edited credential under the previous server's id —
+ * breaking the server being edited and overwriting the one that was working.
+ */
+class ServerHeadersViewModel(
+    private val serverDataStore: ServerDataStore,
+    private val serverHeadersDataStore: ServerHeadersDataStore,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(ServerHeadersUiState())
+    val uiState: StateFlow<ServerHeadersUiState> = _uiState.asStateFlow()
+
+    /** The URL whose stored headers are currently loaded, or null before the first resolution. */
+    private var loadedFor: String? = null
+
+    init {
+        viewModelScope.launch {
+            serverDataStore.currentUrlFlow.distinctUntilChanged().collect { url ->
+                if (url.isBlank()) return@collect
+                val saved = serverHeadersDataStore.headersForServer(url)
+                val previous = loadedFor
+                loadedFor = url
+                val state = _uiState.value
+                // Keep edits ONLY across the very first resolution (blank → the active server): the
+                // user can start typing into the section before ServerDataStore's warm-up lands, and
+                // those rows were always meant for "this server". A genuine server *change* is the
+                // opposite case — the rows belong to the server that just went away, so carrying them
+                // over is precisely the mix-up this observation exists to prevent.
+                val keepEdits = previous == null && state.isDirty
+                _uiState.value = if (keepEdits) {
+                    state.copy(serverUrl = url)
+                } else {
+                    state.copy(
+                        serverUrl = url,
+                        headers = saved.map { (name, value) -> CustomHeaderRow(name, value) },
+                        error = null,
+                        isDirty = false,
+                    )
+                }
+            }
+        }
+    }
+
+    fun addHeaderRow() {
+        _uiState.value = _uiState.value.copy(
+            headers = _uiState.value.headers + CustomHeaderRow(),
+            error = null,
+            isDirty = true,
+        )
+    }
+
+    fun removeHeaderRow(index: Int) {
+        val current = _uiState.value.headers
+        if (index !in current.indices) return
+        _uiState.value = _uiState.value.copy(
+            headers = current.filterIndexed { i, _ -> i != index },
+            error = null,
+            isDirty = true,
+        )
+    }
+
+    fun onNameChanged(index: Int, name: String) = update(index) { it.copy(name = name) }
+
+    fun onValueChanged(index: Int, value: String) = update(index) { it.copy(value = value) }
+
+    private fun update(index: Int, transform: (CustomHeaderRow) -> CustomHeaderRow) {
+        val current = _uiState.value.headers
+        if (index !in current.indices) return
+        _uiState.value = _uiState.value.copy(
+            headers = current.mapIndexed { i, row -> if (i == index) transform(row) else row },
+            // Clear on edit — a rejection pinned to a stale index points at the wrong row after an
+            // add or remove.
+            error = null,
+            isDirty = true,
+        )
+    }
+
+    /**
+     * Throws away unsaved edits and restores what is actually persisted.
+     *
+     * The editor lives in a dismissible dialog but this ViewModel outlives it, so without an explicit
+     * revert an abandoned edit would still be sitting there the next time it opens — presenting a
+     * half-typed credential as if it were the active one.
+     */
+    fun discardEdits() {
+        val url = _uiState.value.serverUrl
+        if (url.isBlank()) {
+            _uiState.value = _uiState.value.copy(headers = emptyList(), error = null, isDirty = false)
+            return
+        }
+        viewModelScope.launch {
+            val saved = serverHeadersDataStore.headersForServer(url)
+            _uiState.value = _uiState.value.copy(
+                headers = saved.map { (name, value) -> CustomHeaderRow(name, value) },
+                error = null,
+                isDirty = false,
+            )
+        }
+    }
+
+    /** Clears the one-shot success flag once the UI has shown its confirmation. */
+    fun consumeSaved() {
+        if (_uiState.value.saved) _uiState.value = _uiState.value.copy(saved = false)
+    }
+
+    /** Clears the one-shot failure flag once the UI has shown it. */
+    fun consumeSaveFailure() {
+        if (_uiState.value.saveFailure != null) _uiState.value = _uiState.value.copy(saveFailure = null)
+    }
+
+    /**
+     * Validate and persist. Nothing here retries or re-probes the server: the store is Flow-backed, so
+     * the next request picks the new values up on its own, and in-flight requests keep the headers
+     * they were snapshotted with (immutable by design).
+     */
+    fun save() {
+        val rows = _uiState.value.headers
+        firstInvalid(rows)?.let { rejection ->
+            _uiState.value = _uiState.value.copy(error = rejection)
+            return
+        }
+
+        viewModelScope.launch {
+            _uiState.value = _uiState.value.copy(isSaving = true, error = null)
+            // Re-resolve rather than giving up on a blank URL: the Save button is enabled as soon as
+            // a row is edited, which can be before ServerDataStore has warmed up. Returning silently
+            // there drops the credential with no write, no error and no way to retry.
+            val url = _uiState.value.serverUrl.ifBlank { serverDataStore.awaitBaseUrl() }
+            // Honour the store's own verdict: setHeaders no-ops when the URL yields no server id, and
+            // confirming "saved" over that is a lie the user cannot see through.
+            val persisted = url.isNotBlank() && serverHeadersDataStore.setHeaders(url, rows.toHeaderMap())
+            _uiState.value = _uiState.value.copy(
+                isSaving = false,
+                serverUrl = if (url.isNotBlank()) url else _uiState.value.serverUrl,
+                isDirty = !persisted,
+                saved = persisted,
+                saveFailure = if (persisted) null else ServerHeadersSaveFailure.NoActiveServer,
+            )
+        }
+    }
+
+    /** The first row that can't be sent, or null. Fully blank rows are skipped, not rejected. */
+    private fun firstInvalid(rows: List<CustomHeaderRow>): ServerHeaderError? =
+        rows.withIndex().firstNotNullOfOrNull { (index, row) ->
+            if (row.name.isBlank() && row.value.isBlank()) {
+                null
+            } else {
+                CustomHeaderRules.validate(row.name, row.value)?.let { ServerHeaderError(index, it) }
+            }
+        }
+
+    /** Drops blank rows and normalizes what's left. Later rows win on a duplicate name. */
+    private fun List<CustomHeaderRow>.toHeaderMap(): Map<String, String> =
+        filterNot { it.name.isBlank() && it.value.isBlank() }
+            .associate { it.name.trim() to CustomHeaderRules.normalizeValue(it.value) }
+}


### PR DESCRIPTION
## Summary

LibreChat deployments behind an access gateway (Cloudflare Access, Authelia, Authentik,
oauth2-proxy) are unreachable from the app: the gateway answers instead of the server, and every
request fails. This adds optional user-configured static request headers, stored per server, so a
gateway that authenticates on headers can be satisfied.

A Cloudflare Access rejection is additionally recognised as its own failure and given actionable
wording, since it arrives as a `200 text/html` sign-in page rather than an error status and would
otherwise read as a generic transport problem.

## Changes

**Header storage and injection** (`core/data`, `core/network`)

- Headers are stored per server under a `srv:<serverId>:custom_headers` preference key and survive
  logout — they are required in order to log back in. They are held as plaintext JSON in the shared
  preference store rather than the encrypted token store: losing this value means a server the user
  can no longer reach at all rather than a re-login prompt, and `allowBackup=false` closes the
  realistic Android exfiltration path.
- Injected on all three HTTP clients (main, streaming, refresh) and the iOS SSE transport. Without
  the refresh client the session would die at its first token refresh.
- On the main and streaming clients, injection reads the per-request identity snapshot, so a header
  edit cannot retroactively alter an in-flight request. The refresh client has no switch barrier and
  reads the store at request-build time.
- Headers are host-scoped: on the Ktor clients an authority other than the configured server gets
  none. The iOS SSE transport dials the snapshot's base URL and never follows redirects, so its
  scoping is structural rather than a check.
- Custom `Cookie` values are merged with the app's own refresh cookie into a single header rather
  than emitted twice. On a name collision the app's own segment wins and the user's is dropped.

**Scoping and validation**

- Custom headers are stripped when a redirect leaves the server's authority, and re-attached if the
  chain returns to it. Ktor's redirect handling forwards every header except `Authorization`, and
  `FilesApi.downloadFromUrl` fetches server-supplied absolute URLs, so an off-domain hop would
  otherwise carry the gateway secret. Scheme, host and port are all compared, so a same-host
  `https → http` downgrade is caught too; an unrecognised base URL fails closed.
- Header names are RFC 7230 tokens. Values allow printable US-ASCII plus tab — spaces included,
  empty permitted — and are trimmed at the edges.
- Thirteen names the transport or app owns are reserved, including `authorization`, `user-agent`,
  `host`, `accept`, `content-type`, `content-length`, `transfer-encoding` and
  `proxy-authorization`. `Cookie` is deliberately *not* reserved, since most self-hosted gateways
  authenticate on one.

**Error reporting** (`core/common`, `feature/chat`)

- `safeApiCall` no longer puts an exception's own message in front of the user. Failures are
  classified into broad kinds — network, timeout, malformed response, access gateway, server,
  unknown — and rendered with wording written for a person; the exception and its cause chain go to
  the log. `Result.Error` gains a `kind` field and `ApiException` a `serverAuthored` flag.
- Server-authored text is still shown when it reads like a message, so responses such as "Invalid
  credentials" are preserved.
- The chat stream is collected directly rather than through `safeApiCall`, and now calls the same
  classifier explicitly. Its failure kind also supplies the network flag on that path, which was
  hardcoded false — so a send that fails before the stream opens (sending while offline, say) arms
  the connectivity observer that resumes an existing conversation. Failures *during* an open stream
  are untouched: the SSE client reports those in-band and already sets the flag on its I/O-failure
  path.
- A send that fails before the server acknowledges it now removes the optimistic user message and
  returns the typed text to the composer, instead of leaving it looking sent. Applies to any
  pre-acknowledgement failure, not only gateway ones.
- Cloudflare Access detection keys off `WWW-Authenticate: Cloudflare-Access`, in an `HttpSend`
  interceptor on the main client. A response validator cannot do this: following the redirect yields
  a valid `200`. No response body is read, so streaming is unaffected. Gateways that do not set that
  header still fall back to the generic malformed-response wording.
- `:core:common` takes a new dependency on Kermit so the discarded detail can be logged.

**UI** (`core/ui`, `feature/auth`, `feature/settings`)

- An "Advanced" section on the server URL screen configures headers before signing in. They are
  persisted on Connect, keyed to the normalized URL, and only when a row was actually edited. In
  add-account mode the active server's headers are deliberately not prefilled, so the live server
  cannot be edited by mistake.
- Settings → Account → Server connection (under Security) opens the same editor after login, with a
  discard-confirmation when leaving unsaved edits. A save that cannot resolve a server keeps the
  dialog open with the rows intact.
- Values are masked by default with a per-row reveal toggle.
- The editor lays out from the width it is given: stacked when narrow, side by side when there is
  room, so both callers get the right layout with no per-surface plumbing.
- Leaving add-account mode no longer requires killing the app: a latched validation flag is now
  consumed after navigation.
- All new strings are added in the 10 locales the affected modules already carry.

## Testing / verification

- Unit tests for header validation, host scoping, cookie merging, Cloudflare Access detection, the
  redirect strip, failure classification, the un-send behaviour and both view models.
- A contract test pins the Ktor redirect behaviour the strip depends on.
- `./gradlew test detekt detektMetadataCommonMain :app:assembleDebug` passes.
- Verified on device against a live Cloudflare Access deployment: config load, login, conversation
  list, SSE streaming, image loading and token refresh all succeed with headers configured, and an
  unprotected server is unaffected with none configured.
- With a deliberately wrong gateway credential the chat surface reports the actionable gateway
  message and no exception text, the unsent message is removed, and the typed text returns to the
  composer. Sending while offline arms the connectivity observer, which resumes the conversation
  when the network returns.
- The side-by-side header layout has no automated coverage and was not reached on device: a phone
  dialog stays below the width threshold in both orientations, so it needs a tablet.

## Notes

- Only Cloudflare Access is detected as a distinct failure. Other gateways are reachable via headers
  but their rejections still surface as a generic malformed response.
- OAuth/social login cannot work behind a header-authenticated gateway: the provider flow opens in a
  system browser that cannot carry the headers.
- `Authorization` stays reserved, as it carries the LibreChat session, so HTTP Basic gateways are not
  supported.
- iOS mirrors the shared changes but was not built or run.
