### PR TITLE
test(data): de-flake the lastUsed warming round-trip

### DIFF
--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/datastore/DataStoreRoundTripTest.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/datastore/DataStoreRoundTripTest.kt
@@ -207,15 +207,19 @@ class DataStoreRoundTripTest {
         val job = launch { store.lastUsedModel.collect { emissions.add(it) } }
         advanceUntilIdle()
         // While the account is Warming the flow is suppressed (no null emission that a seeder would
-        // mistake for "no last-used saved").
+        // mistake for "no last-used saved"). Asserting an ABSENCE legitimately needs a snapshot, so
+        // the collector stays for this half.
         assertThat(emissions).isEmpty()
+        job.cancel()
 
         provider.set(AccountId("srv:acctX"))
         store.setLastUsedModel("openAI", "gpt-4o")
-        advanceUntilIdle()
-        assertThat(emissions.last()).isEqualTo("gpt-4o")
 
-        job.cancel()
+        // Await with first(), NOT a collector plus advanceUntilIdle(): this DataStore takes no
+        // `scope`, so it reads the file on Dispatchers.IO — real threads on the real clock — while
+        // advanceUntilIdle() only drains the virtual scheduler. Snapshotting a collector after it
+        // races real disk I/O and flakes as "List is empty" under load.
+        assertThat(store.lastUsedModel.first()).isEqualTo("gpt-4o")
     }
 
     // --- SettingsDataStore: model usage ranking (home-screen shortcuts) ---


### PR DESCRIPTION
## Summary

`DataStoreRoundTripTest.settingsDataStore_lastUsed_suppressedWhileWarming_thenEmitsOnResolve` fails
intermittently — first seen on CI, and on a loaded machine roughly three runs in five locally.

## Cause

The store is built with no `scope` argument, so DataStore defaults to `Dispatchers.IO`: the file read
runs on real threads on the real clock, while `advanceUntilIdle()` drains only the virtual scheduler.
Snapshotting the collected list after it was a race against actual disk I/O — which is why the
failure is always "List is empty" (no value yet) and never a wrong value.

41 of the 42 assertions in this file await via `first()`, which suspends until the emission arrives.
The one that uses a collector plus `advanceUntilIdle()` is the one that flakes.

## Changes

- The resolve half awaits the emission with `first()`, matching the rest of the file.
- The warming half keeps its collector: asserting an *absence* legitimately needs a snapshot, and was
  never the flaky part.

No product code changes.

## Verification

Validated the way the flake actually reproduces: 6/6 full-suite `:core:data` runs. Isolated
`--tests` reruns passed 8/8 even before this change, which is why the flake survived so long — the
obvious check always looks green.
