### PR TITLE
fix(chat): accept 4+ backtick fences in artifact detection

### DIFF
--- a/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/components/artifact/ArtifactDetectorTest.kt
+++ b/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/components/artifact/ArtifactDetectorTest.kt
@@ -114,6 +114,73 @@ Global temperatures are rising.
     }
 
     @Test
+    fun `detects artifact fenced with 4 backticks`() {
+        // LibreChat's server-side artifact prompt defaults to a 4-backtick fence
+        // (bumping to 5+ only if the content itself contains a 4-backtick run), so a
+        // 3-backtick-only regex misses every artifact real backends actually emit.
+        val text = """
+:::artifact{identifier="report" type="text/markdown" title="Report"}
+````markdown
+# Report
+
+## Section
+Body text.
+````
+:::
+        """.trimIndent()
+
+        val segments = detectArtifacts(text)
+        assertEquals(1, segments.size)
+        val ref = segments[0] as ArtifactSegment.ArtifactReference
+        assertEquals("report", ref.artifact.identifier)
+        assertEquals("text/markdown", ref.artifact.type)
+        assertEquals("markdown", ref.artifact.language)
+        assertTrue(ref.artifact.content.contains("# Report"))
+    }
+
+    @Test
+    fun `4-backtick fence correctly wraps content containing a 3-backtick code block`() {
+        // This is the actual scenario the artifact instructions bump the fence length for:
+        // a markdown/document artifact whose own content demonstrates a fenced code block.
+        val text = """
+:::artifact{identifier="guide" type="text/markdown" title="Guide"}
+````markdown
+# Guide
+
+Run this:
+
+```bash
+echo hello
+```
+````
+:::
+        """.trimIndent()
+
+        val segments = detectArtifacts(text)
+        assertEquals(1, segments.size)
+        val ref = segments[0] as ArtifactSegment.ArtifactReference
+        assertEquals("guide", ref.artifact.identifier)
+        assertTrue(ref.artifact.content.contains("```bash"))
+        assertTrue(ref.artifact.content.contains("echo hello"))
+    }
+
+    @Test
+    fun `mismatched fence lengths do not match as an artifact`() {
+        // A 4-backtick opening fence must be closed with 4 backticks, not 3 — otherwise
+        // the embedded 3-backtick block from the previous test would close the artifact early.
+        val text = """
+:::artifact{identifier="bad" type="text/markdown" title="Bad"}
+````markdown
+content
+```
+:::
+        """.trimIndent()
+
+        val segments = detectArtifacts(text)
+        assertTrue(segments.none { it is ArtifactSegment.ArtifactReference })
+    }
+
+    @Test
     fun `detects plain text artifact`() {
         val text = """
 :::artifact{identifier="notes" type="text/plain" title="Notes"}

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/ArtifactDetector.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/ArtifactDetector.kt
@@ -3,17 +3,18 @@ package com.garfiec.librechat.feature.chat.components.artifact
 /**
  * Matches the remark-directive artifact format:
  *   :::artifact{key="value" ...}
- *   ```optionalLanguage
- *   content
- *   ```
+ *   ```optionalLanguage          (3 or more backticks; LibreChat's own server prompt
+ *   content                       defaults to 4, bumping to 5+ if content itself
+ *   ```                           contains a 4-backtick run)
  *   :::
  *
  * Group 1: attribute string inside braces
- * Group 2: optional language hint after opening backticks
- * Group 3: content between the fences
+ * Group 2: the opening fence (captured so the closing fence must match the same length)
+ * Group 3: optional language hint after opening backticks
+ * Group 4: content between the fences
  */
 private val ARTIFACT_REGEX = Regex(
-    """:::artifact\{([^}]*)\}\s*```(\w*)\n([\s\S]*?)```\s*:::""",
+    """:::artifact\{([^}]*)\}\s*(`{3,})(\w*)\n([\s\S]*?)\2\s*:::""",
 )
 
 /**
@@ -40,8 +41,8 @@ fun detectArtifacts(text: String): List<ArtifactSegment> {
         }
 
         val attrString = match.groupValues[1]
-        val languageHint = match.groupValues[2].ifEmpty { null }
-        val content = match.groupValues[3].trimEnd()
+        val languageHint = match.groupValues[3].ifEmpty { null }
+        val content = match.groupValues[4].trimEnd()
         val attrs = mutableMapOf<String, String>()
         ATTR_REGEX.findAll(attrString).forEach { attrMatch ->
             attrs[attrMatch.groupValues[1]] = attrMatch.groupValues[2]


### PR DESCRIPTION
## Summary
- `ArtifactDetector`'s `ARTIFACT_REGEX` only matched artifacts fenced with exactly 3 backticks.
- LibreChat's own server-side artifact prompt (`api/app/clients/prompts/artifacts.js`) defaults to a **4-backtick** fence, bumping to 5+ when the artifact content itself contains a 4-backtick run — this is documented, standard behavior from any real LibreChat backend, not model- or config-specific.
- Any artifact whose content includes an embedded fenced code block (e.g. a markdown document with a shell/code example) triggers the 4-backtick fence and silently failed to parse: the directive fell through to plain-text rendering, showing the raw `:::artifact{...}` line literally above a markdown-rendered code block instead of a proper artifact card.

Found this while testing the app against a real self-hosted LibreChat server whose model reliably produced 4-backtick-fenced markdown artifacts.

## Fix
Match 3+ backticks and require the closing fence to be the same length as the opening one via a backreference (`` (`{3,})...\2 ``), which is the actual contract the server-side prompt describes — not a loosened match, since mismatched fence lengths correctly fail to parse (see the new `mismatched fence lengths do not match as an artifact` test).

## Test plan
- [x] Added 3 new test cases to `ArtifactDetectorTest`: a 4-backtick fence, a 4-backtick fence wrapping content that itself contains a 3-backtick code block (the actual scenario that forces the longer fence), and a mismatched-fence-length negative case.
- [x] `./gradlew :feature:chat:testDebugUnitTest --tests "...ArtifactDetectorTest"` — all 21 tests pass (18 existing + 3 new), no regressions.
- [x] `./gradlew detekt` — clean.
- [x] Manually verified on a physical iOS device against a real self-hosted LibreChat server: a markdown artifact with an embedded code block that previously rendered as literal `:::artifact{...}` text + a bare code block now renders correctly as an artifact card.