### PR TITLE
fix(chat): surface offline message-load failures instead of a blank thread

### DIFF
--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatContent.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatContent.kt
@@ -14,6 +14,7 @@ import com.garfiec.librechat.core.common.EndpointConstants
 import com.garfiec.librechat.core.ui.components.LoadingIndicator
 import com.garfiec.librechat.feature.chat.components.LandingContent
 import com.garfiec.librechat.feature.chat.components.MessageList
+import com.garfiec.librechat.feature.chat.components.MessagesUnavailable
 import com.garfiec.librechat.feature.chat.util.MessageNode
 import com.garfiec.librechat.feature.chat.util.collapseParallelToPrimary
 import com.garfiec.librechat.feature.chat.viewmodel.ActiveToolCall
@@ -85,7 +86,17 @@ internal fun ColumnScope.ChatContent(
                     model ?: "Assistant"
                 }
             }
-            if (comparisonState.isEnabled) {
+            // Ahead of the comparison branch, matching iOS: with nothing to show, empty comparison
+            // panes are less use than the failure state. !isStreaming is load-bearing — a
+            // handed-off new chat is legitimately empty until the first message lands.
+            if (uiState.messagesLoadFailed && uiState.displayMessages.isEmpty() &&
+                !uiState.isStreaming
+            ) {
+                MessagesUnavailable(
+                    onRetry = viewModel::refreshMessages,
+                    modifier = topInsetModifier,
+                )
+            } else if (comparisonState.isEnabled) {
                 ComparisonPanes(
                     uiState = uiState,
                     viewModel = viewModel,

--- a/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModelMessageLoadFailureTest.kt
+++ b/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModelMessageLoadFailureTest.kt
@@ -1,0 +1,228 @@
+package com.garfiec.librechat.feature.chat.viewmodel
+
+import com.garfiec.librechat.core.common.identity.AccountId
+import com.garfiec.librechat.core.common.identity.AccountState
+import com.garfiec.librechat.core.common.identity.InMemoryActiveAccountProvider
+import com.garfiec.librechat.core.common.result.Result
+import com.garfiec.librechat.core.data.datastore.ChatFontSize
+import com.garfiec.librechat.core.data.datastore.ChatHeaderAlignment
+import com.garfiec.librechat.core.data.datastore.ChatHeaderContent
+import com.garfiec.librechat.core.data.datastore.ContextBarPlacement
+import com.garfiec.librechat.core.data.datastore.StarredModelsDisplay
+import com.garfiec.librechat.core.data.repository.AgentRepository
+import com.garfiec.librechat.core.data.repository.ChatRepository
+import com.garfiec.librechat.core.data.repository.ConfigRepository
+import com.garfiec.librechat.core.data.repository.ConversationRepository
+import com.garfiec.librechat.core.data.repository.DraftRepository
+import com.garfiec.librechat.core.data.repository.EndpointTokenRepository
+import com.garfiec.librechat.core.data.repository.FavoritesRepository
+import com.garfiec.librechat.core.data.repository.FileRepository
+import com.garfiec.librechat.core.data.repository.KeyRepository
+import com.garfiec.librechat.core.data.repository.McpRepository
+import com.garfiec.librechat.core.data.repository.MessageRepository
+import com.garfiec.librechat.core.data.repository.PresetRepository
+import com.garfiec.librechat.core.data.repository.PromptRepository
+import com.garfiec.librechat.core.data.repository.RoleRepository
+import com.garfiec.librechat.core.data.repository.ShareRepository
+import com.garfiec.librechat.core.data.repository.UserRepository
+import com.garfiec.librechat.core.data.util.PermissionGate
+import com.garfiec.librechat.core.model.Message
+import com.garfiec.librechat.feature.chat.viewmodel.delegate.PlatformDelegateFactory
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlinx.serialization.json.Json
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Regression guard: a conversation not in the Room cache, opened offline, must surface an error and
+ * a retryable empty state rather than a blank message area.
+ *
+ * Asserts at the ViewModel level against a repository that fails the way the real one does — by
+ * RETURNING `Result.Error`, since `getMessages` is `safeApiCall`-wrapped and lets only
+ * `CancellationException` propagate. A throwing fake, or a delegate-level test, passes against the
+ * broken shape and proves nothing.
+ *
+ * Assertions target [ChatUiState.messagesLoadFailed] rather than `error`: `error` is a channel every
+ * loader shares, so a later init-time write can overwrite this one and make the assertion about mock
+ * ordering instead of behavior.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class ChatViewModelMessageLoadFailureTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    private val agentRepository = mockk<AgentRepository>(relaxed = true)
+    private val chatRepository = mockk<ChatRepository>(relaxed = true)
+    private val messageRepository = mockk<MessageRepository>(relaxed = true)
+    private val fileRepository = mockk<FileRepository>(relaxed = true)
+    private val configRepository = mockk<ConfigRepository>(relaxed = true)
+    private val conversationRepository = mockk<ConversationRepository>(relaxed = true)
+    private val endpointTokenRepository = mockk<EndpointTokenRepository>(relaxed = true)
+    private val draftRepository = mockk<DraftRepository>(relaxed = true)
+    private val favoritesRepository = mockk<FavoritesRepository>(relaxed = true)
+    private val keyRepository = mockk<KeyRepository>(relaxed = true)
+    private val presetRepository = mockk<PresetRepository>(relaxed = true)
+    private val promptRepository = mockk<PromptRepository>(relaxed = true)
+    private val shareRepository = mockk<ShareRepository>(relaxed = true)
+    private val mcpRepository = mockk<McpRepository>(relaxed = true)
+    private val userRepository = mockk<UserRepository>(relaxed = true)
+    private val roleRepository = mockk<RoleRepository>(relaxed = true)
+    private val permissionGate = mockk<PermissionGate>(relaxed = true)
+    private val connectivityObserver =
+        mockk<com.garfiec.librechat.core.common.network.ConnectivityObserver>(relaxed = true)
+    private val serverDataStore =
+        mockk<com.garfiec.librechat.core.data.datastore.ServerDataStore>(relaxed = true)
+    private val settingsDataStore =
+        mockk<com.garfiec.librechat.core.data.datastore.SettingsDataStore>(relaxed = true)
+    private val platformDelegateFactory = mockk<PlatformDelegateFactory>(relaxed = true)
+    private val serverFileSelectionHandoff = mockk<ServerFileSelectionHandoff>(relaxed = true)
+
+    private val selectionHandoff = NewChatSelectionHandoff()
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+
+        every { configRepository.startupConfig } returns MutableStateFlow(null)
+        every { configRepository.detectedBackendVersion } returns MutableStateFlow("0.8.7")
+        every { roleRepository.userPermissions } returns MutableStateFlow(null)
+        every { configRepository.endpointConfigs } returns MutableStateFlow(emptyMap())
+        every { configRepository.availableModels } returns MutableStateFlow(emptyMap())
+        every { favoritesRepository.favorites } returns MutableStateFlow(emptyList())
+        every { settingsDataStore.selectedMcpServers } returns flowOf(emptySet())
+        every { settingsDataStore.enabledTools } returns flowOf(emptySet())
+        every { serverFileSelectionHandoff.selectionsFor(any()) } returns emptyFlow()
+        every { keyRepository.keyInvalidations } returns MutableSharedFlow()
+        every { platformDelegateFactory.createShareConsumer().shareAvailable } returns MutableSharedFlow()
+
+        // `uiState` is combine(_uiState, these pref flows).stateIn(Eagerly, ChatUiState()): until
+        // EVERY one of them emits, `uiState.value` is the untouched initial state no matter what
+        // the ViewModel did. Relaxed mocks never emit — these stubs are load-bearing.
+        every { serverDataStore.currentUrlFlow } returns MutableStateFlow("https://example.test")
+        every { settingsDataStore.chatFontSize } returns MutableStateFlow(ChatFontSize.MEDIUM)
+        every { settingsDataStore.starredModelsDisplay } returns MutableStateFlow(StarredModelsDisplay.OFF)
+        every { settingsDataStore.chatHeaderContent } returns MutableStateFlow(ChatHeaderContent.MODEL)
+        every { settingsDataStore.chatHeaderAlignment } returns MutableStateFlow(ChatHeaderAlignment.CENTER)
+        every { settingsDataStore.contextBarPlacement } returns MutableStateFlow(ContextBarPlacement.HIDDEN)
+        every { settingsDataStore.contextGaugeExpanded } returns MutableStateFlow(false)
+
+        // The offline case: nothing cached, so the Room read-through emits an empty list.
+        every { messageRepository.observeMessages(any()) } returns flowOf(emptyList())
+        coEvery { conversationRepository.getConversation(any(), any()) } returns Result.Error(message = "test")
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun failedMessageLoadWithEmptyCacheSurfacesErrorAndRetryableEmptyState() = runTest(testDispatcher) {
+        coEvery { messageRepository.getMessages(any()) } returns Result.Error(message = "boom")
+
+        val viewModel = newViewModel(initialConversationId = "conv-1")
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertTrue("expected the retryable empty state to be armed", state.messagesLoadFailed)
+        // Must leave LOADING, or the screen spins forever instead of showing the empty state.
+        assertEquals(ChatScreenState.ACTIVE, state.screenState)
+    }
+
+    @Test
+    fun failedMessageLoadStaysSilentWhenAHandedOffChatAlreadyHasContent() = runTest(testDispatcher) {
+        // A chat handed off from the landing page carries its just-sent user message, and the
+        // server persists the request only once the reply completes — so this fetch is expected to
+        // fail while the reply streams. Reporting it would pop an error over a working chat.
+        coEvery { messageRepository.getMessages(any()) } returns Result.Error(message = "boom")
+        selectionHandoff.put(
+            conversationId = "conv-1",
+            endpoint = "openAI",
+            model = "gpt-4",
+            optimisticUserMessage = Message(
+                messageId = "user-msg-1",
+                conversationId = "conv-1",
+                isCreatedByUser = true,
+                text = "hello",
+            ),
+        )
+
+        val viewModel = newViewModel(initialConversationId = "conv-1")
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertFalse("seeded chat must not arm the empty state", state.messagesLoadFailed)
+    }
+
+    @Test
+    fun successfulMessageLoadLeavesEmptyStateDisarmed() = runTest(testDispatcher) {
+        // The offline cache-hit path: the repository swallows the network failure and returns the
+        // cached rows as Success, so the empty state must stay down.
+        val cached = listOf(
+            Message(
+                messageId = "m-1",
+                conversationId = "conv-1",
+                isCreatedByUser = true,
+                text = "cached",
+            ),
+        )
+        coEvery { messageRepository.getMessages(any()) } returns Result.Success(cached)
+        every { messageRepository.observeMessages(any()) } returns flowOf(cached)
+
+        val viewModel = newViewModel(initialConversationId = "conv-1")
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertFalse("cache hit must not arm the empty state", state.messagesLoadFailed)
+        assertEquals(ChatScreenState.ACTIVE, state.screenState)
+    }
+
+    private fun newViewModel(initialConversationId: String?): ChatViewModel =
+        ChatViewModel(
+            initialConversationId = initialConversationId,
+            initialAgentId = null,
+            agentRepository = agentRepository,
+            chatRepository = chatRepository,
+            messageRepository = messageRepository,
+            fileRepository = fileRepository,
+            configRepository = configRepository,
+            conversationRepository = conversationRepository,
+            endpointTokenRepository = endpointTokenRepository,
+            draftRepository = draftRepository,
+            favoritesRepository = favoritesRepository,
+            keyRepository = keyRepository,
+            presetRepository = presetRepository,
+            promptRepository = promptRepository,
+            shareRepository = shareRepository,
+            mcpRepository = mcpRepository,
+            userRepository = userRepository,
+            roleRepository = roleRepository,
+            permissionGate = permissionGate,
+            connectivityObserver = connectivityObserver,
+            serverDataStore = serverDataStore,
+            settingsDataStore = settingsDataStore,
+            platformDelegateFactory = platformDelegateFactory,
+            json = Json { ignoreUnknownKeys = true },
+            defaultDispatcher = testDispatcher,
+            selectionHandoff = selectionHandoff,
+            serverFileSelectionHandoff = serverFileSelectionHandoff,
+            activeAccountProvider = InMemoryActiveAccountProvider(AccountState.Resolved(AccountId("srv:user-1"))),
+        )
+}

--- a/feature/chat/src/commonMain/composeResources/values/strings.xml
+++ b/feature/chat/src/commonMain/composeResources/values/strings.xml
@@ -239,6 +239,10 @@
     <string name="cd_open_pdf">Open PDF</string>
     <string name="retry">Retry</string>
 
+    <!-- Messages unavailable (fetch failed, nothing cached) -->
+    <string name="messages_unavailable_title">Messages unavailable</string>
+    <string name="messages_unavailable_body">This conversation couldn't be loaded and no offline copy is saved on this device.</string>
+
     <!-- Model selector sheet -->
     <string name="cd_selected">Selected</string>
     <string name="cd_public_agent">Public agent</string>

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/MessagesUnavailable.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/MessagesUnavailable.kt
@@ -1,0 +1,64 @@
+package com.garfiec.librechat.feature.chat.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CloudOff
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.garfiec.librechat.feature.chat.resources.*
+import com.garfiec.librechat.feature.chat.resources.Res
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * Shown in place of the message list when the fetch failed and there was no cached copy to fall
+ * back to — e.g. a conversation opened for the first time while offline.
+ */
+@Composable
+internal fun MessagesUnavailable(
+    onRetry: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.fillMaxSize().padding(32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Icon(
+            imageVector = Icons.Default.CloudOff,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.size(48.dp),
+        )
+        Spacer(Modifier.height(16.dp))
+        Text(
+            text = stringResource(Res.string.messages_unavailable_title),
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+            textAlign = TextAlign.Center,
+        )
+        Spacer(Modifier.height(8.dp))
+        Text(
+            text = stringResource(Res.string.messages_unavailable_body),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
+        )
+        Spacer(Modifier.height(16.dp))
+        TextButton(onClick = onRetry) {
+            Text(stringResource(Res.string.retry))
+        }
+    }
+}

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatUiState.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatUiState.kt
@@ -131,6 +131,7 @@ data class ChatUiState(
     val streamingAttachments: List<Attachment> get() = content.streamingAttachments
     val retryInfo: RetryInfo? get() = content.retryInfo
     val isRefreshingMessages: Boolean get() = content.isRefreshingMessages
+    val messagesLoadFailed: Boolean get() = content.messagesLoadFailed
     val contextUsage: ContextUsage? get() = content.contextUsage
     val tokenUsage: TokenUsage? get() = content.tokenUsage
     val conversationId: String? get() = conversation.conversationId

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModel.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModel.kt
@@ -612,15 +612,37 @@ class ChatViewModel(
         // re-enable comparison after the user has toggled it off for the session.
         var autoRehydrateHandled = false
         roomObserverJob = viewModelScope.launch {
-            try {
-                messageRepository.getMessages(conversationId)
-            } catch (e: Exception) {
-                Logger.e(e) { "Failed to fetch messages for $conversationId" }
-                _uiState.update {
-                    it.copy(
-                        error = "Could not load messages",
-                        content = it.content.copy(screenState = ChatScreenState.ACTIVE),
-                    )
+            // getMessages is safeApiCall-wrapped: it reports failure by RETURNING Result.Error and
+            // lets only CancellationException propagate, so the result must be consumed — a
+            // try/catch here can never see a network failure. An Error also means the cache was
+            // empty: the repository falls back to cached rows and returns those as Success.
+            when (val result = messageRepository.getMessages(conversationId)) {
+                is Result.Error -> {
+                    Logger.e(result.exception) { "Failed to fetch messages for $conversationId" }
+                    _uiState.update {
+                        // Only report when the failure actually leaves the screen empty. A
+                        // handed-off new chat streams with just its seeded user message and the
+                        // server persists the request only on completion, so this fetch is
+                        // expected to fail there — reporting it would fire mid-stream on a chat
+                        // that is working fine.
+                        if (it.isStreaming || it.displayMessages.isNotEmpty()) {
+                            it
+                        } else {
+                            it.copy(
+                                // App-authored copy only — Ktor builds exception messages out of
+                                // the request URL, so result.message can leak an access gateway's
+                                // redirect JWT on screen (#287).
+                                error = "Could not load messages",
+                                content = it.content.copy(
+                                    screenState = ChatScreenState.ACTIVE,
+                                    messagesLoadFailed = true,
+                                ),
+                            )
+                        }
+                    }
+                }
+                else -> _uiState.update {
+                    it.copy(content = it.content.copy(messagesLoadFailed = false))
                 }
             }
             // buildActiveMessagePath is pure/synchronous CPU work; computing it on the Default

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/MessagesState.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/MessagesState.kt
@@ -39,6 +39,12 @@ data class MessagesState(
     /** SSE reconnection retry state (null when not retrying). */
     val retryInfo: RetryInfo? = null,
     val isRefreshingMessages: Boolean = false,
+    /**
+     * The message fetch failed *and* the cache had nothing to fall back to. Drives the retryable
+     * empty state; the `error` banner is transient and cannot carry this on its own. Cleared by
+     * any load that succeeds (including an offline cache hit).
+     */
+    val messagesLoadFailed: Boolean = false,
     /** Latest context-window usage snapshot for the gauge (`on_context_usage` SSE / projection). */
     val contextUsage: ContextUsage? = null,
     /** Latest per-call provider token usage (`on_token_usage` SSE). */

--- a/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/screen/PlatformScreens.ios.kt
+++ b/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/screen/PlatformScreens.ios.kt
@@ -49,6 +49,7 @@ import com.garfiec.librechat.feature.chat.components.IosChatInput
 import com.garfiec.librechat.feature.chat.components.LandingContent
 import com.garfiec.librechat.feature.chat.components.ChatRoot
 import com.garfiec.librechat.feature.chat.components.MessageList
+import com.garfiec.librechat.feature.chat.components.MessagesUnavailable
 import com.garfiec.librechat.feature.chat.components.PresetPicker
 import com.garfiec.librechat.feature.chat.components.SavePresetDialog
 import com.garfiec.librechat.feature.chat.resources.*
@@ -522,6 +523,14 @@ private fun IosChatBody(
             ) {
                 CircularProgressIndicator(modifier = Modifier.size(36.dp))
             }
+        }
+        // `hasMessages` folds in isStreaming, which is load-bearing: a handed-off new chat is
+        // legitimately empty until the first message lands, and must not render as a failure.
+        uiState.messagesLoadFailed && !hasMessages -> {
+            MessagesUnavailable(
+                onRetry = viewModel::refreshMessages,
+                modifier = topPaddedFill,
+            )
         }
         uiState.comparisonState.isEnabled -> {
             ComparisonPanes(


### PR DESCRIPTION
## Problem

Opening a conversation that is not in the Room cache while offline rendered a correct app-bar title, a working composer, and a **permanently empty message area** — no error, no offline affordance, no retry.

The cause is a composition fault rather than a logic fault. `MessageRepository.getMessages` is `safeApiCall`-wrapped, so it reports failure by **returning** `Result.Error` and lets only `CancellationException` propagate. `loadConversation` guarded it with `try/catch (e: Exception)` and discarded the returned value — so the catch was unreachable for any network failure, and there was no path from a failed fetch to `uiState.error`.

## Fix

Consume the result. `Result.Error` sets the error banner and a new `MessagesState.messagesLoadFailed`; anything else clears the flag — which covers the offline cache-hit path, since the repository falls back to cached rows and returns them as `Success`. An `Error` therefore means the cache was empty too and the screen genuinely has nothing to show.

The error banner is a transient snackbar, so on its own it would leave the thread blank moments later. The flag also drives a retryable `MessagesUnavailable` empty state, wired on Android and iOS, with Retry reusing `refreshMessages()`.

Both the banner and the flag are suppressed when the screen already has content — `isStreaming` or a non-empty `displayMessages`. A chat handed off from the landing page carries its just-sent user message and the server persists the request only once the reply completes, so this fetch is *expected* to fail there; without the gate the fix would pop an error over a chat that is working correctly.

The banner text is app-authored rather than `result.message`: Ktor composes exception messages out of the request URL, so surfacing it could render an access gateway's redirect complete with its `meta=` JWT on screen (#287).

## Notes for review

- **The test is deliberately shaped.** `ChatViewModelMessageLoadFailureTest` asserts at the ViewModel level against a repository that fails by *returning* `Result.Error`, matching how `safeApiCall` actually behaves. It asserts on `messagesLoadFailed` rather than `error`, because `error` is a channel every loader shares — a later init-time write can overwrite this one, which would make the assertion about ordering rather than behavior.
- **Worth knowing when adding tests here:** `uiState` is a `combine(...).stateIn(Eagerly, ChatUiState())` over `_uiState` and four flows, one of which fans out into several more. Until *every* one emits, `uiState.value` is the untouched default regardless of what the ViewModel did, and relaxed mocks never emit — so they all need stubbing (seven here) or assertions read a state the ViewModel never published.
- **Branch order.** The failure state is checked ahead of the comparison-panes branch on both platforms: with nothing to render, empty comparison panes are less useful than the failure state. Android previously ordered these the other way round from iOS.

## Verification

`:feature:chat`, `:core:data` and `:core:common` unit tests, `detektMetadataCommonMain`, and `:app:assembleDebug` all pass.

Manual pass on a Pixel 10 Pro Fold emulator from a clean install and fresh login, and confirmed on a physical Pixel 9 Pro Fold:

| Scenario | Result |
|---|---|
| Conversation list online | renders |
| Thread online | renders, caches |
| Conversation list offline | renders + "No internet connection" banner |
| **Uncached thread offline** | **empty state + Retry + banner** (was: blank) |
| Retry while still offline | re-fails cleanly, state persists |
| Retry after reconnect | loads thread, state clears |
| Cached thread offline, in-app and cold start | renders, unaffected |

## Known gaps

- The two new strings are English-only; the module carries nine other locales, so non-English users see English here until they are translated.
- `MessagesUnavailable` does not surface `isRefreshingMessages`, so a slow Retry gives no in-place progress feedback.

## Follow-ups, not in scope

- `loadConversation` awaits the network fetch before subscribing the Room observer, so cached content cannot paint until the GET settles — including when the app already knows it is offline. Stale-while-revalidate would remove that wait: #300.
- Cached rows are keyed by server id alone, with `accountId` a plain unindexed column, so a fetch by one identity can re-label another's rows. Not filed as an issue yet; it needs a schema change and a migration, and is deliberately out of scope here.
