### PR TITLE
chore(data,auth): state header-store rules as rules, not as history

### DIFF
--- a/app/src/test/kotlin/com/garfiec/librechat/ServerHeaderEditorContractTest.kt
+++ b/app/src/test/kotlin/com/garfiec/librechat/ServerHeaderEditorContractTest.kt
@@ -35,13 +35,13 @@ import org.junit.Test
  *
  * **A credential that is on disk is only ever removed by a user action that named it.**
  *
- * Lives in `:app` because it is the only module that can see both editors, and because every defect
- * this file exists for was a *composition* fault — the editor and the store each behaving correctly
- * on their own. Both ViewModels are therefore driven against a **real** [ServerRepositoryImpl] over
- * an in-memory DAO, not a mocked repository: a `mockk<ServerRepository>` cannot exhibit a failed
- * read, a refused write, or a read that suspends, which is exactly the state space these bugs live
- * in. The per-editor tests in each feature module keep their mocks for the cases that don't need a
- * real store.
+ * Lives in `:app` because it is the only module that can see both editors, and because the ways this
+ * contract breaks are *composition* faults — the editor and the store each behaving correctly on
+ * their own. Both ViewModels are therefore driven against a **real** [ServerRepositoryImpl] over an
+ * in-memory DAO, not a mocked repository: a `mockk<ServerRepository>` cannot exhibit a failed read, a
+ * refused write, or a read that suspends, which is exactly the state space these failures live in.
+ * The per-editor tests in each feature module keep their mocks for the cases that don't need a real
+ * store.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 class ServerHeaderEditorContractTest {

--- a/core/data/CLAUDE.md
+++ b/core/data/CLAUDE.md
@@ -121,24 +121,24 @@ re-login through the normal expired-session flow.
 - **A read failure is not "no headers".** `headersForServer` returns null when the store could not be
   read, and both editors render that as a warning instead of an empty list — an empty editor reads as
   "your credential is gone", and saving from it would make that true. Rules that keep the contract
-  honest, each with a test because each was once wrong: a row that won't decode is tracked per-server
-  rather than skipped, as is one whose pairs all sanitize away (both otherwise report as "none
-  configured"); a successful write does not clear the failure flag (a write proves one row is
-  writable, not that the others were ever read); and the read is re-attempted after a failure (it is
-  otherwise attempted once, so one transient error disables headers until the process is killed).
+  honest, each with a test: a row that won't decode is tracked per-server rather than skipped, as is
+  one whose pairs all sanitize away (both otherwise report as "none configured"); a successful write
+  does not clear the failure flag (a write proves one row is writable, not that the others were ever
+  read); and the read is re-attempted after a failure (it is otherwise attempted once, so one
+  transient error disables headers until the process is killed).
 - **The empty-write refusal lives in `setHeaders`, not in the editors.** An empty map is a delete, and
   this repository is the only thing that knows whether the value it is about to destroy was ever
   successfully read — so it refuses that one combination itself and reports
-  `HeaderWriteFailure.UnverifiedDelete`. Both editors write through it. Enforcing it caller-side is
-  what the two editors did before, and they took turns being the one that forgot. A **non-empty**
-  write always goes through: re-entering the credential is the recovery path.
+  `HeaderWriteFailure.UnverifiedDelete`. Both editors write through it. Enforcing it caller-side means
+  a copy of the rule in each editor, either of which can omit it. A **non-empty** write always goes
+  through: re-entering the credential is the recovery path.
 - **Two read paths, and the request path never retries.** `headersFor` / `awaitWarm` serve the request
   pipeline from a snapshot seeded once at startup; `headersForServer` serves the editors and reads
-  through to the table every call. **Don't merge them back.** They were one path, and the retry policy
-  that tried to serve both oscillated across three reviews: bounded, one transient failure disabled
-  headers for the process; unbounded, an unreadable database queued every request behind the same
-  failing query. Split, there is no policy to tune — opening an editor is what heals a store that
-  failed at startup, and that is the moment a user is waiting for the answer anyway.
+  through to the table every call. **Don't merge them.** No single retry policy serves both: bounded,
+  one transient failure disables headers for the rest of the process; unbounded, an unreadable
+  database queues every request behind the same failing query. Split, there is no policy to tune —
+  opening an editor is what heals a store that failed at startup, and that is the moment a user is
+  waiting for the answer anyway.
 - **A write outranks a later failed read** (`writtenHere`). This class is the table's only writer, so
   a value it wrote is not in doubt even when the table stops reading. Without it a store whose reads
   fail but whose writes land confirms a save and then reports it unreadable, and the user re-enters a

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/ServerRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/ServerRepositoryImpl.kt
@@ -30,11 +30,10 @@ import kotlin.concurrent.Volatile
  *
  * **Two read paths, deliberately.** [headersFor] / [awaitWarm] serve the request pipeline from a
  * snapshot seeded once at startup and never re-read; [headersForServer] serves the editors and reads
- * through to the table every time. They were one path once, and the retry policy that tried to serve
- * both oscillated across three reviews — bounded, it disabled headers for the process after a
- * transient failure; unbounded, it queued every request behind a failing query. Splitting them
- * removes the question: the request path never retries, and opening an editor is what heals a store
- * that failed at startup.
+ * through to the table every time. **Don't merge them:** no single retry policy serves both —
+ * bounded, a transient failure disables headers for the rest of the process; unbounded, an
+ * unreadable database queues every request behind the same failing query. Split, the request path
+ * never retries, and opening an editor is what heals a store that failed at startup.
  */
 class ServerRepositoryImpl(
     private val serverDao: ServerDao,
@@ -167,8 +166,7 @@ class ServerRepositoryImpl(
                 if (sanitized.isEmpty() && (readFailed || serverId in unreadable)) {
                     // An empty write is a delete, and this store could not show the caller what it is
                     // about to destroy. The rule lives here rather than in the editors because this is
-                    // the only layer that knows the read failed — each editor has, at some point, been
-                    // the one that forgot.
+                    // the only layer that knows the read failed.
                     return@withLock HeaderWriteResult.Refused(HeaderWriteFailure.UnverifiedDelete)
                 }
                 try {

--- a/feature/auth/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/auth/viewmodel/ServerUrlViewModelTest.kt
+++ b/feature/auth/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/auth/viewmodel/ServerUrlViewModelTest.kt
@@ -51,8 +51,9 @@ class ServerUrlViewModelTest {
     @Before
     fun setup() {
         Dispatchers.setMain(testDispatcher)
-        // A relaxed Boolean is false, which Connect now reads as "the credential never reached
-        // disk" and stops on. Default to a store that works; the tests about failure say so.
+        // A relaxed default is not HeaderWriteResult.Saved, and Connect stops on anything else —
+        // reading it as "the credential never reached disk". Default to a store that works; the
+        // tests about failure say so.
         coEvery { serverRepository.setHeaders(any(), any()) } returns HeaderWriteResult.Saved
         // Pass block-running calls through so the probe actually executes.
         coEvery { accountSwitcher.withPendingIdentity(any<suspend () -> Result<StartupConfig>>()) } coAnswers {

--- a/feature/auth/src/commonMain/kotlin/com/garfiec/librechat/feature/auth/screen/ServerUrlScreen.kt
+++ b/feature/auth/src/commonMain/kotlin/com/garfiec/librechat/feature/auth/screen/ServerUrlScreen.kt
@@ -133,8 +133,7 @@ fun ServerUrlScreen(
                 // A save failure supersedes the load warning: it is the more recent, more actionable
                 // of the two, and the load warning is what the refused save was reacting to.
                 // Each case gets the same wording as its Settings counterpart: the two editors write
-                // to one store, and telling the user two different things about one failure is how
-                // "couldn't save" became "your device storage is broken" on this screen.
+                // to one store, so one failure must not be described two different ways.
                 storeWarning = when (uiState.headersSaveFailure) {
                     HeaderWriteFailure.UnverifiedDelete ->
                         stringResource(UiRes.string.server_headers_unverified_delete)


### PR DESCRIPTION
Follow-up to #298. Comment-only — no code or behaviour changes.

## Why

Several comments in the gateway-header code described how the feature was built rather than how it behaves: which review round reversed a decision, which of the two editors had a rule wrong at the time. That reads as scar tissue to anyone who wasn't there, and it makes the invariants a future change has to respect hard to pick out from the narration around them.

## Changes

- `ServerRepositoryImpl` — the two-read-path rationale keeps both failure modes it exists to avoid, and now states the rule outright (don't merge them back) instead of implying it from history.
- `core/data/CLAUDE.md` — three narration passages reframed to the rules they imply.
- `ServerHeaderEditorContractTest` — keeps the reason it uses a real repository rather than a mock, which is what stops the harness being swapped back.
- `ServerUrlScreen` — the two editors must not describe one failure two ways.
- `ServerUrlViewModelTest` — corrects a stale comment describing `setHeaders` as returning a `Boolean`; it returns a typed outcome.

Deliberately kept: the no-migration note in `core/data/CLAUDE.md`. It reads like history but is a live calendar-dependent hazard — cutting a release from `develop` between the two parts loses user credentials silently on upgrade.

## Verification

`:core:data`, `:feature:auth`, `:feature:settings` and `:app` unit tests, `detekt`, `detektMetadataCommonMain` — all green. Every changed Kotlin line is a comment (verified by diffing with comment lines filtered out).