### PR TITLE
fix(chat): remove the inert auto-send switch from the variable dialog

### DIFF
--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatScreen.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatScreen.kt
@@ -681,7 +681,7 @@ actual fun ChatScreen(
         VariableInputDialog(
             promptTemplate = pending.template,
             variables = pending.variables,
-            onInsert = { interpolated, _ -> viewModel.confirmVariablePrompt(interpolated) },
+            onInsert = viewModel::confirmVariablePrompt,
             onDismiss = viewModel::dismissVariablePrompt,
         )
     }

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/prompts/PromptsLibraryScreen.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/prompts/PromptsLibraryScreen.kt
@@ -106,7 +106,7 @@ fun PromptsLibraryScreen(
             VariableInputDialog(
                 promptTemplate = uiState.variablePromptTemplate,
                 variables = uiState.variableNames,
-                onInsert = { interpolated, _ ->
+                onInsert = { interpolated ->
                     viewModel.dismissVariableDialog()
                     onUseInChat(interpolated)
                 },

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/prompts/components/VariableInputDialog.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/prompts/components/VariableInputDialog.kt
@@ -2,13 +2,11 @@ package com.garfiec.librechat.feature.chat.prompts.components
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
@@ -16,16 +14,11 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateMapOf
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.garfiec.librechat.feature.chat.prompts.substitutePromptVariables
@@ -37,12 +30,11 @@ import org.jetbrains.compose.resources.stringResource
 fun VariableInputDialog(
     promptTemplate: String,
     variables: List<String>,
-    onInsert: (interpolatedText: String, autoSend: Boolean) -> Unit,
+    onInsert: (interpolatedText: String) -> Unit,
     onDismiss: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val variableValues = remember { mutableStateMapOf<String, String>() }
-    var autoSend by remember { mutableStateOf(false) }
 
     val preview = substitutePromptVariables(promptTemplate, variableValues)
 
@@ -86,27 +78,11 @@ fun VariableInputDialog(
                         modifier = Modifier.padding(12.dp),
                     )
                 }
-
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Text(
-                        text = "Auto-send",
-                        style = MaterialTheme.typography.bodyMedium,
-                        modifier = Modifier.weight(1f),
-                    )
-                    Spacer(modifier = Modifier.width(8.dp))
-                    Switch(
-                        checked = autoSend,
-                        onCheckedChange = { autoSend = it },
-                    )
-                }
             }
         },
         confirmButton = {
             TextButton(
-                onClick = { onInsert(preview, autoSend) },
+                onClick = { onInsert(preview) },
                 enabled = variables.all { (variableValues[it] ?: "").isNotBlank() },
             ) {
                 Text(stringResource(Res.string.action_insert))

--- a/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/screen/PlatformScreens.ios.kt
+++ b/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/screen/PlatformScreens.ios.kt
@@ -393,7 +393,7 @@ actual fun ChatScreen(
         VariableInputDialog(
             promptTemplate = pending.template,
             variables = pending.variables,
-            onInsert = { interpolated, _ -> viewModel.confirmVariablePrompt(interpolated) },
+            onInsert = viewModel::confirmVariablePrompt,
             onDismiss = viewModel::dismissVariablePrompt,
         )
     }


### PR DESCRIPTION
Closes #307.

## Summary

`VariableInputDialog` rendered an "Auto-send" switch that nothing acted on. The dialog owned the state and passed it out through `onInsert`, but every caller discarded it — the interpolated prompt was inserted into the composer and never sent, whichever way the switch was flipped. Its label was also a hardcoded English literal rather than a `stringResource`, so it ignored the app language. This removes the control.

## Changes

- Drop the `autoSend` state, the label/`Switch` row, and the `autoSend` parameter from `VariableInputDialog`'s `onInsert`, which becomes `(interpolatedText: String) -> Unit`.
- Update the three call sites — the Android and iOS `ChatScreen` actuals and `PromptsLibraryScreen` — to the single-argument form. The two platform screens now pass `viewModel::confirmVariablePrompt` directly, matching the `onDismiss` reference beside them.

Nothing else changes: insert is still gated on every variable being non-blank, the preview still interpolates live, and inserting still fills the composer without sending.

## Testing

- `:feature:chat:testDebugUnitTest` and `detektMetadataCommonMain` pass.
- `:feature:chat:compileKotlinIosSimulatorArm64` passes — one call site is in `iosMain`, which an Android build never compiles.
- Device-tested on an emulator: opened a prompt carrying a `{{variable}}` from both the composer's `/` picker and the library's "Use in Chat". The dialog renders only the fields, preview and Cancel/Insert, with no `Switch` in the view hierarchy; insert stays disabled until the variable is filled; and inserting from either path leaves the text in the composer unsent.

## Notes

Auto-send is deliberately not wired up here. Upstream's `autoSendPrompts` defaults on in the web client; this client diverges because a mis-tap in a suggestion list firing a message is a worse failure on a phone. If it is wanted later it belongs in settings as a real preference rather than a per-dialog toggle.

No string resources were removed — no `auto_send` key ever existed in any locale.
