### PR TITLE
fix(chat): render cached messages on open instead of waiting on the fetch

### DIFF
--- a/feature/chat/CLAUDE.md
+++ b/feature/chat/CLAUDE.md
@@ -40,8 +40,33 @@
 ## Screen States
 `ChatScreenState` enum: `LANDING` | `LOADING` | `ACTIVE`
 - **Landing**: no conversation selected, shows greeting + model icon + optional conversation starters
-- **Loading**: spinner while fetching messages for a conversation
+- **Loading**: full-screen spinner — *nothing is cached* and the message fetch has not settled
 - **Active**: message list + streaming content + input area
+
+### Cache-first open (#300)
+`loadConversation(conversationId, cacheFirst)` picks the ordering between the Room read-through
+and the server fetch. `cacheFirst = true` subscribes the observer first and revalidates in a child
+coroutine, so an **open** paints the cached copy immediately instead of holding the spinner
+through a GET that is retried twice with exponential backoff before it can fail. `ChatViewModel.init`
+is the only opt-in; every other caller stays network-first **deliberately**. Each of them reloads
+precisely because the server holds something the cache does not — a just-finalized turn
+(`SendCompletionDelegate`), a just-created branch (`ComparisonModeDelegate.branchFromComparison`),
+a stream that ended server-side (`StreamingManagerDelegate`'s `StreamError` / `ResumeExpired` /
+`attemptNetworkRecovery`, plus the `launchStream` safety net), or an explicit refresh
+(`refreshMessages`) — so a cache emission there serves a snapshot that predates the very thing
+being fetched. After a Final that is also the completion flash: the finalized turn is in memory
+and Room stays stale until `cacheMessages` lands, so painting the cache re-renders the pre-Final tree.
+
+Two consequences worth knowing before touching that block:
+- The fetch's settle is a **`combine` input**, not a flag read inside `collect`. A conversation
+  with genuinely zero messages upserts nothing, so Room never emits again — without the
+  re-emission the screen spins forever. The comparison auto-rehydrate latch is gated on the same
+  input so it still burns on the *authoritative* tail, not a stale cached one.
+- `isRefreshingMessages` now means "a messages fetch is in flight" (pull-to-refresh **or** a
+  background revalidate) and drives `MessageList`'s pull-to-refresh indicator, which animates off
+  that boolean with no gesture. `refreshMessages` early-returns while it is set, which is what
+  keeps the two paths from racing each other's clear — and which means a pull issued during the
+  open's revalidate is dropped rather than queued, since a fetch is already running.
 
 ## Navigation
 - Sealed interface: `ChatRoute : NavKey` with typed route classes

--- a/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModelCacheFirstLoadTest.kt
+++ b/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModelCacheFirstLoadTest.kt
@@ -1,0 +1,248 @@
+package com.garfiec.librechat.feature.chat.viewmodel
+
+import com.garfiec.librechat.core.common.identity.AccountId
+import com.garfiec.librechat.core.common.identity.AccountState
+import com.garfiec.librechat.core.common.identity.InMemoryActiveAccountProvider
+import com.garfiec.librechat.core.common.result.Result
+import com.garfiec.librechat.core.data.datastore.ChatFontSize
+import com.garfiec.librechat.core.data.datastore.ChatHeaderAlignment
+import com.garfiec.librechat.core.data.datastore.ChatHeaderContent
+import com.garfiec.librechat.core.data.datastore.ContextBarPlacement
+import com.garfiec.librechat.core.data.datastore.StarredModelsDisplay
+import com.garfiec.librechat.core.data.repository.AgentRepository
+import com.garfiec.librechat.core.data.repository.ChatRepository
+import com.garfiec.librechat.core.data.repository.ConfigRepository
+import com.garfiec.librechat.core.data.repository.ConversationRepository
+import com.garfiec.librechat.core.data.repository.DraftRepository
+import com.garfiec.librechat.core.data.repository.EndpointTokenRepository
+import com.garfiec.librechat.core.data.repository.FavoritesRepository
+import com.garfiec.librechat.core.data.repository.FileRepository
+import com.garfiec.librechat.core.data.repository.KeyRepository
+import com.garfiec.librechat.core.data.repository.McpRepository
+import com.garfiec.librechat.core.data.repository.MessageRepository
+import com.garfiec.librechat.core.data.repository.PresetRepository
+import com.garfiec.librechat.core.data.repository.PromptRepository
+import com.garfiec.librechat.core.data.repository.RoleRepository
+import com.garfiec.librechat.core.data.repository.ShareRepository
+import com.garfiec.librechat.core.data.repository.UserRepository
+import com.garfiec.librechat.core.data.util.PermissionGate
+import com.garfiec.librechat.core.model.Message
+import com.garfiec.librechat.feature.chat.viewmodel.delegate.PlatformDelegateFactory
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlinx.serialization.json.Json
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Opening a conversation must render the cached copy immediately and revalidate behind it (#300).
+ *
+ * Every test drives `ChatViewModel.init`, which is the only call site that opts into `cacheFirst`.
+ * `getMessages` is held on a [CompletableDeferred] so the window between "cache emitted" and
+ * "fetch settled" is observable rather than raced past.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class ChatViewModelCacheFirstLoadTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    private val agentRepository = mockk<AgentRepository>(relaxed = true)
+    private val chatRepository = mockk<ChatRepository>(relaxed = true)
+    private val messageRepository = mockk<MessageRepository>(relaxed = true)
+    private val fileRepository = mockk<FileRepository>(relaxed = true)
+    private val configRepository = mockk<ConfigRepository>(relaxed = true)
+    private val conversationRepository = mockk<ConversationRepository>(relaxed = true)
+    private val endpointTokenRepository = mockk<EndpointTokenRepository>(relaxed = true)
+    private val draftRepository = mockk<DraftRepository>(relaxed = true)
+    private val favoritesRepository = mockk<FavoritesRepository>(relaxed = true)
+    private val keyRepository = mockk<KeyRepository>(relaxed = true)
+    private val presetRepository = mockk<PresetRepository>(relaxed = true)
+    private val promptRepository = mockk<PromptRepository>(relaxed = true)
+    private val shareRepository = mockk<ShareRepository>(relaxed = true)
+    private val mcpRepository = mockk<McpRepository>(relaxed = true)
+    private val userRepository = mockk<UserRepository>(relaxed = true)
+    private val roleRepository = mockk<RoleRepository>(relaxed = true)
+    private val permissionGate = mockk<PermissionGate>(relaxed = true)
+    private val connectivityObserver =
+        mockk<com.garfiec.librechat.core.common.network.ConnectivityObserver>(relaxed = true)
+    private val serverDataStore =
+        mockk<com.garfiec.librechat.core.data.datastore.ServerDataStore>(relaxed = true)
+    private val settingsDataStore =
+        mockk<com.garfiec.librechat.core.data.datastore.SettingsDataStore>(relaxed = true)
+    private val platformDelegateFactory = mockk<PlatformDelegateFactory>(relaxed = true)
+    private val serverFileSelectionHandoff = mockk<ServerFileSelectionHandoff>(relaxed = true)
+
+    private val selectionHandoff = NewChatSelectionHandoff()
+
+    /** Holds `getMessages` open so the pre-settle window can be asserted on. */
+    private val fetchGate = CompletableDeferred<Result<List<Message>>>()
+
+    private val cachedMessages = listOf(
+        Message(
+            messageId = "m-1",
+            conversationId = "conv-1",
+            isCreatedByUser = true,
+            text = "cached",
+        ),
+    )
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+
+        every { configRepository.startupConfig } returns MutableStateFlow(null)
+        every { configRepository.detectedBackendVersion } returns MutableStateFlow("0.8.7")
+        every { roleRepository.userPermissions } returns MutableStateFlow(null)
+        every { configRepository.endpointConfigs } returns MutableStateFlow(emptyMap())
+        every { configRepository.availableModels } returns MutableStateFlow(emptyMap())
+        every { favoritesRepository.favorites } returns MutableStateFlow(emptyList())
+        every { settingsDataStore.selectedMcpServers } returns flowOf(emptySet())
+        every { settingsDataStore.enabledTools } returns flowOf(emptySet())
+        every { serverFileSelectionHandoff.selectionsFor(any()) } returns emptyFlow()
+        every { keyRepository.keyInvalidations } returns MutableSharedFlow()
+        every { platformDelegateFactory.createShareConsumer().shareAvailable } returns MutableSharedFlow()
+
+        // `uiState` is combine(_uiState, these pref flows).stateIn(Eagerly, ChatUiState()): until
+        // EVERY one of them emits, `uiState.value` is the untouched initial state no matter what
+        // the ViewModel did. Relaxed mocks never emit — these stubs are load-bearing.
+        every { serverDataStore.currentUrlFlow } returns MutableStateFlow("https://example.test")
+        every { settingsDataStore.chatFontSize } returns MutableStateFlow(ChatFontSize.MEDIUM)
+        every { settingsDataStore.starredModelsDisplay } returns MutableStateFlow(StarredModelsDisplay.OFF)
+        every { settingsDataStore.chatHeaderContent } returns MutableStateFlow(ChatHeaderContent.MODEL)
+        every { settingsDataStore.chatHeaderAlignment } returns MutableStateFlow(ChatHeaderAlignment.CENTER)
+        every { settingsDataStore.contextBarPlacement } returns MutableStateFlow(ContextBarPlacement.HIDDEN)
+        every { settingsDataStore.contextGaugeExpanded } returns MutableStateFlow(false)
+
+        coEvery { conversationRepository.getConversation(any(), any()) } returns Result.Error(message = "test")
+        coEvery { messageRepository.getMessages(any()) } coAnswers { fetchGate.await() }
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun cachedMessagesRenderBeforeTheFetchSettles() = runTest(testDispatcher) {
+        every { messageRepository.observeMessages(any()) } returns flowOf(cachedMessages)
+
+        val viewModel = newViewModel()
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertEquals(ChatScreenState.ACTIVE, state.screenState)
+        assertEquals(1, state.displayMessages.size)
+        assertTrue("the in-flight revalidate must show an indicator", state.isRefreshingMessages)
+    }
+
+    @Test
+    fun theRevalidateIndicatorClearsWhenTheFetchSettles() = runTest(testDispatcher) {
+        every { messageRepository.observeMessages(any()) } returns flowOf(cachedMessages)
+
+        val viewModel = newViewModel()
+        advanceUntilIdle()
+        // Asserted on both sides of the settle: `assertFalse` alone would pass just as well against
+        // a build that never raises the indicator at all.
+        assertTrue(viewModel.uiState.value.isRefreshingMessages)
+
+        fetchGate.complete(Result.Success(cachedMessages))
+        advanceUntilIdle()
+
+        assertFalse(viewModel.uiState.value.isRefreshingMessages)
+    }
+
+    @Test
+    fun anEmptyCacheKeepsTheSpinnerUntilTheFetchSettles() = runTest(testDispatcher) {
+        every { messageRepository.observeMessages(any()) } returns flowOf(emptyList())
+
+        val viewModel = newViewModel()
+        advanceUntilIdle()
+
+        // Without this, an uncached online open would flash a blank thread before the messages land.
+        assertEquals(ChatScreenState.LOADING, viewModel.uiState.value.screenState)
+    }
+
+    @Test
+    fun settlingWithNoMessagesReleasesTheSpinner() = runTest(testDispatcher) {
+        // A conversation that genuinely has no messages: the fetch succeeds, the upsert writes
+        // nothing, and Room never emits a second time. The only thing that can release the spinner
+        // is the settle itself re-running the combine — so this fails if `revalidated` is read as a
+        // plain flag inside collect instead of being a combine input.
+        every { messageRepository.observeMessages(any()) } returns flowOf(emptyList())
+
+        val viewModel = newViewModel()
+        advanceUntilIdle()
+        fetchGate.complete(Result.Success(emptyList()))
+        advanceUntilIdle()
+
+        assertEquals(ChatScreenState.ACTIVE, viewModel.uiState.value.screenState)
+        assertFalse(viewModel.uiState.value.messagesLoadFailed)
+    }
+
+    @Test
+    fun aFailedRevalidateOverCachedMessagesStaysSilent() = runTest(testDispatcher) {
+        // The ordinary offline open. The retryable empty state from #299 is for an empty cache
+        // only — arming it here would cover a thread the user can read perfectly well.
+        every { messageRepository.observeMessages(any()) } returns flowOf(cachedMessages)
+
+        val viewModel = newViewModel()
+        advanceUntilIdle()
+        fetchGate.complete(Result.Error(message = "offline"))
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertFalse("cached rows must not arm the empty state", state.messagesLoadFailed)
+        assertEquals(ChatScreenState.ACTIVE, state.screenState)
+        assertEquals(1, state.displayMessages.size)
+    }
+
+    private fun newViewModel(): ChatViewModel =
+        ChatViewModel(
+            initialConversationId = "conv-1",
+            initialAgentId = null,
+            agentRepository = agentRepository,
+            chatRepository = chatRepository,
+            messageRepository = messageRepository,
+            fileRepository = fileRepository,
+            configRepository = configRepository,
+            conversationRepository = conversationRepository,
+            endpointTokenRepository = endpointTokenRepository,
+            draftRepository = draftRepository,
+            favoritesRepository = favoritesRepository,
+            keyRepository = keyRepository,
+            presetRepository = presetRepository,
+            promptRepository = promptRepository,
+            shareRepository = shareRepository,
+            mcpRepository = mcpRepository,
+            userRepository = userRepository,
+            roleRepository = roleRepository,
+            permissionGate = permissionGate,
+            connectivityObserver = connectivityObserver,
+            serverDataStore = serverDataStore,
+            settingsDataStore = settingsDataStore,
+            platformDelegateFactory = platformDelegateFactory,
+            json = Json { ignoreUnknownKeys = true },
+            defaultDispatcher = testDispatcher,
+            selectionHandoff = selectionHandoff,
+            serverFileSelectionHandoff = serverFileSelectionHandoff,
+            promptInsertionHandoff = PromptInsertionHandoff(),
+            activeAccountProvider = InMemoryActiveAccountProvider(AccountState.Resolved(AccountId("srv:user-1"))),
+        )
+}

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModel.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModel.kt
@@ -50,6 +50,7 @@ import com.garfiec.librechat.feature.chat.components.AttachedFile
 import com.garfiec.librechat.feature.chat.components.ParsedMarkdownCache
 import com.garfiec.librechat.feature.chat.model.PresetDisplayData
 import com.garfiec.librechat.feature.chat.model.PromptMentionDisplayData
+import com.garfiec.librechat.feature.chat.util.MessageNode
 import com.garfiec.librechat.feature.chat.util.NEW_CHAT_DRAFT_KEY
 import com.garfiec.librechat.feature.chat.util.buildActiveMessagePath
 import com.garfiec.librechat.feature.chat.util.extractBranchMedia
@@ -453,7 +454,7 @@ class ChatViewModel(
                     )
                 }
             }
-            loadConversation(conversationId)
+            loadConversation(conversationId, cacheFirst = true)
             loadConversationModel(conversationId)
             restoreDraft(conversationId)
             // Check if there's an active stream for this conversation (e.g. when
@@ -598,7 +599,58 @@ class ChatViewModel(
 
     // ── Core chat flow ──────────────────────────────────────────────
 
-    private fun loadConversation(conversationId: String) {
+    /**
+     * Fetches the conversation's messages and records the outcome.
+     *
+     * `getMessages` is `safeApiCall`-wrapped: it reports failure by RETURNING [Result.Error] and
+     * lets only `CancellationException` propagate, so the result must be consumed — a `try/catch`
+     * around it can never see a network failure. An `Error` also means the cache was empty: the
+     * repository falls back to cached rows and returns those as `Success`.
+     */
+    private suspend fun revalidateMessages(conversationId: String) {
+        when (val result = messageRepository.getMessages(conversationId)) {
+            is Result.Error -> {
+                Logger.e(result.exception) { "Failed to fetch messages for $conversationId" }
+                _uiState.update {
+                    // Only report when the failure actually leaves the screen empty. A revalidate
+                    // that fails over cached rows is the ordinary offline case, and a handed-off
+                    // new chat streams with just its seeded user message while the server persists
+                    // the request only on completion — this fetch is *expected* to fail there.
+                    if (it.isStreaming || it.displayMessages.isNotEmpty()) {
+                        it
+                    } else {
+                        it.copy(
+                            // App-authored copy only — Ktor builds exception messages out of
+                            // the request URL, so result.message can leak an access gateway's
+                            // redirect JWT on screen (#287).
+                            error = "Could not load messages",
+                            content = it.content.copy(
+                                screenState = ChatScreenState.ACTIVE,
+                                messagesLoadFailed = true,
+                            ),
+                        )
+                    }
+                }
+            }
+            else -> _uiState.update {
+                it.copy(content = it.content.copy(messagesLoadFailed = false))
+            }
+        }
+    }
+
+    /**
+     * Subscribes the Room read-through for [conversationId] and revalidates it from the server.
+     *
+     * [cacheFirst] picks the ordering. `false` (the default) awaits the fetch before subscribing,
+     * so the first emission is the authoritative one. Every other caller reloads precisely because
+     * the server holds something the cache does not — a just-finalized turn, a just-created branch,
+     * a stream that ended server-side, or an explicit refresh — so a cache emission there serves a
+     * snapshot that predates the thing being fetched. After a Final that is also the completion
+     * flash: the finalized turn is in memory and Room stays stale until `cacheMessages` lands, so
+     * painting the cache would re-render the pre-Final tree. `true` subscribes first and revalidates
+     * in the background; `init` is the only opt-in (#300).
+     */
+    private fun loadConversation(conversationId: String, cacheFirst: Boolean = false) {
         // SECURITY: do not remove — temp-chat data-at-rest guard.
         // Defense-in-depth for temporary chats: never route a temp conversation
         // through the Room read-through, which would upsert its message rows to disk (the
@@ -613,38 +665,26 @@ class ChatViewModel(
         // re-enable comparison after the user has toggled it off for the session.
         var autoRehydrateHandled = false
         roomObserverJob = viewModelScope.launch {
-            // getMessages is safeApiCall-wrapped: it reports failure by RETURNING Result.Error and
-            // lets only CancellationException propagate, so the result must be consumed — a
-            // try/catch here can never see a network failure. An Error also means the cache was
-            // empty: the repository falls back to cached rows and returns those as Success.
-            when (val result = messageRepository.getMessages(conversationId)) {
-                is Result.Error -> {
-                    Logger.e(result.exception) { "Failed to fetch messages for $conversationId" }
-                    _uiState.update {
-                        // Only report when the failure actually leaves the screen empty. A
-                        // handed-off new chat streams with just its seeded user message and the
-                        // server persists the request only on completion, so this fetch is
-                        // expected to fail there — reporting it would fire mid-stream on a chat
-                        // that is working fine.
-                        if (it.isStreaming || it.displayMessages.isNotEmpty()) {
-                            it
-                        } else {
-                            it.copy(
-                                // App-authored copy only — Ktor builds exception messages out of
-                                // the request URL, so result.message can leak an access gateway's
-                                // redirect JWT on screen (#287).
-                                error = "Could not load messages",
-                                content = it.content.copy(
-                                    screenState = ChatScreenState.ACTIVE,
-                                    messagesLoadFailed = true,
-                                ),
-                            )
-                        }
+            // A flow, not a plain flag: it is a `combine` input below, so settling re-runs the
+            // transform even when Room never emits again — a conversation with genuinely zero
+            // messages upserts nothing, and an empty cache offline emits `[]` once. Read as a
+            // flag inside `collect`, both spin forever.
+            val revalidated = MutableStateFlow(false)
+            if (cacheFirst) {
+                // A child of roomObserverJob, so re-entering loadConversation cancels it with the
+                // observer.
+                launch {
+                    _uiState.update { it.copy(content = it.content.copy(isRefreshingMessages = true)) }
+                    try {
+                        revalidateMessages(conversationId)
+                    } finally {
+                        _uiState.update { it.copy(content = it.content.copy(isRefreshingMessages = false)) }
                     }
+                    revalidated.value = true
                 }
-                else -> _uiState.update {
-                    it.copy(content = it.content.copy(messagesLoadFailed = false))
-                }
+            } else {
+                revalidateMessages(conversationId)
+                revalidated.value = true
             }
             // buildActiveMessagePath is pure/synchronous CPU work; computing it on the Default
             // dispatcher keeps the tree walk off Main. Combining the active-branch selection in
@@ -655,7 +695,8 @@ class ChatViewModel(
             combine(
                 messageRepository.observeMessages(conversationId),
                 _uiState.map { it.activeBranches }.distinctUntilChanged(),
-            ) { messages, branches ->
+                revalidated,
+            ) { messages, branches, settled ->
                 // Reuse on-screen Message instances that changed only in volatile fields, so
                 // the rebuilt path stays value-equal and the cosmetic Room reconcile conflates
                 // instead of re-rendering the list (see [stabilizeMessageInstances]). The
@@ -678,19 +719,33 @@ class ChatViewModel(
                     stabilized.none { it.messageId == seed.messageId }
                 }
                 val merged = retainedPending?.let { stabilized + it } ?: stabilized
-                Triple(merged, buildActiveMessagePath(merged, branches), retainedPending)
+                MessagePathEmission(
+                    messages = merged,
+                    displayMessages = buildActiveMessagePath(merged, branches),
+                    retainedPending = retainedPending,
+                    revalidated = settled,
+                )
             }
                 .flowOn(defaultDispatcher)
-                .collect { (messages, displayMessages, retainedPending) ->
+                .collect { emission ->
+                    val displayMessages = emission.displayMessages
+                    val settled = emission.revalidated
                     _uiState.update {
                         it.copy(
                             content = it.content.copy(
-                                messages = messages,
+                                messages = emission.messages,
                                 displayMessages = displayMessages,
-                                screenState = ChatScreenState.ACTIVE,
+                                // Cached rows go straight to ACTIVE; an empty cache keeps
+                                // spinning, so an uncached online open never flashes a blank
+                                // thread first. Settling releases it either way.
+                                screenState = if (displayMessages.isNotEmpty() || settled) {
+                                    ChatScreenState.ACTIVE
+                                } else {
+                                    it.content.screenState
+                                },
                                 // Null once the server echoes its own copy (or there was never a seed) →
                                 // a later server-side delete can then still remove the row.
-                                pendingResumeUserMessage = retainedPending,
+                                pendingResumeUserMessage = emission.retainedPending,
                             ),
                         )
                     }
@@ -699,7 +754,10 @@ class ChatViewModel(
                     // else records it was a comparison. Only when not streaming and not already
                     // comparing (respects a session toggle-off); the branched-away case has a
                     // single-agent tail, so it naturally shows the normal view.
-                    if (!autoRehydrateHandled && displayMessages.isNotEmpty()) {
+                    // Gated on `settled` so the latch burns on the AUTHORITATIVE tail, not a stale
+                    // cached one: a comparison tail that exists only server-side would otherwise
+                    // never rehydrate.
+                    if (!autoRehydrateHandled && settled && displayMessages.isNotEmpty()) {
                         autoRehydrateHandled = true
                         val state = _uiState.value
                         val tail = displayMessages.lastOrNull()?.message
@@ -1720,3 +1778,10 @@ class ChatViewModel(
         }
     }
 }
+
+private data class MessagePathEmission(
+    val messages: List<Message>,
+    val displayMessages: List<MessageNode>,
+    val retainedPending: Message?,
+    val revalidated: Boolean,
+)

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/MessagesState.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/MessagesState.kt
@@ -38,6 +38,12 @@ data class MessagesState(
     val streamingAttachments: List<Attachment> = emptyList(),
     /** SSE reconnection retry state (null when not retrying). */
     val retryInfo: RetryInfo? = null,
+    /**
+     * A messages fetch is in flight — a pull-to-refresh, or the background revalidate behind a
+     * cache-first open. Drives `MessageList`'s pull-to-refresh indicator, which animates off this
+     * boolean alone and needs no gesture. `refreshMessages` early-returns while it is set, so the
+     * two paths cannot race each other's clear.
+     */
     val isRefreshingMessages: Boolean = false,
     /**
      * The message fetch failed *and* the cache had nothing to fall back to. Drives the retryable


### PR DESCRIPTION
Closes #300.

## Problem

Opening a conversation held a spinner until the network settled, even when the messages were already cached and the offline banner was already up. `loadConversation` awaited `messageRepository.getMessages` before subscribing the Room observer, and on this path `screenState` only reached `ACTIVE` from inside that observer's `collect` — so nothing could paint until the fetch resolved. `GET` is retry-eligible (`maxRetries = 2`, `exponentialDelay()`), so an offline open spent the full retry ladder showing a spinner over readable data.

## Fix

`loadConversation(conversationId, cacheFirst: Boolean = false)`. With `cacheFirst`, the Room observer is subscribed first and the fetch runs in a child coroutine, so cached rows render immediately and the fetch becomes a background revalidate.

**`ChatViewModel.init` is the only opt-in.** Every other caller keeps the network-first ordering, deliberately: each of them reloads precisely because the server holds something the cache does not — a just-finalized turn, a just-created branch, a stream that ended server-side, or an explicit refresh — so a cache emission there would serve a snapshot that predates the very thing being fetched. After a Final that is also the completion flash: the finalized turn is in memory and Room stays stale until `cacheMessages` lands, so painting the cache would re-render the pre-Final tree.

For the init path, `screenState` now leaves `LOADING` only once there is something to show *or* the fetch has settled, so an uncached open still shows the spinner rather than flashing a blank thread. (The expression preserves the current `screenState` rather than asserting `LOADING`; `init` is what sets `LOADING` in the first place.)

The fetch's settle is a `combine` input rather than a flag read inside `collect`. That matters for two cases where Room cannot emit again on its own: a conversation with genuinely zero messages upserts nothing, so without the re-emission the screen would spin forever; and an empty cache offline emits `[]` once and is done. Comparison auto-rehydration is gated on the same input, so its latch still burns on the authoritative tail rather than a stale cached one.

The `getMessages` result handling moves into `revalidateMessages` unchanged apart from comments. Its "only report when the screen is empty" gate does more work now — a revalidate that fails over cached rows is the ordinary offline case and stays silent.

The `combine` transform's `Triple` becomes a named `MessagePathEmission` so the settle can ride along.

## Indicator

`isRefreshingMessages` widens from "a pull-to-refresh is running" to "a messages fetch is in flight", and is set around the background revalidate. The cached rows are already on screen, so a full-screen spinner would be wrong, but the in-flight fetch still needs an affordance of its own.

No new composable on either platform: `MessageList` already wraps its list in a `PullToRefreshBox` whose indicator animates off that boolean alone — no gesture involved — and Android, iOS and `ComparisonPanes` all already pass it. The visible change is that the indicator now appears briefly on every conversation open, where before it only followed a user pull.

One consequence worth knowing: `refreshMessages` early-returns while the flag is set, so a pull issued during the open's revalidate is dropped rather than queued. That early return is also what keeps the two paths from racing each other's clear.

## Notes for review

- **The tests hold `getMessages` on a `CompletableDeferred`.** The window between "cache emitted" and "fetch settled" is the entire behavior under test; a fake that returns immediately races straight past it and passes against the old ordering.
- **`settlingWithNoMessagesReleasesTheSpinner` is the structural one.** Its source flow completes after a single empty emission, so a settle read as a plain flag inside `collect` could never re-run the transform — it is the only one of the five that a flag would break.

## Verification

`:feature:chat` unit tests, `detektMetadataCommonMain` and `:app:assembleDebug` pass; manually confirmed on a physical Pixel 9 Pro Fold.

Two mutations were run against the branch to check the new tests actually bite: reverting the `init` call site to `cacheFirst = false` fails the three tests that seed cached rows, and reading the settle as `revalidated.value` inside the transform fails `settlingWithNoMessagesReleasesTheSpinner`.

## Known gaps

- `MessagesUnavailable` has no progress affordance, so a slow Retry gives no in-place feedback.
- Android's content `when` keys on `screenState` unconditionally, where iOS additionally requires `displayMessages.isEmpty()`. The new `screenState` expression never produces the combination that would expose the difference, so this is left as-is.
- `refreshMessages` still issues two GETs (its own, then `loadConversation`'s). Out of scope here.
