### PR TITLE
feat(network): extend access-gateway detection to SSE and token refresh

### DIFF
--- a/core/common/src/commonMain/kotlin/com/garfiec/librechat/core/common/result/FailureMessages.kt
+++ b/core/common/src/commonMain/kotlin/com/garfiec/librechat/core/common/result/FailureMessages.kt
@@ -7,7 +7,6 @@ package com.garfiec.librechat.core.common.result
  * connection, not a retry.
  */
 class AccessGatewayException(
-    val serverUrl: String? = null,
     cause: Throwable? = null,
 ) : Exception("Access gateway rejected the request", cause)
 
@@ -120,6 +119,12 @@ internal fun classifyFailure(throwable: Throwable): FailureKind {
 }
 
 private const val TRAVERSAL_LIMIT = 8
+
+/**
+ * The safe, user-facing text for a [FailureKind], for callers that already know the kind. Use this
+ * rather than [toSafeError] as a string lookup — that also logs at ERROR.
+ */
+fun FailureKind.message(): String = defaultMessage()
 
 /** The safe, user-facing text for a [FailureKind]. */
 internal fun FailureKind.defaultMessage(): String = when (this) {

--- a/core/common/src/commonTest/kotlin/com/garfiec/librechat/core/common/result/SafeErrorMessageTest.kt
+++ b/core/common/src/commonTest/kotlin/com/garfiec/librechat/core/common/result/SafeErrorMessageTest.kt
@@ -52,7 +52,7 @@ class SafeErrorMessageTest {
 
     @Test
     fun `an access gateway rejection is its own actionable category`() {
-        val error = AccessGatewayException(serverUrl = "https://chat-test.example.org").toSafeError()
+        val error = AccessGatewayException().toSafeError()
 
         assertEquals(FailureKind.AccessGateway, error.kind)
         assertEquals(FailureMessages.GATEWAY, error.message)

--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/datastore/CommonTokenDataStoreGatewayTest.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/datastore/CommonTokenDataStoreGatewayTest.kt
@@ -1,0 +1,155 @@
+package com.garfiec.librechat.core.data.datastore
+
+import com.garfiec.librechat.core.network.client.GatewayDetectionPlugin
+import com.garfiec.librechat.core.network.client.RefreshResult
+import com.google.common.truth.Truth.assertThat
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.defaultRequest
+import io.ktor.client.request.url
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+/**
+ * Token refresh when an access gateway answers instead of the server (issue #287). Deliberately not
+ * symmetrical with a 401: a gateway rejection says nothing about whether the LibreChat session is
+ * alive, so it must never cause a logout.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class CommonTokenDataStoreGatewayTest {
+
+    private companion object {
+        const val SERVER = "https://chat.example.com"
+        const val CF_CHALLENGE = "Cloudflare-Access"
+        const val ACCESS_LOGIN = "https://team.cloudflareaccess.com/cdn-cgi/access/login/chat.example.com"
+    }
+
+    private class FakeStore(
+        refreshClient: Lazy<HttpClient>,
+        seed: Map<String, String> = emptyMap(),
+    ) : CommonTokenDataStore(refreshClient) {
+        val store = seed.toMutableMap()
+
+        init {
+            initializeTokenCache()
+        }
+
+        override fun readValue(key: String): String? = store[key]
+        override fun writeValue(key: String, value: String) {
+            store[key] = value
+        }
+
+        override fun writeValues(values: Map<String, String>) {
+            store.putAll(values)
+        }
+
+        override fun removeValue(key: String) {
+            store.remove(key)
+        }
+
+        override fun onKeystoreCorruption() = Unit
+    }
+
+    private fun accessKey(account: String) = "acct:$account:access_token"
+    private fun refreshKeyOf(account: String) = "acct:$account:refresh_token"
+
+    private fun seededStore(refreshClient: Lazy<HttpClient>) = FakeStore(
+        refreshClient,
+        seed = mapOf(
+            "active_account_id" to "acctA",
+            accessKey("acctA") to "A-access",
+            refreshKeyOf("acctA") to "A-refresh",
+        ),
+    )
+
+    private fun refreshClientWith(engine: MockEngine): Lazy<HttpClient> = lazy {
+        HttpClient(engine) {
+            install(ContentNegotiation) { json() }
+            install(GatewayDetectionPlugin)
+            defaultRequest {
+                url(SERVER)
+                contentType(ContentType.Application.Json)
+            }
+        }
+    }
+
+    /**
+     * The gateway's 302 challenge, and nothing else: refresh is a POST, and Ktor only redirects Get
+     * and Head, so the sign-in page on the other end is never fetched on this client. Detection
+     * reads the challenge off the 302 itself, which is why it works here at all.
+     */
+    private fun gatewayEngine(onServerRequest: () -> Unit) = MockEngine {
+        onServerRequest()
+        respond(
+            content = "",
+            status = HttpStatusCode.Found,
+            headers = headersOf(
+                HttpHeaders.Location to listOf(ACCESS_LOGIN),
+                HttpHeaders.WWWAuthenticate to listOf(CF_CHALLENGE),
+            ),
+        )
+    }
+
+    /** The broken credential is the gateway's — the LibreChat session was never rejected. */
+    @Test
+    fun `a gateway-blocked refresh keeps the session instead of expiring it`() = runTest {
+        val store = seededStore(refreshClientWith(gatewayEngine {}))
+
+        val result = store.refreshAccessToken()
+
+        assertThat(result).isEqualTo(RefreshResult.Transient)
+        // The tokens must survive for the retry that follows the header fix.
+        assertThat(store.store[refreshKeyOf("acctA")]).isEqualTo("A-refresh")
+        assertThat(store.store[accessKey("acctA")]).isEqualTo("A-access")
+    }
+
+    /** Deterministic until the user edits the credential, and the budget is spent under the flight lock. */
+    @Test
+    fun `a gateway-blocked refresh is attempted once, not retried`() = runTest {
+        var attempts = 0
+        val store = seededStore(refreshClientWith(gatewayEngine { attempts++ }))
+
+        store.refreshAccessToken()
+
+        assertThat(attempts).isEqualTo(1)
+    }
+
+    /**
+     * Pinned because the fold it bypasses is easy to reintroduce: a refresh that saw a 401 normally
+     * settles as expired, so this arm must return on its own rather than through `settle()`.
+     */
+    @Test
+    fun `a gateway block after a 401 does not promote the attempt into a logout`() = runTest {
+        var attempts = 0
+        val engine = MockEngine {
+            attempts++
+            if (attempts == 1) {
+                respond(content = "", status = HttpStatusCode.Unauthorized)
+            } else {
+                respond(
+                    content = "",
+                    status = HttpStatusCode.Found,
+                    headers = headersOf(
+                        HttpHeaders.Location to listOf(ACCESS_LOGIN),
+                        HttpHeaders.WWWAuthenticate to listOf(CF_CHALLENGE),
+                    ),
+                )
+            }
+        }
+        val store = seededStore(refreshClientWith(engine))
+
+        val result = store.refreshAccessToken()
+
+        assertThat(result).isEqualTo(RefreshResult.Transient)
+        assertThat(store.store[refreshKeyOf("acctA")]).isEqualTo("A-refresh")
+    }
+}

--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/repository/ConfigRepositoryImplTest.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/repository/ConfigRepositoryImplTest.kt
@@ -1,5 +1,7 @@
 package com.garfiec.librechat.core.data.repository
 
+import com.garfiec.librechat.core.common.result.AccessGatewayException
+import com.garfiec.librechat.core.common.result.FailureKind
 import com.garfiec.librechat.core.common.result.Result
 import com.garfiec.librechat.core.data.datastore.ConfigCacheDataStore
 import com.garfiec.librechat.core.model.EndpointConfig
@@ -103,5 +105,25 @@ class ConfigRepositoryImplTest {
         assertThat(repo.startupConfig.value).isNull()
         assertThat(repo.endpointConfigs.value).isEmpty()
         assertThat(repo.availableModels.value).isEmpty()
+    }
+
+    /**
+     * The config probe is where a gateway-blocked server is met first, before login. The kind matters
+     * as much as the wording — it is what a UI layer would localize or branch on.
+     */
+    @Test
+    fun `a gateway rejection is reported as a gateway problem, not an unreachable server`() = runTest {
+        coEvery { configApi.getStartupConfig() } throws AccessGatewayException()
+        val repo = repository()
+
+        val result = repo.validateServerUrl("https://b.example.com")
+
+        val error = result as Result.Error
+        assertThat(error.kind).isEqualTo(FailureKind.AccessGateway)
+        assertThat(error.message).doesNotContain("Could not reach the server")
+        // Not the shared post-login wording: it points at Settings, which needs the sign-in the
+        // gateway is blocking.
+        assertThat(error.message).doesNotContain("Settings")
+        assertThat(error.message).contains("Advanced")
     }
 }

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/CommonTokenDataStore.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/CommonTokenDataStore.kt
@@ -2,6 +2,7 @@ package com.garfiec.librechat.core.data.datastore
 
 import co.touchlab.kermit.Logger
 import com.garfiec.librechat.core.common.extensions.trimTrailingSlash
+import com.garfiec.librechat.core.common.result.AccessGatewayException
 import com.garfiec.librechat.core.logging.Diag
 import com.garfiec.librechat.core.logging.LogOrigin
 import com.garfiec.librechat.core.model.response.RefreshResponse
@@ -356,6 +357,9 @@ abstract class CommonTokenDataStore(
                         // request timeout; stop. A session already confirmed dead by a prior 401 still
                         // routes to re-auth; otherwise keep the session (a later request/relaunch recovers).
                         RefreshAttempt.TransportError -> return@withLock settle()
+                        // Never `settle()`: a gateway rejection says nothing about whether the session
+                        // is alive, so it must not promote a prior 401 into a logout. See GatewayBlocked.
+                        RefreshAttempt.GatewayBlocked -> return@withLock RefreshResult.Transient
                         RefreshAttempt.AuthRejected -> {
                             sawHardRejection = true
                             retryBackoffMillis(attempt)
@@ -428,6 +432,16 @@ abstract class CommonTokenDataStore(
                     RefreshAttempt.Retryable
                 }
             }
+        } catch (e: AccessGatewayException) {
+            // This POST never reached LibreChat and no retry will change that — stop spending the
+            // budget under the flight lock.
+            Diag.w(
+                "Auth",
+                origin = LogOrigin.NETWORK,
+                throwable = e,
+                attrs = mapOf("event" to "refresh_gateway_blocked"),
+            ) { "Access gateway rejected the token refresh" }
+            RefreshAttempt.GatewayBlocked
         } catch (e: Exception) {
             if (isKeystoreException(e)) {
                 Diag.e(
@@ -576,6 +590,18 @@ abstract class CommonTokenDataStore(
 
         /** Transport failure (server unreachable). Terminal → Transient, so we don't retry under the lock. */
         data object TransportError : RefreshAttempt
+
+        /**
+         * An access gateway intercepted the refresh (issue #287). Terminal → Transient.
+         *
+         * Deliberately **not** HardExpired: the request never reached LibreChat, so it is no evidence
+         * the session is dead, and logging out over it costs a re-login on top of the header fix.
+         * Nor retryable — every attempt in the budget meets the same gateway.
+         *
+         * Accepted cost: returning directly also discards a `sawHardRejection` from an earlier
+         * attempt in the same loop, so a real 401 followed by a gateway block keeps a dead session.
+         */
+        data object GatewayBlocked : RefreshAttempt
     }
 
     companion object {

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/ConfigRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/ConfigRepositoryImpl.kt
@@ -3,7 +3,9 @@ package com.garfiec.librechat.core.data.repository
 import co.touchlab.kermit.Logger
 import com.garfiec.librechat.core.common.BackendVersion
 import com.garfiec.librechat.core.common.generated.BackendCommitMap
+import com.garfiec.librechat.core.common.result.AccessGatewayException
 import com.garfiec.librechat.core.common.result.ApiException
+import com.garfiec.librechat.core.common.result.FailureKind
 import com.garfiec.librechat.core.common.result.Result
 import com.garfiec.librechat.core.common.result.safeApiCall
 import com.garfiec.librechat.core.data.datastore.ConfigCacheDataStore
@@ -110,6 +112,17 @@ class ConfigRepositoryImpl(
             Result.Error(e, message)
         } catch (e: HttpRequestTimeoutException) {
             Result.Error(e, "Connection timed out. Check the URL and try again.")
+        } catch (e: AccessGatewayException) {
+            // Must stay above the blanket catch, which would call a reachable-and-answering gateway a
+            // connection problem. Worded here rather than via FailureKind.message(): both callers are
+            // the pre-login server screen, and the shared wording points at Settings — which needs
+            // the sign-in the gateway is blocking.
+            Result.Error(
+                exception = e,
+                message = "Your server's access gateway rejected this request. " +
+                    "Check the gateway headers under Advanced.",
+                kind = FailureKind.AccessGateway,
+            )
         } catch (e: Exception) {
             Result.Error(e, "Could not reach the server. Check the URL and your connection.")
         }

--- a/core/network/CLAUDE.md
+++ b/core/network/CLAUDE.md
@@ -83,6 +83,54 @@ Host-scoping for these is stricter than for the bearer (`isSameServerAuthority` 
 `isSameHostAsServer`, both in `HostScoping.kt`): scheme + host + port, and fail-closed. A gateway token
 is long-lived and never rotates, so an `http://` downgrade or an unknown base URL must not carry it.
 
+### Detecting the gateway (as opposed to sending headers to it)
+
+`GatewayDetectionPlugin` turns a rejection into a typed `AccessGatewayException`, and is installed on
+**all three** Ktor clients. `AccessGatewaySignal` holds the one predicate every transport shares.
+
+- **It must stay an `HttpSend` interceptor.** Ktor installs `HttpResponseValidator` before
+  `HttpRedirect` and reverses the `HttpSend` chain, so the validator is outermost and sees only the
+  final 200. The 302 carrying `WWW-Authenticate: Cloudflare-Access` is visible *inside* the redirect
+  loop and nowhere else. Moved to the validator, the branch is dead code no test would catch.
+- **Never read the body.** The interceptor runs for every response including streaming ones.
+- **Read every `WWW-Authenticate` line, not one of them.** It is a list, and a gateway in front of a
+  server that already challenges with `Bearer` puts its own challenge on a second line. The two
+  transports read the header from opposite ends by default — Ktor's `headers[name]` returns the
+  *first* line, a naive raw parser keeps the *last* — so either one alone detects a two-line
+  challenge only when it happens to land on the line that transport kept. Ktor scans `getAll(...)`;
+  `HttpResponseParser` folds repeats into one comma-separated value per RFC 7230 §3.2.2. A shared
+  predicate does not make the transports agree if they disagree about what to feed it.
+- **Install it on every new client.** The absence is silent and platform-specific:
+  `GatewayDetectionInstallTest` asserts the presence on all three from the real Koin graph, because a
+  per-client test installs the plugin itself and so can never observe it missing from the module.
+- **Cloudflare Access only, deliberately.** Cookie-based gateways (Authelia, oauth2-proxy) send no
+  comparable header and degrade to the generic message. The rejected alternative — inferring a gateway
+  from `text/html` served off the server's authority — has to stay correct against every legitimate
+  off-authority redirect the app makes (presigned downloads, object storage). Reconsider on a real
+  report, not pre-emptively.
+- **Terminal, never retried — and that takes three separate opt-outs, not one.** A rejection is
+  deterministic until the user edits the credential, so a backoff ladder only delays the report and
+  then names the wrong cause. `SseClient` and the refresh loop each exit on it, *and*
+  `configureRetryPolicy` excludes it from `retryOnExceptionIf`: `HttpRequestRetry` is installed
+  before `GatewayDetectionPlugin` and Ktor runs the first-installed `HttpSend` interceptor outermost,
+  so it sees the thrown exception and would re-send every retry-safe GET. Excluded in the predicate
+  rather than by install order, so the plugin stays outermost for the transient failures it exists
+  to absorb.
+- **Match the gateway error on the cause chain, not the exception type.** `SseClient` learns of it by
+  the byte channel being cancelled with it, and Ktor re-throws that wrapped in a
+  `ClosedByteChannelException` — which form arrives depends on whether the parse side or the pump job
+  loses the race to fail the scope. A type-exact `catch` therefore works most of the time, which is
+  the worst failure rate to debug: use `accessGatewayCause()`.
+- **A gateway block is not an expired session.** The refresh path maps it to
+  `RefreshAttempt.GatewayBlocked` → `Transient`, and deliberately not through `settle()`: the request
+  never reached LibreChat, so it is no evidence the session is dead, and logging out over it costs the
+  user a re-login on top of the header fix. Nothing is surfaced from there — every other request rides
+  the main client, which raises the same typed error on the screen the user is looking at.
+
+The iOS SSE transport is not a Ktor client and carries its own check against `AccessGatewaySignal`,
+placed **before** its status check: a rejection is a non-2xx, so left to the status branch it becomes a
+bare `SseHttpStatusException(302)` that `SseClient` retries five times before blaming the network.
+
 The editor UI is shared: `CustomHeadersEditor` in `:core:ui` backs both the pre-login server screen
 (`feature/auth`) and the post-login Settings → Account → Server connection dialog (`feature/settings`),
 and its strings live in `core/ui`'s `composeResources`. `:core:ui` deliberately does **not** depend on

--- a/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/client/GatewayDetectionPluginTest.kt
+++ b/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/client/GatewayDetectionPluginTest.kt
@@ -5,6 +5,7 @@ import com.google.common.truth.Truth.assertThat
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.HttpRequestRetry
 import io.ktor.client.request.get
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpHeaders
@@ -32,14 +33,8 @@ class GatewayDetectionPluginTest {
             "Cloudflare-Access resource_metadata=\"https://chat.example.com/.well-known\""
     }
 
-    private class FakeServerUrlProvider(private val baseUrl: String) : ServerUrlProvider {
-        override fun getBaseUrl(): String = baseUrl
-    }
-
     private fun clientWith(engine: MockEngine): HttpClient = HttpClient(engine) {
-        install(GatewayDetectionPlugin) {
-            serverUrlProvider = FakeServerUrlProvider(SERVER)
-        }
+        install(GatewayDetectionPlugin)
     }
 
     /**
@@ -68,7 +63,6 @@ class GatewayDetectionPluginTest {
             clientWith(engine).get("$SERVER/api/config")
         }
 
-        assertThat(failure.serverUrl).isEqualTo(SERVER)
         // The gateway's URL and JWT must not ride along on the exception the UI classifies.
         assertThat(failure.message.orEmpty()).doesNotContain("cloudflareaccess")
         assertThat(failure.message.orEmpty()).doesNotContain("meta=")
@@ -121,5 +115,54 @@ class GatewayDetectionPluginTest {
 
         assertThat(clientWith(engine).get("$SERVER/api/config").status)
             .isEqualTo(HttpStatusCode.Unauthorized)
+    }
+
+    /**
+     * Both plugins installed in the real client's order, because the ordering is the bug: Ktor runs
+     * the first-installed `HttpSend` interceptor outermost, so `HttpRequestRetry` sees the thrown
+     * exception and re-sends. A test that installs only the detection plugin passes either way.
+     */
+    @Test
+    fun `a gateway rejection is not retried by the retry plugin`() = runTest {
+        var requests = 0
+        val engine = MockEngine {
+            requests++
+            respond(
+                content = "",
+                status = HttpStatusCode.Found,
+                headers = headersOf(
+                    HttpHeaders.WWWAuthenticate to listOf(CF_CHALLENGE),
+                    HttpHeaders.Location to listOf(ACCESS_LOGIN),
+                ),
+            )
+        }
+        val client = HttpClient(engine) {
+            install(HttpRequestRetry) { configureRetryPolicy() }
+            install(GatewayDetectionPlugin)
+        }
+
+        assertFailsWith<AccessGatewayException> { client.get("$SERVER/api/config") }
+
+        assertThat(requests).isEqualTo(1)
+    }
+
+    /**
+     * Ktor's `headers[name]` hands back only the first line. `AccessGatewaySignalTest` cannot reach
+     * this: the predicate is given one already-chosen value, and choosing the wrong one is the bug.
+     */
+    @Test
+    fun `the challenge is found when it arrives on a second header line`() = runTest {
+        val engine = MockEngine {
+            respond(
+                content = "",
+                status = HttpStatusCode.Found,
+                headers = headersOf(
+                    HttpHeaders.WWWAuthenticate to listOf("Bearer realm=\"api\"", CF_CHALLENGE),
+                    HttpHeaders.Location to listOf(ACCESS_LOGIN),
+                ),
+            )
+        }
+
+        assertFailsWith<AccessGatewayException> { clientWith(engine).get("$SERVER/api/config") }
     }
 }

--- a/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/di/GatewayDetectionInstallTest.kt
+++ b/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/di/GatewayDetectionInstallTest.kt
@@ -1,0 +1,103 @@
+package com.garfiec.librechat.core.network.di
+
+import com.garfiec.librechat.core.common.di.KoinQualifiers
+import com.garfiec.librechat.core.common.identity.AccountId
+import com.garfiec.librechat.core.common.identity.AccountState
+import com.garfiec.librechat.core.common.identity.ActiveAccountProvider
+import com.garfiec.librechat.core.common.identity.InMemoryActiveAccountProvider
+import com.garfiec.librechat.core.logging.redact.LogRedactor
+import com.garfiec.librechat.core.network.client.GatewayDetectionPlugin
+import com.garfiec.librechat.core.network.client.RefreshResult
+import com.garfiec.librechat.core.network.client.ServerHeadersProvider
+import com.garfiec.librechat.core.network.client.ServerUrlProvider
+import com.garfiec.librechat.core.network.client.TokenManager
+import com.google.common.truth.Truth.assertThat
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.pluginOrNull
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import org.junit.After
+import org.junit.Test
+import org.koin.core.KoinApplication
+import org.koin.core.qualifier.Qualifier
+import org.koin.dsl.koinApplication
+import org.koin.dsl.module
+
+/**
+ * Which clients carry gateway detection, asserted on the graph the app actually builds. Nothing else
+ * in the suite can notice a missing install: a per-client test installs the plugin itself.
+ */
+class GatewayDetectionInstallTest {
+
+    private var app: KoinApplication? = null
+
+    @After
+    fun tearDown() {
+        app?.close()
+    }
+
+    private class FakeServerUrlProvider : ServerUrlProvider {
+        override fun getBaseUrl(): String = "https://chat.example.com"
+    }
+
+    private class FakeServerHeadersProvider : ServerHeadersProvider {
+        override suspend fun awaitWarm() = Unit
+        override fun headersFor(baseUrl: String): Map<String, String> = emptyMap()
+    }
+
+    private class FakeTokenManager : TokenManager {
+        private val expired = MutableSharedFlow<Unit>()
+        override val sessionExpiredFlow: SharedFlow<Unit> = expired
+        override val isAuthenticated: Boolean = false
+        override suspend fun getAccessToken(): String? = null
+        override suspend fun setTokens(accessToken: String, refreshToken: String) = Unit
+        override suspend fun refreshAccessToken(): RefreshResult = RefreshResult.Transient
+        override suspend fun clearTokens() = Unit
+        override suspend fun getAccessTokenFor(accountId: String): String? = null
+        override suspend fun getStagedAccessToken(): String? = null
+        override suspend fun clearStagedTokens() = Unit
+        override suspend fun selectAccount(accountId: String) = Unit
+        override suspend fun removeAccount(accountId: String) = Unit
+        override suspend fun refreshAccessTokenFor(accountId: String, baseUrl: String): RefreshResult =
+            RefreshResult.Transient
+
+        override suspend fun onAccountResolved(accountId: String) = Unit
+        override fun emitSessionExpired(expiredAccountId: String?) = Unit
+    }
+
+    private fun client(qualifier: Qualifier?): HttpClient {
+        val koin = app ?: koinApplication {
+            modules(
+                networkModule,
+                module {
+                    single<ServerUrlProvider> { FakeServerUrlProvider() }
+                    single<ServerHeadersProvider> { FakeServerHeadersProvider() }
+                    single<TokenManager> { FakeTokenManager() }
+                    // Bound in :core:data and :core:logging in the real graph.
+                    single<ActiveAccountProvider> {
+                        InMemoryActiveAccountProvider(AccountState.Resolved(AccountId("srv-1:user-a")))
+                    }
+                    single { LogRedactor() }
+                },
+            )
+        }.also { app = it }
+        return if (qualifier == null) koin.koin.get() else koin.koin.get(qualifier)
+    }
+
+    @Test
+    fun `the main client detects gateway rejections`() {
+        assertThat(client(null).pluginOrNull(GatewayDetectionPlugin)).isNotNull()
+    }
+
+    /** Without it the sign-in page reaches the SSE parser and the chat hangs with no error at all. */
+    @Test
+    fun `the streaming client detects gateway rejections`() {
+        assertThat(client(KoinQualifiers.Streaming).pluginOrNull(GatewayDetectionPlugin)).isNotNull()
+    }
+
+    /** Without it the gateway's 302 classifies as a transient server error and the session never recovers. */
+    @Test
+    fun `the refresh client detects gateway rejections`() {
+        assertThat(client(KoinQualifiers.Refresh).pluginOrNull(GatewayDetectionPlugin)).isNotNull()
+    }
+}

--- a/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/sse/SseClientGatewayTest.kt
+++ b/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/sse/SseClientGatewayTest.kt
@@ -1,0 +1,145 @@
+package com.garfiec.librechat.core.network.sse
+
+import com.garfiec.librechat.core.common.identity.AccountId
+import com.garfiec.librechat.core.common.identity.AccountState
+import com.garfiec.librechat.core.common.identity.InMemoryActiveAccountProvider
+import com.garfiec.librechat.core.common.result.AccessGatewayException
+import com.garfiec.librechat.core.model.StreamEvent
+import com.garfiec.librechat.core.network.client.GatewayDetectionPlugin
+import com.google.common.truth.Truth.assertThat
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.MockEngineConfig
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.defaultRequest
+import io.ktor.client.request.url
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.utils.io.ClosedByteChannelException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import org.junit.Test
+
+/**
+ * The streaming path's gateway behaviour, end to end: detection plugin → transport → [SseClient].
+ *
+ * Asserted end to end rather than on the plugin alone because every part of it is a composition
+ * property: a plugin that throws correctly still hangs the chat if it is installed on the wrong
+ * client, and an [SseClient] that lacks the gateway arm still burns the full retry ladder.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class SseClientGatewayTest {
+
+    private companion object {
+        const val SERVER = "https://chat.example.com"
+        const val ACCESS_LOGIN =
+            "https://team.cloudflareaccess.com/cdn-cgi/access/login/chat.example.com?meta=eyJhbGci"
+        const val CF_CHALLENGE = "Cloudflare-Access"
+    }
+
+    /**
+     * The server 302s with the Access challenge; the redirect target serves the sign-in page as a
+     * 200. Pinned to `Dispatchers.Unconfined` for the same reason as `SseClientOriginBindingTest` —
+     * a handler on a real thread lets `runTest` fast-forward virtual time into the stall watchdog.
+     */
+    private fun gatewayClient(onRequest: () -> Unit): HttpClient {
+        val engine = MockEngine(
+            MockEngineConfig().apply {
+                dispatcher = Dispatchers.Unconfined
+                addHandler { request ->
+                    if (request.url.host == "chat.example.com") {
+                        onRequest()
+                        respond(
+                            content = "",
+                            status = HttpStatusCode.Found,
+                            headers = headersOf(
+                                HttpHeaders.Location to listOf(ACCESS_LOGIN),
+                                HttpHeaders.WWWAuthenticate to listOf(CF_CHALLENGE),
+                            ),
+                        )
+                    } else {
+                        respond(
+                            content = "<html>sign in</html>",
+                            status = HttpStatusCode.OK,
+                            headers = headersOf(HttpHeaders.ContentType to listOf("text/html")),
+                        )
+                    }
+                }
+            },
+        )
+        return HttpClient(engine) {
+            install(GatewayDetectionPlugin)
+            defaultRequest { url(SERVER) }
+        }
+    }
+
+    @Test
+    fun `a gateway-blocked stream reports the gateway instead of hanging`() = runTest(UnconfinedTestDispatcher()) {
+        var requestCount = 0
+        val client = SseClient(
+            json = Json { ignoreUnknownKeys = true },
+            transport = SseHttpTransport(gatewayClient { requestCount++ }),
+            activeAccountProvider = InMemoryActiveAccountProvider(AccountState.Resolved(AccountId("srv-1:user-a"))),
+        )
+
+        val events = client.connect("api/agents/chat/stream/abc").toList()
+
+        val errors = events.filterIsInstance<StreamEvent.Error>()
+        assertThat(errors).hasSize(1)
+        // Substance, not the whole string: it must name the gateway and point somewhere actionable.
+        assertThat(errors.single().message).contains("gateway")
+        assertThat(errors.single().message).contains("Settings")
+        // Not a network blip — offering a retry affordance here would retry into the same rejection.
+        assertThat(errors.single().isNetworkError).isFalse()
+    }
+
+    /**
+     * The wrapped form: the transport cancels the byte channel with the error and Ktor hands it back
+     * inside a `ClosedByteChannelException`, so a type-exact catch is race-dependent.
+     *
+     * Injected rather than raced, because the tests above cannot produce this shape at all —
+     * MockEngine on an unconfined dispatcher fails the transport before the parse loop suspends.
+     */
+    @Test
+    fun `a gateway error wrapped by the channel close is still terminal`() = runTest(UnconfinedTestDispatcher()) {
+        val engine = MockEngine(
+            MockEngineConfig().apply {
+                dispatcher = Dispatchers.Unconfined
+                addHandler { throw ClosedByteChannelException(AccessGatewayException()) }
+            },
+        )
+        val client = SseClient(
+            json = Json { ignoreUnknownKeys = true },
+            transport = SseHttpTransport(HttpClient(engine) { defaultRequest { url(SERVER) } }),
+            activeAccountProvider = InMemoryActiveAccountProvider(AccountState.Resolved(AccountId("srv-1:user-a"))),
+        )
+
+        val events = client.connect("api/agents/chat/stream/abc").toList()
+
+        val errors = events.filterIsInstance<StreamEvent.Error>()
+        assertThat(errors).hasSize(1)
+        assertThat(errors.single().message).contains("gateway")
+        assertThat(events.filterIsInstance<StreamEvent.Retrying>()).isEmpty()
+    }
+
+    /** The generic arm would retry five times with backoff and then report the wrong cause. */
+    @Test
+    fun `a gateway-blocked stream is not retried`() = runTest(UnconfinedTestDispatcher()) {
+        var requestCount = 0
+        val client = SseClient(
+            json = Json { ignoreUnknownKeys = true },
+            transport = SseHttpTransport(gatewayClient { requestCount++ }),
+            activeAccountProvider = InMemoryActiveAccountProvider(AccountState.Resolved(AccountId("srv-1:user-a"))),
+        )
+
+        val events = client.connect("api/agents/chat/stream/abc").toList()
+
+        assertThat(requestCount).isEqualTo(1)
+        assertThat(events.filterIsInstance<StreamEvent.Retrying>()).isEmpty()
+    }
+}

--- a/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/AccessGatewaySignal.kt
+++ b/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/AccessGatewaySignal.kt
@@ -1,0 +1,21 @@
+package com.garfiec.librechat.core.network.client
+
+/**
+ * The single definition of "an access gateway answered this, not the server" (issue #287).
+ *
+ * Must stay the only copy: the Ktor plugin and the iOS raw-socket SSE transport share nothing else,
+ * and a second copy would let one platform drift and go quietly undetected. Cloudflare Access only —
+ * see `core/network/CLAUDE.md` for why cookie-based gateways are out of scope.
+ */
+internal object AccessGatewaySignal {
+
+    /** The `WWW-Authenticate` scheme Cloudflare Access answers a rejected request with. */
+    const val SCHEME = "Cloudflare-Access"
+
+    /**
+     * Whether a `WWW-Authenticate` value is a gateway challenge. Substring, not equality: the header
+     * is a comma-separated list and the scheme may carry parameters.
+     */
+    fun isGatewayChallenge(wwwAuthenticate: String?): Boolean =
+        wwwAuthenticate?.contains(SCHEME, ignoreCase = true) == true
+}

--- a/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/GatewayDetectionPlugin.kt
+++ b/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/GatewayDetectionPlugin.kt
@@ -8,9 +8,6 @@ import io.ktor.client.plugins.plugin
 import io.ktor.http.HttpHeaders
 import io.ktor.util.AttributeKey
 
-/** The `WWW-Authenticate` scheme Cloudflare Access answers a rejected request with. */
-private const val CLOUDFLARE_ACCESS_SCHEME = "Cloudflare-Access"
-
 /**
  * Turns an access gateway's interception into a typed [AccessGatewayException] (issue #287).
  *
@@ -29,34 +26,34 @@ private const val CLOUDFLARE_ACCESS_SCHEME = "Cloudflare-Access"
  * - **Status is useless.** Following the redirect yields **200** `text/html`, so nothing
  *   status-based ever fires — which is why `HttpResponseValidator` cannot do this job.
  *
- * Installed on the main client only, so it covers config, auth, user and the chat POST. The SSE and
- * refresh clients are not covered and fail differently: a hung stream, and a silently unrecoverable
- * session.
+ * Install on **every** Ktor client — main, streaming and refresh. Each fails silently and
+ * differently without it; `GatewayDetectionInstallTest` pins the set. The iOS SSE transport is not a
+ * Ktor client and carries its own check against [AccessGatewaySignal].
  *
- * A gateway that is not Cloudflare Access (Authelia, oauth2-proxy) does not set this header; those
- * still degrade to the generic "unexpected response from the server" rather than leaking anything.
+ * The exception deliberately carries **no server identity**: the live base URL is the wrong server
+ * for a pinned multi-account refresh, and the SSE snapshot's URL is untrimmed. Add one back only
+ * from the pinned URL, alongside the thing that displays it.
  */
-class GatewayDetectionPlugin private constructor(
-    private val serverUrlProvider: ServerUrlProvider?,
-) {
-    class Config {
-        var serverUrlProvider: ServerUrlProvider? = null
-    }
+class GatewayDetectionPlugin private constructor() {
+
+    class Config
 
     companion object : HttpClientPlugin<Config, GatewayDetectionPlugin> {
         override val key = AttributeKey<GatewayDetectionPlugin>("GatewayDetection")
 
         override fun prepare(block: Config.() -> Unit): GatewayDetectionPlugin =
-            GatewayDetectionPlugin(Config().apply(block).serverUrlProvider)
+            GatewayDetectionPlugin()
 
         override fun install(plugin: GatewayDetectionPlugin, scope: HttpClient) {
             scope.plugin(HttpSend).intercept { request ->
                 val call = execute(request)
-                val wwwAuthenticate = call.response.headers[HttpHeaders.WWWAuthenticate].orEmpty()
-                if (wwwAuthenticate.contains(CLOUDFLARE_ACCESS_SCHEME, ignoreCase = true)) {
+                // Every line, not `headers[...]`: that returns only the first, and a gateway fronting
+                // a server that already answers 401 with `Bearer` puts its challenge on a second line.
+                val challenges = call.response.headers.getAll(HttpHeaders.WWWAuthenticate)
+                if (challenges?.any(AccessGatewaySignal::isGatewayChallenge) == true) {
                     // Thrown from inside the redirect loop, so it surfaces instead of the sign-in
                     // page the redirect would otherwise deliver as a perfectly valid 200.
-                    throw AccessGatewayException(serverUrl = plugin.serverUrlProvider?.getBaseUrl())
+                    throw AccessGatewayException()
                 }
                 call
             }

--- a/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/LibreChatHttpClient.kt
+++ b/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/LibreChatHttpClient.kt
@@ -1,6 +1,7 @@
 package com.garfiec.librechat.core.network.client
 
 import co.touchlab.kermit.Logger
+import com.garfiec.librechat.core.common.result.AccessGatewayException
 import com.garfiec.librechat.core.logging.Diag
 import com.garfiec.librechat.core.logging.LogOrigin
 import com.garfiec.librechat.core.logging.redact.LogRedactor
@@ -97,9 +98,7 @@ object LibreChatHttpClient {
 
         // Must see the gateway's own 302, so it has to be inside the redirect loop — following that
         // redirect yields a 200 sign-in page, which no status-based check can catch.
-        install(GatewayDetectionPlugin) {
-            this.serverUrlProvider = serverUrlProvider
-        }
+        install(GatewayDetectionPlugin)
 
         // The SwitchBarrierPlugin (when a SwitchGate is wired) captures a consistent
         // (url, bearer, account) snapshot per request and resolves the URL against it, subsuming
@@ -220,7 +219,12 @@ internal fun HttpRequestRetryConfig.configureRetryPolicy() {
         request.method.isRetrySafe() && response.status.value in 500..599
     }
     retryOnExceptionIf(maxRetries = 2) { request, cause ->
-        request.method.isRetrySafe() && cause !is kotlinx.coroutines.CancellationException
+        request.method.isRetrySafe() &&
+            cause !is kotlinx.coroutines.CancellationException &&
+            // Deterministic until the user edits the credential, so retrying only delays the report.
+            // Excluded here rather than by install order: this plugin is installed first and so runs
+            // outermost, which it must stay for the transient failures it exists to absorb.
+            cause !is AccessGatewayException
     }
     exponentialDelay()
 }

--- a/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/di/NetworkModule.kt
+++ b/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/di/NetworkModule.kt
@@ -30,6 +30,7 @@ import com.garfiec.librechat.core.network.api.SpeechApi
 import com.garfiec.librechat.core.network.api.TagsApi
 import com.garfiec.librechat.core.network.api.UserApi
 import com.garfiec.librechat.core.network.client.AuthInterceptorPlugin
+import com.garfiec.librechat.core.network.client.GatewayDetectionPlugin
 import com.garfiec.librechat.core.network.client.LibreChatHttpClient
 import com.garfiec.librechat.core.network.client.ServerHeadersPlugin
 import com.garfiec.librechat.core.network.client.ServerHeadersProvider
@@ -113,6 +114,9 @@ val networkModule = module {
                 this.serverHeadersProvider = serverHeadersProvider
                 this.serverUrlProvider = serverUrlProvider
             }
+            // No HttpResponseValidator here, so without this the gateway's 302→200 sign-in page
+            // reaches the SSE parser as a valid response and the chat hangs with no error.
+            install(GatewayDetectionPlugin)
             install(SwitchBarrierPlugin) {
                 this.switchGate = switchGate
             }
@@ -139,9 +143,10 @@ val networkModule = module {
             }
             // `/api/auth/refresh` is gated by the access gateway like every other route, and this
             // client has neither a SwitchBarrier snapshot nor an AuthInterceptor to hang an append on.
-            // Without this the session dies at the first refresh: the gateway's 302→200 HTML
-            // deserializes as garbage, which `performRefresh` classifies as Retryable — so it never
-            // routes to re-auth and never recovers, it just silently stops working.
+            // Without this the session dies at the first refresh: refresh is a POST, which Ktor does
+            // not redirect, so the gateway's bare 302 falls to `performRefresh`'s catch-all arm and
+            // classifies as Retryable — it never routes to re-auth and never recovers, it just
+            // silently stops working.
             //
             // ServerUrlReadyPlugin could not host this: it intercepts before HttpRequestPipeline.Before,
             // where `context.url.host` is still empty and no host-scoping is possible.
@@ -149,6 +154,9 @@ val networkModule = module {
                 this.serverHeadersProvider = serverHeadersProvider
                 this.serverUrlProvider = serverUrlProvider
             }
+            // Detection reads the challenge off that 302 directly, so it does not depend on the
+            // redirect being followed — which on a POST it is not. See RefreshAttempt.GatewayBlocked.
+            install(GatewayDetectionPlugin)
             install(HttpTimeout) {
                 requestTimeoutMillis = 15_000
                 connectTimeoutMillis = 10_000

--- a/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/sse/HttpResponseParser.kt
+++ b/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/sse/HttpResponseParser.kt
@@ -176,9 +176,11 @@ class HttpResponseParser {
         }
         val name = line.substring(0, colon).trim().lowercase()
         val value = line.substring(colon + 1).trim()
-        // Duplicate headers: last-wins is fine for what we use (Content-Length,
-        // Transfer-Encoding, Content-Type). No need to handle comma-folded duplicates.
-        headers[name] = value
+        // Repeated field lines fold into one comma-separated value (RFC 7230 §3.2.2). Not last-wins:
+        // the gateway check reads `WWW-Authenticate`, which is a list and can carry the Access
+        // challenge on any line — dropping a line makes a blocked stream look healthy.
+        val existing = headers[name]
+        headers[name] = if (existing == null) value else "$existing, $value"
         return true
     }
 

--- a/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/sse/SseClient.kt
+++ b/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/sse/SseClient.kt
@@ -3,6 +3,9 @@ package com.garfiec.librechat.core.network.sse
 import co.touchlab.kermit.Logger
 import com.garfiec.librechat.core.common.identity.ActiveAccountProvider
 import com.garfiec.librechat.core.common.identity.currentAccountId
+import com.garfiec.librechat.core.common.result.AccessGatewayException
+import com.garfiec.librechat.core.common.result.FailureKind
+import com.garfiec.librechat.core.common.result.message
 import com.garfiec.librechat.core.logging.Diag
 import com.garfiec.librechat.core.logging.LogOrigin
 import com.garfiec.librechat.core.model.StreamEvent
@@ -146,16 +149,31 @@ class SseClient(
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
-                Diag.w(
-                    "SSE",
-                    origin = LogOrigin.NETWORK,
-                    throwable = e,
-                    attrs = mapOf("attempt" to attempt.toString()),
-                ) { "SSE connection error" }
-                attempt++
-                if (attempt > maxRetries) {
-                    emit(StreamEvent.Error(message = "Connection failed. Please try again."))
+                // Cause chain, never a type-exact `catch`: the transport reports by cancelling the
+                // byte channel, which Ktor re-throws wrapped, and which form arrives is a race.
+                val gateway = e.accessGatewayCause()
+                if (gateway != null) {
+                    Diag.w(
+                        "SSE",
+                        origin = LogOrigin.NETWORK,
+                        throwable = gateway,
+                        attrs = mapOf("attempt" to attempt.toString()),
+                    ) { "SSE blocked by access gateway" }
+                    // Terminal — every remaining attempt would be rejected by the same gateway.
+                    emit(StreamEvent.Error(message = FailureKind.AccessGateway.message()))
                     done = true
+                } else {
+                    Diag.w(
+                        "SSE",
+                        origin = LogOrigin.NETWORK,
+                        throwable = e,
+                        attrs = mapOf("attempt" to attempt.toString()),
+                    ) { "SSE connection error" }
+                    attempt++
+                    if (attempt > maxRetries) {
+                        emit(StreamEvent.Error(message = "Connection failed. Please try again."))
+                        done = true
+                    }
                 }
             }
 
@@ -192,3 +210,20 @@ class SseClient(
         }
     }
 }
+
+/**
+ * The [AccessGatewayException] at or beneath this throwable, or null. The failure reaches the stream
+ * loop either raw or wrapped by whatever cancelled the byte channel — see the call site. Bounded, so
+ * a looping cause chain cannot spin here.
+ */
+private fun Throwable.accessGatewayCause(): AccessGatewayException? {
+    var current: Throwable? = this
+    repeat(CAUSE_TRAVERSAL_LIMIT) {
+        val error = current ?: return null
+        if (error is AccessGatewayException) return error
+        current = error.cause?.takeIf { it !== error }
+    }
+    return null
+}
+
+private const val CAUSE_TRAVERSAL_LIMIT = 8

--- a/core/network/src/commonTest/kotlin/com/garfiec/librechat/core/network/client/AccessGatewaySignalTest.kt
+++ b/core/network/src/commonTest/kotlin/com/garfiec/librechat/core/network/client/AccessGatewaySignalTest.kt
@@ -1,0 +1,55 @@
+package com.garfiec.librechat.core.network.client
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The predicate every transport's gateway check routes through — these cases pin what the Ktor
+ * clients and the iOS raw-socket transport agree counts as a rejection.
+ */
+class AccessGatewaySignalTest {
+
+    @Test
+    fun `the bare scheme is a challenge`() {
+        assertTrue(AccessGatewaySignal.isGatewayChallenge("Cloudflare-Access"))
+    }
+
+    /** What the live rig actually sends: the scheme followed by parameters. */
+    @Test
+    fun `the scheme with parameters is a challenge`() {
+        assertTrue(
+            AccessGatewaySignal.isGatewayChallenge(
+                "Cloudflare-Access resource_metadata=\"https://chat.example.com/.well-known\"",
+            ),
+        )
+    }
+
+    /** The header is a comma-separated list, so matching only a prefix would miss the gateway. */
+    @Test
+    fun `the scheme is found when it is not the first challenge listed`() {
+        assertTrue(AccessGatewaySignal.isGatewayChallenge("Basic realm=\"x\", Cloudflare-Access"))
+    }
+
+    @Test
+    fun `matching is case-insensitive`() {
+        assertTrue(AccessGatewaySignal.isGatewayChallenge("cloudflare-access"))
+    }
+
+    /** The header is absent on every successful response, so a null must never read as a rejection. */
+    @Test
+    fun `an absent header is not a challenge`() {
+        assertFalse(AccessGatewaySignal.isGatewayChallenge(null))
+        assertFalse(AccessGatewaySignal.isGatewayChallenge(""))
+    }
+
+    /**
+     * LibreChat's own 401s carry `Bearer` — treating those as a gateway block would send a user with
+     * an ordinary expired session to edit headers that are fine.
+     */
+    @Test
+    fun `an unrelated challenge is not a gateway block`() {
+        assertFalse(AccessGatewaySignal.isGatewayChallenge("Bearer realm=\"api\""))
+        assertFalse(AccessGatewaySignal.isGatewayChallenge("Basic realm=\"proxy\""))
+    }
+}

--- a/core/network/src/commonTest/kotlin/com/garfiec/librechat/core/network/sse/HttpResponseParserTest.kt
+++ b/core/network/src/commonTest/kotlin/com/garfiec/librechat/core/network/sse/HttpResponseParserTest.kt
@@ -1,5 +1,6 @@
 package com.garfiec.librechat.core.network.sse
 
+import com.garfiec.librechat.core.network.client.AccessGatewaySignal
 import com.garfiec.librechat.core.network.sse.HttpResponseParser.ParseEvent
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -271,5 +272,54 @@ class HttpResponseParserTest {
         assertEquals(2, bodyChunks.size)
         assertEquals("foo", bodyChunks[0].bytes.decodeToString())
         assertEquals("bar", bodyChunks[1].bytes.decodeToString())
+    }
+
+    /** Repeated field lines fold into one comma-separated value (RFC 7230 §3.2.2), not last-wins. */
+    @Test
+    fun repeatedHeaderLinesFoldIntoOneValue() {
+        val parser = HttpResponseParser()
+        val events = parser.feed(
+            (
+                "HTTP/1.1 302 Found\r\n" +
+                    "WWW-Authenticate: Bearer realm=\"api\"\r\n" +
+                    "WWW-Authenticate: Cloudflare-Access\r\n" +
+                    "\r\n"
+                ).bytes(),
+        )
+
+        val headers = events.filterIsInstance<ParseEvent.HeadersComplete>().single()
+        assertEquals("Bearer realm=\"api\", Cloudflare-Access", headers.headers["www-authenticate"])
+    }
+
+    /**
+     * Why the fold matters: the gateway check reads this header, and dropping a line makes a blocked
+     * stream indistinguishable from a healthy one — no events, no error, no cause.
+     */
+    @Test
+    fun aFoldedChallengeIsStillRecognisedWhicheverLineCarriesIt() {
+        fun challengeValue(first: String, second: String): String? {
+            val parser = HttpResponseParser()
+            val events = parser.feed(
+                (
+                    "HTTP/1.1 302 Found\r\n" +
+                        "WWW-Authenticate: $first\r\n" +
+                        "WWW-Authenticate: $second\r\n" +
+                        "\r\n"
+                    ).bytes(),
+            )
+            return events.filterIsInstance<ParseEvent.HeadersComplete>().single()
+                .headers["www-authenticate"]
+        }
+
+        assertTrue(
+            AccessGatewaySignal.isGatewayChallenge(
+                challengeValue("Bearer realm=\"api\"", "Cloudflare-Access"),
+            ),
+        )
+        assertTrue(
+            AccessGatewaySignal.isGatewayChallenge(
+                challengeValue("Cloudflare-Access", "Bearer realm=\"api\""),
+            ),
+        )
     }
 }

--- a/core/network/src/iosMain/kotlin/com/garfiec/librechat/core/network/sse/SseHttpTransport.ios.kt
+++ b/core/network/src/iosMain/kotlin/com/garfiec/librechat/core/network/sse/SseHttpTransport.ios.kt
@@ -1,6 +1,8 @@
 package com.garfiec.librechat.core.network.sse
 
 import co.touchlab.kermit.Logger
+import com.garfiec.librechat.core.common.result.AccessGatewayException
+import com.garfiec.librechat.core.network.client.AccessGatewaySignal
 import com.garfiec.librechat.core.network.client.BearerResult
 import com.garfiec.librechat.core.network.client.LibreChatHttpClient
 import com.garfiec.librechat.core.network.client.SwitchGate
@@ -272,6 +274,14 @@ actual class SseHttpTransport(
                         for (event in events) {
                             when (event) {
                                 is HttpResponseParser.ParseEvent.HeadersComplete -> {
+                                    // Must stay above the status check: a rejection is a non-2xx, so
+                                    // below it the challenge is lost and it becomes a bare 302 that
+                                    // SseClient retries five times before blaming the network.
+                                    // Parser headers are lower-cased.
+                                    if (AccessGatewaySignal.isGatewayChallenge(event.headers["www-authenticate"])) {
+                                        handleError(AccessGatewayException())
+                                        return@nw_connection_receive
+                                    }
                                     if (event.statusCode !in SUCCESS_LOW..SUCCESS_HIGH) {
                                         handleError(SseHttpStatusException(event.statusCode))
                                         return@nw_connection_receive


### PR DESCRIPTION
## Summary

Detection of an access gateway answering in place of the server (#287) was installed on the main HTTP client only. The two clients it missed fail silently and differently: the streaming client issues a GET, so Ktor follows the rejection redirect to a 200 sign-in page and feeds the HTML to the SSE parser, and chat hangs with no error at all; the refresh client issues a POST, which Ktor does not redirect, so the bare 302 falls to `performRefresh`'s catch-all arm and classifies as a transient server error — the session stops working, retries the budget, and never reports why.

## Changes

- Install `GatewayDetectionPlugin` on the streaming and refresh clients. `GatewayDetectionInstallTest` asserts its presence on all three from the real Koin graph, since a per-client test installs the plugin itself and can never observe it missing.
- iOS SSE transport checks the Access challenge on the parsed response headers ahead of its status branch, so a rejection is not reported as a bare 302.
- `AccessGatewaySignal` — one predicate shared by the Ktor clients and the raw iOS transport. Detection reads every `WWW-Authenticate` field line, and `HttpResponseParser` folds repeated field lines into one comma-separated value (RFC 7230 §3.2.2); the two transports otherwise read the header from opposite ends and a two-line challenge is seen on only one platform.
- A rejection is terminal rather than retried: `SseClient` and the refresh loop stop on it, and on the main client `configureRetryPolicy` excludes the exception, since `HttpRequestRetry` is installed before the detection plugin and so runs outside it and would otherwise re-send every retry-safe request into the same refusal. (`HttpRequestRetry` is not installed on the other two clients.)
- `SseClient` matches on the cause chain, since the transport reports by cancelling the byte channel and Ktor re-throws the cause wrapped.
- Token refresh classifies a rejection as `RefreshAttempt.GatewayBlocked`, treated as transient: the request never reached the server, so it is not evidence the session is dead and must not force re-auth.
- The pre-login config probe reports a gateway rejection as such, pointing at the Advanced section on that screen, instead of falling into the blanket "could not reach the server" catch.
- `AccessGatewayException` no longer carries a server URL, and `FailureKind.message()` exposes the user-facing wording without `toSafeError`'s logging side effect.
- The SSE gateway error is emitted with `isNetworkError = false`, so the retry affordance the generic connection-failure arm offers is withheld — retrying reaches the same refusal.
- The header fold in `HttpResponseParser` applies to every header, not only `WWW-Authenticate`. The only header the parser consumes itself is `transfer-encoding`, matched with `contains("chunked")`, which folding leaves intact.
- `core/network/CLAUDE.md` gains a section recording the invariants: `HttpSend` rather than the validator, no body read, install on every client, and the three separate opt-outs that keep a rejection un-retried.

## Testing

- `:core:network`, `:core:data`, `:core:common` unit tests; `detekt`, `detektMetadataCommonMain`, `:app:assembleDebug`, and a Kotlin/Native compile of `:core:network`.
- Device-tested against a live Cloudflare Access deployment with an invalid service token: every main-client call reports the gateway, a chat send fails in ~100 ms with the gateway message rather than hanging, and no request is retried. Restoring a valid token returns the app to normal operation.

## Deliberate decisions

- A gateway block bypasses `settle()` in the refresh loop, which discards a hard rejection recorded by an earlier attempt: a real 401 on attempt 0 followed by a gateway block on attempt 1 keeps a session the server has already killed, and the user has no way to discover they must sign out and back in. That ordering needs the gateway credential to die inside a single retry loop against a session that expired moments earlier — preferred over the opposite error, which is logging people out of working sessions whenever a gateway hiccups.
- `AccessGatewayException` drops its `serverUrl`, and `GatewayDetectionPlugin.Config` is now empty. Nothing read the field, and the value has no unambiguous source once more than one transport raises the exception — the live base URL is the wrong server for a pinned multi-account refresh. Reintroduce it from the pinned URL only alongside something that displays it.

## Notes

- Detection keys on the Cloudflare Access challenge header. Cookie-based gateways (Authelia, oauth2-proxy) send no equivalent and continue to degrade to the generic message.
- The streaming and refresh paths were not exercised on device and rest on unit tests: chat's POST goes through the main client and fails first, so a uniformly-blocking gateway cannot reach the streaming GET, and the refresh path needs a token expiry during rejection. iOS was not device-tested.
- The new pre-login message is a hardcoded English string, matching the other messages in the same `when` — `:core:data` has no `composeResources`. It rides `FailureKind` so a UI layer can localize by kind later.
