### PR TITLE
feat(theme): change default accent color from lavender to turquoise

### DIFF
--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/ThemeDataStore.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/ThemeDataStore.kt
@@ -77,7 +77,7 @@ class ThemeDataStore(
         prefs[KEY_THEME].toThemeMode()
     }
 
-    /** Accent seed color as an ARGB int. Defaults to the lavender brand hue. */
+    /** Accent seed color as an ARGB int. Defaults to the turquoise brand hue. */
     val accentColor: Flow<Int> = dataStore.data.map { prefs ->
         prefs[KEY_ACCENT_COLOR] ?: DEFAULT_ACCENT_COLOR
     }
@@ -106,8 +106,8 @@ class ThemeDataStore(
     }
 
     companion object {
-        /** Lavender brand hue (ARGB) used when no accent has been chosen. */
-        val DEFAULT_ACCENT_COLOR: Int = 0xFF8B5CF6.toInt()
+        /** Turquoise brand hue (ARGB) used when no accent has been chosen. Matches `DefaultAccentSeed` in :core:ui. */
+        val DEFAULT_ACCENT_COLOR: Int = 0xFF00D8BB.toInt()
 
         private val KEY_THEME = stringPreferencesKey("theme_mode")
         private val KEY_ACCENT_COLOR = intPreferencesKey("accent_color")

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/ThemeDataStore.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/ThemeDataStore.kt
@@ -6,6 +6,7 @@ import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
+import com.garfiec.librechat.core.model.DEFAULT_ACCENT_SEED_ARGB
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
@@ -106,8 +107,12 @@ class ThemeDataStore(
     }
 
     companion object {
-        /** Turquoise brand hue (ARGB) used when no accent has been chosen. Matches `DefaultAccentSeed` in :core:ui. */
-        val DEFAULT_ACCENT_COLOR: Int = 0xFF00D8BB.toInt()
+        /**
+         * Turquoise brand hue (ARGB) used when no accent has been chosen. Derived from the
+         * canonical [DEFAULT_ACCENT_SEED_ARGB] in `:core:model`, same as `DefaultAccentSeed`
+         * in `:core:ui`.
+         */
+        val DEFAULT_ACCENT_COLOR: Int = DEFAULT_ACCENT_SEED_ARGB.toInt()
 
         private val KEY_THEME = stringPreferencesKey("theme_mode")
         private val KEY_ACCENT_COLOR = intPreferencesKey("accent_color")

--- a/core/model/src/commonMain/kotlin/com/garfiec/librechat/core/model/Constants.kt
+++ b/core/model/src/commonMain/kotlin/com/garfiec/librechat/core/model/Constants.kt
@@ -10,3 +10,12 @@ const val SAVED_TAG = "Saved"
  * (see AccountClaimDao.claimLegacyRows).
  */
 const val NEW_CHAT_DRAFT_KEY: String = "__new_chat__"
+
+/**
+ * Default accent seed color as `0xAARRGGBB` — the turquoise brand hue of the app icon's cable,
+ * sampled from the iOS 1024px icon asset. Canonical here in `:core:model` (the shared, pure-Kotlin
+ * module both consumers depend on) so the Compose seed (`DefaultAccentSeed` in `:core:ui`) and the
+ * persisted-preference fallback (`ThemeDataStore.DEFAULT_ACCENT_COLOR` in `:core:data`) derive from
+ * one literal and can never drift.
+ */
+const val DEFAULT_ACCENT_SEED_ARGB: Long = 0xFF00D8BB

--- a/core/ui/src/commonMain/kotlin/com/garfiec/librechat/core/ui/theme/AccentColors.kt
+++ b/core/ui/src/commonMain/kotlin/com/garfiec/librechat/core/ui/theme/AccentColors.kt
@@ -1,14 +1,14 @@
 package com.garfiec.librechat.core.ui.theme
 
 import androidx.compose.ui.graphics.Color
+import com.garfiec.librechat.core.model.DEFAULT_ACCENT_SEED_ARGB
 
 /**
- * The default accent seed color (the turquoise brand hue of the app icon's cable,
- * `0xFF00D8BB`, sampled from the iOS icon asset). Used to generate the Material 3
- * scheme when the user has not chosen a custom accent and wallpaper-based dynamic
- * color is off.
+ * The default accent seed color (the turquoise brand hue of the app icon, canonical value
+ * in [DEFAULT_ACCENT_SEED_ARGB]). Used to generate the Material 3 scheme when the user has
+ * not chosen a custom accent and wallpaper-based dynamic color is off.
  */
-val DefaultAccentSeed = Color(0xFF00D8BB)
+val DefaultAccentSeed = Color(DEFAULT_ACCENT_SEED_ARGB)
 
 /**
  * Curated set of accent seed colors offered in the picker. The full Material 3

--- a/core/ui/src/commonMain/kotlin/com/garfiec/librechat/core/ui/theme/AccentColors.kt
+++ b/core/ui/src/commonMain/kotlin/com/garfiec/librechat/core/ui/theme/AccentColors.kt
@@ -3,24 +3,25 @@ package com.garfiec.librechat.core.ui.theme
 import androidx.compose.ui.graphics.Color
 
 /**
- * The default accent seed color (the app's original lavender brand hue, `0xFF8B5CF6`).
- * Used to generate the Material 3 scheme when the user has not chosen a custom accent
- * and wallpaper-based dynamic color is off.
+ * The default accent seed color (the turquoise brand hue of the app icon's cable,
+ * `0xFF00D8BB`, sampled from the iOS icon asset). Used to generate the Material 3
+ * scheme when the user has not chosen a custom accent and wallpaper-based dynamic
+ * color is off.
  */
-val DefaultAccentSeed = Color(0xFF8B5CF6)
+val DefaultAccentSeed = Color(0xFF00D8BB)
 
 /**
  * Curated set of accent seed colors offered in the picker. The full Material 3
  * [androidx.compose.material3.ColorScheme] is generated from whichever seed the
- * user selects, so these are source colors, not final role colors. Lavender
+ * user selects, so these are source colors, not final role colors. Turquoise
  * (the default) is listed first.
  */
 val AccentColorPresets: List<Color> = listOf(
-    DefaultAccentSeed, // Lavender (default)
+    DefaultAccentSeed, // Turquoise (default, matches the app icon)
     Color(0xFF3B82F6), // Blue
     Color(0xFF6366F1), // Indigo
+    Color(0xFF8B5CF6), // Lavender (the original brand hue)
     Color(0xFF06B6D4), // Cyan
-    Color(0xFF14B8A6), // Teal
     Color(0xFF22C55E), // Green
     Color(0xFFF59E0B), // Amber
     Color(0xFFF97316), // Orange

--- a/core/ui/src/commonMain/kotlin/com/garfiec/librechat/core/ui/theme/Theme.kt
+++ b/core/ui/src/commonMain/kotlin/com/garfiec/librechat/core/ui/theme/Theme.kt
@@ -29,7 +29,7 @@ expect fun supportsDynamicColor(): Boolean
  * 1. [useDynamicColor] on **and** the platform supports it -> wallpaper-based scheme.
  * 2. Otherwise the full scheme is generated from [accentColor] via MaterialKolor
  *    ([rememberDynamicColorScheme], remembered/keyed on its inputs). The default
- *    [accentColor] reproduces the app's original lavender brand hue.
+ *    [accentColor] matches the turquoise brand hue of the app icon.
  */
 @Composable
 fun LibreChatTheme(


### PR DESCRIPTION
## Summary
- Change the default Material 3 accent seed from lavender (`0xFF8B5CF6`) to turquoise (`0xFF00D8BB`), matching the cable in the updated app icon (sampled from the iOS 1024px icon asset — median of 2,670 saturated pixels)
- The full color scheme is generated from the seed via MaterialKolor, so every color role (buttons, chips, selection, etc.) follows automatically on both Android and iOS
- Turquoise now leads the accent preset picker as the default; lavender remains available as a regular preset
- The old Teal preset (`0xFF14B8A6`) is dropped as near-identical in hue to the new default; Cyan (`0xFF06B6D4`) remains, keeping the picker at 11 swatches
- `DEFAULT_ACCENT_COLOR` in `core:data` (the stored-preference fallback and pre-warm-up first-frame value) is updated in lockstep with `DefaultAccentSeed` in `core:ui`

## Behavior notes
- Users who explicitly picked an accent color (including lavender) keep their stored choice — only the out-of-the-box default changes
- Wallpaper-based dynamic color (Material You) is unaffected

## Testing
- `:core:ui` and `:core:data` compile cleanly (`compileDebugKotlinAndroid`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)