### PR TITLE
fix(chat): replace the artifact regex with a line scanner (#301, #303)

### DIFF
--- a/feature/chat/CLAUDE.md
+++ b/feature/chat/CLAUDE.md
@@ -154,7 +154,25 @@ Two consequences worth knowing before touching that block:
 - Both dispatched from `ContentPartRenderer` — tool calls with name containing `dall` route to ImageGenCard
 
 ## Artifacts
-- `ArtifactDetector` parses remark-directive format `:::artifact{identifier="id" type="..." title="..."}` with backtick-fenced content; `groupArtifactVersions()` groups by identifier
+- `ArtifactDetector` is a **line scanner**, not a regex — ported in shape from upstream's
+  `findArtifactClose`/`getOpeningCodeFence` (`packages/api/src/artifacts/update.ts`), because the real
+  contract is "whatever micromark parses", not a pattern. It accepts backtick **and** tilde fences of
+  any length ≥3 (closing fence `{n,}`, i.e. *at least* as long), unfenced content, leaf directives
+  (`::artifact{…}`), CRLF, `[label]` between name and attributes, and quoted/unquoted/valueless
+  attributes. `groupArtifactVersions()` groups by identifier.
+- **Three divergences from the web client are deliberate** — do not "fix" them: `::: trailing` closes
+  the artifact here (web swallows the rest of the message; upstream's own two implementations
+  disagree), a tab-indented content fence renders here (web emits garbage), and attribute-less
+  `:::artifact` produces nothing (web paints no card either — `updateArtifact` early-returns on the
+  all-defaults key). A 25-case differential corpus pins all of this in `ArtifactDetectorCorpusTest`:
+  **22/25 agreement, divergent set exactly {10, 23, 25}**. Any *other* row diverging is a regression.
+- **`Artifact.isComplete`** is false when the closing `:::` never arrived — truncated mid-write, or
+  still streaming. Incomplete artifacts render their **source** via `IncompleteArtifact` → `CodeBlock`,
+  bypassing the inline prefs entirely, and they *do* count for in-conversation search. Both rules are
+  load-bearing: every inline pref defaults to off, so the normal path would collapse them to a button
+  and take partial content off screen, and half-written markup in a WebView is a blank box. An
+  unclosed directive with **no** opening fence is *not* emitted at all — that's a prose mention, and
+  emitting it would swallow the rest of the reply.
 - Supported types: `text/html`, `image/svg+xml`, `application/vnd.react`, `application/vnd.mermaid`, `text/markdown`/`text/md`, `text/plain`, `application/vnd.code-html`
 - `MermaidWebContent` renders Mermaid diagrams via CDN mermaid.js with zoom controls and dark theme
 - `MarkdownWebContent` renders Markdown via CDN marked.js + highlight.js with GFM and syntax highlighting

--- a/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/components/SearchMatchEnumerationTest.kt
+++ b/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/components/SearchMatchEnumerationTest.kt
@@ -24,6 +24,44 @@ class SearchMatchEnumerationTest {
     private fun textPart(text: String) = MessageContentPart(type = ContentType.TEXT, text = text)
     private fun thinkPart(think: String) = MessageContentPart(type = ContentType.THINK, think = think)
 
+    // --- artifacts (see the render-order contract in SearchMatchEnumeration.kt) ---
+
+    // NB: these must go through a TEXT *part*. A message with no content parts renders
+    // message.text via MarkdownContent with no artifact split at all (clause 1 of the contract) —
+    // that gap is #304, tracked separately.
+
+    @Test
+    fun `complete artifact content is not counted`() {
+        // Whether a complete artifact renders inline depends on a UI preference the ViewModel
+        // cannot see, so its content is excluded from navigable occurrences.
+        val msg = message(
+            parts = listOf(
+                textPart(
+                    "before match\n\n" +
+                        ":::artifact{identifier=\"a\" type=\"text/html\" title=\"A\"}\n" +
+                        "```html\n<p>match match match</p>\n```\n:::",
+                ),
+            ),
+        )
+        assertThat(countMessageOccurrences(msg, "match")).isEqualTo(1)
+    }
+
+    @Test
+    fun `incomplete artifact content is counted`() {
+        // An incomplete artifact always renders its source (IncompleteArtifact -> CodeBlock)
+        // regardless of that preference, so its matches are on screen and must be navigable.
+        val msg = message(
+            parts = listOf(
+                textPart(
+                    "before match\n\n" +
+                        ":::artifact{identifier=\"a\" type=\"text/html\" title=\"A\"}\n" +
+                        "```html\n<p>match match</p>",
+                ),
+            ),
+        )
+        assertThat(countMessageOccurrences(msg, "match")).isEqualTo(3)
+    }
+
     // --- plain text / fallback (no parts) ---
 
     @Test

--- a/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/components/artifact/ArtifactDetectorCorpusTest.kt
+++ b/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/components/artifact/ArtifactDetectorCorpusTest.kt
@@ -1,0 +1,270 @@
+package com.garfiec.librechat.feature.chat.components.artifact
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Differential corpus: the 25 cases that were run through upstream's **actual** parser
+ * (`mdast-util-from-markdown` + `micromark-extension-directive` + gfm, mirroring `parseToMdast` in
+ * `client/src/components/Chat/Messages/Content/splitMarkdown.ts`) to establish what the web client
+ * really renders. Each row's expectation equals that measured result, except the three rows marked
+ * `DELIBERATE DIVERGENCE` — cases 10, 23 and 25, documented in [detectArtifacts]'s KDoc — which pin
+ * *our* intended behavior instead. So the scanner agrees with web on 22 of 25, and a change that
+ * makes any *other* row fail is a regression, not a new trade-off.
+ *
+ * "Upstream renders an artifact" means *the card paints*, not
+ * merely that micromark emits a directive node. `updateArtifact`
+ * (`client/src/components/Artifacts/Artifact.tsx`) early-returns when identifier, type and title are
+ * all absent, so `ArtifactButton` receives null and renders nothing. Case 10 is exactly that trap.
+ */
+class ArtifactDetectorCorpusTest {
+
+    private data class Case(
+        val name: String,
+        val input: String,
+        /** Expected artifact count. */
+        val cards: Int,
+        /** Expected content of the first artifact, or null when no card is expected. */
+        val content: String? = null,
+        val complete: Boolean = true,
+        val type: String? = null,
+        val language: String? = null,
+    )
+
+    private val cases = listOf(
+        Case("01 baseline 3-fence", art("```md\nhello\n```"), 1, "hello", language = "md"),
+        Case("02 4-fence (dev default)", art("````md\nhello\n````"), 1, "hello", language = "md"),
+        Case("03 5-fence wrapping 4-fence", art("`````md\n````\ninner\n````\n`````"), 1, "````\ninner\n````"),
+        Case("04 4-open / 5-close", art("````md\nhello\n`````"), 1, "hello"),
+        // A 3-backtick line cannot close a 4-backtick fence, so the block runs to the container close.
+        Case("05 4-open / 3-close", art("````md\nhello\n```"), 1, "hello\n```"),
+        Case("06 tilde fence", art("~~~md\nhello\n~~~"), 1, "hello", language = "md"),
+        Case("07 unfenced content", art("hello world"), 1, "hello world"),
+        // Leaf directive: valid upstream, no body.
+        Case("08 leaf directive", "::artifact{identifier=\"x\" type=\"text/markdown\" title=\"X\"}", 1, ""),
+        // Text directive is rewritten to literal text upstream — never an artifact.
+        Case("09 text directive", "see :artifact{identifier=\"x\"} inline", 0),
+        // DELIBERATE DIVERGENCE: micromark emits a node, but no card paints (default-key early return).
+        Case("10 no attributes", ":::artifact\n```md\nhello\n```\n:::", 0),
+        Case("11 four colons", "::::artifact{identifier=\"x\" type=\"text/markdown\" title=\"X\"}\n" +
+            "```md\nhello\n```\n::::", 1, "hello"),
+        Case("12 info string w/ attrs", art("```html title=\"a\"\nhello\n```"), 1, "hello", language = "html"),
+        Case("13 CRLF line endings", art("```md\nhello\n```").replace("\n", "\r\n"), 1, "hello"),
+        Case("14 indented opening fence", art("  ```md\nhello\n  ```"), 1, "hello"),
+        Case("15 indented closing colons", "$OPEN\n```md\nhello\n```\n  :::", 1, "hello"),
+        // Unclosed with an unclosed fence = truncated mid-artifact. Emitted, but marked incomplete.
+        Case("16 unclosed artifact (stream)", "$OPEN\n````md\n# partial heading\nsome text so far",
+            1, "# partial heading\nsome text so far", complete = false),
+        Case("17 unclosed fence, closed colons", "$OPEN\n````md\nhello\n:::", 1, "hello"),
+        Case("18 unquoted attr values", ":::artifact{identifier=x type=text/markdown title=X}\n" +
+            "```md\nhello\n```\n:::", 1, "hello", type = "text/markdown"),
+        Case("19 blank line before fence", art("\n```md\nhello\n```"), 1, "hello"),
+        Case("20 two artifacts (4 then 3)", art("````md\none\n````") + "\n\nsome text\n\n" +
+            ":::artifact{identifier=\"y\" type=\"text/markdown\" title=\"X\"}\n```md\ntwo\n```\n:::",
+            2, "one"),
+        Case("21 3-fence w/ inner 3-fence", art("```md\n```bash\necho hi\n```\n```"), 1, "```bash\necho hi"),
+        Case("22 lang hint w/ hyphen", art("```mermaid-js\ngraph TD\n```"), 1, "graph TD", language = "mermaid-js"),
+        // DELIBERATE DIVERGENCE: web keeps reading (content `hello\n::: trailing`); the backend
+        // scanner closes here, and so do we.
+        Case("23 trailing text after close", art("```md\nhello\n```").dropLast(3) + "::: trailing", 1, "hello"),
+        Case("24 no newline after close", art("```md\nhello\n```"), 1, "hello"),
+        // DELIBERATE DIVERGENCE: web demotes a tab-indented fence to an indented code block and
+        // produces garbage (```mdhello); we render the artifact.
+        Case("25 tab-indented fence", art("\t```md\nhello\n```"), 1, "hello"),
+    )
+
+    @Test
+    fun `scanner matches the measured upstream corpus`() {
+        val failures = mutableListOf<String>()
+        for (case in cases) {
+            val artifacts = detectArtifacts(case.input)
+                .filterIsInstance<ArtifactSegment.ArtifactReference>()
+                .map { it.artifact }
+
+            if (artifacts.size != case.cards) {
+                failures += "${case.name}: expected ${case.cards} card(s), got ${artifacts.size}"
+                continue
+            }
+            val first = artifacts.firstOrNull() ?: continue
+            if (case.content != null && first.content != case.content) {
+                failures += "${case.name}: content expected ${case.content.q()}, got ${first.content.q()}"
+            }
+            if (first.isComplete != case.complete) {
+                failures += "${case.name}: isComplete expected ${case.complete}, got ${first.isComplete}"
+            }
+            case.type?.let { if (first.type != it) failures += "${case.name}: type expected $it, got ${first.type}" }
+            case.language?.let {
+                if (first.language != it) failures += "${case.name}: language expected $it, got ${first.language}"
+            }
+        }
+        assertEquals("corpus divergences:\n" + failures.joinToString("\n"), emptyList<String>(), failures)
+    }
+
+    // ─── behaviours where we intentionally beat upstream's backend scanner ───
+
+    @Test
+    fun `directive inside a fenced code block is not an artifact`() {
+        // upstream's findAllArtifacts uses a plain indexOf and would eat this; micromark does not,
+        // and neither do we. Without this a message explaining the artifact format renders as a card.
+        val text = "Here's how the format works:\n\n" +
+            "````\n$OPEN\n```md\nhello\n```\n:::\n````\n\nMake sense?"
+
+        val segments = detectArtifacts(text)
+        assertEquals(0, segments.count { it is ArtifactSegment.ArtifactReference })
+    }
+
+    @Test
+    fun `mid-line directive is not an artifact`() {
+        val text = "as in $OPEN inline\n```md\nhello\n```\n:::"
+        assertEquals(0, detectArtifacts(text).count { it is ArtifactSegment.ArtifactReference })
+    }
+
+    @Test
+    fun `directive indented four spaces is not an artifact`() {
+        // 4+ spaces is an indented code block in CommonMark; micromark emits no directive.
+        val text = "    $OPEN\n```md\nhello\n```\n:::"
+        assertEquals(0, detectArtifacts(text).count { it is ArtifactSegment.ArtifactReference })
+    }
+
+    @Test
+    fun `unclosed directive with no fence does not swallow the rest of the message`() {
+        // The regression this scanner must not introduce: a stray directive in prose would otherwise
+        // take every following paragraph off-screen behind a collapsed artifact button.
+        val text = "You can write $OPEN to make one.\n\nIt renders as a card.\n\nHope that helps!"
+
+        val segments = detectArtifacts(text)
+        assertEquals(0, segments.count { it is ArtifactSegment.ArtifactReference })
+        val rendered = segments.filterIsInstance<ArtifactSegment.Text>().joinToString("\n") { it.text }
+        assertEquals(true, rendered.contains("Hope that helps!"))
+    }
+
+    @Test
+    fun `text after an unclosed artifact whose fence closed is never dropped`() {
+        // If the artifact segment ran to EOF while its content stopped at the closing fence,
+        // everything between them would belong to no segment at all and vanish —
+        // not hidden behind a card, gone. Nothing may ever be invisible.
+        val text = "$OPEN\n```html\n<p>hi</p>\n```\n\nAnd here is more discussion that must stay visible."
+
+        val segments = detectArtifacts(text)
+        val artifact = segments.filterIsInstance<ArtifactSegment.ArtifactReference>().single().artifact
+        assertEquals("<p>hi</p>", artifact.content)
+        val rendered = segments.filterIsInstance<ArtifactSegment.Text>().joinToString("\n") { it.text }
+        assertEquals("And here is more discussion that must stay visible.", rendered)
+    }
+
+    @Test
+    fun `prose describing the format keeps its trailing sentence`() {
+        val text = "Write this:\n$OPEN\n```html\nyour html\n```\nand then close it with three colons."
+
+        val segments = detectArtifacts(text)
+        val rendered = segments.filterIsInstance<ArtifactSegment.Text>().joinToString("\n") { it.text }
+        assertEquals(true, rendered.contains("and then close it with three colons."))
+    }
+
+    @Test
+    fun `a brace inside a quoted attribute value does not void the directive`() {
+        // A naive first-`}` scan would truncate the attribute string mid-quote, so `parseAttributes`
+        // would hit an unterminated quote and the whole artifact would fall back to raw directive
+        // text — exactly the symptom this scanner exists to remove. Upstream renders both of these.
+        val braced = detectArtifacts(":::artifact{identifier=\"x\" title=\"The {config} object\"}\n```\nhi\n```\n:::")
+            .filterIsInstance<ArtifactSegment.ArtifactReference>()
+            .single().artifact
+        assertEquals("The {config} object", braced.title)
+
+        val closer = detectArtifacts(":::artifact{identifier=\"x\" title=\"a} b\"}\n```\nhi\n```\n:::")
+            .filterIsInstance<ArtifactSegment.ArtifactReference>()
+            .single().artifact
+        assertEquals("a} b", closer.title)
+    }
+
+    @Test
+    fun `an empty shortcut voids the directive and dotted shortcuts split`() {
+        val empty = ":::artifact{# type=\"text/html\" title=\"T\"}\n```html\nhi\n```\n:::"
+        assertEquals(0, detectArtifacts(empty).count { it is ArtifactSegment.ArtifactReference })
+
+        // `#a.b` is id=a plus class=b upstream, not a single id of "a.b".
+        val split = detectArtifacts(":::artifact{#a.b type=\"text/html\"}\n```html\nhi\n```\n:::")
+            .filterIsInstance<ArtifactSegment.ArtifactReference>()
+            .single().artifact
+        assertEquals("a", split.identifier)
+    }
+
+    @Test
+    fun `shorter closing run does not close a longer opening run`() {
+        // micromark requires the close to be no shorter than the open; upstream's backend scanner
+        // (startsWith(":::")) accepts the short run and is wrong here.
+        val text = "::::artifact{identifier=\"x\" type=\"text/markdown\" title=\"X\"}\n" +
+            "```md\nhello\n```\n:::\nstill inside\n::::"
+
+        val artifact = detectArtifacts(text)
+            .filterIsInstance<ArtifactSegment.ArtifactReference>()
+            .single().artifact
+        assertEquals("hello", artifact.content)
+    }
+
+    // ─── attribute grammar, verified against micromark's factory-attributes.js ───
+
+    @Test
+    fun `unquoted value keeps a brace but a quote character voids the directive`() {
+        // valueUnquoted consumes `{` into the value, but returns nok on " ' < = > ` — which aborts
+        // the whole attribute block, so upstream renders no card at all.
+        val kept = detectArtifacts(":::artifact{identifier=x type=a{b title=X}\n```\nhi\n```\n:::")
+            .filterIsInstance<ArtifactSegment.ArtifactReference>()
+            .single().artifact
+        assertEquals("a{b", kept.type)
+
+        val voided = ":::artifact{identifier=x type=a\"b title=X}\n```\nhi\n```\n:::"
+        assertEquals(0, detectArtifacts(voided).count { it is ArtifactSegment.ArtifactReference })
+    }
+
+    @Test
+    fun `label between name and attributes is accepted and dropped`() {
+        val text = ":::artifact[Some Label]{identifier=\"x\" type=\"text/html\" title=\"X\"}\n" +
+            "```html\nhi\n```\n:::"
+
+        val artifact = detectArtifacts(text)
+            .filterIsInstance<ArtifactSegment.ArtifactReference>()
+            .single().artifact
+        assertEquals("x", artifact.identifier)
+        // upstream's extractContent folds the label into the content; we deliberately do not.
+        assertEquals("hi", artifact.content)
+    }
+
+    @Test
+    fun `space before the attribute brace voids the directive`() {
+        val text = ":::artifact {identifier=\"x\" type=\"text/html\" title=\"X\"}\n```html\nhi\n```\n:::"
+        assertEquals(0, detectArtifacts(text).count { it is ArtifactSegment.ArtifactReference })
+    }
+
+    @Test
+    fun `hash and dot shortcuts map to id and class`() {
+        val text = ":::artifact{#my-id .my-class type=\"text/html\"}\n```html\nhi\n```\n:::"
+        val artifact = detectArtifacts(text)
+            .filterIsInstance<ArtifactSegment.ArtifactReference>()
+            .single().artifact
+        // `identifier` is absent, so the `id` shortcut supplies it.
+        assertEquals("my-id", artifact.identifier)
+    }
+
+    // ─── identifier fallback ───
+
+    @Test
+    fun `two attribute-less artifacts get distinct synthetic identifiers`() {
+        // The fallback key groups versions across a whole conversation, so it must stay a character
+        // offset — a line index would collide across messages and group unrelated artifacts.
+        val text = ":::artifact{type=\"text/html\"}\n```\none\n```\n:::\n\n" +
+            ":::artifact{type=\"text/html\"}\n```\ntwo\n```\n:::"
+
+        val grouped = groupArtifactVersions(detectArtifacts(text))
+        assertEquals(2, grouped.size)
+    }
+
+    private companion object {
+        const val OPEN = ":::artifact{identifier=\"x\" type=\"text/markdown\" title=\"X\"}"
+
+        /** Wraps [body] in the standard container directive used by most corpus rows. */
+        fun art(body: String): String = "$OPEN\n$body\n:::"
+
+        fun String.q(): String = "\"" + replace("\n", "\\n") + "\""
+    }
+}

--- a/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/components/artifact/ArtifactDetectorTest.kt
+++ b/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/components/artifact/ArtifactDetectorTest.kt
@@ -165,9 +165,12 @@ echo hello
     }
 
     @Test
-    fun `mismatched fence lengths do not match as an artifact`() {
-        // A 4-backtick opening fence must be closed with 4 backticks, not 3 — otherwise
-        // the embedded 3-backtick block from the previous test would close the artifact early.
+    fun `mismatched fence lengths still produce an artifact, with the stray fence as content`() {
+        // Inverted from the assertion #296 shipped. A 3-backtick line cannot close a 4-backtick
+        // fence, so the code block simply runs to the container close — upstream renders this as an
+        // artifact whose content includes the stray fence, and the differential corpus confirms it.
+        // The previous test's embedded 3-backtick block is still safe: it is inside a 4-backtick
+        // fence that closes properly, so the artifact never ends early.
         val text = """
 :::artifact{identifier="bad" type="text/markdown" title="Bad"}
 ````markdown
@@ -177,7 +180,11 @@ content
         """.trimIndent()
 
         val segments = detectArtifacts(text)
-        assertTrue(segments.none { it is ArtifactSegment.ArtifactReference })
+        assertEquals(1, segments.size)
+        val ref = segments[0] as ArtifactSegment.ArtifactReference
+        assertEquals("bad", ref.artifact.identifier)
+        assertEquals("content\n```", ref.artifact.content)
+        assertTrue(ref.artifact.isComplete)
     }
 
     @Test
@@ -307,6 +314,16 @@ Let me know if you want changes.
         val segments = detectArtifacts(text)
         assertEquals(1, segments.size)
         assertTrue(segments[0] is ArtifactSegment.Text)
+        assertEquals(text, (segments[0] as ArtifactSegment.Text).text)
+    }
+
+    @Test
+    fun `plain text keeps surrounding whitespace verbatim`() {
+        // Web hands the raw text to react-markdown, so a 4-space-indented first line is an indented
+        // code block there — trimming here would render it as a paragraph instead.
+        val text = "    indented code line\n\nA paragraph after it.\n"
+        val segments = detectArtifacts(text)
+        assertEquals(1, segments.size)
         assertEquals(text, (segments[0] as ArtifactSegment.Text).text)
     }
 

--- a/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/components/artifact/InlineArtifactStrategyTest.kt
+++ b/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/components/artifact/InlineArtifactStrategyTest.kt
@@ -100,4 +100,32 @@ class InlineArtifactStrategyTest {
         )
         assertEquals(InlineArtifactStrategy.WebViewSlot, result)
     }
+
+    @Test
+    fun `empty content dispatches without throwing for every type`() {
+        // Leaf directives (`::artifact{…}`, no body) make empty content reachable for the first
+        // time. The ladder must stay total — in particular isCacheableMermaid("") must not throw
+        // and must not claim a cache hit.
+        val expected = ArtifactType.entries.associateWith { type ->
+            when (type) {
+                ArtifactType.MARKDOWN -> InlineArtifactStrategy.NativeMarkdown
+                ArtifactType.SVG -> InlineArtifactStrategy.IntrinsicSvg
+                else -> InlineArtifactStrategy.WebViewSlot
+            }
+        }
+        val actual = ArtifactType.entries.associateWith { type ->
+            selectInlineArtifactStrategy(type = type, content = "", cachedMermaidSvg = null)
+        }
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `empty mermaid content does not take the cached-svg path`() {
+        val result = selectInlineArtifactStrategy(
+            type = ArtifactType.MERMAID,
+            content = "",
+            cachedMermaidSvg = "<svg/>",
+        )
+        assertEquals(InlineArtifactStrategy.WebViewSlot, result)
+    }
 }

--- a/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/util/ConversationMediaExtractorTest.kt
+++ b/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/util/ConversationMediaExtractorTest.kt
@@ -1,0 +1,93 @@
+package com.garfiec.librechat.feature.chat.util
+
+import com.garfiec.librechat.core.model.ContentType
+import com.garfiec.librechat.core.model.Message
+import com.garfiec.librechat.core.model.content.MessageContentPart
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Covers the Artifacts/Links tabs' extraction. The artifact half is deliberately per-content-part:
+ * joining parts first would build a string that renders nowhere, and an unclosed directive in one
+ * part would swallow the parts after it.
+ */
+class ConversationMediaExtractorTest {
+
+    private fun message(text: String = "", parts: List<MessageContentPart>? = null) =
+        Message(messageId = "m1", conversationId = "c1", text = text, content = parts)
+
+    private fun textPart(text: String) = MessageContentPart(type = ContentType.TEXT, text = text)
+
+    private fun thinkPart(think: String) = MessageContentPart(type = ContentType.THINK, think = think)
+
+    private fun artifact(id: String, body: String = "hello") =
+        ":::artifact{identifier=\"$id\" type=\"text/html\" title=\"$id\"}\n```html\n$body\n```\n:::"
+
+    @Test
+    fun `extracts artifacts from a message without content parts`() {
+        val groups = extractConversationArtifacts(listOf(message(text = artifact("a"))))
+        assertEquals(1, groups.size)
+        assertEquals("a", groups[0][0].identifier)
+    }
+
+    @Test
+    fun `groups versions of the same identifier across messages`() {
+        val groups = extractConversationArtifacts(
+            listOf(
+                message(text = artifact("counter", "v1")),
+                message(
+                    text = ":::artifact{identifier=\"counter\" type=\"text/html\" title=\"C\" " +
+                        "version=\"2\"}\n```html\nv2\n```\n:::",
+                ),
+            ),
+        )
+        assertEquals(1, groups.size)
+        assertEquals(listOf(1, 2), groups[0].map { it.version })
+    }
+
+    @Test
+    fun `an unclosed directive in one part does not swallow later parts`() {
+        // The regression per-part detection exists to prevent: joined, the truncated artifact in
+        // part 1 would run to the end of the joined string and absorb part 2's real artifact.
+        val message = message(
+            parts = listOf(
+                textPart(":::artifact{identifier=\"cut\" type=\"text/html\" title=\"Cut\"}\n```html\n<p>partial"),
+                textPart(artifact("whole")),
+            ),
+        )
+
+        val groups = extractConversationArtifacts(listOf(message))
+        // The truncated one is excluded (incomplete); the intact one survives intact.
+        assertEquals(1, groups.size)
+        assertEquals("whole", groups[0][0].identifier)
+    }
+
+    @Test
+    fun `incomplete artifacts are excluded from the gallery`() {
+        val truncated = ":::artifact{identifier=\"cut\" type=\"text/html\" title=\"Cut\"}\n```html\n<p>partial"
+        assertEquals(emptyList<Any>(), extractConversationArtifacts(listOf(message(text = truncated))))
+    }
+
+    @Test
+    fun `think parts are scanned independently of text parts`() {
+        val message = message(
+            parts = listOf(thinkPart("reasoning about it"), textPart(artifact("a"))),
+        )
+        val groups = extractConversationArtifacts(listOf(message))
+        assertEquals(1, groups.size)
+        assertEquals("a", groups[0][0].identifier)
+    }
+
+    @Test
+    fun `links are still extracted across parts and deduped`() {
+        val message = message(
+            parts = listOf(
+                textPart("see https://example.com/a for more"),
+                textPart("also https://example.com/a and https://other.test/b"),
+            ),
+        )
+        val links = extractConversationLinks(listOf(message))
+        assertEquals(listOf("https://example.com/a", "https://other.test/b"), links.map { it.url })
+        assertEquals("example.com", links[0].host)
+    }
+}

--- a/feature/chat/src/commonMain/composeResources/values-ar/strings.xml
+++ b/feature/chat/src/commonMain/composeResources/values-ar/strings.xml
@@ -259,6 +259,7 @@
     <string name="cd_previous_version">الإصدار السابق</string>
     <string name="cd_next_version">الإصدار التالي</string>
     <string name="artifact_version">الإصدار %1$d/%2$d</string>
+    <string name="artifact_incomplete">غير مكتمل</string>
     <!-- Prompts -->
     <string name="prompts_library">مكتبة المطالبات</string>
     <string name="use_in_chat">استخدام في المحادثة</string>

--- a/feature/chat/src/commonMain/composeResources/values-de/strings.xml
+++ b/feature/chat/src/commonMain/composeResources/values-de/strings.xml
@@ -259,6 +259,7 @@
     <string name="cd_previous_version">Vorherige Version</string>
     <string name="cd_next_version">Nächste Version</string>
     <string name="artifact_version">v%1$d/%2$d</string>
+    <string name="artifact_incomplete">Unvollständig</string>
     <!-- Prompts -->
     <string name="prompts_library">Prompt-Bibliothek</string>
     <string name="use_in_chat">Im Chat verwenden</string>

--- a/feature/chat/src/commonMain/composeResources/values-es/strings.xml
+++ b/feature/chat/src/commonMain/composeResources/values-es/strings.xml
@@ -259,6 +259,7 @@
     <string name="cd_previous_version">Versión anterior</string>
     <string name="cd_next_version">Versión siguiente</string>
     <string name="artifact_version">v%1$d/%2$d</string>
+    <string name="artifact_incomplete">Incompleto</string>
     <!-- Prompts -->
     <string name="prompts_library">Biblioteca de prompts</string>
     <string name="use_in_chat">Usar en el chat</string>

--- a/feature/chat/src/commonMain/composeResources/values-fr/strings.xml
+++ b/feature/chat/src/commonMain/composeResources/values-fr/strings.xml
@@ -259,6 +259,7 @@
     <string name="cd_previous_version">Version précédente</string>
     <string name="cd_next_version">Version suivante</string>
     <string name="artifact_version">v%1$d/%2$d</string>
+    <string name="artifact_incomplete">Incomplet</string>
     <!-- Prompts -->
     <string name="prompts_library">Bibliothèque d'invites</string>
     <string name="use_in_chat">Utiliser dans la discussion</string>

--- a/feature/chat/src/commonMain/composeResources/values-ja/strings.xml
+++ b/feature/chat/src/commonMain/composeResources/values-ja/strings.xml
@@ -259,6 +259,7 @@
     <string name="cd_previous_version">前のバージョン</string>
     <string name="cd_next_version">次のバージョン</string>
     <string name="artifact_version">v%1$d/%2$d</string>
+    <string name="artifact_incomplete">不完全</string>
     <!-- Prompts -->
     <string name="prompts_library">プロンプトライブラリ</string>
     <string name="use_in_chat">チャットで使用</string>

--- a/feature/chat/src/commonMain/composeResources/values-ko/strings.xml
+++ b/feature/chat/src/commonMain/composeResources/values-ko/strings.xml
@@ -259,6 +259,7 @@
     <string name="cd_previous_version">이전 버전</string>
     <string name="cd_next_version">다음 버전</string>
     <string name="artifact_version">v%1$d/%2$d</string>
+    <string name="artifact_incomplete">미완성</string>
     <!-- Prompts -->
     <string name="prompts_library">프롬프트 라이브러리</string>
     <string name="use_in_chat">채팅에서 사용</string>

--- a/feature/chat/src/commonMain/composeResources/values-pt/strings.xml
+++ b/feature/chat/src/commonMain/composeResources/values-pt/strings.xml
@@ -259,6 +259,7 @@
     <string name="cd_previous_version">Versão anterior</string>
     <string name="cd_next_version">Próxima versão</string>
     <string name="artifact_version">v%1$d/%2$d</string>
+    <string name="artifact_incomplete">Incompleto</string>
     <!-- Prompts -->
     <string name="prompts_library">Biblioteca de prompts</string>
     <string name="use_in_chat">Usar na conversa</string>

--- a/feature/chat/src/commonMain/composeResources/values-ru/strings.xml
+++ b/feature/chat/src/commonMain/composeResources/values-ru/strings.xml
@@ -259,6 +259,7 @@
     <string name="cd_previous_version">Предыдущая версия</string>
     <string name="cd_next_version">Следующая версия</string>
     <string name="artifact_version">v%1$d/%2$d</string>
+    <string name="artifact_incomplete">Не завершено</string>
     <!-- Prompts -->
     <string name="prompts_library">Библиотека промптов</string>
     <string name="use_in_chat">Использовать в чате</string>

--- a/feature/chat/src/commonMain/composeResources/values-zh/strings.xml
+++ b/feature/chat/src/commonMain/composeResources/values-zh/strings.xml
@@ -259,6 +259,7 @@
     <string name="cd_previous_version">上一个版本</string>
     <string name="cd_next_version">下一个版本</string>
     <string name="artifact_version">v%1$d/%2$d</string>
+    <string name="artifact_incomplete">未完成</string>
     <!-- Prompts -->
     <string name="prompts_library">提示词库</string>
     <string name="use_in_chat">在聊天中使用</string>

--- a/feature/chat/src/commonMain/composeResources/values/strings.xml
+++ b/feature/chat/src/commonMain/composeResources/values/strings.xml
@@ -299,6 +299,7 @@
     <string name="artifact_version">v%1$d/%2$d</string>
     <string name="artifact_view_source">View source</string>
     <string name="artifact_view_preview">View preview</string>
+    <string name="artifact_incomplete">Incomplete</string>
 
     <!-- Prompts -->
     <string name="prompts_library">Prompts Library</string>

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/SearchMatchEnumeration.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/SearchMatchEnumeration.kt
@@ -3,6 +3,7 @@ package com.garfiec.librechat.feature.chat.components
 import com.garfiec.librechat.core.model.ContentType
 import com.garfiec.librechat.core.model.Message
 import com.garfiec.librechat.core.model.content.MessageContentPart
+import com.garfiec.librechat.feature.chat.components.artifact.Artifact
 import com.garfiec.librechat.feature.chat.components.artifact.ArtifactSegment
 import com.garfiec.librechat.feature.chat.components.artifact.detectArtifacts
 
@@ -17,10 +18,15 @@ import com.garfiec.librechat.feature.chat.components.artifact.detectArtifacts
 //  1. Content parts in list order; only TEXT/TEXT_DELTA (part.text) and THINK (part.think)
 //     render searchable text. Messages without parts render message.text via
 //     MarkdownContent directly (no artifact split).
-//  2. TEXT parts split on artifact directives first (TextContentPart); only the plain
-//     Text segments are enumerated — inline-artifact content is highlighted but not
-//     navigable (whether it renders inline at all depends on a UI preference the
-//     ViewModel cannot see).
+//  2. TEXT parts split on artifact directives first (TextContentPart). Plain Text segments are
+//     enumerated. Artifact segments depend on Artifact.isComplete:
+//       - complete   -> contributes 0. Content is highlighted but not navigable, because whether it
+//                       renders inline at all depends on a UI preference the ViewModel cannot see.
+//       - incomplete -> contributes its content's occurrences. An incomplete artifact always renders
+//                       its source via IncompleteArtifact -> CodeBlock, regardless of that
+//                       preference, so it IS on screen and must be navigable. Counted flat (not via
+//                       parseMarkdownSegments) because CodeBlock lays the content out as one text
+//                       block — including for mermaid, which is not routed to a WebView here.
 //  3. Within a text run, parseMarkdownSegments order. LatexBlock and mermaid CodeBlocks
 //     render as native/WebView content with no text layout, so they contribute nothing.
 //     Table occurrences are counted per cell (headers left-to-right, then rows
@@ -54,6 +60,14 @@ internal fun countMarkdownOccurrences(text: String, query: String): Int {
     return parseMarkdownSegments(text).sumOf { countSegmentOccurrences(it, query) }
 }
 
+/**
+ * Occurrences contributed by one artifact segment (see contract above). Shared by both walks —
+ * the ViewModel-side enumeration here and the renderer-side offset table in `TextContentPart` — so
+ * that the two can never disagree about how many occurrences an artifact owns.
+ */
+internal fun countArtifactOccurrences(artifact: Artifact, query: String): Int =
+    if (artifact.isComplete) 0 else countOccurrences(artifact.content, query)
+
 /** Occurrences in a TEXT part's body, honoring the artifact split (see contract above). */
 internal fun countTextPartOccurrences(text: String, query: String): Int {
     // Same fast-path bail: skip detectArtifacts + parsing when the query can't be here.
@@ -61,7 +75,7 @@ internal fun countTextPartOccurrences(text: String, query: String): Int {
     return detectArtifacts(text).sumOf { segment ->
         when (segment) {
             is ArtifactSegment.Text -> countMarkdownOccurrences(segment.text, query)
-            is ArtifactSegment.ArtifactReference -> 0
+            is ArtifactSegment.ArtifactReference -> countArtifactOccurrences(segment.artifact, query)
         }
     }
 }

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/TextArtifactContentPart.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/TextArtifactContentPart.kt
@@ -14,6 +14,7 @@ import com.garfiec.librechat.core.ui.theme.isSurfaceDark
 import com.garfiec.librechat.feature.chat.components.artifact.ArtifactButton
 import com.garfiec.librechat.feature.chat.components.artifact.ArtifactSegment
 import com.garfiec.librechat.feature.chat.components.artifact.ArtifactType
+import com.garfiec.librechat.feature.chat.components.artifact.IncompleteArtifact
 import com.garfiec.librechat.feature.chat.components.artifact.InlineArtifactStrategy
 import com.garfiec.librechat.feature.chat.components.artifact.InlineArtifactView
 import com.garfiec.librechat.feature.chat.components.artifact.InlineMarkdownArtifact
@@ -62,17 +63,22 @@ internal fun TextContentPart(
         val inlinePrefs = LocalInlineArtifactPrefs.current
         val openArtifact = LocalOpenArtifact.current
         val addToHomeScreen = LocalAddArtifactToHomeScreen.current
-        // Per-Text-segment occurrence base offsets (artifact content contributes none — see the
-        // SearchMatchEnumeration render-order contract). Computed once per (segments, query): the
-        // per-segment countMarkdownOccurrences re-parses markdown, so keeping it off recomposition matters.
+        // Per-segment occurrence base offsets. Complete artifacts contribute none; incomplete ones
+        // contribute their source's occurrences, since they always render it — see the
+        // SearchMatchEnumeration render-order contract, whose countArtifactOccurrences is shared
+        // with the ViewModel-side walk so the two can never disagree.
+        // Computed once per (segments, query): the per-segment countMarkdownOccurrences re-parses
+        // markdown, so keeping it off recomposition matters.
         val textOffsets = remember(segments, searchQuery) {
             IntArray(segments.size).also { offsets ->
                 if (!searchQuery.isNullOrBlank()) {
                     var acc = 0
                     segments.forEachIndexed { i, segment ->
                         offsets[i] = acc
-                        if (segment is ArtifactSegment.Text) {
-                            acc += countMarkdownOccurrences(segment.text, searchQuery)
+                        acc += when (segment) {
+                            is ArtifactSegment.Text -> countMarkdownOccurrences(segment.text, searchQuery)
+                            is ArtifactSegment.ArtifactReference ->
+                                countArtifactOccurrences(segment.artifact, searchQuery)
                         }
                     }
                 }
@@ -95,7 +101,19 @@ internal fun TextContentPart(
                     is ArtifactSegment.ArtifactReference -> {
                         val versions = versionMap[segment.artifact.identifier] ?: listOf(segment.artifact)
                         Spacer(modifier = Modifier.height(8.dp))
-                        if (inlinePrefs.shouldRenderInline(segment.artifact.type)) {
+                        if (!segment.artifact.isComplete) {
+                            // Truncated or still streaming: show source, never a collapsed button and
+                            // never a WebView. See IncompleteArtifact's KDoc for why this outranks
+                            // the inline preference.
+                            IncompleteArtifact(
+                                artifact = segment.artifact,
+                                onTap = { openArtifact?.invoke(segment.artifact, versions) },
+                                modifier = Modifier.fillMaxWidth(),
+                                searchQuery = searchQuery,
+                                searchFocusedOccurrence = searchFocusedOccurrence - textOffsets[index],
+                                onFocusedOccurrencePosition = onFocusedOccurrencePosition,
+                            )
+                        } else if (inlinePrefs.shouldRenderInline(segment.artifact.type)) {
                             val type = ArtifactType.from(segment.artifact.type)
                             val cachedSvg = rememberCachedMermaidSvg(segment.artifact.content, type)
                             when (val strategy = selectInlineArtifactStrategy(type, segment.artifact.content, cachedSvg)) {

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/Artifact.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/Artifact.kt
@@ -23,4 +23,10 @@ data class Artifact(
     val language: String?,
     val content: String,
     val version: Int = 1,
+    /**
+     * False when the artifact's closing `:::` never arrived — a reply truncated mid-artifact, or a
+     * live stream still in flight. Such artifacts render their **source** rather than being
+     * executed; see [IncompleteArtifact]'s KDoc for why that outranks the inline preferences.
+     */
+    val isComplete: Boolean = true,
 )

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/ArtifactDetector.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/ArtifactDetector.kt
@@ -1,75 +1,122 @@
 package com.garfiec.librechat.feature.chat.components.artifact
 
 /**
- * Matches the remark-directive artifact format:
- *   :::artifact{key="value" ...}
- *   ```optionalLanguage          (3 or more backticks; LibreChat's own server prompt
- *   content                       defaults to 4, bumping to 5+ if content itself
- *   ```                           contains a 4-backtick run)
- *   :::
+ * Artifact detection.
  *
- * Group 1: attribute string inside braces
- * Group 2: the opening fence (captured so the closing fence must match the same length)
- * Group 3: optional language hint after opening backticks
- * Group 4: content between the fences
+ * Upstream never parses artifacts with a regex — the format is a remark-directive container inside a
+ * CommonMark document, so the real contract is "whatever micromark parses". This is a line scanner
+ * ported in shape from `findArtifactClose` / `getOpeningCodeFence` in upstream's
+ * `packages/api/src/artifacts/update.ts`, which is close enough to that contract to agree with the
+ * web client on 22 of a 25-case differential corpus.
+ *
+ * The three remaining divergences are deliberate, not bugs:
+ *  - `::: trailing` closes the artifact here; remark-directive does not, so web swallows the rest of
+ *    the message. Upstream's own backend scanner agrees with us — its two implementations disagree
+ *    with each other, so "match web exactly" is not a well-defined target.
+ *  - A tab-indented content fence renders here; web demotes it to an indented code block and
+ *    produces garbage.
+ *  - `:::artifact` with no `{…}` produces nothing here. Micromark emits a directive node, but
+ *    `updateArtifact` early-returns on the all-defaults key, so no card paints on web either.
+ *  - The *closing* `:::` is accepted at any indent, while the opening directive is capped at 3
+ *    columns. Micromark would treat a deeply-indented close as an indented code block; upstream's
+ *    backend scanner accepts it, and so do we.
+ *
+ * Line endings are normalised to `\n`, so [ArtifactSegment.Text] from a CRLF message loses its `\r`.
+ * Harmless for markdown rendering.
  */
-private val ARTIFACT_REGEX = Regex(
-    """:::artifact\{([^}]*)\}\s*(`{3,})(\w*)\n([\s\S]*?)\2\s*:::""",
-)
+
+private const val ARTIFACT_NAME = "artifact"
+
+/** Cheap bail token: contained by both `:::artifact` and the leaf `::artifact`, but not `:artifact`. */
+private const val ARTIFACT_HINT = "::artifact"
+
+/** CommonMark block starts allow at most 3 columns of indent; 4+ is an indented code block. */
+private const val MAX_DIRECTIVE_INDENT = 3
+
+private const val TAB_WIDTH = 4
+
+private const val MIN_FENCE_LENGTH = 3
+
+/** Minimum colons for a container directive (`:::`); two colons is a leaf directive. */
+private const val MIN_CONTAINER_COLONS = 3
 
 /**
- * Parses key="value" pairs from the attribute string inside {braces}.
+ * Characters that make `micromark-extension-directive` abort the *entire* attribute block
+ * (`factory-attributes.js` `valueUnquoted` returns `nok` on these), meaning the directive does not
+ * parse at all and no card renders. They do not merely terminate the value. Note `{` is absent —
+ * upstream consumes it into the value, so `type=a{b` parses as `a{b`.
  */
-private val ATTR_REGEX = Regex(
-    """(\w+)\s*=\s*"([^"]*)"""",
-)
+private const val ATTR_ABORT_CHARS = "\"'<=>`"
+
+private class CodeFence(val marker: Char, val length: Int)
+
+private class OpeningFence(val fence: CodeFence, val contentStart: Int, val info: String)
+
+private class DirectiveLine(val colons: Int, val attrs: String)
+
+private class ArtifactClose(val start: Int, val end: Int)
 
 /**
- * Detects artifact markers in message text and returns a list of segments
- * with the artifacts extracted.
+ * Detects artifact markers in message text and returns a list of segments with the artifacts
+ * extracted. Artifacts whose closing `:::` never arrives are returned with
+ * [Artifact.isComplete]` = false` — but only when a code fence was opened, which is what
+ * distinguishes a reply truncated mid-artifact from a stray `:::artifact{…}` mentioned in prose.
+ * Without that guard the latter would swallow the rest of the message into a collapsed card.
+ *
+ * **The fence requirement has a real cost, not just a latency one.** An artifact truncated *before*
+ * its fence arrives is not detected — including an unfenced artifact truncated mid-content, a form
+ * upstream does render. The first two self-heal as soon as the fence streams in; the unfenced case
+ * does not. That is the accepted price of the prose guard: dropping to raw directive text is
+ * recoverable, silently eating a paragraph is not.
+ *
+ * Every character of the input ends up in exactly one segment or is deliberately trimmed whitespace.
+ * No branch may leave a gap between where an artifact's content stops and where its segment ends —
+ * see the `end` computation in `readArtifactAt`.
  */
 fun detectArtifacts(text: String): List<ArtifactSegment> {
+    // Before normalising: a line scanner has no literal-prefix fast path of its own, and this runs
+    // inside a Compose `remember` and per-keystroke during in-conversation search.
+    if (!text.contains(ARTIFACT_HINT)) {
+        return if (text.isBlank()) emptyList() else listOf(ArtifactSegment.Text(text))
+    }
+    val source = if (text.indexOf('\r') < 0) text else text.replace("\r\n", "\n").replace('\r', '\n')
+
     val segments = mutableListOf<ArtifactSegment>()
     var lastIndex = 0
+    var cursor = 0
+    var enclosingFence: CodeFence? = null
 
-    ARTIFACT_REGEX.findAll(text).forEach { match ->
-        if (match.range.first > lastIndex) {
-            val before = text.substring(lastIndex, match.range.first).trim()
-            if (before.isNotEmpty()) {
-                segments.add(ArtifactSegment.Text(before))
-            }
+    while (cursor < source.length) {
+        val lineEnd = lineEndAt(source, cursor)
+        val line = source.substring(cursor, lineEnd)
+
+        if (enclosingFence != null) {
+            // A `:::artifact` inside a fenced code block is literal text, not a directive. Upstream's
+            // backend scanner gets this wrong (plain indexOf); micromark gets it right, and so do we.
+            if (isClosingCodeFence(line, enclosingFence)) enclosingFence = null
+            cursor = nextLineStart(source, lineEnd)
+            continue
         }
 
-        val attrString = match.groupValues[1]
-        val languageHint = match.groupValues[3].ifEmpty { null }
-        val content = match.groupValues[4].trimEnd()
-        val attrs = mutableMapOf<String, String>()
-        ATTR_REGEX.findAll(attrString).forEach { attrMatch ->
-            attrs[attrMatch.groupValues[1]] = attrMatch.groupValues[2]
+        val artifact = readArtifactAt(source, cursor, lineEnd)
+        if (artifact != null) {
+            appendTextBefore(segments, source, lastIndex, cursor)
+            segments.add(ArtifactSegment.ArtifactReference(artifact.artifact))
+            lastIndex = artifact.end
+            cursor = artifact.end
+            continue
         }
 
-        val artifact = Artifact(
-            identifier = attrs["identifier"] ?: attrs["id"] ?: "artifact-${match.range.first}",
-            type = attrs["type"] ?: "text/plain",
-            title = attrs["title"] ?: "Artifact",
-            language = languageHint ?: attrs["language"],
-            content = content,
-            version = attrs["version"]?.toIntOrNull() ?: 1,
-        )
-        segments.add(ArtifactSegment.ArtifactReference(artifact))
-        lastIndex = match.range.last + 1
+        codeFenceOf(line)?.let { enclosingFence = it }
+        cursor = nextLineStart(source, lineEnd)
     }
 
-    if (lastIndex < text.length) {
-        val remaining = text.substring(lastIndex).trim()
-        if (remaining.isNotEmpty()) {
-            segments.add(ArtifactSegment.Text(remaining))
-        }
+    if (lastIndex < source.length) {
+        val remaining = source.substring(lastIndex).trim()
+        if (remaining.isNotEmpty()) segments.add(ArtifactSegment.Text(remaining))
     }
 
-    if (segments.isEmpty() && text.isNotBlank()) {
-        segments.add(ArtifactSegment.Text(text))
-    }
+    if (segments.isEmpty() && source.isNotBlank()) segments.add(ArtifactSegment.Text(source))
 
     return segments
 }
@@ -84,4 +131,328 @@ fun groupArtifactVersions(segments: List<ArtifactSegment>): Map<String, List<Art
         .map { it.artifact }
         .groupBy { it.identifier }
         .mapValues { (_, artifacts) -> artifacts.sortedBy { it.version } }
+}
+
+private class ScannedArtifact(val artifact: Artifact, val end: Int)
+
+private fun appendTextBefore(
+    segments: MutableList<ArtifactSegment>,
+    source: String,
+    from: Int,
+    to: Int,
+) {
+    if (to <= from) return
+    val before = source.substring(from, to).trim()
+    if (before.isNotEmpty()) segments.add(ArtifactSegment.Text(before))
+}
+
+/** Reads a whole artifact starting on the line at [lineStart], or null when that line isn't one. */
+private fun readArtifactAt(source: String, lineStart: Int, lineEnd: Int): ScannedArtifact? {
+    val directive = readDirectiveLine(source, lineStart, lineEnd) ?: return null
+    val attrs = parseAttributes(directive.attrs) ?: return null
+
+    if (directive.colons < MIN_CONTAINER_COLONS) {
+        // Leaf directive `::artifact{…}` — no body, so it ends with its own line.
+        val end = nextLineStart(source, lineEnd)
+        return ScannedArtifact(buildArtifact(attrs, lineStart, null, "", true), end)
+    }
+
+    val close = findArtifactClose(source, lineEnd, directive.colons)
+    val contentStart = nextLineStart(source, lineEnd)
+    val contentEnd = close?.start ?: source.length
+    val opening = openingCodeFence(source, contentStart, contentEnd)
+
+    // Unclosed with no fence at all is ambiguous — most likely prose that merely mentions the
+    // directive. Emitting would hide the rest of the message behind a collapsed card.
+    if (close == null && opening == null) return null
+
+    val fenceClose = opening?.let {
+        findClosingCodeFenceStart(source, it.contentStart, contentEnd, it.fence)
+    } ?: -1
+
+    val content = if (opening == null) {
+        source.substring(contentStart, contentEnd).trim()
+    } else {
+        val end = if (fenceClose < 0) contentEnd else fenceClose
+        source.substring(opening.contentStart, end).trimEnd()
+    }
+    val language = opening?.info?.trim()?.takeWhile { !it.isWhitespace() }?.ifEmpty { null }
+
+    // Where the artifact *segment* ends must never run past where its content ends, or the text in
+    // between belongs to neither and vanishes from the screen entirely. That happens for an unclosed
+    // directive whose fence closed normally: content stops at the fence, so the segment must too, and
+    // the tail is emitted as ordinary text. `isComplete` stays false — the directive really is
+    // unterminated, and treating it as done would mount a WebView on content the model may still be
+    // appending to.
+    val end = when {
+        close != null -> close.end
+        fenceClose >= 0 -> nextLineStart(source, lineEndAt(source, fenceClose))
+        else -> source.length
+    }
+
+    return ScannedArtifact(
+        artifact = buildArtifact(attrs, lineStart, language, content, close != null),
+        end = end,
+    )
+}
+
+private fun buildArtifact(
+    attrs: Map<String, String>,
+    directiveStart: Int,
+    language: String?,
+    content: String,
+    isComplete: Boolean,
+): Artifact = Artifact(
+    // Offset into the normalised string. Must stay an offset, not a line index: this key groups
+    // versions across a whole conversation, so a line index would collide across messages.
+    identifier = attrs["identifier"] ?: attrs["id"] ?: "artifact-$directiveStart",
+    type = attrs["type"] ?: "text/plain",
+    title = attrs["title"] ?: "Artifact",
+    language = language ?: attrs["language"],
+    content = content,
+    version = attrs["version"]?.toIntOrNull() ?: 1,
+    isComplete = isComplete,
+)
+
+/** Parses `:::artifact[optional label]{attrs}`, or null when the line isn't an artifact directive. */
+private fun readDirectiveLine(source: String, lineStart: Int, lineEnd: Int): DirectiveLine? {
+    val line = source.substring(lineStart, lineEnd)
+    val firstContent = line.indexOfFirst { !it.isWhitespace() }
+    if (firstContent < 0 || indentWidth(line, firstContent) > MAX_DIRECTIVE_INDENT) return null
+
+    var i = firstContent
+    var colons = 0
+    while (i < line.length && line[i] == ':') {
+        colons++
+        i++
+    }
+    // One colon is a text directive, which upstream rewrites to literal text — never an artifact.
+    if (colons < 2 || !line.startsWith(ARTIFACT_NAME, i)) return null
+    i += ARTIFACT_NAME.length
+
+    // Optional label: `factory-label.js` sits between the name and the attributes upstream.
+    // Upstream's extractContent folds the label into the content; we drop it.
+    if (i < line.length && line[i] == '[') {
+        val labelEnd = line.indexOf(']', i + 1)
+        if (labelEnd < 0) return null
+        i = labelEnd + 1
+    }
+
+    // No space is allowed before the brace — `:::artifact {…}` parses as zero directives upstream.
+    if (i >= line.length || line[i] != '{') return null
+    val braceEnd = closingBraceIndex(line, i + 1)
+    if (braceEnd < 0) return null
+
+    return DirectiveLine(colons, line.substring(i + 1, braceEnd))
+}
+
+/**
+ * Index of the `}` that closes the attribute block, skipping quoted runs — a `}` inside a quoted
+ * value does not end the block upstream, so `title="The {config} object"` is a valid directive.
+ * A naive first-`}` scan truncates the attribute string mid-quote and voids the whole artifact.
+ */
+private fun closingBraceIndex(line: String, from: Int): Int {
+    var i = from
+    var quote: Char? = null
+    while (i < line.length) {
+        val c = line[i]
+        when {
+            quote != null -> if (c == quote) quote = null
+            c == '"' || c == '\'' -> quote = c
+            c == '}' -> return i
+        }
+        i++
+    }
+    return -1
+}
+
+/** Visual indent width of [line] up to [index], counting a tab as [TAB_WIDTH] columns. */
+private fun indentWidth(line: String, index: Int): Int {
+    var width = 0
+    for (i in 0 until index) width += if (line[i] == '\t') TAB_WIDTH else 1
+    return width
+}
+
+/**
+ * Attribute parser mirroring `micromark-extension-directive`'s `factory-attributes.js`. Returns null
+ * when the attribute block is invalid upstream, in which case the whole directive does not parse.
+ */
+private fun parseAttributes(attrString: String): Map<String, String>? {
+    val attrs = mutableMapOf<String, String>()
+    var i = 0
+    while (i < attrString.length) {
+        val c = attrString[i]
+        if (c.isWhitespace()) {
+            i++
+            continue
+        }
+        if (c == '#' || c == '.') {
+            val start = i + 1
+            var end = start
+            // `.` and `#` terminate a shortcut rather than extending it, so `#a.b` is id=a + class=b.
+            while (end < attrString.length && isAttrNameChar(attrString[end]) &&
+                attrString[end] != '.' && attrString[end] != '#'
+            ) {
+                end++
+            }
+            // An empty shortcut (`{# …}`) is `nok` upstream — it voids the entire block.
+            if (end == start) return null
+            attrs[if (c == '#') "id" else "class"] = attrString.substring(start, end)
+            i = end
+            continue
+        }
+
+        val nameStart = i
+        if (!isAttrNameStart(c)) return null
+        while (i < attrString.length && isAttrNameChar(attrString[i])) i++
+        val name = attrString.substring(nameStart, i)
+
+        var j = i
+        while (j < attrString.length && attrString[j].isWhitespace()) j++
+        if (j >= attrString.length || attrString[j] != '=') {
+            attrs[name] = ""
+            i = j
+            continue
+        }
+        j++
+        while (j < attrString.length && attrString[j].isWhitespace()) j++
+
+        if (j < attrString.length && (attrString[j] == '"' || attrString[j] == '\'')) {
+            val quote = attrString[j]
+            val valueStart = j + 1
+            val valueEnd = attrString.indexOf(quote, valueStart)
+            if (valueEnd < 0) return null
+            attrs[name] = attrString.substring(valueStart, valueEnd)
+            i = valueEnd + 1
+        } else {
+            var end = j
+            // Unquoted values terminate ONLY on whitespace or `}`; `{` is consumed into the value.
+            while (end < attrString.length && !attrString[end].isWhitespace() && attrString[end] != '}') {
+                if (attrString[end] in ATTR_ABORT_CHARS) return null
+                end++
+            }
+            attrs[name] = attrString.substring(j, end)
+            i = end
+        }
+    }
+    return attrs
+}
+
+private fun isAttrNameStart(c: Char): Boolean = c.isLetter() || c == '_' || c == ':'
+
+private fun isAttrNameChar(c: Char): Boolean = c.isLetterOrDigit() || c == '-' || c == '.' || c == ':' || c == '_'
+
+private fun lineEndAt(text: String, start: Int): Int {
+    val index = text.indexOf('\n', start)
+    return if (index < 0) text.length else index
+}
+
+private fun nextLineStart(text: String, lineEnd: Int): Int =
+    if (lineEnd >= text.length) text.length else lineEnd + 1
+
+private fun codeFenceOf(line: String): CodeFence? {
+    val trimmed = line.trimStart()
+    val marker = trimmed.firstOrNull() ?: return null
+    if (marker != '`' && marker != '~') return null
+    var length = 0
+    while (length < trimmed.length && trimmed[length] == marker) length++
+    return if (length < MIN_FENCE_LENGTH) null else CodeFence(marker, length)
+}
+
+/** CommonMark closing fences must be *at least* as long as the opening one, not exactly equal. */
+private fun isClosingCodeFence(line: String, opening: CodeFence): Boolean {
+    val trimmed = line.trim()
+    var count = 0
+    while (count < trimmed.length && trimmed[count] == opening.marker) count++
+    if (count < opening.length) return false
+    return trimmed.drop(count).all { it.isWhitespace() }
+}
+
+/**
+ * The `:::` that closes the artifact. Mirrors upstream's `findArtifactClose`, including the fallback:
+ * a `:::` seen while inside a code fence is remembered rather than accepted, and a matching closing
+ * fence discards it. That is what lets a 4-open/3-close artifact end at its `:::` with the stray
+ * fence kept as content.
+ */
+private fun findArtifactClose(source: String, directiveLineEnd: Int, minColons: Int): ArtifactClose? {
+    var cursor = nextLineStart(source, directiveLineEnd)
+    var codeFence: CodeFence? = null
+    var fallback: ArtifactClose? = null
+
+    while (cursor < source.length) {
+        val lineEnd = lineEndAt(source, cursor)
+        val line = source.substring(cursor, lineEnd)
+
+        val close = closeRangeAt(source, cursor, lineEnd, minColons)
+        if (close != null) {
+            if (codeFence == null) return close
+            if (fallback == null) fallback = close
+        }
+
+        val fence = codeFenceOf(line)
+        if (fence != null && codeFence == null) {
+            codeFence = fence
+        } else if (codeFence != null && isClosingCodeFence(line, codeFence)) {
+            codeFence = null
+            fallback = null
+        }
+
+        cursor = nextLineStart(source, lineEnd)
+    }
+
+    return if (codeFence != null) fallback else null
+}
+
+/**
+ * A closing `:::` run of at least [minColons] — micromark requires the close to be no shorter than
+ * the open, so `::::artifact` is not closed by `:::`. Upstream's backend scanner accepts the shorter
+ * run; we follow micromark here. Trailing text after the run still closes (see the class KDoc).
+ */
+private fun closeRangeAt(source: String, lineStart: Int, lineEnd: Int, minColons: Int): ArtifactClose? {
+    val line = source.substring(lineStart, lineEnd)
+    val firstContent = line.indexOfFirst { !it.isWhitespace() }
+    if (firstContent < 0) return null
+
+    var i = firstContent
+    var colons = 0
+    while (i < line.length && line[i] == ':') {
+        colons++
+        i++
+    }
+    if (colons < minColons || line.startsWith(ARTIFACT_NAME, i)) return null
+
+    return ArtifactClose(lineStart + firstContent, lineStart + i)
+}
+
+private fun openingCodeFence(source: String, contentStart: Int, contentEnd: Int): OpeningFence? {
+    if (contentStart >= contentEnd) return null
+    val content = source.substring(contentStart, contentEnd)
+    val firstContent = content.indexOfFirst { !it.isWhitespace() }
+    if (firstContent < 0) return null
+
+    val fenceStart = contentStart + firstContent
+    val lineEnd = lineEndAt(source, fenceStart)
+    val line = source.substring(fenceStart, lineEnd)
+    val fence = codeFenceOf(line) ?: return null
+
+    return OpeningFence(
+        fence = fence,
+        contentStart = nextLineStart(source, lineEnd),
+        info = line.trimStart().drop(fence.length),
+    )
+}
+
+private fun findClosingCodeFenceStart(
+    source: String,
+    start: Int,
+    end: Int,
+    opening: CodeFence,
+): Int {
+    var cursor = start
+    while (cursor < end) {
+        val lineEnd = lineEndAt(source, cursor)
+        if (isClosingCodeFence(source.substring(cursor, lineEnd), opening)) return cursor
+        cursor = nextLineStart(source, lineEnd)
+    }
+    return -1
 }

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/ArtifactDetector.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/ArtifactDetector.kt
@@ -9,7 +9,7 @@ package com.garfiec.librechat.feature.chat.components.artifact
  * `packages/api/src/artifacts/update.ts`, which is close enough to that contract to agree with the
  * web client on 22 of a 25-case differential corpus.
  *
- * The three remaining divergences are deliberate, not bugs:
+ * The divergences are deliberate, not bugs (the first three are the corpus's divergent rows):
  *  - `::: trailing` closes the artifact here; remark-directive does not, so web swallows the rest of
  *    the message. Upstream's own backend scanner agrees with us — its two implementations disagree
  *    with each other, so "match web exactly" is not a well-defined target.
@@ -20,6 +20,9 @@ package com.garfiec.librechat.feature.chat.components.artifact
  *  - The *closing* `:::` is accepted at any indent, while the opening directive is capped at 3
  *    columns. Micromark would treat a deeply-indented close as an indented code block; upstream's
  *    backend scanner accepts it, and so do we.
+ *  - An unclosed directive whose fence *did* close ends its segment at the fence, with the trailing
+ *    text emitted as ordinary text. Micromark runs the container to EOF and folds that tail into the
+ *    card's content instead. Both keep the tail visible — ours keeps prose out of the artifact.
  *
  * Line endings are normalised to `\n`, so [ArtifactSegment.Text] from a CRLF message loses its `\r`.
  * Harmless for markdown rendering.

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/IncompleteArtifact.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/IncompleteArtifact.kt
@@ -1,0 +1,79 @@
+package com.garfiec.librechat.feature.chat.components.artifact
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.layout.LayoutCoordinates
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.garfiec.librechat.feature.chat.components.CodeBlock
+import com.garfiec.librechat.feature.chat.resources.Res
+import com.garfiec.librechat.feature.chat.resources.artifact_incomplete
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * Renders an artifact whose closing `:::` never arrived — a reply truncated mid-artifact, or a live
+ * stream still in flight ([Artifact.isComplete]` == false`).
+ *
+ * Such artifacts show their **source**, deliberately bypassing both the inline-artifact preferences
+ * and [selectInlineArtifactStrategy]. Two reasons, and both matter:
+ *
+ *  - Every inline preference defaults to off, so the normal path would render a collapsed
+ *    [ArtifactButton] and take the partial content off screen. Text that renders fine today would
+ *    silently disappear behind a tap — the opposite of an improvement.
+ *  - Half-written markup handed to a WebView renders a blank box with no recourse. Source is both
+ *    safer and more useful: readable, selectable, and searchable.
+ *
+ * Search matches here **are** counted (unlike complete artifacts, whose content contributes zero) —
+ * see the render-order contract in `SearchMatchEnumeration`. That is why this composable takes the
+ * focused-occurrence plumbing and forwards it to [CodeBlock].
+ */
+@Composable
+fun IncompleteArtifact(
+    artifact: Artifact,
+    onTap: () -> Unit,
+    modifier: Modifier = Modifier,
+    searchQuery: String? = null,
+    searchFocusedOccurrence: Int = -1,
+    onFocusedOccurrencePosition: ((LayoutCoordinates, Rect) -> Unit)? = null,
+) {
+    ArtifactCardSurface(onTap = onTap, modifier = modifier) {
+        Column(modifier = Modifier.fillMaxWidth().padding(12.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = artifact.title,
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f, fill = false),
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    text = stringResource(Res.string.artifact_incomplete),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+            CodeBlock(
+                code = artifact.content,
+                language = artifact.language,
+                modifier = Modifier.fillMaxWidth(),
+                searchQuery = searchQuery,
+                searchFocusedOccurrence = searchFocusedOccurrence,
+                onFocusedMatchPosition = onFocusedOccurrencePosition,
+            )
+        }
+    }
+}

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/util/ConversationMediaExtractor.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/util/ConversationMediaExtractor.kt
@@ -74,7 +74,8 @@ private val URL_REGEX = Regex("""https?://[^\s<>()\[\]"']+""")
 fun extractConversationLinks(messages: List<Message>): List<ConversationLink> {
     val links = mutableListOf<ConversationLink>()
     for (message in messages) {
-        val text = message.searchableText()
+        // Joining is harmless here — a URL never spans two parts, and this only feeds a regex.
+        val text = message.artifactSearchTexts().joinToString("\n")
         if (text.isBlank()) continue
         URL_REGEX.findAll(text).forEach { match ->
             val url = match.value.trimEnd('.', ',', ';', ':', '!', '?')
@@ -90,26 +91,37 @@ fun extractConversationLinks(messages: List<Message>): List<ConversationLink> {
  * identifier in first-seen order; each group is the version history sorted ascending (so the tile
  * shows the latest version + count, and tapping opens the panel with all versions). Mirrors
  * `groupArtifactVersions` but spans the whole conversation rather than one message.
+ *
+ * Detection runs **per content part**, matching how the parts actually render. Joining them first
+ * would build a string that exists nowhere on screen, and an unclosed directive in one part would
+ * swallow every following part — including THINK text — into a single bogus entry.
+ *
+ * Incomplete artifacts (truncated mid-write, so no closing `:::`) are excluded: the gallery is a
+ * list of finished artifacts, and a partial one has nothing useful to open.
  */
 fun extractConversationArtifacts(messages: List<Message>): List<List<Artifact>> {
     val all = mutableListOf<Artifact>()
     for (message in messages) {
-        val text = message.searchableText()
-        if (text.isBlank()) continue
-        detectArtifacts(text).forEach { segment ->
-            if (segment is ArtifactSegment.ArtifactReference) all += segment.artifact
+        for (text in message.artifactSearchTexts()) {
+            if (text.isBlank()) continue
+            detectArtifacts(text).forEach { segment ->
+                if (segment is ArtifactSegment.ArtifactReference && segment.artifact.isComplete) {
+                    all += segment.artifact
+                }
+            }
         }
     }
     // groupBy yields a LinkedHashMap, preserving first-seen identifier order.
     return all.groupBy { it.identifier }.map { (_, versions) -> versions.sortedBy { it.version } }
 }
 
-private fun Message.searchableText(): String {
+/** Each independently-rendered text run of a message, in render order (see the note above). */
+private fun Message.artifactSearchTexts(): List<String> {
     val parts = content
     return if (!parts.isNullOrEmpty()) {
-        parts.mapNotNull { it.text ?: it.think }.joinToString("\n")
+        parts.mapNotNull { it.text ?: it.think }
     } else {
-        text
+        listOf(text)
     }
 }
 


### PR DESCRIPTION
## Summary

Artifact detection used a single regex, but the artifact format is a remark-directive container inside a CommonMark document — the real contract is "whatever micromark parses". The regex missed forms real backends emit — tilde/long fences, CRLF, unfenced content — leaving raw `:::artifact{…}` text in the chat, and mis-rendered others (non-double-quoted attributes produced a card with the wrong type and title). This ports the shape of upstream's backend line scanner (`packages/api/src/artifacts/update.ts`) and adds a completeness-aware rendering path for artifacts truncated mid-write.

## Changes

- **Detection** (`ArtifactDetector`): line scanner replacing the regex. Newly detected: tilde fences, any fence length ≥3 (closing fence at-least-as-long), unfenced content, CRLF, leaf `::artifact{…}` directives, `[label]`, non-`\w` info strings. Tightened to match micromark: directives inside fenced code blocks, mid-line, or indented 4+ columns are not artifacts. Measured against upstream's real parser on a 25-case differential corpus: agreement goes **11/25 → 22/25**. The three residual divergences (cases 10, 23, 25) are deliberate and documented in the KDoc; every other corpus row's expectation equals upstream's measured result, so a change that makes any other row fail is a regression.
- **Reverses a #296 assertion**: mismatched fence lengths (e.g. a 4-backtick fence "closed" by 3 backticks) now produce an artifact, matching upstream — the closing fence must be *at least* as long, and a shorter run is content.
- **Attribute grammar** mirrors micromark's `factory-attributes.js`: single-quoted/unquoted/valueless attributes, `#id`/`.class` shortcuts, quote-aware brace scanning, and the six abort characters that void the whole directive.
- **Incomplete artifacts**: `Artifact.isComplete = false` when the closing `:::` never arrived. These render **source-first** via the new `IncompleteArtifact` (CodeBlock + "Incomplete" label, tap still opens the artifact panel), bypassing the inline prefs — every pref defaults off, so the normal path would collapse partial content behind a button, and half-written markup in a WebView is a blank box. An unclosed directive with **no** opening fence is a prose mention and is not emitted at all — nothing after it gets swallowed.
- **Search**: incomplete artifacts' visible source counts for in-conversation search (both enumeration walks share the new `countArtifactOccurrences`); complete artifacts still contribute 0.
- **Artifacts tab**: `extractConversationArtifacts` now scans per content part (a joined string renders nowhere, and an unclosed directive in part 1 would swallow every later part) and excludes incomplete artifacts.
- **i18n**: new `artifact_incomplete` string, translated in all 9 locales.

## Testing

- New 25-case differential corpus test whose row expectations pin upstream's measured parser output (deliberate divergences marked); new tests for search enumeration, empty-content inline strategy, and the media extractor (previously untested). Full `:feature:chat` unit suite, `detekt detektMetadataCommonMain`, and the Kotlin/Native iOS compile are green.
- Device-tested on an emulator: fenced and unfenced complete artifacts render cards; a truncated artifact renders the incomplete source card and survives a persistence round-trip; a bare prose `:::artifact{…}` mention swallows nothing; search counts and navigates exactly per the contract.

## Notes

- Messages with no artifact now pass through **verbatim** (the old path trimmed surrounding whitespace). This matches what web feeds its renderer — e.g. a reply opening with a 4-space-indented line is an indented code block, not a paragraph. Pinned by a test.
- Pre-existing wrinkle made more frequent, not fixed here: with the markdown inline pref on, `InlineMarkdownArtifact` highlights search matches but contributes 0 to the count, so those highlights are skipped by prev/next (documented in its KDoc).
- Live streaming still shows the raw directive until the message finalizes (#302); legacy no-parts messages still bypass detection on the chat render path (#304 — the Artifacts tab already falls back to `message.text`). This PR supplies the emit-on-unclosed capability #302 needs and removes its WebView-thrash risk (incomplete → source → no WebView mounts mid-stream).

Closes #301
Closes #303
