### PR TITLE
fix(chat): run artifact detection on the streaming message (#302)

### DIFF
--- a/feature/chat/CLAUDE.md
+++ b/feature/chat/CLAUDE.md
@@ -116,6 +116,14 @@ Two consequences worth knowing before touching that block:
 - `ChatViewModel.sendMessage()` calls `ChatRepository.startChat()` which returns `Flow<StreamEvent>`
 - Two-phase: POST /api/agents/chat -> streamId, then GET SSE stream
 - `streamingBuffer: StringBuilder` accumulates text deltas
+- **The live bubble renders through `TextContentPart(streaming = true)`** (#302), so artifact
+  detection runs on every flush — an unclosed artifact streams as its source via
+  `IncompleteArtifact` instead of raw `:::artifact{…}` text. The `streaming` flag must stay
+  threaded down to every `MarkdownContent` and `CodeBlock` beneath it: dropping it reintroduces
+  the per-delta Loading flash + LRU pollution documented in `CachedMarkdown`'s KDoc (the #169
+  class), and `CodeBlock`'s off-main highlight retention keys off it. The bubble passes no
+  `searchQuery` — the streaming message is outside the search enumeration, which is what keeps
+  the two search walks lockstep-free here.
 - Tool calls tracked in `activeToolCalls` list (start -> complete lifecycle)
 - **Stream termination is a chokepoint** for every *event-driven* end — clean/aborted Final, error, failed abort, watchdog, resume-found-expired — which funnel through the single private `endStream(reason)` in `StreamingManagerDelegate` (the one exception is a flow that ends with neither Final nor Error — a clean SSE EOF or a stream-GET 404 — which the caller's `onTerminated` safety net clears directly; a known gap, don't rely on `endStream` being the *only* teardown); the sealed reason (`Finalized` / `StreamError` / `AbortFallback` / `ResumeExpired`) decides job cancel, state write, queue policy, and whether a reload is allowed. A per-session Int counter latches each session to at most ONE end, and stale ends from a previous session are no-ops — do not add teardown steps at call sites; add them to the reason table. Structural invariant this encodes: **nothing reloads on an abort path** — the server emits the aborted frame BEFORE persisting, so any refetch there races the save (and the optimistic user message was never in Room, so a reload can lose it entirely). `Finalized` writes no state: the atomic finalize in `finalizeChatDisplay` owns that (the no-completion-flash invariant)
 - `stopGeneration()` POSTs `chatRepository.abortChat()` and **deliberately does not cancel the stream job.** The abort POST only acks (`{ success, aborted }`); the server ends the run by emitting an ordinary `final` frame flagged `aborted` over the same SSE stream, and *that* frame carries the partial's content parts. Cancelling the collector was the original bug — the stopped reply vanished. `handleFinal` reads `aborted` off the frame, not off local stop state, so a Stop from another client is handled identically. Stop-specific behavior: no auto-TTS, no `gen_title`, no queue drain (the hold is re-asserted). `abortRequested` guards double-taps. Works before the `created` milestone too — a null stream id makes the abort route fall back to one of the caller's active jobs (the *oldest*, and the client can't tell which, since `ChatAbortResponse` drops the returned `aborted` id — so with a second stream live server-side a null-key Stop can hit the wrong job; known gap). An acked abort arms a 15s watchdog; if the frame never lands (dead socket) or the POST fails, `endStream(AbortFallback)` stops locally with the partial preserved and NO reload
@@ -264,6 +272,10 @@ existing upload/usage path already handles them.
   and take partial content off screen, and half-written markup in a WebView is a blank box. An
   unclosed directive with **no** opening fence is *not* emitted at all — that's a prose mention, and
   emitting it would swallow the rest of the reply.
+- **While streaming, complete artifacts are gated to `ArtifactButton`** even when an inline pref is
+  on (`shouldRenderInlineArtifact`): the segment subtree recomposes per delta, and an inline preview
+  reloads its WebView on every content change (mermaid recreates its view outright). The real
+  preview mounts once, at settle, where the streaming→final swap replaces the subtree anyway.
 - Supported types: `text/html`, `image/svg+xml`, `application/vnd.react`, `application/vnd.mermaid`, `text/markdown`/`text/md`, `text/plain`, `application/vnd.code-html`
 - `MermaidWebContent` renders Mermaid diagrams via CDN mermaid.js with zoom controls and dark theme
 - `MarkdownWebContent` renders Markdown via CDN marked.js + highlight.js with GFM and syntax highlighting

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/components/MarkdownContent.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/components/MarkdownContent.kt
@@ -143,6 +143,7 @@ actual fun MarkdownContent(
                             searchQuery = if (isSearchActive) searchQuery else null,
                             searchFocusedOccurrence = focusedInSegment,
                             onFocusedMatchPosition = onFocusedOccurrencePosition,
+                            streaming = streaming,
                         )
                     }
                     if (index < segments.lastIndex) Spacer(modifier = Modifier.height(8.dp))

--- a/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/components/artifact/ArtifactDetectorTest.kt
+++ b/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/components/artifact/ArtifactDetectorTest.kt
@@ -1,6 +1,7 @@
 package com.garfiec.librechat.feature.chat.components.artifact
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -325,6 +326,35 @@ Let me know if you want changes.
         val segments = detectArtifacts(text)
         assertEquals(1, segments.size)
         assertEquals(text, (segments[0] as ArtifactSegment.Text).text)
+    }
+
+    @Test
+    fun `streaming prefixes progress from text to incomplete to complete`() {
+        // The live bubble re-runs detection on the growing buffer every flush (#302). Phases:
+        // directive line alone is prose (the fence guard), the opening fence makes it an
+        // incomplete artifact, and only the closing ::: completes it.
+        val directive = """:::artifact{identifier="demo" type="text/html" title="Demo"}"""
+
+        val directiveOnly = detectArtifacts(directive)
+        assertEquals(1, directiveOnly.size)
+        assertTrue(directiveOnly[0] is ArtifactSegment.Text)
+
+        val fenceOpen = detectArtifacts("$directive\n```html\n<p>hi")
+        val partial = (fenceOpen.single() as ArtifactSegment.ArtifactReference).artifact
+        assertFalse(partial.isComplete)
+        assertEquals("<p>hi", partial.content)
+
+        val fenceGrown = detectArtifacts("$directive\n```html\n<p>hi</p>\n<p>more</p>")
+        val grown = (fenceGrown.single() as ArtifactSegment.ArtifactReference).artifact
+        assertFalse(grown.isComplete)
+        assertEquals("<p>hi</p>\n<p>more</p>", grown.content)
+
+        val closed = detectArtifacts("$directive\n```html\n<p>hi</p>\n<p>more</p>\n```\n:::\nAfter.")
+        assertEquals(2, closed.size)
+        val complete = (closed[0] as ArtifactSegment.ArtifactReference).artifact
+        assertTrue(complete.isComplete)
+        assertEquals("<p>hi</p>\n<p>more</p>", complete.content)
+        assertEquals("After.", (closed[1] as ArtifactSegment.Text).text)
     }
 
     @Test

--- a/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/components/artifact/InlineArtifactStrategyTest.kt
+++ b/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/components/artifact/InlineArtifactStrategyTest.kt
@@ -1,7 +1,9 @@
 package com.garfiec.librechat.feature.chat.components.artifact
 
+import com.garfiec.librechat.core.data.datastore.InlineArtifactPrefs
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class InlineArtifactStrategyTest {
@@ -127,5 +129,21 @@ class InlineArtifactStrategyTest {
             cachedMermaidSvg = "<svg/>",
         )
         assertEquals(InlineArtifactStrategy.WebViewSlot, result)
+    }
+
+    @Test
+    fun `streaming gates inline rendering off for every type`() {
+        val allOn = InlineArtifactPrefs(mermaid = true, svg = true, html = true, react = true, markdown = true)
+        val types = listOf(
+            "application/vnd.mermaid",
+            "image/svg+xml",
+            "text/html",
+            "application/vnd.react",
+            "text/markdown",
+        )
+        types.forEach { type ->
+            assertTrue(shouldRenderInlineArtifact(allOn, type, streaming = false), type)
+            assertFalse(shouldRenderInlineArtifact(allOn, type, streaming = true), type)
+        }
     }
 }

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/CodeBlock.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/CodeBlock.kt
@@ -27,7 +27,9 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -62,6 +64,9 @@ fun CodeBlock(
     searchQuery: String? = null,
     searchFocusedOccurrence: Int = -1,
     onFocusedMatchPosition: ((LayoutCoordinates, Rect) -> Unit)? = null,
+    // While streaming, [code] grows every flush and the highlight re-runs from scratch, so it is
+    // computed off the main thread with the previous result retained.
+    streaming: Boolean = false,
 ) {
     var showCopied by remember { mutableStateOf(false) }
 
@@ -128,14 +133,10 @@ fun CodeBlock(
                 .padding(12.dp),
         ) {
             val isDarkTheme = isSystemInDarkTheme()
-            val highlightedCode = remember(code, language, searchQuery, searchFocusedOccurrence, isDarkTheme) {
-                val syntax = highlightSyntax(code, language?.lowercase())
-                if (searchQuery.isNullOrBlank()) {
-                    syntax
-                } else {
-                    addSearchSpans(syntax, searchQuery, searchFocusedOccurrence, isDarkTheme)
-                }
-            }
+            val highlightedCode = rememberHighlightedCode(
+                input = HighlightInput(code, language, searchQuery, searchFocusedOccurrence, isDarkTheme),
+                streaming = streaming,
+            )
             val focusedRange = remember(code, searchQuery, searchFocusedOccurrence) {
                 if (searchQuery.isNullOrBlank()) {
                     null
@@ -156,6 +157,51 @@ fun CodeBlock(
             )
         }
     }
+}
+
+private data class HighlightInput(
+    val code: String,
+    val language: String?,
+    val searchQuery: String?,
+    val searchFocusedOccurrence: Int,
+    val isDarkTheme: Boolean,
+)
+
+private fun highlight(input: HighlightInput): AnnotatedString {
+    val syntax = highlightSyntax(input.code, input.language?.lowercase())
+    return if (input.searchQuery.isNullOrBlank()) {
+        syntax
+    } else {
+        addSearchSpans(syntax, input.searchQuery, input.searchFocusedOccurrence, input.isDarkTheme)
+    }
+}
+
+/**
+ * Highlights [input]. While [streaming], the compute runs off the main thread with the previous
+ * result retained (and the first input highlighted synchronously) so the code never blanks.
+ */
+@Composable
+private fun rememberHighlightedCode(
+    input: HighlightInput,
+    streaming: Boolean,
+): AnnotatedString {
+    if (!streaming) {
+        return remember(input) { highlight(input) }
+    }
+
+    val latestInput by rememberUpdatedState(input)
+    val initialInput = remember { input }
+    var highlighted by remember { mutableStateOf(highlight(initialInput)) }
+
+    LaunchedEffect(Unit) {
+        collectDerived(
+            inputs = snapshotFlow { latestInput },
+            alreadyDerived = initialInput,
+            derive = ::highlight,
+        ) { highlighted = it }
+    }
+
+    return highlighted
 }
 
 // --- Syntax highlighting engine ---

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/MarkdownSegmentState.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/MarkdownSegmentState.kt
@@ -51,12 +51,25 @@ internal suspend fun collectMarkdownSegments(
     parse: (String) -> List<MarkdownSegment> = ::parseMarkdownSegments,
     parseContext: CoroutineContext = Dispatchers.Default,
     onSegments: (List<MarkdownSegment>) -> Unit,
+) = collectDerived(texts, alreadyParsed, parse, parseContext, onSegments)
+
+/**
+ * Derives a value from the latest input in [inputs] on [deriveContext], skipping inputs equal to
+ * the previous one. [deriveContext] must differ from the caller's dispatcher, or a cancelled
+ * derivation publishes its result instead of being discarded.
+ */
+internal suspend fun <I, O> collectDerived(
+    inputs: Flow<I>,
+    alreadyDerived: I,
+    derive: (I) -> O,
+    deriveContext: CoroutineContext = Dispatchers.Default,
+    onResult: (O) -> Unit,
 ) {
-    var lastParsed = alreadyParsed
-    texts.conflate().collect { t ->
-        if (t == lastParsed) return@collect
-        val parsed = withContext(parseContext) { parse(t) }
-        onSegments(parsed)
-        lastParsed = t
+    var lastInput = alreadyDerived
+    inputs.conflate().collect { input ->
+        if (input == lastInput) return@collect
+        val result = withContext(deriveContext) { derive(input) }
+        onResult(result)
+        lastInput = input
     }
 }

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/StreamingMessageBubble.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/StreamingMessageBubble.kt
@@ -148,7 +148,9 @@ private fun ThreadStreamingBubble(
                 },
         ) {
             if (streamingContent.isNotBlank()) {
-                MarkdownContent(
+                // Routed through TextContentPart so artifact directives render as cards while the
+                // reply streams (#302) — an unclosed artifact shows its source via IncompleteArtifact.
+                TextContentPart(
                     text = streamingContent,
                     fontSizeMultiplier = fontSizeMultiplier,
                     useKatex = useKatex,
@@ -236,7 +238,9 @@ private fun TwoSidedStreamingBubble(
             )
             Spacer(modifier = Modifier.height(4.dp))
             if (streamingContent.isNotBlank()) {
-                MarkdownContent(
+                // Routed through TextContentPart so artifact directives render as cards while the
+                // reply streams (#302) — an unclosed artifact shows its source via IncompleteArtifact.
+                TextContentPart(
                     text = streamingContent,
                     fontSizeMultiplier = fontSizeMultiplier,
                     useKatex = useKatex,

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/TextArtifactContentPart.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/TextArtifactContentPart.kt
@@ -29,7 +29,7 @@ import com.garfiec.librechat.feature.chat.components.artifact.groupArtifactVersi
 import com.garfiec.librechat.feature.chat.components.artifact.isCacheableMermaid
 import com.garfiec.librechat.feature.chat.components.artifact.mermaidCacheKey
 import com.garfiec.librechat.feature.chat.components.artifact.selectInlineArtifactStrategy
-import com.garfiec.librechat.feature.chat.components.artifact.shouldRenderInline
+import com.garfiec.librechat.feature.chat.components.artifact.shouldRenderInlineArtifact
 
 // ─── TextContentPart ────────────────────────────────────────────────
 
@@ -42,6 +42,10 @@ internal fun TextContentPart(
     searchQuery: String? = null,
     searchFocusedOccurrence: Int = -1,
     onFocusedOccurrencePosition: ((LayoutCoordinates, Rect) -> Unit)? = null,
+    // True while rendering the live reply bubble. Must reach every MarkdownContent below (or the
+    // per-delta Loading flash and LRU pollution documented in CachedMarkdown return) and gates
+    // inline artifact previews to buttons (see shouldRenderInlineArtifact).
+    streaming: Boolean = false,
 ) {
     if (text.isBlank()) return
 
@@ -57,6 +61,7 @@ internal fun TextContentPart(
             searchQuery,
             searchFocusedOccurrence,
             onFocusedOccurrencePosition,
+            streaming = streaming,
         )
     } else {
         val versionMap = remember(segments) { groupArtifactVersions(segments) }
@@ -96,6 +101,7 @@ internal fun TextContentPart(
                             searchQuery,
                             searchFocusedOccurrence - textOffsets[index],
                             onFocusedOccurrencePosition,
+                            streaming = streaming,
                         )
                     }
                     is ArtifactSegment.ArtifactReference -> {
@@ -112,8 +118,9 @@ internal fun TextContentPart(
                                 searchQuery = searchQuery,
                                 searchFocusedOccurrence = searchFocusedOccurrence - textOffsets[index],
                                 onFocusedOccurrencePosition = onFocusedOccurrencePosition,
+                                streaming = streaming,
                             )
-                        } else if (inlinePrefs.shouldRenderInline(segment.artifact.type)) {
+                        } else if (shouldRenderInlineArtifact(inlinePrefs, segment.artifact.type, streaming)) {
                             val type = ArtifactType.from(segment.artifact.type)
                             val cachedSvg = rememberCachedMermaidSvg(segment.artifact.content, type)
                             when (val strategy = selectInlineArtifactStrategy(type, segment.artifact.content, cachedSvg)) {

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/IncompleteArtifact.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/IncompleteArtifact.kt
@@ -46,6 +46,7 @@ fun IncompleteArtifact(
     searchQuery: String? = null,
     searchFocusedOccurrence: Int = -1,
     onFocusedOccurrencePosition: ((LayoutCoordinates, Rect) -> Unit)? = null,
+    streaming: Boolean = false,
 ) {
     ArtifactCardSurface(onTap = onTap, modifier = modifier) {
         Column(modifier = Modifier.fillMaxWidth().padding(12.dp)) {
@@ -73,6 +74,7 @@ fun IncompleteArtifact(
                 searchQuery = searchQuery,
                 searchFocusedOccurrence = searchFocusedOccurrence,
                 onFocusedMatchPosition = onFocusedOccurrencePosition,
+                streaming = streaming,
             )
         }
     }

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/InlineArtifactPrefsExt.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/artifact/InlineArtifactPrefsExt.kt
@@ -16,3 +16,10 @@ fun InlineArtifactPrefs.shouldRenderInline(type: String): Boolean =
         ArtifactType.MARKDOWN -> markdown
         ArtifactType.PLAIN, ArtifactType.CODE -> false
     }
+
+/**
+ * [shouldRenderInline], additionally gated off while the message is still streaming — an inline
+ * preview would reload its WebView on every delta. Full rationale: feature/chat/CLAUDE.md, Artifacts.
+ */
+fun shouldRenderInlineArtifact(prefs: InlineArtifactPrefs, type: String, streaming: Boolean): Boolean =
+    !streaming && prefs.shouldRenderInline(type)

--- a/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/components/PlatformChatComponents.ios.kt
+++ b/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/components/PlatformChatComponents.ios.kt
@@ -545,6 +545,7 @@ actual fun MarkdownContent(
                             searchQuery = if (isSearchActive) searchQuery else null,
                             searchFocusedOccurrence = focusedInSegment,
                             onFocusedMatchPosition = onFocusedOccurrencePosition,
+                            streaming = streaming,
                         )
                     }
                     if (index < segments.lastIndex) Spacer(modifier = Modifier.height(8.dp))


### PR DESCRIPTION
## Summary

While a reply streamed, the live bubble rendered its text via `MarkdownContent` directly — artifact detection only ran after finalize — so an artifact appeared as literal `:::artifact{…}` text plus a code block until the reply finalized. The bubble now renders through the same `TextContentPart` the settled path uses, with a `streaming` flag threaded down, so artifacts stream as cards.

## Changes

- **`StreamingMessageBubble`** (both layout variants) renders `streamingContent` through `TextContentPart(streaming = true)`. An artifact whose closing `:::` hasn't arrived yet streams as its source via `IncompleteArtifact`; a directive line whose fence hasn't arrived still renders as text — the detector's prose guard, unchanged, which keeps streaming and persisted rendering in agreement.
- **`streaming` threaded down** through `TextContentPart` → both of its `MarkdownContent` call sites → `IncompleteArtifact` → `CodeBlock`, preserving `CachedMarkdown`'s streaming behavior (retained state, no cache writes) on every text segment.
- **Inline previews gated off while streaming** (`shouldRenderInlineArtifact`): a complete artifact stays a button until the message settles — an inline preview would reload its WebView on every delta. Only affects users who opted into the off-by-default inline prefs.
- **`CodeBlock` highlights subsequent deltas off the main thread while streaming**, with last-result retention (the first input is highlighted synchronously so the block never renders empty), via `collectDerived` (generalized from `collectMarkdownSegments`, which now delegates to it). Both platform `MarkdownContent` actuals pass the flag through, which also removes pre-existing per-flush main-thread highlight work on ordinary streaming code fences.
- **Search unaffected**: the streaming message remains outside in-conversation search enumeration; the bubble passes no search query.

## Testing

- New unit tests: the detector's streaming progression (directive-only → incomplete with growing content → complete), and the streaming gate over every inline-preview type. Full `./gradlew test`, `detekt detektMetadataCommonMain :app:lint`, and the Kotlin/Native iOS compile are green.
- Device-tested on an emulator: a long artifact streams as a growing source card with no persistent raw directive and no per-tick flashing of surrounding text; Stop mid-artifact persists the partial as the incomplete card; with the inline HTML pref enabled, a closed artifact stays a button until settle, then swaps once to the preview; an ordinary streaming ```kotlin fence stays syntax-highlighted.

## Notes

- Legacy messages with no `content` parts still bypass detection on the chat render path (#304).

Closes #302
