### PR TITLE
feat(theme): change the default accent seed from turquoise to blue

### DIFF
--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/ThemeDataStore.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/ThemeDataStore.kt
@@ -78,7 +78,7 @@ class ThemeDataStore(
         prefs[KEY_THEME].toThemeMode()
     }
 
-    /** Accent seed color as an ARGB int. Defaults to the turquoise brand hue. */
+    /** Accent seed color as an ARGB int. Falls back to [DEFAULT_ACCENT_COLOR] when unset. */
     val accentColor: Flow<Int> = dataStore.data.map { prefs ->
         prefs[KEY_ACCENT_COLOR] ?: DEFAULT_ACCENT_COLOR
     }
@@ -108,9 +108,10 @@ class ThemeDataStore(
 
     companion object {
         /**
-         * Turquoise brand hue (ARGB) used when no accent has been chosen. Derived from the
-         * canonical [DEFAULT_ACCENT_SEED_ARGB] in `:core:model`, same as `DefaultAccentSeed`
-         * in `:core:ui`.
+         * Accent seed (ARGB) used when no accent has been chosen. Derived from the canonical
+         * [DEFAULT_ACCENT_SEED_ARGB] in `:core:model`, same as `DefaultAccentSeed` in `:core:ui`.
+         * Only ever a fallback for a missing preference, so changing it moves users who never
+         * picked an accent and leaves everyone else on their stored value.
          */
         val DEFAULT_ACCENT_COLOR: Int = DEFAULT_ACCENT_SEED_ARGB.toInt()
 

--- a/core/model/src/commonMain/kotlin/com/garfiec/librechat/core/model/Constants.kt
+++ b/core/model/src/commonMain/kotlin/com/garfiec/librechat/core/model/Constants.kt
@@ -12,10 +12,13 @@ const val SAVED_TAG = "Saved"
 const val NEW_CHAT_DRAFT_KEY: String = "__new_chat__"
 
 /**
- * Default accent seed color as `0xAARRGGBB` — the turquoise brand hue of the app icon's cable,
- * sampled from the iOS 1024px icon asset. Canonical here in `:core:model` (the shared, pure-Kotlin
- * module both consumers depend on) so the Compose seed (`DefaultAccentSeed` in `:core:ui`) and the
- * persisted-preference fallback (`ThemeDataStore.DEFAULT_ACCENT_COLOR` in `:core:data`) derive from
- * one literal and can never drift.
+ * Default accent seed color as `0xAARRGGBB`. Canonical here in `:core:model` (the shared,
+ * pure-Kotlin module both consumers depend on) so the Compose seed (`DefaultAccentSeed` in
+ * `:core:ui`) and the persisted-preference fallback (`ThemeDataStore.DEFAULT_ACCENT_COLOR` in
+ * `:core:data`) derive from one literal and can never drift.
+ *
+ * Only this color's **hue** reaches the generated scheme — see `LibreChatTheme` for why. Its
+ * chroma and tone are inert there, so judge a replacement by the roles it generates, never by
+ * how the hex reads as a swatch.
  */
-const val DEFAULT_ACCENT_SEED_ARGB: Long = 0xFF00D8BB
+const val DEFAULT_ACCENT_SEED_ARGB: Long = 0xFF3B82F6

--- a/core/ui/src/commonMain/kotlin/com/garfiec/librechat/core/ui/theme/AccentColors.kt
+++ b/core/ui/src/commonMain/kotlin/com/garfiec/librechat/core/ui/theme/AccentColors.kt
@@ -4,24 +4,28 @@ import androidx.compose.ui.graphics.Color
 import com.garfiec.librechat.core.model.DEFAULT_ACCENT_SEED_ARGB
 
 /**
- * The default accent seed color (the turquoise brand hue of the app icon, canonical value
- * in [DEFAULT_ACCENT_SEED_ARGB]). Used to generate the Material 3 scheme when the user has
- * not chosen a custom accent and wallpaper-based dynamic color is off.
+ * The default accent seed color (canonical value in [DEFAULT_ACCENT_SEED_ARGB]). Used to
+ * generate the Material 3 scheme when the user has not chosen a custom accent and
+ * wallpaper-based dynamic color is off.
  */
 val DefaultAccentSeed = Color(DEFAULT_ACCENT_SEED_ARGB)
 
 /**
  * Curated set of accent seed colors offered in the picker. The full Material 3
  * [androidx.compose.material3.ColorScheme] is generated from whichever seed the
- * user selects, so these are source colors, not final role colors. Turquoise
- * (the default) is listed first.
+ * user selects, so these are source colors, not final role colors — the swatch a
+ * user taps is not the color the app will paint.
+ *
+ * The default is listed first and must not be repeated further down: the picker marks
+ * selection by comparing each preset's ARGB against the working value, so a duplicate
+ * renders as two simultaneously selected swatches.
  */
 val AccentColorPresets: List<Color> = listOf(
-    DefaultAccentSeed, // Turquoise (default, matches the app icon)
-    Color(0xFF3B82F6), // Blue
+    DefaultAccentSeed, // Blue (default)
     Color(0xFF6366F1), // Indigo
     Color(0xFF8B5CF6), // Lavender (the original brand hue)
     Color(0xFF06B6D4), // Cyan
+    Color(0xFF00D8BB), // Turquoise (matches the app icon's cable)
     Color(0xFF22C55E), // Green
     Color(0xFFF59E0B), // Amber
     Color(0xFFF97316), // Orange

--- a/core/ui/src/commonMain/kotlin/com/garfiec/librechat/core/ui/theme/Theme.kt
+++ b/core/ui/src/commonMain/kotlin/com/garfiec/librechat/core/ui/theme/Theme.kt
@@ -28,8 +28,12 @@ expect fun supportsDynamicColor(): Boolean
  * Color resolution precedence:
  * 1. [useDynamicColor] on **and** the platform supports it -> wallpaper-based scheme.
  * 2. Otherwise the full scheme is generated from [accentColor] via MaterialKolor
- *    ([rememberDynamicColorScheme], remembered/keyed on its inputs). The default
- *    [accentColor] matches the turquoise brand hue of the app icon.
+ *    ([rememberDynamicColorScheme], remembered/keyed on its inputs).
+ *
+ * [PaletteStyle.TonalSpot] keeps only the seed's hue — every role is re-derived at a fixed
+ * chroma and a fixed per-role tone, so no role in the generated scheme resolves to the seed hex.
+ * The hue feeds the neutral palette as well as the accent one, which is why it tints surfaces
+ * app-wide.
  */
 @Composable
 fun LibreChatTheme(


### PR DESCRIPTION
## Summary
- Change the default Material 3 accent seed from turquoise (`0xFF00D8BB`) to blue (`0xFF3B82F6`)
- Turquoise was picked to match the cable in the app icon, but that match never reached the screen: `LibreChatTheme` generates the scheme with `PaletteStyle.TonalSpot`, which keeps only the seed's **hue** and re-derives every role at a fixed chroma and a fixed per-role tone. No role in the generated scheme resolves to the seed hex — at hue 181 the app renders `primary` as `#226A5D` in light and `#9DD1C3` in dark
- The seed hue also drives the **neutral** palette, so it tinted every background in the app rather than just the accented controls — `surface` `#F6FAF7` in light, `#0A0F0E` in dark. Hue 266 yields near-neutral cool greys instead
- Blue leads the accent preset picker as the default; turquoise moves down into the picker body and stays selectable, keeping the picker at 11 swatches with no other preset changed
- `LibreChatTheme`'s KDoc now records the TonalSpot behavior, and `DEFAULT_ACCENT_SEED_ARGB` points at it — so a future candidate is judged by the roles it generates rather than by how the swatch reads

## Behavior notes
- Users who explicitly picked an accent color (including turquoise) keep their stored choice — the seed is only a fallback for a missing preference, so only the out-of-the-box default changes
- Applies to both platforms: `supportsDynamicColor()` is `false` on iOS, so iOS always renders the seed-generated scheme
- Wallpaper-based dynamic color (Material You) is unaffected
- A preset equal to the default must not also appear later in `AccentColorPresets` — the picker marks selection by comparing each preset's ARGB against the working value, so a duplicate would render as two simultaneously selected swatches. Noted in the KDoc

## Out of scope
- `PaletteStyle` stays `TonalSpot`, which desaturates every seed (`#3B82F6` generates a slate `#495F8B`). A more saturated accent would mean changing the style, which affects all 11 presets — a separate decision

## Testing
- `assembleDebug`, `detektMetadataCommonMain` and `./gradlew test` pass
- Not verified on a device
- The role and surface hexes quoted above are generated at runtime and appear in no source file. They were computed by reproducing MaterialKolor's TonalSpot output with the `materialyoucolor` package (`SchemeTonalSpot` at contrast 0.0), not read off a build
- No test asserts the default accent value, so nothing in the suite gates this either way
