### PR TITLE
fix(auth): stop replaying an expired session and bouncing off Login (#325)

### DIFF
--- a/app/src/test/kotlin/com/garfiec/librechat/navigation/NavigatorTest.kt
+++ b/app/src/test/kotlin/com/garfiec/librechat/navigation/NavigatorTest.kt
@@ -150,9 +150,6 @@ class NavigatorTest {
 
     @Test
     fun `navigateToAuth is a no-op deeper in the auth flow`() {
-        // A dead session is reported by more than one caller (a cold start fans out several requests
-        // and each 401 settles on its own). A straggler landing after the user has moved on to Login
-        // must not reset them back to ServerUrl and discard what they typed.
         val navigator = createNavigator(ServerUrl, Login)
         navigator.navigateToAuth()
         assertEquals(listOf(ServerUrl, Login), navigator.backStack.toList())

--- a/app/src/test/kotlin/com/garfiec/librechat/navigation/NavigatorTest.kt
+++ b/app/src/test/kotlin/com/garfiec/librechat/navigation/NavigatorTest.kt
@@ -149,6 +149,23 @@ class NavigatorTest {
     }
 
     @Test
+    fun `navigateToAuth is a no-op deeper in the auth flow`() {
+        // A dead session is reported by more than one caller (a cold start fans out several requests
+        // and each 401 settles on its own). A straggler landing after the user has moved on to Login
+        // must not reset them back to ServerUrl and discard what they typed.
+        val navigator = createNavigator(ServerUrl, Login)
+        navigator.navigateToAuth()
+        assertEquals(listOf(ServerUrl, Login), navigator.backStack.toList())
+    }
+
+    @Test
+    fun `navigateToAuth is a no-op when already on ServerUrl`() {
+        val navigator = createNavigator(ServerUrl)
+        navigator.navigateToAuth()
+        assertEquals(listOf(ServerUrl), navigator.backStack.toList())
+    }
+
+    @Test
     fun `navigateToChat no-arg clears stack and adds NewChat()`() {
         val navigator = createNavigator(ServerUrl, Login)
         navigator.navigateToChat()

--- a/app/src/test/kotlin/com/garfiec/librechat/navigation/NavigatorTest.kt
+++ b/app/src/test/kotlin/com/garfiec/librechat/navigation/NavigatorTest.kt
@@ -3,7 +3,10 @@ package com.garfiec.librechat.navigation
 import androidx.navigation3.runtime.NavBackStack
 import androidx.navigation3.runtime.NavKey
 import com.garfiec.librechat.feature.agents.navigation.AgentMarketplace
+import com.garfiec.librechat.feature.auth.navigation.AddAccountLogin
+import com.garfiec.librechat.feature.auth.navigation.AddAccountServerUrl
 import com.garfiec.librechat.feature.auth.navigation.Login
+import com.garfiec.librechat.feature.auth.navigation.Register
 import com.garfiec.librechat.feature.auth.navigation.ServerUrl
 import com.garfiec.librechat.feature.chat.navigation.Chat
 import com.garfiec.librechat.feature.chat.navigation.NewChat
@@ -158,6 +161,24 @@ class NavigatorTest {
     @Test
     fun `navigateToAuth is a no-op when already on ServerUrl`() {
         val navigator = createNavigator(ServerUrl)
+        navigator.navigateToAuth()
+        assertEquals(listOf(ServerUrl), navigator.backStack.toList())
+    }
+
+    @Test
+    fun `navigateToAuth still resets out of an add-account flow`() {
+        // The add flow belongs to the session that just ended, and the nav host cancels the pending
+        // add by watching these routes leave the stack — so the guard must not apply here.
+        val navigator = createNavigator(NewChat(), SettingsTabbed, AddAccountServerUrl, AddAccountLogin)
+        navigator.navigateToAuth()
+        assertEquals(listOf(ServerUrl), navigator.backStack.toList())
+    }
+
+    @Test
+    fun `navigateToAuth resets from a shared route stacked above an add-account login`() {
+        // Register/2FA/forgot-password are shared routes reached from add-mode login; they sit above
+        // an AddAccountLogin entry, so the whole stack has to be checked, not just the top.
+        val navigator = createNavigator(AddAccountServerUrl, AddAccountLogin, Register)
         navigator.navigateToAuth()
         assertEquals(listOf(ServerUrl), navigator.backStack.toList())
     }

--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/datastore/AccountRegistryTest.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/datastore/AccountRegistryTest.kt
@@ -11,6 +11,7 @@ import com.garfiec.librechat.core.common.identity.InMemoryActiveAccountProvider
 import com.garfiec.librechat.core.common.identity.deriveAccountId
 import com.garfiec.librechat.core.common.identity.deriveServerId
 import com.garfiec.librechat.core.network.client.RefreshResult
+import com.garfiec.librechat.core.network.client.SessionEndReason
 import com.garfiec.librechat.core.network.client.TokenManager
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.CoroutineScope
@@ -153,7 +154,7 @@ class AccountRegistryTest {
         override suspend fun refreshAccessTokenFor(accountId: String, baseUrl: String): RefreshResult = RefreshResult.HardExpired
         override suspend fun onAccountResolved(accountId: String) {}
         override suspend fun onAccountCleared() { cleared = true }
-        override fun emitSessionExpired(expiredAccountId: String?) {}
-        override val sessionExpiredFlow: SharedFlow<Unit> = MutableSharedFlow()
+        override fun emitSessionExpired(expiredAccountId: String?, reason: SessionEndReason) {}
+        override val sessionExpiredFlow: SharedFlow<SessionEndReason> = MutableSharedFlow()
     }
 }

--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/datastore/CommonTokenDataStoreAccountKeyingTest.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/datastore/CommonTokenDataStoreAccountKeyingTest.kt
@@ -471,7 +471,10 @@ class CommonTokenDataStoreAccountKeyingTest {
         }
 
         store.emitSessionExpired("acctA")
-        store.emitSessionExpired() // unscoped (legacy/active) always emits
+        // The unscoped (legacy/active) form emits too — once a re-authentication has re-armed the
+        // one-signal-per-dead-session latch. See CommonTokenDataStoreSessionExpiryTest.
+        store.setTokens("A-access-2", "A-refresh-2")
+        store.emitSessionExpired()
 
         assertThat(emissions).isEqualTo(2)
         job.cancel()

--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/datastore/CommonTokenDataStoreConcurrencyTest.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/datastore/CommonTokenDataStoreConcurrencyTest.kt
@@ -240,9 +240,14 @@ class CommonTokenDataStoreConcurrencyTest {
 
             assertThat(result).isEqualTo(RefreshResult.HardExpired)
             assertThat(requestCount).isEqualTo(3)
-            // A hard-expired refresh does NOT clear the stored tokens: a relaunch may still recover,
-            // and the session-expired routing (not this store) owns navigation to re-auth.
-            assertThat(store.persistedRefresh()).isEqualTo("initial-refresh")
+            // A settled hard expiry DOES clear the stored tokens. This previously retained them on
+            // the theory that a relaunch might still recover — it can't: the retry budget above has
+            // already absorbed a transient rejection, so reaching here means the session is dead, and
+            // `isLoggedIn()` is a token-PRESENCE check. Retained, the dead pair made every subsequent
+            // cold start re-enter the logged-in graph, fan out requests, collect 401s and bounce to
+            // auth — forever. The user is routed to re-auth either way; only the replay differs.
+            assertThat(store.persistedRefresh()).isNull()
+            assertThat(store.persistedAccess()).isNull()
         }
 
     @Test

--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/datastore/CommonTokenDataStoreConcurrencyTest.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/datastore/CommonTokenDataStoreConcurrencyTest.kt
@@ -240,12 +240,9 @@ class CommonTokenDataStoreConcurrencyTest {
 
             assertThat(result).isEqualTo(RefreshResult.HardExpired)
             assertThat(requestCount).isEqualTo(3)
-            // A settled hard expiry DOES clear the stored tokens. This previously retained them on
-            // the theory that a relaunch might still recover — it can't: the retry budget above has
-            // already absorbed a transient rejection, so reaching here means the session is dead, and
-            // `isLoggedIn()` is a token-PRESENCE check. Retained, the dead pair made every subsequent
-            // cold start re-enter the logged-in graph, fan out requests, collect 401s and bounce to
-            // auth — forever. The user is routed to re-auth either way; only the replay differs.
+            // A settled hard expiry clears the stored tokens: the retry budget above has already
+            // absorbed any transient rejection, so reaching here means the session is dead. Retaining
+            // them replays it forever — `isLoggedIn()` is a token-PRESENCE check.
             assertThat(store.persistedRefresh()).isNull()
             assertThat(store.persistedAccess()).isNull()
         }

--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/datastore/CommonTokenDataStoreSessionExpiryTest.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/datastore/CommonTokenDataStoreSessionExpiryTest.kt
@@ -21,13 +21,10 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
 /**
- * What happens to local state when a session dies.
- *
- * Two properties, both of which the app depends on at cold start: a refresh the server rejects must
- * DROP the account's tokens (`isLoggedIn()` is a presence check, so a retained dead token is replayed
- * on every launch — the logged-in UI renders, fans out requests, collects 401s and bounces to auth),
- * and a dead session must report itself exactly ONCE however many requests discover it (each report
- * replays the logout navigation).
+ * What happens to local state when a session dies. Two properties the app depends on at cold start:
+ * a refresh the server rejects must DROP the account's tokens (`isLoggedIn()` is a presence check, so
+ * a retained dead token is replayed on every launch), and a dead session must report itself exactly
+ * ONCE however many requests discover it (each report replays the logout navigation).
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 class CommonTokenDataStoreSessionExpiryTest {
@@ -86,8 +83,6 @@ class CommonTokenDataStoreSessionExpiryTest {
         ),
     )
 
-    // --- the slot is dropped on a hard rejection, kept on a recoverable one ---
-
     @Test
     fun `a rejected refresh drops the account's tokens`() = runTest {
         val store = seededStore(refreshClientAnswering(HttpStatusCode.Unauthorized))
@@ -108,8 +103,7 @@ class CommonTokenDataStoreSessionExpiryTest {
 
         store.refreshAccessTokenFor("acctA", SERVER)
 
-        // Only the tokens go: the account must stay listed and re-loginable, and the cold-start
-        // account gate must still resolve the same identity.
+        // Only the tokens go — the account must stay listed and re-loginable.
         assertThat(store.store["active_account_id"]).isEqualTo("acctA")
     }
 
@@ -152,8 +146,6 @@ class CommonTokenDataStoreSessionExpiryTest {
         assertThat(result).isEqualTo(RefreshResult.Refreshed)
         assertThat(store.store[accessKey("acctA")]).isEqualTo("A-access-2")
     }
-
-    // --- one signal per dead session ---
 
     @Test
     fun `a dead session reports its expiry once however many requests discover it`() = runTest {

--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/datastore/CommonTokenDataStoreSessionExpiryTest.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/datastore/CommonTokenDataStoreSessionExpiryTest.kt
@@ -1,0 +1,223 @@
+package com.garfiec.librechat.core.data.datastore
+
+import com.garfiec.librechat.core.network.client.RefreshResult
+import com.google.common.truth.Truth.assertThat
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.engine.mock.respondError
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.defaultRequest
+import io.ktor.client.request.url
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+/**
+ * What happens to local state when a session dies.
+ *
+ * Two properties, both of which the app depends on at cold start: a refresh the server rejects must
+ * DROP the account's tokens (`isLoggedIn()` is a presence check, so a retained dead token is replayed
+ * on every launch — the logged-in UI renders, fans out requests, collects 401s and bounces to auth),
+ * and a dead session must report itself exactly ONCE however many requests discover it (each report
+ * replays the logout navigation).
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class CommonTokenDataStoreSessionExpiryTest {
+
+    private companion object {
+        const val SERVER = "https://chat.example.com"
+    }
+
+    private class FakeStore(
+        refreshClient: Lazy<HttpClient>,
+        seed: Map<String, String> = emptyMap(),
+    ) : CommonTokenDataStore(refreshClient) {
+        val store = seed.toMutableMap()
+
+        init {
+            initializeTokenCache()
+        }
+
+        override fun readValue(key: String): String? = store[key]
+        override fun writeValue(key: String, value: String) {
+            store[key] = value
+        }
+
+        override fun writeValues(values: Map<String, String>) {
+            store.putAll(values)
+        }
+
+        override fun removeValue(key: String) {
+            store.remove(key)
+        }
+
+        override fun onKeystoreCorruption() = Unit
+    }
+
+    private fun accessKey(account: String) = "acct:$account:access_token"
+    private fun refreshKeyOf(account: String) = "acct:$account:refresh_token"
+
+    private val noRefresh: Lazy<HttpClient> = lazy { error("refresh client not expected in this test") }
+
+    private fun refreshClientAnswering(status: HttpStatusCode): Lazy<HttpClient> = lazy {
+        HttpClient(MockEngine { respondError(status) }) {
+            install(ContentNegotiation) { json() }
+            defaultRequest {
+                url(SERVER)
+                contentType(ContentType.Application.Json)
+            }
+        }
+    }
+
+    private fun seededStore(refreshClient: Lazy<HttpClient>) = FakeStore(
+        refreshClient,
+        seed = mapOf(
+            "active_account_id" to "acctA",
+            accessKey("acctA") to "A-access",
+            refreshKeyOf("acctA") to "A-refresh",
+        ),
+    )
+
+    // --- the slot is dropped on a hard rejection, kept on a recoverable one ---
+
+    @Test
+    fun `a rejected refresh drops the account's tokens`() = runTest {
+        val store = seededStore(refreshClientAnswering(HttpStatusCode.Unauthorized))
+
+        val result = store.refreshAccessTokenFor("acctA", SERVER)
+
+        assertThat(result).isEqualTo(RefreshResult.HardExpired)
+        assertThat(store.store[accessKey("acctA")]).isNull()
+        assertThat(store.store[refreshKeyOf("acctA")]).isNull()
+        // The cold-start check reads through these, so this is what stops the replay.
+        assertThat(store.isAuthenticated).isFalse()
+        assertThat(store.getAccessToken()).isNull()
+    }
+
+    @Test
+    fun `a rejected refresh leaves the account itself intact`() = runTest {
+        val store = seededStore(refreshClientAnswering(HttpStatusCode.Unauthorized))
+
+        store.refreshAccessTokenFor("acctA", SERVER)
+
+        // Only the tokens go: the account must stay listed and re-loginable, and the cold-start
+        // account gate must still resolve the same identity.
+        assertThat(store.store["active_account_id"]).isEqualTo("acctA")
+    }
+
+    @Test
+    fun `a server error keeps the session`() = runTest {
+        val store = seededStore(refreshClientAnswering(HttpStatusCode.InternalServerError))
+
+        val result = store.refreshAccessTokenFor("acctA", SERVER)
+
+        // A 5xx is a server-side blip, not evidence the session is dead — tearing down here would
+        // log the user out over a transient failure a later request would have recovered from.
+        assertThat(result).isEqualTo(RefreshResult.Transient)
+        assertThat(store.store[accessKey("acctA")]).isEqualTo("A-access")
+        assertThat(store.store[refreshKeyOf("acctA")]).isEqualTo("A-refresh")
+        assertThat(store.isAuthenticated).isTrue()
+    }
+
+    @Test
+    fun `a successful refresh keeps the session`() = runTest {
+        val refreshClient = lazy {
+            HttpClient(
+                MockEngine {
+                    respond(
+                        content = """{"token":"A-access-2"}""",
+                        headers = headersOf("Content-Type", listOf(ContentType.Application.Json.toString())),
+                    )
+                },
+            ) {
+                install(ContentNegotiation) { json() }
+                defaultRequest {
+                    url(SERVER)
+                    contentType(ContentType.Application.Json)
+                }
+            }
+        }
+        val store = seededStore(refreshClient)
+
+        val result = store.refreshAccessTokenFor("acctA", SERVER)
+
+        assertThat(result).isEqualTo(RefreshResult.Refreshed)
+        assertThat(store.store[accessKey("acctA")]).isEqualTo("A-access-2")
+    }
+
+    // --- one signal per dead session ---
+
+    @Test
+    fun `a dead session reports its expiry once however many requests discover it`() = runTest {
+        val store = seededStore(noRefresh)
+        var emissions = 0
+        val job = backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            store.sessionExpiredFlow.collect { emissions++ }
+        }
+
+        // A cold start fans out a dozen or so requests; each 401 settles independently and lands here.
+        repeat(12) { store.emitSessionExpired("acctA") }
+
+        assertThat(emissions).isEqualTo(1)
+        job.cancel()
+    }
+
+    @Test
+    fun `a new sign-in re-arms the expiry signal`() = runTest {
+        val store = seededStore(noRefresh)
+        var emissions = 0
+        val job = backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            store.sessionExpiredFlow.collect { emissions++ }
+        }
+
+        store.emitSessionExpired("acctA")
+        store.setTokens("new-access", "new-refresh")
+        store.emitSessionExpired()
+
+        // A latch left set would swallow the NEXT session's expiry entirely.
+        assertThat(emissions).isEqualTo(2)
+        job.cancel()
+    }
+
+    @Test
+    fun `removing an account re-arms the expiry signal`() = runTest {
+        val store = seededStore(noRefresh)
+        var emissions = 0
+        val job = backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            store.sessionExpiredFlow.collect { emissions++ }
+        }
+
+        store.emitSessionExpired("acctA")
+        // AccountSwitcher's remove-last-account path: removeAccount, then this same signal is reused
+        // to drive nav-to-auth. Swallowing it would strand the user in a logged-out shell.
+        store.removeAccount("acctA")
+        store.emitSessionExpired()
+
+        assertThat(emissions).isEqualTo(2)
+        job.cancel()
+    }
+
+    @Test
+    fun `an explicit logout re-arms the expiry signal`() = runTest {
+        val store = seededStore(noRefresh)
+        var emissions = 0
+        val job = backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            store.sessionExpiredFlow.collect { emissions++ }
+        }
+
+        store.emitSessionExpired("acctA")
+        store.clearTokens()
+        store.emitSessionExpired()
+
+        assertThat(emissions).isEqualTo(2)
+        job.cancel()
+    }
+}

--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/repository/AccountSwitcherRemoveTest.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/repository/AccountSwitcherRemoveTest.kt
@@ -8,6 +8,7 @@ import com.garfiec.librechat.core.common.identity.AccountState.Resolved
 import com.garfiec.librechat.core.common.identity.deriveAccountId
 import com.garfiec.librechat.core.common.identity.deriveServerId
 import com.garfiec.librechat.core.data.datastore.AccountEntry
+import com.garfiec.librechat.core.network.client.SessionEndReason
 import com.google.common.truth.Truth.assertThat
 import io.mockk.coVerify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -122,6 +123,9 @@ class AccountSwitcherRemoveTest {
             assertThat(h.sessionCacheCleaner.fileClearCount).isEqualTo(1)
             assertThat(h.roster.snapshot().entries).isEmpty()
             assertThat(h.tokenManager.expiredEmissions).containsExactly(null)
+            // Reported as a deliberate sign-out, not an expiry: the user asked for this, so the UI
+            // must not tell them their session ran out.
+            assertThat(h.tokenManager.expiredReasons).containsExactly(SessionEndReason.SIGNED_OUT)
             coVerify(exactly = 1) { h.dataPurger.purge(accountA) }
             // The URL is deliberately retained (logout parity) so the login screen comes back prefilled.
             assertThat(h.serverDataStore.getBaseUrl()).isEqualTo(serverA)

--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/repository/AccountSwitcherTestHarness.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/repository/AccountSwitcherTestHarness.kt
@@ -9,6 +9,7 @@ import com.garfiec.librechat.core.data.datastore.AccountRoster
 import com.garfiec.librechat.core.data.datastore.AccountScopedPrefsPurger
 import com.garfiec.librechat.core.data.datastore.ServerDataStore
 import com.garfiec.librechat.core.network.client.RefreshResult
+import com.garfiec.librechat.core.network.client.SessionEndReason
 import com.garfiec.librechat.core.network.client.SwitchGate
 import com.garfiec.librechat.core.network.client.TokenManager
 import io.mockk.mockk
@@ -28,6 +29,7 @@ internal class RecordingTokenManager : TokenManager {
     val selections = mutableListOf<String>()
     val removedAccounts = mutableListOf<String>()
     val expiredEmissions = mutableListOf<String?>()
+    val expiredReasons = mutableListOf<SessionEndReason>()
 
     override val isAuthenticated: Boolean = true
     override suspend fun getAccessToken(): String? = null
@@ -55,10 +57,11 @@ internal class RecordingTokenManager : TokenManager {
     override suspend fun onAccountCleared() {
         clearedActive = true
     }
-    override fun emitSessionExpired(expiredAccountId: String?) {
+    override fun emitSessionExpired(expiredAccountId: String?, reason: SessionEndReason) {
         expiredEmissions += expiredAccountId
+        expiredReasons += reason
     }
-    override val sessionExpiredFlow: SharedFlow<Unit> = MutableSharedFlow()
+    override val sessionExpiredFlow: SharedFlow<SessionEndReason> = MutableSharedFlow()
 }
 
 internal class RecordingSwitchCacheCleaner : SwitchCacheCleaner {

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/CommonTokenDataStore.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/CommonTokenDataStore.kt
@@ -10,6 +10,7 @@ import com.garfiec.librechat.core.network.client.CookieHelper
 import com.garfiec.librechat.core.network.client.PinnedServerBaseUrlKey
 import com.garfiec.librechat.core.network.client.RefreshResult
 import com.garfiec.librechat.core.network.client.SecureTokenStorage
+import com.garfiec.librechat.core.network.client.SessionEndReason
 import com.garfiec.librechat.core.network.client.TokenManager
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
@@ -136,8 +137,12 @@ abstract class CommonTokenDataStore(
         tokenEpochs[key] = (tokenEpochs[key] ?: 0) + 1
     }
 
-    private val _sessionExpired = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
-    override val sessionExpiredFlow: SharedFlow<Unit> = _sessionExpired.asSharedFlow()
+    private val _sessionExpired = MutableSharedFlow<SessionEndReason>(extraBufferCapacity = 1)
+    override val sessionExpiredFlow: SharedFlow<SessionEndReason> = _sessionExpired.asSharedFlow()
+
+    /** True once the current session's expiry has been reported. See [emitSessionExpired]. */
+    @Volatile
+    private var sessionExpiryReported = false
 
     // Platform implementations provide a plain synchronously-readable key/value secure store.
     protected abstract fun readValue(key: String): String?
@@ -163,6 +168,7 @@ abstract class CommonTokenDataStore(
         // Only the bare (staging) slot's truth changes; keyed slots (and their in-flight refreshes,
         // which write their own slot) stay valid.
         bumpEpoch(null)
+        resetSessionExpiryLatch()
         cachedAccessToken = accessToken
         activeAccountKey = null
         // Drop the persisted mirror BEFORE staging, so a crash in the staging window (before
@@ -210,6 +216,7 @@ abstract class CommonTokenDataStore(
      * [TokenManager.onAccountCleared], which delegates to it). Caller holds [stateMutex].
      */
     private fun tearDownActiveSessionLocked() {
+        resetSessionExpiryLatch()
         bumpEpoch(activeAccountKey)
         // The bare staging slot is purged below too (when the active slot is keyed) — bump it so an
         // in-flight bare refresh can't resurrect the staged pair.
@@ -257,9 +264,11 @@ abstract class CommonTokenDataStore(
         writeValue(KEY_ACTIVE_ACCOUNT, accountId)
         activeAccountKey = accountId
         cachedAccessToken = readValue(accessKey(accountId))
+        resetSessionExpiryLatch()
     }
 
     override suspend fun removeAccount(accountId: String) = stateMutex.withLock {
+        resetSessionExpiryLatch()
         bumpEpoch(accountId)
         removeValue(accessKey(accountId))
         removeValue(refreshKey(accountId))
@@ -307,6 +316,9 @@ abstract class CommonTokenDataStore(
      * if a later attempt hit a transient blip); a purely transient run (5xx / rate-limit) stays
      * [Transient] so the session is kept. A transport failure (server unreachable) is terminal-Transient
      * rather than retried, so the flight lock is not held across repeated full request timeouts.
+     *
+     * A settled [HardExpired] also **drops the account's token slot**. The session is provably dead at
+     * that point, and a retained dead token is replayed on every subsequent cold start — see [settle].
      */
     private suspend fun performRefresh(
         accountKey: String?,
@@ -318,14 +330,31 @@ abstract class CommonTokenDataStore(
             // hit a transient blip; a purely transient run (5xx / rate-limit / transport) keeps the
             // session. This fold is the terminal classification for every non-Success exit of the loop.
             var sawHardRejection = false
-            fun settle(): RefreshResult =
-                if (sawHardRejection) RefreshResult.HardExpired else RefreshResult.Transient
+            // The epoch the most recent attempt captured. [settle] drops the slot against it, so a
+            // teardown that landed while the last POST was in flight still wins.
+            var lastEpoch = NO_EPOCH
+            suspend fun settle(): RefreshResult =
+                if (sawHardRejection) {
+                    // The server rejected this refresh token, so the session is dead — drop the slot.
+                    // Retained, it is replayed forever: `isLoggedIn()` is a token-PRESENCE check, so
+                    // every later cold start re-enters the logged-in graph and 401s its way back out.
+                    invalidateRefresh(accountKey, lastEpoch)
+                    Diag.w(
+                        "Auth",
+                        origin = LogOrigin.CLIENT,
+                        attrs = mapOf("event" to "session_torn_down", "reason" to "refresh_rejected"),
+                    ) { "Session expired - cleared the account's tokens" }
+                    RefreshResult.HardExpired
+                } else {
+                    RefreshResult.Transient
+                }
             repeat(MAX_REFRESH_ATTEMPTS) { attempt ->
                 // Capture the slot's epoch BEFORE the stored-token read, so any teardown of THIS slot
                 // that races the POST below is detected (and its result discarded) with no lock held
                 // across the network call. Re-read each attempt: a teardown or a sibling that landed
                 // between retries must be seen.
                 val epochAtStart = stateMutex.withLock { epochOf(accountKey) }
+                lastEpoch = epochAtStart
                 val storedRefreshToken = readValue(refreshKey(accountKey))
                 if (storedRefreshToken.isNullOrBlank()) {
                     // Attempt 0 with no token = no session at all → hard. A LATER attempt losing the
@@ -531,7 +560,14 @@ abstract class CommonTokenDataStore(
         true
     }
 
-    /** Drop [accountKey]'s slot after a hard auth failure — unless a teardown already owns the slot. */
+    /**
+     * Drop [accountKey]'s slot after a hard auth failure — unless a teardown already owns the slot.
+     *
+     * Only the account's own keys go: the roster entry, the active-account mirror and
+     * [activeAccountKey] all stay, so the account remains listed and re-loginable and the cold-start
+     * account gate still resolves the same identity. Nulling the cached bearer is what makes
+     * `isAuthenticated` (and through it `isLoggedIn()`) false.
+     */
     private suspend fun invalidateRefresh(accountKey: String?, epochAtStart: Int) = stateMutex.withLock {
         if (epochOf(accountKey) != epochAtStart) return@withLock
         bumpEpoch(accountKey)
@@ -546,12 +582,36 @@ abstract class CommonTokenDataStore(
 
     override suspend fun clearTokens() = stateMutex.withLock { tearDownActiveSessionLocked() }
 
-    override fun emitSessionExpired(expiredAccountId: String?) {
+    override fun emitSessionExpired(expiredAccountId: String?, reason: SessionEndReason) {
         // Scoped emit: only the ACTIVE binding's expiry routes the app to re-auth. A straggler
         // failure for a switched-away (retained) account is not a live-session event — its slot is
         // just stale until that account is selected again. Null = active/legacy session: always emit.
         if (expiredAccountId != null && expiredAccountId != activeAccountKey) return
-        _sessionExpired.tryEmit(Unit)
+        // One signal per dead session. A cold start fans out ~a dozen requests, every one of which
+        // 401s and reaches here independently, spread far enough apart by the refresh retry/backoff
+        // that the flow's 1-slot buffer coalesces nothing — and each emission replays the logout
+        // navigation, which is what used to yank a user off Login back to the server screen.
+        // Cleared by [resetSessionExpiryLatch] on every transition that establishes or tears down a
+        // session, so the NEXT session can report its own expiry. A racing double-emit is possible
+        // (plain @Volatile, no CAS) and deliberately tolerated: the navigator's own guard absorbs it.
+        if (sessionExpiryReported) return
+        sessionExpiryReported = true
+        _sessionExpired.tryEmit(reason)
+    }
+
+    /**
+     * Re-arm [emitSessionExpired] for a new session. Must run on every path that establishes or tears
+     * one down — a latch left set silently swallows the NEXT session's expiry signal, including the
+     * one `AccountSwitcher` reuses to route a remove-last-account teardown to auth.
+     *
+     * Called from [setTokens] (every interactive sign-in: login / OAuth / 2FA), [selectAccount],
+     * [removeAccount] and [tearDownActiveSessionLocked]. Deliberately **not** from
+     * `onAccountResolved`: it is the re-home half of a sign-in [setTokens] already covered, and it
+     * also runs on the cold-start restore path — where re-arming mid-storm would let the same dead
+     * session report itself twice.
+     */
+    private fun resetSessionExpiryLatch() {
+        sessionExpiryReported = false
     }
 
     // --- SecureTokenStorage ---
@@ -612,6 +672,10 @@ abstract class CommonTokenDataStore(
 
         /** [flights] key for the bare (null-account) refresh path. */
         private const val BARE_FLIGHT_KEY = ""
+
+        /** "No attempt has captured an epoch yet". Never equals a real epoch, so an
+         *  [invalidateRefresh] against it is a no-op rather than an unguarded clear. */
+        private const val NO_EPOCH = -1
 
         /** Total refresh attempts (initial + retries) before a persistent failure is classified. */
         private const val MAX_REFRESH_ATTEMPTS = 3

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/CommonTokenDataStore.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/CommonTokenDataStore.kt
@@ -363,6 +363,10 @@ abstract class CommonTokenDataStore(
                             origin = LogOrigin.CLIENT,
                             attrs = mapOf("event" to "session_expired", "reason" to "no_refresh_token"),
                         ) { "No refresh token available" }
+                        // Drop the slot here too, not just in [settle]. A torn pair (refresh gone,
+                        // access retained) would otherwise keep `isLoggedIn()` true forever, which is
+                        // the same replay this path exists to end. A no-op when the slot is empty.
+                        invalidateRefresh(accountKey, epochAtStart)
                         RefreshResult.HardExpired
                     } else {
                         RefreshResult.Transient
@@ -599,8 +603,11 @@ abstract class CommonTokenDataStore(
      * one `AccountSwitcher` reuses to route a remove-last-account teardown to auth.
      *
      * Deliberately **not** called from `onAccountResolved`: it is the re-home half of a sign-in
-     * [setTokens] already covers, and it also runs on the cold-start restore path — where re-arming
-     * mid-storm would let the same dead session report itself twice.
+     * [setTokens] already covers, and it runs *after* the account gate opens — so re-arming there
+     * would let the same dead session report itself twice mid-storm. [selectAccount] also runs on the
+     * cold-start path but re-arms safely because its cold-start call happens inside the roster seed,
+     * before the gate opens and therefore before any request can 401. Moving either call across that
+     * gate reintroduces the double-report.
      */
     private fun resetSessionExpiryLatch() {
         sessionExpiryReported = false

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/CommonTokenDataStore.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/CommonTokenDataStore.kt
@@ -140,7 +140,6 @@ abstract class CommonTokenDataStore(
     private val _sessionExpired = MutableSharedFlow<SessionEndReason>(extraBufferCapacity = 1)
     override val sessionExpiredFlow: SharedFlow<SessionEndReason> = _sessionExpired.asSharedFlow()
 
-    /** True once the current session's expiry has been reported. See [emitSessionExpired]. */
     @Volatile
     private var sessionExpiryReported = false
 
@@ -317,8 +316,7 @@ abstract class CommonTokenDataStore(
      * [Transient] so the session is kept. A transport failure (server unreachable) is terminal-Transient
      * rather than retried, so the flight lock is not held across repeated full request timeouts.
      *
-     * A settled [HardExpired] also **drops the account's token slot**. The session is provably dead at
-     * that point, and a retained dead token is replayed on every subsequent cold start — see [settle].
+     * A settled [HardExpired] also **drops the account's token slot** — see [settle].
      */
     private suspend fun performRefresh(
         accountKey: String?,
@@ -335,9 +333,8 @@ abstract class CommonTokenDataStore(
             var lastEpoch = NO_EPOCH
             suspend fun settle(): RefreshResult =
                 if (sawHardRejection) {
-                    // The server rejected this refresh token, so the session is dead — drop the slot.
-                    // Retained, it is replayed forever: `isLoggedIn()` is a token-PRESENCE check, so
-                    // every later cold start re-enters the logged-in graph and 401s its way back out.
+                    // The session is dead, so drop the slot. `isLoggedIn()` is a token-PRESENCE check:
+                    // a retained dead pair is replayed on every later cold start.
                     invalidateRefresh(accountKey, lastEpoch)
                     Diag.w(
                         "Auth",
@@ -564,9 +561,8 @@ abstract class CommonTokenDataStore(
      * Drop [accountKey]'s slot after a hard auth failure — unless a teardown already owns the slot.
      *
      * Only the account's own keys go: the roster entry, the active-account mirror and
-     * [activeAccountKey] all stay, so the account remains listed and re-loginable and the cold-start
-     * account gate still resolves the same identity. Nulling the cached bearer is what makes
-     * `isAuthenticated` (and through it `isLoggedIn()`) false.
+     * [activeAccountKey] all stay, so the account remains listed and re-loginable. Nulling the cached
+     * bearer is what makes `isAuthenticated` (and through it `isLoggedIn()`) false.
      */
     private suspend fun invalidateRefresh(accountKey: String?, epochAtStart: Int) = stateMutex.withLock {
         if (epochOf(accountKey) != epochAtStart) return@withLock
@@ -587,13 +583,11 @@ abstract class CommonTokenDataStore(
         // failure for a switched-away (retained) account is not a live-session event — its slot is
         // just stale until that account is selected again. Null = active/legacy session: always emit.
         if (expiredAccountId != null && expiredAccountId != activeAccountKey) return
-        // One signal per dead session. A cold start fans out ~a dozen requests, every one of which
-        // 401s and reaches here independently, spread far enough apart by the refresh retry/backoff
-        // that the flow's 1-slot buffer coalesces nothing — and each emission replays the logout
-        // navigation, which is what used to yank a user off Login back to the server screen.
-        // Cleared by [resetSessionExpiryLatch] on every transition that establishes or tears down a
-        // session, so the NEXT session can report its own expiry. A racing double-emit is possible
-        // (plain @Volatile, no CAS) and deliberately tolerated: the navigator's own guard absorbs it.
+        // One signal per dead session. A cold start fans out ~a dozen requests, each of which 401s and
+        // reaches here independently, spread far enough apart by the refresh retry/backoff that the
+        // flow's 1-slot buffer coalesces nothing — and every emission replays the logout navigation.
+        // A racing double-emit is possible (plain @Volatile, no CAS) and deliberately tolerated: the
+        // navigator's own guard absorbs it.
         if (sessionExpiryReported) return
         sessionExpiryReported = true
         _sessionExpired.tryEmit(reason)
@@ -604,11 +598,9 @@ abstract class CommonTokenDataStore(
      * one down — a latch left set silently swallows the NEXT session's expiry signal, including the
      * one `AccountSwitcher` reuses to route a remove-last-account teardown to auth.
      *
-     * Called from [setTokens] (every interactive sign-in: login / OAuth / 2FA), [selectAccount],
-     * [removeAccount] and [tearDownActiveSessionLocked]. Deliberately **not** from
-     * `onAccountResolved`: it is the re-home half of a sign-in [setTokens] already covered, and it
-     * also runs on the cold-start restore path — where re-arming mid-storm would let the same dead
-     * session report itself twice.
+     * Deliberately **not** called from `onAccountResolved`: it is the re-home half of a sign-in
+     * [setTokens] already covers, and it also runs on the cold-start restore path — where re-arming
+     * mid-storm would let the same dead session report itself twice.
      */
     private fun resetSessionExpiryLatch() {
         sessionExpiryReported = false

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/AccountSwitcher.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/AccountSwitcher.kt
@@ -16,6 +16,7 @@ import com.garfiec.librechat.core.model.config.StartupConfig
 import com.garfiec.librechat.core.network.client.EmptyServerHeadersProvider
 import com.garfiec.librechat.core.network.client.PendingRequestIdentity
 import com.garfiec.librechat.core.network.client.ServerHeadersProvider
+import com.garfiec.librechat.core.network.client.SessionEndReason
 import com.garfiec.librechat.core.network.client.SwitchGate
 import com.garfiec.librechat.core.network.client.TokenManager
 import kotlinx.coroutines.NonCancellable
@@ -364,7 +365,7 @@ class AccountSwitcher(
             }
             // Reuse the session-expired channel to drive nav-to-auth reactively; the settings screen
             // that triggered the removal has no navigator reference of its own.
-            tokenManager.emitSessionExpired()
+            tokenManager.emitSessionExpired(reason = SessionEndReason.SIGNED_OUT)
         }
         if (removed) {
             accountDataPurger.purge(AccountId(accountId))

--- a/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/client/AuthInterceptorTest.kt
+++ b/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/client/AuthInterceptorTest.kt
@@ -3,6 +3,7 @@ package com.garfiec.librechat.core.network.client
 import com.garfiec.librechat.core.common.identity.AccountId
 import com.garfiec.librechat.core.common.identity.AccountState
 import com.garfiec.librechat.core.common.identity.InMemoryActiveAccountProvider
+import com.garfiec.librechat.core.network.client.SessionEndReason
 import com.google.common.truth.Truth.assertThat
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
@@ -30,8 +31,8 @@ class AuthInterceptorTest {
         var refreshCallCount = 0
         var sessionExpiredCount = 0
         var lastExpiredAccountId: String? = null
-        private val _sessionExpiredFlow = MutableSharedFlow<Unit>()
-        override val sessionExpiredFlow: SharedFlow<Unit> = _sessionExpiredFlow
+        private val _sessionExpiredFlow = MutableSharedFlow<SessionEndReason>()
+        override val sessionExpiredFlow: SharedFlow<SessionEndReason> = _sessionExpiredFlow
         override val isAuthenticated: Boolean get() = accessToken != null
 
         override suspend fun getAccessToken(): String? = accessToken
@@ -70,7 +71,7 @@ class AuthInterceptorTest {
             accessToken = null
         }
 
-        override fun emitSessionExpired(expiredAccountId: String?) {
+        override fun emitSessionExpired(expiredAccountId: String?, reason: SessionEndReason) {
             sessionExpiredCount++
             lastExpiredAccountId = expiredAccountId
         }

--- a/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/client/ServerHeadersPluginTest.kt
+++ b/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/client/ServerHeadersPluginTest.kt
@@ -1,5 +1,6 @@
 package com.garfiec.librechat.core.network.client
 
+import com.garfiec.librechat.core.network.client.SessionEndReason
 import com.google.common.truth.Truth.assertThat
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
@@ -51,8 +52,8 @@ class ServerHeadersPluginTest {
     /** Enough of a [TokenManager] to drive one 401 → refresh → retry cycle. */
     private class FakeTokenManager : TokenManager {
         private var accessToken: String? = "initial-token"
-        private val _sessionExpiredFlow = MutableSharedFlow<Unit>()
-        override val sessionExpiredFlow: SharedFlow<Unit> = _sessionExpiredFlow
+        private val _sessionExpiredFlow = MutableSharedFlow<SessionEndReason>()
+        override val sessionExpiredFlow: SharedFlow<SessionEndReason> = _sessionExpiredFlow
         override val isAuthenticated: Boolean get() = accessToken != null
         override suspend fun getAccessToken(): String? = accessToken
         override suspend fun setTokens(accessToken: String, refreshToken: String) {
@@ -77,7 +78,7 @@ class ServerHeadersPluginTest {
             refreshAccessToken()
 
         override suspend fun onAccountResolved(accountId: String) = Unit
-        override fun emitSessionExpired(expiredAccountId: String?) = Unit
+        override fun emitSessionExpired(expiredAccountId: String?, reason: SessionEndReason) = Unit
     }
 
     private fun createClient(

--- a/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/client/SwitchGateTest.kt
+++ b/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/client/SwitchGateTest.kt
@@ -3,6 +3,7 @@ package com.garfiec.librechat.core.network.client
 import com.garfiec.librechat.core.common.identity.AccountId
 import com.garfiec.librechat.core.common.identity.AccountState.Resolved
 import com.garfiec.librechat.core.common.identity.InMemoryActiveAccountProvider
+import com.garfiec.librechat.core.network.client.SessionEndReason
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -40,8 +41,8 @@ class SwitchGateTest {
         override suspend fun refreshAccessTokenFor(accountId: String, baseUrl: String): RefreshResult = RefreshResult.HardExpired
         override suspend fun onAccountResolved(accountId: String) = Unit
         override suspend fun onAccountCleared() = Unit
-        override fun emitSessionExpired(expiredAccountId: String?) = Unit
-        override val sessionExpiredFlow: SharedFlow<Unit> = MutableSharedFlow()
+        override fun emitSessionExpired(expiredAccountId: String?, reason: SessionEndReason) = Unit
+        override val sessionExpiredFlow: SharedFlow<SessionEndReason> = MutableSharedFlow()
     }
 
     private class FakeServerUrlProvider(private val baseUrl: String) : ServerUrlProvider {

--- a/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/di/GatewayDetectionInstallTest.kt
+++ b/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/di/GatewayDetectionInstallTest.kt
@@ -10,6 +10,7 @@ import com.garfiec.librechat.core.network.client.GatewayDetectionPlugin
 import com.garfiec.librechat.core.network.client.RefreshResult
 import com.garfiec.librechat.core.network.client.ServerHeadersProvider
 import com.garfiec.librechat.core.network.client.ServerUrlProvider
+import com.garfiec.librechat.core.network.client.SessionEndReason
 import com.garfiec.librechat.core.network.client.TokenManager
 import com.google.common.truth.Truth.assertThat
 import io.ktor.client.HttpClient
@@ -46,8 +47,8 @@ class GatewayDetectionInstallTest {
     }
 
     private class FakeTokenManager : TokenManager {
-        private val expired = MutableSharedFlow<Unit>()
-        override val sessionExpiredFlow: SharedFlow<Unit> = expired
+        private val expired = MutableSharedFlow<SessionEndReason>()
+        override val sessionExpiredFlow: SharedFlow<SessionEndReason> = expired
         override val isAuthenticated: Boolean = false
         override suspend fun getAccessToken(): String? = null
         override suspend fun setTokens(accessToken: String, refreshToken: String) = Unit
@@ -62,7 +63,7 @@ class GatewayDetectionInstallTest {
             RefreshResult.Transient
 
         override suspend fun onAccountResolved(accountId: String) = Unit
-        override fun emitSessionExpired(expiredAccountId: String?) = Unit
+        override fun emitSessionExpired(expiredAccountId: String?, reason: SessionEndReason) = Unit
     }
 
     private fun client(qualifier: Qualifier?): HttpClient {

--- a/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/LibreChatHttpClient.kt
+++ b/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/LibreChatHttpClient.kt
@@ -141,7 +141,7 @@ object LibreChatHttpClient {
                         // the server being ADDED belongs to the add flow, mirroring the 401 path.
                         val identity = response.call.request.attributes.getOrNull(RequestIdentityKey)
                         if (identity?.isPending != true) {
-                            tokenManager.emitSessionExpired(identity?.accountId)
+                            tokenManager.emitSessionExpired(identity?.accountId, SessionEndReason.BANNED)
                         }
                     }
 

--- a/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/SessionEndReason.kt
+++ b/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/SessionEndReason.kt
@@ -1,0 +1,21 @@
+package com.garfiec.librechat.core.network.client
+
+/**
+ * Why the app is being routed back to the auth flow.
+ *
+ * All three ride the same signal because they need the same navigation, but they are not the same
+ * event to a user: only [EXPIRED] arrives unannounced, so it is the only one that owes an
+ * explanation. Telling someone who just tapped "Log out" that their session expired is noise, and
+ * saying it to someone the server blocked is wrong — [ApiException.isBanned] already reports that on
+ * the screen they were looking at.
+ */
+enum class SessionEndReason {
+    /** The server rejected the session: a refresh answered 401/403, or there was no token to send. */
+    EXPIRED,
+
+    /** The user signed out, or removed their last account. */
+    SIGNED_OUT,
+
+    /** The server banned the account mid-session. */
+    BANNED,
+}

--- a/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/SessionEndReason.kt
+++ b/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/SessionEndReason.kt
@@ -3,11 +3,9 @@ package com.garfiec.librechat.core.network.client
 /**
  * Why the app is being routed back to the auth flow.
  *
- * All three ride the same signal because they need the same navigation, but they are not the same
- * event to a user: only [EXPIRED] arrives unannounced, so it is the only one that owes an
- * explanation. Telling someone who just tapped "Log out" that their session expired is noise, and
- * saying it to someone the server blocked is wrong — [ApiException.isBanned] already reports that on
- * the screen they were looking at.
+ * All three ride the same signal because they need the same navigation, but only [EXPIRED] arrives
+ * unannounced, so it is the only one that may be reported to the user. A ban is already surfaced by
+ * `ApiException.isBanned`, and a deliberate sign-out needs no explanation at all.
  */
 enum class SessionEndReason {
     /** The server rejected the session: a refresh answered 401/403, or there was no token to send. */

--- a/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/TokenManager.kt
+++ b/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/TokenManager.kt
@@ -101,6 +101,15 @@ interface TokenManager {
      * account's session. The expired account keeps its rows and roster entry — re-auth restores it
      * without data loss. Null = the active/legacy session; always emits.
      */
-    fun emitSessionExpired(expiredAccountId: String? = null)
-    val sessionExpiredFlow: SharedFlow<Unit>
+    fun emitSessionExpired(
+        expiredAccountId: String? = null,
+        reason: SessionEndReason = SessionEndReason.EXPIRED,
+    )
+
+    /**
+     * Emits once per ended session. Implementations coalesce: a cold start fans out several requests
+     * and every one of them discovers the same dead session independently, and each emission replays
+     * the logout navigation.
+     */
+    val sessionExpiredFlow: SharedFlow<SessionEndReason>
 }

--- a/scripts/devcheck/devcheck.sh
+++ b/scripts/devcheck/devcheck.sh
@@ -6,6 +6,8 @@
 #
 # NEVER uninstall the app: the AndroidKeyStore master key backing EncryptedSharedPreferences is
 # dropped on uninstall, which makes a restored snapshot undecryptable. Update with `adb install -r`.
+#
+# Set ANDROID_SERIAL when more than one device is attached; every adb call below honors it.
 set -euo pipefail
 
 PKG=com.garfiec.librechat

--- a/scripts/devcheck/devcheck.sh
+++ b/scripts/devcheck/devcheck.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# Replayable device checks for the session-expiry navigation fixes.
+#
+# The app data dir is snapshotted while the session is dead, then restored before each run, so the
+# same expired-refresh-token cold start can be replayed as many times as needed.
+#
+# NEVER uninstall the app: the AndroidKeyStore master key backing EncryptedSharedPreferences is
+# dropped on uninstall, which makes a restored snapshot undecryptable. Update with `adb install -r`.
+set -euo pipefail
+
+PKG=com.garfiec.librechat
+STATE_DIR="${DEVCHECK_STATE_DIR:-$HOME/Documents/code/librechat/.device-state}"
+SNAPSHOT="$STATE_DIR/broken-session.tar"
+REMOTE_TAR=/data/local/tmp/devcheck-restore.tar
+
+mkdir -p "$STATE_DIR"
+
+die() { echo "devcheck: $*" >&2; exit 1; }
+
+cmd_snapshot() {
+  adb shell am force-stop "$PKG"
+  adb exec-out run-as "$PKG" tar cf - shared_prefs databases files no_backup > "$SNAPSHOT"
+  echo "snapshot -> $SNAPSHOT ($(tar tf "$SNAPSHOT" | wc -l | tr -d ' ') entries)"
+}
+
+cmd_restore() {
+  [ -f "$SNAPSHOT" ] || die "no snapshot at $SNAPSHOT"
+  adb shell am force-stop "$PKG"
+  # Pushed to a world-readable path rather than piped over stdin: adb's pty mangles binary input.
+  adb push "$SNAPSHOT" "$REMOTE_TAR" >/dev/null
+  adb shell chmod 644 "$REMOTE_TAR"
+  adb shell "run-as $PKG sh -c 'rm -rf shared_prefs databases files && tar xf $REMOTE_TAR'"
+  adb shell rm -f "$REMOTE_TAR"
+  echo "restored $(adb shell run-as "$PKG" ls shared_prefs | tr -d '\r' | wc -l | tr -d ' ') shared_prefs files"
+}
+
+# Number of stored <string> rows in the encrypted token store. Two of them are Tink keysets
+# (key + value); every persisted token adds one more. Keys are encrypted too, so the count is the
+# only thing readable from outside the app.
+cmd_tokens() {
+  adb shell run-as "$PKG" cat shared_prefs/librechat_tokens.xml 2>/dev/null |
+    grep -c '<string name=' || echo 0
+}
+
+# Named explicitly: the debug build ships LeakCanary, which registers a second LAUNCHER activity,
+# so `monkey -c android.intent.category.LAUNCHER` opens the leak list instead of the app.
+launch() {
+  # Always force-stop first: `am start` onto a live task just resumes it, so nothing re-composes and
+  # no cold-start work runs — a "clean" capture that only proves the app was already open.
+  adb shell am force-stop "$PKG"
+  adb shell am start -W -n "$PKG/.MainActivity" >/dev/null 2>&1
+}
+
+capture() {
+  local label="$1"
+  adb logcat -d -v threadtime > "$STATE_DIR/$label.log"
+  adb shell uiautomator dump /sdcard/devcheck-ui.xml >/dev/null 2>&1 || true
+  adb pull /sdcard/devcheck-ui.xml "$STATE_DIR/$label.ui.xml" >/dev/null 2>&1 || true
+  echo "captured -> $STATE_DIR/$label.log"
+}
+
+# Reads a uiautomator dump on stdin, prints "x1 y1 x2 y2" for the first node with the given text.
+boundsOf() {
+  grep "text=\"$1\"" |
+    sed -n 's/.*bounds="\[\([0-9]*\),\([0-9]*\)\]\[\([0-9]*\),\([0-9]*\)\].*/\1 \2 \3 \4/p' | head -1
+}
+
+tapBounds() {
+  # shellcheck disable=SC2086
+  set -- $1 "$2"
+  local x=$((($1 + $3) / 2)) y=$((($2 + $4) / 2))
+  adb shell input tap "$x" "$y"
+  echo "tapped $5 at $x,$y (t+${SECONDS}s)"
+}
+
+cmd_run() {
+  local label="${1:?usage: run <label> [seconds]}" secs="${2:-15}"
+  echo "tokens before: $(cmd_tokens)"
+  adb logcat -c
+  launch
+  sleep "$secs"
+  capture "$label"
+  echo "tokens after:  $(cmd_tokens)"
+}
+
+# Launch, then tap Connect as soon as the ServerUrl screen paints — this races the tail of the 401
+# storm, which is what used to yank the user off Login back to ServerUrl.
+cmd_tap_connect() {
+  local label="${1:?usage: tap-connect <label> [seconds]}" secs="${2:-20}"
+  echo "tokens before: $(cmd_tokens)"
+  adb logcat -c
+  launch
+  local deadline=$((SECONDS + 15)) bounds=""
+  while [ $SECONDS -lt $deadline ]; do
+    adb shell uiautomator dump /sdcard/devcheck-poll.xml >/dev/null 2>&1 || true
+    local dump
+    dump=$(adb shell cat /sdcard/devcheck-poll.xml 2>/dev/null | tr '>' '\n' || true)
+    # The signed-out notice covers the screen; clear it before reaching for Connect.
+    local dismiss
+    dismiss=$(printf '%s\n' "$dump" | boundsOf 'Dismiss' || true)
+    if [ -n "$dismiss" ]; then tapBounds "$dismiss" "Dismiss"; continue; fi
+    bounds=$(printf '%s\n' "$dump" | boundsOf 'Connect' || true)
+    [ -n "$bounds" ] && break
+  done
+  if [ -n "$bounds" ]; then
+    tapBounds "$bounds" "Connect"
+  else
+    echo "WARN: Connect button never appeared" >&2
+  fi
+  sleep "$secs"
+  capture "$label"
+  echo "tokens after:  $(cmd_tokens)"
+}
+
+cmd_assert() {
+  local label="${1:?usage: assert <label>}"
+  local log="$STATE_DIR/$label.log"
+  [ -f "$log" ] || die "no capture at $log"
+  echo "=== $label ==="
+  printf '%-42s %s\n' \
+    "401 received (refresh legs entered)" "$(grep -c '401 received, attempting token refresh' "$log" || true)" \
+    "refresh_rejected (refresh POSTs)"    "$(grep -c 'refresh_rejected' "$log" || true)" \
+    "Token refresh failed (settled)"      "$(grep -c 'Token refresh failed - session expired' "$log" || true)" \
+    "session_torn_down"                   "$(grep -c 'session_torn_down' "$log" || true)" \
+    "401 after retry"                     "$(grep -c '401 after retry' "$log" || true)"
+  echo "screen sequence:"
+  { grep -o '"screen":"[A-Za-z]*"' "$log" || true; } |
+    sed 's/.*:"//;s/"//' | awk 'NR==1||$0!=p{print "  "NR": "$0}{p=$0}'
+}
+
+case "${1:-}" in
+  snapshot)    shift; cmd_snapshot "$@" ;;
+  restore)     shift; cmd_restore "$@" ;;
+  run)         shift; cmd_run "$@" ;;
+  tap-connect) shift; cmd_tap_connect "$@" ;;
+  assert)      shift; cmd_assert "$@" ;;
+  tokens)      shift; cmd_tokens "$@" ;;
+  *) die "usage: devcheck.sh {snapshot|restore|run <label> [s]|tap-connect <label> [s]|assert <label>|tokens}" ;;
+esac

--- a/scripts/devcheck/devcheck.sh
+++ b/scripts/devcheck/devcheck.sh
@@ -11,7 +11,7 @@
 set -euo pipefail
 
 PKG=com.garfiec.librechat
-STATE_DIR="${DEVCHECK_STATE_DIR:-$HOME/Documents/code/librechat/.device-state}"
+STATE_DIR="${DEVCHECK_STATE_DIR:-${TMPDIR:-/tmp}/switchboard-devcheck}"
 SNAPSHOT="$STATE_DIR/broken-session.tar"
 REMOTE_TAR=/data/local/tmp/devcheck-restore.tar
 

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -11,4 +11,9 @@
     <string name="version_mismatch_message">This app was built for LibreChat v%1$s, but your server is running v%2$s. Some features may not work correctly.</string>
     <string name="dismiss">Dismiss</string>
     <string name="dont_warn_again">Don't warn again</string>
+
+    <!-- Session expiry notice -->
+    <string name="session_expired_title">Signed out</string>
+    <string name="session_expired_message">Your session has expired. Sign in again to continue.</string>
+    <string name="session_expired_message_named">Your session for %1$s has expired. Sign in again to continue.</string>
 </resources>

--- a/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/LibreChatNavHost.kt
+++ b/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/LibreChatNavHost.kt
@@ -48,6 +48,7 @@ import com.garfiec.librechat.core.ui.theme.AppLocale
 import com.garfiec.librechat.feature.agents.navigation.AgentMarketplace
 import com.garfiec.librechat.feature.agents.navigation.agentsEntries
 import com.garfiec.librechat.feature.auth.navigation.AddAccountServerUrl
+import com.garfiec.librechat.feature.auth.navigation.ServerUrl
 import com.garfiec.librechat.feature.auth.navigation.authEntries
 import com.garfiec.librechat.feature.auth.navigation.isAddAccountFlowRoute
 import com.garfiec.librechat.feature.chat.navigation.Chat
@@ -109,8 +110,14 @@ fun LibreChatNavHost(
 ) {
     val isLoggedIn by navHostViewModel.isLoggedIn.collectAsStateWithLifecycle()
 
-    // Stable start key — auth redirect handled via LaunchedEffect below.
-    val backStack = rememberNavBackStack(navigationSavedStateConfig, NewChat())
+    // Start key comes from the synchronous logged-in seed, not a fixed NewChat. Starting logged-in
+    // and redirecting away composes the chat shell for real and then plays NavDisplay's transition
+    // animation over it — a third of a second of "signed in" before the auth screen, on every
+    // logged-out cold start. The redirect below still runs, as the catch-up for the async re-resolve.
+    val backStack = rememberNavBackStack(
+        navigationSavedStateConfig,
+        if (navHostViewModel.isLoggedIn.value) NewChat() else ServerUrl,
+    )
     val navigator = remember(backStack) { Navigator(backStack) }
 
     // Redirect to auth if not logged in — once per saved-state lifecycle, NOT on every recreation.
@@ -240,9 +247,8 @@ fun LibreChatNavHost(
             )
         }
 
-        // Being dropped back on the server screen with no explanation is the part users report as a
-        // bug. Rendered here rather than inside the auth screens because it sits above NavDisplay and
-        // so survives the back-stack reset that put them there.
+        // Rendered here rather than inside the auth screens: it sits above NavDisplay and so survives
+        // the back-stack reset that routed the user to auth in the first place.
         val sessionExpiredNotice by navHostViewModel.sessionExpiredNotice.collectAsStateWithLifecycle()
         sessionExpiredNotice?.let { accountLabel ->
             SessionExpiredDialog(

--- a/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/LibreChatNavHost.kt
+++ b/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/LibreChatNavHost.kt
@@ -113,7 +113,8 @@ fun LibreChatNavHost(
     // Start key comes from the synchronous logged-in seed, not a fixed NewChat. Starting logged-in
     // and redirecting away composes the chat shell for real and then plays NavDisplay's transition
     // animation over it — a third of a second of "signed in" before the auth screen, on every
-    // logged-out cold start. The redirect below still runs, as the catch-up for the async re-resolve.
+    // logged-out cold start. This reads the same seed the redirect below does, which leaves that
+    // redirect a backstop for the deep-link path rather than the thing that picks the screen.
     val backStack = rememberNavBackStack(
         navigationSavedStateConfig,
         if (navHostViewModel.isLoggedIn.value) NewChat() else ServerUrl,

--- a/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/LibreChatNavHost.kt
+++ b/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/LibreChatNavHost.kt
@@ -73,6 +73,9 @@ import com.garfiec.librechat.feature.skills.navigation.skillsEntries
 import com.garfiec.librechat.shared.resources.Res
 import com.garfiec.librechat.shared.resources.dismiss
 import com.garfiec.librechat.shared.resources.dont_warn_again
+import com.garfiec.librechat.shared.resources.session_expired_message
+import com.garfiec.librechat.shared.resources.session_expired_message_named
+import com.garfiec.librechat.shared.resources.session_expired_title
 import com.garfiec.librechat.shared.resources.version_mismatch_message
 import com.garfiec.librechat.shared.resources.version_mismatch_title
 import kotlinx.coroutines.Dispatchers
@@ -236,7 +239,47 @@ fun LibreChatNavHost(
                 onDismissPermanently = navHostViewModel::dismissVersionWarningPermanently,
             )
         }
+
+        // Being dropped back on the server screen with no explanation is the part users report as a
+        // bug. Rendered here rather than inside the auth screens because it sits above NavDisplay and
+        // so survives the back-stack reset that put them there.
+        val sessionExpiredNotice by navHostViewModel.sessionExpiredNotice.collectAsStateWithLifecycle()
+        sessionExpiredNotice?.let { accountLabel ->
+            SessionExpiredDialog(
+                accountLabel = accountLabel,
+                onDismiss = navHostViewModel::dismissSessionExpiredNotice,
+            )
+        }
     }
+}
+
+/** Reports an unannounced sign-out. [accountLabel] is blank when the account can't be named. */
+@Composable
+private fun SessionExpiredDialog(accountLabel: String, onDismiss: () -> Unit) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = {
+            Text(
+                text = stringResource(Res.string.session_expired_title),
+                style = MaterialTheme.typography.headlineSmall,
+            )
+        },
+        text = {
+            Text(
+                text = if (accountLabel.isBlank()) {
+                    stringResource(Res.string.session_expired_message)
+                } else {
+                    stringResource(Res.string.session_expired_message_named, accountLabel)
+                },
+                style = MaterialTheme.typography.bodyMedium,
+            )
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(Res.string.dismiss))
+            }
+        },
+    )
 }
 
 @Composable

--- a/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/NavHostViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/NavHostViewModel.kt
@@ -23,6 +23,7 @@ import com.garfiec.librechat.core.data.util.SessionTaskRunner
 import com.garfiec.librechat.core.model.Banner
 import com.garfiec.librechat.core.network.client.AccountReadyGate
 import com.garfiec.librechat.core.network.client.ServerUrlProvider
+import com.garfiec.librechat.core.network.client.SessionEndReason
 import com.garfiec.librechat.core.network.client.TokenManager
 import com.garfiec.librechat.feature.conversations.drawer.AccountUiModel
 import kotlinx.coroutines.CancellationException
@@ -82,7 +83,17 @@ class NavHostViewModel(
     val banners: StateFlow<List<Banner>> = bannerStateHolder.banners
     val dismissedBannerIds: StateFlow<Set<String>> = bannerStateHolder.dismissedBannerIds
 
-    val sessionExpired: SharedFlow<Unit> = tokenManager.sessionExpiredFlow
+    val sessionExpired: SharedFlow<SessionEndReason> = tokenManager.sessionExpiredFlow
+
+    /** The account label to report an unannounced sign-out for, or null when there is nothing to
+     *  report. Set only for [SessionEndReason.EXPIRED] — see [SessionEndReason]. Empty string means
+     *  "expired, but the account could not be named". */
+    private val _sessionExpiredNotice = MutableStateFlow<String?>(null)
+    val sessionExpiredNotice: StateFlow<String?> = _sessionExpiredNotice.asStateFlow()
+
+    fun dismissSessionExpiredNotice() {
+        _sessionExpiredNotice.value = null
+    }
 
     // The live identity for the NavHost's account hygiene (Coil cache clear + back-stack reset on
     // an account flip). Exposed as STATE rather than a transition flow so the UI can persist the
@@ -179,6 +190,24 @@ class NavHostViewModel(
             }
         }
         bannerStateHolder.fetchBanners()
+        // A dead session has to lower the flag, not just navigate. `isLoggedIn()` is a token-PRESENCE
+        // check and the 401 path produces no [AccountTransition.Ended], so without this the flag stays
+        // true for the rest of the process — every consumer of it (and the first-frame routing after
+        // an Activity recreation) keeps believing the user is signed in while they sit on auth.
+        viewModelScope.launch {
+            tokenManager.sessionExpiredFlow.collect { reason ->
+                val wasLoggedIn = _isLoggedIn.value
+                _isLoggedIn.value = false
+                // Only announce an expiry to someone the app believed was signed in. A logged-out cold
+                // start still fires requests (banners, the drawer); each 401s with no token to refresh
+                // and settles as expired, and reporting those would put the dialog on every launch.
+                // The account label resolves here because the expiry teardown clears only the token
+                // slot — the roster entry is still there.
+                if (reason == SessionEndReason.EXPIRED && wasLoggedIn) {
+                    _sessionExpiredNotice.value = expiredAccountLabel().orEmpty()
+                }
+            }
+        }
         // The active account changed underneath this Activity-scoped VM (switch / add-completion /
         // remove → Switched; remove-last → Ended; plain logout also lands here as Ended, where the
         // clears below just repeat logout()'s — idempotent). This is the nav/session half of the
@@ -256,6 +285,15 @@ class NavHostViewModel(
             Logger.w(e) { "Account restore failed on cold start; will retry on reconnect" }
             false
         }
+
+    /** The display label of the account whose session just ended, or null when it can't be named —
+     *  a legacy pre-tenancy session, or one whose roster entry has already gone. */
+    private suspend fun expiredAccountLabel(): String? {
+        val activeId = (activeAccountProvider.state.value as? AccountState.Resolved)?.id?.value ?: return null
+        return accountRoster.entriesFlow().firstOrNull()
+            ?.firstOrNull { it.accountId == activeId }
+            ?.displayLabel
+    }
 
     private fun retryAccountRestoreOnReconnect() {
         viewModelScope.launch {

--- a/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/NavHostViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/NavHostViewModel.kt
@@ -190,19 +190,16 @@ class NavHostViewModel(
             }
         }
         bannerStateHolder.fetchBanners()
-        // A dead session has to lower the flag, not just navigate. `isLoggedIn()` is a token-PRESENCE
-        // check and the 401 path produces no [AccountTransition.Ended], so without this the flag stays
-        // true for the rest of the process — every consumer of it (and the first-frame routing after
-        // an Activity recreation) keeps believing the user is signed in while they sit on auth.
+        // A dead session has to lower the flag, not just navigate: the 401 path produces no
+        // [AccountTransition.Ended], so without this the flag stays true for the rest of the process
+        // and the first-frame routing after an Activity recreation still believes the user is signed in.
         viewModelScope.launch {
             tokenManager.sessionExpiredFlow.collect { reason ->
                 val wasLoggedIn = _isLoggedIn.value
                 _isLoggedIn.value = false
                 // Only announce an expiry to someone the app believed was signed in. A logged-out cold
                 // start still fires requests (banners, the drawer); each 401s with no token to refresh
-                // and settles as expired, and reporting those would put the dialog on every launch.
-                // The account label resolves here because the expiry teardown clears only the token
-                // slot — the roster entry is still there.
+                // and settles as expired, so dropping [wasLoggedIn] puts the dialog on every launch.
                 if (reason == SessionEndReason.EXPIRED && wasLoggedIn) {
                     _sessionExpiredNotice.value = expiredAccountLabel().orEmpty()
                 }

--- a/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/Navigator.kt
+++ b/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/Navigator.kt
@@ -67,8 +67,18 @@ class Navigator(val backStack: NavBackStack<NavKey>) {
         }
     }
 
-    /** Clear back stack and navigate to auth (session expiry / logout). */
+    /**
+     * Clear back stack and navigate to auth (session expiry / logout).
+     *
+     * No-ops when the user is already in the auth flow, matching the dedupe its siblings above
+     * already do. A dead session is reported by more than one caller — a cold start fans out several
+     * requests and each 401 settles independently — and without this a straggler landing after the
+     * user has moved on to Login (or Register, or 2FA) resets them all the way back to [ServerUrl],
+     * discarding whatever they had typed. There is nothing to re-route to: they are on the very
+     * screen this would send them to.
+     */
     fun navigateToAuth() {
+        if (isInAuthFlow) return
         backStack.clear()
         backStack.add(ServerUrl)
     }

--- a/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/Navigator.kt
+++ b/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/Navigator.kt
@@ -70,12 +70,10 @@ class Navigator(val backStack: NavBackStack<NavKey>) {
     /**
      * Clear back stack and navigate to auth (session expiry / logout).
      *
-     * No-ops when the user is already in the auth flow, matching the dedupe its siblings above
-     * already do. A dead session is reported by more than one caller — a cold start fans out several
-     * requests and each 401 settles independently — and without this a straggler landing after the
-     * user has moved on to Login (or Register, or 2FA) resets them all the way back to [ServerUrl],
-     * discarding whatever they had typed. There is nothing to re-route to: they are on the very
-     * screen this would send them to.
+     * No-ops when already in the auth flow, matching the dedupe its siblings above do. A dead session
+     * is reported by more than one caller (a cold start fans out several requests and each 401 settles
+     * independently), and a straggler landing after the user has moved on to Login/Register/2FA would
+     * otherwise reset them to [ServerUrl] and discard what they had typed.
      */
     fun navigateToAuth() {
         if (isInAuthFlow) return

--- a/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/Navigator.kt
+++ b/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/Navigator.kt
@@ -4,6 +4,7 @@ import androidx.navigation3.runtime.NavBackStack
 import androidx.navigation3.runtime.NavKey
 import com.garfiec.librechat.feature.auth.navigation.AuthRoute
 import com.garfiec.librechat.feature.auth.navigation.ServerUrl
+import com.garfiec.librechat.feature.auth.navigation.isAddAccountFlowRoute
 import com.garfiec.librechat.feature.chat.navigation.Chat
 import com.garfiec.librechat.feature.chat.navigation.NewChat
 import com.garfiec.librechat.feature.settings.navigation.ProviderKeys
@@ -76,7 +77,10 @@ class Navigator(val backStack: NavBackStack<NavKey>) {
      * otherwise reset them to [ServerUrl] and discard what they had typed.
      */
     fun navigateToAuth() {
-        if (isInAuthFlow) return
+        // An add-account flow is not "already at the destination": it belongs to the session that
+        // just ended, and the nav host cancels the pending add by watching those routes leave the
+        // stack — so skipping the reset there would strand the flow with a dead parent session.
+        if (isInAuthFlow && backStack.none { it.isAddAccountFlowRoute }) return
         backStack.clear()
         backStack.add(ServerUrl)
     }


### PR DESCRIPTION
## Summary

An expired refresh token left local state the app replayed on every launch, and the routing back to
auth ran once per in-flight request instead of once per ended session. Cold-starting into a dead
session rendered the cached conversation UI, fanned out its startup requests, collected 401s and
dropped the user on the server-URL screen — every launch, until they signed in again. A straggler
401 arriving after they had tapped Connect and reached Login reset them back to the server screen.
Separately, a logged-out cold start composed the chat shell and then animated it away, so even once
the session was cleared the app still opened on about a third of a second of "signed in".

## Changes

**Drop the tokens a rejected refresh proves are dead** (`CommonTokenDataStore.performRefresh`)

- A settled 401-driven `HardExpired` now clears the refreshed account's token slot, as does the
  no-stored-refresh-token arm. `isLoggedIn()` is a token-*presence* check, so a retained dead pair
  made every later cold start re-enter the logged-in graph and 401 its way back out.
- Only the tokens go: the roster entry and the active-account mirror stay, so the account remains
  listed and re-loginable. This applies to whichever account was refreshed — a retained,
  switched-away account whose refresh is rejected also loses its slot, and (as before) does not
  route the live session to auth.
- A run that saw **no** auth rejection is unchanged: a 5xx, a rate-limit, a transport failure or a
  gateway rejection still keeps the session, and the retry budget still absorbs a transient 401
  before anything is torn down. A transport failure *following* a 401 was already classified
  `HardExpired`; it now clears the slot along with it.

**Emit one session-ended signal per session** (`CommonTokenDataStore.emitSessionExpired`)

- Latched, re-armed by every transition that establishes or tears down a session (`setTokens`,
  `selectAccount`, `removeAccount`, the active-session teardown). `AccountSwitcher` reuses this
  channel for its remove-last-account teardown, so the re-arm points are load-bearing.
- The latch is a plain `@Volatile` check-then-set, not a CAS, so the guarantee is best-effort — a
  racing double-emit is possible and deliberately tolerated, because the navigator guard absorbs it.

**Guard the navigation reset** (`Navigator.navigateToAuth`)

- No-ops when already in the auth flow, matching the dedupe `navigateToTopLevel` and
  `navigateToProviderKeys` already do. Re-running it discarded whatever the user had typed on Login.
- The guard covers the whole auth flow, so a genuine expiry landing while the user sits on Register,
  2FA, or password reset is also swallowed — intended, since they are already where it would send
  them. The add-account flow is deliberately **excluded**: those routes belong to the session that
  just ended, and the nav host cancels a pending add by watching them leave the back stack.

**Choose the auth start key instead of redirecting to it** (`LibreChatNavHost`)

- The back stack was created at `NewChat()` unconditionally and a `LaunchedEffect` redirected away
  when logged out — which composes the chat shell for real and then plays `NavDisplay`'s transition
  animation over it. It now starts from the same synchronous logged-in seed, so the wrong screen is
  never composed. The redirect reads that same seed, which leaves it a backstop for the deep-link
  path rather than the thing that picks the screen.
- Side effect: that shell was also firing the startup fetches. A logged-out cold start now enters
  the refresh leg once rather than a dozen times.

**Lower the logged-in flag when a session ends** (`NavHostViewModel`)

- It previously only fell on an `AccountTransition.Ended`, which the 401 path never produces. It now
  falls for every session end — expiry, sign-out and ban alike.

**Explain an unannounced sign-out**

- `sessionExpiredFlow` changes from `SharedFlow<Unit>` to `SharedFlow<SessionEndReason>` and
  `emitSessionExpired` gains a defaulted `reason`. That is a signature change on the `:core:network`
  `TokenManager` interface, which `:shared` exports into `Shared.framework`, so `SessionEndReason`
  is new bridged Swift surface; no Swift consumer reads it today.
- Only `EXPIRED` surfaces a dialog, and only to a session the app believed was live. A deliberate
  logout (`SIGNED_OUT`) stays silent because the user asked for it. A mid-session ban (`BANNED`)
  stays silent because a "your session expired" dialog would misreport it — note that nothing else
  surfaces a mid-session ban either, so that case is routed to auth without explanation.
- The dialog names the account when the roster can resolve it, and renders above `NavDisplay` so it
  outlives the back-stack reset that put the user on the auth screen.

## Testing

- **Unit** — new `CommonTokenDataStoreSessionExpiryTest`: a rejected refresh clears the slot and
  leaves the account intact, a 5xx keeps the session, a dead session reports once across twelve
  discoveries, and each re-arm path restores the signal. New `NavigatorTest` cases for the guard,
  including that it still resets out of an add-account flow. `AccountSwitcherRemoveTest` pins the
  remove-last reason as `SIGNED_OUT`.
- **Two existing tests had their expectations inverted** by the teardown and the latch:
  `CommonTokenDataStoreConcurrencyTest` (a hard expiry now clears both slots) and
  `CommonTokenDataStoreAccountKeyingTest` (a second unscoped emit now needs a re-arm first).
- **Gate** — `:app`, `:core:data`, `:core:network`, `:shared` unit tests, `detektMetadataCommonMain`
  (the task that actually covers `commonMain`), and `:app:lint`.
- **Device** — Pixel 9 Pro Fold, replaying a real expired session captured off the device. The route
  trace went from `NewChat → ServerUrl → Login → ServerUrl` to `NewChat → ServerUrl → Login`, and
  the second cold start goes straight to `ServerUrl` with no refresh POSTs where before it repeated
  the full storm indefinitely. A 30 fps screen recording of a logged-out cold start shows the chat
  screen for about eleven consecutive frames before this change and not at all after it.
- **Not yet re-run on device:** the add-account guard exclusion and the no-refresh-token teardown
  landed after that pass and are covered by unit tests only.
- **Not verified: iOS.** Every changed production file is `commonMain`, so the start key, the guard,
  the latch and the dialog all ship there; the iOS SSE transport's own 401 recovery picks up the
  defaulted `EXPIRED`. Correct by inspection, but no iOS build or device run was done.

## Notes

- The launch that *discovers* the session is dead still shows the logged-in UI first: the tokens are
  still on disk, so the seed is legitimately true, and the refresh loop spends its retry budget
  before it will call the session dead. Removing that needs the client to know the token's expiry,
  which is #323. Every launch after it is clean.
- One expired-session behaviour is deliberately reversed. Retaining the tokens through a hard expiry
  was a choice, not an oversight, resting on a relaunch being able to recover the session. It
  cannot: the retry budget has already absorbed any transient rejection before `settle()` runs, so
  reaching `HardExpired` means the session is dead. The user is routed to re-auth either way; only
  the per-launch replay differs.
- The three new strings are English-only. The nine locales under
  `shared/src/commonMain/composeResources/values-*` do not carry them and will fall back.
- `scripts/devcheck/devcheck.sh` snapshots and restores the app data dir over `run-as` so a dead
  session can be replayed on a device, and counts the refresh legs and route breadcrumbs the app
  already logs. It needs a debuggable build, its `restore` deletes live app data before unpacking,
  and it must never uninstall — that drops the AndroidKeyStore master key and makes a restored token
  store undecryptable.
- The refresh fan-out itself is unchanged: a cold start into a live-looking session still enters the
  refresh leg once per in-flight request (#323), and that work still runs on the caller's thread
  (#326).
