### PR TITLE
feat(chat): make message text selectable in the transcript (#311)

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -37,9 +37,16 @@ File: `.github/workflows/ci.yml`
 
 #### `android` (Build Android App)
 - `./gradlew :app:assembleDebug`
+- `./gradlew :feature:chat:assembleDebugAndroidTest` — compile-only gate for the chat instrumented
+  suite, which *runs* on a local emulator (`connectedDebugAndroidTest`), never in CI. Scoped to the
+  one module deliberately: a repo-wide `assembleDebugAndroidTest` would also compile `:app`'s stale
+  `androidTest` sources.
+- Uploads the debug APK as an artifact (90-day retention) and posts its download link to the PR
 
 #### `ios` (Build iOS App)
 - Selects latest stable Xcode
+- Runs `./gradlew :shared:iosSimulatorArm64Test` (the iOS Koin graph test — the `ubuntu` `test` job
+  cannot run Kotlin/Native tests)
 - Caches `~/.konan`
 - Runs `xcodebuild` for the iOS simulator (arm64-only, no signing). The Kotlin framework is built by the Xcode "Compile Kotlin Framework" build phase (`./gradlew :shared:embedAndSignAppleFrameworkForXcode`) — no separate link step.
 
@@ -56,6 +63,7 @@ File: `.github/workflows/ci.yml`
 ### Notes
 
 - No release signing configured yet
-- No instrumented/UI tests in CI (only unit tests)
-- APK / iOS app are built but NOT uploaded as artifacts
+- Instrumented/UI tests are never *executed* in CI (no emulator) — `:feature:chat`'s suite is only
+  compiled, as a gate. Executed test coverage in CI is unit tests plus the iOS Koin graph test.
+- The debug APK is uploaded as an artifact; the iOS app is built but not uploaded
 - Detekt SARIF is uploaded to GitHub Code Scanning (requires GitHub Advanced Security for private repos)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,13 @@ jobs:
       - name: Build debug APK
         run: ./gradlew :app:assembleDebug
 
+      # Compile-only gate for :feature:chat's instrumented tests (they execute on a
+      # local emulator via connectedDebugAndroidTest, never in CI). Scoped to the one
+      # module on purpose: a repo-wide assembleDebugAndroidTest would also compile
+      # :app's stale androidTest sources.
+      - name: Compile chat instrumented tests
+        run: ./gradlew :feature:chat:assembleDebugAndroidTest
+
       - name: Upload debug APK
         id: upload_apk
         if: always() && hashFiles('app/build/outputs/apk/debug/app-debug.apk') != ''

--- a/feature/chat/build.gradle.kts
+++ b/feature/chat/build.gradle.kts
@@ -29,5 +29,15 @@ kotlin {
         getByName("androidUnitTest").dependencies {
             implementation(libs.koin.test)
         }
+        named("androidInstrumentedTest").dependencies {
+            implementation(libs.junit)
+            implementation(libs.android.test.runner)
+            implementation(libs.android.test.ext.junit)
+            implementation(libs.compose.ui.test)
+            implementation(libs.compose.ui.test.manifest)
+            // Pin espresso ≥3.7.0: the 3.5.x pulled in transitively by ui-test-junit4 injects
+            // input via InputManager.getInstance, which no longer exists on API 36+.
+            implementation(libs.espresso.core)
+        }
     }
 }

--- a/feature/chat/src/androidInstrumentedTest/kotlin/com/garfiec/librechat/feature/chat/components/MessageSelectionInstrumentedTest.kt
+++ b/feature/chat/src/androidInstrumentedTest/kotlin/com/garfiec/librechat/feature/chat/components/MessageSelectionInstrumentedTest.kt
@@ -1,0 +1,343 @@
+package com.garfiec.librechat.feature.chat.components
+
+import android.content.ClipboardManager
+import androidx.compose.foundation.text.contextmenu.data.TextContextMenuItem
+import androidx.compose.foundation.text.contextmenu.data.TextContextMenuKeys
+import androidx.compose.foundation.text.contextmenu.data.TextContextMenuSession
+import androidx.compose.foundation.text.contextmenu.provider.LocalTextContextMenuToolbarProvider
+import androidx.compose.foundation.text.contextmenu.provider.TextContextMenuDataProvider
+import androidx.compose.foundation.text.contextmenu.provider.TextContextMenuProvider
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.ClipEntry
+import androidx.compose.ui.platform.Clipboard
+import androidx.compose.ui.platform.LocalClipboard
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.platform.UriHandler
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.longClick
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTouchInput
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.garfiec.librechat.core.model.Message
+import com.garfiec.librechat.core.ui.theme.LibreChatTheme
+import com.garfiec.librechat.feature.chat.util.MessageNode
+import kotlinx.coroutines.awaitCancellation
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * On-device checks for in-message text selection (issue #311).
+ *
+ * Compose exposes no semantics for SelectionContainer selection state on plain
+ * BasicText, so assertions go through the composition locals the selection
+ * machinery talks to:
+ *  - [RecordingContextMenuProvider] via [LocalTextContextMenuToolbarProvider] —
+ *    with foundation's `isNewContextMenuEnabled` default, the selection toolbar
+ *    is requested through this provider (NOT the legacy `LocalTextToolbar`);
+ *    `showTextContextMenu` runs exactly when a non-empty selection exists, and
+ *    its data carries the live copy / select-all actions.
+ *  - [RecordingClipboard] via [LocalClipboard] — invoking the copy item routes
+ *    the selected text here, which both proves WHAT was selected and sidesteps
+ *    the API 29+ background clipboard-read restriction.
+ *
+ * The host is the real gesture stack: MessageList (LazyColumn) → MessageBubble
+ * (whole-bubble clickable) → MessageContentAndActions (SelectionContainer). No
+ * ViewModel, no Koin — plain data in.
+ */
+@RunWith(AndroidJUnit4::class)
+class MessageSelectionInstrumentedTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    private lateinit var menuProvider: RecordingContextMenuProvider
+    private lateinit var clipboard: RecordingClipboard
+    private lateinit var uriHandler: RecordingUriHandler
+
+    @Before
+    fun setUp() {
+        menuProvider = RecordingContextMenuProvider()
+        clipboard = RecordingClipboard()
+        uriHandler = RecordingUriHandler()
+    }
+
+    // ─── Harness ────────────────────────────────────────────────────
+
+    /**
+     * Stands in for the platform selection-toolbar provider. [showTextContextMenu]
+     * suspends for as long as the menu is "shown" (the selection machinery cancels
+     * it to hide), so the recorded [lastDataProvider] stays live-queryable.
+     */
+    class RecordingContextMenuProvider : TextContextMenuProvider {
+        var shownCount = 0
+        var lastDataProvider: TextContextMenuDataProvider? = null
+
+        override suspend fun showTextContextMenu(dataProvider: TextContextMenuDataProvider) {
+            shownCount++
+            lastDataProvider = dataProvider
+            awaitCancellation()
+        }
+
+        /** Live lookup of a menu item by [TextContextMenuKeys] key. */
+        fun item(key: Any): TextContextMenuItem? = lastDataProvider
+            ?.data()
+            ?.components
+            ?.filterIsInstance<TextContextMenuItem>()
+            ?.firstOrNull { it.key == key }
+    }
+
+    private object NoOpSession : TextContextMenuSession {
+        override fun close() = Unit
+    }
+
+    /** Records [setClipEntry] instead of touching the system clipboard. */
+    class RecordingClipboard : Clipboard {
+        var lastEntry: ClipEntry? = null
+
+        val lastText: String?
+            get() = lastEntry?.clipData?.let { clip ->
+                (0 until clip.itemCount).joinToString("") { clip.getItemAt(it).text?.toString().orEmpty() }
+            }
+
+        override suspend fun getClipEntry(): ClipEntry? = lastEntry
+
+        override suspend fun setClipEntry(clipEntry: ClipEntry?) {
+            lastEntry = clipEntry
+        }
+
+        override val nativeClipboard: ClipboardManager
+            get() = InstrumentationRegistry.getInstrumentation().targetContext
+                .getSystemService(ClipboardManager::class.java)
+    }
+
+    class RecordingUriHandler : UriHandler {
+        val opened = mutableListOf<String>()
+        override fun openUri(uri: String) {
+            opened += uri
+        }
+    }
+
+    private fun userMessage(id: String, text: String) = Message(
+        messageId = id,
+        conversationId = CONVO,
+        text = text,
+        isCreatedByUser = true,
+    )
+
+    private fun assistantMessage(id: String, text: String) = Message(
+        messageId = id,
+        conversationId = CONVO,
+        text = text,
+        isCreatedByUser = false,
+        sender = SENDER,
+    )
+
+    private fun setChat(
+        vararg messages: Message,
+        isStreaming: Boolean = false,
+        streamingContent: String = "",
+    ) {
+        composeRule.setContent {
+            // ParsedMarkdownCache is normally provided by ChatRoot; the harness renders
+            // MessageList directly, so it supplies its own.
+            val markdownCache = remember { ParsedMarkdownCache() }
+            CompositionLocalProvider(
+                LocalTextContextMenuToolbarProvider provides menuProvider,
+                LocalClipboard provides clipboard,
+                LocalUriHandler provides uriHandler,
+                LocalParsedMarkdownCache provides markdownCache,
+            ) {
+                LibreChatTheme {
+                    MessageList(
+                        displayMessages = messages.map { MessageNode(it, emptyList(), 0, 1) },
+                        isStreaming = isStreaming,
+                        streamingContent = streamingContent,
+                        onSiblingNavigation = { _, _ -> },
+                        onEditMessage = {},
+                        onRegenerateMessage = {},
+                        onCopyMessage = {},
+                        userName = USER_NAME,
+                    )
+                }
+            }
+        }
+    }
+
+    /** Waits out the markdown parse: the node bearing [text] must be on screen. */
+    private fun awaitText(text: String) {
+        composeRule.waitUntil(timeoutMillis = 10_000) {
+            composeRule.onAllNodes(hasText(text, substring = true), useUnmergedTree = true)
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+    }
+
+    private fun longPressText(text: String) {
+        awaitText(text)
+        composeRule.onNodeWithText(text, substring = true, useUnmergedTree = true)
+            .performTouchInput { longClick() }
+        composeRule.waitForIdle()
+    }
+
+    private fun awaitSelectionMenu() {
+        composeRule.waitUntil(timeoutMillis = 5_000) { menuProvider.shownCount > 0 }
+    }
+
+    /** Invokes a toolbar item by key on the UI thread and settles. */
+    private fun invokeMenuItem(key: Any, label: String) {
+        val item = menuProvider.item(key)
+        assertNotNull("selection toolbar offered no $label action", item)
+        composeRule.runOnIdle { item!!.onClick(NoOpSession) }
+        composeRule.waitForIdle()
+    }
+
+    /** Invokes the toolbar copy and returns what landed on the fake clipboard. */
+    private fun copyViaMenu(): String {
+        invokeMenuItem(TextContextMenuKeys.CopyKey, "copy")
+        val text = clipboard.lastText
+        assertNotNull("copy wrote nothing to the clipboard", text)
+        return text!!
+    }
+
+    // ─── Tests ──────────────────────────────────────────────────────
+
+    @Test
+    fun longPressOnProseSelectsWordAndCopies() {
+        setChat(assistantMessage("m1", "Alpha beta gamma delta epsilon."))
+
+        longPressText("beta gamma")
+        awaitSelectionMenu()
+
+        val copied = copyViaMenu()
+        assertTrue(
+            "expected a word from the prose, got \"$copied\"",
+            copied.isNotBlank() && "Alpha beta gamma delta epsilon.".contains(copied.trim()),
+        )
+    }
+
+    @Test
+    fun longPressDoesNotToggleActionRow_tapDoes() {
+        setChat(assistantMessage("m1", "Some selectable reply text here."))
+
+        // Long-press = selection, not the bubble's tap-to-reveal.
+        longPressText("selectable reply")
+        awaitSelectionMenu()
+        composeRule.onNodeWithTag("message_actions", useUnmergedTree = true).assertDoesNotExist()
+
+        // Tap on bubble chrome (the sender row) still toggles the action row.
+        composeRule.onNodeWithText(SENDER, useUnmergedTree = true).performClick()
+        composeRule.waitForIdle()
+        composeRule.onNodeWithTag("message_actions", useUnmergedTree = true).assertExists()
+
+        // And a plain tap on the prose itself passes through the SelectionContainer
+        // to the same clickable, toggling it back off.
+        composeRule.onNodeWithText("selectable reply", substring = true, useUnmergedTree = true)
+            .performClick()
+        composeRule.waitForIdle()
+        composeRule.onNodeWithTag("message_actions", useUnmergedTree = true).assertDoesNotExist()
+    }
+
+    @Test
+    fun selectAllSpansParagraphsWithinOneMessage() {
+        // Two paragraphs render as two BasicText nodes sharing one per-message
+        // SelectionRegistrar; select-all must sweep both.
+        setChat(
+            assistantMessage("m1", "Opening paragraph words.\n\nClosing paragraph words."),
+        )
+
+        longPressText("Opening paragraph")
+        awaitSelectionMenu()
+        invokeMenuItem(TextContextMenuKeys.SelectAllKey, "select-all")
+
+        val copied = copyViaMenu()
+        assertTrue("missing first paragraph in \"$copied\"", copied.contains("Opening paragraph"))
+        assertTrue("missing second paragraph in \"$copied\"", copied.contains("Closing paragraph"))
+    }
+
+    @Test
+    fun selectAllExcludesChromeInsideMessage() {
+        // A fenced block contributes a "kotlin" language badge; select-all must
+        // sweep prose + code but never the badge (DisableSelection chrome).
+        setChat(
+            assistantMessage(
+                "m1",
+                "Look at this:\n\n```kotlin\nval uniqueTokenXyz = 42\n```\n\nDone.",
+            ),
+        )
+
+        longPressText("uniqueTokenXyz")
+        awaitSelectionMenu()
+        invokeMenuItem(TextContextMenuKeys.SelectAllKey, "select-all")
+
+        val copied = copyViaMenu()
+        assertTrue("code text missing from \"$copied\"", copied.contains("uniqueTokenXyz"))
+        assertTrue("prose missing from \"$copied\"", copied.contains("Look at this"))
+        // "kotlin" appears rendered only as the CodeBlock header badge (the fence
+        // marker itself is markdown syntax, never rendered) — so its presence in the
+        // copy means DisableSelection chrome leaked into the sweep.
+        assertTrue("chrome badge leaked into selection: \"$copied\"", !copied.contains("kotlin"))
+    }
+
+    @Test
+    fun codeBlockTextIsSelectableDespiteHorizontalScroll() {
+        setChat(
+            assistantMessage("m1", "Intro.\n\n```\nval uniqueTokenXyz = compute(1, 2)\n```"),
+        )
+
+        // A long-press is stationary, so the horizontalScroll wrapper never
+        // contends for the gesture (handle-dragging inside the scroller is the
+        // manual-pass check).
+        longPressText("uniqueTokenXyz")
+        awaitSelectionMenu()
+
+        val copied = copyViaMenu()
+        assertTrue(
+            "expected code text, got \"$copied\"",
+            copied.contains("uniqueTokenXyz") || "val uniqueTokenXyz = compute(1, 2)".contains(copied.trim()),
+        )
+    }
+
+    @Test
+    fun streamingBubbleIsNotSelectable() {
+        setChat(
+            userMessage("m1", "A question."),
+            isStreaming = true,
+            streamingContent = "Streaming reply body still growing",
+        )
+
+        longPressText("Streaming reply body")
+        assertEquals(
+            "selection toolbar must not appear on the streaming bubble",
+            0,
+            menuProvider.shownCount,
+        )
+    }
+
+    @Test
+    fun linkClickStillOpensInsideSelectionContainer() {
+        // The whole paragraph is the link, so clicking the node center hits it.
+        setChat(assistantMessage("m1", "[Docs](https://example.com/docs)"))
+
+        awaitText("Docs")
+        composeRule.onNodeWithText("Docs", substring = true, useUnmergedTree = true)
+            .performClick()
+        composeRule.waitForIdle()
+
+        assertEquals(listOf("https://example.com/docs"), uriHandler.opened)
+    }
+
+    private companion object {
+        const val CONVO = "convo-1"
+        const val SENDER = "TestBot"
+        const val USER_NAME = "TestUser"
+    }
+}

--- a/feature/chat/src/androidInstrumentedTest/kotlin/com/garfiec/librechat/feature/chat/components/MessageSelectionInstrumentedTest.kt
+++ b/feature/chat/src/androidInstrumentedTest/kotlin/com/garfiec/librechat/feature/chat/components/MessageSelectionInstrumentedTest.kt
@@ -23,11 +23,14 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTouchInput
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import com.garfiec.librechat.core.model.ContentType
 import com.garfiec.librechat.core.model.Message
+import com.garfiec.librechat.core.model.content.MessageContentPart
 import com.garfiec.librechat.core.ui.theme.LibreChatTheme
 import com.garfiec.librechat.feature.chat.util.MessageNode
 import kotlinx.coroutines.awaitCancellation
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -80,12 +83,19 @@ class MessageSelectionInstrumentedTest {
      */
     class RecordingContextMenuProvider : TextContextMenuProvider {
         var shownCount = 0
+
+        /** Incremented when the machinery cancels a show — i.e. when the selection went away. */
+        var hiddenCount = 0
         var lastDataProvider: TextContextMenuDataProvider? = null
 
         override suspend fun showTextContextMenu(dataProvider: TextContextMenuDataProvider) {
             shownCount++
             lastDataProvider = dataProvider
-            awaitCancellation()
+            try {
+                awaitCancellation()
+            } finally {
+                hiddenCount++
+            }
         }
 
         /** Live lookup of a menu item by [TextContextMenuKeys] key. */
@@ -192,6 +202,7 @@ class MessageSelectionInstrumentedTest {
         composeRule.waitUntil(timeoutMillis = 5_000) { menuProvider.shownCount > 0 }
     }
 
+
     /** Invokes a toolbar item by key on the UI thread and settles. */
     private fun invokeMenuItem(key: Any, label: String) {
         val item = menuProvider.item(key)
@@ -199,6 +210,10 @@ class MessageSelectionInstrumentedTest {
         composeRule.runOnIdle { item!!.onClick(NoOpSession) }
         composeRule.waitForIdle()
     }
+
+    /** A long-press selects a word, so anything shorter means the gesture degraded. */
+    private fun isWordLike(text: String): Boolean =
+        text.length >= 3 && text.all { it.isLetterOrDigit() || it == '_' }
 
     /** Invokes the toolbar copy and returns what landed on the fake clipboard. */
     private fun copyViaMenu(): String {
@@ -217,12 +232,16 @@ class MessageSelectionInstrumentedTest {
         longPressText("beta gamma")
         awaitSelectionMenu()
 
-        val copied = copyViaMenu()
+        val copied = copyViaMenu().trim()
         assertTrue(
             "expected a word from the prose, got \"$copied\"",
-            copied.isNotBlank() && "Alpha beta gamma delta epsilon.".contains(copied.trim()),
+            "Alpha beta gamma delta epsilon.".contains(copied),
         )
+        // A long-press selects a whole word. Without this, a degraded gesture that caught a
+        // single stray character would still satisfy the substring check above.
+        assertTrue("expected a whole word, got \"$copied\"", isWordLike(copied))
     }
+
 
     @Test
     fun longPressDoesNotToggleActionRow_tapDoes() {
@@ -233,17 +252,27 @@ class MessageSelectionInstrumentedTest {
         awaitSelectionMenu()
         composeRule.onNodeWithTag("message_actions", useUnmergedTree = true).assertDoesNotExist()
 
-        // Tap on bubble chrome (the sender row) still toggles the action row.
-        composeRule.onNodeWithText(SENDER, useUnmergedTree = true).performClick()
+        // A plain tap on the prose passes through the SelectionContainer to the bubble's
+        // clickable and reveals the row. It also puts the selection away — the two are one
+        // gesture by construction: the tap itself does not clear anything on this Compose
+        // version; the action row appearing relayouts the message, and THAT drops the
+        // selection. Suppressing the toggle to "protect" the selection therefore strands it
+        // with no way to dismiss it (measured on device — see the toolbar counters below).
+        val hiddenBefore = menuProvider.hiddenCount
+        composeRule.onNodeWithText("selectable reply", substring = true, useUnmergedTree = true)
+            .performClick()
         composeRule.waitForIdle()
         composeRule.onNodeWithTag("message_actions", useUnmergedTree = true).assertExists()
+        composeRule.waitUntil(timeoutMillis = 5_000) { menuProvider.hiddenCount > hiddenBefore }
 
-        // And a plain tap on the prose itself passes through the SelectionContainer
-        // to the same clickable, toggling it back off.
+        // The selection is gone for good: a further tap neither revives the toolbar nor is
+        // swallowed — it simply toggles the row back off.
+        val shownBefore = menuProvider.shownCount
         composeRule.onNodeWithText("selectable reply", substring = true, useUnmergedTree = true)
             .performClick()
         composeRule.waitForIdle()
         composeRule.onNodeWithTag("message_actions", useUnmergedTree = true).assertDoesNotExist()
+        assertEquals("selection came back after being dismissed", shownBefore, menuProvider.shownCount)
     }
 
     @Test
@@ -299,12 +328,58 @@ class MessageSelectionInstrumentedTest {
         longPressText("uniqueTokenXyz")
         awaitSelectionMenu()
 
-        val copied = copyViaMenu()
+        val copied = copyViaMenu().trim()
         assertTrue(
-            "expected code text, got \"$copied\"",
-            copied.contains("uniqueTokenXyz") || "val uniqueTokenXyz = compute(1, 2)".contains(copied.trim()),
+            "expected a word from the code line, got \"$copied\"",
+            "val uniqueTokenXyz = compute(1, 2)".contains(copied) && isWordLike(copied),
         )
     }
+
+    @Test
+    fun quotedExcerptIsSelectable() {
+        // A quote is conversation text the user pulled forward, not chrome: the passage it came
+        // from may be far up the thread, so copying it back out has to work.
+        setChat(
+            userMessage("m1", "What about this?").copy(quotes = listOf("Quoted excerpt from earlier")),
+        )
+
+        longPressText("Quoted excerpt")
+        awaitSelectionMenu()
+
+        val copied = copyViaMenu().trim()
+        assertTrue(
+            "expected a word from the quote, got \"$copied\"",
+            "Quoted excerpt from earlier".contains(copied) && isWordLike(copied),
+        )
+    }
+
+    @Test
+    fun incompleteArtifactSourceIsSelectable() {
+        // A truncated artifact renders its source through CodeBlock — message text like any other
+        // fenced block (search counts it), so selection has to reach it. Only the finished
+        // artifact's tap-to-open card is chrome.
+        setChat(
+            assistantMessage("m1", "").copy(
+                content = listOf(
+                    MessageContentPart(
+                        type = ContentType.TEXT,
+                        text = "Here it is:\n\n:::artifact{identifier=demo type=text/markdown title=Demo}\n" +
+                            "```md\npartialArtifactToken lives here\n```",
+                    ),
+                ),
+            ),
+        )
+
+        longPressText("partialArtifactToken")
+        awaitSelectionMenu()
+
+        val copied = copyViaMenu().trim()
+        assertTrue(
+            "expected a word from the artifact source, got \"$copied\"",
+            "partialArtifactToken lives here".contains(copied) && isWordLike(copied),
+        )
+    }
+
 
     @Test
     fun streamingBubbleIsNotSelectable() {
@@ -315,11 +390,12 @@ class MessageSelectionInstrumentedTest {
         )
 
         longPressText("Streaming reply body")
-        assertEquals(
-            "selection toolbar must not appear on the streaming bubble",
-            0,
-            menuProvider.shownCount,
-        )
+        // Asserting the counter straight away would race the show: every positive test in this
+        // file waits seconds for the same signal. Give it a comparable window to stay at zero.
+        val toolbarAppeared = runCatching {
+            composeRule.waitUntil(timeoutMillis = 3_000) { menuProvider.shownCount > 0 }
+        }.isSuccess
+        assertFalse("selection toolbar must not appear on the streaming bubble", toolbarAppeared)
     }
 
     @Test

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/components/MarkdownContent.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/components/MarkdownContent.kt
@@ -402,12 +402,16 @@ private fun FullscreenTableDialog(
                     .verticalScroll(verticalScrollState)
                     .padding(16.dp),
             ) {
-                MarkdownTable(
-                    headers = headers,
-                    alignments = alignments,
-                    rows = rows,
-                    fontSizeMultiplier = fontSizeMultiplier,
-                )
+                // Own selection scope: this dialog is a separate composition owner, so its cells
+                // must not join the message's registrar. See SubwindowSelectionContainer.
+                SubwindowSelectionContainer {
+                    MarkdownTable(
+                        headers = headers,
+                        alignments = alignments,
+                        rows = rows,
+                        fontSizeMultiplier = fontSizeMultiplier,
+                    )
+                }
             }
         }
     }

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/components/MermaidDiagram.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/components/MermaidDiagram.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.selection.DisableSelection
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Code
@@ -73,41 +74,44 @@ actual fun MermaidDiagram(
             .clip(RoundedCornerShape(8.dp))
             .background(MaterialTheme.colorScheme.surfaceContainerHighest),
     ) {
-        // Header
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .background(MaterialTheme.colorScheme.surfaceContainerHigh)
-                .padding(horizontal = 12.dp, vertical = 4.dp),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Text(
-                text = stringResource(Res.string.label_mermaid),
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-            Spacer(modifier = Modifier.weight(1f))
-            TextButton(
-                onClick = { showCode = !showCode },
+        // Header — chrome, excluded from in-message selection (the WebView below never
+        // participates; the "show code" CodeBlock keeps its own selectable code text).
+        DisableSelection {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(MaterialTheme.colorScheme.surfaceContainerHigh)
+                    .padding(horizontal = 12.dp, vertical = 4.dp),
+                verticalAlignment = Alignment.CenterVertically,
             ) {
-                Icon(
-                    imageVector = if (showCode) Icons.Default.Image else Icons.Default.Code,
-                    contentDescription = stringResource(if (showCode) Res.string.cd_show_diagram else Res.string.cd_view_code),
-                    modifier = Modifier.size(16.dp),
-                )
-                Spacer(modifier = Modifier.width(4.dp))
                 Text(
-                    text = stringResource(if (showCode) Res.string.label_diagram else Res.string.code),
+                    text = stringResource(Res.string.label_mermaid),
                     style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
-            }
-            IconButton(onClick = { showFullscreen = true }) {
-                Icon(
-                    imageVector = Icons.Default.Fullscreen,
-                    contentDescription = stringResource(Res.string.cd_fullscreen),
-                    modifier = Modifier.size(18.dp),
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
+                Spacer(modifier = Modifier.weight(1f))
+                TextButton(
+                    onClick = { showCode = !showCode },
+                ) {
+                    Icon(
+                        imageVector = if (showCode) Icons.Default.Image else Icons.Default.Code,
+                        contentDescription = stringResource(if (showCode) Res.string.cd_show_diagram else Res.string.cd_view_code),
+                        modifier = Modifier.size(16.dp),
+                    )
+                    Spacer(modifier = Modifier.width(4.dp))
+                    Text(
+                        text = stringResource(if (showCode) Res.string.label_diagram else Res.string.code),
+                        style = MaterialTheme.typography.labelSmall,
+                    )
+                }
+                IconButton(onClick = { showFullscreen = true }) {
+                    Icon(
+                        imageVector = Icons.Default.Fullscreen,
+                        contentDescription = stringResource(Res.string.cd_fullscreen),
+                        modifier = Modifier.size(18.dp),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
             }
         }
 

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ActivityGroup.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ActivityGroup.kt
@@ -32,6 +32,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
@@ -131,19 +132,21 @@ internal fun ActivityGroup(
                 tint = MaterialTheme.colorScheme.onSurfaceVariant,
             )
             Spacer(modifier = Modifier.width(8.dp))
-            // Chrome label — excluded from in-message selection ("Select all").
-            Box(modifier = Modifier.weight(1f)) {
-                DisableSelection {
-                    Text(
-                        text = headerLabel,
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = if (group.failed) {
-                            MaterialTheme.colorScheme.error
-                        } else {
-                            MaterialTheme.colorScheme.onSurfaceVariant
-                        },
-                    )
+            val labelColor = if (group.failed) {
+                MaterialTheme.colorScheme.error
+            } else {
+                MaterialTheme.colorScheme.onSurfaceVariant
+            }
+            if (group.labelText.isEmpty()) {
+                // "Used N tools" is our own fallback — chrome, kept out of "Select all". The Box
+                // carries the weight that the DisableSelection lambda cannot (it is not RowScope).
+                Box(modifier = Modifier.weight(1f)) {
+                    DisableSelection { ActivityHeaderLabel(headerLabel, labelColor) }
                 }
+            } else {
+                // The server's own label is message text: SearchMatchEnumeration counts it, so a
+                // user who searched for a phrase and found it here has to be able to copy it too.
+                ActivityHeaderLabel(headerLabel, labelColor, Modifier.weight(1f))
             }
             Icon(
                 if (isExpanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
@@ -163,19 +166,29 @@ internal fun ActivityGroup(
     }
 }
 
+@Composable
+private fun ActivityHeaderLabel(text: String, color: Color, modifier: Modifier = Modifier) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.bodyMedium,
+        color = color,
+        modifier = modifier,
+    )
+}
+
 /**
  * A label whose own block was filtered out of the render. Upstream keeps it as a bare line rather
  * than dropping it — it is still the only description of what happened at that point.
+ *
+ * Selectable: this is the server's text, and search already treats it as message content.
  */
 @Composable
 internal fun OrphanActivityLabel(text: String, modifier: Modifier = Modifier) {
     if (text.isBlank()) return
-    DisableSelection {
-        Text(
-            text = text,
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = modifier.padding(vertical = 4.dp),
-        )
-    }
+    Text(
+        text = text,
+        style = MaterialTheme.typography.bodyMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = modifier.padding(vertical = 4.dp),
+    )
 }

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ActivityGroup.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ActivityGroup.kt
@@ -4,6 +4,7 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.expandVertically
 import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -13,6 +14,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.selection.DisableSelection
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Build
 import androidx.compose.material.icons.filled.ExpandLess
@@ -129,16 +131,20 @@ internal fun ActivityGroup(
                 tint = MaterialTheme.colorScheme.onSurfaceVariant,
             )
             Spacer(modifier = Modifier.width(8.dp))
-            Text(
-                text = headerLabel,
-                style = MaterialTheme.typography.bodyMedium,
-                color = if (group.failed) {
-                    MaterialTheme.colorScheme.error
-                } else {
-                    MaterialTheme.colorScheme.onSurfaceVariant
-                },
-                modifier = Modifier.weight(1f),
-            )
+            // Chrome label — excluded from in-message selection ("Select all").
+            Box(modifier = Modifier.weight(1f)) {
+                DisableSelection {
+                    Text(
+                        text = headerLabel,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = if (group.failed) {
+                            MaterialTheme.colorScheme.error
+                        } else {
+                            MaterialTheme.colorScheme.onSurfaceVariant
+                        },
+                    )
+                }
+            }
             Icon(
                 if (isExpanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
                 contentDescription = null,
@@ -164,10 +170,12 @@ internal fun ActivityGroup(
 @Composable
 internal fun OrphanActivityLabel(text: String, modifier: Modifier = Modifier) {
     if (text.isBlank()) return
-    Text(
-        text = text,
-        style = MaterialTheme.typography.bodyMedium,
-        color = MaterialTheme.colorScheme.onSurfaceVariant,
-        modifier = modifier.padding(vertical = 4.dp),
-    )
+    DisableSelection {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = modifier.padding(vertical = 4.dp),
+        )
+    }
 }

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/CitationChip.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/CitationChip.kt
@@ -202,10 +202,14 @@ fun CitationText(
             onDismissRequest = { activeCitation = null },
             properties = PopupProperties(focusable = true),
         ) {
-            CitationPopup(
-                citation = citation,
-                onDismiss = { activeCitation = null },
-            )
+            // Own selection scope: a popup is a separate composition owner, so its text must not
+            // join the message's registrar. See SubwindowSelectionContainer.
+            SubwindowSelectionContainer {
+                CitationPopup(
+                    citation = citation,
+                    onDismiss = { activeCitation = null },
+                )
+            }
         }
     }
 }

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/CodeBlock.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/CodeBlock.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.selection.DisableSelection
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.ContentCopy
@@ -87,7 +88,8 @@ fun CodeBlock(
                 contentDescription = "$languageLabel code block"
             },
     ) {
-        // Language header with copy button
+        // Language header with copy button. DisableSelection: in-message selection
+        // ("Select all") must sweep the code text below, not this chrome label.
         Row(
             modifier = Modifier
                 .fillMaxWidth()
@@ -95,11 +97,13 @@ fun CodeBlock(
                 .padding(horizontal = 12.dp, vertical = 4.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            Text(
-                text = language?.lowercase() ?: "code",
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
+            DisableSelection {
+                Text(
+                    text = language?.lowercase() ?: "code",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
             Spacer(modifier = Modifier.weight(1f))
             IconButton(
                 onClick = {

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/CollapsibleContentParts.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/CollapsibleContentParts.kt
@@ -5,6 +5,7 @@ import androidx.compose.animation.expandVertically
 import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -15,6 +16,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.selection.DisableSelection
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ExpandLess
 import androidx.compose.material.icons.filled.ExpandMore
@@ -101,6 +103,8 @@ private fun CollapsibleDisclosureCard(
             .clip(RoundedCornerShape(8.dp))
             .background(MaterialTheme.colorScheme.surfaceContainerLow),
     ) {
+        // Header title is chrome — DisableSelection keeps in-message "Select all"
+        // scoped to content text (the body stays selectable).
         Row(
             modifier = Modifier
                 .fillMaxWidth()
@@ -120,12 +124,15 @@ private fun CollapsibleDisclosureCard(
                 tint = MaterialTheme.colorScheme.primary,
             )
             Spacer(modifier = Modifier.width(8.dp))
-            Text(
-                title,
-                style = MaterialTheme.typography.titleSmall,
-                color = MaterialTheme.colorScheme.primary,
-                modifier = Modifier.weight(1f),
-            )
+            Box(modifier = Modifier.weight(1f)) {
+                DisableSelection {
+                    Text(
+                        title,
+                        style = MaterialTheme.typography.titleSmall,
+                        color = MaterialTheme.colorScheme.primary,
+                    )
+                }
+            }
             Icon(
                 if (isExpanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
                 stringResource(if (isExpanded) Res.string.cd_collapse else Res.string.cd_expand),

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/MessageContentAndActions.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/MessageContentAndActions.kt
@@ -300,14 +300,14 @@ internal fun MessageContentAndActions(
             Column {
                 // Verbatim excerpts the user referenced on this turn (v0.8.7), above the user's
                 // text. Created on web; mobile displays them (no creation affordance yet).
+                // Selectable: a quote is conversation text the user pulled forward, not chrome,
+                // and the passage it came from may be far up the thread or on another branch.
                 val quotes = message.quotes
                 if (isUser && !quotes.isNullOrEmpty()) {
-                    DisableSelection {
-                        MessageQuotes(
-                            quotes = quotes,
-                            modifier = Modifier.padding(bottom = 6.dp),
-                        )
-                    }
+                    MessageQuotes(
+                        quotes = quotes,
+                        modifier = Modifier.padding(bottom = 6.dp),
+                    )
                 }
 
                 // Render attached files above message text (matches web app behavior)

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/MessageContentAndActions.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/MessageContentAndActions.kt
@@ -12,6 +12,8 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.text.selection.DisableSelection
+import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.CallSplit
 import androidx.compose.material.icons.automirrored.filled.VolumeUp
@@ -38,6 +40,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.layout.LayoutCoordinates
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.isTraversalGroup
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
@@ -286,134 +289,147 @@ internal fun MessageContentAndActions(
     } else {
         // Single Column root so this branch emits from one source (and the quote chips,
         // files, content, and office previews stack the same as before).
-        Column {
-            // Verbatim excerpts the user referenced on this turn (v0.8.7), above the user's
-            // text. Created on web; mobile displays them (no creation affordance yet).
-            val quotes = message.quotes
-            if (isUser && !quotes.isNullOrEmpty()) {
-                MessageQuotes(
-                    quotes = quotes,
-                    modifier = Modifier.padding(bottom = 6.dp),
-                )
-            }
-
-            // Render attached files above message text (matches web app behavior)
-            val messageFiles = message.files
-            if (!messageFiles.isNullOrEmpty()) {
-                MessageFiles(
-                    files = messageFiles,
-                    baseUrl = baseUrl,
-                    modifier = Modifier.padding(bottom = 4.dp),
-                )
-            }
-
-            val contentParts = message.content
-            if (!contentParts.isNullOrEmpty()) {
-                // Occurrence indices are message-wide (SearchMatchEnumeration): rebase them
-                // per part so each part resolves the focused occurrence within itself. The focused
-                // message contains the query by definition, so the fast-path bail never triggers —
-                // compute each part's starting offset once (not on every recomposition, which would
-                // re-parse every part's markdown each animateScrollBy frame).
-                val partOffsets = remember(contentParts, searchQuery, isCurrentSearchMatch) {
-                    val offsets = IntArray(contentParts.size)
-                    if (isCurrentSearchMatch && !searchQuery.isNullOrBlank()) {
-                        var acc = 0
-                        contentParts.forEachIndexed { i, part ->
-                            offsets[i] = acc
-                            acc += countPartOccurrences(part, searchQuery)
-                        }
-                    }
-                    offsets
-                }
-                // Segment + group the parts ONCE, not while emitting them: a group's header has to
-                // be written before its members, which a Column cannot express without knowing the
-                // group's extent up front. Pure, so the boundaries are unit-testable.
-                val segments = remember(contentParts) { groupContentParts(contentParts) }
-
-                // A collapsed group would swallow the match the user just navigated to, so the
-                // one holding it opens. Resolved once per focus rather than per group per frame.
-                val focusedGroupKey = remember(
-                    segments, partOffsets, searchQuery, searchFocusedOccurrence, isCurrentSearchMatch,
-                ) {
-                    if (!isCurrentSearchMatch || searchQuery.isNullOrBlank() || searchFocusedOccurrence < 0) {
-                        null
-                    } else {
-                        segments.asSequence()
-                            .flatMap { it.groups.asSequence() }
-                            .filterIsInstance<ContentGroup.Activity>()
-                            .firstOrNull { group ->
-                                group.entries.any { entry ->
-                                    val start = partOffsets[entry.index]
-                                    val count = countPartOccurrences(entry.part, searchQuery)
-                                    searchFocusedOccurrence in start until (start + count)
-                                }
-                            }?.key
-                    }
-                }
-
-                @Composable
-                fun PartContent(entry: IndexedContentPart) {
-                    val part = entry.part
-                    val focusedInPart =
-                        if (isCurrentSearchMatch) searchFocusedOccurrence - partOffsets[entry.index] else -1
-                    when (part.type) {
-                        // Handled here rather than in the shared dispatcher because both need the
-                        // viewer's identity, which a single-part renderer has no business knowing.
-                        ContentType.STEER -> part.steerText()?.let { steered ->
-                            SteerContentPart(
-                                text = steered,
-                                userName = userName,
-                                userAvatarUrl = userAvatarUrl,
-                                fontSizeMultiplier = fontSizeMultiplier,
-                                useKatex = useKatex,
-                            )
-                        }
-                        ContentType.ACTIVITY_LABEL -> OrphanActivityLabel(part.activityLabelText())
-                        else -> ContentPartRenderer(
-                            part = part,
-                            baseUrl = baseUrl,
-                            fontSizeMultiplier = fontSizeMultiplier,
-                            useKatex = useKatex,
-                            attachments = message.attachments.orEmpty(),
-                            showImageDescriptions = showImageDescriptions,
-                            searchQuery = if (isSearchMatch) searchQuery else null,
-                            searchFocusedOccurrence = focusedInPart,
-                            onFocusedOccurrencePosition = if (isCurrentSearchMatch) onFocusedOccurrencePosition else null,
-                            stateKey = "${message.messageId}:${entry.index}",
-                            modifier = Modifier.padding(vertical = 2.dp),
+        //
+        // SelectionContainer scope is per-message and content-only: every BasicText-backed
+        // descendant (markdown prose, code, table cells, think bodies) becomes selectable
+        // through one registrar, while chrome (chips, cards, headers) opts out via
+        // DisableSelection so "Select all" copies message text, not UI labels. The action
+        // row below and the editing branch above stay outside — a text field must never
+        // sit inside a SelectionContainer.
+        SelectionContainer {
+            Column {
+                // Verbatim excerpts the user referenced on this turn (v0.8.7), above the user's
+                // text. Created on web; mobile displays them (no creation affordance yet).
+                val quotes = message.quotes
+                if (isUser && !quotes.isNullOrEmpty()) {
+                    DisableSelection {
+                        MessageQuotes(
+                            quotes = quotes,
+                            modifier = Modifier.padding(bottom = 6.dp),
                         )
                     }
                 }
 
-                segments.forEach { segment ->
-                    key(segment.key) {
-                        // A traversal group so the attribution header is read immediately before
-                        // its own content instead of segments interleaving. It is not implicit:
-                        // a plain Column does not set one.
-                        Column(modifier = Modifier.semantics { isTraversalGroup = true }) {
-                            segment.author?.let { author ->
-                                SegmentAuthorHeader(
-                                    author = author,
-                                    messageSender = message.sender,
-                                    messageIconUrl = message.iconURL,
-                                    messageEndpoint = message.endpoint,
+                // Render attached files above message text (matches web app behavior)
+                val messageFiles = message.files
+                if (!messageFiles.isNullOrEmpty()) {
+                    DisableSelection {
+                        MessageFiles(
+                            files = messageFiles,
+                            baseUrl = baseUrl,
+                            modifier = Modifier.padding(bottom = 4.dp),
+                        )
+                    }
+                }
+
+                val contentParts = message.content
+                if (!contentParts.isNullOrEmpty()) {
+                    // Occurrence indices are message-wide (SearchMatchEnumeration): rebase them
+                    // per part so each part resolves the focused occurrence within itself. The focused
+                    // message contains the query by definition, so the fast-path bail never triggers —
+                    // compute each part's starting offset once (not on every recomposition, which would
+                    // re-parse every part's markdown each animateScrollBy frame).
+                    val partOffsets = remember(contentParts, searchQuery, isCurrentSearchMatch) {
+                        val offsets = IntArray(contentParts.size)
+                        if (isCurrentSearchMatch && !searchQuery.isNullOrBlank()) {
+                            var acc = 0
+                            contentParts.forEachIndexed { i, part ->
+                                offsets[i] = acc
+                                acc += countPartOccurrences(part, searchQuery)
+                            }
+                        }
+                        offsets
+                    }
+                    // Segment + group the parts ONCE, not while emitting them: a group's header has to
+                    // be written before its members, which a Column cannot express without knowing the
+                    // group's extent up front. Pure, so the boundaries are unit-testable.
+                    val segments = remember(contentParts) { groupContentParts(contentParts) }
+
+                    // A collapsed group would swallow the match the user just navigated to, so the
+                    // one holding it opens. Resolved once per focus rather than per group per frame.
+                    val focusedGroupKey = remember(
+                        segments, partOffsets, searchQuery, searchFocusedOccurrence, isCurrentSearchMatch,
+                    ) {
+                        if (!isCurrentSearchMatch || searchQuery.isNullOrBlank() || searchFocusedOccurrence < 0) {
+                            null
+                        } else {
+                            segments.asSequence()
+                                .flatMap { it.groups.asSequence() }
+                                .filterIsInstance<ContentGroup.Activity>()
+                                .firstOrNull { group ->
+                                    group.entries.any { entry ->
+                                        val start = partOffsets[entry.index]
+                                        val count = countPartOccurrences(entry.part, searchQuery)
+                                        searchFocusedOccurrence in start until (start + count)
+                                    }
+                                }?.key
+                        }
+                    }
+
+                    @Composable
+                    fun PartContent(entry: IndexedContentPart) {
+                        val part = entry.part
+                        val focusedInPart =
+                            if (isCurrentSearchMatch) searchFocusedOccurrence - partOffsets[entry.index] else -1
+                        when (part.type) {
+                            // Handled here rather than in the shared dispatcher because both need the
+                            // viewer's identity, which a single-part renderer has no business knowing.
+                            ContentType.STEER -> part.steerText()?.let { steered ->
+                                SteerContentPart(
+                                    text = steered,
+                                    userName = userName,
+                                    userAvatarUrl = userAvatarUrl,
+                                    fontSizeMultiplier = fontSizeMultiplier,
+                                    useKatex = useKatex,
                                 )
                             }
-                            segment.groups.forEach { group ->
-                                // Keyed, so per-part state (an expanded thinking block) follows its
-                                // part when grouping shifts it under a wrapper instead of staying
-                                // with whatever now occupies that position.
-                                key(group.key) {
-                                    when (group) {
-                                        is ContentGroup.Single -> PartContent(group.entry)
-                                        is ContentGroup.Activity -> ActivityGroup(
-                                            group = group,
-                                            stateKey = "${message.messageId}:${group.key}",
-                                            autoExpand = group.key == focusedGroupKey,
-                                            autoExpandKey = LocalSearchFocusNonce.current,
-                                        ) {
-                                            group.entries.forEach { entry ->
-                                                key(entry.index) { PartContent(entry) }
+                            ContentType.ACTIVITY_LABEL -> OrphanActivityLabel(part.activityLabelText())
+                            else -> ContentPartRenderer(
+                                part = part,
+                                baseUrl = baseUrl,
+                                fontSizeMultiplier = fontSizeMultiplier,
+                                useKatex = useKatex,
+                                attachments = message.attachments.orEmpty(),
+                                showImageDescriptions = showImageDescriptions,
+                                searchQuery = if (isSearchMatch) searchQuery else null,
+                                searchFocusedOccurrence = focusedInPart,
+                                onFocusedOccurrencePosition = if (isCurrentSearchMatch) onFocusedOccurrencePosition else null,
+                                stateKey = "${message.messageId}:${entry.index}",
+                                modifier = Modifier.padding(vertical = 2.dp),
+                            )
+                        }
+                    }
+
+                    segments.forEach { segment ->
+                        key(segment.key) {
+                            // A traversal group so the attribution header is read immediately before
+                            // its own content instead of segments interleaving. It is not implicit:
+                            // a plain Column does not set one.
+                            Column(modifier = Modifier.semantics { isTraversalGroup = true }) {
+                                segment.author?.let { author ->
+                                    SegmentAuthorHeader(
+                                        author = author,
+                                        messageSender = message.sender,
+                                        messageIconUrl = message.iconURL,
+                                        messageEndpoint = message.endpoint,
+                                    )
+                                }
+                                segment.groups.forEach { group ->
+                                    // Keyed, so per-part state (an expanded thinking block) follows its
+                                    // part when grouping shifts it under a wrapper instead of staying
+                                    // with whatever now occupies that position.
+                                    key(group.key) {
+                                        when (group) {
+                                            is ContentGroup.Single -> PartContent(group.entry)
+                                            is ContentGroup.Activity -> ActivityGroup(
+                                                group = group,
+                                                stateKey = "${message.messageId}:${group.key}",
+                                                autoExpand = group.key == focusedGroupKey,
+                                                autoExpandKey = LocalSearchFocusNonce.current,
+                                            ) {
+                                                group.entries.forEach { entry ->
+                                                    key(entry.index) { PartContent(entry) }
+                                                }
                                             }
                                         }
                                     }
@@ -421,24 +437,26 @@ internal fun MessageContentAndActions(
                             }
                         }
                     }
+                } else if (message.text.isNotBlank()) {
+                    MarkdownContent(
+                        text = message.text,
+                        fontSizeMultiplier = fontSizeMultiplier,
+                        useKatex = useKatex,
+                        searchQuery = if (isSearchMatch) searchQuery else null,
+                        searchFocusedOccurrence = if (isCurrentSearchMatch) searchFocusedOccurrence else -1,
+                        onFocusedOccurrencePosition = if (isCurrentSearchMatch) onFocusedOccurrencePosition else null,
+                    )
                 }
-            } else if (message.text.isNotBlank()) {
-                MarkdownContent(
-                    text = message.text,
-                    fontSizeMultiplier = fontSizeMultiplier,
-                    useKatex = useKatex,
-                    searchQuery = if (isSearchMatch) searchQuery else null,
-                    searchFocusedOccurrence = if (isCurrentSearchMatch) searchFocusedOccurrence else -1,
-                    onFocusedOccurrencePosition = if (isCurrentSearchMatch) onFocusedOccurrencePosition else null,
-                )
-            }
 
-            // Deferred office-doc preview attachments (v0.8.6) on a persisted message
-            // render as their own artifact card. Non-office attachments are unaffected.
-            OfficePreviewAttachments(
-                attachments = message.attachments.orEmpty(),
-                isDarkTheme = isSurfaceDark(),
-            )
+                // Deferred office-doc preview attachments (v0.8.6) on a persisted message
+                // render as their own artifact card. Non-office attachments are unaffected.
+                DisableSelection {
+                    OfficePreviewAttachments(
+                        attachments = message.attachments.orEmpty(),
+                        isDarkTheme = isSurfaceDark(),
+                    )
+                }
+            }
         }
     }
 
@@ -455,7 +473,9 @@ internal fun MessageContentAndActions(
             Column {
                 Spacer(modifier = Modifier.height(4.dp))
                 Row(
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .testTag("message_actions"),
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.SpaceBetween,
                 ) {

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/SharedContentParts.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/SharedContentParts.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.text.selection.DisableSelection
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Videocam
 import androidx.compose.material3.Icon
@@ -79,7 +80,11 @@ internal fun ContentPartDispatcher(
                 stateKey = stateKey,
             )
         }
-        ContentType.TOOL_CALL -> {
+        // Card/media parts are excluded from in-message selection (DisableSelection):
+        // v1 scopes selection to prose, code, tables, and think/summary bodies so a
+        // toolbar "Select all" copies the message's text, not card labels and JSON
+        // dumps. Tool-card output selection is a plausible follow-up.
+        ContentType.TOOL_CALL -> DisableSelection {
             ToolCallDispatcher(
                 part = part,
                 modifier = mod,
@@ -90,14 +95,14 @@ internal fun ContentPartDispatcher(
                 allowSubagentCard = allowSubagentCard,
             )
         }
-        ContentType.IMAGE_FILE -> {
+        ContentType.IMAGE_FILE -> DisableSelection {
             val imageUrl = resolveImageFilePartUrl(part, baseUrl)
             ImageContentPart(imageUrl = imageUrl, modifier = mod)
         }
-        ContentType.IMAGE_URL -> {
+        ContentType.IMAGE_URL -> DisableSelection {
             ImageContentPart(imageUrl = part.imageUrl?.url, modifier = mod)
         }
-        ContentType.VIDEO_URL -> {
+        ContentType.VIDEO_URL -> DisableSelection {
             val videoUrl = part.videoUrl?.url
             if (videoUrl != null) {
                 VideoContent(url = videoUrl, modifier = mod)
@@ -118,13 +123,14 @@ internal fun ContentPartDispatcher(
                 }
             }
         }
-        ContentType.INPUT_AUDIO -> {
+        ContentType.INPUT_AUDIO -> DisableSelection {
             AudioContent(data = part.inputAudio?.data, format = part.inputAudio?.format, modifier = mod)
         }
+        // Error text stays selectable: copying an error verbatim is how it gets reported.
         ContentType.ERROR -> {
             ErrorContentPart(errorText = part.error ?: part.text.orEmpty(), modifier = mod)
         }
-        ContentType.AGENT_UPDATE -> {
+        ContentType.AGENT_UPDATE -> DisableSelection {
             val agentUpdate = part.agentUpdate
             AgentHandoffCard(
                 handoff = AgentHandoff(

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/SteerContentPart.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/SteerContentPart.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.text.selection.DisableSelection
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.SmartToy
 import androidx.compose.material3.MaterialTheme
@@ -47,32 +48,35 @@ internal fun SteerContentPart(
     if (text.isBlank()) return
 
     Column(modifier = modifier.fillMaxWidth().padding(vertical = 8.dp)) {
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            AvatarImage(
-                imageUrl = userAvatarUrl,
-                fallbackText = userName ?: stringResource(Res.string.sender_you),
-                showPersonIcon = userAvatarUrl == null,
-                size = 22.dp,
-                // The label beside it already says the name; AvatarImage otherwise defaults to
-                // "<name> avatar" and TalkBack would read the author twice.
-                contentDescription = null,
-            )
-            Spacer(modifier = Modifier.width(8.dp))
-            Text(
-                // A heading, so TalkBack's next-heading gesture steps between the author changes
-                // in a long response instead of scrubbing through every line.
-                modifier = Modifier.semantics { heading() },
-                text = userName ?: stringResource(Res.string.sender_you),
-                style = MaterialTheme.typography.titleSmall.copy(fontWeight = FontWeight.SemiBold),
-                color = MaterialTheme.colorScheme.onSurface,
-            )
-            Spacer(modifier = Modifier.width(6.dp))
-            // Says why a user message is sitting inside the response.
-            Text(
-                text = stringResource(Res.string.steer_sent_during_reply),
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
+        // Author chrome — excluded from in-message selection; the steer text below stays in.
+        DisableSelection {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                AvatarImage(
+                    imageUrl = userAvatarUrl,
+                    fallbackText = userName ?: stringResource(Res.string.sender_you),
+                    showPersonIcon = userAvatarUrl == null,
+                    size = 22.dp,
+                    // The label beside it already says the name; AvatarImage otherwise defaults to
+                    // "<name> avatar" and TalkBack would read the author twice.
+                    contentDescription = null,
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    // A heading, so TalkBack's next-heading gesture steps between the author changes
+                    // in a long response instead of scrubbing through every line.
+                    modifier = Modifier.semantics { heading() },
+                    text = userName ?: stringResource(Res.string.sender_you),
+                    style = MaterialTheme.typography.titleSmall.copy(fontWeight = FontWeight.SemiBold),
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+                Spacer(modifier = Modifier.width(6.dp))
+                // Says why a user message is sitting inside the response.
+                Text(
+                    text = stringResource(Res.string.steer_sent_during_reply),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
         }
         Spacer(modifier = Modifier.height(4.dp))
         MarkdownContent(
@@ -106,28 +110,31 @@ internal fun SegmentAuthorHeader(
         is SegmentAuthor.Agent -> author.agentId
         SegmentAuthor.Message -> messageSender ?: stringResource(Res.string.sender_assistant)
     }
-    Row(
-        modifier = modifier.fillMaxWidth().padding(top = 8.dp, bottom = 4.dp),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        AvatarImage(
-            imageUrl = if (isOtherAgent) null else messageIconUrl,
-            fallbackText = label,
-            fallbackIconPainter = when {
-                isOtherAgent -> rememberVectorPainter(Icons.Default.SmartToy)
-                messageIconUrl == null -> endpointIconPainter(messageEndpoint)
-                else -> null
-            },
-            tintIcon = isOtherAgent || (messageIconUrl == null && isMonochromeEndpointIcon(messageEndpoint)),
-            size = 22.dp,
-            contentDescription = null,
-        )
-        Spacer(modifier = Modifier.width(8.dp))
-        Text(
-            modifier = Modifier.semantics { heading() },
-            text = label,
-            style = MaterialTheme.typography.titleSmall.copy(fontWeight = FontWeight.SemiBold),
-            color = MaterialTheme.colorScheme.onSurface,
-        )
+    // Attribution chrome — excluded from in-message selection.
+    DisableSelection {
+        Row(
+            modifier = modifier.fillMaxWidth().padding(top = 8.dp, bottom = 4.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            AvatarImage(
+                imageUrl = if (isOtherAgent) null else messageIconUrl,
+                fallbackText = label,
+                fallbackIconPainter = when {
+                    isOtherAgent -> rememberVectorPainter(Icons.Default.SmartToy)
+                    messageIconUrl == null -> endpointIconPainter(messageEndpoint)
+                    else -> null
+                },
+                tintIcon = isOtherAgent || (messageIconUrl == null && isMonochromeEndpointIcon(messageEndpoint)),
+                size = 22.dp,
+                contentDescription = null,
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+                modifier = Modifier.semantics { heading() },
+                text = label,
+                style = MaterialTheme.typography.titleSmall.copy(fontWeight = FontWeight.SemiBold),
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+        }
     }
 }

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/SubwindowSelection.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/SubwindowSelection.kt
@@ -1,0 +1,23 @@
+package com.garfiec.librechat.feature.chat.components
+
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.runtime.Composable
+
+/**
+ * Selection scope for message content that renders in its own composition owner — a `Dialog` or
+ * `Popup` opened from inside a message.
+ *
+ * CompositionLocals cross that boundary but layout hierarchies do not, so without a scope of its
+ * own the subwindow's text registers with the *message's* selection registrar (provided by the
+ * `SelectionContainer` in [MessageContentAndActions]) while its layout nodes live in another
+ * window. One selection then spans two hierarchies: "Select all" emits the subwindow's text a
+ * second time, and resolving a position across the two owners fails outright — `localPositionOf`
+ * rejects nodes that share no ancestor.
+ *
+ * Giving the subwindow its own container keeps its text selectable and makes it a separate
+ * selection, which is also what a user expects from a window they opened deliberately.
+ */
+@Composable
+internal fun SubwindowSelectionContainer(content: @Composable () -> Unit) {
+    SelectionContainer(content = content)
+}

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/TextArtifactContentPart.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/TextArtifactContentPart.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.text.selection.DisableSelection
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -104,7 +105,9 @@ internal fun TextContentPart(
                             streaming = streaming,
                         )
                     }
-                    is ArtifactSegment.ArtifactReference -> {
+                    // Artifact renders are tap-to-open cards, not message prose — excluded
+                    // from in-message selection so "Select all" copies the surrounding text.
+                    is ArtifactSegment.ArtifactReference -> DisableSelection {
                         val versions = versionMap[segment.artifact.identifier] ?: listOf(segment.artifact)
                         Spacer(modifier = Modifier.height(8.dp))
                         if (!segment.artifact.isComplete) {

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/TextArtifactContentPart.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/TextArtifactContentPart.kt
@@ -105,15 +105,15 @@ internal fun TextContentPart(
                             streaming = streaming,
                         )
                     }
-                    // Artifact renders are tap-to-open cards, not message prose — excluded
-                    // from in-message selection so "Select all" copies the surrounding text.
-                    is ArtifactSegment.ArtifactReference -> DisableSelection {
+                    is ArtifactSegment.ArtifactReference -> {
                         val versions = versionMap[segment.artifact.identifier] ?: listOf(segment.artifact)
                         Spacer(modifier = Modifier.height(8.dp))
                         if (!segment.artifact.isComplete) {
                             // Truncated or still streaming: show source, never a collapsed button and
                             // never a WebView. See IncompleteArtifact's KDoc for why this outranks
-                            // the inline preference.
+                            // the inline preference. That source is message text like any other
+                            // fenced block, so it stays selectable — the same reason in-conversation
+                            // search counts it.
                             IncompleteArtifact(
                                 artifact = segment.artifact,
                                 onTap = { openArtifact?.invoke(segment.artifact, versions) },
@@ -123,41 +123,50 @@ internal fun TextContentPart(
                                 onFocusedOccurrencePosition = onFocusedOccurrencePosition,
                                 streaming = streaming,
                             )
-                        } else if (shouldRenderInlineArtifact(inlinePrefs, segment.artifact.type, streaming)) {
-                            val type = ArtifactType.from(segment.artifact.type)
-                            val cachedSvg = rememberCachedMermaidSvg(segment.artifact.content, type)
-                            when (val strategy = selectInlineArtifactStrategy(type, segment.artifact.content, cachedSvg)) {
-                                is InlineArtifactStrategy.CachedMermaidSvg -> InlineSvgSurface(
-                                    svg = strategy.svg,
-                                    onTap = { openArtifact?.invoke(segment.artifact, versions) },
-                                    modifier = Modifier.fillMaxWidth(),
-                                    contentPadding = 4.dp,
-                                )
-                                InlineArtifactStrategy.NativeMarkdown -> InlineMarkdownArtifact(
-                                    artifact = segment.artifact,
-                                    onTap = { openArtifact?.invoke(segment.artifact, versions) },
-                                    modifier = Modifier.fillMaxWidth(),
-                                    fontSizeMultiplier = fontSizeMultiplier,
-                                    searchQuery = searchQuery,
-                                )
-                                InlineArtifactStrategy.IntrinsicSvg -> InlineSvgArtifact(
-                                    artifact = segment.artifact,
-                                    onTap = { openArtifact?.invoke(segment.artifact, versions) },
-                                    modifier = Modifier.fillMaxWidth(),
-                                )
-                                InlineArtifactStrategy.WebViewSlot -> InlineArtifactView(
-                                    artifact = segment.artifact,
-                                    onTap = { openArtifact?.invoke(segment.artifact, versions) },
-                                    modifier = Modifier.fillMaxWidth(),
-                                )
-                            }
                         } else {
-                            ArtifactButton(
-                                artifact = segment.artifact,
-                                onClick = { openArtifact?.invoke(segment.artifact, versions) },
-                                versionCount = versions.size,
-                                onAddToHomeScreen = addToHomeScreen?.let { add -> { add(segment.artifact) } },
-                            )
+                            // A finished artifact renders as a tap-to-open card, not message prose —
+                            // excluded from in-message selection so "Select all" copies the
+                            // surrounding text instead of the card's own labels.
+                            DisableSelection {
+                                if (shouldRenderInlineArtifact(inlinePrefs, segment.artifact.type, streaming)) {
+                                    val type = ArtifactType.from(segment.artifact.type)
+                                    val cachedSvg = rememberCachedMermaidSvg(segment.artifact.content, type)
+                                    val strategy =
+                                        selectInlineArtifactStrategy(type, segment.artifact.content, cachedSvg)
+                                    when (strategy) {
+                                        is InlineArtifactStrategy.CachedMermaidSvg -> InlineSvgSurface(
+                                            svg = strategy.svg,
+                                            onTap = { openArtifact?.invoke(segment.artifact, versions) },
+                                            modifier = Modifier.fillMaxWidth(),
+                                            contentPadding = 4.dp,
+                                        )
+                                        InlineArtifactStrategy.NativeMarkdown -> InlineMarkdownArtifact(
+                                            artifact = segment.artifact,
+                                            onTap = { openArtifact?.invoke(segment.artifact, versions) },
+                                            modifier = Modifier.fillMaxWidth(),
+                                            fontSizeMultiplier = fontSizeMultiplier,
+                                            searchQuery = searchQuery,
+                                        )
+                                        InlineArtifactStrategy.IntrinsicSvg -> InlineSvgArtifact(
+                                            artifact = segment.artifact,
+                                            onTap = { openArtifact?.invoke(segment.artifact, versions) },
+                                            modifier = Modifier.fillMaxWidth(),
+                                        )
+                                        InlineArtifactStrategy.WebViewSlot -> InlineArtifactView(
+                                            artifact = segment.artifact,
+                                            onTap = { openArtifact?.invoke(segment.artifact, versions) },
+                                            modifier = Modifier.fillMaxWidth(),
+                                        )
+                                    }
+                                } else {
+                                    ArtifactButton(
+                                        artifact = segment.artifact,
+                                        onClick = { openArtifact?.invoke(segment.artifact, versions) },
+                                        versionCount = versions.size,
+                                        onAddToHomeScreen = addToHomeScreen?.let { add -> { add(segment.artifact) } },
+                                    )
+                                }
+                            }
                         }
                         Spacer(modifier = Modifier.height(8.dp))
                     }

--- a/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/components/PlatformChatComponents.ios.kt
+++ b/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/components/PlatformChatComponents.ios.kt
@@ -737,12 +737,16 @@ private fun IosFullscreenTableDialog(
                     .verticalScroll(rememberScrollState())
                     .padding(16.dp),
             ) {
-                IosMarkdownTable(
-                    headers = headers,
-                    alignments = alignments,
-                    rows = rows,
-                    fontSizeMultiplier = fontSizeMultiplier,
-                )
+                // Own selection scope: this dialog is a separate composition owner, so its cells
+                // must not join the message's registrar. See SubwindowSelectionContainer.
+                SubwindowSelectionContainer {
+                    IosMarkdownTable(
+                        headers = headers,
+                        alignments = alignments,
+                        rows = rows,
+                        fontSizeMultiplier = fontSizeMultiplier,
+                    )
+                }
             }
         }
     }

--- a/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/components/PlatformMediaComponents.ios.kt
+++ b/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/components/PlatformMediaComponents.ios.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.selection.DisableSelection
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Code
@@ -574,39 +575,42 @@ actual fun MermaidDiagram(
             .clip(RoundedCornerShape(8.dp))
             .background(MaterialTheme.colorScheme.surfaceContainerHighest),
     ) {
-        // Header
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .background(MaterialTheme.colorScheme.surfaceContainerHigh)
-                .padding(horizontal = 12.dp, vertical = 4.dp),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Text(
-                text = stringResource(Res.string.label_mermaid),
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-            Spacer(modifier = Modifier.weight(1f))
-            TextButton(onClick = { showCode = !showCode }) {
-                Icon(
-                    imageVector = if (showCode) Icons.Default.Image else Icons.Default.Code,
-                    contentDescription = stringResource(if (showCode) Res.string.cd_show_diagram else Res.string.cd_view_code),
-                    modifier = Modifier.size(16.dp),
-                )
-                Spacer(modifier = Modifier.width(4.dp))
+        // Header — chrome, excluded from in-message selection (mirrors the Android
+        // MermaidDiagram; the WKWebView below never participates in Compose selection).
+        DisableSelection {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(MaterialTheme.colorScheme.surfaceContainerHigh)
+                    .padding(horizontal = 12.dp, vertical = 4.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
                 Text(
-                    text = stringResource(if (showCode) Res.string.label_diagram else Res.string.label_code),
+                    text = stringResource(Res.string.label_mermaid),
                     style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
-            }
-            IconButton(onClick = { showFullscreen = true }) {
-                Icon(
-                    imageVector = Icons.Default.Fullscreen,
-                    contentDescription = stringResource(Res.string.cd_fullscreen),
-                    modifier = Modifier.size(18.dp),
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
+                Spacer(modifier = Modifier.weight(1f))
+                TextButton(onClick = { showCode = !showCode }) {
+                    Icon(
+                        imageVector = if (showCode) Icons.Default.Image else Icons.Default.Code,
+                        contentDescription = stringResource(if (showCode) Res.string.cd_show_diagram else Res.string.cd_view_code),
+                        modifier = Modifier.size(16.dp),
+                    )
+                    Spacer(modifier = Modifier.width(4.dp))
+                    Text(
+                        text = stringResource(if (showCode) Res.string.label_diagram else Res.string.label_code),
+                        style = MaterialTheme.typography.labelSmall,
+                    )
+                }
+                IconButton(onClick = { showFullscreen = true }) {
+                    Icon(
+                        imageVector = Icons.Default.Fullscreen,
+                        contentDescription = stringResource(Res.string.cd_fullscreen),
+                        modifier = Modifier.size(18.dp),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
             }
         }
 


### PR DESCRIPTION
## Summary

Message text in the transcript could not be selected — long-press did nothing, and the
only way to extract text was the whole-message Copy button. This wraps each message's
content in a `SelectionContainer`, so prose, code blocks, table cells, LaTeX text
fallbacks and think-block bodies support long-press selection, handle dragging and the
platform copy toolbar. Selection is scoped per message; the whole-message Copy button
stays as the fast path.

## Changes

**Selection scope**
- Each message's content column is wrapped in a `SelectionContainer`; the inline-edit
  branch and the action row sit outside it.
- UI chrome is excluded via `DisableSelection` so "Select all" copies message text
  rather than labels: file chips, office-preview attachments, code-block language
  badges and copy buttons, collapsible section headers, Mermaid headers, steer and
  segment attribution rows, tool-call and log cards, image captions, video, audio and
  agent-update content parts, and finished artifact cards.
- Mermaid headers are excluded on both platforms. The WebView/WKWebView below never
  participates in Compose selection anyway, and the "show code" `CodeBlock` keeps its
  own selectable text.
- Content that is message text stays selectable even where it looks like chrome:
  quoted excerpts, server-authored activity labels, and the source shown for an
  incomplete or still-streaming artifact. In-conversation search already counts all
  three, so copy reaches the same text. A finished artifact's tap-to-open card is
  chrome; the source shown for an incomplete or streaming one is not.
- Dialogs and popups opened from a message (fullscreen table view, citation popup)
  open their own selection scope through `SubwindowSelectionContainer`. They are
  separate composition owners that inherit CompositionLocals but not the layout
  hierarchy, so sharing the message's registrar would duplicate text in a "Select all"
  copy and resolve positions across nodes with no common ancestor.
- The streaming bubble is deliberately not selectable — its content shifts on every
  delta, so a selection cannot hold.

**Tests / CI**
- New instrumented suite `MessageSelectionInstrumentedTest` (9 tests) covering
  prose selection and copy, cross-paragraph "Select all", code-block selection under
  horizontal scroll, quoted excerpts, incomplete-artifact source, chrome exclusion,
  link clicks still opening, the streaming bubble staying inert, and the
  long-press/tap arbitration.
- `androidInstrumentedTest` dependencies wired into `feature/chat/build.gradle.kts`.
- CI gains a compile-only gate, `:feature:chat:assembleDebugAndroidTest`, scoped to
  the one module because a repo-wide equivalent would also compile `:app`'s stale
  androidTest sources.
- `.github/CLAUDE.md` updated to describe the CI jobs, including the new compile gate.

## Testing

- `:feature:chat:connectedDebugAndroidTest` — 9/9 green on a Pixel 10 Pro Fold
  emulator (API 37).
- `:app:assembleDebug`, `:feature:chat:testDebugUnitTest`, `detekt`,
  `detektMetadataCommonMain`, `:app:lint` all clean.
- iOS shared-code edits are mirrored but not built.

## Notes

- A tap on a message both clears an active selection and toggles the action row. On
  this Compose version the tap itself does not clear the selection — the action row
  appearing relayouts the message, and that is what drops it. Suppressing the toggle
  leaves the selection with nothing to dismiss it. Measured on device via the toolbar
  show/hide counters in `MessageSelectionInstrumentedTest`.
- Selection cannot span messages. The container is per message by design; one
  container around the `LazyColumn` would corrupt selection across recycled items.
- A font-size change or a stream finalizing clears an active selection, and there is
  no auto-scroll when a selection reaches the viewport edge (no Compose API for it).
- Tool-card output is excluded from selection in this change; making it selectable is
  a plausible follow-up.
