### PR TITLE
chore(chat): trim redundant comments in the selection code (#311)

### DIFF
--- a/feature/chat/src/androidInstrumentedTest/kotlin/com/garfiec/librechat/feature/chat/components/MessageSelectionInstrumentedTest.kt
+++ b/feature/chat/src/androidInstrumentedTest/kotlin/com/garfiec/librechat/feature/chat/components/MessageSelectionInstrumentedTest.kt
@@ -98,7 +98,6 @@ class MessageSelectionInstrumentedTest {
             }
         }
 
-        /** Live lookup of a menu item by [TextContextMenuKeys] key. */
         fun item(key: Any): TextContextMenuItem? = lastDataProvider
             ?.data()
             ?.components
@@ -110,7 +109,6 @@ class MessageSelectionInstrumentedTest {
         override fun close() = Unit
     }
 
-    /** Records [setClipEntry] instead of touching the system clipboard. */
     class RecordingClipboard : Clipboard {
         var lastEntry: ClipEntry? = null
 
@@ -203,7 +201,6 @@ class MessageSelectionInstrumentedTest {
     }
 
 
-    /** Invokes a toolbar item by key on the UI thread and settles. */
     private fun invokeMenuItem(key: Any, label: String) {
         val item = menuProvider.item(key)
         assertNotNull("selection toolbar offered no $label action", item)
@@ -215,7 +212,6 @@ class MessageSelectionInstrumentedTest {
     private fun isWordLike(text: String): Boolean =
         text.length >= 3 && text.all { it.isLetterOrDigit() || it == '_' }
 
-    /** Invokes the toolbar copy and returns what landed on the fake clipboard. */
     private fun copyViaMenu(): String {
         invokeMenuItem(TextContextMenuKeys.CopyKey, "copy")
         val text = clipboard.lastText
@@ -247,17 +243,14 @@ class MessageSelectionInstrumentedTest {
     fun longPressDoesNotToggleActionRow_tapDoes() {
         setChat(assistantMessage("m1", "Some selectable reply text here."))
 
-        // Long-press = selection, not the bubble's tap-to-reveal.
         longPressText("selectable reply")
         awaitSelectionMenu()
         composeRule.onNodeWithTag("message_actions", useUnmergedTree = true).assertDoesNotExist()
 
-        // A plain tap on the prose passes through the SelectionContainer to the bubble's
-        // clickable and reveals the row. It also puts the selection away — the two are one
-        // gesture by construction: the tap itself does not clear anything on this Compose
-        // version; the action row appearing relayouts the message, and THAT drops the
-        // selection. Suppressing the toggle to "protect" the selection therefore strands it
-        // with no way to dismiss it (measured on device — see the toolbar counters below).
+        // A tap both reveals the action row and drops the selection, and the two are one
+        // gesture by construction: the tap clears nothing itself; the action row appearing
+        // relayouts the message, and THAT drops the selection. Suppressing the toggle to
+        // "protect" the selection strands it with no way to dismiss it.
         val hiddenBefore = menuProvider.hiddenCount
         composeRule.onNodeWithText("selectable reply", substring = true, useUnmergedTree = true)
             .performClick()
@@ -265,8 +258,6 @@ class MessageSelectionInstrumentedTest {
         composeRule.onNodeWithTag("message_actions", useUnmergedTree = true).assertExists()
         composeRule.waitUntil(timeoutMillis = 5_000) { menuProvider.hiddenCount > hiddenBefore }
 
-        // The selection is gone for good: a further tap neither revives the toolbar nor is
-        // swallowed — it simply toggles the row back off.
         val shownBefore = menuProvider.shownCount
         composeRule.onNodeWithText("selectable reply", substring = true, useUnmergedTree = true)
             .performClick()
@@ -337,8 +328,6 @@ class MessageSelectionInstrumentedTest {
 
     @Test
     fun quotedExcerptIsSelectable() {
-        // A quote is conversation text the user pulled forward, not chrome: the passage it came
-        // from may be far up the thread, so copying it back out has to work.
         setChat(
             userMessage("m1", "What about this?").copy(quotes = listOf("Quoted excerpt from earlier")),
         )
@@ -355,9 +344,8 @@ class MessageSelectionInstrumentedTest {
 
     @Test
     fun incompleteArtifactSourceIsSelectable() {
-        // A truncated artifact renders its source through CodeBlock — message text like any other
-        // fenced block (search counts it), so selection has to reach it. Only the finished
-        // artifact's tap-to-open card is chrome.
+        // A truncated artifact renders its source through CodeBlock, so the fixture below is a
+        // directive that never closes.
         setChat(
             assistantMessage("m1", "").copy(
                 content = listOf(

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/components/MarkdownContent.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/components/MarkdownContent.kt
@@ -402,8 +402,6 @@ private fun FullscreenTableDialog(
                     .verticalScroll(verticalScrollState)
                     .padding(16.dp),
             ) {
-                // Own selection scope: this dialog is a separate composition owner, so its cells
-                // must not join the message's registrar. See SubwindowSelectionContainer.
                 SubwindowSelectionContainer {
                     MarkdownTable(
                         headers = headers,

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/components/MermaidDiagram.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/components/MermaidDiagram.kt
@@ -74,8 +74,7 @@ actual fun MermaidDiagram(
             .clip(RoundedCornerShape(8.dp))
             .background(MaterialTheme.colorScheme.surfaceContainerHighest),
     ) {
-        // Header — chrome, excluded from in-message selection (the WebView below never
-        // participates; the "show code" CodeBlock keeps its own selectable code text).
+        // Header
         DisableSelection {
             Row(
                 modifier = Modifier

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ActivityGroup.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ActivityGroup.kt
@@ -144,8 +144,8 @@ internal fun ActivityGroup(
                     DisableSelection { ActivityHeaderLabel(headerLabel, labelColor) }
                 }
             } else {
-                // The server's own label is message text: SearchMatchEnumeration counts it, so a
-                // user who searched for a phrase and found it here has to be able to copy it too.
+                // The server's own label is message text — SearchMatchEnumeration counts it, so a
+                // phrase found by search has to be copyable too.
                 ActivityHeaderLabel(headerLabel, labelColor, Modifier.weight(1f))
             }
             Icon(

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/CitationChip.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/CitationChip.kt
@@ -202,8 +202,6 @@ fun CitationText(
             onDismissRequest = { activeCitation = null },
             properties = PopupProperties(focusable = true),
         ) {
-            // Own selection scope: a popup is a separate composition owner, so its text must not
-            // join the message's registrar. See SubwindowSelectionContainer.
             SubwindowSelectionContainer {
                 CitationPopup(
                     citation = citation,

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/CodeBlock.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/CodeBlock.kt
@@ -88,8 +88,7 @@ fun CodeBlock(
                 contentDescription = "$languageLabel code block"
             },
     ) {
-        // Language header with copy button. DisableSelection: in-message selection
-        // ("Select all") must sweep the code text below, not this chrome label.
+        // Language header with copy button
         Row(
             modifier = Modifier
                 .fillMaxWidth()

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/CollapsibleContentParts.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/CollapsibleContentParts.kt
@@ -103,8 +103,6 @@ private fun CollapsibleDisclosureCard(
             .clip(RoundedCornerShape(8.dp))
             .background(MaterialTheme.colorScheme.surfaceContainerLow),
     ) {
-        // Header title is chrome — DisableSelection keeps in-message "Select all"
-        // scoped to content text (the body stays selectable).
         Row(
             modifier = Modifier
                 .fillMaxWidth()

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/MessageContentAndActions.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/MessageContentAndActions.kt
@@ -290,18 +290,16 @@ internal fun MessageContentAndActions(
         // Single Column root so this branch emits from one source (and the quote chips,
         // files, content, and office previews stack the same as before).
         //
-        // SelectionContainer scope is per-message and content-only: every BasicText-backed
-        // descendant (markdown prose, code, table cells, think bodies) becomes selectable
-        // through one registrar, while chrome (chips, cards, headers) opts out via
-        // DisableSelection so "Select all" copies message text, not UI labels. The action
-        // row below and the editing branch above stay outside — a text field must never
-        // sit inside a SelectionContainer.
+        // Selection scope is per-message and content-only: every BasicText-backed descendant
+        // (prose, code, table cells, think bodies) shares one registrar, while chrome opts out
+        // via DisableSelection so "Select all" copies message text, not UI labels. The action
+        // row below and the editing branch above stay outside — a text field must never sit
+        // inside a SelectionContainer.
         SelectionContainer {
             Column {
                 // Verbatim excerpts the user referenced on this turn (v0.8.7), above the user's
                 // text. Created on web; mobile displays them (no creation affordance yet).
-                // Selectable: a quote is conversation text the user pulled forward, not chrome,
-                // and the passage it came from may be far up the thread or on another branch.
+                // Selectable: a quote is conversation text the user pulled forward, not chrome.
                 val quotes = message.quotes
                 if (isUser && !quotes.isNullOrEmpty()) {
                     MessageQuotes(

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/SharedContentParts.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/SharedContentParts.kt
@@ -80,10 +80,8 @@ internal fun ContentPartDispatcher(
                 stateKey = stateKey,
             )
         }
-        // Card/media parts are excluded from in-message selection (DisableSelection):
-        // v1 scopes selection to prose, code, tables, and think/summary bodies so a
-        // toolbar "Select all" copies the message's text, not card labels and JSON
-        // dumps. Tool-card output selection is a plausible follow-up.
+        // Card and media parts are chrome: "Select all" copies the message's text, not
+        // card labels and JSON dumps.
         ContentType.TOOL_CALL -> DisableSelection {
             ToolCallDispatcher(
                 part = part,

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/SteerContentPart.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/SteerContentPart.kt
@@ -48,7 +48,6 @@ internal fun SteerContentPart(
     if (text.isBlank()) return
 
     Column(modifier = modifier.fillMaxWidth().padding(vertical = 8.dp)) {
-        // Author chrome — excluded from in-message selection; the steer text below stays in.
         DisableSelection {
             Row(verticalAlignment = Alignment.CenterVertically) {
                 AvatarImage(
@@ -110,7 +109,6 @@ internal fun SegmentAuthorHeader(
         is SegmentAuthor.Agent -> author.agentId
         SegmentAuthor.Message -> messageSender ?: stringResource(Res.string.sender_assistant)
     }
-    // Attribution chrome — excluded from in-message selection.
     DisableSelection {
         Row(
             modifier = modifier.fillMaxWidth().padding(top = 8.dp, bottom = 4.dp),

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/SubwindowSelection.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/SubwindowSelection.kt
@@ -14,8 +14,7 @@ import androidx.compose.runtime.Composable
  * second time, and resolving a position across the two owners fails outright — `localPositionOf`
  * rejects nodes that share no ancestor.
  *
- * Giving the subwindow its own container keeps its text selectable and makes it a separate
- * selection, which is also what a user expects from a window they opened deliberately.
+ * Its own container keeps the subwindow's text selectable as a separate selection.
  */
 @Composable
 internal fun SubwindowSelectionContainer(content: @Composable () -> Unit) {

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/TextArtifactContentPart.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/TextArtifactContentPart.kt
@@ -112,8 +112,7 @@ internal fun TextContentPart(
                             // Truncated or still streaming: show source, never a collapsed button and
                             // never a WebView. See IncompleteArtifact's KDoc for why this outranks
                             // the inline preference. That source is message text like any other
-                            // fenced block, so it stays selectable — the same reason in-conversation
-                            // search counts it.
+                            // fenced block, so it stays selectable.
                             IncompleteArtifact(
                                 artifact = segment.artifact,
                                 onTap = { openArtifact?.invoke(segment.artifact, versions) },
@@ -124,9 +123,8 @@ internal fun TextContentPart(
                                 streaming = streaming,
                             )
                         } else {
-                            // A finished artifact renders as a tap-to-open card, not message prose —
-                            // excluded from in-message selection so "Select all" copies the
-                            // surrounding text instead of the card's own labels.
+                            // A finished artifact renders as a tap-to-open card, not message prose,
+                            // so it is chrome — unlike the incomplete branch above.
                             DisableSelection {
                                 if (shouldRenderInlineArtifact(inlinePrefs, segment.artifact.type, streaming)) {
                                     val type = ArtifactType.from(segment.artifact.type)

--- a/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/components/PlatformChatComponents.ios.kt
+++ b/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/components/PlatformChatComponents.ios.kt
@@ -737,8 +737,6 @@ private fun IosFullscreenTableDialog(
                     .verticalScroll(rememberScrollState())
                     .padding(16.dp),
             ) {
-                // Own selection scope: this dialog is a separate composition owner, so its cells
-                // must not join the message's registrar. See SubwindowSelectionContainer.
                 SubwindowSelectionContainer {
                     IosMarkdownTable(
                         headers = headers,

--- a/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/components/PlatformMediaComponents.ios.kt
+++ b/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/components/PlatformMediaComponents.ios.kt
@@ -575,8 +575,7 @@ actual fun MermaidDiagram(
             .clip(RoundedCornerShape(8.dp))
             .background(MaterialTheme.colorScheme.surfaceContainerHighest),
     ) {
-        // Header — chrome, excluded from in-message selection (mirrors the Android
-        // MermaidDiagram; the WKWebView below never participates in Compose selection).
+        // Header
         DisableSelection {
             Row(
                 modifier = Modifier


### PR DESCRIPTION
## Summary

Follow-up to #332. A comment audit over the message-selection code found comments that
restate the code they annotate, plus one note duplicated across three call sites. This
removes those and trims a few others. Comments only — no code lines change.

## Changes

- Drop comments that restate their own code: the `DisableSelection` wrappers (the
  wrapper is on the next line, and the scheme is documented once in
  `MessageContentAndActions`), and four test-helper KDocs that paraphrase their
  signatures.
- Collapse the three duplicate copies of the `SubwindowSelectionContainer` rationale at
  its call sites; the KDoc on the function itself is the authoritative home.
- Trim planning and draft-relative wording that does not describe the shipped state.
- Shorten several comments without dropping content.

Deliberately kept, as each records something not recoverable from the code:

- the espresso ≥3.7.0 pin (`InputManager.getInstance` is gone on API 36+), without
  which the dependency reads as removable
- why the CI compile gate is scoped to `:feature:chat`
- that the instrumented harness uses `LocalTextContextMenuToolbarProvider` and not the
  legacy `LocalTextToolbar`
- that `awaitCancellation()` in the recording provider is load-bearing
- that the `Box` in `ActivityGroup` carries a weight the `DisableSelection` lambda
  cannot, since that lambda is not `RowScope`
- why the streaming-bubble test waits out a 3s window, so it is not deleted as dead
  time and the negative assertion made vacuous

## Testing

- `detekt` and `detektMetadataCommonMain` clean.
- No behavior change to verify: filtering the diff for non-comment lines returns nothing.
