### PR TITLE
feat(prefetch): opt-in background warming of the conversation cache

### DIFF
--- a/app/src/test/kotlin/com/garfiec/librechat/KoinGraphVerificationTest.kt
+++ b/app/src/test/kotlin/com/garfiec/librechat/KoinGraphVerificationTest.kt
@@ -3,8 +3,13 @@ package com.garfiec.librechat
 import android.app.Application
 import android.content.Context
 import com.garfiec.librechat.core.common.AppInfo
+import com.garfiec.librechat.core.common.conversation.OpenConversationRegistry
 import com.garfiec.librechat.core.common.identity.ActiveAccountProvider
+import com.garfiec.librechat.core.common.lifecycle.ForegroundSignal
 import com.garfiec.librechat.core.common.network.ConnectivityObserver
+import com.garfiec.librechat.core.common.network.NetworkConditionObserver
+import com.garfiec.librechat.core.common.network.RequestActivityTracker
+import com.garfiec.librechat.core.common.power.PowerStateObserver
 import com.garfiec.librechat.core.data.datastore.AccountRoster
 import com.garfiec.librechat.core.data.datastore.ConfigCacheDataStore
 import com.garfiec.librechat.core.data.datastore.ServerDataStore
@@ -117,6 +122,11 @@ class KoinGraphVerificationTest {
             CoroutineDispatcher::class,
             CoroutineScope::class,
             ConnectivityObserver::class,
+            NetworkConditionObserver::class,
+            PowerStateObserver::class,
+            ForegroundSignal::class,
+            OpenConversationRegistry::class,
+            RequestActivityTracker::class,
             ActiveAccountProvider::class,
             AppInfo::class,
             // core:logging provides

--- a/app/src/test/kotlin/com/garfiec/librechat/KoinGraphVerificationTest.kt
+++ b/app/src/test/kotlin/com/garfiec/librechat/KoinGraphVerificationTest.kt
@@ -15,6 +15,7 @@ import com.garfiec.librechat.core.data.datastore.ConfigCacheDataStore
 import com.garfiec.librechat.core.data.datastore.ServerDataStore
 import com.garfiec.librechat.core.data.datastore.SettingsDataStore
 import com.garfiec.librechat.core.data.datastore.ThemeDataStore
+import com.garfiec.librechat.core.data.prefetch.AttachmentWarmer
 import com.garfiec.librechat.core.data.repository.AccountSwitcher
 import com.garfiec.librechat.core.data.repository.AgentRepository
 import com.garfiec.librechat.core.data.repository.AgentToolsRepository
@@ -204,6 +205,7 @@ class KoinGraphVerificationTest {
             UserRepository::class,
             PermissionGate::class,
             SessionTask::class,
+            AttachmentWarmer::class,
             SessionTaskRunner::class,
             // feature:auth platform provides
             OAuthLauncher::class,

--- a/core/common/build.gradle.kts
+++ b/core/common/build.gradle.kts
@@ -272,6 +272,9 @@ kotlin {
         androidMain.dependencies {
             implementation(libs.coroutines.android)
             implementation(libs.koin.android)
+            // ContextCompat.registerReceiver, for the exported/not-exported flag the power-save
+            // receiver needs. Declared rather than relied on transitively through koin-android.
+            implementation(libs.androidx.core.ktx)
         }
         named("androidUnitTest").dependencies {
             implementation(libs.koin.test)

--- a/core/common/src/androidMain/kotlin/com/garfiec/librechat/core/common/di/CommonPlatformModule.android.kt
+++ b/core/common/src/androidMain/kotlin/com/garfiec/librechat/core/common/di/CommonPlatformModule.android.kt
@@ -3,12 +3,18 @@ package com.garfiec.librechat.core.common.di
 import com.garfiec.librechat.core.common.AndroidAppInfo
 import com.garfiec.librechat.core.common.AppInfo
 import com.garfiec.librechat.core.common.network.AndroidConnectivityObserver
+import com.garfiec.librechat.core.common.network.AndroidNetworkConditionObserver
 import com.garfiec.librechat.core.common.network.ConnectivityObserver
+import com.garfiec.librechat.core.common.network.NetworkConditionObserver
+import com.garfiec.librechat.core.common.power.AndroidPowerStateObserver
+import com.garfiec.librechat.core.common.power.PowerStateObserver
 import org.koin.android.ext.koin.androidContext
 import org.koin.core.module.Module
 import org.koin.dsl.module
 
 actual val commonPlatformModule: Module = module {
     single<ConnectivityObserver> { AndroidConnectivityObserver(androidContext()) }
+    single<NetworkConditionObserver> { AndroidNetworkConditionObserver(androidContext()) }
+    single<PowerStateObserver> { AndroidPowerStateObserver(androidContext()) }
     single<AppInfo> { AndroidAppInfo(androidContext()) }
 }

--- a/core/common/src/androidMain/kotlin/com/garfiec/librechat/core/common/network/AndroidNetworkConditionObserver.kt
+++ b/core/common/src/androidMain/kotlin/com/garfiec/librechat/core/common/network/AndroidNetworkConditionObserver.kt
@@ -1,0 +1,60 @@
+package com.garfiec.librechat.core.common.network
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.net.NetworkRequest
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+
+class AndroidNetworkConditionObserver(
+    private val context: Context,
+) : NetworkConditionObserver {
+
+    // Permission is declared in the app module's AndroidManifest.
+    @SuppressLint("MissingPermission")
+    override val isUnmetered: Flow<Boolean> = callbackFlow {
+        val connectivityManager = context.getSystemService(ConnectivityManager::class.java)
+
+        fun emitCurrent() {
+            val capabilities = connectivityManager.getNetworkCapabilities(connectivityManager.activeNetwork)
+            trySend(capabilities.isUnmetered())
+        }
+
+        emitCurrent()
+
+        val callback = object : ConnectivityManager.NetworkCallback() {
+            // Re-read the ACTIVE network rather than trusting the callback's own capabilities: these
+            // fire per network, and a phone on Wi-Fi still gets cellular callbacks. Answering from
+            // whichever network happened to change would report metered while Wi-Fi carries traffic.
+            override fun onAvailable(network: Network) = emitCurrent()
+            override fun onLost(network: Network) = emitCurrent()
+            override fun onCapabilitiesChanged(
+                network: Network,
+                networkCapabilities: NetworkCapabilities,
+            ) = emitCurrent()
+        }
+
+        val request = NetworkRequest.Builder()
+            .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+            .build()
+        connectivityManager.registerNetworkCallback(request, callback)
+
+        awaitClose { connectivityManager.unregisterNetworkCallback(callback) }
+    }.distinctUntilChanged()
+
+    /**
+     * Both capabilities are required. `NOT_METERED` alone is true on a Wi-Fi link the user has
+     * flagged as metered only when the OS agrees, whereas `TEMPORARILY_NOT_METERED` covers a carrier
+     * zero-rating window that should not be mistaken for a home connection. No network at all
+     * answers `false` — absent capabilities are not an unmetered link.
+     */
+    private fun NetworkCapabilities?.isUnmetered(): Boolean =
+        this != null &&
+            hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) &&
+            hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_METERED)
+}

--- a/core/common/src/androidMain/kotlin/com/garfiec/librechat/core/common/power/AndroidPowerStateObserver.kt
+++ b/core/common/src/androidMain/kotlin/com/garfiec/librechat/core/common/power/AndroidPowerStateObserver.kt
@@ -1,0 +1,40 @@
+package com.garfiec.librechat.core.common.power
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.os.PowerManager
+import androidx.core.content.ContextCompat
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+
+class AndroidPowerStateObserver(
+    private val context: Context,
+) : PowerStateObserver {
+
+    override val isPowerConstrained: Flow<Boolean> = callbackFlow {
+        val powerManager = context.getSystemService(PowerManager::class.java)
+
+        fun emitCurrent() {
+            trySend(powerManager?.isPowerSaveMode == true)
+        }
+
+        emitCurrent()
+
+        val receiver = object : BroadcastReceiver() {
+            override fun onReceive(context: Context?, intent: Intent?) = emitCurrent()
+        }
+        // The broadcast carries no payload, so the mode is re-read rather than parsed out of it.
+        ContextCompat.registerReceiver(
+            context,
+            receiver,
+            IntentFilter(PowerManager.ACTION_POWER_SAVE_MODE_CHANGED),
+            ContextCompat.RECEIVER_NOT_EXPORTED,
+        )
+
+        awaitClose { context.unregisterReceiver(receiver) }
+    }.distinctUntilChanged()
+}

--- a/core/common/src/commonMain/kotlin/com/garfiec/librechat/core/common/conversation/OpenConversationRegistry.kt
+++ b/core/common/src/commonMain/kotlin/com/garfiec/librechat/core/common/conversation/OpenConversationRegistry.kt
@@ -1,0 +1,23 @@
+package com.garfiec.librechat.core.common.conversation
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * The conversation the user currently has open, or `null` when they are anywhere else.
+ *
+ * Exists so cache-mutating background work can leave that one conversation alone. Replacing or
+ * pruning the rows behind the screen the user is reading is the worst failure available to such
+ * work, and it is not otherwise detectable from `:core:data`.
+ */
+class OpenConversationRegistry {
+
+    private val _openConversationId = MutableStateFlow<String?>(null)
+
+    val openConversationId: StateFlow<String?> = _openConversationId.asStateFlow()
+
+    fun set(conversationId: String?) {
+        _openConversationId.value = conversationId
+    }
+}

--- a/core/common/src/commonMain/kotlin/com/garfiec/librechat/core/common/di/CommonModule.kt
+++ b/core/common/src/commonMain/kotlin/com/garfiec/librechat/core/common/di/CommonModule.kt
@@ -1,5 +1,8 @@
 package com.garfiec.librechat.core.common.di
 
+import com.garfiec.librechat.core.common.conversation.OpenConversationRegistry
+import com.garfiec.librechat.core.common.lifecycle.ForegroundSignal
+import com.garfiec.librechat.core.common.network.RequestActivityTracker
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -23,4 +26,10 @@ val commonModule = module {
     single<CoroutineScope>(KoinQualifiers.ApplicationScope) {
         CoroutineScope(SupervisorJob() + get<CoroutineDispatcher>(KoinQualifiers.Default))
     }
+
+    // Activity signals. They belong at the bottom of the module graph: the HTTP layer publishes to
+    // them and the data layer reads them, and neither may depend on the other.
+    single { RequestActivityTracker() }
+    single { ForegroundSignal() }
+    single { OpenConversationRegistry() }
 }

--- a/core/common/src/commonMain/kotlin/com/garfiec/librechat/core/common/identity/SessionManager.kt
+++ b/core/common/src/commonMain/kotlin/com/garfiec/librechat/core/common/identity/SessionManager.kt
@@ -18,9 +18,6 @@ import kotlinx.coroutines.sync.withLock
  * (boot sentinel) and `Resolved(null)` (logged-out) map to "no session". So a session can never form
  * under an unknown or logged-out identity, and a flip to either tears the current one down.
  *
- * Nothing consumes [current] yet: the `SessionWriter`/`AccountScopedDb` facade (the object that
- * actually launches writes in [Session.scope]) is deferred.
- *
  * **Single teardown owner:** the imperative logout path drives [endCurrentSession] (so it can
  * sequence the DELETEs after the join) while this reactive collector handles non-logout flips. The
  * collector also reacts to logout's subsequent flip-to-null, but that reconciles to "no session" as a

--- a/core/common/src/commonMain/kotlin/com/garfiec/librechat/core/common/lifecycle/ForegroundSignal.kt
+++ b/core/common/src/commonMain/kotlin/com/garfiec/librechat/core/common/lifecycle/ForegroundSignal.kt
@@ -1,0 +1,23 @@
+package com.garfiec.librechat.core.common.lifecycle
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * Whether the app is currently on screen.
+ *
+ * Starts `false`: nothing may treat "not yet reported" as foreground, since the first report only
+ * arrives once the UI composes and background work registered at Koin start would otherwise run
+ * during cold start — the worst possible moment for it.
+ */
+class ForegroundSignal {
+
+    private val _isForeground = MutableStateFlow(false)
+
+    val isForeground: StateFlow<Boolean> = _isForeground.asStateFlow()
+
+    fun set(foreground: Boolean) {
+        _isForeground.value = foreground
+    }
+}

--- a/core/common/src/commonMain/kotlin/com/garfiec/librechat/core/common/network/NetworkConditionObserver.kt
+++ b/core/common/src/commonMain/kotlin/com/garfiec/librechat/core/common/network/NetworkConditionObserver.kt
@@ -1,0 +1,18 @@
+package com.garfiec.librechat.core.common.network
+
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Whether the active network is one it is polite to spend bandwidth on.
+ *
+ * Distinct from [ConnectivityObserver], which answers "can we reach the server at all" — a metered
+ * connection is fully connected, and everything the user asks for should still go over it. This
+ * governs only work the user did not ask for.
+ *
+ * Emits `false` while there is no network, so a caller that gates on it does not also need a
+ * connectivity check.
+ */
+interface NetworkConditionObserver {
+    /** True when the active network is unmetered (Wi-Fi/Ethernet, not a cellular or hotspot link). */
+    val isUnmetered: Flow<Boolean>
+}

--- a/core/common/src/commonMain/kotlin/com/garfiec/librechat/core/common/network/PrefetchMarker.kt
+++ b/core/common/src/commonMain/kotlin/com/garfiec/librechat/core/common/network/PrefetchMarker.kt
@@ -1,0 +1,21 @@
+package com.garfiec.librechat.core.common.network
+
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * Marks a coroutine as background prefetch work, exempting its requests from
+ * [RequestActivityTracker].
+ *
+ * Must stay a coroutine-context element, not a request attribute: any path that failed to carry it
+ * would make the prefetcher count itself as user activity and deadlock against its own idle gate,
+ * silently. The Ktor interceptor reads this from the *calling* coroutine's context, which is what
+ * makes it visible there — `RequestActivityPluginTest` pins that.
+ */
+object PrefetchMarker : CoroutineContext.Element {
+
+    override val key: CoroutineContext.Key<*> get() = Key
+
+    object Key : CoroutineContext.Key<PrefetchMarker>
+}
+
+fun CoroutineContext.isPrefetch(): Boolean = this[PrefetchMarker.Key] != null

--- a/core/common/src/commonMain/kotlin/com/garfiec/librechat/core/common/network/RequestActivityTracker.kt
+++ b/core/common/src/commonMain/kotlin/com/garfiec/librechat/core/common/network/RequestActivityTracker.kt
@@ -1,0 +1,43 @@
+package com.garfiec.librechat.core.common.network
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+
+/**
+ * Counts the HTTP work the user is waiting on, so deferred work can stay out of its way.
+ *
+ * "User-initiated" must stay defined by exclusion — everything counts unless it carries
+ * [PrefetchMarker]. Inverted to opt-in, a caller that forgot to register would silently starve the
+ * user's request rather than merely delay background work.
+ */
+class RequestActivityTracker {
+
+    private val _userInFlight = MutableStateFlow(0)
+
+    val userInFlight: StateFlow<Int> = _userInFlight.asStateFlow()
+
+    fun begin() {
+        _userInFlight.update { it + 1 }
+    }
+
+    /**
+     * Floors at zero. An unbalanced [end] is a bug, but the failure mode of letting the count go
+     * negative is that the app looks permanently idle and background work runs during a live
+     * request — the exact thing this class exists to prevent.
+     */
+    fun end() {
+        _userInFlight.update { (it - 1).coerceAtLeast(0) }
+    }
+
+    /** Runs [block] counted as user-initiated work, releasing on completion, failure or cancellation. */
+    suspend fun <T> counted(block: suspend () -> T): T {
+        begin()
+        return try {
+            block()
+        } finally {
+            end()
+        }
+    }
+}

--- a/core/common/src/commonMain/kotlin/com/garfiec/librechat/core/common/power/PowerStateObserver.kt
+++ b/core/common/src/commonMain/kotlin/com/garfiec/librechat/core/common/power/PowerStateObserver.kt
@@ -1,0 +1,13 @@
+package com.garfiec.librechat.core.common.power
+
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Whether the device is asking apps to do less.
+ *
+ * Battery saver is an explicit instruction from the user, not a hint, so background work that is
+ * optional by definition should stop while it is on.
+ */
+interface PowerStateObserver {
+    val isPowerConstrained: Flow<Boolean>
+}

--- a/core/common/src/commonMain/kotlin/com/garfiec/librechat/core/common/result/ApiException.kt
+++ b/core/common/src/commonMain/kotlin/com/garfiec/librechat/core/common/result/ApiException.kt
@@ -24,4 +24,14 @@ class ApiException(
      * but deliberate message can never be silently swallowed by that screen.
      */
     val serverAuthored: Boolean = false,
+    /**
+     * `Retry-After` in seconds, when the server sent one — typically alongside a 429.
+     *
+     * Delta-seconds only; the HTTP-date form parses to null, matching the token-refresh parser this
+     * mirrors. Callers that back off must therefore treat null as "no guidance", not as "retry now".
+     *
+     * Carried on the exception because the response is gone by the time a `Result.Error` reaches a
+     * caller, and this is the one header a caller can act on rather than merely report.
+     */
+    val retryAfterSeconds: Long? = null,
 ) : Exception(message, cause)

--- a/core/common/src/commonTest/kotlin/com/garfiec/librechat/core/common/network/RequestActivityTrackerTest.kt
+++ b/core/common/src/commonTest/kotlin/com/garfiec/librechat/core/common/network/RequestActivityTrackerTest.kt
@@ -1,0 +1,71 @@
+package com.garfiec.librechat.core.common.network
+
+import kotlinx.coroutines.test.runTest
+import kotlin.coroutines.coroutineContext
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class RequestActivityTrackerTest {
+
+    @Test
+    fun `concurrent requests are counted together`() {
+        val tracker = RequestActivityTracker()
+
+        tracker.begin()
+        tracker.begin()
+        assertEquals(2, tracker.userInFlight.value)
+
+        tracker.end()
+        assertEquals(1, tracker.userInFlight.value)
+
+        tracker.end()
+        assertEquals(0, tracker.userInFlight.value)
+    }
+
+    /**
+     * An unbalanced end is a bug either way, but the two failure modes are not equal: floored at
+     * zero the app merely under-counts one request, whereas a negative count reads as "idle" during
+     * live requests, which is precisely what this class exists to prevent.
+     */
+    @Test
+    fun `an unbalanced end cannot drive the count below zero`() {
+        val tracker = RequestActivityTracker()
+
+        tracker.end()
+        assertEquals(0, tracker.userInFlight.value)
+
+        tracker.begin()
+        assertEquals(1, tracker.userInFlight.value)
+    }
+
+    @Test
+    fun `counted releases when its block throws`() = runTest {
+        val tracker = RequestActivityTracker()
+
+        runCatching {
+            tracker.counted<Unit> {
+                assertEquals(1, tracker.userInFlight.value)
+                error("boom")
+            }
+        }
+
+        assertEquals(0, tracker.userInFlight.value)
+    }
+
+    @Test
+    fun `prefetch marker is visible to code the marked block calls`() = runTest {
+        assertFalse(coroutineContext.isPrefetch())
+
+        kotlinx.coroutines.withContext(PrefetchMarker) {
+            // Read through a suspend call rather than inline, because the thing that must see the
+            // marker is the Ktor interceptor several frames below the prefetcher.
+            assertTrue(readIsPrefetch())
+        }
+
+        assertFalse(coroutineContext.isPrefetch())
+    }
+
+    private suspend fun readIsPrefetch(): Boolean = coroutineContext.isPrefetch()
+}

--- a/core/common/src/iosMain/kotlin/com/garfiec/librechat/core/common/di/CommonPlatformModule.ios.kt
+++ b/core/common/src/iosMain/kotlin/com/garfiec/librechat/core/common/di/CommonPlatformModule.ios.kt
@@ -4,10 +4,16 @@ import com.garfiec.librechat.core.common.AppInfo
 import com.garfiec.librechat.core.common.IosAppInfo
 import com.garfiec.librechat.core.common.network.ConnectivityObserver
 import com.garfiec.librechat.core.common.network.IosConnectivityObserver
+import com.garfiec.librechat.core.common.network.IosNetworkConditionObserver
+import com.garfiec.librechat.core.common.network.NetworkConditionObserver
+import com.garfiec.librechat.core.common.power.IosPowerStateObserver
+import com.garfiec.librechat.core.common.power.PowerStateObserver
 import org.koin.core.module.Module
 import org.koin.dsl.module
 
 actual val commonPlatformModule: Module = module {
     single<ConnectivityObserver> { IosConnectivityObserver() }
+    single<NetworkConditionObserver> { IosNetworkConditionObserver() }
+    single<PowerStateObserver> { IosPowerStateObserver() }
     single<AppInfo> { IosAppInfo() }
 }

--- a/core/common/src/iosMain/kotlin/com/garfiec/librechat/core/common/network/IosNetworkConditionObserver.kt
+++ b/core/common/src/iosMain/kotlin/com/garfiec/librechat/core/common/network/IosNetworkConditionObserver.kt
@@ -1,0 +1,37 @@
+package com.garfiec.librechat.core.common.network
+
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import platform.Network.nw_path_get_status
+import platform.Network.nw_path_is_constrained
+import platform.Network.nw_path_is_expensive
+import platform.Network.nw_path_monitor_cancel
+import platform.Network.nw_path_monitor_create
+import platform.Network.nw_path_monitor_set_queue
+import platform.Network.nw_path_monitor_set_update_handler
+import platform.Network.nw_path_monitor_start
+import platform.Network.nw_path_status_satisfied
+import platform.darwin.dispatch_queue_create
+
+@OptIn(ExperimentalForeignApi::class)
+class IosNetworkConditionObserver : NetworkConditionObserver {
+
+    override val isUnmetered: Flow<Boolean> = callbackFlow {
+        val monitor = nw_path_monitor_create()
+        val queue = dispatch_queue_create("com.garfiec.librechat.network.conditions", null)
+
+        nw_path_monitor_set_update_handler(monitor) { path ->
+            // "Expensive" is cellular or a personal hotspot; "constrained" is Low Data Mode, which is
+            // the user asking for exactly this restraint. Either one disqualifies the link.
+            val satisfied = nw_path_get_status(path) == nw_path_status_satisfied
+            trySend(satisfied && !nw_path_is_expensive(path) && !nw_path_is_constrained(path))
+        }
+        nw_path_monitor_set_queue(monitor, queue)
+        nw_path_monitor_start(monitor)
+
+        awaitClose { nw_path_monitor_cancel(monitor) }
+    }.distinctUntilChanged()
+}

--- a/core/common/src/iosMain/kotlin/com/garfiec/librechat/core/common/power/IosPowerStateObserver.kt
+++ b/core/common/src/iosMain/kotlin/com/garfiec/librechat/core/common/power/IosPowerStateObserver.kt
@@ -1,0 +1,32 @@
+package com.garfiec.librechat.core.common.power
+
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import platform.Foundation.NSNotificationCenter
+import platform.Foundation.NSOperationQueue
+import platform.Foundation.NSProcessInfo
+import platform.Foundation.NSProcessInfoPowerStateDidChangeNotification
+// Low Power Mode arrives on NSProcessInfo through an Objective-C category, so Kotlin sees it as an
+// extension function and it has to be imported by name — the bare call does not resolve.
+import platform.Foundation.isLowPowerModeEnabled
+
+class IosPowerStateObserver : PowerStateObserver {
+
+    override val isPowerConstrained: Flow<Boolean> = callbackFlow {
+        fun emitCurrent() {
+            trySend(NSProcessInfo.processInfo.isLowPowerModeEnabled())
+        }
+
+        emitCurrent()
+
+        val observer = NSNotificationCenter.defaultCenter.addObserverForName(
+            name = NSProcessInfoPowerStateDidChangeNotification,
+            `object` = null,
+            queue = NSOperationQueue.mainQueue,
+        ) { _ -> emitCurrent() }
+
+        awaitClose { NSNotificationCenter.defaultCenter.removeObserver(observer) }
+    }.distinctUntilChanged()
+}

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -32,6 +32,9 @@ kotlin {
         androidMain.dependencies {
             implementation(libs.koin.android)
             implementation(libs.security.crypto)
+            // Prefetching attachments warms the singleton image loader's disk cache, which only the
+            // Android side configures. iOS binds a no-op and needs no image dependency at all.
+            implementation(libs.coil3.core)
         }
         named("androidUnitTest").dependencies {
             implementation(libs.koin.test)

--- a/core/data/schemas/com.garfiec.librechat.core.data.db.LibreChatDatabase/9.json
+++ b/core/data/schemas/com.garfiec.librechat.core.data.db.LibreChatDatabase/9.json
@@ -1,0 +1,677 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 9,
+    "identityHash": "bede2f5dc847e04493f7264df196df71",
+    "entities": [
+      {
+        "tableName": "conversations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`conversationId` TEXT NOT NULL, `title` TEXT NOT NULL, `user` TEXT NOT NULL, `endpoint` TEXT, `endpointType` TEXT, `model` TEXT, `agentId` TEXT, `isArchived` INTEGER NOT NULL, `pinned` INTEGER NOT NULL DEFAULT 0, `chatProjectId` TEXT, `tags` TEXT NOT NULL, `iconURL` TEXT, `greeting` TEXT, `modelParams` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, `accountId` TEXT, PRIMARY KEY(`conversationId`))",
+        "fields": [
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "user",
+            "columnName": "user",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endpoint",
+            "columnName": "endpoint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "endpointType",
+            "columnName": "endpointType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "model",
+            "columnName": "model",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "agentId",
+            "columnName": "agentId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isArchived",
+            "columnName": "isArchived",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pinned",
+            "columnName": "pinned",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "chatProjectId",
+            "columnName": "chatProjectId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "tags",
+            "columnName": "tags",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "iconURL",
+            "columnName": "iconURL",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "greeting",
+            "columnName": "greeting",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "modelParams",
+            "columnName": "modelParams",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "conversationId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_conversations_isArchived_updatedAt",
+            "unique": false,
+            "columnNames": [
+              "isArchived",
+              "updatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_conversations_isArchived_updatedAt` ON `${TABLE_NAME}` (`isArchived`, `updatedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`messageId` TEXT NOT NULL, `conversationId` TEXT NOT NULL, `parentMessageId` TEXT, `sender` TEXT, `text` TEXT, `content` TEXT, `isCreatedByUser` INTEGER NOT NULL, `model` TEXT, `endpoint` TEXT, `iconURL` TEXT, `unfinished` INTEGER NOT NULL, `error` INTEGER NOT NULL, `finishReason` TEXT, `tokenCount` INTEGER, `feedback` TEXT, `files` TEXT, `attachments` TEXT, `metadata` TEXT, `quotes` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `accountId` TEXT, PRIMARY KEY(`messageId`))",
+        "fields": [
+          {
+            "fieldPath": "messageId",
+            "columnName": "messageId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "parentMessageId",
+            "columnName": "parentMessageId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sender",
+            "columnName": "sender",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isCreatedByUser",
+            "columnName": "isCreatedByUser",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "model",
+            "columnName": "model",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "endpoint",
+            "columnName": "endpoint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "iconURL",
+            "columnName": "iconURL",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "unfinished",
+            "columnName": "unfinished",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "error",
+            "columnName": "error",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "finishReason",
+            "columnName": "finishReason",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "tokenCount",
+            "columnName": "tokenCount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "feedback",
+            "columnName": "feedback",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "files",
+            "columnName": "files",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "attachments",
+            "columnName": "attachments",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "metadata",
+            "columnName": "metadata",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "quotes",
+            "columnName": "quotes",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "messageId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_messages_conversationId",
+            "unique": false,
+            "columnNames": [
+              "conversationId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_messages_conversationId` ON `${TABLE_NAME}` (`conversationId`)"
+          },
+          {
+            "name": "index_messages_parentMessageId",
+            "unique": false,
+            "columnNames": [
+              "parentMessageId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_messages_parentMessageId` ON `${TABLE_NAME}` (`parentMessageId`)"
+          },
+          {
+            "name": "index_messages_conversationId_createdAt",
+            "unique": false,
+            "columnNames": [
+              "conversationId",
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_messages_conversationId_createdAt` ON `${TABLE_NAME}` (`conversationId`, `createdAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "agents",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT, `description` TEXT, `avatar` TEXT, `provider` TEXT NOT NULL, `model` TEXT NOT NULL, `category` TEXT, `authorName` TEXT, `isPromoted` INTEGER NOT NULL, `conversationStarters` TEXT, `tools` TEXT, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "avatar",
+            "columnName": "avatar",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "provider",
+            "columnName": "provider",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "model",
+            "columnName": "model",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "authorName",
+            "columnName": "authorName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isPromoted",
+            "columnName": "isPromoted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationStarters",
+            "columnName": "conversationStarters",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "tools",
+            "columnName": "tools",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "presets",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`presetId` TEXT NOT NULL, `title` TEXT NOT NULL, `endpoint` TEXT, `model` TEXT, `isDefault` INTEGER NOT NULL, `order` INTEGER, `params` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`presetId`))",
+        "fields": [
+          {
+            "fieldPath": "presetId",
+            "columnName": "presetId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endpoint",
+            "columnName": "endpoint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "model",
+            "columnName": "model",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isDefault",
+            "columnName": "isDefault",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "order",
+            "columnName": "order",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "params",
+            "columnName": "params",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "presetId"
+          ]
+        }
+      },
+      {
+        "tableName": "conversation_tags",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `tag` TEXT NOT NULL, `user` TEXT NOT NULL, `description` TEXT, `count` INTEGER NOT NULL, `position` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `accountId` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tag",
+            "columnName": "tag",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "user",
+            "columnName": "user",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "count",
+            "columnName": "count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_conversation_tags_tag_user",
+            "unique": true,
+            "columnNames": [
+              "tag",
+              "user"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_conversation_tags_tag_user` ON `${TABLE_NAME}` (`tag`, `user`)"
+          }
+        ]
+      },
+      {
+        "tableName": "drafts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`conversation_id` TEXT NOT NULL, `text` TEXT NOT NULL, `updated_at` INTEGER NOT NULL, `accountId` TEXT, PRIMARY KEY(`conversation_id`))",
+        "fields": [
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversation_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "conversation_id"
+          ]
+        }
+      },
+      {
+        "tableName": "artifact_shortcuts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `shortcut_label` TEXT NOT NULL, `emoji` TEXT, `identifier` TEXT NOT NULL, `type` TEXT NOT NULL, `title` TEXT NOT NULL, `language` TEXT, `content` TEXT NOT NULL, `version` INTEGER NOT NULL, `created_at` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shortcutLabel",
+            "columnName": "shortcut_label",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "emoji",
+            "columnName": "emoji",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "identifier",
+            "columnName": "identifier",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "language",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "version",
+            "columnName": "version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "servers",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`server_id` TEXT NOT NULL, `custom_headers` TEXT NOT NULL, PRIMARY KEY(`server_id`))",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "server_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customHeaders",
+            "columnName": "custom_headers",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "server_id"
+          ]
+        }
+      },
+      {
+        "tableName": "prefetch_watermarks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`accountId` TEXT NOT NULL, `conversationId` TEXT NOT NULL, `warmedConversationUpdatedAt` INTEGER NOT NULL, `warmedAt` INTEGER NOT NULL, PRIMARY KEY(`accountId`, `conversationId`))",
+        "fields": [
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "warmedConversationUpdatedAt",
+            "columnName": "warmedConversationUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "warmedAt",
+            "columnName": "warmedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "accountId",
+            "conversationId"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'bede2f5dc847e04493f7264df196df71')"
+    ]
+  }
+}

--- a/core/data/src/androidInstrumentedTest/kotlin/com/garfiec/librechat/core/data/db/RoomMigrationTest.kt
+++ b/core/data/src/androidInstrumentedTest/kotlin/com/garfiec/librechat/core/data/db/RoomMigrationTest.kt
@@ -264,6 +264,51 @@ class RoomMigrationTest {
     }
 
     /**
+     * v8→v9 adds `prefetch_watermarks`. A new-table migration cannot lose data on its own, so what
+     * this actually pins is that the auto-migration matches the committed 9.json schema and that an
+     * upgrade from a populated v8 install still opens — the failure mode being a crash on launch for
+     * every existing user, not a subtle one.
+     */
+    @Test
+    fun migrateV8ToV9_addsPrefetchWatermarksAndKeepsExistingRows() {
+        val db = helper.createDatabase(testDbName, 8)
+        db.insert(
+            "conversations",
+            SQLiteDatabase.CONFLICT_REPLACE,
+            ContentValues().apply {
+                put("conversationId", "conv-v8")
+                put("title", "Existing Chat")
+                put("user", "user-001")
+                put("isArchived", 0)
+                put("tags", "[]")
+                put("createdAt", 1700000000000L)
+                put("updatedAt", 1700000000000L)
+                put("lastSyncedAt", 0L)
+                put("accountId", "srv:user-a")
+            },
+        )
+        db.close()
+
+        val migrated = helper.runMigrationsAndValidate(testDbName, 9, true)
+
+        migrated.query("SELECT title FROM conversations WHERE conversationId = 'conv-v8'").use { cursor ->
+            assertThat(cursor.moveToFirst()).isTrue()
+            assertThat(cursor.getString(0)).isEqualTo("Existing Chat")
+        }
+        // Writable, not merely present: a table the migration created but whose columns disagree with
+        // the entity would still pass a bare existence check.
+        migrated.execSQL(
+            "INSERT INTO prefetch_watermarks " +
+                "(accountId, conversationId, warmedConversationUpdatedAt, warmedAt) " +
+                "VALUES ('srv:user-a', 'conv-v8', 1700000000000, 1700000001000)",
+        )
+        migrated.query("SELECT warmedConversationUpdatedAt FROM prefetch_watermarks").use { cursor ->
+            assertThat(cursor.moveToFirst()).isTrue()
+            assertThat(cursor.getLong(0)).isEqualTo(1700000000000L)
+        }
+    }
+
+    /**
      * Pre-#67 builds wrote Conversation.endpoint and endpointType as the
      * Kotlin enum `.name`. The v3→v4 migration rewrites those rows to the
      * wire-format SerialName so ConversationMapper can drop its read-side shim.

--- a/core/data/src/androidMain/kotlin/com/garfiec/librechat/core/data/di/DataPlatformModule.android.kt
+++ b/core/data/src/androidMain/kotlin/com/garfiec/librechat/core/data/di/DataPlatformModule.android.kt
@@ -10,6 +10,8 @@ import com.garfiec.librechat.core.data.datastore.TokenDataStore
 import com.garfiec.librechat.core.data.db.LibreChatDatabase
 import com.garfiec.librechat.core.data.db.migration.MIGRATION_3_4
 import com.garfiec.librechat.core.data.db.migration.MIGRATION_4_5
+import com.garfiec.librechat.core.data.prefetch.AttachmentWarmer
+import com.garfiec.librechat.core.data.prefetch.CoilAttachmentWarmer
 import com.garfiec.librechat.core.data.repository.AndroidSwitchCacheCleaner
 import com.garfiec.librechat.core.data.repository.CommonSessionCacheCleaner
 import com.garfiec.librechat.core.data.repository.SessionCacheCleaner
@@ -28,6 +30,10 @@ private val Context.settingsDataStore: DataStore<Preferences> by preferencesData
 )
 
 actual val dataPlatformModule: Module = module {
+
+    // Bound per platform rather than defaulted in dataModule: Koin starts with allowOverride(false),
+    // so a common default plus a platform override would throw at launch.
+    single<AttachmentWarmer> { CoilAttachmentWarmer(androidContext()) }
 
     // --- Database ---
     single {

--- a/core/data/src/androidMain/kotlin/com/garfiec/librechat/core/data/prefetch/CoilAttachmentWarmer.kt
+++ b/core/data/src/androidMain/kotlin/com/garfiec/librechat/core/data/prefetch/CoilAttachmentWarmer.kt
@@ -1,0 +1,36 @@
+package com.garfiec.librechat.core.data.prefetch
+
+import android.content.Context
+import coil3.SingletonImageLoader
+import coil3.request.ImageRequest
+import kotlinx.coroutines.CancellationException
+
+/**
+ * Warms Coil's disk cache, which the app configures on Android only.
+ *
+ * Goes through the singleton loader the UI reads from, so a warmed image is a cache hit for the
+ * composable that later asks for it — a private loader would fill a cache nothing looks in.
+ */
+class CoilAttachmentWarmer(
+    private val context: Context,
+) : AttachmentWarmer {
+
+    override val isSupported: Boolean = true
+
+    override suspend fun warm(url: String) {
+        val loader = SingletonImageLoader.get(context)
+        try {
+            loader.execute(
+                ImageRequest.Builder(context)
+                    .data(url)
+                    // Decoding to a bitmap costs memory the user gets no benefit from — nothing is on
+                    // screen. The disk cache entry is the whole point, and it is written either way.
+                    .build(),
+            )
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Exception) {
+            // Opportunistic: a missing or expired attachment must not disturb the pass.
+        }
+    }
+}

--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/di/DataModuleVerificationTest.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/di/DataModuleVerificationTest.kt
@@ -3,7 +3,12 @@ package com.garfiec.librechat.core.data.di
 import android.app.Application
 import android.content.Context
 import androidx.datastore.core.DataStore
+import com.garfiec.librechat.core.common.conversation.OpenConversationRegistry
+import com.garfiec.librechat.core.common.lifecycle.ForegroundSignal
 import com.garfiec.librechat.core.common.network.ConnectivityObserver
+import com.garfiec.librechat.core.common.network.NetworkConditionObserver
+import com.garfiec.librechat.core.common.network.RequestActivityTracker
+import com.garfiec.librechat.core.common.power.PowerStateObserver
 import com.garfiec.librechat.core.network.api.AgentToolsApi
 import com.garfiec.librechat.core.network.api.AgentsApi
 import com.garfiec.librechat.core.network.api.ApiKeysApi
@@ -53,6 +58,12 @@ class DataModuleVerificationTest {
                 CoroutineDispatcher::class,
                 CoroutineScope::class,
                 ConnectivityObserver::class,
+                // The prefetcher's inputs, all bound in :core:common.
+                NetworkConditionObserver::class,
+                PowerStateObserver::class,
+                ForegroundSignal::class,
+                OpenConversationRegistry::class,
+                RequestActivityTracker::class,
                 SseClient::class,
                 AuthApi::class,
                 UserApi::class,

--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchEngineTest.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchEngineTest.kt
@@ -1,0 +1,314 @@
+package com.garfiec.librechat.core.data.prefetch
+
+import com.garfiec.librechat.core.common.conversation.OpenConversationRegistry
+import com.garfiec.librechat.core.common.identity.AccountId
+import com.garfiec.librechat.core.common.network.isPrefetch
+import com.garfiec.librechat.core.common.result.ApiException
+import com.garfiec.librechat.core.common.result.Result
+import com.garfiec.librechat.core.data.db.dao.ConversationDao
+import com.garfiec.librechat.core.data.db.dao.MessageDao
+import com.garfiec.librechat.core.data.db.dao.PrefetchCandidate
+import com.garfiec.librechat.core.data.db.dao.PrefetchWatermarkDao
+import com.garfiec.librechat.core.data.db.entity.PrefetchWatermarkEntity
+import com.garfiec.librechat.core.data.repository.AgentRepository
+import com.garfiec.librechat.core.data.repository.ConfigRepository
+import com.garfiec.librechat.core.data.repository.ConversationRepository
+import com.garfiec.librechat.core.data.repository.MessageRepository
+import com.garfiec.librechat.core.model.Message
+import com.google.common.truth.Truth.assertThat
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.currentTime
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+import kotlin.coroutines.coroutineContext
+
+/**
+ * The prefetcher's behaviour under load and failure, on virtual time.
+ *
+ * These are the properties that decide whether the feature is a good citizen rather than whether it
+ * works: how hard it leans on the server, what it does when told to slow down, and when it gives up.
+ * All of them are invisible in a functional test that only asks whether the cache got warm.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class PrefetchEngineTest {
+
+    private val account = AccountId("srv:user-a")
+
+    private val conversationDao = mockk<ConversationDao>(relaxed = true)
+    private val messageDao = mockk<MessageDao>(relaxed = true)
+    private val watermarkDao = mockk<PrefetchWatermarkDao>(relaxed = true)
+    private val messageRepository = mockk<MessageRepository>()
+    private val conversationRepository = mockk<ConversationRepository>()
+    private val configRepository = mockk<ConfigRepository>(relaxed = true)
+    private val agentRepository = mockk<AgentRepository>(relaxed = true)
+    private val openConversationRegistry = OpenConversationRegistry()
+
+    @Before
+    fun setup() {
+        coEvery { conversationRepository.loadNextPage(any(), any(), any(), any(), any(), any()) } returns
+            Result.Success(null)
+        coEvery { configRepository.fetchEndpoints() } returns Result.Success(emptyMap())
+        coEvery { configRepository.fetchModels() } returns Result.Success(emptyMap())
+        coEvery { agentRepository.getAgents(any()) } returns Result.Success(emptyList())
+        coEvery { watermarkDao.allForAccount(any()) } returns emptyList()
+        coEvery { conversationDao.pinnedForPrefetch(any()) } returns emptyList()
+        coEvery { conversationDao.conversationIdsOlderThan(any(), any()) } returns emptyList()
+    }
+
+    private fun TestScope.engine() = PrefetchEngine(
+        conversationDao = conversationDao,
+        messageDao = messageDao,
+        watermarkDao = watermarkDao,
+        messageRepository = messageRepository,
+        conversationRepository = conversationRepository,
+        configRepository = configRepository,
+        agentRepository = agentRepository,
+        policy = PrefetchPolicy(),
+        openConversationRegistry = openConversationRegistry,
+        ioDispatcher = UnconfinedTestDispatcher(testScheduler),
+        // The scheduler's own time source, so elapsedNow() follows virtual time.
+        timeSource = testScheduler.timeSource,
+        nowMillis = { currentTime },
+    )
+
+    private fun stubRecent(vararg ids: String) {
+        coEvery { conversationDao.recentForPrefetch(any(), any()) } returns
+            ids.mapIndexed { index, id -> PrefetchCandidate(id, updatedAt = 100L + index, pinned = false) }
+    }
+
+    private fun rateLimited(retryAfterSeconds: Long?) = Result.Error(
+        exception = ApiException(
+            statusCode = 429,
+            message = "slow down",
+            retryAfterSeconds = retryAfterSeconds,
+        ),
+    )
+
+    @Test
+    fun `pacing waits five times the observed latency between requests`() = runTest {
+        stubRecent("a", "b")
+        val callTimes = mutableListOf<Long>()
+        coEvery { messageRepository.refreshMessages(any(), any()) } coAnswers {
+            callTimes += currentTime
+            delay(REQUEST_MILLIS)
+            Result.Success(emptyList<Message>())
+        }
+
+        engine().run(account)
+
+        // request time + 5x request time before the next one starts.
+        assertThat(callTimes).hasSize(2)
+        assertThat(callTimes[1] - callTimes[0])
+            .isEqualTo(REQUEST_MILLIS + REQUEST_MILLIS * PrefetchEngine.PACE_FACTOR)
+    }
+
+    /**
+     * The engine calls the ordinary repositories, so the exemption has to be applied by the engine
+     * itself. Without it the first request counts as user activity, closes the gate that permits the
+     * pass, and the prefetcher deadlocks against itself — silently.
+     */
+    @Test
+    fun `every prefetch request runs marked as prefetch work`() = runTest {
+        stubRecent("a")
+        // A real fake, not a mock: MockK invokes `coAnswers` through its own continuation, which does
+        // not carry the caller's coroutine context — so a mock here would report "unmarked" no matter
+        // what the engine does, and this test would fail on correct code.
+        val recordingRepository = MarkerRecordingMessageRepository()
+        val engine = PrefetchEngine(
+            conversationDao = conversationDao,
+            messageDao = messageDao,
+            watermarkDao = watermarkDao,
+            messageRepository = recordingRepository,
+            conversationRepository = conversationRepository,
+            configRepository = configRepository,
+            agentRepository = agentRepository,
+            policy = PrefetchPolicy(),
+            openConversationRegistry = openConversationRegistry,
+            ioDispatcher = UnconfinedTestDispatcher(testScheduler),
+            timeSource = testScheduler.timeSource,
+            nowMillis = { currentTime },
+        )
+
+        engine.run(account)
+
+        assertThat(recordingRepository.sawMarker).isTrue()
+    }
+
+    private class MarkerRecordingMessageRepository : MessageRepository {
+        var sawMarker: Boolean = false
+            private set
+
+        override suspend fun refreshMessages(
+            conversationId: String,
+            originAccount: AccountId?,
+        ): Result<List<Message>> {
+            sawMarker = coroutineContext.isPrefetch()
+            return Result.Success(emptyList())
+        }
+
+        override fun observeMessages(conversationId: String) = throw UnsupportedOperationException()
+        override suspend fun getMessages(conversationId: String) = throw UnsupportedOperationException()
+        override suspend fun cacheMessages(messages: List<Message>, originAccount: AccountId?) = Unit
+        override suspend fun updateFeedback(
+            conversationId: String,
+            messageId: String,
+            feedback: com.garfiec.librechat.core.model.MinimalFeedback?,
+        ) = throw UnsupportedOperationException()
+
+        override suspend fun updateMessageText(conversationId: String, messageId: String, text: String) =
+            throw UnsupportedOperationException()
+
+        override suspend fun branchMessage(conversationId: String, messageId: String, agentId: String?) =
+            throw UnsupportedOperationException()
+    }
+
+    /** A 429 means "slower", not "broken": the server is answering, it is just asking us to wait. */
+    @Test
+    fun `a rate limit waits the server's retry-after and does not stop the pass`() = runTest {
+        stubRecent("a", "b")
+        val callTimes = mutableListOf<Long>()
+        var first = true
+        coEvery { messageRepository.refreshMessages(any(), any()) } coAnswers {
+            callTimes += currentTime
+            if (first) {
+                first = false
+                rateLimited(retryAfterSeconds = 7)
+            } else {
+                Result.Success(emptyList<Message>())
+            }
+        }
+
+        engine().run(account)
+
+        assertThat(callTimes).hasSize(2)
+        assertThat(callTimes[1] - callTimes[0]).isEqualTo(7_000L)
+    }
+
+    /**
+     * Three 429s in a row must not be mistaken for a broken server — otherwise a busy server that is
+     * politely throttling us turns the feature off until the app restarts.
+     */
+    @Test
+    fun `repeated rate limits never trip the breaker`() = runTest {
+        stubRecent("a", "b", "c", "d")
+        var calls = 0
+        coEvery { messageRepository.refreshMessages(any(), any()) } coAnswers {
+            calls++
+            rateLimited(retryAfterSeconds = 1)
+        }
+
+        engine().run(account)
+
+        assertThat(calls).isEqualTo(4)
+    }
+
+    @Test
+    fun `the pass stops after three consecutive failures`() = runTest {
+        stubRecent("a", "b", "c", "d", "e")
+        var calls = 0
+        coEvery { messageRepository.refreshMessages(any(), any()) } coAnswers {
+            calls++
+            Result.Error(exception = ApiException(statusCode = 500, message = "boom"))
+        }
+
+        engine().run(account)
+
+        assertThat(calls).isEqualTo(PrefetchEngine.MAX_CONSECUTIVE_FAILURES)
+    }
+
+    /** "Consecutive" has to mean consecutive, or a flaky server eventually trips the breaker anyway. */
+    @Test
+    fun `a success resets the failure count`() = runTest {
+        stubRecent("a", "b", "c", "d", "e")
+        var calls = 0
+        coEvery { messageRepository.refreshMessages(any(), any()) } coAnswers {
+            calls++
+            // fail, fail, succeed, fail, fail — never three in a row.
+            if (calls == 3) Result.Success(emptyList<Message>()) else Result.Error(exception = ApiException(500, "boom"))
+        }
+
+        engine().run(account)
+
+        assertThat(calls).isEqualTo(5)
+    }
+
+    /**
+     * The breaker is keyed by account rather than a flag, so a switch or a re-login starts clean
+     * while repeated gate flips within one session do not keep retrying a dead server.
+     */
+    @Test
+    fun `a tripped breaker holds for its account and not for another`() = runTest {
+        stubRecent("a", "b", "c", "d")
+        var calls = 0
+        coEvery { messageRepository.refreshMessages(any(), any()) } coAnswers {
+            calls++
+            Result.Error(exception = ApiException(statusCode = 500, message = "boom"))
+        }
+        val engine = engine()
+
+        engine.run(account)
+        val afterFirstPass = calls
+        engine.run(account)
+        val afterSecondPass = calls
+        engine.run(AccountId("srv:user-b"))
+
+        assertThat(afterFirstPass).isEqualTo(PrefetchEngine.MAX_CONSECUTIVE_FAILURES)
+        assertThat(afterSecondPass).isEqualTo(afterFirstPass)
+        assertThat(calls).isGreaterThan(afterSecondPass)
+    }
+
+    @Test
+    fun `a warmed conversation records the version it was warmed against`() = runTest {
+        coEvery { conversationDao.recentForPrefetch(any(), any()) } returns
+            listOf(PrefetchCandidate("a", updatedAt = 4_242L, pinned = false))
+        coEvery { messageRepository.refreshMessages(any(), any()) } returns Result.Success(emptyList())
+
+        val watermark = slot<PrefetchWatermarkEntity>()
+        coEvery { watermarkDao.upsert(capture(watermark)) } returns Unit
+
+        engine().run(account)
+
+        // The conversation's updatedAt, not the time of the warm: only the former can answer
+        // "has the server changed since?".
+        assertThat(watermark.captured.warmedConversationUpdatedAt).isEqualTo(4_242L)
+        assertThat(watermark.captured.accountId).isEqualTo(account.value)
+    }
+
+    @Test
+    fun `pruning drops stale message rows together with their watermarks`() = runTest {
+        stubRecent("recent")
+        coEvery { messageRepository.refreshMessages(any(), any()) } returns Result.Success(emptyList())
+        coEvery { conversationDao.conversationIdsOlderThan(any(), any()) } returns listOf("ancient")
+
+        engine().run(account)
+
+        coVerify(exactly = 1) { messageDao.deleteForConversations(account.value, listOf("ancient")) }
+        // Without this the rows just deleted still look warm and are never fetched again.
+        coVerify(exactly = 1) { watermarkDao.deleteFor(account.value, listOf("ancient")) }
+    }
+
+    @Test
+    fun `pruning spares the open conversation and everything still eligible`() = runTest {
+        stubRecent("eligible")
+        openConversationRegistry.set("open")
+        coEvery { messageRepository.refreshMessages(any(), any()) } returns Result.Success(emptyList())
+        coEvery { conversationDao.conversationIdsOlderThan(any(), any()) } returns
+            listOf("eligible", "open", "genuinely-stale")
+
+        engine().run(account)
+
+        coVerify(exactly = 1) { messageDao.deleteForConversations(account.value, listOf("genuinely-stale")) }
+    }
+
+    private companion object {
+        const val REQUEST_MILLIS = 200L
+    }
+}

--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchEngineTest.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchEngineTest.kt
@@ -5,6 +5,7 @@ import com.garfiec.librechat.core.common.identity.AccountId
 import com.garfiec.librechat.core.common.network.isPrefetch
 import com.garfiec.librechat.core.common.result.ApiException
 import com.garfiec.librechat.core.common.result.Result
+import com.garfiec.librechat.core.data.datastore.SettingsDataStore
 import com.garfiec.librechat.core.data.db.dao.ConversationDao
 import com.garfiec.librechat.core.data.db.dao.MessageDao
 import com.garfiec.librechat.core.data.db.dao.PrefetchCandidate
@@ -15,13 +16,16 @@ import com.garfiec.librechat.core.data.repository.ConfigRepository
 import com.garfiec.librechat.core.data.repository.ConversationRepository
 import com.garfiec.librechat.core.data.repository.MessageRepository
 import com.garfiec.librechat.core.model.Message
+import com.garfiec.librechat.core.network.client.ServerUrlProvider
 import com.google.common.truth.Truth.assertThat
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.currentTime
@@ -50,6 +54,11 @@ class PrefetchEngineTest {
     private val configRepository = mockk<ConfigRepository>(relaxed = true)
     private val agentRepository = mockk<AgentRepository>(relaxed = true)
     private val openConversationRegistry = OpenConversationRegistry()
+    private val settingsDataStore = mockk<SettingsDataStore>(relaxed = true)
+    private val attachmentWarmer = mockk<AttachmentWarmer>(relaxed = true)
+    private val serverUrlProvider = object : ServerUrlProvider {
+        override fun getBaseUrl(): String = "https://chat.example.com"
+    }
 
     @Before
     fun setup() {
@@ -61,6 +70,8 @@ class PrefetchEngineTest {
         coEvery { watermarkDao.allForAccount(any()) } returns emptyList()
         coEvery { conversationDao.pinnedForPrefetch(any()) } returns emptyList()
         coEvery { conversationDao.conversationIdsOlderThan(any(), any()) } returns emptyList()
+        every { settingsDataStore.prefetchAttachmentsEnabled } returns flowOf(false)
+        every { attachmentWarmer.isSupported } returns false
     }
 
     private fun TestScope.engine() = PrefetchEngine(
@@ -73,6 +84,9 @@ class PrefetchEngineTest {
         agentRepository = agentRepository,
         policy = PrefetchPolicy(),
         openConversationRegistry = openConversationRegistry,
+        attachmentWarmer = attachmentWarmer,
+        settingsDataStore = settingsDataStore,
+        serverUrlProvider = serverUrlProvider,
         ioDispatcher = UnconfinedTestDispatcher(testScheduler),
         // The scheduler's own time source, so elapsedNow() follows virtual time.
         timeSource = testScheduler.timeSource,
@@ -132,6 +146,9 @@ class PrefetchEngineTest {
             agentRepository = agentRepository,
             policy = PrefetchPolicy(),
             openConversationRegistry = openConversationRegistry,
+            attachmentWarmer = attachmentWarmer,
+            settingsDataStore = settingsDataStore,
+            serverUrlProvider = serverUrlProvider,
             ioDispatcher = UnconfinedTestDispatcher(testScheduler),
             timeSource = testScheduler.timeSource,
             nowMillis = { currentTime },

--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/repository/MessageRepositoryRefreshProvenanceTest.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/repository/MessageRepositoryRefreshProvenanceTest.kt
@@ -1,0 +1,135 @@
+package com.garfiec.librechat.core.data.repository
+
+import com.garfiec.librechat.core.common.identity.AccountId
+import com.garfiec.librechat.core.common.identity.AccountState
+import com.garfiec.librechat.core.common.identity.InMemoryActiveAccountProvider
+import com.garfiec.librechat.core.common.result.Result
+import com.garfiec.librechat.core.data.datastore.AccountRoster
+import com.garfiec.librechat.core.data.db.dao.MessageDao
+import com.garfiec.librechat.core.data.mapper.toEntity
+import com.garfiec.librechat.core.model.Message
+import com.garfiec.librechat.core.network.api.MessagesApi
+import com.google.common.truth.Truth.assertThat
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * `refreshMessages` replaces a conversation's cached rows, so it is the one message path where
+ * getting provenance wrong destroys data rather than merely mislabelling it.
+ *
+ * The origin parameter guards two different things and both are asserted here: the **network** leg
+ * (a GET issued once the origin account is no longer live rides the new account's bearer and base
+ * URL, carrying this conversation id to a server that never saw it) and the **write** leg (a landing
+ * for an account that has since been removed would resurrect rows the logout purge deleted).
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class MessageRepositoryRefreshProvenanceTest {
+
+    private val messagesApi = mockk<MessagesApi>(relaxed = true)
+    private val messageDao = mockk<MessageDao>(relaxed = true)
+    private val roster = mockk<AccountRoster>(relaxed = true)
+
+    private val accountA = AccountId("srv:user-a")
+    private val accountB = AccountId("srv:user-b")
+    private val activeAccountProvider = InMemoryActiveAccountProvider(AccountState.Resolved(accountA))
+
+    private lateinit var repository: MessageRepositoryImpl
+
+    @Before
+    fun setup() {
+        repository = MessageRepositoryImpl(
+            messagesApi = messagesApi,
+            messageDao = messageDao,
+            activeAccountProvider = activeAccountProvider,
+            roster = roster,
+            dispatcher = UnconfinedTestDispatcher(),
+        )
+        coEvery { roster.contains(any()) } returns true
+        coEvery { messageDao.observeMessagesForAccount(any(), any()) } returns flowOf(emptyList())
+    }
+
+    private fun message(id: String) = Message(
+        messageId = id,
+        conversationId = "conv-1",
+        parentMessageId = null,
+        text = "hello",
+        isCreatedByUser = true,
+    )
+
+    @Test
+    fun `a foreground refresh fetches and replaces under the live account`() = runTest {
+        coEvery { messagesApi.getMessages("conv-1") } returns listOf(message("m1"))
+
+        val result = repository.refreshMessages("conv-1", originAccount = null)
+
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+        coVerify(exactly = 1) { messagesApi.getMessages("conv-1") }
+        coVerify(exactly = 1) {
+            messageDao.replaceAllForConversation("conv-1", accountA.value, any())
+        }
+    }
+
+    @Test
+    fun `an origin-captured refresh proceeds while its origin is still live`() = runTest {
+        coEvery { messagesApi.getMessages("conv-1") } returns listOf(message("m1"))
+
+        repository.refreshMessages("conv-1", originAccount = accountA)
+
+        coVerify(exactly = 1) {
+            messageDao.replaceAllForConversation("conv-1", accountA.value, any())
+        }
+    }
+
+    /**
+     * The important one. After a switch the GET must not be issued at all — not merely have its
+     * result discarded, since by then the id has already been sent to the other account's server.
+     */
+    @Test
+    fun `a refresh for a switched-away account never reaches the network`() = runTest {
+        activeAccountProvider.set(accountB)
+
+        val result = repository.refreshMessages("conv-1", originAccount = accountA)
+
+        coVerify(exactly = 0) { messagesApi.getMessages(any()) }
+        coVerify(exactly = 0) { messageDao.replaceAllForConversation(any(), any(), any()) }
+        assertThat(result).isInstanceOf(Result.Error::class.java)
+    }
+
+    /**
+     * A skip is routine, not a failure, so the cache is served when it holds something. Reporting an
+     * error over a populated cache would surface a post-switch banner for a conversation the user
+     * is no longer looking at.
+     */
+    @Test
+    fun `a skipped refresh serves the cached rows when it has them`() = runTest {
+        activeAccountProvider.set(accountB)
+        coEvery { messageDao.observeMessagesForAccount("conv-1", accountA.value) } returns
+            flowOf(listOf(message("m1").toEntity().copy(accountId = accountA.value)))
+
+        val result = repository.refreshMessages("conv-1", originAccount = accountA)
+
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+        coVerify(exactly = 0) { messagesApi.getMessages(any()) }
+    }
+
+    /**
+     * The account was removed since capture, so its rows were purged at logout. Writing here would
+     * bring them back — invisible to every account-filtered read and unreapable by the scoped purge.
+     */
+    @Test
+    fun `a refresh for a removed account does not resurrect its rows`() = runTest {
+        coEvery { roster.contains(accountA.value) } returns false
+        coEvery { messagesApi.getMessages("conv-1") } returns listOf(message("m1"))
+
+        repository.refreshMessages("conv-1", originAccount = accountA)
+
+        coVerify(exactly = 0) { messageDao.replaceAllForConversation(any(), any(), any()) }
+    }
+}

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/SettingsDataStore.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/SettingsDataStore.kt
@@ -101,6 +101,24 @@ class SettingsDataStore(
         prefs[KEY_AUTO_SCROLL_ENABLED] ?: true
     }
 
+    // Background prefetch. Deliberately global, not account-scoped — these are preferences about
+    // the device's bandwidth and battery. All default off: this spends the user's data on requests
+    // they did not make, which has to be asked for.
+
+    val prefetchEnabled: Flow<Boolean> = dataStore.data.map { prefs ->
+        prefs[KEY_PREFETCH_ENABLED] ?: false
+    }
+
+    /** Nested under [prefetchEnabled]; far heavier than the text it accompanies. */
+    val prefetchAttachmentsEnabled: Flow<Boolean> = dataStore.data.map { prefs ->
+        prefs[KEY_PREFETCH_ATTACHMENTS] ?: false
+    }
+
+    /** Overrides the unmetered-only default, for users who are mostly on cellular. */
+    val prefetchOnMeteredEnabled: Flow<Boolean> = dataStore.data.map { prefs ->
+        prefs[KEY_PREFETCH_ON_METERED] ?: false
+    }
+
     val showThinkingBlocks: Flow<Boolean> = dataStore.data.map { prefs ->
         prefs[KEY_SHOW_THINKING_BLOCKS] ?: true
     }
@@ -342,6 +360,24 @@ class SettingsDataStore(
     suspend fun setAutoScrollEnabled(enabled: Boolean) {
         dataStore.edit { prefs ->
             prefs[KEY_AUTO_SCROLL_ENABLED] = enabled
+        }
+    }
+
+    suspend fun setPrefetchEnabled(enabled: Boolean) {
+        dataStore.edit { prefs ->
+            prefs[KEY_PREFETCH_ENABLED] = enabled
+        }
+    }
+
+    suspend fun setPrefetchAttachmentsEnabled(enabled: Boolean) {
+        dataStore.edit { prefs ->
+            prefs[KEY_PREFETCH_ATTACHMENTS] = enabled
+        }
+    }
+
+    suspend fun setPrefetchOnMeteredEnabled(enabled: Boolean) {
+        dataStore.edit { prefs ->
+            prefs[KEY_PREFETCH_ON_METERED] = enabled
         }
     }
 
@@ -677,6 +713,9 @@ class SettingsDataStore(
         private val KEY_CHAT_HEADER_CONTENT = stringPreferencesKey("chat_header_content")
         private val KEY_CHAT_HEADER_ALIGNMENT = stringPreferencesKey("chat_header_alignment")
         private val KEY_AUTO_SCROLL_ENABLED = booleanPreferencesKey("auto_scroll_enabled")
+        private val KEY_PREFETCH_ENABLED = booleanPreferencesKey("prefetch_enabled")
+        private val KEY_PREFETCH_ATTACHMENTS = booleanPreferencesKey("prefetch_attachments")
+        private val KEY_PREFETCH_ON_METERED = booleanPreferencesKey("prefetch_on_metered")
         private val KEY_SHOW_THINKING_BLOCKS = booleanPreferencesKey("show_thinking_blocks")
         private val KEY_CONTEXT_BAR_PLACEMENT = stringPreferencesKey("context_bar_placement")
         private val KEY_DURING_RUN_ACTION = stringPreferencesKey("during_run_action")

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/db/LibreChatDatabase.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/db/LibreChatDatabase.kt
@@ -14,6 +14,7 @@ import com.garfiec.librechat.core.data.db.dao.ConversationDao
 import com.garfiec.librechat.core.data.db.dao.ConversationTagDao
 import com.garfiec.librechat.core.data.db.dao.DraftDao
 import com.garfiec.librechat.core.data.db.dao.MessageDao
+import com.garfiec.librechat.core.data.db.dao.PrefetchWatermarkDao
 import com.garfiec.librechat.core.data.db.dao.PresetDao
 import com.garfiec.librechat.core.data.db.dao.ServerDao
 import com.garfiec.librechat.core.data.db.entity.AgentEntity
@@ -22,6 +23,7 @@ import com.garfiec.librechat.core.data.db.entity.ConversationEntity
 import com.garfiec.librechat.core.data.db.entity.ConversationTagEntity
 import com.garfiec.librechat.core.data.db.entity.DraftEntity
 import com.garfiec.librechat.core.data.db.entity.MessageEntity
+import com.garfiec.librechat.core.data.db.entity.PrefetchWatermarkEntity
 import com.garfiec.librechat.core.data.db.entity.PresetEntity
 import com.garfiec.librechat.core.data.db.entity.ServerEntity
 
@@ -35,8 +37,9 @@ import com.garfiec.librechat.core.data.db.entity.ServerEntity
         DraftEntity::class,
         ArtifactShortcutEntity::class,
         ServerEntity::class,
+        PrefetchWatermarkEntity::class,
     ],
-    version = 8,
+    version = 9,
     exportSchema = true,
     autoMigrations = [
         AutoMigration(from = 1, to = 2),
@@ -52,6 +55,8 @@ import com.garfiec.librechat.core.data.db.entity.ServerEntity
         AutoMigration(from = 6, to = 7),
         // 7 -> 8 adds the device-scoped servers table (per-deployment registry; gateway headers).
         AutoMigration(from = 7, to = 8),
+        // 8 -> 9 adds the account-scoped prefetch_watermarks table (background cache warming).
+        AutoMigration(from = 8, to = 9),
     ],
 )
 @TypeConverters(Converters::class)
@@ -66,6 +71,7 @@ abstract class LibreChatDatabase : RoomDatabase() {
     abstract fun accountClaimDao(): AccountClaimDao
     abstract fun artifactShortcutDao(): ArtifactShortcutDao
     abstract fun serverDao(): ServerDao
+    abstract fun prefetchWatermarkDao(): PrefetchWatermarkDao
 }
 
 // Room KSP auto-generates the actual implementations for each platform

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/db/dao/ConversationDao.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/db/dao/ConversationDao.kt
@@ -8,6 +8,13 @@ import com.garfiec.librechat.core.common.identity.CrossAccount
 import com.garfiec.librechat.core.data.db.entity.ConversationEntity
 import kotlinx.coroutines.flow.Flow
 
+/** The three columns the prefetcher's selection and freshness rules need. */
+data class PrefetchCandidate(
+    val conversationId: String,
+    val updatedAt: Long,
+    val pinned: Boolean,
+)
+
 @Dao
 interface ConversationDao {
 
@@ -25,6 +32,25 @@ interface ConversationDao {
 
     @Query("SELECT * FROM conversations WHERE conversationId = :id AND accountId = :accountId")
     fun observeByIdForAccount(id: String, accountId: String): Flow<ConversationEntity?>
+
+    // --- Background prefetch. Projections rather than entities: the prefetcher needs three columns
+    // and reading the entity would decode the `tags` JSON of every row for nothing. ---
+
+    @Query(
+        "SELECT conversationId, updatedAt, pinned FROM conversations " +
+            "WHERE accountId = :accountId AND isArchived = 0 ORDER BY updatedAt DESC LIMIT :limit",
+    )
+    suspend fun recentForPrefetch(accountId: String, limit: Int): List<PrefetchCandidate>
+
+    @Query(
+        "SELECT conversationId, updatedAt, pinned FROM conversations " +
+            "WHERE accountId = :accountId AND isArchived = 0 AND pinned = 1",
+    )
+    suspend fun pinnedForPrefetch(accountId: String): List<PrefetchCandidate>
+
+    /** Prune candidates. Archived rows are included: they are the least likely to be reopened. */
+    @Query("SELECT conversationId FROM conversations WHERE accountId = :accountId AND updatedAt < :cutoff")
+    suspend fun conversationIdsOlderThan(accountId: String, cutoff: Long): List<String>
 
     @Upsert
     suspend fun upsert(conversation: ConversationEntity)

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/db/dao/MessageDao.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/db/dao/MessageDao.kt
@@ -57,4 +57,12 @@ interface MessageDao {
     // Logout / account-remove scoped purge (the leak fix): delete only this account's rows.
     @Query("DELETE FROM messages WHERE accountId = :accountId")
     suspend fun deleteAllForAccount(accountId: String)
+
+    /**
+     * Prune: drops cached messages for conversations the prefetcher no longer keeps warm. The
+     * conversation rows themselves stay, so the list remains complete and reopening one simply
+     * re-fetches. Chunk the ids — SQLite binds at most ~999 variables per statement.
+     */
+    @Query("DELETE FROM messages WHERE accountId = :accountId AND conversationId IN (:conversationIds)")
+    suspend fun deleteForConversations(accountId: String, conversationIds: List<String>)
 }

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/db/dao/PrefetchWatermarkDao.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/db/dao/PrefetchWatermarkDao.kt
@@ -1,0 +1,32 @@
+package com.garfiec.librechat.core.data.db.dao
+
+import androidx.room.Dao
+import androidx.room.Query
+import androidx.room.Upsert
+import com.garfiec.librechat.core.data.db.entity.PrefetchWatermarkEntity
+
+/**
+ * Every query is account-scoped. `prefetch_watermarks` is not one of the tables the tenancy detekt
+ * rule infers, so nothing would fail the build if it weren't — which is exactly why it is written
+ * that way by hand rather than left to the rule.
+ */
+@Dao
+interface PrefetchWatermarkDao {
+
+    @Query("SELECT * FROM prefetch_watermarks WHERE accountId = :accountId")
+    suspend fun allForAccount(accountId: String): List<PrefetchWatermarkEntity>
+
+    @Upsert
+    suspend fun upsert(watermark: PrefetchWatermarkEntity)
+
+    /**
+     * Drops watermarks alongside the message rows they describe. Deleting messages without this
+     * leaves the conversation looking permanently warm, so it is never re-fetched and never
+     * repopulates — call the two together.
+     */
+    @Query("DELETE FROM prefetch_watermarks WHERE accountId = :accountId AND conversationId IN (:conversationIds)")
+    suspend fun deleteFor(accountId: String, conversationIds: List<String>)
+
+    @Query("DELETE FROM prefetch_watermarks WHERE accountId = :accountId")
+    suspend fun deleteAllForAccount(accountId: String)
+}

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/db/entity/PrefetchWatermarkEntity.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/db/entity/PrefetchWatermarkEntity.kt
@@ -1,0 +1,29 @@
+package com.garfiec.librechat.core.data.db.entity
+
+import androidx.room.Entity
+
+/**
+ * What the background prefetcher had when it last warmed a conversation's messages.
+ *
+ * Change detection needs a value the server's `updatedAt` can be compared against, and
+ * [ConversationEntity] cannot hold it: that row is a server mirror, overwritten on every list sync,
+ * so a locally-written column there would be reset by the very sync that reports the change.
+ *
+ * [warmedConversationUpdatedAt] is the conversation's `updatedAt` **as it was when we warmed it** —
+ * not the time we warmed it. A thread is re-warmed exactly when the server reports a newer value,
+ * which is why this feature needs no TTL: an unchanged thread is never re-fetched at all.
+ *
+ * Must be deleted with the account by `AccountDataPurger`: otherwise a re-login finds watermarks for
+ * rows the purge already removed and skips warming them.
+ */
+@Entity(
+    tableName = "prefetch_watermarks",
+    primaryKeys = ["accountId", "conversationId"],
+)
+data class PrefetchWatermarkEntity(
+    val accountId: String,
+    val conversationId: String,
+    val warmedConversationUpdatedAt: Long,
+    /** Wall clock of the last warm. Diagnostics only — nothing branches on it. */
+    val warmedAt: Long,
+)

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/di/DataModule.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/di/DataModule.kt
@@ -13,6 +13,10 @@ import com.garfiec.librechat.core.data.datastore.ServerDataStore
 import com.garfiec.librechat.core.data.datastore.SettingsDataStore
 import com.garfiec.librechat.core.data.datastore.ThemeDataStore
 import com.garfiec.librechat.core.data.db.LibreChatDatabase
+import com.garfiec.librechat.core.data.prefetch.PrefetchController
+import com.garfiec.librechat.core.data.prefetch.PrefetchEngine
+import com.garfiec.librechat.core.data.prefetch.PrefetchGate
+import com.garfiec.librechat.core.data.prefetch.PrefetchPolicy
 import com.garfiec.librechat.core.data.repository.AccountClaimReconciler
 import com.garfiec.librechat.core.data.repository.AccountDataPurger
 import com.garfiec.librechat.core.data.repository.AccountSessionEstablisher
@@ -114,6 +118,7 @@ val dataModule = module {
     single { get<LibreChatDatabase>().accountClaimDao() }
     single { get<LibreChatDatabase>().artifactShortcutDao() }
     single { get<LibreChatDatabase>().serverDao() }
+    single { get<LibreChatDatabase>().prefetchWatermarkDao() }
 
     // --- Account identity (row-tenancy) ---
 
@@ -175,12 +180,13 @@ val dataModule = module {
             messageDao = get(),
             draftDao = get(),
             tagDao = get(),
+            prefetchWatermarkDao = get(),
             ioDispatcher = get(KoinQualifiers.IO),
         )
     }
-    // Sole owner of account-Session transitions. Lazy (not createdAtStart): instantiated when the
-    // logout path (AuthRepositoryImpl) first resolves it, at which point its collector starts. Its
-    // `current` session flow has no consumer yet — the SessionWriter facade that would is deferred.
+    // Sole owner of account-Session transitions. Constructed eagerly in practice, because
+    // PrefetchController (createdAtStart) resolves it: `current` now has a consumer, so the
+    // collector starts at Koin start rather than when the logout path first resolves it.
     single {
         SessionManager(
             activeAccountProvider = get(),
@@ -271,6 +277,36 @@ val dataModule = module {
         SessionTaskRunner(
             tasks = getAll<SessionTask>(),
             applicationScope = get<CoroutineScope>(KoinQualifiers.ApplicationScope),
+        )
+    }
+
+    // --- Background prefetch (opt-in, off by default) ---
+
+    singleOf(::PrefetchPolicy)
+    singleOf(::PrefetchGate)
+    single {
+        PrefetchEngine(
+            conversationDao = get(),
+            messageDao = get(),
+            watermarkDao = get(),
+            messageRepository = get(),
+            conversationRepository = get(),
+            configRepository = get(),
+            agentRepository = get(),
+            policy = get(),
+            openConversationRegistry = get(),
+            ioDispatcher = get(KoinQualifiers.IO),
+        )
+    }
+    // Eager: its entire job is to collect SessionManager.current, so a lazy binding nobody resolves
+    // would simply never start. Not a SessionTask — those fire on login, cold start and switch, but
+    // never on a return to the foreground, which is most of when this should run.
+    single(createdAtStart = true) {
+        PrefetchController(
+            sessionManager = get(),
+            gate = get(),
+            engine = get(),
+            appScope = get<CoroutineScope>(KoinQualifiers.ApplicationScope),
         )
     }
 

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/di/DataModule.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/di/DataModule.kt
@@ -184,9 +184,9 @@ val dataModule = module {
             ioDispatcher = get(KoinQualifiers.IO),
         )
     }
-    // Sole owner of account-Session transitions. Constructed eagerly in practice, because
-    // PrefetchController (createdAtStart) resolves it: `current` now has a consumer, so the
-    // collector starts at Koin start rather than when the logout path first resolves it.
+    // Sole owner of account-Session transitions. Lazy, but constructed at Koin start in practice
+    // because PrefetchController (createdAtStart) resolves it — so its collector is running before
+    // the logout path ever asks for it.
     single {
         SessionManager(
             activeAccountProvider = get(),
@@ -295,6 +295,9 @@ val dataModule = module {
             agentRepository = get(),
             policy = get(),
             openConversationRegistry = get(),
+            attachmentWarmer = get(),
+            settingsDataStore = get(),
+            serverUrlProvider = get(),
             ioDispatcher = get(KoinQualifiers.IO),
         )
     }

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/prefetch/AttachmentWarmer.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/prefetch/AttachmentWarmer.kt
@@ -1,0 +1,19 @@
+package com.garfiec.librechat.core.data.prefetch
+
+/**
+ * Pulls image bytes into the platform image cache ahead of time.
+ *
+ * Keep image-library types out of this signature: it is what lets `:core:data` avoid a dependency
+ * on the image loader, and what lets a platform with no disk cache bind a no-op.
+ */
+interface AttachmentWarmer {
+
+    /**
+     * True when warming actually caches anything on this platform. The settings UI hides the toggle
+     * when it does not — a switch that silently does nothing is worse than an absent one.
+     */
+    val isSupported: Boolean
+
+    /** Fetches [url] into the image cache. Failures are not worth reporting: this is opportunistic. */
+    suspend fun warm(url: String)
+}

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchController.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchController.kt
@@ -1,0 +1,40 @@
+package com.garfiec.librechat.core.data.prefetch
+
+import com.garfiec.librechat.core.common.identity.SessionManager
+import com.garfiec.librechat.core.logging.Diag
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+
+/**
+ * Starts and stops the prefetcher.
+ *
+ * Passes must keep running in the [com.garfiec.librechat.core.common.identity.Session]'s own scope.
+ * That is what makes account attribution structural — `Session.accountId` is captured when identity
+ * resolves and never changes, so no suspend point can move a warmed conversation onto another
+ * account — and what cancels in-flight work on a switch, since ending a session cancels its scope.
+ */
+class PrefetchController(
+    private val sessionManager: SessionManager,
+    private val gate: PrefetchGate,
+    private val engine: PrefetchEngine,
+    appScope: CoroutineScope,
+) {
+
+    init {
+        appScope.launch {
+            sessionManager.current.collectLatest { session ->
+                if (session == null) return@collectLatest
+                session.scope.launch {
+                    // collectLatest, not collect: it is the only thing that cancels an in-flight
+                    // pass when the gate closes. There is no per-condition teardown anywhere else.
+                    gate.isOpen().collectLatest { open ->
+                        if (!open) return@collectLatest
+                        Diag.d("Prefetch") { "gate opened" }
+                        engine.run(session.accountId)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchEngine.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchEngine.kt
@@ -5,6 +5,7 @@ import com.garfiec.librechat.core.common.identity.AccountId
 import com.garfiec.librechat.core.common.network.PrefetchMarker
 import com.garfiec.librechat.core.common.result.ApiException
 import com.garfiec.librechat.core.common.result.Result
+import com.garfiec.librechat.core.data.datastore.SettingsDataStore
 import com.garfiec.librechat.core.data.db.dao.ConversationDao
 import com.garfiec.librechat.core.data.db.dao.MessageDao
 import com.garfiec.librechat.core.data.db.dao.PrefetchCandidate
@@ -15,9 +16,15 @@ import com.garfiec.librechat.core.data.repository.ConfigRepository
 import com.garfiec.librechat.core.data.repository.ConversationRepository
 import com.garfiec.librechat.core.data.repository.MessageRepository
 import com.garfiec.librechat.core.logging.Diag
+import com.garfiec.librechat.core.model.Message
+import com.garfiec.librechat.core.model.media.resolveAttachmentUrl
+import com.garfiec.librechat.core.model.media.resolveFileReferenceUrl
+import com.garfiec.librechat.core.model.media.resolveImageFilePartUrl
+import com.garfiec.librechat.core.network.client.ServerUrlProvider
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
 import kotlin.time.Clock
 import kotlin.time.Duration
@@ -30,19 +37,15 @@ import kotlin.time.TimeSource
  * Warms the cache for the conversations the user is likeliest to open next, one request at a time,
  * only while [PrefetchGate] is open.
  *
- * Everything here is shaped by one rule: this work is optional, so it yields to anything that isn't.
- * The gate cancels it rather than it polling for permission; it never runs two requests at once; and
- * it paces itself against the server's own observed latency rather than a fixed interval, so a slow
- * or loaded server automatically gets asked less often.
- *
- * A pass runs in three stages, and the order is load-bearing:
+ * A pass runs in four stages, and the order is load-bearing:
  *
  * 1. **Refresh the conversation list.** Freshness is decided by comparing each conversation's
  *    `updatedAt` against the watermark from its last warm — and that `updatedAt` is read from Room.
  *    Without syncing the list first the engine compares watermarks against the same stale timestamps
  *    it wrote them from, concludes nothing has changed, and never warms anything again.
  * 2. **Warm messages** for whatever that reveals as stale.
- * 3. **Prune** message rows for conversations that have aged out of the warm set.
+ * 3. **Warm ancillary reference data** — endpoints, models, agents — once per account per process.
+ * 4. **Prune** message rows for conversations that have aged out of the warm set.
  */
 class PrefetchEngine(
     private val conversationDao: ConversationDao,
@@ -54,20 +57,21 @@ class PrefetchEngine(
     private val agentRepository: AgentRepository,
     private val policy: PrefetchPolicy,
     private val openConversationRegistry: OpenConversationRegistry,
+    private val attachmentWarmer: AttachmentWarmer,
+    private val settingsDataStore: SettingsDataStore,
+    private val serverUrlProvider: ServerUrlProvider,
     private val ioDispatcher: CoroutineDispatcher,
-    // Defaulted rather than injected: both are test seams, and a bare function type is not something
-    // Koin can resolve — supplying them from the module would need `Function0` whitelisted in the
-    // graph verification, which would then stop catching genuinely unresolvable dependencies.
+    // Test seams; keep them defaulted rather than injected. Supplying them from the module would
+    // need `Function0` whitelisted in the graph verification, which would then stop catching
+    // genuinely unresolvable dependencies.
     private val timeSource: TimeSource = TimeSource.Monotonic,
     private val nowMillis: () -> Long = { Clock.System.now().toEpochMilliseconds() },
 ) {
 
     /**
-     * The account whose pass gave up, if any.
-     *
-     * Keyed by account rather than a plain flag because this engine is a singleton that outlives any
-     * one session: keyed, a switch or re-login starts clean, while repeated gate flips within one
-     * session do not keep retrying a server that has already failed three times in a row.
+     * The account whose pass gave up, if any. Must stay keyed by account, not a flag: this engine is
+     * a singleton outliving any one session, so a flag would either survive a switch or reset on
+     * every gate flip and keep retrying a dead server.
      */
     private var trippedForAccountId: String? = null
 
@@ -161,6 +165,7 @@ class PrefetchEngine(
                     is StepOutcome.Ok -> {
                         consecutiveFailures = 0
                         recordWatermark(candidate)
+                        warmAttachments((result as Result.Success).data)
                     }
                     // Rate limiting means "slower", not "broken", so it deliberately does not count
                     // toward the breaker — the server is answering, it is just asking us to wait.
@@ -220,6 +225,30 @@ class PrefetchEngine(
             Diag.d("Prefetch", attrs = mapOf("pruned" to prunable.size.toString())) { "pruned stale message cache" }
         }
 
+        /**
+         * Pulls a thread's images into the image cache, behind its own opt-in. Each image is a
+         * request and stays paced like every other one — images are megabytes where the text is
+         * kilobytes, so a burst here is what would flood the connection.
+         */
+        private suspend fun warmAttachments(messages: List<Message>) {
+            if (!attachmentWarmer.isSupported) return
+            if (!settingsDataStore.prefetchAttachmentsEnabled.first()) return
+
+            val baseUrl = serverUrlProvider.getBaseUrl()
+            if (baseUrl.isBlank()) return
+
+            messages.asSequence()
+                .flatMap { imageUrlsOf(it, baseUrl) }
+                .distinct()
+                .take(MAX_ATTACHMENTS_PER_CONVERSATION)
+                .toList()
+                .forEach { url ->
+                    val start = timeSource.markNow()
+                    attachmentWarmer.warm(url)
+                    delay(paceAfter(start.elapsedNow()))
+                }
+        }
+
         private suspend fun recordWatermark(candidate: PrefetchCandidate) {
             // Watermark the value fetched against, not "now": the question this answers is "has the
             // server changed since?", which a wall-clock time cannot.
@@ -235,7 +264,6 @@ class PrefetchEngine(
             }
         }
 
-        /** Runs a paced, breaker-counted step whose result is not otherwise used. */
         private suspend fun runStep(block: suspend () -> Result<*>) {
             val start = timeSource.markNow()
             val result = block()
@@ -259,6 +287,19 @@ class PrefetchEngine(
             return true
         }
     }
+
+    /**
+     * Every image URL a message would render, resolved exactly the way the UI resolves them — via
+     * the shared resolver in `:core:model`, so a warmed entry is a cache hit for the composable that
+     * later asks for it rather than a near-miss under a slightly different URL.
+     */
+    private fun imageUrlsOf(message: Message, baseUrl: String): Sequence<String> = sequence {
+        message.files?.forEach { file -> resolveFileReferenceUrl(file, baseUrl)?.let { yield(it) } }
+        message.attachments?.forEach { attachment ->
+            resolveAttachmentUrl(attachment, baseUrl)?.let { yield(it) }
+        }
+        message.content?.forEach { part -> resolveImageFilePartUrl(part, baseUrl)?.let { yield(it) } }
+    }.filterNot { it.startsWith(DATA_URI_PREFIX) } // Already inline; there is nothing to fetch.
 
     private fun outcomeOf(result: Result<*>): StepOutcome = when (result) {
         is Result.Success -> StepOutcome.Ok
@@ -299,6 +340,10 @@ class PrefetchEngine(
 
         private const val HTTP_TOO_MANY_REQUESTS = 429
         private const val PRUNE_CHUNK = 400
+
+        /** Ceiling per conversation. A single thread of screenshots must not become the whole pass. */
+        private const val MAX_ATTACHMENTS_PER_CONVERSATION = 20
+        private const val DATA_URI_PREFIX = "data:"
         private val MIN_PACE = 250.milliseconds
         private val MAX_PACE = 30.seconds
         private val DEFAULT_RATE_LIMIT_BACKOFF = 60.seconds

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchEngine.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchEngine.kt
@@ -1,0 +1,307 @@
+package com.garfiec.librechat.core.data.prefetch
+
+import com.garfiec.librechat.core.common.conversation.OpenConversationRegistry
+import com.garfiec.librechat.core.common.identity.AccountId
+import com.garfiec.librechat.core.common.network.PrefetchMarker
+import com.garfiec.librechat.core.common.result.ApiException
+import com.garfiec.librechat.core.common.result.Result
+import com.garfiec.librechat.core.data.db.dao.ConversationDao
+import com.garfiec.librechat.core.data.db.dao.MessageDao
+import com.garfiec.librechat.core.data.db.dao.PrefetchCandidate
+import com.garfiec.librechat.core.data.db.dao.PrefetchWatermarkDao
+import com.garfiec.librechat.core.data.db.entity.PrefetchWatermarkEntity
+import com.garfiec.librechat.core.data.repository.AgentRepository
+import com.garfiec.librechat.core.data.repository.ConfigRepository
+import com.garfiec.librechat.core.data.repository.ConversationRepository
+import com.garfiec.librechat.core.data.repository.MessageRepository
+import com.garfiec.librechat.core.logging.Diag
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
+import kotlin.time.Clock
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.TimeSource
+
+/**
+ * Warms the cache for the conversations the user is likeliest to open next, one request at a time,
+ * only while [PrefetchGate] is open.
+ *
+ * Everything here is shaped by one rule: this work is optional, so it yields to anything that isn't.
+ * The gate cancels it rather than it polling for permission; it never runs two requests at once; and
+ * it paces itself against the server's own observed latency rather than a fixed interval, so a slow
+ * or loaded server automatically gets asked less often.
+ *
+ * A pass runs in three stages, and the order is load-bearing:
+ *
+ * 1. **Refresh the conversation list.** Freshness is decided by comparing each conversation's
+ *    `updatedAt` against the watermark from its last warm — and that `updatedAt` is read from Room.
+ *    Without syncing the list first the engine compares watermarks against the same stale timestamps
+ *    it wrote them from, concludes nothing has changed, and never warms anything again.
+ * 2. **Warm messages** for whatever that reveals as stale.
+ * 3. **Prune** message rows for conversations that have aged out of the warm set.
+ */
+class PrefetchEngine(
+    private val conversationDao: ConversationDao,
+    private val messageDao: MessageDao,
+    private val watermarkDao: PrefetchWatermarkDao,
+    private val messageRepository: MessageRepository,
+    private val conversationRepository: ConversationRepository,
+    private val configRepository: ConfigRepository,
+    private val agentRepository: AgentRepository,
+    private val policy: PrefetchPolicy,
+    private val openConversationRegistry: OpenConversationRegistry,
+    private val ioDispatcher: CoroutineDispatcher,
+    // Defaulted rather than injected: both are test seams, and a bare function type is not something
+    // Koin can resolve — supplying them from the module would need `Function0` whitelisted in the
+    // graph verification, which would then stop catching genuinely unresolvable dependencies.
+    private val timeSource: TimeSource = TimeSource.Monotonic,
+    private val nowMillis: () -> Long = { Clock.System.now().toEpochMilliseconds() },
+) {
+
+    /**
+     * The account whose pass gave up, if any.
+     *
+     * Keyed by account rather than a plain flag because this engine is a singleton that outlives any
+     * one session: keyed, a switch or re-login starts clean, while repeated gate flips within one
+     * session do not keep retrying a server that has already failed three times in a row.
+     */
+    private var trippedForAccountId: String? = null
+
+    /** Accounts whose slow-moving reference data has been warmed once this process. */
+    private val ancillaryWarmed = mutableSetOf<String>()
+
+    suspend fun run(accountId: AccountId) {
+        if (trippedForAccountId == accountId.value) return
+
+        // Everything below is marked, so none of these requests count as user activity. Without it
+        // the engine's own first request closes the gate that permits it and the pass deadlocks —
+        // silently, since a closed gate is indistinguishable from a busy user.
+        withContext(PrefetchMarker) {
+            val pass = Pass(accountId)
+
+            if (!pass.warmConversationList()) return@withContext
+            val eligible = pass.eligible()
+            if (!pass.warmMessages(eligible)) return@withContext
+            pass.warmAncillary()
+            pass.prune(eligible)
+        }
+    }
+
+    /**
+     * One pass's mutable bookkeeping. Held here rather than on the engine so a cancelled pass leaves
+     * nothing behind — only the breaker and the ancillary set outlive a pass, and both are keyed by
+     * account deliberately.
+     */
+    private inner class Pass(private val accountId: AccountId) {
+
+        private var consecutiveFailures = 0
+
+        /** Returns false when the pass should stop because the breaker tripped. */
+        suspend fun warmConversationList(): Boolean {
+            var cursor: String? = null
+            var page = 0
+            do {
+                val start = timeSource.markNow()
+                val result = conversationRepository.loadNextPage(cursor = cursor)
+                val elapsed = start.elapsedNow()
+
+                cursor = when (val outcome = outcomeOf(result)) {
+                    is StepOutcome.Ok -> {
+                        consecutiveFailures = 0
+                        (result as Result.Success).data
+                    }
+                    is StepOutcome.RateLimited -> {
+                        delay(outcome.backoff)
+                        return true // Stop paging; messages will still be warmed on stale data.
+                    }
+                    StepOutcome.Failed -> return !tripBreaker()
+                }
+                page++
+                delay(paceAfter(elapsed))
+            } while (cursor != null && page <= EXTRA_LIST_PAGES)
+            return true
+        }
+
+        suspend fun eligible(): List<PrefetchCandidate> = withContext(ioDispatcher) {
+            policy.eligible(
+                recent = conversationDao.recentForPrefetch(accountId.value, PrefetchPolicy.RECENT_LIMIT),
+                pinned = conversationDao.pinnedForPrefetch(accountId.value),
+            )
+        }
+
+        /** Returns false when the breaker tripped partway through. */
+        suspend fun warmMessages(eligible: List<PrefetchCandidate>): Boolean {
+            val watermarks = withContext(ioDispatcher) {
+                watermarkDao.allForAccount(accountId.value)
+                    .associate { it.conversationId to it.warmedConversationUpdatedAt }
+            }
+            val work = policy.selectWork(
+                eligible = eligible,
+                watermarks = watermarks,
+                openConversationId = openConversationRegistry.openConversationId.value,
+            )
+            Diag.d(
+                "Prefetch",
+                attrs = mapOf("eligible" to eligible.size.toString(), "stale" to work.size.toString()),
+            ) { "warming messages" }
+
+            for (candidate in work) {
+                val start = timeSource.markNow()
+                val result = messageRepository.refreshMessages(
+                    candidate.conversationId,
+                    originAccount = accountId,
+                )
+                val elapsed = start.elapsedNow()
+
+                when (val outcome = outcomeOf(result)) {
+                    is StepOutcome.Ok -> {
+                        consecutiveFailures = 0
+                        recordWatermark(candidate)
+                    }
+                    // Rate limiting means "slower", not "broken", so it deliberately does not count
+                    // toward the breaker — the server is answering, it is just asking us to wait.
+                    is StepOutcome.RateLimited -> {
+                        Diag.d(
+                            "Prefetch",
+                            attrs = mapOf("backoffMs" to outcome.backoff.inWholeMilliseconds.toString()),
+                        ) { "rate limited" }
+                        delay(outcome.backoff)
+                        continue
+                    }
+                    StepOutcome.Failed -> if (tripBreaker()) return false
+                }
+                delay(paceAfter(elapsed))
+            }
+            return true
+        }
+
+        /**
+         * Endpoints, models and the agent list: small, slow-moving, and needed by the first screen
+         * the user opens. Warmed once per account per process rather than every pass — a pass runs
+         * whenever the user goes idle, and re-fetching reference data that rarely changes on each of
+         * those would be most of the prefetcher's traffic.
+         */
+        suspend fun warmAncillary() {
+            if (!ancillaryWarmed.add(accountId.value)) return
+            runStep { configRepository.fetchEndpoints() }
+            runStep { configRepository.fetchModels() }
+            runStep { agentRepository.getAgents() }
+        }
+
+        /**
+         * Drops cached messages for conversations that have fallen out of the warm set and have not
+         * been touched in [PRUNE_AGE]. Conversation rows themselves are kept, so the list stays
+         * complete and reopening a pruned thread simply fetches it again.
+         */
+        suspend fun prune(eligible: List<PrefetchCandidate>) = withContext(ioDispatcher) {
+            val cutoff = nowMillis() - PRUNE_AGE.inWholeMilliseconds
+            val stale = conversationDao.conversationIdsOlderThan(accountId.value, cutoff)
+            val protectedIds = policy.protectedFromPruning(
+                eligible = eligible,
+                openConversationId = openConversationRegistry.openConversationId.value,
+            )
+            val prunable = stale.filterNot { it in protectedIds }
+            if (prunable.isEmpty()) return@withContext
+
+            // Chunked because SQLite binds at most ~999 variables per statement, and the first prune
+            // on a long-lived install is exactly where that limit is met.
+            prunable.chunked(PRUNE_CHUNK).forEach { chunk ->
+                withContext(NonCancellable) {
+                    messageDao.deleteForConversations(accountId.value, chunk)
+                    // Together, always: a watermark left behind reports its conversation as warm, so
+                    // the rows just deleted would never be fetched again.
+                    watermarkDao.deleteFor(accountId.value, chunk)
+                }
+            }
+            Diag.d("Prefetch", attrs = mapOf("pruned" to prunable.size.toString())) { "pruned stale message cache" }
+        }
+
+        private suspend fun recordWatermark(candidate: PrefetchCandidate) {
+            // Watermark the value fetched against, not "now": the question this answers is "has the
+            // server changed since?", which a wall-clock time cannot.
+            withContext(ioDispatcher + NonCancellable) {
+                watermarkDao.upsert(
+                    PrefetchWatermarkEntity(
+                        accountId = accountId.value,
+                        conversationId = candidate.conversationId,
+                        warmedConversationUpdatedAt = candidate.updatedAt,
+                        warmedAt = nowMillis(),
+                    ),
+                )
+            }
+        }
+
+        /** Runs a paced, breaker-counted step whose result is not otherwise used. */
+        private suspend fun runStep(block: suspend () -> Result<*>) {
+            val start = timeSource.markNow()
+            val result = block()
+            val elapsed = start.elapsedNow()
+            when (val outcome = outcomeOf(result)) {
+                is StepOutcome.Ok -> consecutiveFailures = 0
+                is StepOutcome.RateLimited -> delay(outcome.backoff)
+                StepOutcome.Failed -> tripBreaker()
+            }
+            delay(paceAfter(elapsed))
+        }
+
+        /** Counts a failure; returns true once the pass should stop. */
+        private fun tripBreaker(): Boolean {
+            consecutiveFailures++
+            if (consecutiveFailures < MAX_CONSECUTIVE_FAILURES) return false
+            // Give up for this account rather than working through the whole list against a server
+            // that is plainly not answering.
+            trippedForAccountId = accountId.value
+            Diag.w("Prefetch") { "prefetch stopped after $MAX_CONSECUTIVE_FAILURES consecutive failures" }
+            return true
+        }
+    }
+
+    private fun outcomeOf(result: Result<*>): StepOutcome = when (result) {
+        is Result.Success -> StepOutcome.Ok
+        is Result.Loading -> StepOutcome.Failed
+        is Result.Error -> {
+            val api = result.exception as? ApiException
+            if (api?.statusCode == HTTP_TOO_MANY_REQUESTS) {
+                // Honour the server's own number when it sent one; otherwise wait a fixed period
+                // rather than not at all, since the one thing a 429 rules out is retrying now.
+                StepOutcome.RateLimited(api.retryAfterSeconds?.seconds ?: DEFAULT_RATE_LIMIT_BACKOFF)
+            } else {
+                StepOutcome.Failed
+            }
+        }
+    }
+
+    /**
+     * Wait proportionally to how long the last request took, so the prefetcher's share of the server
+     * shrinks as the server slows down. Clamped at both ends: a fast local server should not be
+     * hammered, and one request that burns the full 30s timeout should not stall the pass for two
+     * and a half minutes.
+     */
+    private fun paceAfter(elapsed: Duration): Duration =
+        (elapsed * PACE_FACTOR).coerceIn(MIN_PACE, MAX_PACE)
+
+    private sealed interface StepOutcome {
+        data object Ok : StepOutcome
+        data class RateLimited(val backoff: Duration) : StepOutcome
+        data object Failed : StepOutcome
+    }
+
+    companion object {
+        const val PACE_FACTOR = 5
+        const val MAX_CONSECUTIVE_FAILURES = 3
+
+        /** Pages of the conversation list to warm beyond the first. */
+        const val EXTRA_LIST_PAGES = 2
+
+        private const val HTTP_TOO_MANY_REQUESTS = 429
+        private const val PRUNE_CHUNK = 400
+        private val MIN_PACE = 250.milliseconds
+        private val MAX_PACE = 30.seconds
+        private val DEFAULT_RATE_LIMIT_BACKOFF = 60.seconds
+        private val PRUNE_AGE = 90.days
+    }
+}

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchGate.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchGate.kt
@@ -1,0 +1,47 @@
+package com.garfiec.librechat.core.data.prefetch
+
+import com.garfiec.librechat.core.common.lifecycle.ForegroundSignal
+import com.garfiec.librechat.core.common.network.NetworkConditionObserver
+import com.garfiec.librechat.core.common.network.RequestActivityTracker
+import com.garfiec.librechat.core.common.power.PowerStateObserver
+import com.garfiec.librechat.core.data.datastore.SettingsDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+
+/**
+ * The single answer to "may background prefetching run right now".
+ *
+ * Everything that should stop the prefetcher is folded into one boolean, so the engine has no
+ * conditions of its own to check and `PrefetchController` needs no per-condition teardown.
+ */
+class PrefetchGate(
+    private val foregroundSignal: ForegroundSignal,
+    private val settingsDataStore: SettingsDataStore,
+    private val networkConditionObserver: NetworkConditionObserver,
+    private val powerStateObserver: PowerStateObserver,
+    private val requestActivityTracker: RequestActivityTracker,
+) {
+
+    /**
+     * Nested rather than flat because Kotlin's [combine] takes at most five flows and there are six
+     * inputs. The network pair nests naturally: the override only ever modifies the metering answer.
+     */
+    private val networkAllowed: Flow<Boolean> = combine(
+        networkConditionObserver.isUnmetered,
+        settingsDataStore.prefetchOnMeteredEnabled,
+    ) { unmetered, allowMetered -> unmetered || allowMetered }
+
+    fun isOpen(): Flow<Boolean> = combine(
+        foregroundSignal.isForeground,
+        settingsDataStore.prefetchEnabled,
+        networkAllowed,
+        powerStateObserver.isPowerConstrained.map { !it },
+        // No debounce and no quiet-period timer: the rule is "not while a request is in flight", not
+        // "not near one". Adding a settle delay here would also delay resuming after every tap.
+        requestActivityTracker.userInFlight.map { it == 0 },
+    ) { foreground, enabled, network, powerOk, idle ->
+        foreground && enabled && network && powerOk && idle
+    }.distinctUntilChanged()
+}

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchPolicy.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchPolicy.kt
@@ -1,0 +1,72 @@
+package com.garfiec.librechat.core.data.prefetch
+
+import com.garfiec.librechat.core.data.db.dao.PrefetchCandidate
+
+/**
+ * Decides *what* the prefetcher warms. Pure — no I/O, no clock, no coroutines — because this is the
+ * part whose rules are worth pinning exactly, and everything around it needs a live database or a
+ * network to exercise.
+ */
+class PrefetchPolicy {
+
+    /**
+     * The conversations worth keeping warm: the [RECENT_LIMIT] most recently updated, plus every
+     * pinned one however old.
+     *
+     * Pinning is the user saying "this one matters" in the only way the app offers, so a pinned
+     * conversation stays warm after it has fallen out of the recent window. Archived rows are
+     * excluded by the queries that produce these lists — out of sight, so warming them spends the
+     * user's bandwidth on something they deliberately put away.
+     */
+    fun eligible(
+        recent: List<PrefetchCandidate>,
+        pinned: List<PrefetchCandidate>,
+    ): List<PrefetchCandidate> = (recent + pinned).distinctBy { it.conversationId }
+
+    /**
+     * The subset of [eligible] that actually needs fetching, in the order to fetch it.
+     *
+     * Freshness is decided by the server's `updatedAt` against the watermark from the last warm, so
+     * an unchanged conversation is never re-fetched — which is why this feature needs no TTL, and why
+     * a pass over an unchanged account issues no message requests at all. The list refresh that feeds
+     * it still runs.
+     *
+     * The open conversation is excluded unconditionally. Warming it would replace the rows behind
+     * the screen the user is reading, and no ordering or timing makes that acceptable.
+     */
+    fun selectWork(
+        eligible: List<PrefetchCandidate>,
+        watermarks: Map<String, Long>,
+        openConversationId: String?,
+    ): List<PrefetchCandidate> = eligible
+        .asSequence()
+        .filter { it.conversationId != openConversationId }
+        .filter { candidate ->
+            val warmed = watermarks[candidate.conversationId]
+            warmed == null || warmed < candidate.updatedAt
+        }
+        // Pinned first, then most recent. If the gate closes partway through — which is the normal
+        // way a pass ends, not an exception — what got warmed is what the user is likeliest to open.
+        .sortedWith(compareByDescending<PrefetchCandidate> { it.pinned }.thenByDescending { it.updatedAt })
+        .toList()
+
+    /**
+     * The conversations whose cached messages must survive pruning: everything eligible, plus the
+     * open one.
+     *
+     * The open conversation is named separately rather than assumed to be eligible. It usually is —
+     * a conversation being read was recently updated — but "usually" is not a guarantee, and the
+     * cost of being wrong is the user's messages vanishing mid-read.
+     */
+    fun protectedFromPruning(
+        eligible: List<PrefetchCandidate>,
+        openConversationId: String?,
+    ): Set<String> = buildSet {
+        eligible.forEach { add(it.conversationId) }
+        openConversationId?.let { add(it) }
+    }
+
+    companion object {
+        const val RECENT_LIMIT = 20
+    }
+}

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/AccountDataPurger.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/AccountDataPurger.kt
@@ -5,6 +5,7 @@ import com.garfiec.librechat.core.data.db.dao.ConversationDao
 import com.garfiec.librechat.core.data.db.dao.ConversationTagDao
 import com.garfiec.librechat.core.data.db.dao.DraftDao
 import com.garfiec.librechat.core.data.db.dao.MessageDao
+import com.garfiec.librechat.core.data.db.dao.PrefetchWatermarkDao
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
 
@@ -23,6 +24,7 @@ class AccountDataPurger(
     private val messageDao: MessageDao,
     private val draftDao: DraftDao,
     private val tagDao: ConversationTagDao,
+    private val prefetchWatermarkDao: PrefetchWatermarkDao,
     private val ioDispatcher: CoroutineDispatcher,
 ) {
 
@@ -32,5 +34,8 @@ class AccountDataPurger(
         draftDao.deleteAllForAccount(id)
         tagDao.deleteAllForAccount(id)
         conversationDao.deleteAllForAccount(id)
+        // Must go with the messages: a watermark outliving the rows it describes reads as "already
+        // warm", so a re-login would never re-fetch the conversations this purge just emptied.
+        prefetchWatermarkDao.deleteAllForAccount(id)
     }
 }

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/MessageRepository.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/MessageRepository.kt
@@ -21,7 +21,19 @@ interface MessageRepository {
      * active account. See `resolveWriteAccountId`.
      */
     suspend fun cacheMessages(messages: List<Message>, originAccount: AccountId?)
-    suspend fun refreshMessages(conversationId: String): Result<List<Message>>
+
+    /**
+     * Re-reads a conversation's messages from the server and **replaces** its cached rows, so
+     * server-side deletions disappear locally where [getMessages]' upsert would leave them behind.
+     *
+     * [originAccount] carries the same origin-capture contract as [cacheMessages], and here it gates
+     * the network leg too: a deferred caller whose origin is no longer the live account is skipped
+     * rather than sending that account's conversation id to a different server under a different
+     * bearer. Deliberately no default — a silent one would let new deferred callers compile with
+     * land-time attribution, which is the mis-attribution this parameter exists to prevent. Pass null
+     * from foreground callers, where entry *is* land time.
+     */
+    suspend fun refreshMessages(conversationId: String, originAccount: AccountId?): Result<List<Message>>
     suspend fun updateFeedback(conversationId: String, messageId: String, feedback: MinimalFeedback?): Result<Unit>
     suspend fun updateMessageText(conversationId: String, messageId: String, text: String): Result<Unit>
     suspend fun branchMessage(conversationId: String, messageId: String, agentId: String? = null): Result<Message>

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/MessageRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/MessageRepositoryImpl.kt
@@ -18,10 +18,12 @@ import com.garfiec.librechat.core.model.request.BranchMessageRequest
 import com.garfiec.librechat.core.model.request.UpdateMessageRequest
 import com.garfiec.librechat.core.network.api.MessagesApi
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.withContext
 
 class MessageRepositoryImpl(
     private val messagesApi: MessagesApi,
@@ -74,13 +76,39 @@ class MessageRepositoryImpl(
         messageDao.upsertAll(messages.entitiesFor(accountId))
     }
 
-    override suspend fun refreshMessages(conversationId: String): Result<List<Message>> {
+    override suspend fun refreshMessages(
+        conversationId: String,
+        originAccount: AccountId?,
+    ): Result<List<Message>> {
+        // Origin-capture: a deferred caller may reach here after a switch. The GET rides the LIVE
+        // snapshot, so firing it once the origin is no longer active would carry this conversation id
+        // to another account's server under its bearer. Serve the cache instead — a routine skip.
+        if (!originTransportAllowed(originAccount, activeAccountProvider)) {
+            val account = resolveWriteAccountId(originAccount, activeAccountProvider, roster)
+            val cached = account
+                ?.let { messageDao.observeMessagesForAccount(conversationId, it).first() }
+                ?: emptyList()
+            return if (cached.isNotEmpty()) {
+                Result.Success(cached.toModels())
+            } else {
+                Result.Error(IllegalStateException("Skipped message refresh for a non-active account"))
+            }
+        }
         return safeApiCall {
-            val accountId = activeAccountProvider.currentAccountId()?.value
+            val accountId = resolveWriteAccountId(originAccount, activeAccountProvider, roster)
             val messages = messagesApi.getMessages(conversationId)
             if (accountId != null) {
-                // Full replace: delete stale cache then insert fresh server data (delete leg scoped to account)
-                messageDao.replaceAllForConversation(conversationId, accountId, messages.entitiesFor(accountId))
+                // Full replace: delete stale cache then insert fresh server data (delete leg scoped
+                // to account). NonCancellable so a cancelled caller cannot abandon the thread between
+                // the delete and the insert legs — the transaction would roll back, but this keeps the
+                // "one whole thread per transaction" contract true rather than merely usually true.
+                withContext(NonCancellable) {
+                    messageDao.replaceAllForConversation(
+                        conversationId,
+                        accountId,
+                        messages.entitiesFor(accountId),
+                    )
+                }
             }
             messages
         }

--- a/core/data/src/commonTest/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchPolicyTest.kt
+++ b/core/data/src/commonTest/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchPolicyTest.kt
@@ -1,0 +1,121 @@
+package com.garfiec.librechat.core.data.prefetch
+
+import com.garfiec.librechat.core.data.db.dao.PrefetchCandidate
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class PrefetchPolicyTest {
+
+    private val policy = PrefetchPolicy()
+
+    private fun candidate(id: String, updatedAt: Long, pinned: Boolean = false) =
+        PrefetchCandidate(conversationId = id, updatedAt = updatedAt, pinned = pinned)
+
+    @Test
+    fun `eligible unions recent and pinned without duplicating the overlap`() {
+        val recent = listOf(candidate("a", 30), candidate("b", 20, pinned = true))
+        val pinned = listOf(candidate("b", 20, pinned = true), candidate("old", 1, pinned = true))
+
+        val eligible = policy.eligible(recent, pinned)
+
+        assertEquals(listOf("a", "b", "old"), eligible.map { it.conversationId })
+    }
+
+    /** The point of including pinned separately: it survives falling out of the recent window. */
+    @Test
+    fun `a pinned conversation stays eligible however old it is`() {
+        val eligible = policy.eligible(
+            recent = List(PrefetchPolicy.RECENT_LIMIT) { candidate("recent-$it", 1000L + it) },
+            pinned = listOf(candidate("ancient", 1, pinned = true)),
+        )
+
+        assertTrue(eligible.any { it.conversationId == "ancient" })
+    }
+
+    @Test
+    fun `work is limited to conversations the server has changed since the last warm`() {
+        val eligible = listOf(
+            candidate("unchanged", updatedAt = 100),
+            candidate("changed", updatedAt = 200),
+            candidate("never-warmed", updatedAt = 50),
+        )
+        val watermarks = mapOf("unchanged" to 100L, "changed" to 150L)
+
+        val work = policy.selectWork(eligible, watermarks, openConversationId = null)
+
+        assertEquals(setOf("changed", "never-warmed"), work.map { it.conversationId }.toSet())
+    }
+
+    /**
+     * An equal watermark means "warmed against exactly this version". Treating it as stale would make
+     * the prefetcher re-fetch every eligible conversation on every pass, forever.
+     */
+    @Test
+    fun `an equal watermark is not stale`() {
+        val work = policy.selectWork(
+            eligible = listOf(candidate("a", updatedAt = 100)),
+            watermarks = mapOf("a" to 100L),
+            openConversationId = null,
+        )
+
+        assertTrue(work.isEmpty())
+    }
+
+    /** Replacing the rows behind the screen the user is reading is the worst failure available. */
+    @Test
+    fun `the open conversation is never warmed even when stale`() {
+        val work = policy.selectWork(
+            eligible = listOf(candidate("open", updatedAt = 200), candidate("other", updatedAt = 200)),
+            watermarks = emptyMap(),
+            openConversationId = "open",
+        )
+
+        assertEquals(listOf("other"), work.map { it.conversationId })
+    }
+
+    /**
+     * A pass usually ends by the gate closing partway through, not by finishing, so the order decides
+     * what actually gets warmed.
+     */
+    @Test
+    fun `work is ordered pinned first then most recently updated`() {
+        val work = policy.selectWork(
+            eligible = listOf(
+                candidate("old-pinned", updatedAt = 1, pinned = true),
+                candidate("newest", updatedAt = 300),
+                candidate("middle", updatedAt = 200),
+            ),
+            watermarks = emptyMap(),
+            openConversationId = null,
+        )
+
+        assertEquals(listOf("old-pinned", "newest", "middle"), work.map { it.conversationId })
+    }
+
+    @Test
+    fun `pruning protects everything eligible`() {
+        val eligible = listOf(candidate("a", 10), candidate("b", 20))
+
+        val protectedIds = policy.protectedFromPruning(eligible, openConversationId = null)
+
+        assertEquals(setOf("a", "b"), protectedIds)
+    }
+
+    /**
+     * Named separately rather than assumed eligible. A conversation being read is *usually* recently
+     * updated, but "usually" is not a guarantee and the cost of being wrong is the user's messages
+     * disappearing mid-read.
+     */
+    @Test
+    fun `pruning protects the open conversation even when it is not eligible`() {
+        val protectedIds = policy.protectedFromPruning(
+            eligible = listOf(candidate("a", 10)),
+            openConversationId = "open-but-ancient",
+        )
+
+        assertTrue("open-but-ancient" in protectedIds)
+        assertFalse("b" in protectedIds)
+    }
+}

--- a/core/data/src/iosMain/kotlin/com/garfiec/librechat/core/data/di/DataPlatformModule.ios.kt
+++ b/core/data/src/iosMain/kotlin/com/garfiec/librechat/core/data/di/DataPlatformModule.ios.kt
@@ -11,6 +11,8 @@ import com.garfiec.librechat.core.data.datastore.ServerUrlKeychainFallback
 import com.garfiec.librechat.core.data.db.LibreChatDatabase
 import com.garfiec.librechat.core.data.db.migration.MIGRATION_3_4
 import com.garfiec.librechat.core.data.db.migration.MIGRATION_4_5
+import com.garfiec.librechat.core.data.prefetch.AttachmentWarmer
+import com.garfiec.librechat.core.data.prefetch.NoopAttachmentWarmer
 import com.garfiec.librechat.core.data.repository.CommonSessionCacheCleaner
 import com.garfiec.librechat.core.data.repository.IosSwitchCacheCleaner
 import com.garfiec.librechat.core.data.repository.SessionCacheCleaner
@@ -37,6 +39,8 @@ private fun ensureDirectoryExists(path: String) {
 }
 
 actual val dataPlatformModule: Module = module {
+
+    single<AttachmentWarmer> { NoopAttachmentWarmer() }
 
     // --- Database ---
     single {

--- a/core/data/src/iosMain/kotlin/com/garfiec/librechat/core/data/prefetch/NoopAttachmentWarmer.kt
+++ b/core/data/src/iosMain/kotlin/com/garfiec/librechat/core/data/prefetch/NoopAttachmentWarmer.kt
@@ -1,0 +1,13 @@
+package com.garfiec.librechat.core.data.prefetch
+
+/**
+ * iOS configures Coil with a memory cache only (`LibreChatApp`), so there is no disk cache for a
+ * warm to survive into — a fetched image would be evicted long before the user opened the
+ * conversation, having spent their bandwidth for nothing.
+ *
+ * Give iOS a disk cache and this becomes a real implementation.
+ */
+class NoopAttachmentWarmer : AttachmentWarmer {
+    override val isSupported: Boolean = false
+    override suspend fun warm(url: String) = Unit
+}

--- a/core/model/src/commonMain/kotlin/com/garfiec/librechat/core/model/media/ImageUrlResolver.kt
+++ b/core/model/src/commonMain/kotlin/com/garfiec/librechat/core/model/media/ImageUrlResolver.kt
@@ -1,4 +1,4 @@
-package com.garfiec.librechat.feature.chat.util
+package com.garfiec.librechat.core.model.media
 
 import com.garfiec.librechat.core.model.Attachment
 import com.garfiec.librechat.core.model.FileReference
@@ -7,14 +7,13 @@ import com.garfiec.librechat.core.model.content.MessageContentPart
 /**
  * Single source of truth for turning a message's image reference into a loadable URL.
  *
- * Every image surface — the inline renderers (`MessageFiles`, `SharedContentParts`), the
- * image-gen tool-call parser (`ToolCallParsing`), and the full-screen media collector
- * ([extractBranchMedia]) — calls these, so the viewer always resolves the exact URL the message
- * rendered. Changing how images resolve here changes every place at once; no per-call-site copy.
+ * Every image surface must route through these rather than keep a per-call-site copy: the renderers
+ * and the background prefetcher have to agree on the exact URL, or a warmed cache entry is a
+ * near-miss under a slightly different one rather than a hit.
  */
 
 /** Resolves a full URL for an attached [FileReference], handling relative paths. */
-internal fun resolveFileReferenceUrl(file: FileReference, baseUrl: String): String? =
+fun resolveFileReferenceUrl(file: FileReference, baseUrl: String): String? =
     resolveImageUrl(file.filepath, file.fileId, baseUrl, includeBareSlash = true)
 
 /**
@@ -24,7 +23,7 @@ internal fun resolveFileReferenceUrl(file: FileReference, baseUrl: String): Stri
  * `/foo/x.png`, not `/images/...`) through `/api/files/`, matching how `ContentPartRenderer` has
  * always rendered these. A [FileReference] instead serves it directly off `baseUrl`.
  */
-internal fun resolveImageFilePartUrl(part: MessageContentPart, baseUrl: String): String? =
+fun resolveImageFilePartUrl(part: MessageContentPart, baseUrl: String): String? =
     resolveImageUrl(part.imageFile?.filepath, part.imageFile?.fileId, baseUrl, includeBareSlash = false)
 
 /**
@@ -34,7 +33,7 @@ internal fun resolveImageFilePartUrl(part: MessageContentPart, baseUrl: String):
  * served directly off `baseUrl` ([relativePathPrefix] = `/`), not through `/api/files/`, matching
  * how `parseImageGenResult` has always built generated-image URLs.
  */
-internal fun resolveAttachmentUrl(attachment: Attachment?, baseUrl: String): String? {
+fun resolveAttachmentUrl(attachment: Attachment?, baseUrl: String): String? {
     if (attachment == null) return null
     return resolveImageUrl(
         attachment.filepath,

--- a/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/client/RequestActivityPluginTest.kt
+++ b/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/client/RequestActivityPluginTest.kt
@@ -1,0 +1,136 @@
+package com.garfiec.librechat.core.network.client
+
+import com.garfiec.librechat.core.common.network.PrefetchMarker
+import com.garfiec.librechat.core.common.network.RequestActivityTracker
+import com.garfiec.librechat.core.network.di.NetworkGraphTestFakes
+import com.google.common.truth.Truth.assertThat
+import io.ktor.client.engine.HttpClientEngine
+import io.ktor.client.engine.HttpClientEngineFactory
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.MockEngineConfig
+import io.ktor.client.engine.mock.MockRequestHandler
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.engine.mock.respondError
+import io.ktor.client.request.get
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import org.junit.Test
+
+/**
+ * The idle signal's behaviour, asserted through the real client factory so the production plugin
+ * order is what is under test.
+ *
+ * The exemption test is the load-bearing one. If [PrefetchMarker] does not reach the interceptor's
+ * coroutine context, the prefetcher counts its own requests as user activity and blocks against its
+ * own idle gate — it then does nothing, forever, raising no error and failing no other test. That
+ * failure is invisible to every other kind of check, which is why it is asserted directly here
+ * rather than inferred from the feature working.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class RequestActivityPluginTest {
+
+    private companion object {
+        const val URL = "https://chat.example.com/api/messages/conv-1"
+    }
+
+    /**
+     * Handlers run on `Dispatchers.Unconfined` for the same reason as the SSE tests: a handler parked
+     * on a real thread lets `runTest` fast-forward virtual time past the request timeout.
+     */
+    private fun engineFactory(handler: MockRequestHandler) =
+        object : HttpClientEngineFactory<MockEngineConfig> {
+            override fun create(block: MockEngineConfig.() -> Unit): HttpClientEngine =
+                MockEngine(
+                    MockEngineConfig().apply(block).apply {
+                        dispatcher = Dispatchers.Unconfined
+                        addHandler(handler)
+                    },
+                )
+        }
+
+    @Test
+    fun `an ordinary request counts as user activity while it is in flight`() = runTest {
+        val tracker = RequestActivityTracker()
+        var inFlightDuringCall = -1
+        val client = NetworkGraphTestFakes.mainClient(
+            engineFactory { inFlightDuringCall = tracker.userInFlight.value; respond("{}") },
+            tracker,
+        )
+
+        client.get(URL)
+
+        assertThat(inFlightDuringCall).isEqualTo(1)
+        assertThat(tracker.userInFlight.value).isEqualTo(0)
+    }
+
+    /**
+     * The whole prefetch design rests on this. A marked coroutine's requests must be invisible to the
+     * tracker, or background work can never run.
+     */
+    @Test
+    fun `a prefetch-marked request is not counted`() = runTest {
+        val tracker = RequestActivityTracker()
+        var inFlightDuringCall = -1
+        val client = NetworkGraphTestFakes.mainClient(
+            engineFactory { inFlightDuringCall = tracker.userInFlight.value; respond("{}") },
+            tracker,
+        )
+
+        withContext(PrefetchMarker) {
+            client.get(URL)
+        }
+
+        assertThat(inFlightDuringCall).isEqualTo(0)
+        assertThat(tracker.userInFlight.value).isEqualTo(0)
+    }
+
+    /**
+     * The plugin is installed ahead of `HttpRequestRetry`, making it the outermost `HttpSend`
+     * interceptor, so a call the user perceives as one request stays counted across its retries.
+     * Installed the other way round the count would drop to zero between attempts and background
+     * work would start in the gap — which is exactly when the network is already struggling.
+     */
+    @Test
+    fun `a retried request stays counted for the whole call`() = runTest {
+        val tracker = RequestActivityTracker()
+        val observed = mutableListOf<Int>()
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            tracker.userInFlight.toList(observed)
+        }
+
+        var attempts = 0
+        val client = NetworkGraphTestFakes.mainClient(
+            engineFactory {
+                attempts++
+                if (attempts < 3) respondError(HttpStatusCode.InternalServerError) else respond("{}")
+            },
+            tracker,
+        )
+
+        client.get(URL)
+
+        assertThat(attempts).isEqualTo(3)
+        // Not [0, 1, 0, 1, 0, 1, 0]: one rise, one fall, no gap the retries can be seen through.
+        assertThat(observed).containsExactly(0, 1, 0).inOrder()
+    }
+
+    /** A thrown request must not strand the count, or the app looks busy forever. */
+    @Test
+    fun `a failing request releases the count`() = runTest {
+        val tracker = RequestActivityTracker()
+        val client = NetworkGraphTestFakes.mainClient(
+            engineFactory { respondError(HttpStatusCode.NotFound) },
+            tracker,
+        )
+
+        runCatching { client.get(URL) }
+
+        assertThat(tracker.userInFlight.value).isEqualTo(0)
+    }
+}

--- a/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/client/RetryAfterPropagationTest.kt
+++ b/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/client/RetryAfterPropagationTest.kt
@@ -1,0 +1,82 @@
+package com.garfiec.librechat.core.network.client
+
+import com.garfiec.librechat.core.common.network.RequestActivityTracker
+import com.garfiec.librechat.core.common.result.ApiException
+import com.garfiec.librechat.core.network.di.NetworkGraphTestFakes
+import com.google.common.truth.Truth.assertThat
+import io.ktor.client.engine.HttpClientEngine
+import io.ktor.client.engine.HttpClientEngineFactory
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.MockEngineConfig
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.request.get
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+/**
+ * `Retry-After` has to survive onto [ApiException], because by the time a caller holds a
+ * `Result.Error` the response is gone. Without this the only sane back-off for a rate-limited caller
+ * is a guess, and a guess that is too short is what gets a client throttled harder.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class RetryAfterPropagationTest {
+
+    private companion object {
+        const val URL = "https://chat.example.com/api/messages/conv-1"
+    }
+
+    private fun client(status: HttpStatusCode, retryAfter: String?) =
+        NetworkGraphTestFakes.mainClient(
+            object : HttpClientEngineFactory<MockEngineConfig> {
+                override fun create(block: MockEngineConfig.() -> Unit): HttpClientEngine =
+                    MockEngine(
+                        MockEngineConfig().apply(block).apply {
+                            dispatcher = Dispatchers.Unconfined
+                            addHandler {
+                                respond(
+                                    content = "{}",
+                                    status = status,
+                                    headers = retryAfter
+                                        ?.let { headersOf(HttpHeaders.RetryAfter, it) }
+                                        ?: headersOf(),
+                                )
+                            }
+                        },
+                    )
+            },
+            RequestActivityTracker(),
+        )
+
+    private suspend fun apiExceptionFrom(status: HttpStatusCode, retryAfter: String?): ApiException =
+        runCatching { client(status, retryAfter).get(URL) }
+            .exceptionOrNull() as ApiException
+
+    @Test
+    fun `a rate limit carries its retry-after`() = runTest {
+        val error = apiExceptionFrom(HttpStatusCode.TooManyRequests, "30")
+
+        assertThat(error.statusCode).isEqualTo(429)
+        assertThat(error.retryAfterSeconds).isEqualTo(30L)
+    }
+
+    @Test
+    fun `a response without the header carries no guidance`() = runTest {
+        assertThat(apiExceptionFrom(HttpStatusCode.TooManyRequests, null).retryAfterSeconds).isNull()
+    }
+
+    /**
+     * The HTTP-date form parses to null rather than to zero. Zero would read as "retry immediately",
+     * turning the one response that asks a client to slow down into the one that speeds it up.
+     */
+    @Test
+    fun `the http-date form is treated as no guidance rather than as zero`() = runTest {
+        val error = apiExceptionFrom(HttpStatusCode.TooManyRequests, "Wed, 21 Oct 2026 07:28:00 GMT")
+
+        assertThat(error.retryAfterSeconds).isNull()
+    }
+}

--- a/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/di/GatewayDetectionInstallTest.kt
+++ b/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/di/GatewayDetectionInstallTest.kt
@@ -1,28 +1,14 @@
 package com.garfiec.librechat.core.network.di
 
 import com.garfiec.librechat.core.common.di.KoinQualifiers
-import com.garfiec.librechat.core.common.identity.AccountId
-import com.garfiec.librechat.core.common.identity.AccountState
-import com.garfiec.librechat.core.common.identity.ActiveAccountProvider
-import com.garfiec.librechat.core.common.identity.InMemoryActiveAccountProvider
-import com.garfiec.librechat.core.logging.redact.LogRedactor
 import com.garfiec.librechat.core.network.client.GatewayDetectionPlugin
-import com.garfiec.librechat.core.network.client.RefreshResult
-import com.garfiec.librechat.core.network.client.ServerHeadersProvider
-import com.garfiec.librechat.core.network.client.ServerUrlProvider
-import com.garfiec.librechat.core.network.client.SessionEndReason
-import com.garfiec.librechat.core.network.client.TokenManager
 import com.google.common.truth.Truth.assertThat
 import io.ktor.client.HttpClient
 import io.ktor.client.plugins.pluginOrNull
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.SharedFlow
 import org.junit.After
 import org.junit.Test
 import org.koin.core.KoinApplication
 import org.koin.core.qualifier.Qualifier
-import org.koin.dsl.koinApplication
-import org.koin.dsl.module
 
 /**
  * Which clients carry gateway detection, asserted on the graph the app actually builds. Nothing else
@@ -37,52 +23,9 @@ class GatewayDetectionInstallTest {
         app?.close()
     }
 
-    private class FakeServerUrlProvider : ServerUrlProvider {
-        override fun getBaseUrl(): String = "https://chat.example.com"
-    }
-
-    private class FakeServerHeadersProvider : ServerHeadersProvider {
-        override suspend fun awaitWarm() = Unit
-        override fun headersFor(baseUrl: String): Map<String, String> = emptyMap()
-    }
-
-    private class FakeTokenManager : TokenManager {
-        private val expired = MutableSharedFlow<SessionEndReason>()
-        override val sessionExpiredFlow: SharedFlow<SessionEndReason> = expired
-        override val isAuthenticated: Boolean = false
-        override suspend fun getAccessToken(): String? = null
-        override suspend fun setTokens(accessToken: String, refreshToken: String) = Unit
-        override suspend fun refreshAccessToken(): RefreshResult = RefreshResult.Transient
-        override suspend fun clearTokens() = Unit
-        override suspend fun getAccessTokenFor(accountId: String): String? = null
-        override suspend fun getStagedAccessToken(): String? = null
-        override suspend fun clearStagedTokens() = Unit
-        override suspend fun selectAccount(accountId: String) = Unit
-        override suspend fun removeAccount(accountId: String) = Unit
-        override suspend fun refreshAccessTokenFor(accountId: String, baseUrl: String): RefreshResult =
-            RefreshResult.Transient
-
-        override suspend fun onAccountResolved(accountId: String) = Unit
-        override fun emitSessionExpired(expiredAccountId: String?, reason: SessionEndReason) = Unit
-    }
-
     private fun client(qualifier: Qualifier?): HttpClient {
-        val koin = app ?: koinApplication {
-            modules(
-                networkModule,
-                module {
-                    single<ServerUrlProvider> { FakeServerUrlProvider() }
-                    single<ServerHeadersProvider> { FakeServerHeadersProvider() }
-                    single<TokenManager> { FakeTokenManager() }
-                    // Bound in :core:data and :core:logging in the real graph.
-                    single<ActiveAccountProvider> {
-                        InMemoryActiveAccountProvider(AccountState.Resolved(AccountId("srv-1:user-a")))
-                    }
-                    single { LogRedactor() }
-                },
-            )
-        }.also { app = it }
-        return if (qualifier == null) koin.koin.get() else koin.koin.get(qualifier)
+        val koin = app ?: NetworkGraphTestFakes.koinApp().also { app = it }
+        return NetworkGraphTestFakes.client(koin, qualifier)
     }
 
     @Test

--- a/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/di/NetworkGraphTestFakes.kt
+++ b/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/di/NetworkGraphTestFakes.kt
@@ -1,0 +1,102 @@
+package com.garfiec.librechat.core.network.di
+
+import com.garfiec.librechat.core.common.identity.AccountId
+import com.garfiec.librechat.core.common.identity.AccountState
+import com.garfiec.librechat.core.common.identity.ActiveAccountProvider
+import com.garfiec.librechat.core.common.identity.InMemoryActiveAccountProvider
+import com.garfiec.librechat.core.common.network.RequestActivityTracker
+import com.garfiec.librechat.core.logging.redact.LogRedactor
+import com.garfiec.librechat.core.network.client.LibreChatHttpClient
+import com.garfiec.librechat.core.network.client.RefreshResult
+import com.garfiec.librechat.core.network.client.ServerHeadersProvider
+import com.garfiec.librechat.core.network.client.ServerUrlProvider
+import com.garfiec.librechat.core.network.client.SessionEndReason
+import com.garfiec.librechat.core.network.client.TokenManager
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.HttpClientEngineFactory
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.serialization.json.Json
+import org.koin.core.KoinApplication
+import org.koin.core.qualifier.Qualifier
+import org.koin.dsl.koinApplication
+import org.koin.dsl.module
+
+/**
+ * Builds the real [networkModule] against fakes for the bindings other modules own.
+ *
+ * Shared by the install tests, which exist to catch a plugin that is missing from a client in the
+ * graph the app actually builds — something a test that constructs its own client can never observe.
+ */
+internal object NetworkGraphTestFakes {
+
+    private class FakeServerUrlProvider : ServerUrlProvider {
+        override fun getBaseUrl(): String = "https://chat.example.com"
+    }
+
+    private class FakeServerHeadersProvider : ServerHeadersProvider {
+        override suspend fun awaitWarm() = Unit
+        override fun headersFor(baseUrl: String): Map<String, String> = emptyMap()
+    }
+
+    private class FakeTokenManager : TokenManager {
+        private val expired = MutableSharedFlow<SessionEndReason>()
+        override val sessionExpiredFlow: SharedFlow<SessionEndReason> = expired
+        override val isAuthenticated: Boolean = false
+        override suspend fun getAccessToken(): String? = null
+        override suspend fun setTokens(accessToken: String, refreshToken: String) = Unit
+        override suspend fun refreshAccessToken(): RefreshResult = RefreshResult.Transient
+        override suspend fun clearTokens() = Unit
+        override suspend fun getAccessTokenFor(accountId: String): String? = null
+        override suspend fun getStagedAccessToken(): String? = null
+        override suspend fun clearStagedTokens() = Unit
+        override suspend fun selectAccount(accountId: String) = Unit
+        override suspend fun removeAccount(accountId: String) = Unit
+        override suspend fun refreshAccessTokenFor(accountId: String, baseUrl: String): RefreshResult =
+            RefreshResult.Transient
+
+        override suspend fun onAccountResolved(accountId: String) = Unit
+        override fun emitSessionExpired(expiredAccountId: String?, reason: SessionEndReason) = Unit
+    }
+
+    fun koinApp(): KoinApplication = koinApplication {
+        modules(
+            networkModule,
+            module {
+                single<ServerUrlProvider> { FakeServerUrlProvider() }
+                single<ServerHeadersProvider> { FakeServerHeadersProvider() }
+                single<TokenManager> { FakeTokenManager() }
+                // Bound in :core:data, :core:logging and :core:common in the real graph.
+                single<ActiveAccountProvider> {
+                    InMemoryActiveAccountProvider(AccountState.Resolved(AccountId("srv-1:user-a")))
+                }
+                single { LogRedactor() }
+                single { RequestActivityTracker() }
+            },
+        )
+    }
+
+    /** Resolves a client from [app]; null [qualifier] is the main client. */
+    fun client(app: KoinApplication, qualifier: Qualifier?): HttpClient =
+        if (qualifier == null) app.koin.get() else app.koin.get(qualifier)
+
+    /**
+     * The main client over an arbitrary engine, built through the real factory.
+     *
+     * Behavioural tests go through [LibreChatHttpClient.create] rather than hand-assembling a client
+     * so they observe the production plugin *order* — which is what decides whether a retried call
+     * counts once or three times.
+     */
+    fun mainClient(
+        engineFactory: HttpClientEngineFactory<*>,
+        requestActivityTracker: RequestActivityTracker,
+    ): HttpClient = LibreChatHttpClient.create(
+        engineFactory = engineFactory,
+        json = Json { ignoreUnknownKeys = true },
+        tokenManager = FakeTokenManager(),
+        serverUrlProvider = FakeServerUrlProvider(),
+        redactor = LogRedactor(),
+        serverHeadersProvider = FakeServerHeadersProvider(),
+        requestActivityTracker = requestActivityTracker,
+    )
+}

--- a/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/di/NetworkModuleVerificationTest.kt
+++ b/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/di/NetworkModuleVerificationTest.kt
@@ -3,6 +3,7 @@ package com.garfiec.librechat.core.network.di
 import android.app.Application
 import android.content.Context
 import com.garfiec.librechat.core.common.identity.ActiveAccountProvider
+import com.garfiec.librechat.core.common.network.RequestActivityTracker
 import com.garfiec.librechat.core.network.client.AccountReadyGate
 import com.garfiec.librechat.core.network.client.ServerHeadersProvider
 import com.garfiec.librechat.core.network.client.ServerUrlProvider
@@ -29,6 +30,9 @@ class NetworkModuleVerificationTest {
                 AccountReadyGate::class,
                 // Gateway headers (issue #287) are stored in :core:data, same as the URL and tokens.
                 ServerHeadersProvider::class,
+                // The idle signal is bound in :core:common; both the main client and SseClient
+                // report to it.
+                RequestActivityTracker::class,
             ),
         )
     }

--- a/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/di/RequestActivityInstallTest.kt
+++ b/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/di/RequestActivityInstallTest.kt
@@ -1,0 +1,55 @@
+package com.garfiec.librechat.core.network.di
+
+import com.garfiec.librechat.core.common.di.KoinQualifiers
+import com.garfiec.librechat.core.network.client.RequestActivityPlugin
+import com.google.common.truth.Truth.assertThat
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.pluginOrNull
+import org.junit.After
+import org.junit.Test
+import org.koin.core.KoinApplication
+import org.koin.core.qualifier.Qualifier
+
+/**
+ * Which clients report request activity, asserted on the graph the app actually builds.
+ *
+ * Both directions matter. Missing from the main client, background work never sees the user's
+ * requests and runs on top of them. Present on the streaming client, a stream would be counted twice
+ * on Android and once on iOS — whose SSE never touches a Ktor client — so the two platforms would
+ * disagree about when the app is idle.
+ */
+class RequestActivityInstallTest {
+
+    private var app: KoinApplication? = null
+
+    @After
+    fun tearDown() {
+        app?.close()
+    }
+
+    private fun client(qualifier: Qualifier?): HttpClient {
+        val koin = app ?: NetworkGraphTestFakes.koinApp().also { app = it }
+        return NetworkGraphTestFakes.client(koin, qualifier)
+    }
+
+    @Test
+    fun `the main client reports request activity`() {
+        assertThat(client(null).pluginOrNull(RequestActivityPlugin)).isNotNull()
+    }
+
+    /** SseClient reports the stream itself, on both platforms; this would double-count on Android. */
+    @Test
+    fun `the streaming client does not report request activity`() {
+        assertThat(client(KoinQualifiers.Streaming).pluginOrNull(RequestActivityPlugin)).isNull()
+    }
+
+    /**
+     * A token refresh is plumbing the user never asked for, and it fires while their request is
+     * already counted by the main client's plugin — counting it again would say "busy" for work that
+     * is only happening because of work already counted.
+     */
+    @Test
+    fun `the refresh client does not report request activity`() {
+        assertThat(client(KoinQualifiers.Refresh).pluginOrNull(RequestActivityPlugin)).isNull()
+    }
+}

--- a/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/sse/SseClientActivityTest.kt
+++ b/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/sse/SseClientActivityTest.kt
@@ -1,0 +1,104 @@
+package com.garfiec.librechat.core.network.sse
+
+import com.garfiec.librechat.core.common.network.RequestActivityTracker
+import com.google.common.truth.Truth.assertThat
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.MockEngineConfig
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.defaultRequest
+import io.ktor.client.request.url
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import org.junit.Test
+
+/**
+ * A live stream counts as user activity for its whole duration, so background work stays off the
+ * network while a reply is being written.
+ *
+ * Reported by [SseClient] rather than by a Ktor plugin because iOS streams over a custom transport
+ * no plugin can observe — so these assertions are what make the two platforms agree about when the
+ * app is idle. The release cases matter most: a stranded count would leave the app looking
+ * permanently busy, and background work would then never run again for the life of the process.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class SseClientActivityTest {
+
+    // Unconfined for the same reason as SseClientOriginBindingTest: a handler on a real thread lets
+    // runTest fast-forward virtual time into the parser's stall watchdog.
+    private fun client(body: String, status: HttpStatusCode = HttpStatusCode.OK): HttpClient {
+        val engine = MockEngine(
+            MockEngineConfig().apply {
+                dispatcher = Dispatchers.Unconfined
+                addHandler { respond(body, status) }
+            },
+        )
+        return HttpClient(engine) {
+            defaultRequest { url("https://a.example.com") }
+        }
+    }
+
+    private fun sseClient(http: HttpClient, tracker: RequestActivityTracker) = SseClient(
+        json = Json { ignoreUnknownKeys = true },
+        transport = SseHttpTransport(http),
+        requestActivityTracker = tracker,
+    )
+
+    /** Building a Flow opens no stream, so it must not make the app look busy. */
+    @Test
+    fun `an uncollected stream is not counted`() = runTest(UnconfinedTestDispatcher()) {
+        val tracker = RequestActivityTracker()
+
+        sseClient(client("data: {\"created\":true}\n\n"), tracker).connect("api/agents/chat/stream/abc")
+
+        assertThat(tracker.userInFlight.value).isEqualTo(0)
+    }
+
+    @Test
+    fun `a stream is counted while it is being collected`() = runTest(UnconfinedTestDispatcher()) {
+        val tracker = RequestActivityTracker()
+        var inFlightDuringStream = -1
+
+        sseClient(client("data: {\"created\":true}\n\n"), tracker)
+            .connect("api/agents/chat/stream/abc")
+            .collect { inFlightDuringStream = tracker.userInFlight.value }
+
+        assertThat(inFlightDuringStream).isEqualTo(1)
+        assertThat(tracker.userInFlight.value).isEqualTo(0)
+    }
+
+    /**
+     * The retry ladder is exhausted and the flow ends by emitting an error event rather than
+     * throwing, so a `finally` on the collector would never see a failure — the count has to be
+     * released on ordinary completion too.
+     */
+    @Test
+    fun `a failing stream releases the count`() = runTest(UnconfinedTestDispatcher()) {
+        val tracker = RequestActivityTracker()
+
+        sseClient(client("boom", HttpStatusCode.InternalServerError), tracker)
+            .connect("api/agents/chat/stream/abc")
+            .collect { }
+
+        assertThat(tracker.userInFlight.value).isEqualTo(0)
+    }
+
+    /** The common case at the end of a chat: the user leaves and the collector is torn down. */
+    @Test
+    fun `an abandoned stream releases the count`() = runTest(UnconfinedTestDispatcher()) {
+        val tracker = RequestActivityTracker()
+
+        // `first()` cancels the flow as soon as one event arrives, which is a collector going away
+        // mid-stream — the path that strands a count when release is tied to completion alone.
+        sseClient(client("data: {\"created\":true}\n\n"), tracker)
+            .connect("api/agents/chat/stream/abc")
+            .first()
+
+        assertThat(tracker.userInFlight.value).isEqualTo(0)
+    }
+}

--- a/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/LibreChatHttpClient.kt
+++ b/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/LibreChatHttpClient.kt
@@ -1,6 +1,7 @@
 package com.garfiec.librechat.core.network.client
 
 import co.touchlab.kermit.Logger
+import com.garfiec.librechat.core.common.network.RequestActivityTracker
 import com.garfiec.librechat.core.common.result.AccessGatewayException
 import com.garfiec.librechat.core.logging.Diag
 import com.garfiec.librechat.core.logging.LogOrigin
@@ -40,6 +41,7 @@ object LibreChatHttpClient {
         accountReadyGate: AccountReadyGate? = null,
         switchGate: SwitchGate? = null,
         serverHeadersProvider: ServerHeadersProvider = EmptyServerHeadersProvider,
+        requestActivityTracker: RequestActivityTracker? = null,
         debug: Boolean = false,
     ): HttpClient = HttpClient(engineFactory) {
         install(ContentNegotiation) {
@@ -75,6 +77,14 @@ object LibreChatHttpClient {
             requestTimeoutMillis = 30_000
             connectTimeoutMillis = 10_000
             socketTimeoutMillis = 120_000
+        }
+
+        // First HttpSend interceptor installed, so it is the outermost one: a call that retries,
+        // redirects or replays after a token refresh counts once, not once per wire send.
+        if (requestActivityTracker != null) {
+            install(RequestActivityPlugin) {
+                this.tracker = requestActivityTracker
+            }
         }
 
         install(HttpRequestRetry) {
@@ -151,6 +161,9 @@ object LibreChatHttpClient {
                         isBanned = isBanned,
                         body = bodyText.ifBlank { null },
                         serverAuthored = extracted.serverAuthored,
+                        retryAfterSeconds = response.headers[HttpHeaders.RetryAfter]
+                            ?.trim()
+                            ?.toLongOrNull(),
                     )
                 }
             }

--- a/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/RequestActivityPlugin.kt
+++ b/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/RequestActivityPlugin.kt
@@ -1,0 +1,58 @@
+package com.garfiec.librechat.core.network.client
+
+import com.garfiec.librechat.core.common.network.PrefetchMarker
+import com.garfiec.librechat.core.common.network.RequestActivityTracker
+import com.garfiec.librechat.core.common.network.isPrefetch
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.HttpClientPlugin
+import io.ktor.client.plugins.HttpSend
+import io.ktor.client.plugins.plugin
+import io.ktor.util.AttributeKey
+import kotlin.coroutines.coroutineContext
+
+/**
+ * Reports every request the user is waiting on to [RequestActivityTracker], so background work can
+ * hold off while one is in flight.
+ *
+ * **Install first**, ahead of `HttpRequestRetry`. Ktor runs the first-installed `HttpSend`
+ * interceptor outermost, so from here a retried, redirected or auth-replayed call is one unit of
+ * user-visible work rather than three — which is what the gate should be measuring.
+ *
+ * Exemption comes from [PrefetchMarker] on the calling coroutine's context — see that class. The
+ * `coroutineContext` read below must stay the caller's coroutine, or the prefetcher counts itself
+ * and silently never runs; `RequestActivityPluginTest` asserts it.
+ *
+ * Deliberately **not** installed on the streaming client: `SseClient` reports the stream itself, so
+ * installing here too would double-count the stream GET on Android only.
+ */
+class RequestActivityPlugin private constructor(
+    private val tracker: RequestActivityTracker,
+) {
+
+    class Config {
+        var tracker: RequestActivityTracker? = null
+    }
+
+    companion object : HttpClientPlugin<Config, RequestActivityPlugin> {
+        override val key = AttributeKey<RequestActivityPlugin>("RequestActivity")
+
+        override fun prepare(block: Config.() -> Unit): RequestActivityPlugin {
+            val config = Config().apply(block)
+            return RequestActivityPlugin(
+                tracker = requireNotNull(config.tracker) {
+                    "RequestActivityPlugin requires a RequestActivityTracker"
+                },
+            )
+        }
+
+        override fun install(plugin: RequestActivityPlugin, scope: HttpClient) {
+            scope.plugin(HttpSend).intercept { request ->
+                if (coroutineContext.isPrefetch()) {
+                    execute(request)
+                } else {
+                    plugin.tracker.counted { execute(request) }
+                }
+            }
+        }
+    }
+}

--- a/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/di/NetworkModule.kt
+++ b/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/di/NetworkModule.kt
@@ -96,6 +96,7 @@ val networkModule = module {
             accountReadyGate = getOrNull(),
             switchGate = get(),
             serverHeadersProvider = get(),
+            requestActivityTracker = get(),
         )
     }
 
@@ -174,7 +175,14 @@ val networkModule = module {
     // SSE — SseHttpTransport is provided by networkPlatformModule because its
     // constructor signature differs between Android (takes the Ktor streaming
     // HttpClient) and iOS (takes NWConnection dependencies in Phase 2).
-    single { SseClient(json = get(), transport = get(), activeAccountProvider = get()) }
+    single {
+        SseClient(
+            json = get(),
+            transport = get(),
+            activeAccountProvider = get(),
+            requestActivityTracker = get(),
+        )
+    }
 
     // API services
     singleOf(::AgentsApi)

--- a/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/sse/SseClient.kt
+++ b/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/sse/SseClient.kt
@@ -3,6 +3,7 @@ package com.garfiec.librechat.core.network.sse
 import co.touchlab.kermit.Logger
 import com.garfiec.librechat.core.common.identity.ActiveAccountProvider
 import com.garfiec.librechat.core.common.identity.currentAccountId
+import com.garfiec.librechat.core.common.network.RequestActivityTracker
 import com.garfiec.librechat.core.common.result.AccessGatewayException
 import com.garfiec.librechat.core.common.result.FailureKind
 import com.garfiec.librechat.core.common.result.message
@@ -18,6 +19,8 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.onCompletion
+import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
 import kotlin.math.min
@@ -26,6 +29,7 @@ class SseClient(
     private val json: Json,
     private val transport: SseHttpTransport,
     private val activeAccountProvider: ActiveAccountProvider? = null,
+    private val requestActivityTracker: RequestActivityTracker? = null,
 ) {
     private val mapper = SseEventMapper(json)
     private val lineParser = SseLineParser()
@@ -209,6 +213,13 @@ class SseClient(
             emit(StreamEvent.Error(message = "Unexpected error: ${e.message}"))
         }
     }
+        // A stream counts as in-flight for its whole duration, not just its GET. Reported here
+        // rather than from RequestActivityPlugin because iOS streams over a custom NWConnection
+        // transport no Ktor plugin can observe. Must stay tied to collection, and the release must
+        // stay on onCompletion — it covers cancellation too, and a stranded count leaves the app
+        // looking permanently busy so background work never runs again this process.
+        .onStart { requestActivityTracker?.begin() }
+        .onCompletion { requestActivityTracker?.end() }
 }
 
 /**

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/MessageFiles.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/MessageFiles.kt
@@ -43,9 +43,9 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import coil3.compose.SubcomposeAsyncImage
 import com.garfiec.librechat.core.model.FileReference
+import com.garfiec.librechat.core.model.media.resolveFileReferenceUrl
 import com.garfiec.librechat.feature.chat.resources.*
 import com.garfiec.librechat.feature.chat.resources.Res
-import com.garfiec.librechat.feature.chat.util.resolveFileReferenceUrl
 import org.jetbrains.compose.resources.stringResource
 
 /**

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/SharedContentParts.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/SharedContentParts.kt
@@ -20,9 +20,9 @@ import androidx.compose.ui.unit.dp
 import com.garfiec.librechat.core.model.Attachment
 import com.garfiec.librechat.core.model.ContentType
 import com.garfiec.librechat.core.model.content.MessageContentPart
+import com.garfiec.librechat.core.model.media.resolveImageFilePartUrl
 import com.garfiec.librechat.feature.chat.resources.*
 import com.garfiec.librechat.feature.chat.resources.Res
-import com.garfiec.librechat.feature.chat.util.resolveImageFilePartUrl
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ToolCallAttachments.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ToolCallAttachments.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.garfiec.librechat.core.model.Attachment
+import com.garfiec.librechat.core.model.media.resolveAttachmentUrl
 import com.garfiec.librechat.core.ui.media.rememberShareFile
 import com.garfiec.librechat.feature.chat.components.artifact.Artifact
 import com.garfiec.librechat.feature.chat.components.artifact.ArtifactButton
@@ -39,7 +40,6 @@ import com.garfiec.librechat.feature.chat.resources.Res
 import com.garfiec.librechat.feature.chat.resources.attachment_fallback
 import com.garfiec.librechat.feature.chat.resources.cd_open_pdf
 import com.garfiec.librechat.feature.chat.resources.pdf_document
-import com.garfiec.librechat.feature.chat.util.resolveAttachmentUrl
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
 

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ToolCallParsing.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ToolCallParsing.kt
@@ -6,7 +6,7 @@ import com.garfiec.librechat.core.model.AskUserQuestionOption
 import com.garfiec.librechat.core.model.AskUserQuestionRequest
 import com.garfiec.librechat.core.model.Attachment
 import com.garfiec.librechat.core.model.content.AgentToolCall
-import com.garfiec.librechat.feature.chat.util.resolveAttachmentUrl
+import com.garfiec.librechat.core.model.media.resolveAttachmentUrl
 import com.garfiec.librechat.feature.chat.viewmodel.ActiveToolCall
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/util/BranchMedia.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/util/BranchMedia.kt
@@ -3,6 +3,8 @@ package com.garfiec.librechat.feature.chat.util
 import com.garfiec.librechat.core.model.Attachment
 import com.garfiec.librechat.core.model.ContentType
 import com.garfiec.librechat.core.model.Message
+import com.garfiec.librechat.core.model.media.resolveFileReferenceUrl
+import com.garfiec.librechat.core.model.media.resolveImageFilePartUrl
 import com.garfiec.librechat.core.ui.media.MediaItem
 import com.garfiec.librechat.feature.chat.components.isImageGenToolCall
 import com.garfiec.librechat.feature.chat.components.parseImageGenResult

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModel.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModel.kt
@@ -42,6 +42,7 @@ import com.garfiec.librechat.core.model.MinimalFeedback
 import com.garfiec.librechat.core.model.Preset
 import com.garfiec.librechat.core.model.config.InterfaceConfig
 import com.garfiec.librechat.core.model.error.UserKeyError
+import com.garfiec.librechat.core.model.media.resolveFileReferenceUrl
 import com.garfiec.librechat.core.model.permissions.Permission
 import com.garfiec.librechat.core.model.permissions.PermissionType
 import com.garfiec.librechat.core.model.permissions.UserRolePermissions
@@ -61,7 +62,6 @@ import com.garfiec.librechat.feature.chat.util.buildActiveMessagePath
 import com.garfiec.librechat.feature.chat.util.extractBranchMedia
 import com.garfiec.librechat.feature.chat.util.hasParallelParts
 import com.garfiec.librechat.feature.chat.util.isImageType
-import com.garfiec.librechat.feature.chat.util.resolveFileReferenceUrl
 import com.garfiec.librechat.feature.chat.util.stabilizeMessageInstances
 import com.garfiec.librechat.feature.chat.util.visionUnreadableImageNames
 import com.garfiec.librechat.feature.chat.viewmodel.delegate.ComparisonModeDelegate

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModel.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModel.kt
@@ -1548,7 +1548,9 @@ class ChatViewModel(
         if (_uiState.value.isRefreshingMessages) return
         _uiState.update { it.copy(content = it.content.copy(isRefreshingMessages = true)) }
         viewModelScope.launch {
-            messageRepository.refreshMessages(conversationId)
+            // Foreground pull-to-refresh: the user is looking at this conversation now, so entry is
+            // land time and the live account is the right one to attribute to.
+            messageRepository.refreshMessages(conversationId, originAccount = null)
             loadConversation(conversationId)
             _uiState.update { it.copy(content = it.content.copy(isRefreshingMessages = false)) }
         }

--- a/feature/settings/src/androidMain/kotlin/com/garfiec/librechat/feature/settings/util/AndroidCacheCleaner.kt
+++ b/feature/settings/src/androidMain/kotlin/com/garfiec/librechat/feature/settings/util/AndroidCacheCleaner.kt
@@ -10,4 +10,12 @@ class AndroidCacheCleaner(private val context: Context) : PlatformCacheCleaner {
             context.cacheDir.deleteRecursively()
         }
     }
+
+    override suspend fun cacheSizeBytes(): Long = withContext(Dispatchers.IO) {
+        // Walks the same directory clearCache() empties, so the figure drops to roughly zero when the
+        // user taps Clear — which is the only behaviour that makes a size readout worth showing.
+        runCatching {
+            context.cacheDir.walkBottomUp().filter { it.isFile }.sumOf { it.length() }
+        }.getOrDefault(0L)
+    }
 }

--- a/feature/settings/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/settings/di/SettingsModuleVerificationTest.kt
+++ b/feature/settings/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/settings/di/SettingsModuleVerificationTest.kt
@@ -6,6 +6,7 @@ import com.garfiec.librechat.core.common.AppInfo
 import com.garfiec.librechat.core.data.datastore.ServerDataStore
 import com.garfiec.librechat.core.data.datastore.SettingsDataStore
 import com.garfiec.librechat.core.data.datastore.ThemeDataStore
+import com.garfiec.librechat.core.data.prefetch.AttachmentWarmer
 import com.garfiec.librechat.core.data.repository.ApiKeyRepository
 import com.garfiec.librechat.core.data.repository.AuthRepository
 import com.garfiec.librechat.core.data.repository.BalanceRepository
@@ -58,6 +59,7 @@ class SettingsModuleVerificationTest {
                 ServerRepository::class,
                 SettingsDataStore::class,
                 ContentReader::class,
+                AttachmentWarmer::class,
                 PlatformCacheCleaner::class,
                 SpeechSettingsFactory::class,
                 DiagnosticLogRepository::class,

--- a/feature/settings/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/settings/viewmodel/SettingsViewModelTest.kt
+++ b/feature/settings/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/settings/viewmodel/SettingsViewModelTest.kt
@@ -110,6 +110,11 @@ class SettingsViewModelTest {
         every { settingsDataStore.sttLanguage } returns MutableStateFlow("")
         every { settingsDataStore.sttOnDevice } returns MutableStateFlow(true)
         every { settingsDataStore.sttEndOfSpeech } returns MutableStateFlow(false)
+        // The preferences state is one combine chain, so a source that never emits stalls all of it —
+        // an unstubbed flow here shows up as an unrelated setting silently keeping its default.
+        every { settingsDataStore.prefetchEnabled } returns MutableStateFlow(false)
+        every { settingsDataStore.prefetchAttachmentsEnabled } returns MutableStateFlow(false)
+        every { settingsDataStore.prefetchOnMeteredEnabled } returns MutableStateFlow(false)
         every { settingsDataStore.chatLayoutStyle } returns MutableStateFlow(ChatLayoutConstants.THREAD)
         every { settingsDataStore.showAvatars } returns MutableStateFlow(true)
         every { settingsDataStore.showBubbles } returns MutableStateFlow(false)

--- a/feature/settings/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/settings/viewmodel/SettingsViewModelTest.kt
+++ b/feature/settings/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/settings/viewmodel/SettingsViewModelTest.kt
@@ -9,6 +9,7 @@ import com.garfiec.librechat.core.data.datastore.ServerDataStore
 import com.garfiec.librechat.core.data.datastore.SettingsDataStore
 import com.garfiec.librechat.core.data.datastore.ThemeDataStore
 import com.garfiec.librechat.core.data.datastore.ThemeMode
+import com.garfiec.librechat.core.data.prefetch.AttachmentWarmer
 import com.garfiec.librechat.core.data.repository.AuthRepository
 import com.garfiec.librechat.core.data.repository.BalanceRepository
 import com.garfiec.librechat.core.data.repository.ConfigRepository
@@ -166,6 +167,10 @@ class SettingsViewModelTest {
             override val versionName = "0.1.0"
             override val versionCode = 1L
             override val gitSha = "testsha0"
+        },
+        attachmentWarmer = object : AttachmentWarmer {
+            override val isSupported = true
+            override suspend fun warm(url: String) = Unit
         },
         ioDispatcher = testDispatcher,
     )

--- a/feature/settings/src/commonMain/composeResources/values-ar/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-ar/strings.xml
@@ -73,6 +73,8 @@
     <string name="prefetch_enabled_desc">Load recent and pinned conversations in the background so they open instantly. Runs only while the app is idle.</string>
     <string name="prefetch_on_metered">Use mobile data</string>
     <string name="prefetch_on_metered_desc">Allow prefetching on metered connections. Off by default to avoid unexpected data usage.</string>
+    <string name="prefetch_attachments">Prefetch images</string>
+    <string name="prefetch_attachments_desc">Also download images and attachments. Uses considerably more data.</string>
     <string name="section_memories">الذكريات</string>
     <string name="section_personalization">التخصيص</string>
     <string name="section_presets">الإعدادات المسبقة</string>
@@ -247,6 +249,7 @@
     <string name="archived_conversations">المحادثات المؤرشفة</string>
     <string name="export_all_data">تصدير جميع البيانات</string>
     <string name="shared_links">الروابط المشتركة</string>
+    <string name="clear_cache_with_size">Clear Cache (%1$s)</string>
     <string name="clear_cache">مسح ذاكرة التخزين المؤقت</string>
     <string name="revoke_all_api_keys">إبطال جميع مفاتيح API</string>
     <string name="revoking">جارٍ الإبطال…</string>

--- a/feature/settings/src/commonMain/composeResources/values-ar/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-ar/strings.xml
@@ -68,6 +68,11 @@
     <string name="section_language">اللغة</string>
     <string name="section_layout">التخطيط</string>
     <string name="section_mcp_servers">خوادم MCP</string>
+    <string name="section_prefetch">Background prefetch</string>
+    <string name="prefetch_enabled">Prefetch conversations</string>
+    <string name="prefetch_enabled_desc">Load recent and pinned conversations in the background so they open instantly. Runs only while the app is idle.</string>
+    <string name="prefetch_on_metered">Use mobile data</string>
+    <string name="prefetch_on_metered_desc">Allow prefetching on metered connections. Off by default to avoid unexpected data usage.</string>
     <string name="section_memories">الذكريات</string>
     <string name="section_personalization">التخصيص</string>
     <string name="section_presets">الإعدادات المسبقة</string>

--- a/feature/settings/src/commonMain/composeResources/values-de/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-de/strings.xml
@@ -68,6 +68,11 @@
     <string name="section_language">Sprache</string>
     <string name="section_layout">Layout</string>
     <string name="section_mcp_servers">MCP-Server</string>
+    <string name="section_prefetch">Background prefetch</string>
+    <string name="prefetch_enabled">Prefetch conversations</string>
+    <string name="prefetch_enabled_desc">Load recent and pinned conversations in the background so they open instantly. Runs only while the app is idle.</string>
+    <string name="prefetch_on_metered">Use mobile data</string>
+    <string name="prefetch_on_metered_desc">Allow prefetching on metered connections. Off by default to avoid unexpected data usage.</string>
     <string name="section_memories">Erinnerungen</string>
     <string name="section_personalization">Personalisierung</string>
     <string name="section_presets">Vorlagen</string>

--- a/feature/settings/src/commonMain/composeResources/values-de/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-de/strings.xml
@@ -73,6 +73,8 @@
     <string name="prefetch_enabled_desc">Load recent and pinned conversations in the background so they open instantly. Runs only while the app is idle.</string>
     <string name="prefetch_on_metered">Use mobile data</string>
     <string name="prefetch_on_metered_desc">Allow prefetching on metered connections. Off by default to avoid unexpected data usage.</string>
+    <string name="prefetch_attachments">Prefetch images</string>
+    <string name="prefetch_attachments_desc">Also download images and attachments. Uses considerably more data.</string>
     <string name="section_memories">Erinnerungen</string>
     <string name="section_personalization">Personalisierung</string>
     <string name="section_presets">Vorlagen</string>
@@ -247,6 +249,7 @@
     <string name="archived_conversations">Archivierte Unterhaltungen</string>
     <string name="export_all_data">Alle Daten exportieren</string>
     <string name="shared_links">Geteilte Links</string>
+    <string name="clear_cache_with_size">Clear Cache (%1$s)</string>
     <string name="clear_cache">Cache leeren</string>
     <string name="revoke_all_api_keys">Alle API-Schlüssel widerrufen</string>
     <string name="revoking">Wird widerrufen…</string>

--- a/feature/settings/src/commonMain/composeResources/values-es/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-es/strings.xml
@@ -68,6 +68,11 @@
     <string name="section_language">Idioma</string>
     <string name="section_layout">Diseño</string>
     <string name="section_mcp_servers">Servidores MCP</string>
+    <string name="section_prefetch">Background prefetch</string>
+    <string name="prefetch_enabled">Prefetch conversations</string>
+    <string name="prefetch_enabled_desc">Load recent and pinned conversations in the background so they open instantly. Runs only while the app is idle.</string>
+    <string name="prefetch_on_metered">Use mobile data</string>
+    <string name="prefetch_on_metered_desc">Allow prefetching on metered connections. Off by default to avoid unexpected data usage.</string>
     <string name="section_memories">Recuerdos</string>
     <string name="section_personalization">Personalización</string>
     <string name="section_presets">Preajustes</string>

--- a/feature/settings/src/commonMain/composeResources/values-es/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-es/strings.xml
@@ -73,6 +73,8 @@
     <string name="prefetch_enabled_desc">Load recent and pinned conversations in the background so they open instantly. Runs only while the app is idle.</string>
     <string name="prefetch_on_metered">Use mobile data</string>
     <string name="prefetch_on_metered_desc">Allow prefetching on metered connections. Off by default to avoid unexpected data usage.</string>
+    <string name="prefetch_attachments">Prefetch images</string>
+    <string name="prefetch_attachments_desc">Also download images and attachments. Uses considerably more data.</string>
     <string name="section_memories">Recuerdos</string>
     <string name="section_personalization">Personalización</string>
     <string name="section_presets">Preajustes</string>
@@ -247,6 +249,7 @@
     <string name="archived_conversations">Conversaciones archivadas</string>
     <string name="export_all_data">Exportar todos los datos</string>
     <string name="shared_links">Enlaces compartidos</string>
+    <string name="clear_cache_with_size">Clear Cache (%1$s)</string>
     <string name="clear_cache">Borrar caché</string>
     <string name="revoke_all_api_keys">Revocar todas las claves de API</string>
     <string name="revoking">Revocando…</string>

--- a/feature/settings/src/commonMain/composeResources/values-fr/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-fr/strings.xml
@@ -68,6 +68,11 @@
     <string name="section_language">Langue</string>
     <string name="section_layout">Disposition</string>
     <string name="section_mcp_servers">Serveurs MCP</string>
+    <string name="section_prefetch">Background prefetch</string>
+    <string name="prefetch_enabled">Prefetch conversations</string>
+    <string name="prefetch_enabled_desc">Load recent and pinned conversations in the background so they open instantly. Runs only while the app is idle.</string>
+    <string name="prefetch_on_metered">Use mobile data</string>
+    <string name="prefetch_on_metered_desc">Allow prefetching on metered connections. Off by default to avoid unexpected data usage.</string>
     <string name="section_memories">Mémoires</string>
     <string name="section_personalization">Personnalisation</string>
     <string name="section_presets">Préréglages</string>

--- a/feature/settings/src/commonMain/composeResources/values-fr/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-fr/strings.xml
@@ -73,6 +73,8 @@
     <string name="prefetch_enabled_desc">Load recent and pinned conversations in the background so they open instantly. Runs only while the app is idle.</string>
     <string name="prefetch_on_metered">Use mobile data</string>
     <string name="prefetch_on_metered_desc">Allow prefetching on metered connections. Off by default to avoid unexpected data usage.</string>
+    <string name="prefetch_attachments">Prefetch images</string>
+    <string name="prefetch_attachments_desc">Also download images and attachments. Uses considerably more data.</string>
     <string name="section_memories">Mémoires</string>
     <string name="section_personalization">Personnalisation</string>
     <string name="section_presets">Préréglages</string>
@@ -247,6 +249,7 @@
     <string name="archived_conversations">Conversations archivées</string>
     <string name="export_all_data">Exporter toutes les données</string>
     <string name="shared_links">Liens partagés</string>
+    <string name="clear_cache_with_size">Clear Cache (%1$s)</string>
     <string name="clear_cache">Vider le cache</string>
     <string name="revoke_all_api_keys">Révoquer toutes les clés API</string>
     <string name="revoking">Révocation…</string>

--- a/feature/settings/src/commonMain/composeResources/values-ja/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-ja/strings.xml
@@ -68,6 +68,11 @@
     <string name="section_language">言語</string>
     <string name="section_layout">レイアウト</string>
     <string name="section_mcp_servers">MCPサーバー</string>
+    <string name="section_prefetch">Background prefetch</string>
+    <string name="prefetch_enabled">Prefetch conversations</string>
+    <string name="prefetch_enabled_desc">Load recent and pinned conversations in the background so they open instantly. Runs only while the app is idle.</string>
+    <string name="prefetch_on_metered">Use mobile data</string>
+    <string name="prefetch_on_metered_desc">Allow prefetching on metered connections. Off by default to avoid unexpected data usage.</string>
     <string name="section_memories">メモリ</string>
     <string name="section_personalization">パーソナライズ</string>
     <string name="section_presets">プリセット</string>

--- a/feature/settings/src/commonMain/composeResources/values-ja/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-ja/strings.xml
@@ -73,6 +73,8 @@
     <string name="prefetch_enabled_desc">Load recent and pinned conversations in the background so they open instantly. Runs only while the app is idle.</string>
     <string name="prefetch_on_metered">Use mobile data</string>
     <string name="prefetch_on_metered_desc">Allow prefetching on metered connections. Off by default to avoid unexpected data usage.</string>
+    <string name="prefetch_attachments">Prefetch images</string>
+    <string name="prefetch_attachments_desc">Also download images and attachments. Uses considerably more data.</string>
     <string name="section_memories">メモリ</string>
     <string name="section_personalization">パーソナライズ</string>
     <string name="section_presets">プリセット</string>
@@ -247,6 +249,7 @@
     <string name="archived_conversations">アーカイブ済みの会話</string>
     <string name="export_all_data">すべてのデータをエクスポート</string>
     <string name="shared_links">共有リンク</string>
+    <string name="clear_cache_with_size">Clear Cache (%1$s)</string>
     <string name="clear_cache">キャッシュをクリア</string>
     <string name="revoke_all_api_keys">すべてのAPIキーを取り消す</string>
     <string name="revoking">取り消し中…</string>

--- a/feature/settings/src/commonMain/composeResources/values-ko/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-ko/strings.xml
@@ -68,6 +68,11 @@
     <string name="section_language">언어</string>
     <string name="section_layout">레이아웃</string>
     <string name="section_mcp_servers">MCP 서버</string>
+    <string name="section_prefetch">Background prefetch</string>
+    <string name="prefetch_enabled">Prefetch conversations</string>
+    <string name="prefetch_enabled_desc">Load recent and pinned conversations in the background so they open instantly. Runs only while the app is idle.</string>
+    <string name="prefetch_on_metered">Use mobile data</string>
+    <string name="prefetch_on_metered_desc">Allow prefetching on metered connections. Off by default to avoid unexpected data usage.</string>
     <string name="section_memories">메모리</string>
     <string name="section_personalization">개인화</string>
     <string name="section_presets">프리셋</string>

--- a/feature/settings/src/commonMain/composeResources/values-ko/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-ko/strings.xml
@@ -73,6 +73,8 @@
     <string name="prefetch_enabled_desc">Load recent and pinned conversations in the background so they open instantly. Runs only while the app is idle.</string>
     <string name="prefetch_on_metered">Use mobile data</string>
     <string name="prefetch_on_metered_desc">Allow prefetching on metered connections. Off by default to avoid unexpected data usage.</string>
+    <string name="prefetch_attachments">Prefetch images</string>
+    <string name="prefetch_attachments_desc">Also download images and attachments. Uses considerably more data.</string>
     <string name="section_memories">메모리</string>
     <string name="section_personalization">개인화</string>
     <string name="section_presets">프리셋</string>
@@ -247,6 +249,7 @@
     <string name="archived_conversations">보관된 대화</string>
     <string name="export_all_data">모든 데이터 내보내기</string>
     <string name="shared_links">공유 링크</string>
+    <string name="clear_cache_with_size">Clear Cache (%1$s)</string>
     <string name="clear_cache">캐시 지우기</string>
     <string name="revoke_all_api_keys">모든 API 키 해제</string>
     <string name="revoking">해제하는 중…</string>

--- a/feature/settings/src/commonMain/composeResources/values-pt/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-pt/strings.xml
@@ -73,6 +73,8 @@
     <string name="prefetch_enabled_desc">Load recent and pinned conversations in the background so they open instantly. Runs only while the app is idle.</string>
     <string name="prefetch_on_metered">Use mobile data</string>
     <string name="prefetch_on_metered_desc">Allow prefetching on metered connections. Off by default to avoid unexpected data usage.</string>
+    <string name="prefetch_attachments">Prefetch images</string>
+    <string name="prefetch_attachments_desc">Also download images and attachments. Uses considerably more data.</string>
     <string name="section_memories">Memórias</string>
     <string name="section_personalization">Personalização</string>
     <string name="section_presets">Predefinições</string>
@@ -247,6 +249,7 @@
     <string name="archived_conversations">Conversas arquivadas</string>
     <string name="export_all_data">Exportar todos os dados</string>
     <string name="shared_links">Links compartilhados</string>
+    <string name="clear_cache_with_size">Clear Cache (%1$s)</string>
     <string name="clear_cache">Limpar cache</string>
     <string name="revoke_all_api_keys">Revogar todas as chaves de API</string>
     <string name="revoking">Revogando…</string>

--- a/feature/settings/src/commonMain/composeResources/values-pt/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-pt/strings.xml
@@ -68,6 +68,11 @@
     <string name="section_language">Idioma</string>
     <string name="section_layout">Layout</string>
     <string name="section_mcp_servers">Servidores MCP</string>
+    <string name="section_prefetch">Background prefetch</string>
+    <string name="prefetch_enabled">Prefetch conversations</string>
+    <string name="prefetch_enabled_desc">Load recent and pinned conversations in the background so they open instantly. Runs only while the app is idle.</string>
+    <string name="prefetch_on_metered">Use mobile data</string>
+    <string name="prefetch_on_metered_desc">Allow prefetching on metered connections. Off by default to avoid unexpected data usage.</string>
     <string name="section_memories">Memórias</string>
     <string name="section_personalization">Personalização</string>
     <string name="section_presets">Predefinições</string>

--- a/feature/settings/src/commonMain/composeResources/values-ru/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-ru/strings.xml
@@ -73,6 +73,8 @@
     <string name="prefetch_enabled_desc">Load recent and pinned conversations in the background so they open instantly. Runs only while the app is idle.</string>
     <string name="prefetch_on_metered">Use mobile data</string>
     <string name="prefetch_on_metered_desc">Allow prefetching on metered connections. Off by default to avoid unexpected data usage.</string>
+    <string name="prefetch_attachments">Prefetch images</string>
+    <string name="prefetch_attachments_desc">Also download images and attachments. Uses considerably more data.</string>
     <string name="section_memories">Память</string>
     <string name="section_personalization">Персонализация</string>
     <string name="section_presets">Пресеты</string>
@@ -247,6 +249,7 @@
     <string name="archived_conversations">Архивированные беседы</string>
     <string name="export_all_data">Экспортировать все данные</string>
     <string name="shared_links">Общие ссылки</string>
+    <string name="clear_cache_with_size">Clear Cache (%1$s)</string>
     <string name="clear_cache">Очистить кэш</string>
     <string name="revoke_all_api_keys">Отозвать все API-ключи</string>
     <string name="revoking">Отзыв…</string>

--- a/feature/settings/src/commonMain/composeResources/values-ru/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-ru/strings.xml
@@ -68,6 +68,11 @@
     <string name="section_language">Язык</string>
     <string name="section_layout">Макет</string>
     <string name="section_mcp_servers">Серверы MCP</string>
+    <string name="section_prefetch">Background prefetch</string>
+    <string name="prefetch_enabled">Prefetch conversations</string>
+    <string name="prefetch_enabled_desc">Load recent and pinned conversations in the background so they open instantly. Runs only while the app is idle.</string>
+    <string name="prefetch_on_metered">Use mobile data</string>
+    <string name="prefetch_on_metered_desc">Allow prefetching on metered connections. Off by default to avoid unexpected data usage.</string>
     <string name="section_memories">Память</string>
     <string name="section_personalization">Персонализация</string>
     <string name="section_presets">Пресеты</string>

--- a/feature/settings/src/commonMain/composeResources/values-zh/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-zh/strings.xml
@@ -73,6 +73,8 @@
     <string name="prefetch_enabled_desc">Load recent and pinned conversations in the background so they open instantly. Runs only while the app is idle.</string>
     <string name="prefetch_on_metered">Use mobile data</string>
     <string name="prefetch_on_metered_desc">Allow prefetching on metered connections. Off by default to avoid unexpected data usage.</string>
+    <string name="prefetch_attachments">Prefetch images</string>
+    <string name="prefetch_attachments_desc">Also download images and attachments. Uses considerably more data.</string>
     <string name="section_memories">记忆</string>
     <string name="section_personalization">个性化</string>
     <string name="section_presets">预设</string>
@@ -247,6 +249,7 @@
     <string name="archived_conversations">已归档对话</string>
     <string name="export_all_data">导出全部数据</string>
     <string name="shared_links">分享链接</string>
+    <string name="clear_cache_with_size">Clear Cache (%1$s)</string>
     <string name="clear_cache">清除缓存</string>
     <string name="revoke_all_api_keys">吊销所有 API 密钥</string>
     <string name="revoking">吊销中…</string>

--- a/feature/settings/src/commonMain/composeResources/values-zh/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-zh/strings.xml
@@ -68,6 +68,11 @@
     <string name="section_language">语言</string>
     <string name="section_layout">布局</string>
     <string name="section_mcp_servers">MCP 服务器</string>
+    <string name="section_prefetch">Background prefetch</string>
+    <string name="prefetch_enabled">Prefetch conversations</string>
+    <string name="prefetch_enabled_desc">Load recent and pinned conversations in the background so they open instantly. Runs only while the app is idle.</string>
+    <string name="prefetch_on_metered">Use mobile data</string>
+    <string name="prefetch_on_metered_desc">Allow prefetching on metered connections. Off by default to avoid unexpected data usage.</string>
     <string name="section_memories">记忆</string>
     <string name="section_personalization">个性化</string>
     <string name="section_presets">预设</string>

--- a/feature/settings/src/commonMain/composeResources/values/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values/strings.xml
@@ -74,6 +74,8 @@
     <string name="prefetch_enabled_desc">Load recent and pinned conversations in the background so they open instantly. Runs only while the app is idle.</string>
     <string name="prefetch_on_metered">Use mobile data</string>
     <string name="prefetch_on_metered_desc">Allow prefetching on metered connections. Off by default to avoid unexpected data usage.</string>
+    <string name="prefetch_attachments">Prefetch images</string>
+    <string name="prefetch_attachments_desc">Also download images and attachments. Uses considerably more data.</string>
     <string name="section_memories">Memories</string>
     <string name="section_personalization">Personalization</string>
     <string name="section_presets">Presets</string>
@@ -279,6 +281,7 @@
     <string name="archived_conversations">Archived Conversations</string>
     <string name="export_all_data">Export All Data</string>
     <string name="shared_links">Shared Links</string>
+    <string name="clear_cache_with_size">Clear Cache (%1$s)</string>
     <string name="clear_cache">Clear Cache</string>
     <string name="revoke_all_api_keys">Revoke All API Keys</string>
     <string name="revoking">Revoking…</string>

--- a/feature/settings/src/commonMain/composeResources/values/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values/strings.xml
@@ -69,6 +69,11 @@
     <string name="section_language">Language</string>
     <string name="section_layout">Layout</string>
     <string name="section_mcp_servers">MCP Servers</string>
+    <string name="section_prefetch">Background prefetch</string>
+    <string name="prefetch_enabled">Prefetch conversations</string>
+    <string name="prefetch_enabled_desc">Load recent and pinned conversations in the background so they open instantly. Runs only while the app is idle.</string>
+    <string name="prefetch_on_metered">Use mobile data</string>
+    <string name="prefetch_on_metered_desc">Allow prefetching on metered connections. Off by default to avoid unexpected data usage.</string>
     <string name="section_memories">Memories</string>
     <string name="section_personalization">Personalization</string>
     <string name="section_presets">Presets</string>

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/di/SettingsModule.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/di/SettingsModule.kt
@@ -44,6 +44,7 @@ val settingsModule = module {
             configRepository = get(),
             diagnosticLogRepository = get(),
             appInfo = get(),
+            attachmentWarmer = get(),
             ioDispatcher = get(KoinQualifiers.IO),
         )
     }

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/ChatSettingsSection.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/ChatSettingsSection.kt
@@ -217,12 +217,14 @@ internal fun GroupLabel(text: String) {
     )
 }
 
+/** The module's shared title/description/switch row. */
 @Composable
-private fun ToggleRow(
+internal fun ToggleRow(
     title: String,
     description: String,
     checked: Boolean,
     onChange: (Boolean) -> Unit,
+    enabled: Boolean = true,
 ) {
     Row(
         modifier = Modifier.fillMaxWidth(),
@@ -232,17 +234,27 @@ private fun ToggleRow(
             Text(
                 text = title,
                 style = MaterialTheme.typography.bodyLarge,
+                color = if (enabled) {
+                    MaterialTheme.colorScheme.onSurface
+                } else {
+                    MaterialTheme.colorScheme.onSurface.copy(alpha = DISABLED_ALPHA)
+                },
             )
             Text(
                 text = description,
                 style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(
+                    alpha = if (enabled) 1f else DISABLED_ALPHA,
+                ),
             )
         }
         Spacer(modifier = Modifier.width(16.dp))
         Switch(
             checked = checked,
             onCheckedChange = onChange,
+            enabled = enabled,
         )
     }
 }
+
+private const val DISABLED_ALPHA = 0.38f

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/DataSettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/DataSettingsScreen.kt
@@ -187,6 +187,7 @@ fun DataSettingsContent(
                     onArtifactShortcutsClick = onNavigateToArtifactShortcuts,
                     onClearCacheClick = { showClearCacheDialog = true },
                     isCacheClearing = uiState.isCacheClearing,
+                    cacheSizeBytes = uiState.cacheSizeBytes,
                     onRevokeKeysClick = { showRevokeKeysDialog = true },
                     isKeyRevoking = uiState.isKeyRevoking,
                 )
@@ -199,8 +200,11 @@ fun DataSettingsContent(
                 PrefetchSettingsSection(
                     prefetchEnabled = uiState.prefetchEnabled,
                     prefetchOnMeteredEnabled = uiState.prefetchOnMeteredEnabled,
+                    prefetchAttachmentsEnabled = uiState.prefetchAttachmentsEnabled,
+                    prefetchAttachmentsSupported = uiState.prefetchAttachmentsSupported,
                     onPrefetchEnabledChange = viewModel::setPrefetchEnabled,
                     onPrefetchOnMeteredChange = viewModel::setPrefetchOnMeteredEnabled,
+                    onPrefetchAttachmentsChange = viewModel::setPrefetchAttachmentsEnabled,
                 )
             }
 
@@ -333,6 +337,7 @@ private fun DataExtraActions(
     onArtifactShortcutsClick: () -> Unit,
     onClearCacheClick: () -> Unit,
     isCacheClearing: Boolean,
+    cacheSizeBytes: Long?,
     onRevokeKeysClick: () -> Unit,
     isKeyRevoking: Boolean,
 ) {
@@ -381,13 +386,23 @@ private fun DataExtraActions(
                 }
             }
 
-            // Clear cache
+            // Clear cache. The size is only shown once read and non-zero — a "(0 B)" on a cache that
+            // simply hasn't been measured yet reads as a broken feature rather than an empty one.
             OutlinedButton(
                 onClick = onClearCacheClick,
                 enabled = !isCacheClearing,
                 modifier = Modifier.fillMaxWidth(),
             ) {
-                Text(stringResource(if (isCacheClearing) Res.string.clearing else Res.string.clear_cache))
+                Text(
+                    when {
+                        isCacheClearing -> stringResource(Res.string.clearing)
+                        cacheSizeBytes != null && cacheSizeBytes > 0 -> stringResource(
+                            Res.string.clear_cache_with_size,
+                            formatBytes(cacheSizeBytes),
+                        )
+                        else -> stringResource(Res.string.clear_cache)
+                    },
+                )
             }
 
             // Revoke API keys

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/DataSettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/DataSettingsScreen.kt
@@ -192,6 +192,18 @@ fun DataSettingsContent(
                 )
             }
 
+            item(key = "prefetch_header") {
+                SectionHeader(stringResource(Res.string.section_prefetch))
+            }
+            item(key = "prefetch_settings") {
+                PrefetchSettingsSection(
+                    prefetchEnabled = uiState.prefetchEnabled,
+                    prefetchOnMeteredEnabled = uiState.prefetchOnMeteredEnabled,
+                    onPrefetchEnabledChange = viewModel::setPrefetchEnabled,
+                    onPrefetchOnMeteredChange = viewModel::setPrefetchOnMeteredEnabled,
+                )
+            }
+
             // Memories section — hidden entirely when the server's MEMORIES.USE role
             // permission is denied. The user-level opt-out (`memoriesEnabled`) stays
             // independent and only hides the list inside this section.

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/DataSettingsSection.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/DataSettingsSection.kt
@@ -216,7 +216,7 @@ internal fun DataSettingsSection(
  * Compact human-readable byte size (e.g. `123 KB`, `1.2 MB`) for the export-logs button label.
  * Uses binary (1024) units; one decimal place above KB.
  */
-private fun formatBytes(bytes: Long): String {
+internal fun formatBytes(bytes: Long): String {
     if (bytes < 1024) return "$bytes B"
     val kb = bytes / 1024.0
     if (kb < 1024) return "${kb.toInt()} KB"

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/PrefetchSettingsSection.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/PrefetchSettingsSection.kt
@@ -8,6 +8,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.garfiec.librechat.feature.settings.resources.Res
+import com.garfiec.librechat.feature.settings.resources.prefetch_attachments
+import com.garfiec.librechat.feature.settings.resources.prefetch_attachments_desc
 import com.garfiec.librechat.feature.settings.resources.prefetch_enabled
 import com.garfiec.librechat.feature.settings.resources.prefetch_enabled_desc
 import com.garfiec.librechat.feature.settings.resources.prefetch_on_metered
@@ -25,8 +27,11 @@ import org.jetbrains.compose.resources.stringResource
 fun PrefetchSettingsSection(
     prefetchEnabled: Boolean,
     prefetchOnMeteredEnabled: Boolean,
+    prefetchAttachmentsEnabled: Boolean,
+    prefetchAttachmentsSupported: Boolean,
     onPrefetchEnabledChange: (Boolean) -> Unit,
     onPrefetchOnMeteredChange: (Boolean) -> Unit,
+    onPrefetchAttachmentsChange: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -41,6 +46,17 @@ fun PrefetchSettingsSection(
             checked = prefetchEnabled,
             onChange = onPrefetchEnabledChange,
         )
+        // Hidden, not disabled, where there is no image cache to warm: a greyed row invites the user
+        // to turn prefetching on to reach a switch that would still do nothing.
+        if (prefetchAttachmentsSupported) {
+            ToggleRow(
+                title = stringResource(Res.string.prefetch_attachments),
+                description = stringResource(Res.string.prefetch_attachments_desc),
+                checked = prefetchAttachmentsEnabled,
+                onChange = onPrefetchAttachmentsChange,
+                enabled = prefetchEnabled,
+            )
+        }
         ToggleRow(
             title = stringResource(Res.string.prefetch_on_metered),
             description = stringResource(Res.string.prefetch_on_metered_desc),

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/PrefetchSettingsSection.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/PrefetchSettingsSection.kt
@@ -1,0 +1,52 @@
+package com.garfiec.librechat.feature.settings.screen
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.garfiec.librechat.feature.settings.resources.Res
+import com.garfiec.librechat.feature.settings.resources.prefetch_enabled
+import com.garfiec.librechat.feature.settings.resources.prefetch_enabled_desc
+import com.garfiec.librechat.feature.settings.resources.prefetch_on_metered
+import com.garfiec.librechat.feature.settings.resources.prefetch_on_metered_desc
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * Background prefetch controls.
+ *
+ * The network override is rendered but **disabled** while prefetching is off, rather than hidden.
+ * Hiding it would reflow the section on every toggle, and a greyed row is what tells the user the
+ * setting exists at all.
+ */
+@Composable
+fun PrefetchSettingsSection(
+    prefetchEnabled: Boolean,
+    prefetchOnMeteredEnabled: Boolean,
+    onPrefetchEnabledChange: (Boolean) -> Unit,
+    onPrefetchOnMeteredChange: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        ToggleRow(
+            title = stringResource(Res.string.prefetch_enabled),
+            description = stringResource(Res.string.prefetch_enabled_desc),
+            checked = prefetchEnabled,
+            onChange = onPrefetchEnabledChange,
+        )
+        ToggleRow(
+            title = stringResource(Res.string.prefetch_on_metered),
+            description = stringResource(Res.string.prefetch_on_metered_desc),
+            checked = prefetchOnMeteredEnabled,
+            onChange = onPrefetchOnMeteredChange,
+            enabled = prefetchEnabled,
+        )
+    }
+}

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/util/PlatformCacheCleaner.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/util/PlatformCacheCleaner.kt
@@ -2,4 +2,14 @@ package com.garfiec.librechat.feature.settings.util
 
 interface PlatformCacheCleaner {
     suspend fun clearCache()
+
+    /**
+     * Bytes held in the cache directory — images and downloaded files.
+     *
+     * Deliberately **not** the Room database. Two reasons, and both would make the number a lie:
+     * [clearCache] does not touch it (`librechat.db` lives outside the cache directory), and SQLite
+     * does not release pages on delete without a `VACUUM`, so a conversation-cache figure would not
+     * move after clearing or pruning. A number that never changes reads as a bug.
+     */
+    suspend fun cacheSizeBytes(): Long
 }

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/SettingsPreferencesController.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/SettingsPreferencesController.kt
@@ -73,6 +73,9 @@ private data class AdditionalPreferences(
     val chatHeaderAlignment: ChatHeaderAlignment = ChatHeaderAlignment.LEFT,
     val contextBarPlacement: ContextBarPlacement = ContextBarPlacement.OPTIONS_SHEET,
     val duringRunAction: DuringRunAction = DuringRunAction.QUEUE,
+    val prefetchEnabled: Boolean = false,
+    val prefetchAttachmentsEnabled: Boolean = false,
+    val prefetchOnMeteredEnabled: Boolean = false,
 )
 
 /**
@@ -219,6 +222,12 @@ class SettingsPreferencesController(
         additional.copy(sttOnDevice = sttOnDevice)
     }.combine(settingsDataStore.sttEndOfSpeech) { additional, sttEndOfSpeech ->
         additional.copy(sttEndOfSpeech = sttEndOfSpeech)
+    }.combine(settingsDataStore.prefetchEnabled) { additional, prefetch ->
+        additional.copy(prefetchEnabled = prefetch)
+    }.combine(settingsDataStore.prefetchAttachmentsEnabled) { additional, prefetchAttachments ->
+        additional.copy(prefetchAttachmentsEnabled = prefetchAttachments)
+    }.combine(settingsDataStore.prefetchOnMeteredEnabled) { additional, prefetchOnMetered ->
+        additional.copy(prefetchOnMeteredEnabled = prefetchOnMetered)
     }.stateIn(scope, SharingStarted.Eagerly, AdditionalPreferences(true, false, "", "", true))
 
     /** The single public UI state that merges DataStore preferences with imperative state. */
@@ -268,6 +277,9 @@ class SettingsPreferencesController(
             chatHeaderAlignment = additional.chatHeaderAlignment,
             contextBarPlacement = additional.contextBarPlacement,
             duringRunAction = additional.duringRunAction,
+            prefetchEnabled = additional.prefetchEnabled,
+            prefetchAttachmentsEnabled = additional.prefetchAttachmentsEnabled,
+            prefetchOnMeteredEnabled = additional.prefetchOnMeteredEnabled,
         )
     }.stateIn(scope, SharingStarted.Eagerly, SettingsUiState())
 
@@ -303,6 +315,18 @@ class SettingsPreferencesController(
 
     fun setAutoScrollEnabled(enabled: Boolean) {
         scope.launch { settingsDataStore.setAutoScrollEnabled(enabled) }
+    }
+
+    fun setPrefetchEnabled(enabled: Boolean) {
+        scope.launch { settingsDataStore.setPrefetchEnabled(enabled) }
+    }
+
+    fun setPrefetchAttachmentsEnabled(enabled: Boolean) {
+        scope.launch { settingsDataStore.setPrefetchAttachmentsEnabled(enabled) }
+    }
+
+    fun setPrefetchOnMeteredEnabled(enabled: Boolean) {
+        scope.launch { settingsDataStore.setPrefetchOnMeteredEnabled(enabled) }
     }
 
     fun setShowThinkingBlocks(show: Boolean) {

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/SettingsUiState.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/SettingsUiState.kt
@@ -92,6 +92,9 @@ data class SettingsUiState(
     /** What the composer's send does mid-run (v0.8.8 steering): inject into the running reply,
      *  or queue for after it. Honoured only where the server supports steering. */
     val duringRunAction: DuringRunAction = DuringRunAction.QUEUE,
+    val prefetchEnabled: Boolean = false,
+    val prefetchAttachmentsEnabled: Boolean = false,
+    val prefetchOnMeteredEnabled: Boolean = false,
     val showImageDescriptions: Boolean = false,
     val dismissKeyboardOnSend: Boolean = false,
     // Data management

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/SettingsUiState.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/SettingsUiState.kt
@@ -95,6 +95,11 @@ data class SettingsUiState(
     val prefetchEnabled: Boolean = false,
     val prefetchAttachmentsEnabled: Boolean = false,
     val prefetchOnMeteredEnabled: Boolean = false,
+    /** Whether this platform has an image cache worth warming; false hides the toggle. */
+    val prefetchAttachmentsSupported: Boolean = false,
+    /** Cached images and files, in bytes; null until read. Excludes the database — see
+     *  [com.garfiec.librechat.feature.settings.util.PlatformCacheCleaner.cacheSizeBytes]. */
+    val cacheSizeBytes: Long? = null,
     val showImageDescriptions: Boolean = false,
     val dismissKeyboardOnSend: Boolean = false,
     // Data management

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/SettingsViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/SettingsViewModel.kt
@@ -15,6 +15,7 @@ import com.garfiec.librechat.core.data.datastore.SettingsDataStore
 import com.garfiec.librechat.core.data.datastore.StarredModelsDisplay
 import com.garfiec.librechat.core.data.datastore.ThemeDataStore
 import com.garfiec.librechat.core.data.datastore.ThemeMode
+import com.garfiec.librechat.core.data.prefetch.AttachmentWarmer
 import com.garfiec.librechat.core.data.repository.AuthRepository
 import com.garfiec.librechat.core.data.repository.BalanceRepository
 import com.garfiec.librechat.core.data.repository.ConfigRepository
@@ -72,12 +73,18 @@ class SettingsViewModel(
     private val configRepository: ConfigRepository,
     diagnosticLogRepository: DiagnosticLogRepository,
     appInfo: AppInfo,
+    attachmentWarmer: AttachmentWarmer,
     ioDispatcher: CoroutineDispatcher,
 ) : ViewModel() {
 
     /** Raw state for everything not driven by DataStore flows. */
     private val _uiState = MutableStateFlow(
-        SettingsUiState(appVersion = appInfo.versionName, gitSha = appInfo.gitSha),
+        SettingsUiState(
+            appVersion = appInfo.versionName,
+            gitSha = appInfo.gitSha,
+            // Constant per platform, so it is seeded rather than observed.
+            prefetchAttachmentsSupported = attachmentWarmer.isSupported,
+        ),
     )
 
     private val stateHandle = SettingsStateHandle(_uiState, viewModelScope)
@@ -121,6 +128,7 @@ class SettingsViewModel(
         observePermissionFlags()
         observeAccountDeletionPolicy()
         dataDelegate.loadLogsBufferSize()
+        dataDelegate.loadCacheSize()
     }
 
     /**

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/SettingsViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/SettingsViewModel.kt
@@ -232,6 +232,18 @@ class SettingsViewModel(
         prefsController.setAutoScrollEnabled(enabled)
     }
 
+    fun setPrefetchEnabled(enabled: Boolean) {
+        prefsController.setPrefetchEnabled(enabled)
+    }
+
+    fun setPrefetchAttachmentsEnabled(enabled: Boolean) {
+        prefsController.setPrefetchAttachmentsEnabled(enabled)
+    }
+
+    fun setPrefetchOnMeteredEnabled(enabled: Boolean) {
+        prefsController.setPrefetchOnMeteredEnabled(enabled)
+    }
+
     fun setShowThinkingBlocks(show: Boolean) {
         prefsController.setShowThinkingBlocks(show)
     }

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/delegate/DataManagementDelegate.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/delegate/DataManagementDelegate.kt
@@ -212,12 +212,28 @@ class DataManagementDelegate(
         }
     }
 
+    fun loadCacheSize() {
+        stateHandle.scope.launch {
+            try {
+                val bytes = cacheCleaner.cacheSizeBytes()
+                stateHandle.update { copy(cacheSizeBytes = bytes) }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Logger.d(e) { "Failed to read cache size" }
+            }
+        }
+    }
+
     fun clearCache() {
         stateHandle.scope.launch {
             stateHandle.update { copy(isCacheClearing = true) }
             try {
                 cacheCleaner.clearCache()
-                stateHandle.update { copy(isCacheClearing = false) }
+                // Re-read rather than assume zero: the directory is shared, and something may have
+                // written to it between the walk and the delete.
+                val bytes = cacheCleaner.cacheSizeBytes()
+                stateHandle.update { copy(isCacheClearing = false, cacheSizeBytes = bytes) }
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {

--- a/feature/settings/src/iosMain/kotlin/com/garfiec/librechat/feature/settings/di/SettingsPlatformModule.ios.kt
+++ b/feature/settings/src/iosMain/kotlin/com/garfiec/librechat/feature/settings/di/SettingsPlatformModule.ios.kt
@@ -17,6 +17,8 @@ import org.koin.dsl.module
 import platform.Foundation.NSCachesDirectory
 import platform.Foundation.NSData
 import platform.Foundation.NSFileManager
+import platform.Foundation.NSFileSize
+import platform.Foundation.NSNumber
 import platform.Foundation.NSSearchPathForDirectoriesInDomains
 import platform.Foundation.NSURL
 import platform.Foundation.NSUserDomainMask
@@ -76,6 +78,30 @@ actual val settingsPlatformModule: Module = module {
                     } catch (e: Exception) {
                         Logger.w(e) { "Failed to clear caches" }
                     }
+                }
+            }
+
+            override suspend fun cacheSizeBytes(): Long = withContext(Dispatchers.Default) {
+                try {
+                    val cachePath = NSSearchPathForDirectoriesInDomains(
+                        NSCachesDirectory,
+                        NSUserDomainMask,
+                        true,
+                    ).firstOrNull() as? String ?: return@withContext 0L
+                    val fm = NSFileManager.defaultManager
+                    // One level deep, matching what clearCache() removes: the readout and the button
+                    // must describe the same bytes, or clearing appears not to work.
+                    val contents = fm.contentsOfDirectoryAtPath(cachePath, null) as? List<*>
+                    contents.orEmpty().sumOf { item ->
+                        val name = item as? String ?: return@sumOf 0L
+                        val attrs = fm.attributesOfItemAtPath("$cachePath/$name", null)
+                        (attrs?.get(NSFileSize) as? NSNumber)?.longLongValue ?: 0L
+                    }
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    Logger.w(e) { "Failed to size caches" }
+                    0L
                 }
             }
         }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -169,6 +169,7 @@ media3-ui = { group = "androidx.media3", name = "media3-ui", version.ref = "medi
 media3-datasource = { group = "androidx.media3", name = "media3-datasource", version.ref = "media3" }
 
 # Image Loading
+coil3-core = { group = "io.coil-kt.coil3", name = "coil", version.ref = "coil3" }
 coil3-compose = { group = "io.coil-kt.coil3", name = "coil-compose", version.ref = "coil3" }
 coil3-network-ktor = { group = "io.coil-kt.coil3", name = "coil-network-ktor3", version.ref = "coil3" }
 coil3-svg = { group = "io.coil-kt.coil3", name = "coil-svg", version.ref = "coil3" }

--- a/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/LibreChatNavHost.kt
+++ b/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/LibreChatNavHost.kt
@@ -23,6 +23,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberDrawerState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -33,6 +34,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDecorator
 import androidx.navigation3.runtime.entryProvider
@@ -41,7 +45,9 @@ import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
 import androidx.navigation3.ui.NavDisplay
 import coil3.SingletonImageLoader
 import coil3.compose.LocalPlatformContext
+import com.garfiec.librechat.core.common.conversation.OpenConversationRegistry
 import com.garfiec.librechat.core.common.identity.AccountState
+import com.garfiec.librechat.core.common.lifecycle.ForegroundSignal
 import com.garfiec.librechat.core.logging.Diag
 import com.garfiec.librechat.core.ui.components.BannerDisplay
 import com.garfiec.librechat.core.ui.theme.AppLocale
@@ -110,6 +116,27 @@ fun LibreChatNavHost(
 ) {
     val isLoggedIn by navHostViewModel.isLoggedIn.collectAsStateWithLifecycle()
 
+    // Publish foreground state for deferred background work. onDispose reports background because a
+    // host leaving composition is the app going away as far as any consumer is concerned.
+    val foregroundSignal = koinInject<ForegroundSignal>()
+    val lifecycleOwner = LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner, foregroundSignal) {
+        val observer = LifecycleEventObserver { _, event ->
+            when (event) {
+                Lifecycle.Event.ON_START -> foregroundSignal.set(true)
+                Lifecycle.Event.ON_STOP -> foregroundSignal.set(false)
+                else -> Unit
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose {
+            lifecycleOwner.lifecycle.removeObserver(observer)
+            foregroundSignal.set(false)
+        }
+    }
+
+    val openConversationRegistry = koinInject<OpenConversationRegistry>()
+
     // Start key comes from the synchronous logged-in seed, not a fixed NewChat. Starting logged-in
     // and redirecting away composes the chat shell for real and then plays NavDisplay's transition
     // animation over it — a third of a second of "signed in" before the auth screen, on every
@@ -153,6 +180,9 @@ fun LibreChatNavHost(
     LaunchedEffect(navigator.currentRoute) {
         val conversationId = (navigator.currentRoute as? Chat)?.conversationId
         drawerViewModel.setActiveConversation(conversationId)
+        // Same answer, different audience: the drawer highlights this conversation, background cache
+        // work has to leave it alone. A non-chat route clears it — nothing open, nothing protected.
+        openConversationRegistry.set(conversationId)
 
         // Navigation breadcrumb: route type name only — low cardinality, content-free.
         val screen = navigator.currentRoute?.let { it::class.simpleName } ?: "none"


### PR DESCRIPTION
## Summary

Opening a conversation that isn't cached costs a full round-trip. `loadConversation(cacheFirst = true)`
(#310) already reads cache-first, but nothing fills the cache ahead of time. This adds an opt-in warmer
that populates the Room cache while the app is idle, so a cache-first open paints immediately.

Off by default. In-app only — no WorkManager, no background-scheduling dependency — and built around the
rule that this work is optional and yields to anything that isn't.

## Changes

**Signals — `:core:common`, `:core:network`**

- `RequestActivityTracker` counts the HTTP work the user is waiting on. Everything counts unless it
  carries `PrefetchMarker`, a coroutine-context element, so a caller that forgets to register merely
  delays background work rather than starving a user request.
- `RequestActivityPlugin` reports from the main Ktor client, installed ahead of `HttpRequestRetry` so it
  is the outermost `HttpSend` interceptor and a retried or auth-replayed call counts once. SSE reports
  from `SseClient` instead, because iOS streams over a transport no Ktor plugin can observe; neither the
  streaming nor the refresh client gets the plugin.
- `ForegroundSignal` and `OpenConversationRegistry`, both published from `LibreChatNavHost` so Android
  and iOS read one signal.
- `NetworkConditionObserver` (metered) and `PowerStateObserver` (power save / Low Power Mode), with
  Android and iOS actuals. The Android power observer is why `:core:common` androidMain now declares
  `androidx.core.ktx` directly rather than relying on it transitively.
- `MessageRepository.refreshMessages` gains `originAccount` (no default value), matching
  `refreshConversation`. When the origin is not the live account the fetch is skipped and cached rows
  are returned instead — or an error, if the cache is empty — rather than riding the wrong bearer and
  base URL. The Room write is now wrapped in `NonCancellable`, which also hardens the existing
  foreground path. Before this PR the sole caller was `ChatViewModel` (pull-to-refresh and the
  error-state Retry button), which passes null; the prefetch engine is the second caller and passes its
  session account.
- `ApiException` gains `retryAfterSeconds`, populated in the response validator. Delta-seconds only,
  matching the existing token-refresh parser.

**Engine — `:core:data`**

- `PrefetchGate` folds foreground state, the setting, network metering, battery saver and in-flight user
  requests into one boolean; `PrefetchController` collects it with `collectLatest`, so any of them
  closing cancels a pass at its next suspension point. A pass starts on a rising edge of that gate —
  there is no loop and no timer, so an app that stays idle does not keep re-running passes.
- Passes run in `Session.scope`. `Session.accountId` is captured when identity resolves and never
  changes, so it is the origin account threaded into the message refresh and into every watermark and
  prune write, and an account switch cancels in-flight work by cancelling the scope. This is the first
  consumer of `Session`. `PrefetchController` is `createdAtStart`, which makes `SessionManager`
  constructed at Koin start for the first time.
- A pass refreshes the conversation list (up to three pages), warms messages for the eligible set, warms
  endpoints/models/agents once per account per process, then prunes. List-first is load-bearing:
  freshness compares each conversation's `updatedAt` against the watermark from its last warm, and that
  `updatedAt` comes from Room. The list refresh is real network work on every pass; the message warm is
  what goes quiet once everything is fresh.
- Selection is the 20 most recently updated non-archived conversations plus every pinned non-archived
  one, never the conversation on screen. Unchanged conversations are never re-fetched, so there is no
  TTL and no per-session cap. Pruning, by contrast, deliberately does consider archived conversations.
- One request in flight at a time. The wait after each request is five times how long that request took,
  clamped to [250 ms, 30 s]. A 429 honours `Retry-After`, falls back to 60 s without it, and does not
  count toward the breaker. Three consecutive real failures trip the breaker, which stops prefetching
  for that account for the rest of the process; nothing resets it on its own.
- Pruning drops cached messages for conversations outside the eligible set untouched for three months,
  keeping the conversation rows so the list stays complete. Watermarks are deleted with them — one left
  behind reports its conversation as warm, so the rows just deleted would never be fetched again.
- New `prefetch_watermarks` table; Room `version = 9` with `AutoMigration(8 → 9)`, schema JSON committed.
  `AccountDataPurger` clears watermarks on logout.

**Attachments and cache readout**

- A second toggle nested under prefetching, off by default, paced like every other request rather than
  fetched in a burst, with a per-conversation ceiling of 20 so one thread of images cannot become the
  whole pass.
- `AttachmentWarmer` carries no image-library types in its signature, so commonMain stays loader-free.
  Android warms Coil's disk cache through the singleton loader the UI reads from (`:core:data`
  androidMain picks up `coil3-core` for this); iOS binds a no-op, because `LibreChatApp` configures Coil
  with a memory cache only, and the toggle is hidden there rather than shipped inert.
- `ImageUrlResolver` moves from `:feature:chat` to `:core:model`, beside the types it maps: a warmed
  entry is only a cache hit if it was stored under the URL the composable later asks for, and a feature
  module cannot be depended on. Its three functions go from `internal` to published `:core:model` API.
- `SettingsViewModel` takes an `AttachmentWarmer` so the toggle can read `isSupported`; this is
  `:feature:settings`' first dependency on a `:core:data` prefetch type.
- Clear Cache now shows the size it will free — images and files, deliberately not the database.
  `clearCache()` does not touch `librechat.db`, and SQLite does not release pages on delete without a
  `VACUUM`, so a conversation-cache figure would not move after clearing or pruning.

**Settings**

- Three global preferences, all off by default: prefetch, use mobile data, prefetch images. New
  "Background prefetch" section in Data settings. `ToggleRow` becomes `internal` and gains an `enabled`
  parameter so the two dependent switches can grey out; it is shared with Chat settings.
- Strings are added to English and to all nine locale files, but the locale files carry the English text
  — they are stubs awaiting translation, not translations.

## Testing

Unit tests green across `:core:common`, `:core:network`, `:core:data`, `:feature:settings` and `:app`;
`detekt` and `detektMetadataCommonMain` clean. New coverage pins the `PrefetchMarker` exemption against
a `MockEngine`, SSE begin/end on both terminal and cancellation, plugin presence on the main client but
not the streaming or refresh clients, `Retry-After` propagation, `refreshMessages` provenance,
`PrefetchPolicy` selection/ordering/freshness, and the engine's pacing, 429 handling, breaker, watermark
writes and pruning under virtual time. `RoomMigrationTest` covers 8 → 9 as an instrumented test.

`PrefetchGate` and `PrefetchController` have no unit tests — the cancellation behaviour they provide was
exercised on device rather than in a harness.

Device pass on a Pixel 10 Pro Fold emulator (API 37) against a live server:

- 8 → 9 migration over populated data, no crash, existing rows preserved
- off by default: no requests and no watermarks through an idle foreground session
- a full 20-conversation warm, pinned conversations first
- inter-request spacing 0.31–0.65 s, one request at a time, no overlap
- freshness: later passes find nothing stale and issue no message requests
- metered gate blocks on cellular, the override releases it
- battery saver blocks and clears
- backgrounding stops a pass, returning to foreground resumes
- completely silent for the duration of a 31 s SSE stream
- the open conversation is excluded while open and warmed after leaving it
- attachment warming grows Coil's disk cache; the Clear Cache readout drops after clearing
- pruning deletes cached messages and their watermarks together, keeping conversation rows

## Notes

- iOS is mirrored but not built, per project convention. Attachment prefetch is a no-op there by design.
- Two behaviours are unverified end to end. Account scoping is covered by unit tests but was only weakly
  exercised on device, and the pinned branch of selection is hard to observe at all: pinning bumps the
  server's `updatedAt`, so a pinned conversation enters the recent set anyway.
- The gate has no input-quiescence term, so an image decode and Room write can land mid-fling. No jank
  was seen, but nothing stress-scrolled during a pass. It is a one-line addition to the existing
  `combine` if it turns out to matter.
