### PR TITLE
chore(build): install debug builds alongside release

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,16 @@ adb install app/build/outputs/apk/debug/app-debug.apk
 
 Or run directly via Android Studio's run configuration.
 
+Debug builds carry a `.debug` applicationId suffix, so they install as
+`com.garfiec.librechat.debug` under the launcher name **Switchboard Dev** (with a distinct
+icon backdrop) and coexist with a released install instead of colliding with it. The two
+are separate apps to Android: each keeps its own login, Room cache, and preferences, and
+neither can see the other's data. Release builds keep the bare `com.garfiec.librechat` —
+update channels track that package name, so it must not gain a suffix.
+
+Both installs register the `librechat://` scheme, so opening such a URL by hand may prompt
+you to pick an app. Home-screen shortcuts are unaffected; they target an explicit component.
+
 ### iOS
 
 Build and run on the iOS Simulator from CLI:

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -12,6 +12,14 @@ android {
         applicationId = "com.garfiec.librechat"
     }
 
+    buildTypes {
+        debug {
+            // Release must keep the bare id — Obtainium tracks updates by package name.
+            applicationIdSuffix = ".debug"
+            versionNameSuffix = "-debug"
+        }
+    }
+
     signingConfigs {
         getByName("debug") {
             storeFile = file("debug.keystore")

--- a/app/src/debug/res/values/ic_launcher_background.xml
+++ b/app/src/debug/res/values/ic_launcher_background.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="ic_launcher_background">#4A2B0F</color>
+</resources>

--- a/app/src/debug/res/values/strings.xml
+++ b/app/src/debug/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">Switchboard Dev</string>
+</resources>

--- a/scripts/devcheck/devcheck.sh
+++ b/scripts/devcheck/devcheck.sh
@@ -10,7 +10,11 @@
 # Set ANDROID_SERIAL when more than one device is attached; every adb call below honors it.
 set -euo pipefail
 
-PKG=com.garfiec.librechat
+# run-as only works on a debuggable build, so these checks target the .debug install.
+PKG="${DEVCHECK_PKG:-com.garfiec.librechat.debug}"
+# Spelled out in full: the applicationId is suffixed but the code namespace is not, so a relative
+# `$PKG/.MainActivity` resolves to a class that does not exist.
+ACTIVITY=com.garfiec.librechat.MainActivity
 STATE_DIR="${DEVCHECK_STATE_DIR:-${TMPDIR:-/tmp}/switchboard-devcheck}"
 SNAPSHOT="$STATE_DIR/broken-session.tar"
 REMOTE_TAR=/data/local/tmp/devcheck-restore.tar
@@ -50,7 +54,7 @@ launch() {
   # Always force-stop first: `am start` onto a live task just resumes it, so nothing re-composes and
   # no cold-start work runs — a "clean" capture that only proves the app was already open.
   adb shell am force-stop "$PKG"
-  adb shell am start -W -n "$PKG/.MainActivity" >/dev/null 2>&1
+  adb shell am start -W -n "$PKG/$ACTIVITY" >/dev/null 2>&1
 }
 
 capture() {


### PR DESCRIPTION
## Summary

Debug and release builds shared one `applicationId`, so they could not coexist on a
device: installing one meant uninstalling the other and losing its login and cache.
(The signing keys differ too, so the install fails outright rather than upgrading in
place.) This suffixes the debug applicationId so a development build sits alongside a
released install.

## Changes

- **`app/build.gradle.kts`** — the debug build type gains `applicationIdSuffix = ".debug"`
  and `versionNameSuffix = "-debug"`. Release keeps the bare `com.garfiec.librechat`;
  update channels track that package name.
- **`app/src/debug/res/values/`** — debug-only resource overrides: launcher name
  "Switchboard Dev" and a distinct adaptive-icon backdrop, so the two installs are
  tellable apart. Only the icon's background layer is overridden.
- **`scripts/devcheck/devcheck.sh`** — targets the debug package (overridable via
  `DEVCHECK_PKG`) and spells the launcher component out in full. The applicationId is
  suffixed but the code namespace is not, so the relative `.MainActivity` form resolves
  to a class that does not exist.
- **`CONTRIBUTING.md`** — documents the side-by-side install and the shared URL scheme.

Debug builds now show `2026.08.0-debug` in Settings → About. Nothing parses that string.

## Testing

- `:app:assembleDebug` and `:app:lintDebug` pass.
- Debug APK badging: package `com.garfiec.librechat.debug`, versionName
  `2026.08.0-debug`, label "Switchboard Dev".
- Merged debug manifest: all six provider authorities carry the suffixed id
  (fileprovider, compose-resources, androidx-startup, LeakCanary ×2, plumber). The
  release merged manifest still declares the bare package.
- Emulator: the debug build installed alongside an existing `com.garfiec.librechat`
  install with no provider conflict, producing two launcher entries with distinct
  icons. `am start -n <pkg>/.MainActivity` fails against the suffixed package; the
  fully-qualified form launches.

Data isolation between the two installs is a platform guarantee — a distinct
applicationId means a distinct UID and data directory — rather than something observed
here. Not exercised at runtime: independent sessions across the two installs, file
attachment, and artifact-shortcut pinning. Every FileProvider authority in the codebase
is built from `context.packageName`, so none of them is hardcoded. No physical-device pass.

## Notes

- Both installs register the `librechat://` scheme. Opening such a URL may show a
  chooser — including an OAuth redirect, on a deployment configured to redirect back to
  the app that way. Home-screen shortcuts set an explicit component and are unaffected.
- The icons differ only in their background layer, so under themed (monochrome) launcher
  icons the two are identical and only the label distinguishes them.
- iOS has no equivalent split; tracked in #336.
