### PR TITLE
feat(prefetch): make the warm depth configurable

### DIFF
--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchControllerTest.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchControllerTest.kt
@@ -66,6 +66,7 @@ class PrefetchControllerTest {
         coEvery { configRepository.fetchModels() } returns Result.Success(emptyMap())
         coEvery { agentRepository.getAgents(any()) } returns Result.Success(emptyList())
         every { settingsDataStore.prefetchAttachmentsEnabled } returns flowOf(false)
+        every { settingsDataStore.prefetchDepth } returns flowOf(PrefetchDepth.DEFAULT)
         every { attachmentWarmer.isSupported } returns false
 
         var firstCall = true

--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchEngineTest.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchEngineTest.kt
@@ -72,6 +72,7 @@ class PrefetchEngineTest {
         coEvery { conversationDao.pinnedForPrefetch(any()) } returns emptyList()
         coEvery { conversationDao.conversationIdsOlderThan(any(), any()) } returns emptyList()
         every { settingsDataStore.prefetchAttachmentsEnabled } returns flowOf(false)
+        every { settingsDataStore.prefetchDepth } returns flowOf(PrefetchDepth.DEFAULT)
         every { attachmentWarmer.isSupported } returns false
     }
 
@@ -344,6 +345,42 @@ class PrefetchEngineTest {
             PrefetchRunState.WarmingMessages(completed = 1, total = 2),
         ).inOrder()
         assertThat(engine.runState.value.state).isEqualTo(PrefetchRunState.Idle)
+    }
+
+    @Test
+    fun `the configured depth bounds the conversations selected`() = runTest {
+        every { settingsDataStore.prefetchDepth } returns flowOf(50)
+        coEvery { conversationDao.recentForPrefetch(any(), any()) } returns emptyList()
+
+        engine().run(account)
+
+        coVerify { conversationDao.recentForPrefetch(account.value, 50) }
+    }
+
+    @Test
+    fun `a deeper setting pages the conversation list further`() = runTest {
+        every { settingsDataStore.prefetchDepth } returns flowOf(PrefetchDepth.MAX)
+        coEvery { conversationDao.recentForPrefetch(any(), any()) } returns emptyList()
+        coEvery { conversationRepository.loadNextPage(any(), any(), any(), any(), any(), any()) } returns
+            Result.Success("next-cursor")
+
+        engine().run(account)
+
+        coVerify(exactly = PrefetchPolicy().listPagesFor(PrefetchDepth.MAX)) {
+            conversationRepository.loadNextPage(any(), any(), any(), any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `paging stops when the server runs out of conversations`() = runTest {
+        every { settingsDataStore.prefetchDepth } returns flowOf(PrefetchDepth.MAX)
+        coEvery { conversationDao.recentForPrefetch(any(), any()) } returns emptyList()
+
+        engine().run(account)
+
+        coVerify(exactly = 1) {
+            conversationRepository.loadNextPage(any(), any(), any(), any(), any(), any())
+        }
     }
 
     /**

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/SettingsDataStore.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/SettingsDataStore.kt
@@ -5,10 +5,12 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.floatPreferencesKey
+import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import com.garfiec.librechat.core.common.identity.AccountState
 import com.garfiec.librechat.core.common.identity.ActiveAccountProvider
 import com.garfiec.librechat.core.common.identity.currentAccountId
+import com.garfiec.librechat.core.data.prefetch.PrefetchDepth
 import com.garfiec.librechat.core.model.ModelRef
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
@@ -117,6 +119,11 @@ class SettingsDataStore(
     /** Overrides the unmetered-only default, for users who are mostly on cellular. */
     val prefetchOnMeteredEnabled: Flow<Boolean> = dataStore.data.map { prefs ->
         prefs[KEY_PREFETCH_ON_METERED] ?: false
+    }
+
+    /** Clamped on read, not trusted: this value is the request count for every pass. */
+    val prefetchDepth: Flow<Int> = dataStore.data.map { prefs ->
+        (prefs[KEY_PREFETCH_DEPTH] ?: PrefetchDepth.DEFAULT).coerceIn(PrefetchDepth.RANGE)
     }
 
     val showThinkingBlocks: Flow<Boolean> = dataStore.data.map { prefs ->
@@ -372,6 +379,12 @@ class SettingsDataStore(
     suspend fun setPrefetchAttachmentsEnabled(enabled: Boolean) {
         dataStore.edit { prefs ->
             prefs[KEY_PREFETCH_ATTACHMENTS] = enabled
+        }
+    }
+
+    suspend fun setPrefetchDepth(depth: Int) {
+        dataStore.edit { prefs ->
+            prefs[KEY_PREFETCH_DEPTH] = depth.coerceIn(PrefetchDepth.RANGE)
         }
     }
 
@@ -716,6 +729,7 @@ class SettingsDataStore(
         private val KEY_PREFETCH_ENABLED = booleanPreferencesKey("prefetch_enabled")
         private val KEY_PREFETCH_ATTACHMENTS = booleanPreferencesKey("prefetch_attachments")
         private val KEY_PREFETCH_ON_METERED = booleanPreferencesKey("prefetch_on_metered")
+        private val KEY_PREFETCH_DEPTH = intPreferencesKey("prefetch_depth")
         private val KEY_SHOW_THINKING_BLOCKS = booleanPreferencesKey("show_thinking_blocks")
         private val KEY_CONTEXT_BAR_PLACEMENT = stringPreferencesKey("context_bar_placement")
         private val KEY_DURING_RUN_ACTION = stringPreferencesKey("during_run_action")

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/di/DataModule.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/di/DataModule.kt
@@ -332,6 +332,7 @@ val dataModule = module {
             watermarkDao = get(),
             openConversationRegistry = get(),
             activeAccountProvider = get(),
+            settingsDataStore = get(),
         )
     }
 

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchDepth.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchDepth.kt
@@ -1,0 +1,24 @@
+package com.garfiec.librechat.core.data.prefetch
+
+/** How far back the prefetcher keeps conversations warm, in conversations. */
+object PrefetchDepth {
+
+    const val MIN = 10
+
+    const val MAX = 200
+
+    /** Prefetch shipped warming this many; kept as the default so an upgrade changes no behaviour. */
+    const val DEFAULT = 20
+
+    const val STEP = 10
+
+    val RANGE = MIN..MAX
+
+    /** Material3's `Slider.steps` counts only the positions between the ends — hence the -1. */
+    const val STEPS_BETWEEN_ENDS: Int = (MAX - MIN) / STEP - 1
+
+    fun snap(depth: Int): Int {
+        val snapped = ((depth - MIN + STEP / 2) / STEP) * STEP + MIN
+        return snapped.coerceIn(RANGE)
+    }
+}

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchEngine.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchEngine.kt
@@ -103,10 +103,12 @@ class PrefetchEngine(
             // it the engine's own first request closes the gate that permits it and the pass
             // deadlocks — silently, since a closed gate is indistinguishable from a busy user.
             withContext(PrefetchMarker) {
+                // Read once: a depth re-read mid-pass would select rows the list refresh never fetched.
+                val depth = settingsDataStore.prefetchDepth.first()
                 val pass = Pass(accountId)
 
-                if (!pass.warmConversationList()) return@withContext
-                val eligible = pass.eligible()
+                if (!pass.warmConversationList(depth)) return@withContext
+                val eligible = pass.eligible(depth)
                 if (!pass.warmMessages(eligible)) return@withContext
                 pass.warmAncillary()
                 pass.prune(eligible)
@@ -153,8 +155,9 @@ class PrefetchEngine(
         private var consecutiveFailures = 0
 
         /** Returns false when the pass should stop because the breaker tripped. */
-        suspend fun warmConversationList(): Boolean {
+        suspend fun warmConversationList(depth: Int): Boolean {
             publish(accountId, PrefetchRunState.RefreshingList)
+            val pages = policy.listPagesFor(depth)
             var cursor: String? = null
             var page = 0
             do {
@@ -179,13 +182,13 @@ class PrefetchEngine(
                 }
                 page++
                 delay(paceAfter(elapsed))
-            } while (cursor != null && page <= EXTRA_LIST_PAGES)
+            } while (cursor != null && page < pages)
             return true
         }
 
-        suspend fun eligible(): List<PrefetchCandidate> = withContext(ioDispatcher) {
+        suspend fun eligible(depth: Int): List<PrefetchCandidate> = withContext(ioDispatcher) {
             policy.eligible(
-                recent = conversationDao.recentForPrefetch(accountId.value, PrefetchPolicy.RECENT_LIMIT),
+                recent = conversationDao.recentForPrefetch(accountId.value, depth),
                 pinned = conversationDao.pinnedForPrefetch(accountId.value),
             )
         }
@@ -419,9 +422,6 @@ class PrefetchEngine(
     companion object {
         const val PACE_FACTOR = 5
         const val MAX_CONSECUTIVE_FAILURES = 3
-
-        /** Pages of the conversation list to warm beyond the first. */
-        const val EXTRA_LIST_PAGES = 2
 
         private const val HTTP_TOO_MANY_REQUESTS = 429
         private const val PRUNE_CHUNK = 400

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchPolicy.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchPolicy.kt
@@ -10,8 +10,8 @@ import com.garfiec.librechat.core.data.db.dao.PrefetchCandidate
 class PrefetchPolicy {
 
     /**
-     * The conversations worth keeping warm: the [RECENT_LIMIT] most recently updated, plus every
-     * pinned one however old.
+     * The conversations worth keeping warm: the most recently updated, as many as the user's
+     * configured depth, plus every pinned one however old.
      *
      * Pinning is the user saying "this one matters" in the only way the app offers, so a pinned
      * conversation stays warm after it has fallen out of the recent window. Archived rows are
@@ -66,7 +66,23 @@ class PrefetchPolicy {
         openConversationId?.let { add(it) }
     }
 
+    /**
+     * How many pages of the conversation list to refresh to make [depth] reachable.
+     *
+     * Selection reads the local `conversations` table, which holds only what the list refresh has
+     * pulled — so a depth the refresh cannot reach silently warms nothing extra. [MIN_LIST_PAGES] is
+     * a floor, not a starting point: dropping below it would narrow the list refresh for users who
+     * never touch the setting.
+     */
+    fun listPagesFor(depth: Int): Int {
+        val needed = (depth + LIST_PAGE_SIZE - 1) / LIST_PAGE_SIZE
+        return maxOf(needed, MIN_LIST_PAGES)
+    }
+
     companion object {
-        const val RECENT_LIMIT = 20
+        /** Mirrors `ConversationsApi.getConversations`'s default, which the prefetcher never overrides. */
+        const val LIST_PAGE_SIZE = 25
+
+        const val MIN_LIST_PAGES = 3
     }
 }

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchStatusReporter.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchStatusReporter.kt
@@ -5,13 +5,16 @@ import com.garfiec.librechat.core.common.identity.AccountState
 import com.garfiec.librechat.core.common.identity.ActiveAccountProvider
 import com.garfiec.librechat.core.common.identity.currentAccountId
 import com.garfiec.librechat.core.common.identity.flatMapAccountOrEmpty
+import com.garfiec.librechat.core.data.datastore.SettingsDataStore
 import com.garfiec.librechat.core.data.db.dao.ConversationDao
 import com.garfiec.librechat.core.data.db.dao.MessageDao
 import com.garfiec.librechat.core.data.db.dao.PrefetchCandidateDetail
 import com.garfiec.librechat.core.data.db.dao.PrefetchWatermarkDao
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flatMapLatest
 
 /** One conversation's place in the warm set, as the settings readout presents it. */
 data class PrefetchConversationStatus(
@@ -81,6 +84,7 @@ class PrefetchStatusReporter(
     private val watermarkDao: PrefetchWatermarkDao,
     private val openConversationRegistry: OpenConversationRegistry,
     private val activeAccountProvider: ActiveAccountProvider,
+    private val settingsDataStore: SettingsDataStore,
 ) {
 
     fun status(): Flow<PrefetchStatus> = combine(
@@ -115,59 +119,64 @@ class PrefetchStatusReporter(
      * placeholders that [status] replaces, since those come from the gate and the engine rather than
      * the database.
      */
+    @OptIn(ExperimentalCoroutinesApi::class)
     private fun warmSet(): Flow<PrefetchStatus> =
         activeAccountProvider.flatMapAccountOrEmpty(PrefetchStatus.Empty) { accountId ->
-            combine(
-                conversationDao.observeRecentForPrefetch(accountId.value, PrefetchPolicy.RECENT_LIMIT),
-                conversationDao.observePinnedForPrefetch(accountId.value),
-                watermarkDao.observeForAccount(accountId.value),
-                openConversationRegistry.openConversationId,
-            ) { recent, pinned, watermarks, openConversationId ->
-                // The titles the readout needs are dropped by PrefetchPolicy, which works in ids —
-                // so run the real selection and map the result back through the detail rows.
-                val byId = (recent + pinned).associateBy { it.conversationId }
-                val eligible = policy.eligible(
-                    recent = recent.map(PrefetchCandidateDetail::toCandidate),
-                    pinned = pinned.map(PrefetchCandidateDetail::toCandidate),
-                )
-                val warmedAtById = watermarks.associate { it.conversationId to it.warmedAt }
-                // Order matters and is preserved: selectWork returns the work in the order the
-                // engine will actually fetch it — pinned first, then most recent. A pass routinely
-                // ends early when the gate closes, so a list sorted any other way shows the rows
-                // that get dropped above the ones that get warmed.
-                val work = policy.selectWork(
-                    eligible = eligible,
-                    watermarks = watermarks.associate { it.conversationId to it.warmedConversationUpdatedAt },
-                    openConversationId = openConversationId,
-                )
-                val staleIds = work.mapTo(mutableSetOf()) { it.conversationId }
+            // Depth parameterises the recent query rather than filtering its result, so a change has
+            // to re-subscribe — hence flatMapLatest rather than another argument to the combine.
+            settingsDataStore.prefetchDepth.distinctUntilChanged().flatMapLatest { depth ->
+                combine(
+                    conversationDao.observeRecentForPrefetch(accountId.value, depth),
+                    conversationDao.observePinnedForPrefetch(accountId.value),
+                    watermarkDao.observeForAccount(accountId.value),
+                    openConversationRegistry.openConversationId,
+                ) { recent, pinned, watermarks, openConversationId ->
+                    // The titles the readout needs are dropped by PrefetchPolicy, which works in ids —
+                    // so run the real selection and map the result back through the detail rows.
+                    val byId = (recent + pinned).associateBy { it.conversationId }
+                    val eligible = policy.eligible(
+                        recent = recent.map(PrefetchCandidateDetail::toCandidate),
+                        pinned = pinned.map(PrefetchCandidateDetail::toCandidate),
+                    )
+                    val warmedAtById = watermarks.associate { it.conversationId to it.warmedAt }
+                    // Order matters and is preserved: selectWork returns the work in the order the
+                    // engine will actually fetch it — pinned first, then most recent. A pass routinely
+                    // ends early when the gate closes, so a list sorted any other way shows the rows
+                    // that get dropped above the ones that get warmed.
+                    val work = policy.selectWork(
+                        eligible = eligible,
+                        watermarks = watermarks.associate { it.conversationId to it.warmedConversationUpdatedAt },
+                        openConversationId = openConversationId,
+                    )
+                    val staleIds = work.mapTo(mutableSetOf()) { it.conversationId }
 
-                fun rowFor(conversationId: String): PrefetchConversationStatus? {
-                    val detail = byId[conversationId] ?: return null
-                    return PrefetchConversationStatus(
-                        conversationId = detail.conversationId,
-                        title = detail.title,
-                        pinned = detail.pinned,
-                        warmedAt = warmedAtById[detail.conversationId],
-                        isCurrent = detail.conversationId !in staleIds,
+                    fun rowFor(conversationId: String): PrefetchConversationStatus? {
+                        val detail = byId[conversationId] ?: return null
+                        return PrefetchConversationStatus(
+                            conversationId = detail.conversationId,
+                            title = detail.title,
+                            pinned = detail.pinned,
+                            warmedAt = warmedAtById[detail.conversationId],
+                            isCurrent = detail.conversationId !in staleIds,
+                        )
+                    }
+
+                    val current = eligible.mapNotNull { candidate ->
+                        rowFor(candidate.conversationId)?.takeIf { it.isCurrent }
+                    }
+                    val stale = work.mapNotNull { rowFor(it.conversationId) }
+
+                    PrefetchStatus.Empty.copy(
+                        warmedCount = current.size,
+                        eligibleCount = current.size + stale.size,
+                        // Across the whole table, not just the eligible set: this answers "when did this
+                        // last do anything", and a conversation that has since aged out of the warm set
+                        // was still the last thing warmed.
+                        lastWarmedAt = watermarks.maxOfOrNull { it.warmedAt },
+                        warmed = current.sortedByDescending { it.warmedAt ?: 0L },
+                        pending = stale,
                     )
                 }
-
-                val current = eligible.mapNotNull { candidate ->
-                    rowFor(candidate.conversationId)?.takeIf { it.isCurrent }
-                }
-                val stale = work.mapNotNull { rowFor(it.conversationId) }
-
-                PrefetchStatus.Empty.copy(
-                    warmedCount = current.size,
-                    eligibleCount = current.size + stale.size,
-                    // Across the whole table, not just the eligible set: this answers "when did this
-                    // last do anything", and a conversation that has since aged out of the warm set
-                    // was still the last thing warmed.
-                    lastWarmedAt = watermarks.maxOfOrNull { it.warmedAt },
-                    warmed = current.sortedByDescending { it.warmedAt ?: 0L },
-                    pending = stale,
-                )
             }
         }
 }

--- a/core/data/src/commonTest/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchDepthTest.kt
+++ b/core/data/src/commonTest/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchDepthTest.kt
@@ -1,0 +1,49 @@
+package com.garfiec.librechat.core.data.prefetch
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * A step count that does not divide the range puts the slider on positions the store then snaps
+ * away from, and the control jumps under the user's finger.
+ */
+class PrefetchDepthTest {
+
+    @Test
+    fun `the default is what the feature shipped with`() {
+        assertEquals(20, PrefetchDepth.DEFAULT)
+        assertTrue(PrefetchDepth.DEFAULT in PrefetchDepth.RANGE)
+    }
+
+    @Test
+    fun `the range divides evenly into steps`() {
+        assertEquals(0, (PrefetchDepth.MAX - PrefetchDepth.MIN) % PrefetchDepth.STEP)
+        // One slider position per step, minus the two ends.
+        val positions = (PrefetchDepth.MAX - PrefetchDepth.MIN) / PrefetchDepth.STEP + 1
+        assertEquals(positions - 2, PrefetchDepth.STEPS_BETWEEN_ENDS)
+    }
+
+    @Test
+    fun `snapping lands on a step`() {
+        assertEquals(20, PrefetchDepth.snap(21))
+        assertEquals(30, PrefetchDepth.snap(26))
+        assertEquals(30, PrefetchDepth.snap(30))
+    }
+
+    @Test
+    fun `every step is a fixed point of snapping`() {
+        var depth = PrefetchDepth.MIN
+        while (depth <= PrefetchDepth.MAX) {
+            assertEquals(depth, PrefetchDepth.snap(depth))
+            depth += PrefetchDepth.STEP
+        }
+    }
+
+    @Test
+    fun `snapping clamps to the range`() {
+        assertEquals(PrefetchDepth.MIN, PrefetchDepth.snap(0))
+        assertEquals(PrefetchDepth.MIN, PrefetchDepth.snap(-100))
+        assertEquals(PrefetchDepth.MAX, PrefetchDepth.snap(10_000))
+    }
+}

--- a/core/data/src/commonTest/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchPolicyTest.kt
+++ b/core/data/src/commonTest/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchPolicyTest.kt
@@ -27,11 +27,26 @@ class PrefetchPolicyTest {
     @Test
     fun `a pinned conversation stays eligible however old it is`() {
         val eligible = policy.eligible(
-            recent = List(PrefetchPolicy.RECENT_LIMIT) { candidate("recent-$it", 1000L + it) },
+            recent = List(PrefetchDepth.DEFAULT) { candidate("recent-$it", 1000L + it) },
             pinned = listOf(candidate("ancient", 1, pinned = true)),
         )
 
         assertTrue(eligible.any { it.conversationId == "ancient" })
+    }
+
+    @Test
+    fun `list paging covers the configured depth`() {
+        val pageSize = PrefetchPolicy.LIST_PAGE_SIZE
+
+        assertTrue(policy.listPagesFor(PrefetchDepth.MAX) * pageSize >= PrefetchDepth.MAX)
+        assertEquals(8, policy.listPagesFor(PrefetchDepth.MAX))
+        assertEquals(4, policy.listPagesFor(100))
+    }
+
+    @Test
+    fun `a shallow depth still refreshes as much of the list as before`() {
+        assertEquals(PrefetchPolicy.MIN_LIST_PAGES, policy.listPagesFor(PrefetchDepth.DEFAULT))
+        assertEquals(PrefetchPolicy.MIN_LIST_PAGES, policy.listPagesFor(PrefetchDepth.MIN))
     }
 
     @Test

--- a/feature/settings/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/settings/viewmodel/SettingsViewModelTest.kt
+++ b/feature/settings/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/settings/viewmodel/SettingsViewModelTest.kt
@@ -10,6 +10,7 @@ import com.garfiec.librechat.core.data.datastore.SettingsDataStore
 import com.garfiec.librechat.core.data.datastore.ThemeDataStore
 import com.garfiec.librechat.core.data.datastore.ThemeMode
 import com.garfiec.librechat.core.data.prefetch.AttachmentWarmer
+import com.garfiec.librechat.core.data.prefetch.PrefetchDepth
 import com.garfiec.librechat.core.data.repository.AuthRepository
 import com.garfiec.librechat.core.data.repository.BalanceRepository
 import com.garfiec.librechat.core.data.repository.ConfigRepository
@@ -116,6 +117,7 @@ class SettingsViewModelTest {
         every { settingsDataStore.prefetchEnabled } returns MutableStateFlow(false)
         every { settingsDataStore.prefetchAttachmentsEnabled } returns MutableStateFlow(false)
         every { settingsDataStore.prefetchOnMeteredEnabled } returns MutableStateFlow(false)
+        every { settingsDataStore.prefetchDepth } returns MutableStateFlow(PrefetchDepth.DEFAULT)
         every { settingsDataStore.chatLayoutStyle } returns MutableStateFlow(ChatLayoutConstants.THREAD)
         every { settingsDataStore.showAvatars } returns MutableStateFlow(true)
         every { settingsDataStore.showBubbles } returns MutableStateFlow(false)

--- a/feature/settings/src/commonMain/composeResources/values-ar/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-ar/strings.xml
@@ -73,6 +73,9 @@
     <string name="prefetch_enabled_desc">Load recent and pinned conversations in the background so they open instantly. Runs only while the app is idle.</string>
     <string name="prefetch_on_metered">Use mobile data</string>
     <string name="prefetch_on_metered_desc">Allow prefetching on metered connections. Off by default to avoid unexpected data usage.</string>
+    <string name="prefetch_depth">Depth</string>
+    <string name="prefetch_depth_value">%1$d conversations</string>
+    <string name="prefetch_depth_desc">How many recent conversations to keep cached. Pinned conversations are always included, however old.</string>
     <string name="prefetch_attachments">Prefetch images</string>
     <string name="prefetch_attachments_desc">Also download images and attachments. Uses considerably more data.</string>
     <string name="prefetch_activity">Activity</string>

--- a/feature/settings/src/commonMain/composeResources/values-de/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-de/strings.xml
@@ -73,6 +73,9 @@
     <string name="prefetch_enabled_desc">Load recent and pinned conversations in the background so they open instantly. Runs only while the app is idle.</string>
     <string name="prefetch_on_metered">Use mobile data</string>
     <string name="prefetch_on_metered_desc">Allow prefetching on metered connections. Off by default to avoid unexpected data usage.</string>
+    <string name="prefetch_depth">Depth</string>
+    <string name="prefetch_depth_value">%1$d conversations</string>
+    <string name="prefetch_depth_desc">How many recent conversations to keep cached. Pinned conversations are always included, however old.</string>
     <string name="prefetch_attachments">Prefetch images</string>
     <string name="prefetch_attachments_desc">Also download images and attachments. Uses considerably more data.</string>
     <string name="prefetch_activity">Activity</string>

--- a/feature/settings/src/commonMain/composeResources/values-es/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-es/strings.xml
@@ -73,6 +73,9 @@
     <string name="prefetch_enabled_desc">Load recent and pinned conversations in the background so they open instantly. Runs only while the app is idle.</string>
     <string name="prefetch_on_metered">Use mobile data</string>
     <string name="prefetch_on_metered_desc">Allow prefetching on metered connections. Off by default to avoid unexpected data usage.</string>
+    <string name="prefetch_depth">Depth</string>
+    <string name="prefetch_depth_value">%1$d conversations</string>
+    <string name="prefetch_depth_desc">How many recent conversations to keep cached. Pinned conversations are always included, however old.</string>
     <string name="prefetch_attachments">Prefetch images</string>
     <string name="prefetch_attachments_desc">Also download images and attachments. Uses considerably more data.</string>
     <string name="prefetch_activity">Activity</string>

--- a/feature/settings/src/commonMain/composeResources/values-fr/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-fr/strings.xml
@@ -73,6 +73,9 @@
     <string name="prefetch_enabled_desc">Load recent and pinned conversations in the background so they open instantly. Runs only while the app is idle.</string>
     <string name="prefetch_on_metered">Use mobile data</string>
     <string name="prefetch_on_metered_desc">Allow prefetching on metered connections. Off by default to avoid unexpected data usage.</string>
+    <string name="prefetch_depth">Depth</string>
+    <string name="prefetch_depth_value">%1$d conversations</string>
+    <string name="prefetch_depth_desc">How many recent conversations to keep cached. Pinned conversations are always included, however old.</string>
     <string name="prefetch_attachments">Prefetch images</string>
     <string name="prefetch_attachments_desc">Also download images and attachments. Uses considerably more data.</string>
     <string name="prefetch_activity">Activity</string>

--- a/feature/settings/src/commonMain/composeResources/values-ja/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-ja/strings.xml
@@ -73,6 +73,9 @@
     <string name="prefetch_enabled_desc">Load recent and pinned conversations in the background so they open instantly. Runs only while the app is idle.</string>
     <string name="prefetch_on_metered">Use mobile data</string>
     <string name="prefetch_on_metered_desc">Allow prefetching on metered connections. Off by default to avoid unexpected data usage.</string>
+    <string name="prefetch_depth">Depth</string>
+    <string name="prefetch_depth_value">%1$d conversations</string>
+    <string name="prefetch_depth_desc">How many recent conversations to keep cached. Pinned conversations are always included, however old.</string>
     <string name="prefetch_attachments">Prefetch images</string>
     <string name="prefetch_attachments_desc">Also download images and attachments. Uses considerably more data.</string>
     <string name="prefetch_activity">Activity</string>

--- a/feature/settings/src/commonMain/composeResources/values-ko/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-ko/strings.xml
@@ -73,6 +73,9 @@
     <string name="prefetch_enabled_desc">Load recent and pinned conversations in the background so they open instantly. Runs only while the app is idle.</string>
     <string name="prefetch_on_metered">Use mobile data</string>
     <string name="prefetch_on_metered_desc">Allow prefetching on metered connections. Off by default to avoid unexpected data usage.</string>
+    <string name="prefetch_depth">Depth</string>
+    <string name="prefetch_depth_value">%1$d conversations</string>
+    <string name="prefetch_depth_desc">How many recent conversations to keep cached. Pinned conversations are always included, however old.</string>
     <string name="prefetch_attachments">Prefetch images</string>
     <string name="prefetch_attachments_desc">Also download images and attachments. Uses considerably more data.</string>
     <string name="prefetch_activity">Activity</string>

--- a/feature/settings/src/commonMain/composeResources/values-pt/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-pt/strings.xml
@@ -73,6 +73,9 @@
     <string name="prefetch_enabled_desc">Load recent and pinned conversations in the background so they open instantly. Runs only while the app is idle.</string>
     <string name="prefetch_on_metered">Use mobile data</string>
     <string name="prefetch_on_metered_desc">Allow prefetching on metered connections. Off by default to avoid unexpected data usage.</string>
+    <string name="prefetch_depth">Depth</string>
+    <string name="prefetch_depth_value">%1$d conversations</string>
+    <string name="prefetch_depth_desc">How many recent conversations to keep cached. Pinned conversations are always included, however old.</string>
     <string name="prefetch_attachments">Prefetch images</string>
     <string name="prefetch_attachments_desc">Also download images and attachments. Uses considerably more data.</string>
     <string name="prefetch_activity">Activity</string>

--- a/feature/settings/src/commonMain/composeResources/values-ru/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-ru/strings.xml
@@ -73,6 +73,9 @@
     <string name="prefetch_enabled_desc">Load recent and pinned conversations in the background so they open instantly. Runs only while the app is idle.</string>
     <string name="prefetch_on_metered">Use mobile data</string>
     <string name="prefetch_on_metered_desc">Allow prefetching on metered connections. Off by default to avoid unexpected data usage.</string>
+    <string name="prefetch_depth">Depth</string>
+    <string name="prefetch_depth_value">%1$d conversations</string>
+    <string name="prefetch_depth_desc">How many recent conversations to keep cached. Pinned conversations are always included, however old.</string>
     <string name="prefetch_attachments">Prefetch images</string>
     <string name="prefetch_attachments_desc">Also download images and attachments. Uses considerably more data.</string>
     <string name="prefetch_activity">Activity</string>

--- a/feature/settings/src/commonMain/composeResources/values-zh/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-zh/strings.xml
@@ -73,6 +73,9 @@
     <string name="prefetch_enabled_desc">Load recent and pinned conversations in the background so they open instantly. Runs only while the app is idle.</string>
     <string name="prefetch_on_metered">Use mobile data</string>
     <string name="prefetch_on_metered_desc">Allow prefetching on metered connections. Off by default to avoid unexpected data usage.</string>
+    <string name="prefetch_depth">Depth</string>
+    <string name="prefetch_depth_value">%1$d conversations</string>
+    <string name="prefetch_depth_desc">How many recent conversations to keep cached. Pinned conversations are always included, however old.</string>
     <string name="prefetch_attachments">Prefetch images</string>
     <string name="prefetch_attachments_desc">Also download images and attachments. Uses considerably more data.</string>
     <string name="prefetch_activity">Activity</string>

--- a/feature/settings/src/commonMain/composeResources/values/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values/strings.xml
@@ -74,6 +74,9 @@
     <string name="prefetch_enabled_desc">Load recent and pinned conversations in the background so they open instantly. Runs only while the app is idle.</string>
     <string name="prefetch_on_metered">Use mobile data</string>
     <string name="prefetch_on_metered_desc">Allow prefetching on metered connections. Off by default to avoid unexpected data usage.</string>
+    <string name="prefetch_depth">Depth</string>
+    <string name="prefetch_depth_value">%1$d conversations</string>
+    <string name="prefetch_depth_desc">How many recent conversations to keep cached. Pinned conversations are always included, however old.</string>
     <string name="prefetch_attachments">Prefetch images</string>
     <string name="prefetch_attachments_desc">Also download images and attachments. Uses considerably more data.</string>
     <string name="prefetch_activity">Activity</string>

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/DataSettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/DataSettingsScreen.kt
@@ -212,6 +212,8 @@ fun DataSettingsContent(
                     onPrefetchEnabledChange = viewModel::setPrefetchEnabled,
                     onPrefetchOnMeteredChange = viewModel::setPrefetchOnMeteredEnabled,
                     onPrefetchAttachmentsChange = viewModel::setPrefetchAttachmentsEnabled,
+                    prefetchDepth = uiState.prefetchDepth,
+                    onPrefetchDepthChange = viewModel::setPrefetchDepth,
                     status = prefetchState.status,
                     warmedCount = prefetchState.warmedCount,
                     eligibleCount = prefetchState.eligibleCount,

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/PrefetchSettingsSection.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/PrefetchSettingsSection.kt
@@ -12,16 +12,26 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Slider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import com.garfiec.librechat.core.data.prefetch.PrefetchDepth
 import com.garfiec.librechat.feature.settings.resources.Res
 import com.garfiec.librechat.feature.settings.resources.prefetch_activity
 import com.garfiec.librechat.feature.settings.resources.prefetch_attachments
 import com.garfiec.librechat.feature.settings.resources.prefetch_attachments_desc
+import com.garfiec.librechat.feature.settings.resources.prefetch_depth
+import com.garfiec.librechat.feature.settings.resources.prefetch_depth_desc
+import com.garfiec.librechat.feature.settings.resources.prefetch_depth_value
 import com.garfiec.librechat.feature.settings.resources.prefetch_enabled
 import com.garfiec.librechat.feature.settings.resources.prefetch_enabled_desc
 import com.garfiec.librechat.feature.settings.resources.prefetch_on_metered
@@ -33,6 +43,7 @@ import com.garfiec.librechat.feature.settings.resources.prefetch_summary_warmed
 import com.garfiec.librechat.feature.settings.resources.prefetch_summary_warmed_value
 import com.garfiec.librechat.feature.settings.state.PrefetchDisplayStatus
 import org.jetbrains.compose.resources.stringResource
+import kotlin.math.roundToInt
 
 /**
  * Background prefetch controls, with a compact status summary underneath.
@@ -47,6 +58,7 @@ fun PrefetchSettingsSection(
     prefetchOnMeteredEnabled: Boolean,
     prefetchAttachmentsEnabled: Boolean,
     prefetchAttachmentsSupported: Boolean,
+    prefetchDepth: Int,
     status: PrefetchDisplayStatus,
     warmedCount: Int,
     eligibleCount: Int,
@@ -54,6 +66,7 @@ fun PrefetchSettingsSection(
     onPrefetchEnabledChange: (Boolean) -> Unit,
     onPrefetchOnMeteredChange: (Boolean) -> Unit,
     onPrefetchAttachmentsChange: (Boolean) -> Unit,
+    onPrefetchDepthChange: (Int) -> Unit,
     onActivityClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -85,6 +98,12 @@ fun PrefetchSettingsSection(
             description = stringResource(Res.string.prefetch_on_metered_desc),
             checked = prefetchOnMeteredEnabled,
             onChange = onPrefetchOnMeteredChange,
+            enabled = prefetchEnabled,
+        )
+
+        DepthSlider(
+            depth = prefetchDepth,
+            onChange = onPrefetchDepthChange,
             enabled = prefetchEnabled,
         )
 
@@ -124,6 +143,61 @@ fun PrefetchSettingsSection(
                 )
             }
         }
+    }
+}
+
+/**
+ * How many recent conversations to keep warm.
+ *
+ * The position is held locally during the gesture and committed on release: writing on every value
+ * change puts dozens of writes per drag through the preference store, and the status readout
+ * re-subscribes its queries on each one.
+ */
+@Composable
+private fun DepthSlider(depth: Int, onChange: (Int) -> Unit, enabled: Boolean) {
+    var pending by remember { mutableStateOf<Int?>(null) }
+    val shown = pending ?: depth
+    val alpha = if (enabled) 1f else DISABLED_ALPHA
+
+    // Keyed on `pending` as well as `depth`: a commit equal to the stored depth writes an identical
+    // value that the flow conflates, so `depth` never changes and waiting on it alone would strand
+    // the local position with nothing able to clear it.
+    LaunchedEffect(depth, pending) {
+        if (pending == depth) pending = null
+    }
+
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = stringResource(Res.string.prefetch_depth),
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurface.copy(alpha = alpha),
+            )
+            Text(
+                text = stringResource(Res.string.prefetch_depth_value, shown),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = alpha),
+            )
+        }
+        Text(
+            text = stringResource(Res.string.prefetch_depth_desc),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = alpha),
+        )
+        Slider(
+            value = shown.toFloat(),
+            onValueChange = { pending = PrefetchDepth.snap(it.roundToInt()) },
+            // Reads the state, not a composition-captured copy: Material3 can end a gesture in the
+            // same input batch as its last value change, so a captured value is one step stale.
+            onValueChangeFinished = { pending?.let(onChange) },
+            valueRange = PrefetchDepth.MIN.toFloat()..PrefetchDepth.MAX.toFloat(),
+            steps = PrefetchDepth.STEPS_BETWEEN_ENDS,
+            enabled = enabled,
+        )
     }
 }
 

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/SettingsPreferencesController.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/SettingsPreferencesController.kt
@@ -15,6 +15,7 @@ import com.garfiec.librechat.core.data.datastore.SettingsDataStore
 import com.garfiec.librechat.core.data.datastore.StarredModelsDisplay
 import com.garfiec.librechat.core.data.datastore.ThemeDataStore
 import com.garfiec.librechat.core.data.datastore.ThemeMode
+import com.garfiec.librechat.core.data.prefetch.PrefetchDepth
 import com.garfiec.librechat.core.ui.theme.supportsDynamicColor
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.SharingStarted
@@ -76,6 +77,7 @@ private data class AdditionalPreferences(
     val prefetchEnabled: Boolean = false,
     val prefetchAttachmentsEnabled: Boolean = false,
     val prefetchOnMeteredEnabled: Boolean = false,
+    val prefetchDepth: Int = PrefetchDepth.DEFAULT,
 )
 
 /**
@@ -228,6 +230,8 @@ class SettingsPreferencesController(
         additional.copy(prefetchAttachmentsEnabled = prefetchAttachments)
     }.combine(settingsDataStore.prefetchOnMeteredEnabled) { additional, prefetchOnMetered ->
         additional.copy(prefetchOnMeteredEnabled = prefetchOnMetered)
+    }.combine(settingsDataStore.prefetchDepth) { additional, depth ->
+        additional.copy(prefetchDepth = depth)
     }.stateIn(scope, SharingStarted.Eagerly, AdditionalPreferences(true, false, "", "", true))
 
     /** The single public UI state that merges DataStore preferences with imperative state. */
@@ -280,6 +284,7 @@ class SettingsPreferencesController(
             prefetchEnabled = additional.prefetchEnabled,
             prefetchAttachmentsEnabled = additional.prefetchAttachmentsEnabled,
             prefetchOnMeteredEnabled = additional.prefetchOnMeteredEnabled,
+            prefetchDepth = additional.prefetchDepth,
         )
     }.stateIn(scope, SharingStarted.Eagerly, SettingsUiState())
 
@@ -323,6 +328,10 @@ class SettingsPreferencesController(
 
     fun setPrefetchAttachmentsEnabled(enabled: Boolean) {
         scope.launch { settingsDataStore.setPrefetchAttachmentsEnabled(enabled) }
+    }
+
+    fun setPrefetchDepth(depth: Int) {
+        scope.launch { settingsDataStore.setPrefetchDepth(depth) }
     }
 
     fun setPrefetchOnMeteredEnabled(enabled: Boolean) {

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/SettingsUiState.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/SettingsUiState.kt
@@ -14,6 +14,7 @@ import com.garfiec.librechat.core.data.datastore.SettingsDataStore
 import com.garfiec.librechat.core.data.datastore.StarredModelsDisplay
 import com.garfiec.librechat.core.data.datastore.ThemeDataStore
 import com.garfiec.librechat.core.data.datastore.ThemeMode
+import com.garfiec.librechat.core.data.prefetch.PrefetchDepth
 import com.garfiec.librechat.core.model.Memory
 import com.garfiec.librechat.core.model.User
 import com.garfiec.librechat.core.model.config.BuildInfo
@@ -95,6 +96,7 @@ data class SettingsUiState(
     val prefetchEnabled: Boolean = false,
     val prefetchAttachmentsEnabled: Boolean = false,
     val prefetchOnMeteredEnabled: Boolean = false,
+    val prefetchDepth: Int = PrefetchDepth.DEFAULT,
     /** Whether this platform has an image cache worth warming; false hides the toggle. */
     val prefetchAttachmentsSupported: Boolean = false,
     /** Cached images and files, in bytes; null until read. Excludes the database — see

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/SettingsViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/SettingsViewModel.kt
@@ -52,7 +52,9 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
-@Suppress("LongParameterList")
+// TooManyFunctions: the members are one-line forwarders to controllers, one per setting, so the
+// count tracks how many settings exist rather than how much this class does.
+@Suppress("LongParameterList", "TooManyFunctions")
 class SettingsViewModel(
     contentReader: ContentReader,
     cacheCleaner: PlatformCacheCleaner,
@@ -246,6 +248,10 @@ class SettingsViewModel(
 
     fun setPrefetchAttachmentsEnabled(enabled: Boolean) {
         prefsController.setPrefetchAttachmentsEnabled(enabled)
+    }
+
+    fun setPrefetchDepth(depth: Int) {
+        prefsController.setPrefetchDepth(depth)
     }
 
     fun setPrefetchOnMeteredEnabled(enabled: Boolean) {


### PR DESCRIPTION
## Summary

Background prefetching kept the twenty most recently updated conversations warm, plus every pinned one. Twenty is too shallow for a large working set and more than a user on a tight data plan may want, and it was not adjustable. This adds a depth slider to Data settings covering 10–200, defaulting to the 20 already in use.

## Changes

**Setting** — `PrefetchDepth` holds the bounds, the step, and the snap. The slider and the store's clamp both derive from it, so the control cannot offer a value the store would rewrite. The store clamps on read as well as on write, so a value from a future build with a wider range, or a hand-edited store, cannot set the request count for every pass. The slider commits on release rather than per value change: each write re-subscribes the status readout's queries, which sit directly below it.

**Engine** — depth is read once per pass and bounds the recent-conversation query. It also drives how far the pass pages the conversation list: selection reads the local table, so a depth the list refresh cannot reach would select from rows that do not exist yet. `listPagesFor` derives pages from depth, floored at the three pages the pass already refreshed, so a shallow setting does not narrow the list refresh.

**Control** — the slider is disabled and greyed with the rest of the section when prefetching is off, matching the neighbouring toggles.

**Readout** — the status reporter re-subscribes on depth changes, so the summary in Data settings and the activity screen behind it both describe the set the next pass will act on rather than a fixed twenty.

## Testing

Unit tests for the depth constants' self-consistency and snapping, the page derivation including its floor, and that the configured depth reaches both the conversation query and the list paging. `:core:data`, `:feature:settings` and `:app` unit tests, `detekt`, `detektMetadataCommonMain`, `:app:lint` and `:app:assembleDebug` all pass.

Not exercised on a device at this revision. The slider's state handling has no automated coverage — this module has no Compose UI test lane — so that part is reviewed rather than tested.

## Notes

- Changing the depth does not itself start a pass; passes begin on a gate opening, and Warm now on the activity screen forces one.
- Range is 10–200 in steps of 10: coarse enough that the slider lands on round numbers, fine enough to be worth dragging. 200 is reachable by the list refresh, at eight pages of the conversation client's 25-per-page default.
- A deep setting is proportionally more background work: at 200 on a cold cache that is up to eight list pages and 200 message fetches, plus any pinned conversations outside that window, paced against the previous request's latency and cancelled by any user activity.
- `PrefetchStatusReporter` gains a `SettingsDataStore` parameter, and the `PrefetchPolicy.RECENT_LIMIT` / `PrefetchEngine.EXTRA_LIST_PAGES` constants are removed, both now superseded by the setting.
- Strings are added to the English source plus all nine translation files, the latter as English stubs, per project convention.
- `SettingsViewModel` crossed detekt's 100-function threshold and is suppressed in line with the existing precedent in `ChatViewModel` and `SetProviderKeyViewModel`. Its members are almost all one-line forwarders, one per setting.
