### PR TITLE
feat(prefetch): warm conversations in the background, not just on screen

### DIFF
--- a/app/src/test/kotlin/com/garfiec/librechat/KoinGraphVerificationTest.kt
+++ b/app/src/test/kotlin/com/garfiec/librechat/KoinGraphVerificationTest.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import com.garfiec.librechat.core.common.AppInfo
 import com.garfiec.librechat.core.common.conversation.OpenConversationRegistry
 import com.garfiec.librechat.core.common.identity.ActiveAccountProvider
+import com.garfiec.librechat.core.common.lifecycle.DeferredWorkWindow
 import com.garfiec.librechat.core.common.lifecycle.ForegroundSignal
 import com.garfiec.librechat.core.common.network.ConnectivityObserver
 import com.garfiec.librechat.core.common.network.NetworkConditionObserver
@@ -128,6 +129,7 @@ class KoinGraphVerificationTest {
             NetworkConditionObserver::class,
             PowerStateObserver::class,
             ForegroundSignal::class,
+            DeferredWorkWindow::class,
             OpenConversationRegistry::class,
             RequestActivityTracker::class,
             ActiveAccountProvider::class,

--- a/core/common/src/androidMain/kotlin/com/garfiec/librechat/core/common/di/CommonPlatformModule.android.kt
+++ b/core/common/src/androidMain/kotlin/com/garfiec/librechat/core/common/di/CommonPlatformModule.android.kt
@@ -2,6 +2,7 @@ package com.garfiec.librechat.core.common.di
 
 import com.garfiec.librechat.core.common.AndroidAppInfo
 import com.garfiec.librechat.core.common.AppInfo
+import com.garfiec.librechat.core.common.lifecycle.DeferredWorkWindow
 import com.garfiec.librechat.core.common.network.AndroidConnectivityObserver
 import com.garfiec.librechat.core.common.network.AndroidNetworkConditionObserver
 import com.garfiec.librechat.core.common.network.ConnectivityObserver
@@ -17,4 +18,7 @@ actual val commonPlatformModule: Module = module {
     single<NetworkConditionObserver> { AndroidNetworkConditionObserver(androidContext()) }
     single<PowerStateObserver> { AndroidPowerStateObserver(androidContext()) }
     single<AppInfo> { AndroidAppInfo(androidContext()) }
+    // WorkManager can run a pass with no UI, so the window latches on first composition rather than
+    // tracking the foreground.
+    single { DeferredWorkWindow(foregroundSignal = get(), backgroundRunsSupported = true) }
 }

--- a/core/common/src/androidMain/kotlin/com/garfiec/librechat/core/common/di/CommonPlatformModule.android.kt
+++ b/core/common/src/androidMain/kotlin/com/garfiec/librechat/core/common/di/CommonPlatformModule.android.kt
@@ -2,6 +2,7 @@ package com.garfiec.librechat.core.common.di
 
 import com.garfiec.librechat.core.common.AndroidAppInfo
 import com.garfiec.librechat.core.common.AppInfo
+import com.garfiec.librechat.core.common.lifecycle.BackgroundWorkSupport
 import com.garfiec.librechat.core.common.lifecycle.DeferredWorkWindow
 import com.garfiec.librechat.core.common.network.AndroidConnectivityObserver
 import com.garfiec.librechat.core.common.network.AndroidNetworkConditionObserver
@@ -20,5 +21,6 @@ actual val commonPlatformModule: Module = module {
     single<AppInfo> { AndroidAppInfo(androidContext()) }
     // WorkManager can run a pass with no UI, so the window latches on first composition rather than
     // tracking the foreground.
-    single { DeferredWorkWindow(foregroundSignal = get(), backgroundRunsSupported = true) }
+    single { BackgroundWorkSupport.SUPPORTED }
+    single { DeferredWorkWindow(foregroundSignal = get(), support = get()) }
 }

--- a/core/common/src/commonMain/kotlin/com/garfiec/librechat/core/common/lifecycle/DeferredWorkWindow.kt
+++ b/core/common/src/commonMain/kotlin/com/garfiec/librechat/core/common/lifecycle/DeferredWorkWindow.kt
@@ -1,0 +1,66 @@
+package com.garfiec.librechat.core.common.lifecycle
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.update
+
+/**
+ * Whether deferred background work — today, cache prefetching — may run at all.
+ *
+ * This is deliberately *not* "is the app on screen". Two sources open the window:
+ *
+ * - **The UI having started**, which latches and never clears, so work continues after the app
+ *   leaves the screen. It latches rather than tracking the foreground because the thing it needs to
+ *   exclude is cold start, not backgrounding: nothing may run before the first composition, which is
+ *   the worst possible moment to compete for the main thread.
+ * - **An explicit background run**, counted rather than boolean so overlapping runs can't have one
+ *   ending close the window on another.
+ *
+ * The second source is what stops the first from being a trap. A process spawned by a scheduled job
+ * never composes, so the latch would stay false, the window would stay shut, and the job would wake
+ * the process, do nothing, and exit reporting success — silently, because a shut window is
+ * indistinguishable from a busy one at the far end.
+ *
+ * [backgroundRunsSupported] is false on platforms that have no way to keep a suspended process
+ * running, where the latch would let work start and then be frozen mid-request with nothing to
+ * finish or cancel it. Those platforms fall back to the live foreground signal, which is exactly the
+ * behaviour that predates this class.
+ */
+class DeferredWorkWindow(
+    foregroundSignal: ForegroundSignal,
+    private val backgroundRunsSupported: Boolean,
+) {
+
+    private val uiStarted = MutableStateFlow(false)
+    private val backgroundRuns = MutableStateFlow(0)
+
+    /**
+     * The two sources are OR-ed, and which one stands for "the app is available" is fixed at
+     * construction — so only that one is collected. Combining all three and ignoring the unused
+     * input would subscribe to a signal whose every change re-evaluates a term it cannot affect.
+     */
+    private val appAvailable: Flow<Boolean> = when (support) {
+        BackgroundWorkSupport.SUPPORTED -> uiStarted
+        BackgroundWorkSupport.UNSUPPORTED -> foregroundSignal.isForeground
+    }
+
+    val isOpen: Flow<Boolean> = combine(appAvailable, backgroundRuns) { available, runs ->
+        available || runs > 0
+    }.distinctUntilChanged()
+
+    /** Called once the UI has composed. Latches — there is no un-starting. */
+    fun markUiStarted() {
+        uiStarted.value = true
+    }
+
+    fun beginBackgroundRun() {
+        backgroundRuns.update { it + 1 }
+    }
+
+    /** Floored at zero so an unbalanced call can't leave the counter negative and the window stuck. */
+    fun endBackgroundRun() {
+        backgroundRuns.update { (it - 1).coerceAtLeast(0) }
+    }
+}

--- a/core/common/src/commonMain/kotlin/com/garfiec/librechat/core/common/lifecycle/DeferredWorkWindow.kt
+++ b/core/common/src/commonMain/kotlin/com/garfiec/librechat/core/common/lifecycle/DeferredWorkWindow.kt
@@ -23,10 +23,9 @@ import kotlinx.coroutines.flow.update
  * the process, do nothing, and exit reporting success — silently, because a shut window is
  * indistinguishable from a busy one at the far end.
  *
- * [BackgroundWorkSupport.UNSUPPORTED] platforms fall back to the live foreground signal, which is
- * exactly the behaviour that predates this class. Typed rather than a bare `Boolean` so the Koin
- * graph verifier can resolve it — a primitive constructor parameter is unresolvable, and
- * allowlisting `Boolean` would blind the check to every genuinely missing one in this module.
+ * [BackgroundWorkSupport.UNSUPPORTED] platforms fall back to the live foreground signal. Keep this
+ * an enum, not a `Boolean`: the Koin graph verifier cannot resolve a primitive constructor
+ * parameter, and allowlisting `Boolean` would blind it to every genuinely missing one in this module.
  */
 enum class BackgroundWorkSupport {
     /** The platform can run work in a process with no UI — Android, via WorkManager. */
@@ -47,11 +46,8 @@ class DeferredWorkWindow(
     private val uiStarted = MutableStateFlow(false)
     private val backgroundRuns = MutableStateFlow(0)
 
-    /**
-     * The two sources are OR-ed, and which one stands for "the app is available" is fixed at
-     * construction — so only that one is collected. Combining all three and ignoring the unused
-     * input would subscribe to a signal whose every change re-evaluates a term it cannot affect.
-     */
+    // Which source stands for "the app is available" is fixed at construction, so only that one is
+    // collected — subscribing to the other would re-evaluate the combine on changes it cannot affect.
     private val appAvailable: Flow<Boolean> = when (support) {
         BackgroundWorkSupport.SUPPORTED -> uiStarted
         BackgroundWorkSupport.UNSUPPORTED -> foregroundSignal.isForeground

--- a/core/common/src/commonMain/kotlin/com/garfiec/librechat/core/common/lifecycle/DeferredWorkWindow.kt
+++ b/core/common/src/commonMain/kotlin/com/garfiec/librechat/core/common/lifecycle/DeferredWorkWindow.kt
@@ -23,14 +23,25 @@ import kotlinx.coroutines.flow.update
  * the process, do nothing, and exit reporting success — silently, because a shut window is
  * indistinguishable from a busy one at the far end.
  *
- * [backgroundRunsSupported] is false on platforms that have no way to keep a suspended process
- * running, where the latch would let work start and then be frozen mid-request with nothing to
- * finish or cancel it. Those platforms fall back to the live foreground signal, which is exactly the
- * behaviour that predates this class.
+ * [BackgroundWorkSupport.UNSUPPORTED] platforms fall back to the live foreground signal, which is
+ * exactly the behaviour that predates this class. Typed rather than a bare `Boolean` so the Koin
+ * graph verifier can resolve it — a primitive constructor parameter is unresolvable, and
+ * allowlisting `Boolean` would blind the check to every genuinely missing one in this module.
  */
+enum class BackgroundWorkSupport {
+    /** The platform can run work in a process with no UI — Android, via WorkManager. */
+    SUPPORTED,
+
+    /**
+     * The platform suspends a backgrounded process, so latching the window would start work and
+     * then freeze it mid-request with nothing to finish or cancel it.
+     */
+    UNSUPPORTED,
+}
+
 class DeferredWorkWindow(
     foregroundSignal: ForegroundSignal,
-    private val backgroundRunsSupported: Boolean,
+    support: BackgroundWorkSupport,
 ) {
 
     private val uiStarted = MutableStateFlow(false)

--- a/core/common/src/iosMain/kotlin/com/garfiec/librechat/core/common/di/CommonPlatformModule.ios.kt
+++ b/core/common/src/iosMain/kotlin/com/garfiec/librechat/core/common/di/CommonPlatformModule.ios.kt
@@ -18,9 +18,8 @@ actual val commonPlatformModule: Module = module {
     single<NetworkConditionObserver> { IosNetworkConditionObserver() }
     single<PowerStateObserver> { IosPowerStateObserver() }
     single<AppInfo> { IosAppInfo() }
-    // False until the BGTaskScheduler work lands: iOS suspends a backgrounded process, so a latched
-    // window would start a pass and then freeze it mid-request with nothing to finish or cancel it.
-    // Falling back to the foreground signal keeps today's behaviour exactly.
+    // Until BGTaskScheduler lands: iOS suspends a backgrounded process, so a latched window would
+    // start a pass and then freeze it mid-request with nothing to finish or cancel it.
     single { BackgroundWorkSupport.UNSUPPORTED }
     single { DeferredWorkWindow(foregroundSignal = get(), support = get()) }
 }

--- a/core/common/src/iosMain/kotlin/com/garfiec/librechat/core/common/di/CommonPlatformModule.ios.kt
+++ b/core/common/src/iosMain/kotlin/com/garfiec/librechat/core/common/di/CommonPlatformModule.ios.kt
@@ -2,6 +2,7 @@ package com.garfiec.librechat.core.common.di
 
 import com.garfiec.librechat.core.common.AppInfo
 import com.garfiec.librechat.core.common.IosAppInfo
+import com.garfiec.librechat.core.common.lifecycle.BackgroundWorkSupport
 import com.garfiec.librechat.core.common.lifecycle.DeferredWorkWindow
 import com.garfiec.librechat.core.common.network.ConnectivityObserver
 import com.garfiec.librechat.core.common.network.IosConnectivityObserver
@@ -20,5 +21,6 @@ actual val commonPlatformModule: Module = module {
     // False until the BGTaskScheduler work lands: iOS suspends a backgrounded process, so a latched
     // window would start a pass and then freeze it mid-request with nothing to finish or cancel it.
     // Falling back to the foreground signal keeps today's behaviour exactly.
-    single { DeferredWorkWindow(foregroundSignal = get(), backgroundRunsSupported = false) }
+    single { BackgroundWorkSupport.UNSUPPORTED }
+    single { DeferredWorkWindow(foregroundSignal = get(), support = get()) }
 }

--- a/core/common/src/iosMain/kotlin/com/garfiec/librechat/core/common/di/CommonPlatformModule.ios.kt
+++ b/core/common/src/iosMain/kotlin/com/garfiec/librechat/core/common/di/CommonPlatformModule.ios.kt
@@ -2,6 +2,7 @@ package com.garfiec.librechat.core.common.di
 
 import com.garfiec.librechat.core.common.AppInfo
 import com.garfiec.librechat.core.common.IosAppInfo
+import com.garfiec.librechat.core.common.lifecycle.DeferredWorkWindow
 import com.garfiec.librechat.core.common.network.ConnectivityObserver
 import com.garfiec.librechat.core.common.network.IosConnectivityObserver
 import com.garfiec.librechat.core.common.network.IosNetworkConditionObserver
@@ -16,4 +17,8 @@ actual val commonPlatformModule: Module = module {
     single<NetworkConditionObserver> { IosNetworkConditionObserver() }
     single<PowerStateObserver> { IosPowerStateObserver() }
     single<AppInfo> { IosAppInfo() }
+    // False until the BGTaskScheduler work lands: iOS suspends a backgrounded process, so a latched
+    // window would start a pass and then freeze it mid-request with nothing to finish or cancel it.
+    // Falling back to the foreground signal keeps today's behaviour exactly.
+    single { DeferredWorkWindow(foregroundSignal = get(), backgroundRunsSupported = false) }
 }

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -35,6 +35,9 @@ kotlin {
             // Prefetching attachments warms the singleton image loader's disk cache, which only the
             // Android side configures. iOS binds a no-op and needs no image dependency at all.
             implementation(libs.coil3.core)
+            // Scheduled background warming. Android-only: iOS binds a no-op scheduler because
+            // BGTaskScheduler registration has to happen in the app target at launch.
+            implementation(libs.work.runtime)
         }
         named("androidUnitTest").dependencies {
             implementation(libs.koin.test)
@@ -46,6 +49,7 @@ kotlin {
             implementation(libs.room.testing)
             implementation(libs.truth)
             implementation(libs.coroutines.test)
+            implementation(libs.work.testing)
         }
         named("androidInstrumentedTest").dependencies {
             implementation(libs.room.testing)

--- a/core/data/src/androidMain/kotlin/com/garfiec/librechat/core/data/di/DataPlatformModule.android.kt
+++ b/core/data/src/androidMain/kotlin/com/garfiec/librechat/core/data/di/DataPlatformModule.android.kt
@@ -12,6 +12,8 @@ import com.garfiec.librechat.core.data.db.migration.MIGRATION_3_4
 import com.garfiec.librechat.core.data.db.migration.MIGRATION_4_5
 import com.garfiec.librechat.core.data.prefetch.AttachmentWarmer
 import com.garfiec.librechat.core.data.prefetch.CoilAttachmentWarmer
+import com.garfiec.librechat.core.data.prefetch.PrefetchScheduler
+import com.garfiec.librechat.core.data.prefetch.WorkManagerPrefetchScheduler
 import com.garfiec.librechat.core.data.repository.AndroidSwitchCacheCleaner
 import com.garfiec.librechat.core.data.repository.CommonSessionCacheCleaner
 import com.garfiec.librechat.core.data.repository.SessionCacheCleaner
@@ -34,6 +36,7 @@ actual val dataPlatformModule: Module = module {
     // Bound per platform rather than defaulted in dataModule: Koin starts with allowOverride(false),
     // so a common default plus a platform override would throw at launch.
     single<AttachmentWarmer> { CoilAttachmentWarmer(androidContext()) }
+    single<PrefetchScheduler> { WorkManagerPrefetchScheduler(androidContext()) }
 
     // --- Database ---
     single {

--- a/core/data/src/androidMain/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchWorker.kt
+++ b/core/data/src/androidMain/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchWorker.kt
@@ -27,11 +27,10 @@ class PrefetchWorker(
         val outcome = runner.runOnce(BUDGET)
         Diag.d("Prefetch", attrs = mapOf("outcome" to outcome.name)) { "worker finished" }
 
-        // Always success, never retry. `setRequiresDeviceIdle` suppresses WorkManager's backoff, so
-        // a retry would not be rescheduled on a ladder — it would simply wait for the next period,
-        // which is what returning success does anyway, without the failure showing up in job
-        // diagnostics as though something were wrong. Nothing here is lost by waiting: watermarks
-        // make a partial pass resumable, and an unmet constraint is not an error.
+        // Always success, never retry. `setRequiresDeviceIdle` suppresses WorkManager's backoff, so a
+        // retry would just wait for the next period — which success already does, without the job
+        // reading as failed in diagnostics. Nothing is lost by waiting: watermarks make a partial
+        // pass resumable, and an unmet constraint is not an error.
         return Result.success()
     }
 

--- a/core/data/src/androidMain/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchWorker.kt
+++ b/core/data/src/androidMain/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchWorker.kt
@@ -1,0 +1,45 @@
+package com.garfiec.librechat.core.data.prefetch
+
+import android.content.Context
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import com.garfiec.librechat.core.logging.Diag
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+import kotlin.time.Duration.Companion.minutes
+
+/**
+ * Runs one prefetch pass on the schedule set by [WorkManagerPrefetchScheduler].
+ *
+ * Resolves from Koin rather than taking constructor injection: the graph is started in
+ * `Application.onCreate`, and a worker is only ever instantiated when its job runs, which is always
+ * afterwards. That avoids a custom `WorkerFactory` and a `Configuration.Provider` on the Application
+ * for a single worker.
+ */
+class PrefetchWorker(
+    context: Context,
+    params: WorkerParameters,
+) : CoroutineWorker(context, params), KoinComponent {
+
+    private val runner: PrefetchBackgroundRunner by inject()
+
+    override suspend fun doWork(): Result {
+        val outcome = runner.runOnce(BUDGET)
+        Diag.d("Prefetch", attrs = mapOf("outcome" to outcome.name)) { "worker finished" }
+
+        // Always success, never retry. `setRequiresDeviceIdle` suppresses WorkManager's backoff, so
+        // a retry would not be rescheduled on a ladder — it would simply wait for the next period,
+        // which is what returning success does anyway, without the failure showing up in job
+        // diagnostics as though something were wrong. Nothing here is lost by waiting: watermarks
+        // make a partial pass resumable, and an unmet constraint is not an error.
+        return Result.success()
+    }
+
+    private companion object {
+        /**
+         * Comfortably inside WorkManager's ~10-minute execution window, leaving room for the pass to
+         * unwind. A pass that outruns it is not lost — it resumes from its watermarks next time.
+         */
+        val BUDGET = 8.minutes
+    }
+}

--- a/core/data/src/androidMain/kotlin/com/garfiec/librechat/core/data/prefetch/WorkManagerPrefetchScheduler.kt
+++ b/core/data/src/androidMain/kotlin/com/garfiec/librechat/core/data/prefetch/WorkManagerPrefetchScheduler.kt
@@ -14,17 +14,17 @@ import java.util.concurrent.TimeUnit
  * The constraints are the feature, not decoration. Charging plus device-idle means this realistically
  * runs overnight rather than on any fixed cadence — the interval below is how often the system is
  * *allowed* to consider it, not how often it fires. Daytime warming comes from a pass outliving the
- * foreground instead, which is why the two mechanisms ship together.
+ * foreground instead.
  */
 class WorkManagerPrefetchScheduler(private val context: Context) : PrefetchScheduler {
 
     override val isSupported: Boolean = true
 
     override fun ensureScheduled(allowMetered: Boolean) {
-        // What the job was last registered with. Persisted because the comparison has to survive
-        // process death — this runs at every cold start, and the setting it depends on can change
-        // while the app is not running. Absent reads as "unchanged": that means nothing is pending,
-        // and KEEP inserts in that case anyway, so both policies agree there.
+        // What the job was last registered with. Must be persisted: this runs at every cold start and
+        // the setting can change while the app is not running, so the comparison has to survive
+        // process death. Absent reads as "unchanged", which is safe — nothing is pending, and KEEP
+        // inserts in that case anyway.
         val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
         val constraintsChanged = prefs.getBoolean(KEY_SCHEDULED_METERED, allowMetered) != allowMetered
 
@@ -40,13 +40,9 @@ class WorkManagerPrefetchScheduler(private val context: Context) : PrefetchSched
             .build()
 
         // KEEP unless the constraints actually changed. This runs at every process start, including
-        // the process a scheduled run itself woke, and re-registering identical work there churns
-        // the WorkSpec for no benefit — UPDATE bumps its generation and reschedules on a path that
-        // had nothing to change.
-        //
-        // UPDATE is still right when the network constraint genuinely changed, because a job carries
-        // its constraints and KEEP would leave the old one in place with nothing to show the setting
-        // had no effect. That only happens from a foreground toggle.
+        // the process a scheduled run itself woke, where an unconditional UPDATE would bump the
+        // WorkSpec's generation and reschedule with nothing to change. UPDATE is still required when
+        // the network constraint differs, since a job carries the constraints it was registered with.
         WorkManager.getInstance(context).enqueueUniquePeriodicWork(
             WORK_NAME,
             if (constraintsChanged) ExistingPeriodicWorkPolicy.UPDATE else ExistingPeriodicWorkPolicy.KEEP,

--- a/core/data/src/androidMain/kotlin/com/garfiec/librechat/core/data/prefetch/WorkManagerPrefetchScheduler.kt
+++ b/core/data/src/androidMain/kotlin/com/garfiec/librechat/core/data/prefetch/WorkManagerPrefetchScheduler.kt
@@ -1,0 +1,70 @@
+package com.garfiec.librechat.core.data.prefetch
+
+import android.content.Context
+import androidx.work.Constraints
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import java.util.concurrent.TimeUnit
+
+/**
+ * Schedules [PrefetchWorker] to warm the cache while the device is idle and on power.
+ *
+ * The constraints are the feature, not decoration. Charging plus device-idle means this realistically
+ * runs overnight rather than on any fixed cadence — the interval below is how often the system is
+ * *allowed* to consider it, not how often it fires. Daytime warming comes from a pass outliving the
+ * foreground instead, which is why the two mechanisms ship together.
+ */
+class WorkManagerPrefetchScheduler(private val context: Context) : PrefetchScheduler {
+
+    override val isSupported: Boolean = true
+
+    override fun ensureScheduled(allowMetered: Boolean) {
+        // What the job was last registered with. Persisted because the comparison has to survive
+        // process death — this runs at every cold start, and the setting it depends on can change
+        // while the app is not running. Absent reads as "unchanged": that means nothing is pending,
+        // and KEEP inserts in that case anyway, so both policies agree there.
+        val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        val constraintsChanged = prefs.getBoolean(KEY_SCHEDULED_METERED, allowMetered) != allowMetered
+
+        val constraints = Constraints.Builder()
+            .setRequiredNetworkType(if (allowMetered) NetworkType.CONNECTED else NetworkType.UNMETERED)
+            .setRequiresCharging(true)
+            .setRequiresDeviceIdle(true)
+            .setRequiresBatteryNotLow(true)
+            .build()
+
+        val request = PeriodicWorkRequestBuilder<PrefetchWorker>(INTERVAL_HOURS, TimeUnit.HOURS)
+            .setConstraints(constraints)
+            .build()
+
+        // KEEP unless the constraints actually changed. This runs at every process start, including
+        // the process a scheduled run itself woke, and re-registering identical work there churns
+        // the WorkSpec for no benefit — UPDATE bumps its generation and reschedules on a path that
+        // had nothing to change.
+        //
+        // UPDATE is still right when the network constraint genuinely changed, because a job carries
+        // its constraints and KEEP would leave the old one in place with nothing to show the setting
+        // had no effect. That only happens from a foreground toggle.
+        WorkManager.getInstance(context).enqueueUniquePeriodicWork(
+            WORK_NAME,
+            if (constraintsChanged) ExistingPeriodicWorkPolicy.UPDATE else ExistingPeriodicWorkPolicy.KEEP,
+            request,
+        )
+        prefs.edit().putBoolean(KEY_SCHEDULED_METERED, allowMetered).apply()
+    }
+
+    override fun cancel() {
+        // The stored constraint is deliberately left alone: cancelled work is a finished state, so
+        // it is no longer pending and the next KEEP enqueue inserts regardless of what it says.
+        WorkManager.getInstance(context).cancelUniqueWork(WORK_NAME)
+    }
+
+    private companion object {
+        const val WORK_NAME = "librechat-prefetch"
+        const val INTERVAL_HOURS = 6L
+        const val PREFS_NAME = "prefetch_schedule"
+        const val KEY_SCHEDULED_METERED = "scheduled_allow_metered"
+    }
+}

--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/datastore/CommonTokenDataStoreSessionExpiryTest.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/datastore/CommonTokenDataStoreSessionExpiryTest.kt
@@ -212,4 +212,45 @@ class CommonTokenDataStoreSessionExpiryTest {
         assertThat(emissions).isEqualTo(2)
         job.cancel()
     }
+
+    /**
+     * The one-shot latch guards against a cold-start storm replaying the logout navigation a dozen
+     * times. It must not be burnt by an emission nobody received: this flow has replay 0, so a report
+     * made while no navigation host is composed is discarded, and latching on it would consume the
+     * report the next request needs. Background prefetching makes that an ordinary case rather than a
+     * theoretical one.
+     */
+    @Test
+    fun `an expiry discovered with no subscriber leaves the signal armed`() = runTest {
+        val store = FakeStore(lazy { throw AssertionError("no refresh expected") })
+
+        // Nobody listening — the report is dropped, and the latch must survive it.
+        store.emitSessionExpired(null)
+
+        var emissions = 0
+        val job = launch(UnconfinedTestDispatcher(testScheduler)) {
+            store.sessionExpiredFlow.collect { emissions++ }
+        }
+
+        store.emitSessionExpired(null)
+
+        assertThat(emissions).isEqualTo(1)
+        job.cancel()
+    }
+
+    /** The storm guard still holds once someone is actually listening. */
+    @Test
+    fun `repeated expiries with a subscriber report once`() = runTest {
+        val store = FakeStore(lazy { throw AssertionError("no refresh expected") })
+
+        var emissions = 0
+        val job = launch(UnconfinedTestDispatcher(testScheduler)) {
+            store.sessionExpiredFlow.collect { emissions++ }
+        }
+
+        repeat(3) { store.emitSessionExpired(null) }
+
+        assertThat(emissions).isEqualTo(1)
+        job.cancel()
+    }
 }

--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/di/DataModuleVerificationTest.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/di/DataModuleVerificationTest.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import android.content.Context
 import androidx.datastore.core.DataStore
 import com.garfiec.librechat.core.common.conversation.OpenConversationRegistry
+import com.garfiec.librechat.core.common.lifecycle.DeferredWorkWindow
 import com.garfiec.librechat.core.common.lifecycle.ForegroundSignal
 import com.garfiec.librechat.core.common.network.ConnectivityObserver
 import com.garfiec.librechat.core.common.network.NetworkConditionObserver
@@ -62,6 +63,7 @@ class DataModuleVerificationTest {
                 NetworkConditionObserver::class,
                 PowerStateObserver::class,
                 ForegroundSignal::class,
+                DeferredWorkWindow::class,
                 OpenConversationRegistry::class,
                 RequestActivityTracker::class,
                 SseClient::class,

--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchBackgroundRunnerTest.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchBackgroundRunnerTest.kt
@@ -1,0 +1,197 @@
+package com.garfiec.librechat.core.data.prefetch
+
+import com.garfiec.librechat.core.common.identity.AccountId
+import com.garfiec.librechat.core.common.identity.Session
+import com.garfiec.librechat.core.common.identity.SessionManager
+import com.garfiec.librechat.core.common.lifecycle.BackgroundWorkSupport
+import com.garfiec.librechat.core.common.lifecycle.DeferredWorkWindow
+import com.garfiec.librechat.core.common.lifecycle.ForegroundSignal
+import com.garfiec.librechat.core.data.datastore.SettingsDataStore
+import com.google.common.truth.Truth.assertThat
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * The runner's whole job is to wait on someone else's pass without starting a second one, and every
+ * way that goes wrong is silent: a duplicated pass looks like ordinary traffic, and a missed one
+ * looks like an unmet constraint. None of it is observable from the outcome alone, so these tests
+ * drive the pass signal directly.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class PrefetchBackgroundRunnerTest {
+
+    private val account = AccountId("srv:user-a")
+
+    private val passInProgress = MutableStateFlow(false)
+    private val completedPasses = MutableStateFlow(0)
+    private val enabled = MutableStateFlow(true)
+
+    private val controller = mockk<PrefetchController>(relaxed = true)
+    private val engine = mockk<PrefetchEngine>()
+    private val settingsDataStore = mockk<SettingsDataStore>(relaxed = true)
+
+    private val window = DeferredWorkWindow(
+        foregroundSignal = ForegroundSignal(),
+        support = BackgroundWorkSupport.SUPPORTED,
+    )
+
+    private fun TestScope.runner(): PrefetchBackgroundRunner {
+        every { controller.passInProgress } returns passInProgress
+        // A relaxed mock hands back an Object for this, which blows up on the Int read.
+        every { controller.completedPasses } returns completedPasses
+        every { settingsDataStore.prefetchEnabled } returns enabled
+        every { engine.runState } returns
+            MutableStateFlow(PrefetchAccountRunState(account.value, PrefetchRunState.Idle))
+
+        // Mocked rather than constructed: Session's constructor is internal to :core:common.
+        val session = mockk<Session>()
+        every { session.accountId } returns account
+        val sessionManager = mockk<SessionManager>()
+        every { sessionManager.current } returns MutableStateFlow(session)
+
+        return PrefetchBackgroundRunner(
+            sessionManager = sessionManager,
+            controller = controller,
+            engine = engine,
+            deferredWorkWindow = window,
+            settingsDataStore = settingsDataStore,
+            nowMillis = { currentTimeMillis() },
+        )
+    }
+
+    private fun TestScope.currentTimeMillis(): Long = testScheduler.currentTime
+
+    @Test
+    fun `prefetching switched off is reported without touching the controller`() = runTest {
+        enabled.value = false
+
+        assertThat(runner().runOnce(BUDGET)).isEqualTo(PrefetchRunOutcome.DISABLED)
+    }
+
+    /**
+     * The case that matters most. Opening the window is itself a pass trigger, so in a process the
+     * scheduler spawned the rising edge starts a pass with nobody asking. Requesting one as well
+     * would run two full passes back to back.
+     */
+    @Test
+    fun `a pass started by the window opening is not asked for again`() = runTest {
+        val runner = runner()
+        val result = async { runner.runOnce(BUDGET) }
+
+        // The gate's rising edge, standing in for the controller's own collector.
+        advanceTimeBy(100)
+        passInProgress.value = true
+        advanceTimeBy(500)
+        passInProgress.value = false
+        advanceUntilIdle()
+
+        assertThat(result.await()).isEqualTo(PrefetchRunOutcome.COMPLETED)
+        verify(exactly = 0) { controller.requestScheduledRun() }
+    }
+
+    /**
+     * The other half: an already-running process with the gate open has no edge to ride, so nothing
+     * starts on its own and the runner has to ask. Without this the job burns its budget waiting.
+     */
+    @Test
+    fun `a run is requested when nothing starts on its own`() = runTest {
+        every { controller.requestScheduledRun() } answers { passInProgress.value = true }
+
+        val runner = runner()
+        val result = async { runner.runOnce(BUDGET) }
+
+        // Past the grace it waits for a pass to appear on its own, at which point it asks — and the
+        // stub above answers by starting one. Stepping rather than idling, because idling would run
+        // the budget out too and report the pass as overrunning instead of completing.
+        advanceTimeBy(6.seconds)
+        passInProgress.value = false
+        advanceUntilIdle()
+
+        assertThat(result.await()).isEqualTo(PrefetchRunOutcome.COMPLETED)
+        verify(exactly = 1) { controller.requestScheduledRun() }
+    }
+
+    /** A gate that never opens must report, not hang until the platform kills the job. */
+    @Test
+    fun `a gate that never opens is reported as constraints unmet`() = runTest {
+        val runner = runner()
+        val result = async { runner.runOnce(BUDGET) }
+
+        advanceUntilIdle()
+
+        assertThat(result.await()).isEqualTo(PrefetchRunOutcome.CONSTRAINTS_UNMET)
+    }
+
+    /** A pass still running when the budget ends is not an error — watermarks make it resumable. */
+    @Test
+    fun `a pass outlasting the budget is reported as budget expired`() = runTest {
+        val runner = runner()
+        val result = async { runner.runOnce(BUDGET) }
+
+        advanceTimeBy(100)
+        passInProgress.value = true
+        advanceUntilIdle()
+
+        assertThat(result.await()).isEqualTo(PrefetchRunOutcome.BUDGET_EXPIRED)
+    }
+
+    /** Every run records, including the ones that warmed nothing — those are the invisible ones. */
+    @Test
+    fun `the outcome is recorded`() = runTest {
+        val recorded = slot<ScheduledRunRecord>()
+        coEvery { settingsDataStore.recordScheduledRun(any(), capture(recorded)) } returns Unit
+
+        runner().runOnce(BUDGET)
+        advanceUntilIdle()
+
+        assertThat(recorded.captured.outcome).isEqualTo(PrefetchRunOutcome.CONSTRAINTS_UNMET)
+    }
+
+    /** The window must close however the run ended, or the gate stays open on a dead run forever. */
+    @Test
+    fun `the window is closed when the run ends`() = runTest {
+        runner().runOnce(BUDGET)
+        advanceUntilIdle()
+
+        // Nothing marked the UI started, so the window is open only while a background run is.
+        assertThat(window.isOpen.first()).isFalse()
+    }
+
+    private companion object {
+        val BUDGET = 2.minutes
+    }
+
+    /**
+     * WorkManager drops the worker the moment a constraint is lost, cancelling doWork. A cancelled
+     * call never produces a return value, so a record written off the result would silently skip
+     * exactly the runs the readout exists to explain.
+     */
+    @Test
+    fun `a cancelled run still records an outcome`() = runTest {
+        val recorded = slot<ScheduledRunRecord>()
+        coEvery { settingsDataStore.recordScheduledRun(any(), capture(recorded)) } returns Unit
+
+        val runner = runner()
+        val job = launch { runner.runOnce(BUDGET) }
+        advanceTimeBy(100)
+        job.cancelAndJoin()
+
+        assertThat(recorded.captured.outcome).isEqualTo(PrefetchRunOutcome.INTERRUPTED)
+    }
+}

--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchControllerTest.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchControllerTest.kt
@@ -4,6 +4,7 @@ import com.garfiec.librechat.core.common.conversation.OpenConversationRegistry
 import com.garfiec.librechat.core.common.identity.AccountId
 import com.garfiec.librechat.core.common.identity.Session
 import com.garfiec.librechat.core.common.identity.SessionManager
+import com.garfiec.librechat.core.common.lifecycle.ForegroundSignal
 import com.garfiec.librechat.core.common.result.Result
 import com.garfiec.librechat.core.data.datastore.SettingsDataStore
 import com.garfiec.librechat.core.data.db.dao.ConversationDao
@@ -94,6 +95,7 @@ class PrefetchControllerTest {
                 serverUrlProvider = object : ServerUrlProvider {
                     override fun getBaseUrl(): String = "https://chat.example.com"
                 },
+                foregroundSignal = ForegroundSignal().apply { set(true) },
                 ioDispatcher = UnconfinedTestDispatcher(testScheduler),
                 timeSource = testScheduler.timeSource,
                 nowMillis = { 0L },

--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchControllerTest.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchControllerTest.kt
@@ -68,6 +68,9 @@ class PrefetchControllerTest {
         coEvery { agentRepository.getAgents(any()) } returns Result.Success(emptyList())
         every { settingsDataStore.prefetchAttachmentsEnabled } returns flowOf(false)
         every { settingsDataStore.prefetchDepth } returns flowOf(PrefetchDepth.DEFAULT)
+        // See PrefetchEngineTest: a relaxed mock answers 0L, which against virtual time reads as a
+        // list refresh that just happened and skips the stage these tests count calls on.
+        coEvery { settingsDataStore.prefetchListRefreshedAt(any()) } returns null
         every { attachmentWarmer.isSupported } returns false
 
         var firstCall = true

--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchEngineTest.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchEngineTest.kt
@@ -2,6 +2,7 @@ package com.garfiec.librechat.core.data.prefetch
 
 import com.garfiec.librechat.core.common.conversation.OpenConversationRegistry
 import com.garfiec.librechat.core.common.identity.AccountId
+import com.garfiec.librechat.core.common.lifecycle.ForegroundSignal
 import com.garfiec.librechat.core.common.network.isPrefetch
 import com.garfiec.librechat.core.common.result.ApiException
 import com.garfiec.librechat.core.common.result.Result
@@ -61,6 +62,10 @@ class PrefetchEngineTest {
         override fun getBaseUrl(): String = "https://chat.example.com"
     }
 
+    // Foreground by default: pacing differs between the two, so every test that isn't about pacing
+    // should exercise the polite gap the user actually sees.
+    private val foregroundSignal = ForegroundSignal().apply { set(true) }
+
     @Before
     fun setup() {
         coEvery { conversationRepository.loadNextPage(any(), any(), any(), any(), any(), any()) } returns
@@ -89,6 +94,7 @@ class PrefetchEngineTest {
         attachmentWarmer = attachmentWarmer,
         settingsDataStore = settingsDataStore,
         serverUrlProvider = serverUrlProvider,
+        foregroundSignal = foregroundSignal,
         ioDispatcher = UnconfinedTestDispatcher(testScheduler),
         // The scheduler's own time source, so elapsedNow() follows virtual time.
         timeSource = testScheduler.timeSource,
@@ -126,6 +132,52 @@ class PrefetchEngineTest {
     }
 
     /**
+     * Off screen the proportional gap is what would make a pass outlive the window it was given, so
+     * it collapses to the floor. This is the difference between a scheduled run warming the whole
+     * configured depth and warming a fraction of it.
+     */
+    @Test
+    fun `pacing holds only the floor when the app is off screen`() = runTest {
+        foregroundSignal.set(false)
+        stubRecent("a", "b")
+        val callTimes = mutableListOf<Long>()
+        coEvery { messageRepository.refreshMessages(any(), any()) } coAnswers {
+            callTimes += currentTime
+            delay(REQUEST_MILLIS)
+            Result.Success(emptyList<Message>())
+        }
+
+        engine().run(account)
+
+        assertThat(callTimes).hasSize(2)
+        assertThat(callTimes[1] - callTimes[0]).isEqualTo(REQUEST_MILLIS + PrefetchEngine.MIN_PACE_MILLIS)
+    }
+
+    /**
+     * Read live, not captured once per pass: someone who opens the app mid-pass is competing with it
+     * for the connection from that moment, not from the next one.
+     */
+    @Test
+    fun `returning to the foreground restores the polite gap within the same pass`() = runTest {
+        foregroundSignal.set(false)
+        stubRecent("a", "b", "c")
+        val callTimes = mutableListOf<Long>()
+        coEvery { messageRepository.refreshMessages(any(), any()) } coAnswers {
+            callTimes += currentTime
+            // The user comes back while the first request is in flight.
+            if (callTimes.size == 1) foregroundSignal.set(true)
+            delay(REQUEST_MILLIS)
+            Result.Success(emptyList<Message>())
+        }
+
+        engine().run(account)
+
+        assertThat(callTimes).hasSize(3)
+        assertThat(callTimes[1] - callTimes[0])
+            .isEqualTo(REQUEST_MILLIS + REQUEST_MILLIS * PrefetchEngine.PACE_FACTOR)
+    }
+
+    /**
      * The engine calls the ordinary repositories, so the exemption has to be applied by the engine
      * itself. Without it the first request counts as user activity, closes the gate that permits the
      * pass, and the prefetcher deadlocks against itself — silently.
@@ -150,6 +202,7 @@ class PrefetchEngineTest {
             attachmentWarmer = attachmentWarmer,
             settingsDataStore = settingsDataStore,
             serverUrlProvider = serverUrlProvider,
+        foregroundSignal = foregroundSignal,
             ioDispatcher = UnconfinedTestDispatcher(testScheduler),
             timeSource = testScheduler.timeSource,
             nowMillis = { currentTime },

--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchEngineTest.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchEngineTest.kt
@@ -34,6 +34,7 @@ import kotlinx.coroutines.test.currentTime
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Test
+import kotlin.time.Duration.Companion.hours
 import kotlin.coroutines.coroutineContext
 
 /**
@@ -79,6 +80,10 @@ class PrefetchEngineTest {
         every { settingsDataStore.prefetchAttachmentsEnabled } returns flowOf(false)
         every { settingsDataStore.prefetchDepth } returns flowOf(PrefetchDepth.DEFAULT)
         every { attachmentWarmer.isSupported } returns false
+        // Explicitly "never refreshed". A relaxed mock answers 0L here, not null, and against
+        // runTest's clock — which starts at 0 — that reads as "refreshed this instant" and silently
+        // skips the list stage in every test that isn't about the skip.
+        coEvery { settingsDataStore.prefetchListRefreshedAt(any()) } returns null
     }
 
     private fun TestScope.engine() = PrefetchEngine(
@@ -113,6 +118,61 @@ class PrefetchEngineTest {
             retryAfterSeconds = retryAfterSeconds,
         ),
     )
+
+    /**
+     * The prologue is what a short pass spends itself on. At the deepest setting it is eight pages,
+     * and a user who idles in bursts would re-pay it every time and never reach the message stage.
+     */
+    @Test
+    fun `a list refresh completed moments ago is not repeated`() = runTest {
+        coEvery { settingsDataStore.prefetchListRefreshedAt(any()) } returns currentTime
+        stubRecent("a")
+        coEvery { messageRepository.refreshMessages(any(), any()) } returns Result.Success(emptyList())
+
+        engine().run(account)
+
+        coVerify(exactly = 0) { conversationRepository.loadNextPage(any(), any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `an old list refresh is repeated`() = runTest {
+        coEvery { settingsDataStore.prefetchListRefreshedAt(any()) } returns
+            currentTime - 1.hours.inWholeMilliseconds
+        stubRecent("a")
+        coEvery { messageRepository.refreshMessages(any(), any()) } returns Result.Success(emptyList())
+
+        engine().run(account)
+
+        coVerify(atLeast = 1) { conversationRepository.loadNextPage(any(), any(), any(), any(), any(), any()) }
+    }
+
+    /**
+     * Recording a partial run would let the skip suppress the very refresh that never finished,
+     * leaving selection reading timestamps the list stage never brought up to date.
+     */
+    @Test
+    fun `a list refresh cut short is not recorded`() = runTest {
+        coEvery { settingsDataStore.prefetchListRefreshedAt(any()) } returns null
+        coEvery { conversationRepository.loadNextPage(any(), any(), any(), any(), any(), any()) } returns
+            Result.Error(exception = ApiException(statusCode = 500, message = "boom"))
+        stubRecent("a")
+        coEvery { messageRepository.refreshMessages(any(), any()) } returns Result.Success(emptyList())
+
+        engine().run(account)
+
+        coVerify(exactly = 0) { settingsDataStore.recordPrefetchListRefreshed(any(), any()) }
+    }
+
+    @Test
+    fun `a completed list refresh is recorded`() = runTest {
+        coEvery { settingsDataStore.prefetchListRefreshedAt(any()) } returns null
+        stubRecent("a")
+        coEvery { messageRepository.refreshMessages(any(), any()) } returns Result.Success(emptyList())
+
+        engine().run(account)
+
+        coVerify(exactly = 1) { settingsDataStore.recordPrefetchListRefreshed(account.value, any()) }
+    }
 
     @Test
     fun `pacing waits five times the observed latency between requests`() = runTest {

--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchGateTest.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchGateTest.kt
@@ -1,5 +1,6 @@
 package com.garfiec.librechat.core.data.prefetch
 
+import com.garfiec.librechat.core.common.lifecycle.DeferredWorkWindow
 import com.garfiec.librechat.core.common.lifecycle.ForegroundSignal
 import com.garfiec.librechat.core.common.network.ConnectivityObserver
 import com.garfiec.librechat.core.common.network.NetworkConditionObserver
@@ -24,7 +25,8 @@ import org.junit.Test
 @OptIn(ExperimentalCoroutinesApi::class)
 class PrefetchGateTest {
 
-    private val foreground = MutableStateFlow(true)
+    private val uiStarted = MutableStateFlow(true)
+    private val backgroundRunActive = MutableStateFlow(false)
     private val enabled = MutableStateFlow(true)
     private val unmetered = MutableStateFlow(true)
     private val allowMetered = MutableStateFlow(false)
@@ -47,10 +49,18 @@ class PrefetchGateTest {
         val power = object : PowerStateObserver {
             override val isPowerConstrained: Flow<Boolean> = powerConstrained
         }
-        val signal = ForegroundSignal().apply { set(foreground.value) }
+        // Built on the Android binding (background runs supported), so the window latches on
+        // markUiStarted rather than tracking the foreground signal underneath it.
+        val window = DeferredWorkWindow(
+            foregroundSignal = ForegroundSignal(),
+            backgroundRunsSupported = true,
+        ).apply {
+            if (uiStarted.value) markUiStarted()
+            if (backgroundRunActive.value) beginBackgroundRun()
+        }
 
         return PrefetchGate(
-            foregroundSignal = signal,
+            deferredWorkWindow = window,
             settingsDataStore = settings,
             networkConditionObserver = network,
             connectivityObserver = connectivity,
@@ -144,7 +154,7 @@ class PrefetchGateTest {
     @Test
     fun `each unmet condition is reported independently`() = runTest {
         enabled.value = false
-        foreground.value = false
+        uiStarted.value = false
         unmetered.value = false
         powerConstrained.value = true
         tracker.begin()
@@ -152,9 +162,43 @@ class PrefetchGateTest {
         val conditions = gate().conditions().first()
 
         assertThat(conditions.enabled).isFalse()
-        assertThat(conditions.foreground).isFalse()
+        assertThat(conditions.appAvailable).isFalse()
         assertThat(conditions.networkAllowed).isFalse()
         assertThat(conditions.powerAvailable).isFalse()
         assertThat(conditions.appIdle).isFalse()
+    }
+
+    /**
+     * The scheduled-job case, and the one that fails silently if it regresses. A process the job
+     * spawned never composes, so nothing marks the UI started; without the background run opening
+     * the window, the job would wake the process, find the gate shut, and exit reporting success.
+     */
+    @Test
+    fun `a background run opens the gate in a process whose UI never started`() = runTest {
+        uiStarted.value = false
+
+        assertThat(gate().conditions().first().appAvailable).isFalse()
+
+        backgroundRunActive.value = true
+
+        assertThat(gate().conditions().first().appAvailable).isTrue()
+        assertThat(gate().isOpen().first()).isTrue()
+    }
+
+    /** Backgrounding must not stop a pass: that is the whole point of latching rather than tracking. */
+    @Test
+    fun `the window stays open once the UI has started`() = runTest {
+        val window = DeferredWorkWindow(
+            foregroundSignal = ForegroundSignal().apply { set(true) },
+            backgroundRunsSupported = true,
+        )
+        window.markUiStarted()
+
+        assertThat(window.isOpen.first()).isTrue()
+
+        window.beginBackgroundRun()
+        window.endBackgroundRun()
+
+        assertThat(window.isOpen.first()).isTrue()
     }
 }

--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchGateTest.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchGateTest.kt
@@ -1,5 +1,6 @@
 package com.garfiec.librechat.core.data.prefetch
 
+import com.garfiec.librechat.core.common.lifecycle.BackgroundWorkSupport
 import com.garfiec.librechat.core.common.lifecycle.DeferredWorkWindow
 import com.garfiec.librechat.core.common.lifecycle.ForegroundSignal
 import com.garfiec.librechat.core.common.network.ConnectivityObserver
@@ -53,7 +54,7 @@ class PrefetchGateTest {
         // markUiStarted rather than tracking the foreground signal underneath it.
         val window = DeferredWorkWindow(
             foregroundSignal = ForegroundSignal(),
-            backgroundRunsSupported = true,
+            support = BackgroundWorkSupport.SUPPORTED,
         ).apply {
             if (uiStarted.value) markUiStarted()
             if (backgroundRunActive.value) beginBackgroundRun()
@@ -190,7 +191,7 @@ class PrefetchGateTest {
     fun `the window stays open once the UI has started`() = runTest {
         val window = DeferredWorkWindow(
             foregroundSignal = ForegroundSignal().apply { set(true) },
-            backgroundRunsSupported = true,
+            support = BackgroundWorkSupport.SUPPORTED,
         )
         window.markUiStarted()
 

--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchScheduleCoordinatorTest.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchScheduleCoordinatorTest.kt
@@ -23,8 +23,7 @@ import kotlin.test.assertEquals
  * Every assertion here is about a *decision*, not about the resulting job: the scheduler's own
  * `KEEP` makes a redundant registration invisible in WorkManager's tables, so "did the coordinator
  * act" cannot be read back off the job afterwards. Recording the calls is the only way to tell a
- * coordinator that decided to keep the job from one that never ran at all — a distinction that cost
- * a device-testing session to learn.
+ * coordinator that decided to keep the job from one that never ran at all.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 class PrefetchScheduleCoordinatorTest {
@@ -115,9 +114,9 @@ class PrefetchScheduleCoordinatorTest {
         }
 
     /**
-     * The reason this reads identity rather than the session: a null session means both "still
-     * warming" and "signed out", and treating the boot value as signed out made every process start
-     * cancel the pending job — including, in a process the job itself woke, the run in progress.
+     * Why the coordinator reads identity rather than the session: a null session means both "still
+     * warming" and "signed out", and treating the boot value as signed out cancels the pending job at
+     * every process start — including, in a process the job itself woke, the run in progress.
      */
     @Test
     fun `a warming identity decides nothing either way`() =

--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchScheduleCoordinatorTest.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchScheduleCoordinatorTest.kt
@@ -1,0 +1,150 @@
+package com.garfiec.librechat.core.data.prefetch
+
+import com.garfiec.librechat.core.common.identity.AccountId
+import com.garfiec.librechat.core.common.identity.AccountState
+import com.garfiec.librechat.core.common.identity.InMemoryActiveAccountProvider
+import com.garfiec.librechat.core.data.datastore.SettingsDataStore
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import kotlin.test.assertEquals
+
+/**
+ * Whether the OS is asked to wake us up at all.
+ *
+ * Every assertion here is about a *decision*, not about the resulting job: the scheduler's own
+ * `KEEP` makes a redundant registration invisible in WorkManager's tables, so "did the coordinator
+ * act" cannot be read back off the job afterwards. Recording the calls is the only way to tell a
+ * coordinator that decided to keep the job from one that never ran at all — a distinction that cost
+ * a device-testing session to learn.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class PrefetchScheduleCoordinatorTest {
+
+    private val account = AccountId("srv:user-a")
+
+    private val enabled = MutableStateFlow(true)
+    private val onMetered = MutableStateFlow(false)
+
+    private val settingsDataStore = mockk<SettingsDataStore>(relaxed = true).also {
+        every { it.prefetchEnabled } returns enabled
+        every { it.prefetchOnMeteredEnabled } returns onMetered
+    }
+
+    private class RecordingScheduler(override val isSupported: Boolean = true) : PrefetchScheduler {
+        val calls = mutableListOf<String>()
+        override fun ensureScheduled(allowMetered: Boolean) {
+            calls += "schedule(metered=$allowMetered)"
+        }
+
+        override fun cancel() {
+            calls += "cancel"
+        }
+    }
+
+    /**
+     * Runs [body] against a live coordinator, then tears its scope down.
+     *
+     * The coordinator's whole job is an endless collector, so handing it the `TestScope` directly
+     * leaves `runTest` waiting on a coroutine that by design never finishes.
+     */
+    private fun coordinatorTest(
+        initial: AccountState,
+        isSupported: Boolean = true,
+        body: TestScope.(InMemoryActiveAccountProvider, RecordingScheduler) -> Unit,
+    ) = runTest {
+        val provider = InMemoryActiveAccountProvider(initial)
+        val scheduler = RecordingScheduler(isSupported)
+        val scope = CoroutineScope(StandardTestDispatcher(testScheduler))
+        PrefetchScheduleCoordinator(
+            settingsDataStore = settingsDataStore,
+            activeAccountProvider = provider,
+            scheduler = scheduler,
+            appScope = scope,
+        )
+        advanceUntilIdle()
+        try {
+            body(provider, scheduler)
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `a signed-in account with prefetching on registers the job`() =
+        coordinatorTest(AccountState.Resolved(account)) { _, scheduler ->
+            assertEquals(listOf("schedule(metered=false)"), scheduler.calls)
+        }
+
+    @Test
+    fun `signing out cancels the job`() =
+        coordinatorTest(AccountState.Resolved(account)) { provider, scheduler ->
+            provider.clear()
+            advanceUntilIdle()
+
+            assertEquals(listOf("schedule(metered=false)", "cancel"), scheduler.calls)
+        }
+
+    @Test
+    fun `switching prefetching off cancels the job`() =
+        coordinatorTest(AccountState.Resolved(account)) { _, scheduler ->
+            enabled.value = false
+            advanceUntilIdle()
+
+            assertEquals(listOf("schedule(metered=false)", "cancel"), scheduler.calls)
+        }
+
+    @Test
+    fun `changing the metered override re-registers the job`() =
+        coordinatorTest(AccountState.Resolved(account)) { _, scheduler ->
+            onMetered.value = true
+            advanceUntilIdle()
+
+            assertEquals(
+                listOf("schedule(metered=false)", "schedule(metered=true)"),
+                scheduler.calls,
+            )
+        }
+
+    /**
+     * The reason this reads identity rather than the session: a null session means both "still
+     * warming" and "signed out", and treating the boot value as signed out made every process start
+     * cancel the pending job — including, in a process the job itself woke, the run in progress.
+     */
+    @Test
+    fun `a warming identity decides nothing either way`() =
+        coordinatorTest(AccountState.Warming) { _, scheduler ->
+            assertEquals(emptyList(), scheduler.calls)
+        }
+
+    /**
+     * A cold start with no credentials resolves straight to logged-out without ever passing through
+     * a signed-in state. A job registered before the session died is still on the device, so this
+     * has to cancel rather than wait for a transition that never comes.
+     */
+    @Test
+    fun `a cold start that resolves to logged out cancels the job`() =
+        coordinatorTest(AccountState.Warming) { provider, scheduler ->
+            provider.clear()
+            advanceUntilIdle()
+
+            assertEquals(listOf("cancel"), scheduler.calls)
+        }
+
+    @Test
+    fun `a platform that schedules nothing is never asked to`() =
+        coordinatorTest(AccountState.Resolved(account), isSupported = false) { provider, scheduler ->
+            provider.clear()
+            advanceUntilIdle()
+
+            assertEquals(emptyList(), scheduler.calls)
+        }
+}

--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchWorkerTest.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchWorkerTest.kt
@@ -1,0 +1,68 @@
+package com.garfiec.librechat.core.data.prefetch
+
+import androidx.test.core.app.ApplicationProvider
+import androidx.work.ListenableWorker
+import androidx.work.testing.TestListenableWorkerBuilder
+import com.google.common.truth.Truth.assertThat
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.dsl.module
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import kotlin.time.Duration
+
+/**
+ * The worker resolves its dependency from Koin rather than through a `WorkerFactory`, which is a
+ * runtime lookup no compiler checks. It is also the one component here that only ever runs when the
+ * OS decides to run it, so a wiring mistake would surface as a job that quietly does nothing.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class PrefetchWorkerTest {
+
+    private val runner = mockk<PrefetchBackgroundRunner>()
+
+    @After
+    fun tearDown() {
+        stopKoin()
+    }
+
+    private fun startKoinWithRunner() {
+        startKoin { modules(module { single { runner } }) }
+    }
+
+    @Test
+    fun `the worker resolves the runner from Koin and runs a pass`() = runTest {
+        startKoinWithRunner()
+        coEvery { runner.runOnce(any<Duration>()) } returns PrefetchRunOutcome.COMPLETED
+
+        val worker = TestListenableWorkerBuilder<PrefetchWorker>(
+            ApplicationProvider.getApplicationContext(),
+        ).build()
+
+        assertThat(worker.doWork()).isEqualTo(ListenableWorker.Result.success())
+    }
+
+    /**
+     * Every outcome reports success. With `setRequiresDeviceIdle` there is no backoff ladder, so a
+     * retry would just wait for the next period — which success already does, without the job
+     * showing up in diagnostics as a failure.
+     */
+    @Test
+    fun `an unmet constraint is still reported as success`() = runTest {
+        startKoinWithRunner()
+        coEvery { runner.runOnce(any<Duration>()) } returns PrefetchRunOutcome.CONSTRAINTS_UNMET
+
+        val worker = TestListenableWorkerBuilder<PrefetchWorker>(
+            ApplicationProvider.getApplicationContext(),
+        ).build()
+
+        assertThat(worker.doWork()).isEqualTo(ListenableWorker.Result.success())
+    }
+}

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/CommonTokenDataStore.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/CommonTokenDataStore.kt
@@ -593,6 +593,18 @@ abstract class CommonTokenDataStore(
         // A racing double-emit is possible (plain @Volatile, no CAS) and deliberately tolerated: the
         // navigator's own guard absorbs it.
         if (sessionExpiryReported) return
+        // Latch on DELIVERY, not on the attempt. This flow has replay 0, so an emission with no
+        // subscriber is discarded — and burning the one-shot on it would consume the report that the
+        // next request needs. That case is not hypothetical: background prefetching runs in
+        // processes where no navigation host is composed, so a pass can be the first thing to
+        // discover a dead session with nobody able to act on it.
+        //
+        // Guarding here rather than at the callers is what makes it general — every unattended
+        // emitter is covered, present and future, without each one having to remember a convention.
+        if (_sessionExpired.subscriptionCount.value == 0) {
+            Diag.d("Auth") { "session expiry discovered with no subscriber - leaving the signal armed" }
+            return
+        }
         sessionExpiryReported = true
         _sessionExpired.tryEmit(reason)
     }

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/CommonTokenDataStore.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/CommonTokenDataStore.kt
@@ -594,13 +594,9 @@ abstract class CommonTokenDataStore(
         // navigator's own guard absorbs it.
         if (sessionExpiryReported) return
         // Latch on DELIVERY, not on the attempt. This flow has replay 0, so an emission with no
-        // subscriber is discarded — and burning the one-shot on it would consume the report that the
-        // next request needs. That case is not hypothetical: background prefetching runs in
-        // processes where no navigation host is composed, so a pass can be the first thing to
-        // discover a dead session with nobody able to act on it.
-        //
-        // Guarding here rather than at the callers is what makes it general — every unattended
-        // emitter is covered, present and future, without each one having to remember a convention.
+        // subscriber is discarded — and burning the one-shot on it would consume the report the next
+        // request needs, stranding the user in a logged-out shell. Unattended emitters (background
+        // prefetch runs in processes where no navigation host is composed) make that an ordinary case.
         if (_sessionExpired.subscriptionCount.value == 0) {
             Diag.d("Auth") { "session expiry discovered with no subscriber - leaving the signal armed" }
             return

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/SettingsDataStore.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/SettingsDataStore.kt
@@ -471,6 +471,20 @@ class SettingsDataStore(
 
     private fun usageKey(accountId: String) = accountScopedKey(accountId, MODEL_USAGE)
 
+    private fun listRefreshKey(accountId: String) =
+        accountScopedKey(accountId, PREFETCH_LIST_REFRESHED_AT)
+
+    /**
+     * When the prefetcher last paged the whole conversation list for [accountId], or null if it
+     * never has. Account-scoped, so the prefix purge sweeps it on logout with everything else.
+     */
+    suspend fun prefetchListRefreshedAt(accountId: String): Long? =
+        dataStore.data.first()[listRefreshKey(accountId)]?.toLongOrNull()
+
+    suspend fun recordPrefetchListRefreshed(accountId: String, atMillis: Long) {
+        dataStore.edit { prefs -> prefs[listRefreshKey(accountId)] = atMillis.toString() }
+    }
+
     /**
      * Records one "used" tick for [endpoint]/[model] — called once per message sent, the true
      * usage signal (a passively auto-restored model that's never chatted with must not climb the
@@ -740,6 +754,7 @@ class SettingsDataStore(
         private const val LAST_USED_ENDPOINT = "last_used_endpoint"
         private const val LAST_USED_MODEL = "last_used_model"
         private const val MODEL_USAGE = "model_usage"
+        private const val PREFETCH_LIST_REFRESHED_AT = "prefetch_list_refreshed_at"
         private const val MAX_USAGE_ENTRIES = 50
         private const val USAGE_KEY_SEPARATOR = '\u0000'
         private val KEY_DISMISS_KEYBOARD_ON_SEND = booleanPreferencesKey("dismiss_keyboard_on_send")

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/SettingsDataStore.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/SettingsDataStore.kt
@@ -10,7 +10,10 @@ import androidx.datastore.preferences.core.stringPreferencesKey
 import com.garfiec.librechat.core.common.identity.AccountState
 import com.garfiec.librechat.core.common.identity.ActiveAccountProvider
 import com.garfiec.librechat.core.common.identity.currentAccountId
+import com.garfiec.librechat.core.common.identity.flatMapAccountOrEmpty
 import com.garfiec.librechat.core.data.prefetch.PrefetchDepth
+import com.garfiec.librechat.core.data.prefetch.PrefetchRunOutcome
+import com.garfiec.librechat.core.data.prefetch.ScheduledRunRecord
 import com.garfiec.librechat.core.model.ModelRef
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
@@ -485,6 +488,49 @@ class SettingsDataStore(
         dataStore.edit { prefs -> prefs[listRefreshKey(accountId)] = atMillis.toString() }
     }
 
+    /** Forgets the recorded refresh, so the next pass pages the list rather than reusing it. */
+    suspend fun clearPrefetchListRefreshed(accountId: String) {
+        dataStore.edit { prefs -> prefs.remove(listRefreshKey(accountId)) }
+    }
+
+    private fun scheduledRunKey(accountId: String) =
+        accountScopedKey(accountId, PREFETCH_LAST_SCHEDULED_RUN)
+
+    /**
+     * The last scheduled prefetch for the active account, and how it ended.
+     *
+     * Account-scoped, because what a run did is account-specific and every other figure on the
+     * readout is resolved against the active account — a device-level record would show one
+     * account's overnight warm on another account's screen. Emits null rather than nothing while
+     * identity is warming: this feeds a `combine` that would otherwise hold the entire readout blank
+     * until an account resolved.
+     *
+     * Stored as one string so adding a field cannot silently change the shape of an existing
+     * install's value: an entry that does not parse reads as "no run recorded", which is honest.
+     */
+    val lastScheduledRun: Flow<ScheduledRunRecord?> =
+        activeAccountProvider.flatMapAccountOrEmpty<ScheduledRunRecord?>(null) { id ->
+            dataStore.data.map { prefs -> prefs[scheduledRunKey(id.value)]?.let(::decodeScheduledRun) }
+        }
+
+    /** No-ops without an account: a run that never resolved one has nothing to attribute the record to. */
+    suspend fun recordScheduledRun(accountId: String?, record: ScheduledRunRecord) {
+        if (accountId == null) return
+        dataStore.edit { prefs ->
+            prefs[scheduledRunKey(accountId)] = "${record.atMillis}|${record.outcome.name}"
+        }
+    }
+
+    private fun decodeScheduledRun(raw: String): ScheduledRunRecord? {
+        val (millis, outcome) = raw.split('|', limit = 2).takeIf { it.size == 2 } ?: return null
+        return ScheduledRunRecord(
+            atMillis = millis.toLongOrNull() ?: return null,
+            // An outcome this build does not know about (a downgrade) is not worth failing over,
+            // but it must not be guessed at either.
+            outcome = PrefetchRunOutcome.entries.firstOrNull { it.name == outcome } ?: return null,
+        )
+    }
+
     /**
      * Records one "used" tick for [endpoint]/[model] — called once per message sent, the true
      * usage signal (a passively auto-restored model that's never chatted with must not climb the
@@ -755,6 +801,7 @@ class SettingsDataStore(
         private const val LAST_USED_MODEL = "last_used_model"
         private const val MODEL_USAGE = "model_usage"
         private const val PREFETCH_LIST_REFRESHED_AT = "prefetch_list_refreshed_at"
+        private const val PREFETCH_LAST_SCHEDULED_RUN = "prefetch_last_scheduled_run"
         private const val MAX_USAGE_ENTRIES = 50
         private const val USAGE_KEY_SEPARATOR = '\u0000'
         private val KEY_DISMISS_KEYBOARD_ON_SEND = booleanPreferencesKey("dismiss_keyboard_on_send")

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/di/DataModule.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/di/DataModule.kt
@@ -13,6 +13,7 @@ import com.garfiec.librechat.core.data.datastore.ServerDataStore
 import com.garfiec.librechat.core.data.datastore.SettingsDataStore
 import com.garfiec.librechat.core.data.datastore.ThemeDataStore
 import com.garfiec.librechat.core.data.db.LibreChatDatabase
+import com.garfiec.librechat.core.data.prefetch.PrefetchBackgroundRunner
 import com.garfiec.librechat.core.data.prefetch.PrefetchController
 import com.garfiec.librechat.core.data.prefetch.PrefetchEngine
 import com.garfiec.librechat.core.data.prefetch.PrefetchGate
@@ -321,6 +322,15 @@ val dataModule = module {
             gate = get(),
             engine = get(),
             appScope = get<CoroutineScope>(KoinQualifiers.ApplicationScope),
+        )
+    }
+    single {
+        PrefetchBackgroundRunner(
+            sessionManager = get(),
+            controller = get(),
+            engine = get(),
+            deferredWorkWindow = get(),
+            settingsDataStore = get(),
         )
     }
     single {

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/di/DataModule.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/di/DataModule.kt
@@ -18,6 +18,7 @@ import com.garfiec.librechat.core.data.prefetch.PrefetchController
 import com.garfiec.librechat.core.data.prefetch.PrefetchEngine
 import com.garfiec.librechat.core.data.prefetch.PrefetchGate
 import com.garfiec.librechat.core.data.prefetch.PrefetchPolicy
+import com.garfiec.librechat.core.data.prefetch.PrefetchScheduleCoordinator
 import com.garfiec.librechat.core.data.prefetch.PrefetchStatusReporter
 import com.garfiec.librechat.core.data.repository.AccountClaimReconciler
 import com.garfiec.librechat.core.data.repository.AccountDataPurger
@@ -321,6 +322,16 @@ val dataModule = module {
             sessionManager = get(),
             gate = get(),
             engine = get(),
+            appScope = get<CoroutineScope>(KoinQualifiers.ApplicationScope),
+        )
+    }
+    // Eager for the same reason as PrefetchController: its whole job is a collector, so a lazy
+    // binding nobody resolves would never register or cancel anything.
+    single(createdAtStart = true) {
+        PrefetchScheduleCoordinator(
+            settingsDataStore = get(),
+            sessionManager = get(),
+            scheduler = get(),
             appScope = get<CoroutineScope>(KoinQualifiers.ApplicationScope),
         )
     }

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/di/DataModule.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/di/DataModule.kt
@@ -286,7 +286,7 @@ val dataModule = module {
     singleOf(::PrefetchPolicy)
     single {
         PrefetchGate(
-            foregroundSignal = get(),
+            deferredWorkWindow = get(),
             settingsDataStore = get(),
             networkConditionObserver = get(),
             connectivityObserver = get(),
@@ -308,6 +308,7 @@ val dataModule = module {
             attachmentWarmer = get(),
             settingsDataStore = get(),
             serverUrlProvider = get(),
+            foregroundSignal = get(),
             ioDispatcher = get(KoinQualifiers.IO),
         )
     }

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/di/DataModule.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/di/DataModule.kt
@@ -330,7 +330,7 @@ val dataModule = module {
     single(createdAtStart = true) {
         PrefetchScheduleCoordinator(
             settingsDataStore = get(),
-            sessionManager = get(),
+            activeAccountProvider = get(),
             scheduler = get(),
             appScope = get<CoroutineScope>(KoinQualifiers.ApplicationScope),
         )
@@ -355,6 +355,7 @@ val dataModule = module {
             openConversationRegistry = get(),
             activeAccountProvider = get(),
             settingsDataStore = get(),
+            scheduler = get(),
         )
     }
 

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchBackgroundRunner.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchBackgroundRunner.kt
@@ -1,0 +1,108 @@
+package com.garfiec.librechat.core.data.prefetch
+
+import com.garfiec.librechat.core.common.identity.SessionManager
+import com.garfiec.librechat.core.common.lifecycle.DeferredWorkWindow
+import com.garfiec.librechat.core.data.datastore.SettingsDataStore
+import com.garfiec.librechat.core.logging.Diag
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+/** How a scheduled run ended, for the readout and for the platform job's own logging. */
+enum class PrefetchRunOutcome {
+    /** Prefetching is switched off; the job should not have been scheduled at all. */
+    DISABLED,
+
+    /** Nobody is signed in. */
+    NO_SESSION,
+
+    /** The gate never opened — metered connection, battery saver, or the user is mid-request. */
+    CONSTRAINTS_UNMET,
+
+    /** A pass ran to completion. */
+    COMPLETED,
+
+    /** A pass was still going when the budget ran out. It continues if the process outlives us. */
+    BUDGET_EXPIRED,
+
+    /** The breaker is tripped even after a retry: the server is not answering. */
+    STOPPED,
+}
+
+/**
+ * Runs one prefetch pass on behalf of a platform scheduler, within a budget.
+ *
+ * It does **not** drive the engine directly. [PrefetchController]'s single collector is the only
+ * thing serializing passes — the engine has no locking of its own — so this waits on that collector
+ * instead of starting a second pass beside it.
+ *
+ * The subtlety is that opening the window is *itself* a trigger. In a process the scheduler spawned,
+ * nothing has marked the UI started, so [DeferredWorkWindow.beginBackgroundRun] is what opens the
+ * gate, and the gate's rising edge starts a pass with no request from anyone. Asking for one as well
+ * would run two full passes back to back. So this waits for a pass to appear first, and only asks
+ * when none does — which is the already-running-and-idle process, where there is no edge to ride.
+ */
+class PrefetchBackgroundRunner(
+    private val sessionManager: SessionManager,
+    private val controller: PrefetchController,
+    private val engine: PrefetchEngine,
+    private val deferredWorkWindow: DeferredWorkWindow,
+    private val settingsDataStore: SettingsDataStore,
+) {
+
+    suspend fun runOnce(budget: Duration): PrefetchRunOutcome {
+        if (!settingsDataStore.prefetchEnabled.first()) return PrefetchRunOutcome.DISABLED
+
+        deferredWorkWindow.beginBackgroundRun()
+        try {
+            val session = withTimeoutOrNull(SESSION_WAIT) {
+                sessionManager.current.filterNotNull().first()
+            } ?: return PrefetchRunOutcome.NO_SESSION
+
+            if (!awaitPassStart()) {
+                controller.requestScheduledRun()
+                if (!awaitPassStart()) return PrefetchRunOutcome.CONSTRAINTS_UNMET
+            }
+
+            var outcome = awaitPassEnd(budget, session.accountId.value)
+            if (outcome == PrefetchRunOutcome.STOPPED) {
+                // One retry with the breaker cleared. Beyond that the server really is not answering,
+                // and the next scheduled run is hours away — a better time to try than now.
+                controller.requestScheduledRun()
+                if (awaitPassStart()) outcome = awaitPassEnd(budget, session.accountId.value)
+            }
+            Diag.d("Prefetch", attrs = mapOf("outcome" to outcome.name)) { "scheduled run finished" }
+            return outcome
+        } finally {
+            deferredWorkWindow.endBackgroundRun()
+        }
+    }
+
+    /**
+     * Waits briefly for a pass to be under way.
+     *
+     * A pass that started and finished inside this grace reads as "never started", so the caller asks
+     * for another one. That is wasteful only in appearance: the second pass finds the conversation
+     * list already refreshed and nothing stale, which is the cheapest thing this engine does.
+     */
+    private suspend fun awaitPassStart(): Boolean =
+        withTimeoutOrNull(PASS_START_GRACE) { controller.passInProgress.first { it } } != null
+
+    private suspend fun awaitPassEnd(budget: Duration, accountId: String): PrefetchRunOutcome {
+        val finished = withTimeoutOrNull(budget) { controller.passInProgress.first { !it } } != null
+        if (!finished) return PrefetchRunOutcome.BUDGET_EXPIRED
+        return if (engine.runState.value.stateFor(accountId) == PrefetchRunState.Stopped) {
+            PrefetchRunOutcome.STOPPED
+        } else {
+            PrefetchRunOutcome.COMPLETED
+        }
+    }
+
+    private companion object {
+        /** Long enough for a cold process to read the account registry and form a session. */
+        val SESSION_WAIT = 15.seconds
+        val PASS_START_GRACE = 5.seconds
+    }
+}

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchBackgroundRunner.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchBackgroundRunner.kt
@@ -4,11 +4,27 @@ import com.garfiec.librechat.core.common.identity.SessionManager
 import com.garfiec.librechat.core.common.lifecycle.DeferredWorkWindow
 import com.garfiec.librechat.core.data.datastore.SettingsDataStore
 import com.garfiec.librechat.core.logging.Diag
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
+import kotlin.time.Clock
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
+import kotlin.time.TimeMark
+import kotlin.time.TimeSource
+
+/**
+ * The last scheduled run, as the readout presents it.
+ *
+ * Account-scoped, because what a run did belongs to the account it warmed: every other figure on the
+ * readout is resolved against the active account, and a device-level record would show one account's
+ * overnight warm on another account's screen. Scoping it also means the prefix purge sweeps it on
+ * logout along with everything else that account owned.
+ */
+data class ScheduledRunRecord(val atMillis: Long, val outcome: PrefetchRunOutcome)
 
 /** How a scheduled run ended, for the readout and for the platform job's own logging. */
 enum class PrefetchRunOutcome {
@@ -24,11 +40,19 @@ enum class PrefetchRunOutcome {
     /** A pass ran to completion. */
     COMPLETED,
 
-    /** A pass was still going when the budget ran out. It continues if the process outlives us. */
+    /**
+     * A pass was still going when the budget ran out.
+     *
+     * In a process the scheduler woke, closing the window ends it — nothing else holds the gate open
+     * there. It continues only where the UI has started, i.e. ordinary process-tail warming.
+     */
     BUDGET_EXPIRED,
 
     /** The breaker is tripped even after a retry: the server is not answering. */
     STOPPED,
+
+    /** The platform stopped the run before it could reach a verdict — a lost constraint, usually. */
+    INTERRUPTED,
 }
 
 /**
@@ -50,9 +74,33 @@ class PrefetchBackgroundRunner(
     private val engine: PrefetchEngine,
     private val deferredWorkWindow: DeferredWorkWindow,
     private val settingsDataStore: SettingsDataStore,
+    private val nowMillis: () -> Long = { Clock.System.now().toEpochMilliseconds() },
+    private val timeSource: TimeSource = TimeSource.Monotonic,
 ) {
 
     suspend fun runOnce(budget: Duration): PrefetchRunOutcome {
+        // Seeded with INTERRUPTED so a run the platform stops still records something. WorkManager
+        // drops the worker the moment a constraint is lost — the user picking the phone up ends
+        // device-idle — and a cancelled call never produces a return value, so recording off the
+        // result would leave the readout showing an older run as the most recent one.
+        var outcome = PrefetchRunOutcome.INTERRUPTED
+        try {
+            outcome = runPass(budget)
+            return outcome
+        } finally {
+            // Recorded whatever happened, including the outcomes where nothing was warmed. A run that
+            // found the gate shut is the case a user most needs to see, and it is invisible everywhere
+            // else — no watermark moves, and by the time they look the process is long gone.
+            withContext(NonCancellable) {
+                settingsDataStore.recordScheduledRun(recordedAccountId, ScheduledRunRecord(nowMillis(), outcome))
+            }
+        }
+    }
+
+    /** The account the run belonged to, captured once the session resolves. */
+    private var recordedAccountId: String? = null
+
+    private suspend fun runPass(budget: Duration): PrefetchRunOutcome {
         if (!settingsDataStore.prefetchEnabled.first()) return PrefetchRunOutcome.DISABLED
 
         deferredWorkWindow.beginBackgroundRun()
@@ -61,17 +109,19 @@ class PrefetchBackgroundRunner(
                 sessionManager.current.filterNotNull().first()
             } ?: return PrefetchRunOutcome.NO_SESSION
 
-            if (!awaitPassStart()) {
-                controller.requestScheduledRun()
-                if (!awaitPassStart()) return PrefetchRunOutcome.CONSTRAINTS_UNMET
-            }
+            val accountId = session.accountId.value
+            recordedAccountId = accountId
+            // The window opening is itself a trigger, so only ask when nothing started on its own.
+            if (!awaitPassStart() && !requestAndAwaitStart()) return PrefetchRunOutcome.CONSTRAINTS_UNMET
 
-            var outcome = awaitPassEnd(budget, session.accountId.value)
-            if (outcome == PrefetchRunOutcome.STOPPED) {
+            // One deadline for the whole call, not one per attempt: the retry below would otherwise
+            // re-arm the full budget and let a run take twice what the caller allowed for it.
+            val deadline = timeSource.markNow() + budget
+            var outcome = awaitPassEnd(deadline, accountId)
+            if (outcome == PrefetchRunOutcome.STOPPED && requestAndAwaitStart()) {
                 // One retry with the breaker cleared. Beyond that the server really is not answering,
                 // and the next scheduled run is hours away — a better time to try than now.
-                controller.requestScheduledRun()
-                if (awaitPassStart()) outcome = awaitPassEnd(budget, session.accountId.value)
+                outcome = awaitPassEnd(deadline, accountId)
             }
             Diag.d("Prefetch", attrs = mapOf("outcome" to outcome.name)) { "scheduled run finished" }
             return outcome
@@ -87,11 +137,29 @@ class PrefetchBackgroundRunner(
      * for another one. That is wasteful only in appearance: the second pass finds the conversation
      * list already refreshed and nothing stale, which is the cheapest thing this engine does.
      */
-    private suspend fun awaitPassStart(): Boolean =
-        withTimeoutOrNull(PASS_START_GRACE) { controller.passInProgress.first { it } } != null
+    /**
+     * Waits briefly for a pass to be under way, or for one to have completed while we were not
+     * looking — [PrefetchController.passInProgress] conflates, so a short pass can begin and end
+     * between two reads of it and would otherwise be reported as never having started.
+     */
+    private suspend fun awaitPassStart(): Boolean {
+        val before = controller.completedPasses.value
+        return withTimeoutOrNull(PASS_START_GRACE) {
+            combine(controller.passInProgress, controller.completedPasses) { running, completed ->
+                running || completed != before
+            }.first { it }
+        } != null
+    }
 
-    private suspend fun awaitPassEnd(budget: Duration, accountId: String): PrefetchRunOutcome {
-        val finished = withTimeoutOrNull(budget) { controller.passInProgress.first { !it } } != null
+    private suspend fun requestAndAwaitStart(): Boolean {
+        controller.requestScheduledRun()
+        return awaitPassStart()
+    }
+
+    private suspend fun awaitPassEnd(deadline: TimeMark, accountId: String): PrefetchRunOutcome {
+        val remaining = -deadline.elapsedNow()
+        if (remaining <= Duration.ZERO) return PrefetchRunOutcome.BUDGET_EXPIRED
+        val finished = withTimeoutOrNull(remaining) { controller.passInProgress.first { !it } } != null
         if (!finished) return PrefetchRunOutcome.BUDGET_EXPIRED
         return if (engine.runState.value.stateFor(accountId) == PrefetchRunState.Stopped) {
             PrefetchRunOutcome.STOPPED

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchBackgroundRunner.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchBackgroundRunner.kt
@@ -16,14 +16,7 @@ import kotlin.time.Duration.Companion.seconds
 import kotlin.time.TimeMark
 import kotlin.time.TimeSource
 
-/**
- * The last scheduled run, as the readout presents it.
- *
- * Account-scoped, because what a run did belongs to the account it warmed: every other figure on the
- * readout is resolved against the active account, and a device-level record would show one account's
- * overnight warm on another account's screen. Scoping it also means the prefix purge sweeps it on
- * logout along with everything else that account owned.
- */
+/** The last scheduled run, as the readout presents it. Account-scoped — see [SettingsDataStore.lastScheduledRun]. */
 data class ScheduledRunRecord(val atMillis: Long, val outcome: PrefetchRunOutcome)
 
 /** How a scheduled run ended, for the readout and for the platform job's own logging. */
@@ -41,10 +34,8 @@ enum class PrefetchRunOutcome {
     COMPLETED,
 
     /**
-     * A pass was still going when the budget ran out.
-     *
-     * In a process the scheduler woke, closing the window ends it — nothing else holds the gate open
-     * there. It continues only where the UI has started, i.e. ordinary process-tail warming.
+     * A pass was still going when the budget ran out. In a process the scheduler woke, closing the
+     * window ends it; where the UI has started it continues as ordinary process-tail warming.
      */
     BUDGET_EXPIRED,
 
@@ -79,25 +70,21 @@ class PrefetchBackgroundRunner(
 ) {
 
     suspend fun runOnce(budget: Duration): PrefetchRunOutcome {
-        // Seeded with INTERRUPTED so a run the platform stops still records something. WorkManager
-        // drops the worker the moment a constraint is lost — the user picking the phone up ends
-        // device-idle — and a cancelled call never produces a return value, so recording off the
-        // result would leave the readout showing an older run as the most recent one.
+        // Seeded so a run the platform cancels still records something: WorkManager drops the worker
+        // the moment a constraint is lost, and a cancelled call never produces a return value.
         var outcome = PrefetchRunOutcome.INTERRUPTED
         try {
             outcome = runPass(budget)
             return outcome
         } finally {
-            // Recorded whatever happened, including the outcomes where nothing was warmed. A run that
-            // found the gate shut is the case a user most needs to see, and it is invisible everywhere
-            // else — no watermark moves, and by the time they look the process is long gone.
+            // Record every outcome, including the ones that warmed nothing — those are invisible
+            // everywhere else, since no watermark moves and the process is gone by the time anyone looks.
             withContext(NonCancellable) {
                 settingsDataStore.recordScheduledRun(recordedAccountId, ScheduledRunRecord(nowMillis(), outcome))
             }
         }
     }
 
-    /** The account the run belonged to, captured once the session resolves. */
     private var recordedAccountId: String? = null
 
     private suspend fun runPass(budget: Duration): PrefetchRunOutcome {
@@ -130,13 +117,6 @@ class PrefetchBackgroundRunner(
         }
     }
 
-    /**
-     * Waits briefly for a pass to be under way.
-     *
-     * A pass that started and finished inside this grace reads as "never started", so the caller asks
-     * for another one. That is wasteful only in appearance: the second pass finds the conversation
-     * list already refreshed and nothing stale, which is the cheapest thing this engine does.
-     */
     /**
      * Waits briefly for a pass to be under way, or for one to have completed while we were not
      * looking — [PrefetchController.passInProgress] conflates, so a short pass can begin and end

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchController.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchController.kt
@@ -5,9 +5,11 @@ import com.garfiec.librechat.core.logging.Diag
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.launch
 
@@ -27,17 +29,52 @@ class PrefetchController(
 ) {
 
     /**
-     * Manual run requests from settings.
+     * Why a pass was asked for, when something other than the gate opening asked.
+     *
+     * The two differ only in how much they clear first: a person tapping "Warm now" wants everything
+     * retried, while a scheduled run hours later wants the breaker cleared but not the once-per-process
+     * reference-data mark — re-fetching endpoints, models and agents on every scheduled pass would be
+     * most of its traffic.
+     */
+    private enum class RunTrigger {
+        /** The gate's own rising edge, which starts a pass with nobody having asked for one. */
+        GATE_OPENED,
+        MANUAL,
+        SCHEDULED,
+    }
+
+    /**
+     * Run requests from settings and from the scheduler.
      *
      * No replay, and a single slot that drops the older request rather than suspending. Two
      * consequences, both wanted: a request made while the gate is shut has no subscriber at all and
      * is discarded on the spot rather than firing at whatever unrelated moment the gate next opens,
      * and repeated taps during a pass coalesce into one queued run instead of stacking up.
      */
-    private val manualRuns = MutableSharedFlow<Unit>(
+    private val runRequests = MutableSharedFlow<RunTrigger>(
         extraBufferCapacity = 1,
         onBufferOverflow = BufferOverflow.DROP_OLDEST,
     )
+
+    private val _passInProgress = MutableStateFlow(false)
+
+    /**
+     * Whether a pass is running right now, for callers that have to wait one out.
+     *
+     * Published here rather than on the engine because this class owns the only call into it, so
+     * this is the one place that sees a pass begin and end regardless of what triggered it — the
+     * gate opening, a tap, or the scheduler.
+     */
+    val passInProgress: StateFlow<Boolean> = _passInProgress.asStateFlow()
+
+    private val _completedPasses = MutableStateFlow(0)
+
+    /**
+     * How many passes have finished. [passInProgress] conflates, so a pass that begins and ends
+     * between two reads of it is invisible; this only ever moves forward, so a waiter can tell
+     * "nothing ran" from "it ran while I was not looking".
+     */
+    val completedPasses: StateFlow<Int> = _completedPasses.asStateFlow()
 
     init {
         appScope.launch {
@@ -57,12 +94,28 @@ class PrefetchController(
                         // for the button. Running them in one coroutine keeps them serialized
                         // against an engine that has no locking of its own, and inside collectLatest
                         // so the gate closing cancels a manual pass as it cancels an automatic one.
-                        merge(flowOf(false), manualRuns.map { true }).collect { manual ->
-                            if (manual) {
-                                Diag.d("Prefetch") { "manual run requested" }
-                                engine.resetForManualRun(session.accountId)
+                        merge(flowOf(RunTrigger.GATE_OPENED), runRequests).collect { trigger ->
+                            when (trigger) {
+                                RunTrigger.MANUAL -> {
+                                    Diag.d("Prefetch") { "manual run requested" }
+                                    engine.resetForManualRun(session.accountId)
+                                }
+                                RunTrigger.SCHEDULED -> {
+                                    Diag.d("Prefetch") { "scheduled run requested" }
+                                    engine.resetBreaker(session.accountId)
+                                }
+                                RunTrigger.GATE_OPENED -> Unit
                             }
-                            engine.run(session.accountId)
+                            _passInProgress.value = true
+                            try {
+                                engine.run(session.accountId)
+                            } finally {
+                                // Also on cancellation: the gate closing mid-pass is the ordinary way
+                                // a pass ends, and a waiter left believing one is still running would
+                                // sit there until its own budget expired.
+                                _passInProgress.value = false
+                                _completedPasses.value += 1
+                            }
                         }
                     }
                 }
@@ -78,6 +131,18 @@ class PrefetchController(
      * Callers disable the control instead of relying on that, so the drop is a backstop.
      */
     fun requestRun() {
-        manualRuns.tryEmit(Unit)
+        runRequests.tryEmit(RunTrigger.MANUAL)
+    }
+
+    /**
+     * Asks for a pass on behalf of the scheduler, clearing the breaker but not the reference-data
+     * mark.
+     *
+     * Needed because passes start on a *rising edge* of the gate: a scheduled run arriving into a
+     * process that is already running with the gate open has nothing to trigger it, and would
+     * otherwise wait out its whole budget while nothing happened.
+     */
+    fun requestScheduledRun() {
+        runRequests.tryEmit(RunTrigger.SCHEDULED)
     }
 }

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchEngine.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchEngine.kt
@@ -140,11 +140,27 @@ class PrefetchEngine(
      * server.
      */
     fun resetForManualRun(accountId: AccountId) {
+        resetBreaker(accountId)
+        ancillaryWarmed.remove(accountId.value)
+    }
+
+    /**
+     * Clears only the breaker, for a scheduled run.
+     *
+     * The breaker is permanent for the life of the process once tripped, which in a long-lived
+     * process would make every later scheduled run return instantly having done nothing — a server
+     * that was briefly unreachable one evening would stay "down" until the app was killed. Hours
+     * later is a genuinely new attempt, so it gets one.
+     *
+     * Deliberately not [resetForManualRun]: clearing the reference-data mark as well would re-fetch
+     * endpoints, models and agents on every scheduled pass, which for an account with nothing stale
+     * is the entire cost of the pass.
+     */
+    fun resetBreaker(accountId: AccountId) {
         if (trippedForAccountId == accountId.value) {
             trippedForAccountId = null
             publish(accountId, PrefetchRunState.Idle)
         }
-        ancillaryWarmed.remove(accountId.value)
     }
 
     /**

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchEngine.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchEngine.kt
@@ -2,6 +2,7 @@ package com.garfiec.librechat.core.data.prefetch
 
 import com.garfiec.librechat.core.common.conversation.OpenConversationRegistry
 import com.garfiec.librechat.core.common.identity.AccountId
+import com.garfiec.librechat.core.common.lifecycle.ForegroundSignal
 import com.garfiec.librechat.core.common.network.PrefetchMarker
 import com.garfiec.librechat.core.common.result.ApiException
 import com.garfiec.librechat.core.common.result.Result
@@ -63,6 +64,7 @@ class PrefetchEngine(
     private val attachmentWarmer: AttachmentWarmer,
     private val settingsDataStore: SettingsDataStore,
     private val serverUrlProvider: ServerUrlProvider,
+    private val foregroundSignal: ForegroundSignal,
     private val ioDispatcher: CoroutineDispatcher,
     // Test seams; keep them defaulted rather than injected. Supplying them from the module would
     // need `Function0` whitelisted in the graph verification, which would then stop catching
@@ -405,13 +407,29 @@ class PrefetchEngine(
     }
 
     /**
-     * Wait proportionally to how long the last request took, so the prefetcher's share of the server
-     * shrinks as the server slows down. Clamped at both ends: a fast local server should not be
-     * hammered, and one request that burns the full 30s timeout should not stall the pass for two
-     * and a half minutes.
+     * How long to wait before the next request, which depends entirely on whether anyone is looking.
+     *
+     * **On screen**, wait proportionally to how long the last request took, so the prefetcher's share
+     * of the server shrinks as the server slows down. Clamped at both ends: a fast local server
+     * should not be hammered, and one request that burns the full 30s timeout should not stall the
+     * pass for two and a half minutes.
+     *
+     * **Off screen**, hold a flat minimum instead. The proportional gap exists to keep the
+     * prefetcher out of the user's way, and with no foreground work to yield to it only makes a pass
+     * long enough to outlive the window it was given — at the deepest setting, minutes rather than
+     * tens of seconds. The cost is real and accepted: a struggling server no longer sheds this load
+     * automatically, in exactly the situation where nobody is watching to notice. The pass stays
+     * strictly one request at a time, which is what bounds it.
+     *
+     * Read live rather than fixed per pass, so returning to the app restores the polite gap
+     * immediately instead of at the next pass.
      */
     private fun paceAfter(elapsed: Duration): Duration =
-        (elapsed * PACE_FACTOR).coerceIn(MIN_PACE, MAX_PACE)
+        if (foregroundSignal.isForeground.value) {
+            (elapsed * PACE_FACTOR).coerceIn(MIN_PACE, MAX_PACE)
+        } else {
+            MIN_PACE
+        }
 
     private sealed interface StepOutcome {
         data object Ok : StepOutcome
@@ -423,13 +441,16 @@ class PrefetchEngine(
         const val PACE_FACTOR = 5
         const val MAX_CONSECUTIVE_FAILURES = 3
 
+        /** Also the whole gap when the app is off screen — see [paceAfter]. */
+        const val MIN_PACE_MILLIS = 250L
+
         private const val HTTP_TOO_MANY_REQUESTS = 429
         private const val PRUNE_CHUNK = 400
 
         /** Ceiling per conversation. A single thread of screenshots must not become the whole pass. */
         private const val MAX_ATTACHMENTS_PER_CONVERSATION = 20
         private const val DATA_URI_PREFIX = "data:"
-        private val MIN_PACE = 250.milliseconds
+        private val MIN_PACE = MIN_PACE_MILLIS.milliseconds
         private val MAX_PACE = 30.seconds
         private val DEFAULT_RATE_LIMIT_BACKOFF = 60.seconds
         private val PRUNE_AGE = 90.days

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchEngine.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchEngine.kt
@@ -139,9 +139,8 @@ class PrefetchEngine(
     /**
      * Whether the breaker still stops this account, expiring it once [BREAKER_COOLDOWN] has passed.
      *
-     * Without the cooldown a trip is permanent for the life of the process. That was tolerable while
-     * passes only ran on screen — the user was there to press "Warm now". Now that a pass can run
-     * unattended, a network outage at 3am would leave prefetching dead all of the next day in a
+     * The cooldown is load-bearing now that passes run unattended: without it a trip is permanent for
+     * the life of the process, so a night-time outage leaves prefetching dead all the next day in a
      * process Android never got round to killing, with every condition on the readout green.
      */
     private fun breakerHolds(accountId: AccountId): Boolean {
@@ -175,12 +174,8 @@ class PrefetchEngine(
     }
 
     /**
-     * Clears only the breaker, for a scheduled run.
-     *
-     * The breaker is permanent for the life of the process once tripped, which in a long-lived
-     * process would make every later scheduled run return instantly having done nothing — a server
-     * that was briefly unreachable one evening would stay "down" until the app was killed. Hours
-     * later is a genuinely new attempt, so it gets one.
+     * Clears only the breaker, for a scheduled run — without this a long-lived process makes every
+     * later scheduled run return instantly having done nothing.
      *
      * Deliberately not [resetForManualRun]: clearing the reference-data mark as well would re-fetch
      * endpoints, models and agents on every scheduled pass, which for an account with nothing stale
@@ -209,11 +204,10 @@ class PrefetchEngine(
          * Whether the pass has been running unattended for longer than [OFF_SCREEN_BUDGET].
          *
          * A pass started by the gate's rising edge carries no budget of its own — only the scheduled
-         * path passes one — and since the window latches, leaving the app no longer stops it. Without
-         * this bound a pass begun on screen keeps going at the off-screen pacing floor for as long as
-         * the work lasts, which at the deepest depth with attachments on is hundreds of requests at
-         * four a second, against a server nobody is watching. Resets whenever the user comes back, so
-         * an attended pass is never cut short.
+         * path passes one — and since the window latches, leaving the app no longer stops it. This is
+         * the only bound on such a pass, which at the deepest depth with attachments on is hundreds
+         * of requests at four a second against a server nobody is watching. Resets whenever the user
+         * comes back, so an attended pass is never cut short.
          */
         fun outstayedWelcome(): Boolean {
             if (foregroundSignal.isForeground.value) {
@@ -516,10 +510,8 @@ class PrefetchEngine(
      *
      * **Off screen**, hold a flat minimum instead. The proportional gap exists to keep the
      * prefetcher out of the user's way, and with no foreground work to yield to it only makes a pass
-     * long enough to outlive the window it was given — at the deepest setting, minutes rather than
-     * tens of seconds. The cost is real and accepted: a struggling server no longer sheds this load
-     * automatically, in exactly the situation where nobody is watching to notice. The pass stays
-     * strictly one request at a time, which is what bounds it.
+     * long enough to outlive the window it was given. What bounds an off-screen pass instead is that
+     * it stays strictly one request at a time, plus [OFF_SCREEN_BUDGET].
      *
      * Read live rather than fixed per pass, so returning to the app restores the polite gap
      * immediately instead of at the next pass.

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchEngine.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchEngine.kt
@@ -33,7 +33,9 @@ import kotlinx.coroutines.withContext
 import kotlin.time.Clock
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.TimeSource
 
@@ -46,7 +48,9 @@ import kotlin.time.TimeSource
  * 1. **Refresh the conversation list.** Freshness is decided by comparing each conversation's
  *    `updatedAt` against the watermark from its last warm — and that `updatedAt` is read from Room.
  *    Without syncing the list first the engine compares watermarks against the same stale timestamps
- *    it wrote them from, concludes nothing has changed, and never warms anything again.
+ *    it wrote them from, concludes nothing has changed, and never warms anything again. Skipped when
+ *    a previous pass finished paging the list within the last few minutes — the one time-based rule
+ *    in this feature, and it covers this stage only.
  * 2. **Warm messages** for whatever that reveals as stale.
  * 3. **Warm ancillary reference data** — endpoints, models, agents — once per account per process.
  * 4. **Prune** message rows for conversations that have aged out of the warm set.
@@ -80,6 +84,9 @@ class PrefetchEngine(
      */
     private var trippedForAccountId: String? = null
 
+    /** When the breaker tripped, so [BREAKER_COOLDOWN] can expire it rather than it lasting forever. */
+    private var breakerTrippedAtMillis: Long? = null
+
     /** Accounts whose slow-moving reference data has been warmed once this process. */
     private val ancillaryWarmed = mutableSetOf<String>()
 
@@ -95,7 +102,7 @@ class PrefetchEngine(
     }
 
     suspend fun run(accountId: AccountId) {
-        if (trippedForAccountId == accountId.value) {
+        if (breakerHolds(accountId)) {
             publish(accountId, PrefetchRunState.Stopped)
             return
         }
@@ -130,18 +137,41 @@ class PrefetchEngine(
     }
 
     /**
+     * Whether the breaker still stops this account, expiring it once [BREAKER_COOLDOWN] has passed.
+     *
+     * Without the cooldown a trip is permanent for the life of the process. That was tolerable while
+     * passes only ran on screen — the user was there to press "Warm now". Now that a pass can run
+     * unattended, a network outage at 3am would leave prefetching dead all of the next day in a
+     * process Android never got round to killing, with every condition on the readout green.
+     */
+    private fun breakerHolds(accountId: AccountId): Boolean {
+        if (trippedForAccountId != accountId.value) return false
+        val trippedAt = breakerTrippedAtMillis ?: return true
+        if (nowMillis() - trippedAt < BREAKER_COOLDOWN.inWholeMilliseconds) return true
+        Diag.d("Prefetch") { "breaker cooled off; allowing another attempt" }
+        clearBreaker()
+        return false
+    }
+
+    private fun clearBreaker() {
+        trippedForAccountId = null
+        breakerTrippedAtMillis = null
+    }
+
+    /**
      * Clears everything that would make the next pass a no-op, so a manual run is a genuine retry.
      *
-     * Two pieces of state survive a pass and both are otherwise permanent for the life of the
-     * process: the breaker, which makes a briefly-unreachable server indistinguishable from one that
-     * is down for good, and the once-per-process reference-data mark. Clearing only the first leaves
-     * "Warm now" unable to recover the very thing it advertises. Reached only from the manual run, so
-     * a retry is always a deliberate user action rather than an automatic loop against a failing
-     * server.
+     * Three pieces of state survive a pass, and all are otherwise durable: the breaker, which makes a
+     * briefly-unreachable server indistinguishable from one that is down for good; the once-per-process
+     * reference-data mark; and the recorded list refresh, which would otherwise let the manual run skip
+     * the very stage that discovers new conversations. Clearing only some of them leaves "Warm now"
+     * unable to recover the thing it advertises. Reached only from the manual run, so a retry is
+     * always a deliberate user action rather than an automatic loop against a failing server.
      */
-    fun resetForManualRun(accountId: AccountId) {
+    suspend fun resetForManualRun(accountId: AccountId) {
         resetBreaker(accountId)
         ancillaryWarmed.remove(accountId.value)
+        settingsDataStore.clearPrefetchListRefreshed(accountId.value)
     }
 
     /**
@@ -158,7 +188,7 @@ class PrefetchEngine(
      */
     fun resetBreaker(accountId: AccountId) {
         if (trippedForAccountId == accountId.value) {
-            trippedForAccountId = null
+            clearBreaker()
             publish(accountId, PrefetchRunState.Idle)
         }
     }
@@ -172,13 +202,42 @@ class PrefetchEngine(
 
         private var consecutiveFailures = 0
 
+        /** When this pass last found itself off screen, or null while the app is visible. */
+        private var offScreenSince: kotlin.time.TimeMark? = null
+
+        /**
+         * Whether the pass has been running unattended for longer than [OFF_SCREEN_BUDGET].
+         *
+         * A pass started by the gate's rising edge carries no budget of its own — only the scheduled
+         * path passes one — and since the window latches, leaving the app no longer stops it. Without
+         * this bound a pass begun on screen keeps going at the off-screen pacing floor for as long as
+         * the work lasts, which at the deepest depth with attachments on is hundreds of requests at
+         * four a second, against a server nobody is watching. Resets whenever the user comes back, so
+         * an attended pass is never cut short.
+         */
+        fun outstayedWelcome(): Boolean {
+            if (foregroundSignal.isForeground.value) {
+                offScreenSince = null
+                return false
+            }
+            val since = offScreenSince ?: timeSource.markNow().also { offScreenSince = it }
+            if (since.elapsedNow() < OFF_SCREEN_BUDGET) return false
+            Diag.d("Prefetch") { "off-screen budget spent; ending the pass" }
+            return true
+        }
+
         /** Returns false when the pass should stop because the breaker tripped. */
         suspend fun warmConversationList(depth: Int): Boolean {
+            if (listRefreshedRecently()) {
+                Diag.d("Prefetch") { "conversation list refreshed recently; skipping" }
+                return true
+            }
             publish(accountId, PrefetchRunState.RefreshingList)
             val pages = policy.listPagesFor(depth)
             var cursor: String? = null
             var page = 0
             do {
+                if (outstayedWelcome()) return true
                 val start = timeSource.markNow()
                 val result = conversationRepository.loadNextPage(cursor = cursor)
                 val elapsed = start.elapsedNow()
@@ -201,7 +260,30 @@ class PrefetchEngine(
                 page++
                 delay(paceAfter(elapsed))
             } while (cursor != null && page < pages)
+
+            // Only here — every early exit above left the list partly paged, and recording those
+            // would let the skip suppress the refresh that was never finished.
+            settingsDataStore.recordPrefetchListRefreshed(accountId.value, nowMillis())
             return true
+        }
+
+        /**
+         * Whether the list was fully paged recently enough to reuse.
+         *
+         * The prefetcher is edge-triggered and passes are short, so at the deepest settings a user
+         * who idles in bursts can re-pay an eight-page prologue every time and never reach the
+         * message stage. This is scoped to the list stage only: message freshness is still decided
+         * by watermark-versus-`updatedAt` with no TTL anywhere near it.
+         *
+         * The cost is bounded and worth naming: a conversation created on another device inside the
+         * window is invisible to selection until it expires.
+         */
+        private suspend fun listRefreshedRecently(): Boolean {
+            val last = settingsDataStore.prefetchListRefreshedAt(accountId.value) ?: return false
+            val age = nowMillis() - last
+            // A clock that moved backwards (timezone change, NTP correction) reads as a huge or
+            // negative age; refresh rather than trust it.
+            return age in 0 until LIST_REFRESH_TTL.inWholeMilliseconds
         }
 
         suspend fun eligible(depth: Int): List<PrefetchCandidate> = withContext(ioDispatcher) {
@@ -228,6 +310,7 @@ class PrefetchEngine(
             ) { "warming messages" }
 
             work.forEachIndexed { index, candidate ->
+                if (outstayedWelcome()) return true
                 publish(
                     accountId,
                     PrefetchRunState.WarmingMessages(completed = index, total = work.size),
@@ -389,6 +472,7 @@ class PrefetchEngine(
             // Give up for this account rather than working through the whole list against a server
             // that is plainly not answering.
             trippedForAccountId = accountId.value
+            breakerTrippedAtMillis = nowMillis()
             Diag.w("Prefetch") { "prefetch stopped after $MAX_CONSECUTIVE_FAILURES consecutive failures" }
             return true
         }
@@ -470,5 +554,15 @@ class PrefetchEngine(
         private val MAX_PACE = 30.seconds
         private val DEFAULT_RATE_LIMIT_BACKOFF = 60.seconds
         private val PRUNE_AGE = 90.days
+        private val LIST_REFRESH_TTL = 5.minutes
+
+        /** How long a tripped breaker holds before the engine is willing to try again. */
+        private val BREAKER_COOLDOWN = 1.hours
+
+        /**
+         * How long a pass may continue after the app leaves the screen. Generous enough to finish
+         * ordinary work, short enough that an unattended pass cannot run for the life of the process.
+         */
+        private val OFF_SCREEN_BUDGET = 2.minutes
     }
 }

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchGate.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchGate.kt
@@ -1,6 +1,6 @@
 package com.garfiec.librechat.core.data.prefetch
 
-import com.garfiec.librechat.core.common.lifecycle.ForegroundSignal
+import com.garfiec.librechat.core.common.lifecycle.DeferredWorkWindow
 import com.garfiec.librechat.core.common.network.ConnectivityObserver
 import com.garfiec.librechat.core.common.network.NetworkConditionObserver
 import com.garfiec.librechat.core.common.network.RequestActivityTracker
@@ -20,7 +20,12 @@ import kotlinx.coroutines.flow.map
  */
 data class PrefetchConditions(
     val enabled: Boolean,
-    val foreground: Boolean,
+    /**
+     * Whether the app is in a state that permits deferred work — see [DeferredWorkWindow], which
+     * answers "the UI has started, or a background run is under way" on platforms that can keep a
+     * backgrounded process alive, and plain "on screen" on those that cannot.
+     */
+    val appAvailable: Boolean,
     val networkAllowed: Boolean,
     val powerAvailable: Boolean,
     val appIdle: Boolean,
@@ -34,7 +39,7 @@ data class PrefetchConditions(
      */
     val connected: Boolean,
 ) {
-    val isOpen: Boolean get() = enabled && foreground && networkAllowed && powerAvailable && appIdle
+    val isOpen: Boolean get() = enabled && appAvailable && networkAllowed && powerAvailable && appIdle
 }
 
 /**
@@ -44,7 +49,7 @@ data class PrefetchConditions(
  * conditions of its own to check and `PrefetchController` needs no per-condition teardown.
  */
 class PrefetchGate(
-    private val foregroundSignal: ForegroundSignal,
+    private val deferredWorkWindow: DeferredWorkWindow,
     private val settingsDataStore: SettingsDataStore,
     private val networkConditionObserver: NetworkConditionObserver,
     private val connectivityObserver: ConnectivityObserver,
@@ -69,17 +74,17 @@ class PrefetchGate(
     }
 
     fun conditions(): Flow<PrefetchConditions> = combine(
-        foregroundSignal.isForeground,
+        deferredWorkWindow.isOpen,
         settingsDataStore.prefetchEnabled,
         network,
         powerStateObserver.isPowerConstrained.map { !it },
         // No debounce and no quiet-period timer: the rule is "not while a request is in flight", not
         // "not near one". Adding a settle delay here would also delay resuming after every tap.
         requestActivityTracker.userInFlight.map { it == 0 },
-    ) { foreground, enabled, networkState, powerOk, idle ->
+    ) { appAvailable, enabled, networkState, powerOk, idle ->
         PrefetchConditions(
             enabled = enabled,
-            foreground = foreground,
+            appAvailable = appAvailable,
             networkAllowed = networkState.allowed,
             powerAvailable = powerOk,
             appIdle = idle,

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchPolicy.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchPolicy.kt
@@ -27,9 +27,10 @@ class PrefetchPolicy {
      * The subset of [eligible] that actually needs fetching, in the order to fetch it.
      *
      * Freshness is decided by the server's `updatedAt` against the watermark from the last warm, so
-     * an unchanged conversation is never re-fetched — which is why this feature needs no TTL, and why
-     * a pass over an unchanged account issues no message requests at all. The list refresh that feeds
-     * it still runs.
+     * an unchanged conversation is never re-fetched — which is why message freshness needs no TTL,
+     * and why a pass over an unchanged account issues no message requests at all. The list refresh
+     * that feeds it still runs, unless a pass in the last few minutes already completed one; that
+     * skip is the sole time-based rule here and it does not reach this comparison.
      *
      * The open conversation is excluded unconditionally. Warming it would replace the rows behind
      * the screen the user is reading, and no ordering or timing makes that acceptable.

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchScheduleCoordinator.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchScheduleCoordinator.kt
@@ -35,11 +35,10 @@ class PrefetchScheduleCoordinator(
     /**
      * Emits nothing until identity actually resolves.
      *
-     * Read from [ActiveAccountProvider] rather than the session, because a null session means both
-     * "still warming" and "signed out" and those must not act alike here. Treating the boot value as
-     * signed out made every process start cancel the periodic work first — deleting the pending job
-     * so its interval restarted, and, in a process the job itself woke, stopping the running worker
-     * before it could warm anything.
+     * Must read [ActiveAccountProvider], not the session: a null session means both "still warming"
+     * and "signed out", and treating the boot value as signed out cancels the periodic work at every
+     * process start — restarting its interval, and in a process the job itself woke, stopping the
+     * running worker before it warms anything.
      */
     private val signedIn = activeAccountProvider.state
         .mapNotNull { state -> (state as? AccountState.Resolved)?.let { it.id != null } }

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchScheduleCoordinator.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchScheduleCoordinator.kt
@@ -1,0 +1,74 @@
+package com.garfiec.librechat.core.data.prefetch
+
+import com.garfiec.librechat.core.common.identity.AccountState
+import com.garfiec.librechat.core.common.identity.ActiveAccountProvider
+import com.garfiec.librechat.core.data.datastore.SettingsDataStore
+import com.garfiec.librechat.core.logging.Diag
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.mapNotNull
+import kotlinx.coroutines.launch
+
+/**
+ * Keeps the platform's periodic job in step with the settings it depends on.
+ *
+ * Separate from [PrefetchController] because it answers a different question: the controller decides
+ * when a pass may *run*, this decides whether the OS should be waking us up at all.
+ *
+ * Two inputs, both load-bearing:
+ *
+ * - **The metered override**, because a job's network constraint is fixed when it is registered.
+ *   Without re-registering, changing that setting would appear to do nothing until the app was
+ *   reinstalled.
+ * - **Whether anyone is signed in**, because a job left registered after logout wakes the device
+ *   every interval to discover there is no session and exit. Nothing warms, and the wake-ups are
+ *   invisible to the user who thinks they have signed out of the app.
+ */
+class PrefetchScheduleCoordinator(
+    settingsDataStore: SettingsDataStore,
+    activeAccountProvider: ActiveAccountProvider,
+    private val scheduler: PrefetchScheduler,
+    appScope: CoroutineScope,
+) {
+
+    /**
+     * Emits nothing until identity actually resolves.
+     *
+     * Read from [ActiveAccountProvider] rather than the session, because a null session means both
+     * "still warming" and "signed out" and those must not act alike here. Treating the boot value as
+     * signed out made every process start cancel the periodic work first — deleting the pending job
+     * so its interval restarted, and, in a process the job itself woke, stopping the running worker
+     * before it could warm anything.
+     */
+    private val signedIn = activeAccountProvider.state
+        .mapNotNull { state -> (state as? AccountState.Resolved)?.let { it.id != null } }
+
+    private data class ScheduleInputs(
+        val enabled: Boolean,
+        val allowMetered: Boolean,
+        val signedIn: Boolean,
+    )
+
+    init {
+        if (scheduler.isSupported) {
+            appScope.launch {
+                combine(
+                    settingsDataStore.prefetchEnabled,
+                    settingsDataStore.prefetchOnMeteredEnabled,
+                    signedIn,
+                ) { enabled, allowMetered, signedIn ->
+                    ScheduleInputs(enabled, allowMetered, signedIn)
+                }.distinctUntilChanged().collect { inputs ->
+                    if (inputs.enabled && inputs.signedIn) {
+                        Diag.d("Prefetch") { "scheduling periodic warm" }
+                        scheduler.ensureScheduled(inputs.allowMetered)
+                    } else {
+                        Diag.d("Prefetch") { "cancelling periodic warm" }
+                        scheduler.cancel()
+                    }
+                }
+            }
+        }
+    }
+}

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchScheduler.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchScheduler.kt
@@ -1,0 +1,29 @@
+package com.garfiec.librechat.core.data.prefetch
+
+/**
+ * Asks the platform to run a prefetch pass periodically while the device is idle and charging.
+ *
+ * Keep platform scheduler types out of this signature — it is what lets `:core:data` stay free of
+ * WorkManager on the common side, and what lets a platform whose scheduling lives in the app target
+ * bind something that reports itself unavailable.
+ */
+interface PrefetchScheduler {
+
+    /**
+     * True when this platform actually schedules anything. The readout hides the scheduled-run row
+     * when it does not, following [AttachmentWarmer.isSupported] — a row reading "Never" forever is
+     * worse than an absent one, because it looks like a feature that is broken rather than one that
+     * is not there.
+     */
+    val isSupported: Boolean
+
+    /**
+     * Registers (or updates) the periodic job. Idempotent — safe to call on every settings change,
+     * which is required rather than merely allowed: the network constraint is fixed when the job is
+     * registered, so a change to the metered override has no effect until this runs again.
+     */
+    fun ensureScheduled(allowMetered: Boolean)
+
+    /** Removes the job. Called when prefetching is switched off and on logout. */
+    fun cancel()
+}

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchStatusReporter.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchStatusReporter.kt
@@ -82,10 +82,8 @@ data class PrefetchStatus(
  * engine acts on. Selection reuses [PrefetchPolicy] rather than restating its rules, so what the
  * screen calls pending is by construction what the engine would fetch next.
  *
- * The one exception is [PrefetchStatus.lastScheduledRun], and it is an exception because a scheduled
- * run leaves no other trace: a run that found the gate shut moves no watermark, and by the time
- * anyone looks the process that ran it is gone. It is therefore also the one figure on this screen
- * that *can* drift from what happened — treat it as a report, not as derived truth.
+ * The one exception is [PrefetchStatus.lastScheduledRun], persisted because a scheduled run leaves no
+ * other trace — and therefore the one figure here that *can* drift: a report, not derived truth.
  */
 class PrefetchStatusReporter(
     private val gate: PrefetchGate,

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchStatusReporter.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchStatusReporter.kt
@@ -49,7 +49,7 @@ data class PrefetchStatus(
         val Empty = PrefetchStatus(
             conditions = PrefetchConditions(
                 enabled = false,
-                foreground = false,
+                appAvailable = false,
                 networkAllowed = false,
                 powerAvailable = false,
                 appIdle = false,

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchStatusReporter.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/prefetch/PrefetchStatusReporter.kt
@@ -43,6 +43,13 @@ data class PrefetchStatus(
     val lastWarmedAt: Long?,
     val warmed: List<PrefetchConversationStatus>,
     val pending: List<PrefetchConversationStatus>,
+    /**
+     * Whether this platform schedules passes at all. False hides the scheduled-run row rather than
+     * showing one that could only ever read "Never" — see [PrefetchScheduler.isSupported].
+     */
+    val scheduledRunsSupported: Boolean = false,
+    /** The last scheduled run, or null when none has happened yet. */
+    val lastScheduledRun: ScheduledRunRecord? = null,
 ) {
     companion object {
         /** What the readout shows while no account is resolved — logged out, or still warming. */
@@ -69,11 +76,16 @@ data class PrefetchStatus(
  * Assembles the prefetch status readout from the state that already exists — the gate's conditions,
  * the engine's in-flight state, and the watermark table.
  *
- * Nothing here is recorded for the readout's benefit: no counters, no history, no schema. That
- * bounds what it can report (there is no "passes run today", because nothing counts passes) and in
- * exchange it cannot drift from the truth, since every figure is computed from the same rows the
+ * Almost nothing here is recorded for the readout's benefit: no counters, no history, no schema.
+ * That bounds what it can report (there is no "passes run today", because nothing counts passes) and
+ * in exchange it cannot drift from the truth, since every figure is computed from the same rows the
  * engine acts on. Selection reuses [PrefetchPolicy] rather than restating its rules, so what the
  * screen calls pending is by construction what the engine would fetch next.
+ *
+ * The one exception is [PrefetchStatus.lastScheduledRun], and it is an exception because a scheduled
+ * run leaves no other trace: a run that found the gate shut moves no watermark, and by the time
+ * anyone looks the process that ran it is gone. It is therefore also the one figure on this screen
+ * that *can* drift from what happened — treat it as a report, not as derived truth.
  */
 class PrefetchStatusReporter(
     private val gate: PrefetchGate,
@@ -85,6 +97,7 @@ class PrefetchStatusReporter(
     private val openConversationRegistry: OpenConversationRegistry,
     private val activeAccountProvider: ActiveAccountProvider,
     private val settingsDataStore: SettingsDataStore,
+    private val scheduler: PrefetchScheduler,
 ) {
 
     fun status(): Flow<PrefetchStatus> = combine(
@@ -92,8 +105,11 @@ class PrefetchStatusReporter(
         engine.runState,
         warmSet(),
         activeAccountProvider.state,
-    ) { conditions, runState, warmSet, account ->
+        settingsDataStore.lastScheduledRun,
+    ) { conditions, runState, warmSet, account, lastScheduledRun ->
         warmSet.copy(
+            scheduledRunsSupported = scheduler.isSupported,
+            lastScheduledRun = lastScheduledRun,
             conditions = conditions,
             // Resolved against the active account, because the engine is a singleton and its
             // Stopped verdict persists: an unresolved read would report the account whose server

--- a/core/data/src/iosMain/kotlin/com/garfiec/librechat/core/data/di/DataPlatformModule.ios.kt
+++ b/core/data/src/iosMain/kotlin/com/garfiec/librechat/core/data/di/DataPlatformModule.ios.kt
@@ -13,6 +13,8 @@ import com.garfiec.librechat.core.data.db.migration.MIGRATION_3_4
 import com.garfiec.librechat.core.data.db.migration.MIGRATION_4_5
 import com.garfiec.librechat.core.data.prefetch.AttachmentWarmer
 import com.garfiec.librechat.core.data.prefetch.NoopAttachmentWarmer
+import com.garfiec.librechat.core.data.prefetch.NoopPrefetchScheduler
+import com.garfiec.librechat.core.data.prefetch.PrefetchScheduler
 import com.garfiec.librechat.core.data.repository.CommonSessionCacheCleaner
 import com.garfiec.librechat.core.data.repository.IosSwitchCacheCleaner
 import com.garfiec.librechat.core.data.repository.SessionCacheCleaner
@@ -41,6 +43,7 @@ private fun ensureDirectoryExists(path: String) {
 actual val dataPlatformModule: Module = module {
 
     single<AttachmentWarmer> { NoopAttachmentWarmer() }
+    single<PrefetchScheduler> { NoopPrefetchScheduler() }
 
     // --- Database ---
     single {

--- a/core/data/src/iosMain/kotlin/com/garfiec/librechat/core/data/prefetch/NoopPrefetchScheduler.kt
+++ b/core/data/src/iosMain/kotlin/com/garfiec/librechat/core/data/prefetch/NoopPrefetchScheduler.kt
@@ -1,0 +1,18 @@
+package com.garfiec.librechat.core.data.prefetch
+
+/**
+ * iOS has no scheduler here yet, and says so rather than pretending.
+ *
+ * `BGTaskScheduler` handlers must be registered in the app target before launch finishes, so the
+ * scheduling half belongs in Swift rather than in this module — a Kotlin object cannot register it.
+ * Until that lands, [isSupported] is false, which is what keeps the readout from showing a
+ * scheduled-run row that could only ever say "Never".
+ */
+class NoopPrefetchScheduler : PrefetchScheduler {
+
+    override val isSupported: Boolean = false
+
+    override fun ensureScheduled(allowMetered: Boolean) = Unit
+
+    override fun cancel() = Unit
+}

--- a/feature/settings/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/settings/state/PrefetchStatusDisplayTest.kt
+++ b/feature/settings/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/settings/state/PrefetchStatusDisplayTest.kt
@@ -119,7 +119,7 @@ class PrefetchStatusDisplayTest {
     fun `pause reasons are reported in the order the user can act on them`() {
         val everythingUnmet = PrefetchConditions(
             enabled = true,
-            foreground = false,
+            appAvailable = false,
             networkAllowed = false,
             powerAvailable = false,
             appIdle = false,
@@ -132,7 +132,7 @@ class PrefetchStatusDisplayTest {
         assertThat(everythingUnmet.copy(networkAllowed = true, powerAvailable = true).pauseReason())
             .isEqualTo(PrefetchPauseReason.BACKGROUND)
         assertThat(
-            everythingUnmet.copy(networkAllowed = true, powerAvailable = true, foreground = true)
+            everythingUnmet.copy(networkAllowed = true, powerAvailable = true, appAvailable = true)
                 .pauseReason(),
         ).isEqualTo(PrefetchPauseReason.BUSY)
     }
@@ -157,7 +157,7 @@ class PrefetchStatusDisplayTest {
     private companion object {
         val allMet = PrefetchConditions(
             enabled = true,
-            foreground = true,
+            appAvailable = true,
             networkAllowed = true,
             powerAvailable = true,
             appIdle = true,

--- a/feature/settings/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/settings/viewmodel/PrefetchActivityUiStateTest.kt
+++ b/feature/settings/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/settings/viewmodel/PrefetchActivityUiStateTest.kt
@@ -32,7 +32,7 @@ class PrefetchActivityUiStateTest {
         assertThat(state(PrefetchCondition.NETWORK).canWarmNow).isFalse()
         assertThat(state(PrefetchCondition.POWER).canWarmNow).isFalse()
         assertThat(state(PrefetchCondition.IDLE).canWarmNow).isFalse()
-        assertThat(state(PrefetchCondition.FOREGROUND).canWarmNow).isFalse()
+        assertThat(state(PrefetchCondition.APP_AVAILABLE).canWarmNow).isFalse()
     }
 
     /**

--- a/feature/settings/src/commonMain/composeResources/values-ar/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-ar/strings.xml
@@ -101,7 +101,7 @@
     <string name="prefetch_status_paused_busy">Paused — app is busy</string>
     <string name="prefetch_status_paused_background">Paused — app is in the background</string>
     <string name="prefetch_conditions_header">Conditions</string>
-    <string name="prefetch_condition_foreground">App in foreground</string>
+    <string name="prefetch_condition_app_available">App ready</string>
     <string name="prefetch_condition_network">Network</string>
     <string name="prefetch_condition_network_met">Connection allowed</string>
     <string name="prefetch_condition_network_unmet">On mobile data</string>

--- a/feature/settings/src/commonMain/composeResources/values-ar/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-ar/strings.xml
@@ -70,7 +70,7 @@
     <string name="section_mcp_servers">خوادم MCP</string>
     <string name="section_prefetch">Background prefetch</string>
     <string name="prefetch_enabled">Prefetch conversations</string>
-    <string name="prefetch_enabled_desc">Load recent and pinned conversations in the background so they open instantly. Runs only while the app is idle.</string>
+    <string name="prefetch_enabled_desc">Load recent and pinned conversations ahead of time so they open instantly. Runs while the app is idle, and periodically while charging.</string>
     <string name="prefetch_on_metered">Use mobile data</string>
     <string name="prefetch_on_metered_desc">Allow prefetching on metered connections. Off by default to avoid unexpected data usage.</string>
     <string name="prefetch_depth">Depth</string>
@@ -83,6 +83,13 @@
     <string name="prefetch_summary_status">Status</string>
     <string name="prefetch_summary_last_run">Last run</string>
     <string name="prefetch_summary_last_run_never">Never</string>
+    <string name="prefetch_summary_scheduled_run">Last background run</string>
+    <string name="prefetch_run_outcome_disabled">prefetch was off</string>
+    <string name="prefetch_run_outcome_no_session">not signed in</string>
+    <string name="prefetch_run_outcome_constraints">conditions not met</string>
+    <string name="prefetch_run_outcome_budget">ran out of time</string>
+    <string name="prefetch_run_outcome_stopped">server not answering</string>
+    <string name="prefetch_run_outcome_interrupted">interrupted</string>
     <string name="prefetch_summary_warmed">Warmed</string>
     <string name="prefetch_summary_warmed_value">%1$d of %2$d</string>
     <string name="prefetch_status_off">Off</string>

--- a/feature/settings/src/commonMain/composeResources/values-de/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-de/strings.xml
@@ -70,7 +70,7 @@
     <string name="section_mcp_servers">MCP-Server</string>
     <string name="section_prefetch">Background prefetch</string>
     <string name="prefetch_enabled">Prefetch conversations</string>
-    <string name="prefetch_enabled_desc">Load recent and pinned conversations in the background so they open instantly. Runs only while the app is idle.</string>
+    <string name="prefetch_enabled_desc">Load recent and pinned conversations ahead of time so they open instantly. Runs while the app is idle, and periodically while charging.</string>
     <string name="prefetch_on_metered">Use mobile data</string>
     <string name="prefetch_on_metered_desc">Allow prefetching on metered connections. Off by default to avoid unexpected data usage.</string>
     <string name="prefetch_depth">Depth</string>
@@ -83,6 +83,13 @@
     <string name="prefetch_summary_status">Status</string>
     <string name="prefetch_summary_last_run">Last run</string>
     <string name="prefetch_summary_last_run_never">Never</string>
+    <string name="prefetch_summary_scheduled_run">Last background run</string>
+    <string name="prefetch_run_outcome_disabled">prefetch was off</string>
+    <string name="prefetch_run_outcome_no_session">not signed in</string>
+    <string name="prefetch_run_outcome_constraints">conditions not met</string>
+    <string name="prefetch_run_outcome_budget">ran out of time</string>
+    <string name="prefetch_run_outcome_stopped">server not answering</string>
+    <string name="prefetch_run_outcome_interrupted">interrupted</string>
     <string name="prefetch_summary_warmed">Warmed</string>
     <string name="prefetch_summary_warmed_value">%1$d of %2$d</string>
     <string name="prefetch_status_off">Off</string>

--- a/feature/settings/src/commonMain/composeResources/values-de/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-de/strings.xml
@@ -101,7 +101,7 @@
     <string name="prefetch_status_paused_busy">Paused — app is busy</string>
     <string name="prefetch_status_paused_background">Paused — app is in the background</string>
     <string name="prefetch_conditions_header">Conditions</string>
-    <string name="prefetch_condition_foreground">App in foreground</string>
+    <string name="prefetch_condition_app_available">App ready</string>
     <string name="prefetch_condition_network">Network</string>
     <string name="prefetch_condition_network_met">Connection allowed</string>
     <string name="prefetch_condition_network_unmet">On mobile data</string>

--- a/feature/settings/src/commonMain/composeResources/values-es/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-es/strings.xml
@@ -101,7 +101,7 @@
     <string name="prefetch_status_paused_busy">Paused — app is busy</string>
     <string name="prefetch_status_paused_background">Paused — app is in the background</string>
     <string name="prefetch_conditions_header">Conditions</string>
-    <string name="prefetch_condition_foreground">App in foreground</string>
+    <string name="prefetch_condition_app_available">App ready</string>
     <string name="prefetch_condition_network">Network</string>
     <string name="prefetch_condition_network_met">Connection allowed</string>
     <string name="prefetch_condition_network_unmet">On mobile data</string>

--- a/feature/settings/src/commonMain/composeResources/values-es/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-es/strings.xml
@@ -70,7 +70,7 @@
     <string name="section_mcp_servers">Servidores MCP</string>
     <string name="section_prefetch">Background prefetch</string>
     <string name="prefetch_enabled">Prefetch conversations</string>
-    <string name="prefetch_enabled_desc">Load recent and pinned conversations in the background so they open instantly. Runs only while the app is idle.</string>
+    <string name="prefetch_enabled_desc">Load recent and pinned conversations ahead of time so they open instantly. Runs while the app is idle, and periodically while charging.</string>
     <string name="prefetch_on_metered">Use mobile data</string>
     <string name="prefetch_on_metered_desc">Allow prefetching on metered connections. Off by default to avoid unexpected data usage.</string>
     <string name="prefetch_depth">Depth</string>
@@ -83,6 +83,13 @@
     <string name="prefetch_summary_status">Status</string>
     <string name="prefetch_summary_last_run">Last run</string>
     <string name="prefetch_summary_last_run_never">Never</string>
+    <string name="prefetch_summary_scheduled_run">Last background run</string>
+    <string name="prefetch_run_outcome_disabled">prefetch was off</string>
+    <string name="prefetch_run_outcome_no_session">not signed in</string>
+    <string name="prefetch_run_outcome_constraints">conditions not met</string>
+    <string name="prefetch_run_outcome_budget">ran out of time</string>
+    <string name="prefetch_run_outcome_stopped">server not answering</string>
+    <string name="prefetch_run_outcome_interrupted">interrupted</string>
     <string name="prefetch_summary_warmed">Warmed</string>
     <string name="prefetch_summary_warmed_value">%1$d of %2$d</string>
     <string name="prefetch_status_off">Off</string>

--- a/feature/settings/src/commonMain/composeResources/values-fr/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-fr/strings.xml
@@ -70,7 +70,7 @@
     <string name="section_mcp_servers">Serveurs MCP</string>
     <string name="section_prefetch">Background prefetch</string>
     <string name="prefetch_enabled">Prefetch conversations</string>
-    <string name="prefetch_enabled_desc">Load recent and pinned conversations in the background so they open instantly. Runs only while the app is idle.</string>
+    <string name="prefetch_enabled_desc">Load recent and pinned conversations ahead of time so they open instantly. Runs while the app is idle, and periodically while charging.</string>
     <string name="prefetch_on_metered">Use mobile data</string>
     <string name="prefetch_on_metered_desc">Allow prefetching on metered connections. Off by default to avoid unexpected data usage.</string>
     <string name="prefetch_depth">Depth</string>
@@ -83,6 +83,13 @@
     <string name="prefetch_summary_status">Status</string>
     <string name="prefetch_summary_last_run">Last run</string>
     <string name="prefetch_summary_last_run_never">Never</string>
+    <string name="prefetch_summary_scheduled_run">Last background run</string>
+    <string name="prefetch_run_outcome_disabled">prefetch was off</string>
+    <string name="prefetch_run_outcome_no_session">not signed in</string>
+    <string name="prefetch_run_outcome_constraints">conditions not met</string>
+    <string name="prefetch_run_outcome_budget">ran out of time</string>
+    <string name="prefetch_run_outcome_stopped">server not answering</string>
+    <string name="prefetch_run_outcome_interrupted">interrupted</string>
     <string name="prefetch_summary_warmed">Warmed</string>
     <string name="prefetch_summary_warmed_value">%1$d of %2$d</string>
     <string name="prefetch_status_off">Off</string>

--- a/feature/settings/src/commonMain/composeResources/values-fr/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-fr/strings.xml
@@ -101,7 +101,7 @@
     <string name="prefetch_status_paused_busy">Paused — app is busy</string>
     <string name="prefetch_status_paused_background">Paused — app is in the background</string>
     <string name="prefetch_conditions_header">Conditions</string>
-    <string name="prefetch_condition_foreground">App in foreground</string>
+    <string name="prefetch_condition_app_available">App ready</string>
     <string name="prefetch_condition_network">Network</string>
     <string name="prefetch_condition_network_met">Connection allowed</string>
     <string name="prefetch_condition_network_unmet">On mobile data</string>

--- a/feature/settings/src/commonMain/composeResources/values-ja/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-ja/strings.xml
@@ -70,7 +70,7 @@
     <string name="section_mcp_servers">MCPサーバー</string>
     <string name="section_prefetch">Background prefetch</string>
     <string name="prefetch_enabled">Prefetch conversations</string>
-    <string name="prefetch_enabled_desc">Load recent and pinned conversations in the background so they open instantly. Runs only while the app is idle.</string>
+    <string name="prefetch_enabled_desc">Load recent and pinned conversations ahead of time so they open instantly. Runs while the app is idle, and periodically while charging.</string>
     <string name="prefetch_on_metered">Use mobile data</string>
     <string name="prefetch_on_metered_desc">Allow prefetching on metered connections. Off by default to avoid unexpected data usage.</string>
     <string name="prefetch_depth">Depth</string>
@@ -83,6 +83,13 @@
     <string name="prefetch_summary_status">Status</string>
     <string name="prefetch_summary_last_run">Last run</string>
     <string name="prefetch_summary_last_run_never">Never</string>
+    <string name="prefetch_summary_scheduled_run">Last background run</string>
+    <string name="prefetch_run_outcome_disabled">prefetch was off</string>
+    <string name="prefetch_run_outcome_no_session">not signed in</string>
+    <string name="prefetch_run_outcome_constraints">conditions not met</string>
+    <string name="prefetch_run_outcome_budget">ran out of time</string>
+    <string name="prefetch_run_outcome_stopped">server not answering</string>
+    <string name="prefetch_run_outcome_interrupted">interrupted</string>
     <string name="prefetch_summary_warmed">Warmed</string>
     <string name="prefetch_summary_warmed_value">%1$d of %2$d</string>
     <string name="prefetch_status_off">Off</string>

--- a/feature/settings/src/commonMain/composeResources/values-ja/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-ja/strings.xml
@@ -101,7 +101,7 @@
     <string name="prefetch_status_paused_busy">Paused — app is busy</string>
     <string name="prefetch_status_paused_background">Paused — app is in the background</string>
     <string name="prefetch_conditions_header">Conditions</string>
-    <string name="prefetch_condition_foreground">App in foreground</string>
+    <string name="prefetch_condition_app_available">App ready</string>
     <string name="prefetch_condition_network">Network</string>
     <string name="prefetch_condition_network_met">Connection allowed</string>
     <string name="prefetch_condition_network_unmet">On mobile data</string>

--- a/feature/settings/src/commonMain/composeResources/values-ko/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-ko/strings.xml
@@ -70,7 +70,7 @@
     <string name="section_mcp_servers">MCP 서버</string>
     <string name="section_prefetch">Background prefetch</string>
     <string name="prefetch_enabled">Prefetch conversations</string>
-    <string name="prefetch_enabled_desc">Load recent and pinned conversations in the background so they open instantly. Runs only while the app is idle.</string>
+    <string name="prefetch_enabled_desc">Load recent and pinned conversations ahead of time so they open instantly. Runs while the app is idle, and periodically while charging.</string>
     <string name="prefetch_on_metered">Use mobile data</string>
     <string name="prefetch_on_metered_desc">Allow prefetching on metered connections. Off by default to avoid unexpected data usage.</string>
     <string name="prefetch_depth">Depth</string>
@@ -83,6 +83,13 @@
     <string name="prefetch_summary_status">Status</string>
     <string name="prefetch_summary_last_run">Last run</string>
     <string name="prefetch_summary_last_run_never">Never</string>
+    <string name="prefetch_summary_scheduled_run">Last background run</string>
+    <string name="prefetch_run_outcome_disabled">prefetch was off</string>
+    <string name="prefetch_run_outcome_no_session">not signed in</string>
+    <string name="prefetch_run_outcome_constraints">conditions not met</string>
+    <string name="prefetch_run_outcome_budget">ran out of time</string>
+    <string name="prefetch_run_outcome_stopped">server not answering</string>
+    <string name="prefetch_run_outcome_interrupted">interrupted</string>
     <string name="prefetch_summary_warmed">Warmed</string>
     <string name="prefetch_summary_warmed_value">%1$d of %2$d</string>
     <string name="prefetch_status_off">Off</string>

--- a/feature/settings/src/commonMain/composeResources/values-ko/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-ko/strings.xml
@@ -101,7 +101,7 @@
     <string name="prefetch_status_paused_busy">Paused — app is busy</string>
     <string name="prefetch_status_paused_background">Paused — app is in the background</string>
     <string name="prefetch_conditions_header">Conditions</string>
-    <string name="prefetch_condition_foreground">App in foreground</string>
+    <string name="prefetch_condition_app_available">App ready</string>
     <string name="prefetch_condition_network">Network</string>
     <string name="prefetch_condition_network_met">Connection allowed</string>
     <string name="prefetch_condition_network_unmet">On mobile data</string>

--- a/feature/settings/src/commonMain/composeResources/values-pt/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-pt/strings.xml
@@ -101,7 +101,7 @@
     <string name="prefetch_status_paused_busy">Paused — app is busy</string>
     <string name="prefetch_status_paused_background">Paused — app is in the background</string>
     <string name="prefetch_conditions_header">Conditions</string>
-    <string name="prefetch_condition_foreground">App in foreground</string>
+    <string name="prefetch_condition_app_available">App ready</string>
     <string name="prefetch_condition_network">Network</string>
     <string name="prefetch_condition_network_met">Connection allowed</string>
     <string name="prefetch_condition_network_unmet">On mobile data</string>

--- a/feature/settings/src/commonMain/composeResources/values-pt/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-pt/strings.xml
@@ -70,7 +70,7 @@
     <string name="section_mcp_servers">Servidores MCP</string>
     <string name="section_prefetch">Background prefetch</string>
     <string name="prefetch_enabled">Prefetch conversations</string>
-    <string name="prefetch_enabled_desc">Load recent and pinned conversations in the background so they open instantly. Runs only while the app is idle.</string>
+    <string name="prefetch_enabled_desc">Load recent and pinned conversations ahead of time so they open instantly. Runs while the app is idle, and periodically while charging.</string>
     <string name="prefetch_on_metered">Use mobile data</string>
     <string name="prefetch_on_metered_desc">Allow prefetching on metered connections. Off by default to avoid unexpected data usage.</string>
     <string name="prefetch_depth">Depth</string>
@@ -83,6 +83,13 @@
     <string name="prefetch_summary_status">Status</string>
     <string name="prefetch_summary_last_run">Last run</string>
     <string name="prefetch_summary_last_run_never">Never</string>
+    <string name="prefetch_summary_scheduled_run">Last background run</string>
+    <string name="prefetch_run_outcome_disabled">prefetch was off</string>
+    <string name="prefetch_run_outcome_no_session">not signed in</string>
+    <string name="prefetch_run_outcome_constraints">conditions not met</string>
+    <string name="prefetch_run_outcome_budget">ran out of time</string>
+    <string name="prefetch_run_outcome_stopped">server not answering</string>
+    <string name="prefetch_run_outcome_interrupted">interrupted</string>
     <string name="prefetch_summary_warmed">Warmed</string>
     <string name="prefetch_summary_warmed_value">%1$d of %2$d</string>
     <string name="prefetch_status_off">Off</string>

--- a/feature/settings/src/commonMain/composeResources/values-ru/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-ru/strings.xml
@@ -70,7 +70,7 @@
     <string name="section_mcp_servers">Серверы MCP</string>
     <string name="section_prefetch">Background prefetch</string>
     <string name="prefetch_enabled">Prefetch conversations</string>
-    <string name="prefetch_enabled_desc">Load recent and pinned conversations in the background so they open instantly. Runs only while the app is idle.</string>
+    <string name="prefetch_enabled_desc">Load recent and pinned conversations ahead of time so they open instantly. Runs while the app is idle, and periodically while charging.</string>
     <string name="prefetch_on_metered">Use mobile data</string>
     <string name="prefetch_on_metered_desc">Allow prefetching on metered connections. Off by default to avoid unexpected data usage.</string>
     <string name="prefetch_depth">Depth</string>
@@ -83,6 +83,13 @@
     <string name="prefetch_summary_status">Status</string>
     <string name="prefetch_summary_last_run">Last run</string>
     <string name="prefetch_summary_last_run_never">Never</string>
+    <string name="prefetch_summary_scheduled_run">Last background run</string>
+    <string name="prefetch_run_outcome_disabled">prefetch was off</string>
+    <string name="prefetch_run_outcome_no_session">not signed in</string>
+    <string name="prefetch_run_outcome_constraints">conditions not met</string>
+    <string name="prefetch_run_outcome_budget">ran out of time</string>
+    <string name="prefetch_run_outcome_stopped">server not answering</string>
+    <string name="prefetch_run_outcome_interrupted">interrupted</string>
     <string name="prefetch_summary_warmed">Warmed</string>
     <string name="prefetch_summary_warmed_value">%1$d of %2$d</string>
     <string name="prefetch_status_off">Off</string>

--- a/feature/settings/src/commonMain/composeResources/values-ru/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-ru/strings.xml
@@ -101,7 +101,7 @@
     <string name="prefetch_status_paused_busy">Paused — app is busy</string>
     <string name="prefetch_status_paused_background">Paused — app is in the background</string>
     <string name="prefetch_conditions_header">Conditions</string>
-    <string name="prefetch_condition_foreground">App in foreground</string>
+    <string name="prefetch_condition_app_available">App ready</string>
     <string name="prefetch_condition_network">Network</string>
     <string name="prefetch_condition_network_met">Connection allowed</string>
     <string name="prefetch_condition_network_unmet">On mobile data</string>

--- a/feature/settings/src/commonMain/composeResources/values-zh/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-zh/strings.xml
@@ -70,7 +70,7 @@
     <string name="section_mcp_servers">MCP 服务器</string>
     <string name="section_prefetch">Background prefetch</string>
     <string name="prefetch_enabled">Prefetch conversations</string>
-    <string name="prefetch_enabled_desc">Load recent and pinned conversations in the background so they open instantly. Runs only while the app is idle.</string>
+    <string name="prefetch_enabled_desc">Load recent and pinned conversations ahead of time so they open instantly. Runs while the app is idle, and periodically while charging.</string>
     <string name="prefetch_on_metered">Use mobile data</string>
     <string name="prefetch_on_metered_desc">Allow prefetching on metered connections. Off by default to avoid unexpected data usage.</string>
     <string name="prefetch_depth">Depth</string>
@@ -83,6 +83,13 @@
     <string name="prefetch_summary_status">Status</string>
     <string name="prefetch_summary_last_run">Last run</string>
     <string name="prefetch_summary_last_run_never">Never</string>
+    <string name="prefetch_summary_scheduled_run">Last background run</string>
+    <string name="prefetch_run_outcome_disabled">prefetch was off</string>
+    <string name="prefetch_run_outcome_no_session">not signed in</string>
+    <string name="prefetch_run_outcome_constraints">conditions not met</string>
+    <string name="prefetch_run_outcome_budget">ran out of time</string>
+    <string name="prefetch_run_outcome_stopped">server not answering</string>
+    <string name="prefetch_run_outcome_interrupted">interrupted</string>
     <string name="prefetch_summary_warmed">Warmed</string>
     <string name="prefetch_summary_warmed_value">%1$d of %2$d</string>
     <string name="prefetch_status_off">Off</string>

--- a/feature/settings/src/commonMain/composeResources/values-zh/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-zh/strings.xml
@@ -101,7 +101,7 @@
     <string name="prefetch_status_paused_busy">Paused — app is busy</string>
     <string name="prefetch_status_paused_background">Paused — app is in the background</string>
     <string name="prefetch_conditions_header">Conditions</string>
-    <string name="prefetch_condition_foreground">App in foreground</string>
+    <string name="prefetch_condition_app_available">App ready</string>
     <string name="prefetch_condition_network">Network</string>
     <string name="prefetch_condition_network_met">Connection allowed</string>
     <string name="prefetch_condition_network_unmet">On mobile data</string>

--- a/feature/settings/src/commonMain/composeResources/values/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values/strings.xml
@@ -71,7 +71,7 @@
     <string name="section_mcp_servers">MCP Servers</string>
     <string name="section_prefetch">Background prefetch</string>
     <string name="prefetch_enabled">Prefetch conversations</string>
-    <string name="prefetch_enabled_desc">Load recent and pinned conversations in the background so they open instantly. Runs only while the app is idle.</string>
+    <string name="prefetch_enabled_desc">Load recent and pinned conversations ahead of time so they open instantly. Runs while the app is idle, and periodically while charging.</string>
     <string name="prefetch_on_metered">Use mobile data</string>
     <string name="prefetch_on_metered_desc">Allow prefetching on metered connections. Off by default to avoid unexpected data usage.</string>
     <string name="prefetch_depth">Depth</string>
@@ -84,6 +84,13 @@
     <string name="prefetch_summary_status">Status</string>
     <string name="prefetch_summary_last_run">Last run</string>
     <string name="prefetch_summary_last_run_never">Never</string>
+    <string name="prefetch_summary_scheduled_run">Last background run</string>
+    <string name="prefetch_run_outcome_disabled">prefetch was off</string>
+    <string name="prefetch_run_outcome_no_session">not signed in</string>
+    <string name="prefetch_run_outcome_constraints">conditions not met</string>
+    <string name="prefetch_run_outcome_budget">ran out of time</string>
+    <string name="prefetch_run_outcome_stopped">server not answering</string>
+    <string name="prefetch_run_outcome_interrupted">interrupted</string>
     <string name="prefetch_summary_warmed">Warmed</string>
     <string name="prefetch_summary_warmed_value">%1$d of %2$d</string>
     <string name="prefetch_status_off">Off</string>

--- a/feature/settings/src/commonMain/composeResources/values/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values/strings.xml
@@ -102,7 +102,7 @@
     <string name="prefetch_status_paused_busy">Paused — app is busy</string>
     <string name="prefetch_status_paused_background">Paused — app is in the background</string>
     <string name="prefetch_conditions_header">Conditions</string>
-    <string name="prefetch_condition_foreground">App in foreground</string>
+    <string name="prefetch_condition_app_available">App ready</string>
     <string name="prefetch_condition_network">Network</string>
     <string name="prefetch_condition_network_met">Connection allowed</string>
     <string name="prefetch_condition_network_unmet">On mobile data</string>

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/PrefetchActivityScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/PrefetchActivityScreen.kt
@@ -49,6 +49,7 @@ import com.garfiec.librechat.feature.settings.resources.prefetch_row_never_warme
 import com.garfiec.librechat.feature.settings.resources.prefetch_row_pinned
 import com.garfiec.librechat.feature.settings.resources.prefetch_summary_last_run
 import com.garfiec.librechat.feature.settings.resources.prefetch_summary_last_run_never
+import com.garfiec.librechat.feature.settings.resources.prefetch_summary_scheduled_run
 import com.garfiec.librechat.feature.settings.resources.prefetch_summary_status
 import com.garfiec.librechat.feature.settings.resources.prefetch_summary_warmed
 import com.garfiec.librechat.feature.settings.resources.prefetch_summary_warmed_value
@@ -65,9 +66,10 @@ import org.koin.compose.viewmodel.koinViewModel
  * The detail behind the prefetch summary in Data settings: why prefetching is or is not running,
  * what it has cached, and what it still intends to fetch.
  *
- * Every figure is derived live from the watermark table and the gate — nothing is recorded for this
- * screen's benefit — so it cannot report a pass that did not happen, and equally cannot show any
- * history beyond what the watermarks still hold.
+ * Every figure but one is derived live from the watermark table and the gate, so it cannot report a
+ * pass that did not happen, and equally cannot show any history beyond what the watermarks still
+ * hold. The exception is the background-run row, which is persisted because a scheduled pass leaves
+ * no other trace — and which is therefore the one row here that is a report rather than derived.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -116,6 +118,22 @@ fun PrefetchActivityScreen(onNavigateBack: () -> Unit, modifier: Modifier = Modi
                             uiState.eligibleCount,
                         ),
                     )
+                    // Absent, not "Never", where the platform schedules nothing — the row would
+                    // otherwise read as a broken feature rather than an unbuilt one.
+                    if (uiState.scheduledRunsSupported) {
+                        val ranAt = uiState.lastScheduledRunAt?.relativeLabel(timeReference)
+                        // The outcome is what makes this row able to explain a cold cache; without it
+                        // a run that exited on an unmet constraint reads the same as a full warm.
+                        val outcome = uiState.lastScheduledRunOutcome?.label()
+                        DetailRow(
+                            stringResource(Res.string.prefetch_summary_scheduled_run),
+                            when {
+                                ranAt == null -> stringResource(Res.string.prefetch_summary_last_run_never)
+                                outcome == null -> ranAt
+                                else -> "$ranAt · $outcome"
+                            },
+                        )
+                    }
                 }
             }
 

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/PrefetchActivityScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/PrefetchActivityScreen.kt
@@ -122,8 +122,6 @@ fun PrefetchActivityScreen(onNavigateBack: () -> Unit, modifier: Modifier = Modi
                     // otherwise read as a broken feature rather than an unbuilt one.
                     if (uiState.scheduledRunsSupported) {
                         val ranAt = uiState.lastScheduledRunAt?.relativeLabel(timeReference)
-                        // The outcome is what makes this row able to explain a cold cache; without it
-                        // a run that exited on an unmet constraint reads the same as a full warm.
                         val outcome = uiState.lastScheduledRunOutcome?.label()
                         DetailRow(
                             stringResource(Res.string.prefetch_summary_scheduled_run),

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/PrefetchStatusLabels.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/PrefetchStatusLabels.kt
@@ -80,8 +80,7 @@ fun PrefetchCondition.label(): String = stringResource(
 
 /**
  * The detail line beside a condition. App-readiness has none: it is the one condition necessarily
- * met while the screen showing it is on top, so any wording would be filler. That stays true now
- * that the condition also covers background runs — those only ever *add* a reason for it to pass.
+ * met while the screen showing it is on top, so any wording would be filler.
  */
 @Composable
 fun PrefetchConditionRow.detail(): String? = when (condition) {

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/PrefetchStatusLabels.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/PrefetchStatusLabels.kt
@@ -4,7 +4,7 @@ import androidx.compose.runtime.Composable
 import com.garfiec.librechat.feature.settings.resources.Res
 import com.garfiec.librechat.feature.settings.resources.prefetch_condition_enabled
 import com.garfiec.librechat.feature.settings.resources.prefetch_condition_enabled_unmet
-import com.garfiec.librechat.feature.settings.resources.prefetch_condition_foreground
+import com.garfiec.librechat.feature.settings.resources.prefetch_condition_app_available
 import com.garfiec.librechat.feature.settings.resources.prefetch_condition_idle
 import com.garfiec.librechat.feature.settings.resources.prefetch_condition_idle_met
 import com.garfiec.librechat.feature.settings.resources.prefetch_condition_idle_unmet
@@ -63,7 +63,7 @@ fun PrefetchDisplayStatus.label(): String = when (this) {
 fun PrefetchCondition.label(): String = stringResource(
     when (this) {
         PrefetchCondition.ENABLED -> Res.string.prefetch_condition_enabled
-        PrefetchCondition.FOREGROUND -> Res.string.prefetch_condition_foreground
+        PrefetchCondition.APP_AVAILABLE -> Res.string.prefetch_condition_app_available
         PrefetchCondition.NETWORK -> Res.string.prefetch_condition_network
         PrefetchCondition.POWER -> Res.string.prefetch_condition_power
         PrefetchCondition.IDLE -> Res.string.prefetch_condition_idle
@@ -72,12 +72,13 @@ fun PrefetchCondition.label(): String = stringResource(
 )
 
 /**
- * The detail line beside a condition. Foreground has none: it is the one condition that is
- * necessarily met while the screen showing it is on top, so any wording would be filler.
+ * The detail line beside a condition. App-readiness has none: it is the one condition necessarily
+ * met while the screen showing it is on top, so any wording would be filler. That stays true now
+ * that the condition also covers background runs — those only ever *add* a reason for it to pass.
  */
 @Composable
 fun PrefetchConditionRow.detail(): String? = when (condition) {
-    PrefetchCondition.FOREGROUND -> null
+    PrefetchCondition.APP_AVAILABLE -> null
     PrefetchCondition.ENABLED ->
         if (met) null else stringResource(Res.string.prefetch_condition_enabled_unmet)
     // Offline is reported even when the row is otherwise met: with the metered override on, the

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/PrefetchStatusLabels.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/PrefetchStatusLabels.kt
@@ -3,9 +3,9 @@ package com.garfiec.librechat.feature.settings.screen
 import androidx.compose.runtime.Composable
 import com.garfiec.librechat.core.data.prefetch.PrefetchRunOutcome
 import com.garfiec.librechat.feature.settings.resources.Res
+import com.garfiec.librechat.feature.settings.resources.prefetch_condition_app_available
 import com.garfiec.librechat.feature.settings.resources.prefetch_condition_enabled
 import com.garfiec.librechat.feature.settings.resources.prefetch_condition_enabled_unmet
-import com.garfiec.librechat.feature.settings.resources.prefetch_condition_app_available
 import com.garfiec.librechat.feature.settings.resources.prefetch_condition_idle
 import com.garfiec.librechat.feature.settings.resources.prefetch_condition_idle_met
 import com.garfiec.librechat.feature.settings.resources.prefetch_condition_idle_unmet

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/PrefetchStatusLabels.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/screen/PrefetchStatusLabels.kt
@@ -1,6 +1,7 @@
 package com.garfiec.librechat.feature.settings.screen
 
 import androidx.compose.runtime.Composable
+import com.garfiec.librechat.core.data.prefetch.PrefetchRunOutcome
 import com.garfiec.librechat.feature.settings.resources.Res
 import com.garfiec.librechat.feature.settings.resources.prefetch_condition_enabled
 import com.garfiec.librechat.feature.settings.resources.prefetch_condition_enabled_unmet
@@ -18,6 +19,12 @@ import com.garfiec.librechat.feature.settings.resources.prefetch_condition_power
 import com.garfiec.librechat.feature.settings.resources.prefetch_condition_server
 import com.garfiec.librechat.feature.settings.resources.prefetch_condition_server_met
 import com.garfiec.librechat.feature.settings.resources.prefetch_condition_server_unmet
+import com.garfiec.librechat.feature.settings.resources.prefetch_run_outcome_budget
+import com.garfiec.librechat.feature.settings.resources.prefetch_run_outcome_constraints
+import com.garfiec.librechat.feature.settings.resources.prefetch_run_outcome_disabled
+import com.garfiec.librechat.feature.settings.resources.prefetch_run_outcome_interrupted
+import com.garfiec.librechat.feature.settings.resources.prefetch_run_outcome_no_session
+import com.garfiec.librechat.feature.settings.resources.prefetch_run_outcome_stopped
 import com.garfiec.librechat.feature.settings.resources.prefetch_status_off
 import com.garfiec.librechat.feature.settings.resources.prefetch_status_paused_background
 import com.garfiec.librechat.feature.settings.resources.prefetch_status_paused_busy
@@ -98,4 +105,21 @@ fun PrefetchConditionRow.detail(): String? = when (condition) {
     PrefetchCondition.SERVER -> stringResource(
         if (met) Res.string.prefetch_condition_server_met else Res.string.prefetch_condition_server_unmet,
     )
+}
+
+/**
+ * How a scheduled run ended, shown beside its timestamp.
+ *
+ * Null for a completed run: "Last background run: 7 hours ago" already says everything there, and a
+ * suffix on the ordinary case would train the eye to skip the ones that matter.
+ */
+@Composable
+fun PrefetchRunOutcome.label(): String? = when (this) {
+    PrefetchRunOutcome.COMPLETED -> null
+    PrefetchRunOutcome.DISABLED -> stringResource(Res.string.prefetch_run_outcome_disabled)
+    PrefetchRunOutcome.NO_SESSION -> stringResource(Res.string.prefetch_run_outcome_no_session)
+    PrefetchRunOutcome.CONSTRAINTS_UNMET -> stringResource(Res.string.prefetch_run_outcome_constraints)
+    PrefetchRunOutcome.BUDGET_EXPIRED -> stringResource(Res.string.prefetch_run_outcome_budget)
+    PrefetchRunOutcome.STOPPED -> stringResource(Res.string.prefetch_run_outcome_stopped)
+    PrefetchRunOutcome.INTERRUPTED -> stringResource(Res.string.prefetch_run_outcome_interrupted)
 }

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/state/PrefetchStatusDisplay.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/state/PrefetchStatusDisplay.kt
@@ -98,7 +98,7 @@ fun PrefetchConditions.pauseReason(): PrefetchPauseReason? = when {
     !connected -> PrefetchPauseReason.OFFLINE
     !networkAllowed -> PrefetchPauseReason.NETWORK
     !powerAvailable -> PrefetchPauseReason.POWER
-    !foreground -> PrefetchPauseReason.BACKGROUND
+    !appAvailable -> PrefetchPauseReason.BACKGROUND
     !appIdle -> PrefetchPauseReason.BUSY
     else -> null
 }

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/PrefetchActivityViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/PrefetchActivityViewModel.kt
@@ -61,7 +61,7 @@ enum class PrefetchCondition(
     val gatesManualRun: Boolean,
 ) {
     ENABLED(gatesManualRun = true),
-    FOREGROUND(gatesManualRun = true),
+    APP_AVAILABLE(gatesManualRun = true),
     NETWORK(gatesManualRun = true),
     POWER(gatesManualRun = true),
     IDLE(gatesManualRun = true),
@@ -109,7 +109,7 @@ class PrefetchActivityViewModel(
             // off: the route is serializable and restores from a saved back stack, and without this
             // row every condition then reads green while the one unmet condition is the one absent.
             PrefetchConditionRow(PrefetchCondition.ENABLED, conditions.enabled),
-            PrefetchConditionRow(PrefetchCondition.FOREGROUND, conditions.foreground),
+            PrefetchConditionRow(PrefetchCondition.APP_AVAILABLE, conditions.appAvailable),
             PrefetchConditionRow(
                 PrefetchCondition.NETWORK,
                 conditions.networkAllowed,

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/PrefetchActivityViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/PrefetchActivityViewModel.kt
@@ -6,7 +6,6 @@ import com.garfiec.librechat.core.data.prefetch.PrefetchController
 import com.garfiec.librechat.core.data.prefetch.PrefetchConversationStatus
 import com.garfiec.librechat.core.data.prefetch.PrefetchRunOutcome
 import com.garfiec.librechat.core.data.prefetch.PrefetchRunState
-import com.garfiec.librechat.core.data.prefetch.PrefetchRunOutcome
 import com.garfiec.librechat.core.data.prefetch.PrefetchStatus
 import com.garfiec.librechat.core.data.prefetch.PrefetchStatusReporter
 import com.garfiec.librechat.feature.settings.state.PrefetchDisplayStatus

--- a/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/PrefetchActivityViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/com/garfiec/librechat/feature/settings/viewmodel/PrefetchActivityViewModel.kt
@@ -4,7 +4,9 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.garfiec.librechat.core.data.prefetch.PrefetchController
 import com.garfiec.librechat.core.data.prefetch.PrefetchConversationStatus
+import com.garfiec.librechat.core.data.prefetch.PrefetchRunOutcome
 import com.garfiec.librechat.core.data.prefetch.PrefetchRunState
+import com.garfiec.librechat.core.data.prefetch.PrefetchRunOutcome
 import com.garfiec.librechat.core.data.prefetch.PrefetchStatus
 import com.garfiec.librechat.core.data.prefetch.PrefetchStatusReporter
 import com.garfiec.librechat.feature.settings.state.PrefetchDisplayStatus
@@ -25,6 +27,10 @@ data class PrefetchActivityUiState(
     val warmedCount: Int = 0,
     val eligibleCount: Int = 0,
     val lastWarmedAt: Long? = null,
+    /** False on platforms with no scheduler, which hides the row rather than showing "Never". */
+    val scheduledRunsSupported: Boolean = false,
+    val lastScheduledRunAt: Long? = null,
+    val lastScheduledRunOutcome: PrefetchRunOutcome? = null,
     val cachedMessageCount: Int = 0,
     val warmed: List<PrefetchConversationStatus> = emptyList(),
     val pending: List<PrefetchConversationStatus> = emptyList(),
@@ -101,6 +107,9 @@ class PrefetchActivityViewModel(
         warmedCount = warmedCount,
         eligibleCount = eligibleCount,
         lastWarmedAt = lastWarmedAt,
+        scheduledRunsSupported = scheduledRunsSupported,
+        lastScheduledRunAt = lastScheduledRun?.atMillis,
+        lastScheduledRunOutcome = lastScheduledRun?.outcome,
         cachedMessageCount = figures.messages,
         warmed = warmed,
         pending = pending,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,6 +26,7 @@ room = "2.8.4"
 sqlite = "2.6.2"
 datastore = "1.2.1"
 security-crypto = "1.1.0"
+work = "2.11.2"
 
 # Async
 coroutines = "1.11.0"
@@ -144,6 +145,8 @@ sqlite-bundled = { group = "androidx.sqlite", name = "sqlite-bundled", version.r
 # DataStore
 datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastore" }
 security-crypto = { group = "androidx.security", name = "security-crypto", version.ref = "security-crypto" }
+work-runtime = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "work" }
+work-testing = { group = "androidx.work", name = "work-testing", version.ref = "work" }
 
 # Coroutines
 coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "coroutines" }

--- a/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/LibreChatNavHost.kt
+++ b/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/LibreChatNavHost.kt
@@ -47,6 +47,7 @@ import coil3.SingletonImageLoader
 import coil3.compose.LocalPlatformContext
 import com.garfiec.librechat.core.common.conversation.OpenConversationRegistry
 import com.garfiec.librechat.core.common.identity.AccountState
+import com.garfiec.librechat.core.common.lifecycle.DeferredWorkWindow
 import com.garfiec.librechat.core.common.lifecycle.ForegroundSignal
 import com.garfiec.librechat.core.logging.Diag
 import com.garfiec.librechat.core.ui.components.BannerDisplay
@@ -119,11 +120,17 @@ fun LibreChatNavHost(
     // Publish foreground state for deferred background work. onDispose reports background because a
     // host leaving composition is the app going away as far as any consumer is concerned.
     val foregroundSignal = koinInject<ForegroundSignal>()
+    val deferredWorkWindow = koinInject<DeferredWorkWindow>()
     val lifecycleOwner = LocalLifecycleOwner.current
-    DisposableEffect(lifecycleOwner, foregroundSignal) {
+    DisposableEffect(lifecycleOwner, foregroundSignal, deferredWorkWindow) {
         val observer = LifecycleEventObserver { _, event ->
             when (event) {
-                Lifecycle.Event.ON_START -> foregroundSignal.set(true)
+                Lifecycle.Event.ON_START -> {
+                    foregroundSignal.set(true)
+                    // Latches, so this is only ever the first ON_START that matters. It is what
+                    // lets deferred work outlive the foreground, and what keeps it off cold start.
+                    deferredWorkWindow.markUiStarted()
+                }
                 Lifecycle.Event.ON_STOP -> foregroundSignal.set(false)
                 else -> Unit
             }

--- a/shared/src/iosTest/kotlin/com/garfiec/librechat/shared/IosKoinGraphTest.kt
+++ b/shared/src/iosTest/kotlin/com/garfiec/librechat/shared/IosKoinGraphTest.kt
@@ -4,6 +4,7 @@ import com.garfiec.librechat.core.network.api.AgentToolsApi
 import com.garfiec.librechat.core.network.api.PermissionsApi
 import com.garfiec.librechat.core.network.api.SkillsApi
 import com.garfiec.librechat.core.network.sse.SseClient
+import com.garfiec.librechat.core.data.prefetch.PrefetchScheduler
 import org.koin.core.annotation.KoinInternalApi
 import org.koin.dsl.koinApplication
 import kotlin.test.Test
@@ -45,6 +46,7 @@ class IosKoinGraphTest {
             PermissionsApi::class,
             SkillsApi::class,
             SseClient::class,
+            PrefetchScheduler::class,
         ).forEach { c ->
             // hasType (not primaryType ==) so a future `singleOf(::Impl) bind Interface`
             // still matches on its secondary type.


### PR DESCRIPTION
## Summary

Prefetching runs only while the app is on screen and idle, and paces at five times the previous
request's duration — so at the deeper depth settings a cold warm needs several minutes of
uninterrupted foreground time, which is more than a typical session gives it. This lets a pass
outlive the foreground and adds a periodic Android job, so warming can finish while nobody is
watching.

The existing "Prefetch conversations" toggle now covers both; there is no new setting.

## Changes

**Running off screen**
- `DeferredWorkWindow` (`:core:common`) replaces the gate's foreground term. It latches once the UI
  has started and is also held open by an explicit background run, which is what lets a process a
  scheduler spawned — one that never composes — open the gate at all.
- Off-screen passes use a flat 250 ms gap instead of the 5× factor. On-screen pacing is unchanged,
  and the engine reads the foreground signal live, so returning mid-pass restores it immediately.
  **The accepted cost** is that the proportional gap's load-shedding property — the prefetcher's
  share of a slow server shrinking as it slows — is gone precisely where nobody is watching. What
  bounds an off-screen pass instead is that it stays strictly one request at a time, plus a
  2-minute off-screen budget checked in both the list-paging and message loops.
- Platforms that cannot keep a backgrounded process alive fall back to the live foreground signal.
- Because the window latches, the "App in foreground" condition row becomes **"App ready"** and, on
  Android, is permanently met after the first start. `PrefetchPauseReason.BACKGROUND` and its
  "Paused — app is in the background" string are consequently unreachable there; both are still
  shipped for platforms on the foreground fallback.

**Periodic scheduling (Android)**
- A 6-hourly `PeriodicWorkRequest` constrained to charging, device idle, battery-not-low, and a
  network matching the metered setting. The constraints are the feature: this realistically runs
  overnight rather than on a fixed cadence.
- Existing work is kept unless the network constraint actually changed, so the enqueue that runs at
  every process start — including in the process the job itself woke — churns nothing. The value it
  was last registered with is persisted, because that comparison has to survive process death.
- The job is registered while prefetching is on and an account is signed in, and cancelled once
  identity resolves to signed-out or the toggle goes off. While identity is still warming the
  coordinator deliberately decides neither, so a process start cannot cancel its own pending work.
- `PrefetchBackgroundRunner` runs one budgeted pass: it waits on the controller's pass signal rather
  than driving the engine, and asks for a run only when none starts on its own. A scheduled run also
  clears the failure breaker and, if the pass it observed ended stopped, asks once more — without
  that, one unreachable-server episode would make every later scheduled run return instantly.
  `PrefetchWorker` always returns success, so an unmet constraint is not recorded as a job failure.
- iOS binds a scheduler that reports itself unsupported; nothing there schedules yet.

**Reusing a recent list refresh**
- Every pass re-pages the conversation list before it can tell what is stale, which at the deepest
  setting is an eight-page prologue paid again on each short burst. A refresh from the last five
  minutes is now reused. This applies to the list stage only — message freshness is still watermark
  versus `updatedAt` — and the record is written only after a run that finished paging, so a run cut
  short by a rate limit or the breaker cannot suppress the refresh that never completed. A manual
  "Warm now" clears it.

**Reporting**
- A new "Last background run" row shows when a scheduled pass ran and, for most outcomes, why. A run
  that found the gate shut moves no watermark, so without this there is nothing to distinguish a
  feature working quietly from one that never fires. It is account-scoped, and hidden on platforms
  that schedule nothing. Two limitations worth knowing: it is the only figure on that screen that is
  *recorded* rather than derived from the rows the engine acts on, so it is the only one that can
  drift; and the "prefetch was off" / "not signed in" outcomes return before an account resolves, so
  in a freshly spawned process they are not recorded at all.
- The toggle's description no longer says warming happens only while the app is idle.
- New strings are added to all 10 locale files. As with the existing prefetch strings, the nine
  non-English files carry the English text.

**Fixes this depends on** (both conditions exist on `develop` today)
- Session expiry is latched on *delivery* rather than on the attempt. The signal has no replay, so a
  report made while no navigation host is composed was discarded while the one-shot stayed burnt,
  swallowing the report the next request needed. The guard lives at the emitter in
  `CommonTokenDataStore` rather than at each call site, so every unattended emitter is covered —
  present and future — without each one having to remember a convention.
- The failure breaker now expires after an hour instead of lasting for the life of the process.

**Dependency**: adds `androidx.work` (`work-runtime-ktx`, and `work-testing` for the test lane).

## Testing

Unit tests: new suites for the background runner, the worker's Koin resolution, and the schedule
coordinator; additions to the gate, engine, controller, and session-expiry tests.
`:core:common`, `:core:network`, `:core:data`, `:feature:settings` and `:app` unit tests, `detekt`,
`detektMetadataCommonMain`, `:app:lint` and `:app:assembleDebug` all pass.

Device pass on a Pixel 10 Pro Fold emulator against a local LibreChat server:

- The job registers with the intended constraints; a restart with unchanged constraints leaves the
  work untouched, and changing the metered setting re-registers it with the new network constraint.
- A forced job in a killed process warms exactly the conversations that changed server-side, leaves
  an unrelated one untouched, and reports completion.
- Warming continues after the app leaves the screen — conversations warmed with no resumed activity.
- A repeat pass inside the window skips the list stage; "Warm now" in the same window re-pages it.
- The readout shows a clean run as a bare timestamp and a blocked one with its reason.
- A background pass that hard-fails auth with no UI present leaves the expiry signal armed, and the
  expiry surfaces once something is listening.

Not verified: iOS scheduling is not implemented and was not built, and no scheduled job has been
observed firing on its own cadence — every run above was forced.

## Notes

- iOS background scheduling (`BGAppRefreshTask` / `BGProcessingTask`) is a follow-up; this PR only
  makes the shared side ready for it.
- The job is charging + device-idle, so the interval is how often the system may *consider* it, not
  how often it fires; App Standby buckets narrow it further for a rarely-opened app. Daytime warming
  comes from a pass outliving the foreground instead.
- The runner waits a fixed 5 seconds for a pass to appear, and up to 5 seconds more after asking for
  one — spent before the budget clock starts, and not scaled to it. On the test device the gate took
  3–5 seconds of that on a cold process, and one run in five exceeded both windows and was recorded
  as blocked by conditions, which reads the same as genuinely unmet constraints.
- Unattended attachment warming stays behind its existing opt-in.
