### PR TITLE
fix(banner): decode the single banner the server actually sends (#324)

### DIFF
--- a/app/CLAUDE.md
+++ b/app/CLAUDE.md
@@ -78,11 +78,14 @@ This module depends on `:shared`, all `:core:*`, and all `:feature:*` modules.
 It applies convention plugins: `librechat.mobile.application`, `librechat.mobile.compose`, `librechat.mobile.koin`.
 
 ### Server Banners
-- `NavHostViewModel` (shared) fetches banners from `BannerRepository` on init, filters expired via `displayFrom`/`displayTo` with `Instant.parse()`
-- Dismissed banner IDs tracked in-memory via `dismissedBannerIds: StateFlow<Set<String>>` (session-scoped, not persisted)
-- `BannerDisplay` composable shown at top of content in both `PhoneLayout` (shared) and `TabletLayout` (app)
-- Banner types: "info" (blue), "warning" (amber), "error" (red) — defaults to "info" if type is null
-- **Gotcha**: `displayFrom`/`displayTo` are ISO 8601 strings parsed with `Instant.parse()` — wrap in `runCatching` since the format from the server is not guaranteed
+- `GET /api/banner` returns **one banner object, or a 200 with an empty body and no `Content-Type`** — never an array. `BannerApi` reads the raw body for that reason; anything else still throws, so a proxy answering for the API can't read as "no banner configured"
+- `NavHostViewModel` (shared) fetches the banner via `BannerRepository` on init, on account switch and on auth-complete. There is no timer
+- The server applies the `displayFrom`/`displayTo` window and filters `type: 'banner'` itself, so the client does neither — a client-side re-check can only ever subtract from the server's decision, and did so on device-clock skew
+- Dismissal is resolved in `BannerStateHolder`, not the UI: it nulls the banner and records a **(serverId, bannerId)** key, in-memory for the process. Both halves of that key are load-bearing and pull opposite ways — keyed by banner alone, a fleet seeding one bannerId across its servers delivers the next server's banner pre-dismissed; cleared on switch, dismissing A's banner and switching away and back brings A's right back
+- `BannerStateHolder.clearForAccountChange()` drops the banner (scoped to a deployment) on switch and sign-out. It deliberately does **not** touch dismissals
+- `BannerDisplay` composable shown at top of content in both `PhoneLayout` (shared) and `TabletLayout` (app). It takes a nullable banner and decides visibility itself — hoisting the null check to the callers would add/remove it from the tree and kill its enter/exit animation
+- One visual treatment, from `secondaryContainer`/`onSecondaryContainer`. Do not re-introduce a `type`-keyed palette or hardcoded hex: the server only ever sends `type: "banner"`, and fixed colours ignore the accent seed and break in dark mode
+- A `persistable` banner hides the dismiss control (matching web); a banner with no `bannerId` is not rendered at all, since nothing could ever remove it
 
 ### Preset Navigation
 - `PresetManager` route registered in `SettingsNavigation.kt`

--- a/app/src/main/kotlin/com/garfiec/librechat/navigation/TabletLayout.kt
+++ b/app/src/main/kotlin/com/garfiec/librechat/navigation/TabletLayout.kt
@@ -57,8 +57,7 @@ fun TabletLayout(
     modifier: Modifier = Modifier,
 ) {
     // Banner state only -- drawer state is collected inside DrawerContent itself
-    val banners by navHostViewModel.banners.collectAsStateWithLifecycle()
-    val dismissedBannerIds by navHostViewModel.dismissedBannerIds.collectAsStateWithLifecycle()
+    val banner by navHostViewModel.banner.collectAsStateWithLifecycle()
 
     // Persisted sidebar state from DataStore -- single source of truth in the ViewModel.
     // Null until the persisted value resolves; treat unknown as closed for boolean callers.
@@ -216,8 +215,7 @@ fun TabletLayout(
                 MainContent(
                     navigator = navigator,
                     isInAuthFlow = false,
-                    banners = banners,
-                    dismissedBannerIds = dismissedBannerIds,
+                    banner = banner,
                     onDismissBanner = navHostViewModel::dismissBanner,
                     onToggleDrawer = {
                         navHostViewModel.toggleTabletSidebar()
@@ -247,8 +245,7 @@ fun TabletLayout(
         MainContent(
             navigator = navigator,
             isInAuthFlow = true,
-            banners = banners,
-            dismissedBannerIds = dismissedBannerIds,
+            banner = banner,
             onDismissBanner = navHostViewModel::dismissBanner,
             onToggleDrawer = {},
             modifier = Modifier.fillMaxSize(),
@@ -260,19 +257,16 @@ fun TabletLayout(
 private fun MainContent(
     navigator: Navigator,
     isInAuthFlow: Boolean,
-    banners: List<Banner>,
-    dismissedBannerIds: Set<String>,
+    banner: Banner?,
     onDismissBanner: (String) -> Unit,
     onToggleDrawer: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(modifier = modifier) {
-        if (!isInAuthFlow && banners.isNotEmpty()) {
+        if (!isInAuthFlow) {
             BannerDisplay(
-                banners = banners,
-                dismissedIds = dismissedBannerIds,
+                banner = banner,
                 onDismiss = onDismissBanner,
-                modifier = Modifier.padding(top = 4.dp),
             )
         }
         MainNavDisplay(

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/BannerRepository.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/BannerRepository.kt
@@ -3,7 +3,8 @@ package com.garfiec.librechat.core.data.repository
 import com.garfiec.librechat.core.common.result.Result
 import com.garfiec.librechat.core.model.Banner
 
-/** Fetches server-configured banners for display in the app. */
+/** Fetches the server-configured banner for display in the app. */
 interface BannerRepository {
-    suspend fun getBanners(): Result<List<Banner>>
+    /** Returns the active banner, or null when the server has none configured. */
+    suspend fun getBanner(): Result<Banner?>
 }

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/BannerRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/BannerRepositoryImpl.kt
@@ -9,6 +9,6 @@ class BannerRepositoryImpl(
     private val bannerApi: BannerApi,
 ) : BannerRepository {
 
-    override suspend fun getBanners(): Result<List<Banner>> =
-        safeApiCall { bannerApi.getBanners() }
+    override suspend fun getBanner(): Result<Banner?> =
+        safeApiCall { bannerApi.getBanner() }
 }

--- a/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/api/BannerApiTest.kt
+++ b/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/api/BannerApiTest.kt
@@ -1,0 +1,94 @@
+package com.garfiec.librechat.core.network.api
+
+import com.garfiec.librechat.core.model.Banner
+import com.garfiec.librechat.core.network.di.librechatJson
+import com.google.common.truth.Truth.assertThat
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+/**
+ * Pins the response shapes of `GET /api/banner`. The route sends a single banner object, or an
+ * empty body when none is configured — never an array — so decoding it as a list failed on every
+ * server in both states. These cases are the wire captures that regression has to stay fixed
+ * against.
+ *
+ * ContentNegotiation is installed as it is in production to show it cannot rescue any of this:
+ * [BannerApi.getBanner] reads the raw body, so the shipped [librechatJson] below is what decodes.
+ */
+class BannerApiTest {
+
+    private suspend fun getBanner(body: String, contentType: String? = "application/json"): Banner? {
+        val engine = MockEngine {
+            respond(
+                content = body,
+                status = HttpStatusCode.OK,
+                headers = contentType?.let { headersOf(HttpHeaders.ContentType, it) } ?: headersOf(),
+            )
+        }
+        val client = HttpClient(engine) { install(ContentNegotiation) { json(librechatJson) } }
+        return BannerApi(client, librechatJson).getBanner()
+    }
+
+    @Test
+    fun `no banner configured returns null for an empty body with no content type`() = runTest {
+        // The live capture: Express turns res.send(null) into a zero-length body and never sets
+        // Content-Type, so ContentNegotiation cannot engage at all.
+        assertThat(getBanner(body = "", contentType = null)).isNull()
+    }
+
+    @Test
+    fun `banner object decodes with mongo-only fields ignored`() = runTest {
+        val banner = getBanner(
+            """
+            {
+              "_id": "68a1f0c0c0ffee0000000001",
+              "__v": 0,
+              "bannerId": "maintenance-2026-08",
+              "message": "Scheduled maintenance on Sunday.",
+              "displayFrom": "2026-08-01T00:00:00.000Z",
+              "displayTo": null,
+              "type": "banner",
+              "isPublic": true,
+              "persistable": false,
+              "tenantId": "acme",
+              "createdAt": "2026-08-01T00:00:00.000Z",
+              "updatedAt": "2026-08-01T00:00:00.000Z"
+            }
+            """.trimIndent(),
+        )
+
+        assertThat(banner).isNotNull()
+        assertThat(banner?.bannerId).isEqualTo("maintenance-2026-08")
+        assertThat(banner?.message).isEqualTo("Scheduled maintenance on Sunday.")
+        assertThat(banner?.displayFrom).isEqualTo("2026-08-01T00:00:00.000Z")
+        assertThat(banner?.displayTo).isNull()
+        assertThat(banner?.persistable).isFalse()
+    }
+
+    @Test
+    fun `literal null body returns null`() = runTest {
+        assertThat(getBanner("null")).isNull()
+    }
+
+    @Test(expected = Exception::class)
+    fun `html error page surfaces as an error rather than as no banner`() = runTest {
+        // A proxy answering for the API must not read as "no banner is configured" — that is the
+        // silent failure this fix removes, and it would leave nothing in the log to find.
+        getBanner("<!doctype html><html><body>Not found</body></html>", contentType = "text/html")
+    }
+
+    @Test(expected = Exception::class)
+    fun `malformed json still throws so it surfaces as an error`() = runTest {
+        // Only the documented "no banner" shapes are swallowed — a broken payload has to stay
+        // visible, or protocol drift decodes to a silently missing banner.
+        getBanner("""{"bannerId": }""")
+    }
+}

--- a/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/api/BannerApi.kt
+++ b/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/api/BannerApi.kt
@@ -2,15 +2,37 @@ package com.garfiec.librechat.core.network.api
 
 import com.garfiec.librechat.core.model.Banner
 import io.ktor.client.HttpClient
-import io.ktor.client.call.body
 import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
 import io.ktor.http.path
+import kotlinx.serialization.json.Json
 
 class BannerApi constructor(
     private val client: HttpClient,
+    private val json: Json,
 ) {
-    suspend fun getBanners(): List<Banner> =
-        client.get {
+
+    /**
+     * Fetches the active banner, or null when the server has none.
+     *
+     * The endpoint answers with a single banner object — never an array — and signals "no banner"
+     * with an empty body: Express turns `res.send(null)` into a zero-length body *before* the
+     * branch that would default the type to `text/html`, so the response carries no `Content-Type`
+     * at all and ContentNegotiation never engages. Reading the raw body covers both shapes, and
+     * matches [ConfigApi.getEndpoints], which needs the same treatment because this server can
+     * serve JSON under a `text/html` type.
+     *
+     * Any other body still throws. An HTML page here means a proxy is answering for the API — only
+     * a Cloudflare Access challenge is typed (`GatewayDetectionPlugin`), so a cookie-based gateway
+     * or an SPA fallback reaches this decode. Swallowing that would make "the proxy is eating every
+     * response" indistinguishable from "no banner is configured", with nothing in the log — the
+     * same silent failure this fix exists to remove.
+     */
+    suspend fun getBanner(): Banner? {
+        val text = client.get {
             url { path("api/banner") }
-        }.body()
+        }.bodyAsText().trim()
+        if (text.isEmpty() || text == "null") return null
+        return json.decodeFromString<Banner>(text)
+    }
 }

--- a/core/ui/CLAUDE.md
+++ b/core/ui/CLAUDE.md
@@ -22,7 +22,8 @@ Material 3 theme and shared Compose components used across all feature modules. 
 - `SearchBar` - Reusable search input field.
 - `BottomSheetScaffold` - Wrapper for modal bottom sheets.
 - `PullToRefresh` - Pull-to-refresh wrapper.
-- `BannerDisplay` - Dismissible server banner cards (info/warning/error types).
+- `BannerDisplay` - The server banner. The server sends at most one and only ever types it
+  `banner`, so there is a single visual treatment; a `persistable` banner hides the dismiss control.
 
 ### Markdown
 - core/ui does NOT provide a shared markdown renderer. Features render markdown

--- a/core/ui/src/commonMain/composeResources/values/strings.xml
+++ b/core/ui/src/commonMain/composeResources/values/strings.xml
@@ -2,6 +2,8 @@
 <resources>
     <!-- Accessibility label for the bottom-sheet drag handle -->
     <string name="cd_drag_handle">Drag handle</string>
+    <!-- Accessibility label for the close button on a server banner -->
+    <string name="banner_dismiss">Dismiss banner</string>
     <!-- Inline indicator for a PDF page that failed to render -->
     <string name="pdf_page_failed">Couldn't render this page</string>
     <!-- Custom per-server request headers (issue #287); shared by the pre-login

--- a/core/ui/src/commonMain/kotlin/com/garfiec/librechat/core/ui/components/BannerDisplay.kt
+++ b/core/ui/src/commonMain/kotlin/com/garfiec/librechat/core/ui/components/BannerDisplay.kt
@@ -5,7 +5,6 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -14,7 +13,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Info
-import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
@@ -24,100 +22,101 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.semantics.LiveRegionMode
 import androidx.compose.ui.semantics.liveRegion
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import com.garfiec.librechat.core.model.Banner
+import com.garfiec.librechat.core.ui.resources.Res
+import com.garfiec.librechat.core.ui.resources.banner_dismiss
+import org.jetbrains.compose.resources.stringResource
 
 /**
- * Renders a vertical stack of dismissible server banners.
+ * Renders the server banner, if there is one to show.
  *
- * Banners are filtered against [dismissedIds] so dismissed banners stay hidden.
- * Supports three visual types: "info" (blue), "warning" (amber), "error" (red).
+ * The server sends at most one banner and filters it by type and display window itself, so there
+ * is no variant to style for: every banner is informational. A `persistable` banner cannot be
+ * dismissed, matching the web client — the dismiss control is hidden rather than inert.
  */
 @Composable
 fun BannerDisplay(
-    banners: List<Banner>,
-    dismissedIds: Set<String>,
+    banner: Banner?,
     onDismiss: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val visibleBanners = banners.filter { banner ->
-        val id = banner.bannerId ?: return@filter false
-        id !in dismissedIds
-    }
+    val bannerId = banner?.bannerId
+    // Null when `persistable` marks the banner as one the user may not dismiss.
+    val dismissId = bannerId?.takeIf { banner.persistable != true }
+    // Nullability is decided here rather than by the callers so this composable stays in the tree
+    // across the transition: hoisting the check out of it adds and removes the AnimatedVisibility
+    // instead of toggling it, and the enter/exit below then never run. A dismissal reaches this the
+    // same way — the holder nulls the banner — which is what animates it out.
+    //
+    // A banner needs an id even when it can't be dismissed — without one nothing can ever remove
+    // it, so it would stay pinned for the whole process. A blank message would render a card
+    // carrying nothing but the icon.
+    val visible = banner != null && bannerId != null && !banner.message.isNullOrBlank()
 
-    Column(modifier = modifier.fillMaxWidth()) {
-        visibleBanners.forEach { banner ->
-            val bannerId = banner.bannerId ?: return@forEach
-            AnimatedVisibility(
-                visible = true,
-                enter = slideInVertically() + fadeIn(),
-                exit = slideOutVertically() + fadeOut(),
-            ) {
-                BannerCard(
-                    banner = banner,
-                    onDismiss = { onDismiss(bannerId) },
-                )
-            }
-        }
+    AnimatedVisibility(
+        visible = visible,
+        modifier = modifier.fillMaxWidth(),
+        enter = slideInVertically() + fadeIn(),
+        exit = slideOutVertically() + fadeOut(),
+    ) {
+        BannerCard(
+            message = banner?.message.orEmpty(),
+            dismissId = dismissId,
+            onDismiss = onDismiss,
+        )
     }
 }
 
 @Composable
 private fun BannerCard(
-    banner: Banner,
-    onDismiss: () -> Unit,
+    message: String,
+    dismissId: String?,
+    onDismiss: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val bannerType = banner.type ?: "info"
-    val containerColor = when (bannerType) {
-        "warning" -> Color(0xFFFFF3E0) // amber container
-        "error" -> MaterialTheme.colorScheme.errorContainer
-        else -> Color(0xFFE3F2FD) // blue container (info)
-    }
-    val contentColor = when (bannerType) {
-        "warning" -> Color(0xFFE65100)
-        "error" -> MaterialTheme.colorScheme.onErrorContainer
-        else -> Color(0xFF0D47A1)
-    }
-    val icon = when (bannerType) {
-        "warning" -> Icons.Default.Warning
-        "error" -> Icons.Default.Warning
-        else -> Icons.Default.Info
-    }
-
     Card(
         modifier = modifier
             .fillMaxWidth()
             .padding(horizontal = 16.dp, vertical = 4.dp)
             .semantics { liveRegion = LiveRegionMode.Polite },
-        colors = CardDefaults.cardColors(containerColor = containerColor),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.secondaryContainer,
+        ),
     ) {
         Row(
-            modifier = Modifier.padding(start = 16.dp, top = 12.dp, bottom = 12.dp, end = 4.dp),
+            modifier = Modifier.padding(
+                start = 16.dp,
+                top = 12.dp,
+                bottom = 12.dp,
+                end = if (dismissId != null) 4.dp else 16.dp,
+            ),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Icon(
-                imageVector = icon,
-                contentDescription = bannerType,
-                tint = contentColor,
+                imageVector = Icons.Default.Info,
+                // Decorative: the message carries the content.
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSecondaryContainer,
             )
             Spacer(modifier = Modifier.width(12.dp))
             Text(
-                text = banner.message ?: "",
+                text = message,
                 modifier = Modifier.weight(1f),
                 style = MaterialTheme.typography.bodyMedium,
-                color = contentColor,
+                color = MaterialTheme.colorScheme.onSecondaryContainer,
             )
-            IconButton(onClick = onDismiss) {
-                Icon(
-                    imageVector = Icons.Default.Close,
-                    contentDescription = "Dismiss banner",
-                    tint = contentColor,
-                )
+            if (dismissId != null) {
+                IconButton(onClick = { onDismiss(dismissId) }) {
+                    Icon(
+                        imageVector = Icons.Default.Close,
+                        contentDescription = stringResource(Res.string.banner_dismiss),
+                        tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                    )
+                }
             }
         }
     }

--- a/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/BannerStateHolder.kt
+++ b/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/BannerStateHolder.kt
@@ -1,58 +1,100 @@
 package com.garfiec.librechat.shared.navigation
 
 import co.touchlab.kermit.Logger
+import com.garfiec.librechat.core.common.identity.deriveServerId
 import com.garfiec.librechat.core.common.result.Result
 import com.garfiec.librechat.core.data.repository.BannerRepository
 import com.garfiec.librechat.core.model.Banner
+import com.garfiec.librechat.core.network.client.ServerUrlProvider
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlin.time.Clock
-import kotlin.time.Instant
 
+/**
+ * Holds the single server-configured banner. The server returns at most one and applies the
+ * `displayFrom`/`displayTo` window itself, so a successful fetch simply replaces whatever is held.
+ *
+ * Dismissal is resolved here rather than in the UI, so "should this banner show" has one owner.
+ * This holder is Activity-scoped and outlives account switches, so dismissals accumulate for the
+ * process and are keyed by server. Web keeps the accumulating half of that invariant too
+ * (`hideBannerHint` is an appended `string[]`).
+ */
 class BannerStateHolder(
     private val bannerRepository: BannerRepository,
+    private val serverUrlProvider: ServerUrlProvider,
     private val scope: CoroutineScope,
 ) {
 
-    private val _banners = MutableStateFlow<List<Banner>>(emptyList())
-    val banners: StateFlow<List<Banner>> = _banners.asStateFlow()
+    // serverId the held banner came from, so a failed re-fetch can tell a banner carried over from
+    // a PREVIOUS server (clear it — it describes someone else's deployment) apart from a transient
+    // blip on the current one (keep it). Mirrors VersionCheckStateHolder.mismatchServerId.
+    private var bannerServerId: String? = null
 
-    private val _dismissedBannerIds = MutableStateFlow<Set<String>>(emptySet())
-    val dismissedBannerIds: StateFlow<Set<String>> = _dismissedBannerIds.asStateFlow()
+    private val _banner = MutableStateFlow<Banner?>(null)
+    val banner: StateFlow<Banner?> = _banner.asStateFlow()
 
-    fun fetchBanners() {
+    // Dismissals, keyed by (server, banner) and never cleared for the process. Both halves of the
+    // key are load-bearing and pull in opposite directions: keyed by banner alone, a fleet that
+    // seeds one bannerId across its servers delivers the next server's banner pre-dismissed; wiped
+    // on switch, dismissing A's banner and switching away and back brings A's straight back.
+    private val dismissedKeys = mutableSetOf<String>()
+
+    fun fetchBanner() {
         scope.launch {
-            try {
-                val result = bannerRepository.getBanners()
-                if (result is Result.Success) {
-                    val now = Clock.System.now()
-                    _banners.value = result.data.filter { banner ->
-                        val from = banner.displayFrom?.let {
-                            runCatching { Instant.parse(it) }
-                                .onFailure { e -> Logger.w(e) { "Failed to parse banner displayFrom: $it" } }
-                                .getOrNull()
-                        }
-                        val to = banner.displayTo?.let {
-                            runCatching { Instant.parse(it) }
-                                .onFailure { e -> Logger.w(e) { "Failed to parse banner displayTo: $it" } }
-                                .getOrNull()
-                        }
-                        val afterStart = from == null || now >= from
-                        val beforeEnd = to == null || now < to
-                        afterStart && beforeEnd
-                    }
+            // awaitBaseUrl, not getBaseUrl: the init fetch runs inside the ViewModel constructor on
+            // Main.immediate, before the persisted URL has resolved off "", and deriveServerId("")
+            // throws — which would stamp a null id and silently disable the carry-over guard below.
+            val serverId = runCatching { deriveServerId(serverUrlProvider.awaitBaseUrl()).value }
+                .getOrNull()
+            when (val result = bannerRepository.getBanner()) {
+                is Result.Success -> {
+                    bannerServerId = serverId
+                    _banner.value = result.data?.takeUnless { it.isDismissed() }
                 }
-            } catch (e: Exception) {
-                Logger.w(e) { "Failed to fetch banners" }
+                is Result.Error -> {
+                    if (bannerServerId != null && bannerServerId != serverId) {
+                        clearBanner()
+                    }
+                    Logger.w(result.exception) { "Failed to fetch banner: ${result.message}" }
+                }
+                is Result.Loading -> Unit
             }
         }
     }
 
+    /**
+     * Hide the banner and remember it, so the next fetch of the same one on the same server does
+     * not resurrect it. Dropping it here rather than filtering in the UI keeps the decision in one
+     * place; [BannerDisplay] animates it out because it stays composed across the change.
+     */
     fun dismissBanner(bannerId: String) {
-        _dismissedBannerIds.update { it + bannerId }
+        dismissedKeys += dismissKey(bannerServerId, bannerId)
+        _banner.value = null
+    }
+
+    /**
+     * The session this state described has ended (account switched away, or signed out). The banner
+     * is scoped to a deployment, so it must not outlive it — the auth screens only hide it, and it
+     * would otherwise reappear the moment the next login navigates. Dismissals are keyed by server
+     * and deliberately survive: switching away and back must not un-dismiss anything.
+     */
+    fun clearForAccountChange() {
+        clearBanner()
+    }
+
+    private fun Banner.isDismissed(): Boolean {
+        val id = bannerId ?: return false
+        // A persistable banner is one the server says may not be dismissed, so no key can exist.
+        return persistable != true && dismissKey(bannerServerId, id) in dismissedKeys
+    }
+
+    private fun dismissKey(serverId: String?, bannerId: String): String =
+        "${serverId.orEmpty()}\u0000$bannerId"
+
+    private fun clearBanner() {
+        _banner.value = null
+        bannerServerId = null
     }
 }

--- a/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/LibreChatNavHost.kt
+++ b/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/LibreChatNavHost.kt
@@ -13,7 +13,6 @@ import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.DrawerValue
 import androidx.compose.material3.MaterialTheme
@@ -33,7 +32,6 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
@@ -363,8 +361,7 @@ fun PhoneLayout(
     val drawerState = rememberDrawerState(DrawerValue.Closed)
     val scope = rememberCoroutineScope()
     val isLoggedIn by navHostViewModel.isLoggedIn.collectAsStateWithLifecycle()
-    val banners by navHostViewModel.banners.collectAsStateWithLifecycle()
-    val dismissedBannerIds by navHostViewModel.dismissedBannerIds.collectAsStateWithLifecycle()
+    val banner by navHostViewModel.banner.collectAsStateWithLifecycle()
 
     // Reset sidebar mode to Conversations when the drawer closes
     LaunchedEffect(drawerState.isClosed) {
@@ -433,12 +430,10 @@ fun PhoneLayout(
         },
     ) {
         Column(modifier = modifier.fillMaxSize().background(MaterialTheme.colorScheme.background)) {
-            if (!navigator.isInAuthFlow && banners.isNotEmpty()) {
+            if (!navigator.isInAuthFlow) {
                 BannerDisplay(
-                    banners = banners,
-                    dismissedIds = dismissedBannerIds,
+                    banner = banner,
                     onDismiss = navHostViewModel::dismissBanner,
-                    modifier = Modifier.padding(top = 4.dp),
                 )
             }
             MainNavDisplay(

--- a/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/NavHostViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/NavHostViewModel.kt
@@ -63,7 +63,8 @@ class NavHostViewModel(
     private val accountSwitcher: AccountSwitcher,
 ) : ViewModel() {
 
-    private val bannerStateHolder = BannerStateHolder(bannerRepository, viewModelScope)
+    private val bannerStateHolder =
+        BannerStateHolder(bannerRepository, serverUrlProvider, viewModelScope)
     private val versionCheckStateHolder =
         VersionCheckStateHolder(configRepository, settingsDataStore, serverUrlProvider, viewModelScope)
 
@@ -80,8 +81,7 @@ class NavHostViewModel(
 
     val versionMismatch: StateFlow<VersionMismatchState?> = versionCheckStateHolder.versionMismatch
 
-    val banners: StateFlow<List<Banner>> = bannerStateHolder.banners
-    val dismissedBannerIds: StateFlow<Set<String>> = bannerStateHolder.dismissedBannerIds
+    val banner: StateFlow<Banner?> = bannerStateHolder.banner
 
     val sessionExpired: SharedFlow<SessionEndReason> = tokenManager.sessionExpiredFlow
 
@@ -189,7 +189,7 @@ class NavHostViewModel(
                 Logger.w(e) { "Failed to check auth state on init" }
             }
         }
-        bannerStateHolder.fetchBanners()
+        bannerStateHolder.fetchBanner()
         // A dead session has to lower the flag, not just navigate: the 401 path produces no
         // [AccountTransition.Ended], so without this the flag stays true for the rest of the process
         // and the first-frame routing after an Activity recreation still believes the user is signed in.
@@ -230,7 +230,10 @@ class NavHostViewModel(
                     // The switch path never runs the login-side session machinery
                     // (AuthRepositoryImpl fires these on sign-in; logout/re-auth via onAuthComplete)
                     // so the incoming account's session state is fetched here.
-                    bannerStateHolder.fetchBanners()
+                    // Drop the outgoing account's banner before fetching: until this request
+                    // lands, the previous server's banner would render over the new one.
+                    bannerStateHolder.clearForAccountChange()
+                    bannerStateHolder.fetchBanner()
                     versionCheckStateHolder.checkBackendVersion()
                     sessionTaskRunner.runAll()
                 } else if (transition is AccountTransition.Ended) {
@@ -238,6 +241,9 @@ class NavHostViewModel(
                     // first-frame routing is correct. Nav-to-auth itself rides the session-expired
                     // signal emitted by the teardown.
                     _isLoggedIn.value = false
+                    // The banner belongs to the server just signed out of; the auth screens only
+                    // hide it, so without this it reappears the moment the next login navigates.
+                    bannerStateHolder.clearForAccountChange()
                 }
             }
         }
@@ -314,7 +320,7 @@ class NavHostViewModel(
         // login-from-logged-out, so that crossing is wired explicitly there. Session tasks
         // (role fetch, tag refresh, favorites sync) already fired from AuthRepositoryImpl on the
         // preceding login/OAuth/2FA success, so we don't re-run them here.
-        bannerStateHolder.fetchBanners()
+        bannerStateHolder.fetchBanner()
         versionCheckStateHolder.checkBackendVersion()
     }
 

--- a/shared/src/commonTest/kotlin/com/garfiec/librechat/shared/navigation/BannerStateHolderTest.kt
+++ b/shared/src/commonTest/kotlin/com/garfiec/librechat/shared/navigation/BannerStateHolderTest.kt
@@ -1,0 +1,151 @@
+package com.garfiec.librechat.shared.navigation
+
+import com.garfiec.librechat.core.common.result.Result
+import com.garfiec.librechat.core.data.repository.BannerRepository
+import com.garfiec.librechat.core.model.Banner
+import com.garfiec.librechat.core.network.client.ServerUrlProvider
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class BannerStateHolderTest {
+
+    private class FakeBannerRepository(var result: Result<Banner?>) : BannerRepository {
+        override suspend fun getBanner(): Result<Banner?> = result
+    }
+
+    private class FakeServerUrlProvider(var url: String = "https://one.example") : ServerUrlProvider {
+        override fun getBaseUrl(): String = url
+    }
+
+    /** Unconfined so [BannerStateHolder.fetchBanner]'s launch runs to completion inline. */
+    private fun holderFor(
+        result: Result<Banner?>,
+        serverUrlProvider: ServerUrlProvider = FakeServerUrlProvider(),
+    ): Pair<BannerStateHolder, FakeBannerRepository> {
+        val repository = FakeBannerRepository(result)
+        val holder =
+            BannerStateHolder(repository, serverUrlProvider, CoroutineScope(Dispatchers.Unconfined))
+        return holder to repository
+    }
+
+    private fun banner(id: String = "b1") = Banner(bannerId = id, message = "hello")
+
+    @Test
+    fun fetch_publishesTheBanner() {
+        val (holder, _) = holderFor(Result.Success(banner()))
+        holder.fetchBanner()
+        assertEquals("b1", holder.banner.value?.bannerId)
+    }
+
+    @Test
+    fun fetch_clearsWhenTheServerHasNoBanner() {
+        val (holder, repository) = holderFor(Result.Success(banner()))
+        holder.fetchBanner()
+        // e.g. switching to an account on a server with no banner configured.
+        repository.result = Result.Success(null)
+        holder.fetchBanner()
+        assertNull(holder.banner.value)
+    }
+
+    @Test
+    fun fetch_keepsTheBannerWhenTheSameServerFails() {
+        // A blip on the server that sent it is no reason to hide a banner it chose to send.
+        val (holder, repository) = holderFor(Result.Success(banner()))
+        holder.fetchBanner()
+        repository.result = Result.Error(RuntimeException("boom"), "boom")
+        holder.fetchBanner()
+        assertEquals("b1", holder.banner.value?.bannerId)
+    }
+
+    @Test
+    fun fetch_clearsACarriedOverBannerWhenANewServerFails() {
+        // Switching accounts to an unreachable server must not leave the previous server's banner
+        // on screen — it describes a deployment the user is no longer looking at.
+        val serverUrlProvider = FakeServerUrlProvider()
+        val (holder, repository) = holderFor(Result.Success(banner()), serverUrlProvider)
+        holder.fetchBanner()
+        serverUrlProvider.url = "https://two.example"
+        repository.result = Result.Error(RuntimeException("unreachable"), "unreachable")
+        holder.fetchBanner()
+        assertNull(holder.banner.value)
+    }
+
+    @Test
+    fun dismiss_hidesTheBannerAndSurvivesARefetchOfTheSameOne() {
+        val (holder, _) = holderFor(Result.Success(banner()))
+        holder.fetchBanner()
+        holder.dismissBanner("b1")
+        assertNull(holder.banner.value)
+        // onAuthComplete / a later switch re-fetches the identical banner; it must stay hidden.
+        holder.fetchBanner()
+        assertNull(holder.banner.value)
+    }
+
+    @Test
+    fun dismiss_survivesSwitchingAwayAndBack() {
+        // Dismiss A's banner, switch to B, switch back: A's must not return. Wiping dismissals on
+        // switch (or keying them by banner id alone) breaks exactly this.
+        val serverUrlProvider = FakeServerUrlProvider()
+        val (holder, repository) = holderFor(Result.Success(banner()), serverUrlProvider)
+        holder.fetchBanner()
+        holder.dismissBanner("b1")
+
+        serverUrlProvider.url = "https://two.example"
+        holder.clearForAccountChange()
+        repository.result = Result.Success(banner("b2"))
+        holder.fetchBanner()
+        assertEquals("b2", holder.banner.value?.bannerId)
+
+        serverUrlProvider.url = "https://one.example"
+        holder.clearForAccountChange()
+        repository.result = Result.Success(banner("b1"))
+        holder.fetchBanner()
+        assertNull(holder.banner.value)
+    }
+
+    @Test
+    fun dismiss_isScopedToTheServerThatSentTheBanner() {
+        // A fleet seeding one bannerId across its servers must not deliver B's pre-dismissed.
+        val serverUrlProvider = FakeServerUrlProvider()
+        val (holder, _) = holderFor(Result.Success(banner("shared-id")), serverUrlProvider)
+        holder.fetchBanner()
+        holder.dismissBanner("shared-id")
+
+        serverUrlProvider.url = "https://two.example"
+        holder.clearForAccountChange()
+        holder.fetchBanner()
+        assertEquals("shared-id", holder.banner.value?.bannerId)
+    }
+
+    @Test
+    fun dismiss_isIgnoredForAPersistableBanner() {
+        // The server says this one may not be dismissed, so a stray call must not hide it.
+        val persistable = Banner(bannerId = "b1", message = "hello", persistable = true)
+        val (holder, _) = holderFor(Result.Success(persistable))
+        holder.fetchBanner()
+        holder.dismissBanner("b1")
+        holder.fetchBanner()
+        assertEquals("b1", holder.banner.value?.bannerId)
+    }
+
+    @Test
+    fun clearForAccountChange_dropsTheBanner() {
+        val (holder, _) = holderFor(Result.Success(banner()))
+        holder.fetchBanner()
+        holder.clearForAccountChange()
+        assertNull(holder.banner.value)
+    }
+
+    @Test
+    fun clearForAccountChange_alsoDropsTheServerStampSoALaterFailureCannotResurrect() {
+        val (holder, repository) = holderFor(Result.Success(banner()))
+        holder.fetchBanner()
+        holder.clearForAccountChange()
+        repository.result = Result.Error(RuntimeException("unreachable"), "unreachable")
+        holder.fetchBanner()
+        assertNull(holder.banner.value)
+    }
+}


### PR DESCRIPTION
## Summary

The banner feature has never worked on any server. `BannerApi.getBanners()` decoded the response as
`List<Banner>`, but `GET /api/banner` returns **a single banner object, or nothing** — never an
array — so the decode failed in both possible states and `BannerStateHolder`, which only assigns on
success, silently stayed empty. On the common no-banner configuration it also threw on every cold
start, logging a stack trace as `Request failed (MalformedResponse)` in every diagnostic capture.

Verified against v0.8.7 and the pinned dev submodule, which carry a byte-identical route:
`res.status(200).send(await getBanner(req.user))`, where `getBanner` is
`(user?) => Promise<IBanner | null>` and the web client types the response `TBanner | null`.

Two distinct failures, one cause:

- **No banner configured** → Express's `res.send(null)` collapses `null` to `''` *before* the branch
  that would default the content type, so the response is `200`, `content-length: 0`, **no
  `Content-Type`**. `ContentNegotiation` never engages and `.body()` throws
  `NoTransformationFoundException`.
- **Banner configured** → the body is a JSON **object** decoded as an array → `SerializationException`.

## Changes

**Decode what the server actually sends** (`BannerApi`)

- `getBanner(): Banner?` reads the raw body and decodes it, following `ConfigApi.getEndpoints`,
  which needs the same treatment because this server can serve JSON under a `text/html` type. Only
  an empty or literal-`null` body means "no banner".
- Anything else still throws. An HTML body here means a proxy is answering for the API; only a
  Cloudflare Access challenge is typed (`GatewayDetectionPlugin`), so a cookie-based gateway or an
  SPA fallback reaches this decode, and swallowing it would make "the proxy is eating every
  response" indistinguishable from "no banner is configured" with nothing in the log.
- Uses the shared `librechatJson` rather than a fourth private copy.

**Model the response singularly, end to end** (`BannerRepository` → `BannerStateHolder` →
`NavHostViewModel` → `BannerDisplay`)

`List<Banner>` was never a wire shape — upstream uses `findOne`. Adapting only at the API boundary
would have preserved a plurality the server has never had, leaving every consumer with a
"which banner wins" question that has no answer.

**Keep banner state scoped to the deployment it came from** (`BannerStateHolder`)

- The holder is Activity-scoped and outlives account switches, so it records which server the held
  banner came from. A failed re-fetch clears a banner carried over from a *previous* server and
  keeps one for the current server, so a transient blip can't hide a live banner. This mirrors
  `VersionCheckStateHolder`.
- `clearForAccountChange()` drops the banner on account switch and on sign-out. The auth screens
  only hide it, so without this it reappears the moment the next login navigates.
- Dismissal is resolved here rather than in the UI: it nulls the banner and records a
  **(serverId, bannerId)** key for the process. Both halves of that key are load-bearing and pull
  in opposite directions — keyed by banner alone, a fleet that seeds one `bannerId` across its
  servers delivers the next server's banner pre-dismissed; cleared on switch, dismissing a banner
  and switching away and back brings it straight back.
- The client no longer re-applies the `displayFrom`/`displayTo` window. The server's query already
  filters it, nothing re-fetches on a timer so the client copy could not do the long-session job it
  claimed, and it could only ever subtract from the server's decision — a device clock running slow
  suppressed a banner the server had approved.

**Render it correctly** (`BannerDisplay`)

- Honours `persistable` by hiding the dismiss control rather than disabling it, matching web.
- A banner with no `bannerId` is not rendered: nothing could ever remove it, so it would stay
  pinned for the whole process. The pre-fix filter dropped these for the same reason.
- The `type` → info/warning/error mapping is deleted. The server's query filters `type: 'banner'`,
  so only the `else` branch was ever reachable; the values it switched on are not in the schema's
  enum. The hardcoded `Color(0xFFE3F2FD)` / `Color(0xFF0D47A1)` are replaced with
  `secondaryContainer`/`onSecondaryContainer` — the fixed blue was unreadable in dark mode and
  ignored the accent seed, whose hue tints every surface.
- The composable takes a nullable banner and decides visibility itself. Hoisting the null check to
  the callers adds and removes it from the tree instead of toggling it, so the enter/exit
  transitions never run.
- The dismiss label moves from a hardcoded English literal into `core/ui`'s string resources.

## Testing

- **Unit** — new `BannerApiTest` pins each wire shape: empty body with no `Content-Type` (the live
  capture), a banner object with Mongo-only fields, a literal `null`, an HTML page (must surface as
  an error, not as "no banner"), and malformed JSON. New `BannerStateHolderTest` covers publish,
  clear-on-empty, the same-server/different-server failure split, dismissal surviving a re-fetch and
  a switch away and back, per-server dismissal scoping, and persistable ignoring dismissal.
- **Gate** — `:app`, `:core:data`, `:core:network` and `:shared` unit tests,
  `detektMetadataCommonMain` (the task that covers `commonMain`), and `:app:lint`.
- **Device** — Pixel-class emulator against a LibreChat server. With no banner configured, the
  per-cold-start `MalformedResponse` from this path is gone. With one configured, the card renders
  above the chat content on both phone and tablet layouts, is legible in light and dark themes, the
  dismiss control removes it, and marking the banner `persistable` removes the control.
- **Not re-run on device:** the per-server dismissal scoping, the account-transition clearing and
  the display-window removal landed after that pass and are covered by unit tests only.
- **Not verified: iOS.** Every changed production file is `commonMain`, so all of it ships there and
  `Banner`'s shape is unchanged, but no iOS build or run was done.

## Notes

- Dismissal is in-memory for the process. Web persists it to `localStorage`, so a dismissed banner
  returns on the next cold start here. Deliberately out of scope; it needs a DataStore key and
  raises an account-scoping question of its own.
- `message` is rendered as plain text. Web sanitizes and renders it as HTML, so a banner containing
  a link shows raw markup here.
- The new `banner_dismiss` string is English-only; the nine locales in `core/ui` fall back.
- Six API classes now hand-roll some form of "a 2xx Ktor cannot convert", across four different
  intended outcomes. A shared decode helper is worth doing, but folding it in here would put four
  untested endpoints behind a brand-new abstraction.
- `BannerRepositoryImpl` still does not hop to IO; that belongs with the sweep in #326.

Closes #324
