### PR TITLE
fix(chat): keep generated images visible when their tool block collapses

### DIFF
--- a/core/model/src/commonMain/kotlin/com/garfiec/librechat/core/model/FileModel.kt
+++ b/core/model/src/commonMain/kotlin/com/garfiec/librechat/core/model/FileModel.kt
@@ -89,8 +89,8 @@ data class Attachment(
     val expiresAt: Long? = null,
     val width: Int? = null,
     val height: Int? = null,
-    /** File size. Only used to sink zero-byte placeholders below real output when ordering a
-     *  tool call's generated files (upstream `attachmentSalience`); absent means unreported. */
+    /** File size; null means the server did not report it, which is not the same as zero — a
+     *  zero-byte file is an empty placeholder and sorts last (see `attachmentSalience`). */
     val bytes: Long? = null,
     /** Deferred office-doc preview lifecycle (v0.8.6): `pending` while the server
      *  extracts HTML, `ready` once [text]/[textFormat] are set, `failed` on error.

--- a/core/model/src/commonMain/kotlin/com/garfiec/librechat/core/model/FileModel.kt
+++ b/core/model/src/commonMain/kotlin/com/garfiec/librechat/core/model/FileModel.kt
@@ -89,6 +89,9 @@ data class Attachment(
     val expiresAt: Long? = null,
     val width: Int? = null,
     val height: Int? = null,
+    /** File size. Only used to sink zero-byte placeholders below real output when ordering a
+     *  tool call's generated files (upstream `attachmentSalience`); absent means unreported. */
+    val bytes: Long? = null,
     /** Deferred office-doc preview lifecycle (v0.8.6): `pending` while the server
      *  extracts HTML, `ready` once [text]/[textFormat] are set, `failed` on error.
      *  Null for ordinary attachments (treated as already-ready). */

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/components/ContentPartRenderer.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/components/ContentPartRenderer.kt
@@ -20,6 +20,7 @@ actual fun ContentPartRenderer(
     searchFocusedOccurrence: Int,
     onFocusedOccurrencePosition: ((LayoutCoordinates, Rect) -> Unit)?,
     stateKey: String,
+    hideAttachments: Boolean,
 ) {
     ContentPartDispatcher(
         part = part,
@@ -33,5 +34,6 @@ actual fun ContentPartRenderer(
         searchFocusedOccurrence = searchFocusedOccurrence,
         onFocusedOccurrencePosition = onFocusedOccurrencePosition,
         stateKey = stateKey,
+        hideAttachments = hideAttachments,
     )
 }

--- a/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/components/ImageGenParsingTest.kt
+++ b/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/components/ImageGenParsingTest.kt
@@ -6,10 +6,9 @@ import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 
 /**
- * The settled (persisted) image-gen parse. Its streaming sibling is covered by
- * [StreamingImageGenParsingTest]; both had to move off "first attachment wins" together, since
- * `BranchMedia` resolves the gallery's URLs through them and a divergence there opens the wrong
- * image full-screen.
+ * The settled (persisted) image-gen parse; its streaming sibling is [StreamingImageGenParsingTest].
+ * The two must agree, because `BranchMedia` resolves the gallery's URLs through them and a
+ * divergence opens the wrong image full-screen.
  */
 class ImageGenParsingTest {
 

--- a/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/components/ImageGenParsingTest.kt
+++ b/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/components/ImageGenParsingTest.kt
@@ -1,0 +1,108 @@
+package com.garfiec.librechat.feature.chat.components
+
+import com.garfiec.librechat.core.model.Attachment
+import com.garfiec.librechat.core.model.content.AgentToolCall
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * The settled (persisted) image-gen parse. Its streaming sibling is covered by
+ * [StreamingImageGenParsingTest]; both had to move off "first attachment wins" together, since
+ * `BranchMedia` resolves the gallery's URLs through them and a divergence there opens the wrong
+ * image full-screen.
+ */
+class ImageGenParsingTest {
+
+    private val baseUrl = "https://chat.example.com"
+
+    @Test
+    fun `multiple attachments produce multiple image urls in arrival order`() {
+        val toolCall = AgentToolCall(id = "call_1", name = "image_gen_oai", output = "done")
+        val attachments = listOf(
+            Attachment(fileId = "f1", filepath = "/api/files/f1/one.png", toolCallId = "call_1"),
+            Attachment(fileId = "f2", filepath = "/api/files/f2/two.png", toolCallId = "call_1"),
+        )
+
+        val result = parseImageGenResult(toolCall, baseUrl, attachments)
+
+        assertThat(result.imageUrls).containsExactly(
+            "https://chat.example.com/api/files/f1/one.png",
+            "https://chat.example.com/api/files/f2/two.png",
+        ).inOrder()
+        assertThat(result.isGenerating).isFalse()
+    }
+
+    @Test
+    fun `ignores attachments belonging to another tool call`() {
+        val toolCall = AgentToolCall(id = "call_1", name = "image_gen_oai", output = "done")
+        val attachments = listOf(
+            Attachment(fileId = "f1", filepath = "/api/files/f1/one.png", toolCallId = "call_1"),
+            Attachment(fileId = "f9", filepath = "/api/files/f9/other.png", toolCallId = "call_2"),
+        )
+
+        assertThat(parseImageGenResult(toolCall, baseUrl, attachments).imageUrls)
+            .containsExactly("https://chat.example.com/api/files/f1/one.png")
+    }
+
+    @Test
+    fun `attachments win over the output json fallback`() {
+        val toolCall = AgentToolCall(
+            id = "call_1",
+            name = "image_gen_oai",
+            output = """{"url":"https://cdn.example.com/legacy.png"}""",
+        )
+        val attachments = listOf(
+            Attachment(fileId = "f1", filepath = "/api/files/f1/one.png", toolCallId = "call_1"),
+        )
+
+        assertThat(parseImageGenResult(toolCall, baseUrl, attachments).imageUrls)
+            .containsExactly("https://chat.example.com/api/files/f1/one.png")
+    }
+
+    @Test
+    fun `output json fallback still yields a single url when there are no attachments`() {
+        val toolCall = AgentToolCall(
+            id = "call_1",
+            name = "image_gen_oai",
+            output = """{"url":"https://cdn.example.com/legacy.png"}""",
+        )
+
+        val result = parseImageGenResult(toolCall, baseUrl, emptyList())
+
+        assertThat(result.imageUrls).containsExactly("https://cdn.example.com/legacy.png")
+        assertThat(result.isGenerating).isFalse()
+    }
+
+    @Test
+    fun `file id output fallback resolves against the base url`() {
+        val toolCall = AgentToolCall(
+            id = "call_1",
+            name = "image_gen_oai",
+            output = """{"file_id":"abc"}""",
+        )
+
+        assertThat(parseImageGenResult(toolCall, baseUrl, emptyList()).imageUrls)
+            .containsExactly("https://chat.example.com/api/files/abc")
+    }
+
+    @Test
+    fun `no output and no attachments still reads as generating`() {
+        val toolCall = AgentToolCall(id = "call_1", name = "image_gen_oai")
+
+        val result = parseImageGenResult(toolCall, baseUrl, emptyList())
+
+        assertThat(result.imageUrls).isEmpty()
+        assertThat(result.isGenerating).isTrue()
+    }
+
+    @Test
+    fun `duplicate attachment urls collapse`() {
+        val toolCall = AgentToolCall(id = "call_1", name = "image_gen_oai", output = "done")
+        val attachments = listOf(
+            Attachment(fileId = "f1", filepath = "/api/files/f1/one.png", toolCallId = "call_1"),
+            Attachment(fileId = "f1", filepath = "/api/files/f1/one.png", toolCallId = "call_1"),
+        )
+
+        assertThat(parseImageGenResult(toolCall, baseUrl, attachments).imageUrls).hasSize(1)
+    }
+}

--- a/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/components/StreamingImageGenParsingTest.kt
+++ b/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/components/StreamingImageGenParsingTest.kt
@@ -20,7 +20,7 @@ class StreamingImageGenParsingTest {
         val result = parseStreamingImageGenResult(toolCall, baseUrl, emptyList())
 
         assertThat(result.isGenerating).isTrue()
-        assertThat(result.imageUrl).isNull()
+        assertThat(result.imageUrls).isEmpty()
         assertThat(result.prompt).isEqualTo("a red fox")
         assertThat(result.quality).isEqualTo("high")
     }
@@ -39,7 +39,7 @@ class StreamingImageGenParsingTest {
         val result = parseStreamingImageGenResult(toolCall, baseUrl, attachments)
 
         assertThat(result.isGenerating).isFalse()
-        assertThat(result.imageUrl).isEqualTo("https://chat.example.com/api/files/f1/fox.png")
+        assertThat(result.imageUrls).containsExactly("https://chat.example.com/api/files/f1/fox.png")
         assertThat(result.prompt).isEqualTo("a red fox")
     }
 
@@ -53,7 +53,7 @@ class StreamingImageGenParsingTest {
         val result = parseStreamingImageGenResult(toolCall, baseUrl, attachments)
 
         assertThat(result.isGenerating).isTrue()
-        assertThat(result.imageUrl).isNull()
+        assertThat(result.imageUrls).isEmpty()
     }
 
     @Test
@@ -65,7 +65,36 @@ class StreamingImageGenParsingTest {
 
         val result = parseStreamingImageGenResult(toolCall, baseUrl, attachments)
 
-        assertThat(result.imageUrl).isEqualTo("https://cdn.example.com/img.png")
+        assertThat(result.imageUrls).containsExactly("https://cdn.example.com/img.png")
+    }
+
+    @Test
+    fun `every streamed attachment for the call becomes an image url in order`() {
+        val toolCall = ActiveToolCall(id = "call_1", name = "image_gen_oai", input = "{}")
+        val attachments = listOf(
+            Attachment(fileId = "f1", filepath = "/api/files/f1/one.png", toolCallId = "call_1"),
+            Attachment(fileId = "f2", filepath = "/api/files/f2/two.png", toolCallId = "call_1"),
+            Attachment(fileId = "f3", filepath = "/api/files/f3/three.png", toolCallId = "call_other"),
+        )
+
+        val result = parseStreamingImageGenResult(toolCall, baseUrl, attachments)
+
+        assertThat(result.imageUrls).containsExactly(
+            "https://chat.example.com/api/files/f1/one.png",
+            "https://chat.example.com/api/files/f2/two.png",
+        ).inOrder()
+        assertThat(result.isGenerating).isFalse()
+    }
+
+    @Test
+    fun `duplicate attachment urls collapse`() {
+        val toolCall = ActiveToolCall(id = "call_1", name = "image_gen_oai", input = "{}")
+        val attachments = listOf(
+            Attachment(fileId = "f1", filepath = "/api/files/f1/one.png", toolCallId = "call_1"),
+            Attachment(fileId = "f1", filepath = "/api/files/f1/one.png", toolCallId = "call_1"),
+        )
+
+        assertThat(parseStreamingImageGenResult(toolCall, baseUrl, attachments).imageUrls).hasSize(1)
     }
 
     @Test

--- a/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/components/ToolCallAttachmentsTest.kt
+++ b/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/components/ToolCallAttachmentsTest.kt
@@ -211,4 +211,171 @@ class ToolCallAttachmentsTest {
     fun `unknown extension yields no artifact`() {
         assertThat(attachmentToArtifact(Attachment(filename = "receipt.pdf", text = "%PDF"))).isNull()
     }
+
+    // ─── image classification ──────────────────────────────────────
+
+    @Test
+    fun `image mime routes to the image bucket without dimensions`() {
+        val result = partitionToolCallAttachments(
+            listOf(Attachment(fileId = "i", filename = "plot.png", type = "image/png", toolCallId = "c")),
+            "c",
+        )
+        assertThat(result.single()).isInstanceOf(ToolAttachment.Image::class.java)
+    }
+
+    @Test
+    fun `image filename routes to the image bucket without a mime type`() {
+        val result = partitionToolCallAttachments(
+            listOf(Attachment(fileId = "i", filename = "plot.png", toolCallId = "c")),
+            "c",
+        )
+        assertThat(result.single()).isInstanceOf(ToolAttachment.Image::class.java)
+    }
+
+    @Test
+    fun `image filepath alone routes to the image bucket`() {
+        val result = partitionToolCallAttachments(
+            listOf(Attachment(fileId = "i", filepath = "/api/files/i/render.WEBP", toolCallId = "c")),
+            "c",
+        )
+        assertThat(result.single()).isInstanceOf(ToolAttachment.Image::class.java)
+    }
+
+    @Test
+    fun `non image filename without a mime type stays a file chip`() {
+        val result = partitionToolCallAttachments(
+            listOf(Attachment(fileId = "d", filename = "data.bin", toolCallId = "c")),
+            "c",
+        )
+        assertThat(result.single()).isInstanceOf(ToolAttachment.File::class.java)
+    }
+
+    // svg is deliberately absent from the ported upstream extension list, so a type-less .svg keeps
+    // classifying on `attachmentToArtifact` alone exactly as before. It has no artifact branch
+    // either, so it lands as a chip — the point is that widening the list to be "complete" would
+    // silently reroute it into an image preview instead.
+    @Test
+    fun `type-less svg is unaffected by the filename image test`() {
+        val result = partitionToolCallAttachments(
+            listOf(Attachment(fileId = "s", filename = "chart.svg", text = "<svg/>", toolCallId = "c")),
+            "c",
+        )
+        assertThat(result.single()).isInstanceOf(ToolAttachment.File::class.java)
+    }
+
+    // ─── bucketToolAttachments ─────────────────────────────────────
+
+    @Test
+    fun `buckets render files first and images last`() {
+        val items = listOf<ToolAttachment>(
+            ToolAttachment.Image(Attachment(fileId = "i", filename = "a.png", type = "image/png")),
+            ToolAttachment.File(Attachment(fileId = "f", filename = "a.bin")),
+            ToolAttachment.Pdf(Attachment(fileId = "p", filename = "a.pdf", type = "application/pdf")),
+            ToolAttachment.ArtifactContent(
+                Attachment(fileId = "a", filename = "a.md", text = "# hi"),
+                attachmentToArtifact(Attachment(fileId = "a", filename = "a.md", text = "# hi"))!!,
+            ),
+        )
+
+        val buckets = bucketToolAttachments(items)
+
+        assertThat(buckets.map { it::class.java }).containsExactly(
+            ToolAttachmentBucket.Files::class.java,
+            ToolAttachmentBucket.Artifacts::class.java,
+            ToolAttachmentBucket.Pdfs::class.java,
+            ToolAttachmentBucket.Images::class.java,
+        ).inOrder()
+    }
+
+    @Test
+    fun `empty buckets are omitted`() {
+        val buckets = bucketToolAttachments(
+            listOf(ToolAttachment.Image(Attachment(fileId = "i", type = "image/png"))),
+        )
+        assertThat(buckets).hasSize(1)
+        assertThat(buckets.single()).isInstanceOf(ToolAttachmentBucket.Images::class.java)
+    }
+
+    @Test
+    fun `zero byte entries sink within their bucket and the rest keep arrival order`() {
+        val items = listOf<ToolAttachment>(
+            ToolAttachment.File(Attachment(fileId = "empty", filename = "empty.csv", bytes = 0L)),
+            ToolAttachment.File(Attachment(fileId = "real", filename = "real.csv", bytes = 42L)),
+            ToolAttachment.File(Attachment(fileId = "unreported", filename = "unreported.csv")),
+        )
+
+        val files = (bucketToolAttachments(items).single() as ToolAttachmentBucket.Files).items
+
+        assertThat(files.map { it.attachment.fileId })
+            .containsExactly("real", "unreported", "empty").inOrder()
+    }
+
+    // ─── collectGroupAttachments ───────────────────────────────────
+
+    @Test
+    fun `group attachments flatten across tool calls in id order`() {
+        val attachments = listOf(
+            Attachment(fileId = "b", filename = "b.png", type = "image/png", toolCallId = "call_2"),
+            Attachment(fileId = "a", filename = "a.png", type = "image/png", toolCallId = "call_1"),
+        )
+
+        val buckets = collectGroupAttachments(attachments, listOf("call_1", "call_2"))
+
+        val images = (buckets.single() as ToolAttachmentBucket.Images).items
+        assertThat(images.map { it.attachment.fileId }).containsExactly("a", "b").inOrder()
+    }
+
+    @Test
+    fun `group attachments dedupe by file id across calls`() {
+        val attachments = listOf(
+            Attachment(fileId = "shared", filename = "out.png", type = "image/png", toolCallId = "call_1"),
+            Attachment(fileId = "shared", filename = "out.png", type = "image/png", toolCallId = "call_2"),
+        )
+
+        val buckets = collectGroupAttachments(attachments, listOf("call_1", "call_2"))
+
+        assertThat((buckets.single() as ToolAttachmentBucket.Images).items).hasSize(1)
+    }
+
+    // The regression the fileId-only cross-call dedupe key exists to prevent: two calls each
+    // producing their own chart.png are two different files, not one reported twice.
+    @Test
+    fun `group attachments keep same named files from different calls when file id is absent`() {
+        val attachments = listOf(
+            Attachment(filename = "chart.png", type = "image/png", toolCallId = "call_1"),
+            Attachment(filename = "chart.png", type = "image/png", toolCallId = "call_2"),
+        )
+
+        val buckets = collectGroupAttachments(attachments, listOf("call_1", "call_2"))
+
+        assertThat((buckets.single() as ToolAttachmentBucket.Images).items).hasSize(2)
+    }
+
+    @Test
+    fun `empty tool call id list yields nothing`() {
+        val attachments = listOf(
+            Attachment(fileId = "a", filename = "a.png", type = "image/png", toolCallId = "call_1"),
+        )
+        assertThat(collectGroupAttachments(attachments, emptyList())).isEmpty()
+    }
+
+    @Test
+    fun `office preview attachments stay out of the group list`() {
+        val attachments = listOf(
+            Attachment(
+                fileId = "doc",
+                filename = "report.docx",
+                type = ArtifactType.DEFAULT_OFFICE_PREVIEW_MIME,
+                text = "<p>report</p>",
+                toolCallId = "call_1",
+            ),
+        )
+        assertThat(collectGroupAttachments(attachments, listOf("call_1"))).isEmpty()
+    }
+
+    @Test
+    fun `web search sources stay out of the group list`() {
+        val attachments = listOf(Attachment(fileId = "w", type = "web_search", toolCallId = "call_1"))
+        assertThat(collectGroupAttachments(attachments, listOf("call_1"))).isEmpty()
+    }
 }

--- a/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/components/ToolCallAttachmentsTest.kt
+++ b/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/components/ToolCallAttachmentsTest.kt
@@ -250,10 +250,8 @@ class ToolCallAttachmentsTest {
         assertThat(result.single()).isInstanceOf(ToolAttachment.File::class.java)
     }
 
-    // svg is deliberately absent from the ported upstream extension list, so a type-less .svg keeps
-    // classifying on `attachmentToArtifact` alone exactly as before. It has no artifact branch
-    // either, so it lands as a chip — the point is that widening the list to be "complete" would
-    // silently reroute it into an image preview instead.
+    // Guards the deliberate `svg` exclusion from IMAGE_EXTENSIONS: widening that list to be
+    // "complete" reroutes a type-less .svg out of the artifact path and into an image preview.
     @Test
     fun `type-less svg is unaffected by the filename image test`() {
         val result = partitionToolCallAttachments(
@@ -337,8 +335,6 @@ class ToolCallAttachmentsTest {
         assertThat((buckets.single() as ToolAttachmentBucket.Images).items).hasSize(1)
     }
 
-    // The regression the fileId-only cross-call dedupe key exists to prevent: two calls each
-    // producing their own chart.png are two different files, not one reported twice.
     @Test
     fun `group attachments keep same named files from different calls when file id is absent`() {
         val attachments = listOf(

--- a/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/util/BranchMediaTest.kt
+++ b/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/util/BranchMediaTest.kt
@@ -1,0 +1,135 @@
+package com.garfiec.librechat.feature.chat.util
+
+import com.garfiec.librechat.core.model.Attachment
+import com.garfiec.librechat.core.model.ContentType
+import com.garfiec.librechat.core.model.Message
+import com.garfiec.librechat.core.model.content.AgentToolCall
+import com.garfiec.librechat.core.model.content.MessageContentPart
+import com.garfiec.librechat.feature.chat.viewmodel.ActiveToolCall
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * The gallery's contract is that it resolves the exact same URLs the message renderers show. That
+ * is why these read through the same `parseImageGenResult` / `parseStreamingImageGenResult` the
+ * cards use: resolving independently is how tapping image #2 of 3 ends up opening image #1.
+ */
+class BranchMediaTest {
+
+    private val baseUrl = "https://chat.example.com"
+
+    private fun node(message: Message) =
+        MessageNode(message = message, children = emptyList(), siblingIndex = 0, siblingCount = 1)
+
+    private fun imageGenPart(toolCallId: String) = MessageContentPart(
+        type = ContentType.TOOL_CALL,
+        toolCall = AgentToolCall(id = toolCallId, name = "image_gen_oai", output = "done"),
+    )
+
+    private fun message(id: String, parts: List<MessageContentPart>, attachments: List<Attachment>) =
+        Message(
+            messageId = id,
+            conversationId = "c1",
+            text = "",
+            content = parts,
+            attachments = attachments,
+        )
+
+    @Test
+    fun `one image gen call surfaces every image it produced`() {
+        val message = message(
+            id = "m1",
+            parts = listOf(imageGenPart("call_1")),
+            attachments = listOf(
+                Attachment(fileId = "f1", filepath = "/api/files/f1/one.png", toolCallId = "call_1"),
+                Attachment(fileId = "f2", filepath = "/api/files/f2/two.png", toolCallId = "call_1"),
+                Attachment(fileId = "f3", filepath = "/api/files/f3/three.png", toolCallId = "call_1"),
+            ),
+        )
+
+        val media = collectMessageMedia(message, baseUrl)
+
+        assertThat(media.map { it.url }).containsExactly(
+            "https://chat.example.com/api/files/f1/one.png",
+            "https://chat.example.com/api/files/f2/two.png",
+            "https://chat.example.com/api/files/f3/three.png",
+        ).inOrder()
+    }
+
+    @Test
+    fun `two image gen calls in one message surface in content order`() {
+        val message = message(
+            id = "m1",
+            parts = listOf(imageGenPart("call_1"), imageGenPart("call_2")),
+            attachments = listOf(
+                Attachment(fileId = "f2", filepath = "/api/files/f2/two.png", toolCallId = "call_2"),
+                Attachment(fileId = "f1", filepath = "/api/files/f1/one.png", toolCallId = "call_1"),
+            ),
+        )
+
+        val media = collectMessageMedia(message, baseUrl)
+
+        assertThat(media.map { it.url }).containsExactly(
+            "https://chat.example.com/api/files/f1/one.png",
+            "https://chat.example.com/api/files/f2/two.png",
+        ).inOrder()
+    }
+
+    @Test
+    fun `the in flight streaming call contributes every image it has so far`() {
+        val media = extractBranchMedia(
+            displayMessages = emptyList(),
+            activeToolCalls = listOf(ActiveToolCall(id = "call_1", name = "image_gen_oai", input = "{}")),
+            streamingAttachments = listOf(
+                Attachment(fileId = "s1", filepath = "/api/files/s1/a.png", toolCallId = "call_1"),
+                Attachment(fileId = "s2", filepath = "/api/files/s2/b.png", toolCallId = "call_1"),
+            ),
+            baseUrl = baseUrl,
+        )
+
+        assertThat(media.map { it.url }).containsExactly(
+            "https://chat.example.com/api/files/s1/a.png",
+            "https://chat.example.com/api/files/s2/b.png",
+        ).inOrder()
+    }
+
+    @Test
+    fun `persisted and streaming images are deduped by url`() {
+        val message = message(
+            id = "m1",
+            parts = listOf(imageGenPart("call_1")),
+            attachments = listOf(
+                Attachment(fileId = "f1", filepath = "/api/files/f1/one.png", toolCallId = "call_1"),
+            ),
+        )
+
+        val media = extractBranchMedia(
+            displayMessages = listOf(node(message)),
+            activeToolCalls = listOf(ActiveToolCall(id = "call_1", name = "image_gen_oai", input = "{}")),
+            streamingAttachments = listOf(
+                Attachment(fileId = "f1", filepath = "/api/files/f1/one.png", toolCallId = "call_1"),
+            ),
+            baseUrl = baseUrl,
+        )
+
+        assertThat(media).hasSize(1)
+    }
+
+    @Test
+    fun `a non image gen tool call contributes nothing`() {
+        val message = message(
+            id = "m1",
+            parts = listOf(
+                MessageContentPart(
+                    type = ContentType.TOOL_CALL,
+                    toolCall = AgentToolCall(id = "call_1", name = "web_search", output = "done"),
+                ),
+            ),
+            attachments = listOf(
+                Attachment(fileId = "f1", filepath = "/api/files/f1/one.png", toolCallId = "call_1"),
+            ),
+        )
+
+        assertThat(collectMessageMedia(message, baseUrl)).isEmpty()
+    }
+}

--- a/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/util/BranchMediaTest.kt
+++ b/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/util/BranchMediaTest.kt
@@ -10,9 +10,9 @@ import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 
 /**
- * The gallery's contract is that it resolves the exact same URLs the message renderers show. That
- * is why these read through the same `parseImageGenResult` / `parseStreamingImageGenResult` the
- * cards use: resolving independently is how tapping image #2 of 3 ends up opening image #1.
+ * The gallery must resolve the exact same URLs the message renderers show, so it reads through the
+ * same `parseImageGenResult` / `parseStreamingImageGenResult` the cards use — resolving
+ * independently is how tapping image #2 of 3 ends up opening image #1.
  */
 class BranchMediaTest {
 

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ActivityGroup.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ActivityGroup.kt
@@ -73,6 +73,20 @@ internal fun ActivityGroup(
     // a collapsed group swallows a match the user just navigated to.
     autoExpand: Boolean = false,
     autoExpandKey: Any? = null,
+    /**
+     * The files this block's tool calls produced.
+     *
+     * **Load-bearing: rendered as a SIBLING AFTER the collapsible, never inside it.** The block
+     * exists to fold away the *process*; a generated image is the *result*, and folding the result
+     * with it is how multiple generated images disappeared into a "Used 2 tools" header. Upstream
+     * pins the same structure — `ToolCallGroup.tsx` places `<AttachmentGroup>` after the
+     * collapsible div, asserted by `__tests__/ToolCallGroup.test.tsx`. This module has no Compose
+     * test harness, so that assertion has no mobile counterpart and this comment is the contract.
+     *
+     * Unindented on purpose: the body carries the group's indent, the hoisted output reads at the
+     * message's own level. The slot supplies its own top padding so an empty one costs nothing.
+     */
+    hoistedAttachments: @Composable () -> Unit = {},
     body: @Composable () -> Unit,
 ) {
     // Saveable and keyed on the group: this is a LazyColumn item, so scrolling the message out of
@@ -163,6 +177,9 @@ internal fun ActivityGroup(
                 body()
             }
         }
+
+        // Outside the AnimatedVisibility — see the parameter's KDoc.
+        hoistedAttachments()
     }
 }
 

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ActivityGroup.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ActivityGroup.kt
@@ -77,11 +77,9 @@ internal fun ActivityGroup(
      * The files this block's tool calls produced.
      *
      * **Load-bearing: rendered as a SIBLING AFTER the collapsible, never inside it.** The block
-     * exists to fold away the *process*; a generated image is the *result*, and folding the result
-     * with it is how multiple generated images disappeared into a "Used 2 tools" header. Upstream
-     * pins the same structure — `ToolCallGroup.tsx` places `<AttachmentGroup>` after the
-     * collapsible div, asserted by `__tests__/ToolCallGroup.test.tsx`. This module has no Compose
-     * test harness, so that assertion has no mobile counterpart and this comment is the contract.
+     * folds away the *process*; a generated image is the *result*, and moving this inside folds
+     * the result away with it. Upstream pins the same structure in `ToolCallGroup.tsx`
+     * (`__tests__/ToolCallGroup.test.tsx`); this module has no Compose harness to assert it.
      *
      * Unindented on purpose: the body carries the group's indent, the hoisted output reads at the
      * message's own level. The slot supplies its own top padding so an empty one costs nothing.

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ImageGenCard.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ImageGenCard.kt
@@ -2,6 +2,7 @@ package com.garfiec.librechat.feature.chat.components
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -26,6 +27,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -47,7 +49,16 @@ import kotlin.math.pow
 import kotlin.random.Random
 
 data class ImageGenResult(
-    val imageUrl: String? = null,
+    /**
+     * Every image the call produced, in attachment arrival order.
+     *
+     * Deliberately a list where upstream renders only `attachments?.[0]` (`OpenAIImageGen.tsx`):
+     * one image-gen call routinely returns several images, and dropping all but the first is the
+     * same class of defect as burying them in a collapsed block. There is intentionally no
+     * single-image convenience accessor — a shadow `imageUrl` is exactly how a caller keeps
+     * silently showing one of N.
+     */
+    val imageUrls: List<String> = emptyList(),
     val prompt: String? = null,
     val isGenerating: Boolean = false,
     /** Image-gen quality ("low" | "medium" | "high"). Tunes the faux-progress
@@ -55,12 +66,21 @@ data class ImageGenResult(
     val quality: String? = null,
 )
 
-/** Renders a DALL-E / image generation result card. [ImageGenResult.isGenerating] drives spinner vs image display. */
+/**
+ * Renders a DALL-E / image generation result card. [ImageGenResult.isGenerating] drives spinner vs
+ * image display.
+ *
+ * [hideImages] suppresses the media block only — the header, progress and prompt still render, so a
+ * card inside an activity group whose images were hoisted out still reads as "an image was
+ * generated, here is what it was". Web gates the same way (`isAgentStyle && !hideAttachments`
+ * wraps the image block while the icon and progress text sit outside it).
+ */
 @Composable
 fun ImageGenCard(
     result: ImageGenResult,
     modifier: Modifier = Modifier,
     showDescription: Boolean = true,
+    hideImages: Boolean = false,
 ) {
     val openMedia = LocalChatMediaViewer.current
 
@@ -131,74 +151,45 @@ fun ImageGenCard(
                 }
             }
 
-            Spacer(modifier = Modifier.height(8.dp))
+            if (!hideImages) {
+                Spacer(modifier = Modifier.height(8.dp))
 
-            val imageUrl = result.imageUrl
-            if (imageUrl != null) {
-                SubcomposeAsyncImage(
-                    model = imageUrl,
-                    contentDescription = result.prompt ?: stringResource(Res.string.cd_generated_image),
-                    contentScale = ContentScale.FillWidth,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .heightIn(max = 300.dp)
-                        .clip(RoundedCornerShape(8.dp))
-                        .clickable { openMedia(imageUrl) }
-                        .semantics { role = Role.Image },
-                    loading = {
-                        Box(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .height(160.dp)
-                                .background(
-                                    MaterialTheme.colorScheme.surfaceContainerHighest,
-                                    RoundedCornerShape(8.dp),
-                                ),
-                            contentAlignment = Alignment.Center,
-                        ) {
-                            CircularProgressIndicator(modifier = Modifier.size(24.dp))
+                val imageDescription = result.prompt ?: stringResource(Res.string.cd_generated_image)
+                if (result.imageUrls.isNotEmpty()) {
+                    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                        result.imageUrls.forEach { url ->
+                            key(url) {
+                                GeneratedImage(
+                                    url = url,
+                                    contentDescription = imageDescription,
+                                    onClick = { openMedia(url) },
+                                )
+                            }
                         }
-                    },
-                    error = {
-                        Box(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .height(120.dp)
-                                .background(
-                                    MaterialTheme.colorScheme.surfaceContainerHighest,
-                                    RoundedCornerShape(8.dp),
-                                ),
-                            contentAlignment = Alignment.Center,
-                        ) {
-                            Icon(
-                                imageVector = Icons.Default.BrokenImage,
-                                contentDescription = stringResource(Res.string.cd_failed_to_load_generated_image),
-                                modifier = Modifier.size(32.dp),
-                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                            )
-                        }
-                    },
-                )
-            } else if (result.isGenerating) {
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(160.dp)
-                        .clip(RoundedCornerShape(8.dp))
-                        .background(MaterialTheme.colorScheme.surfaceContainerHighest),
-                ) {
-                    PixelRevealCard(
-                        progress = fauxProgress,
-                        modifier = Modifier.fillMaxSize(),
-                        colors = listOf(
-                            MaterialTheme.colorScheme.primary.copy(alpha = 0.35f),
-                            MaterialTheme.colorScheme.primary.copy(alpha = 0.6f),
-                            MaterialTheme.colorScheme.primary.copy(alpha = 0.9f),
-                        ),
-                    )
+                    }
+                } else if (result.isGenerating) {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(160.dp)
+                            .clip(RoundedCornerShape(8.dp))
+                            .background(MaterialTheme.colorScheme.surfaceContainerHighest),
+                    ) {
+                        PixelRevealCard(
+                            progress = fauxProgress,
+                            modifier = Modifier.fillMaxSize(),
+                            colors = listOf(
+                                MaterialTheme.colorScheme.primary.copy(alpha = 0.35f),
+                                MaterialTheme.colorScheme.primary.copy(alpha = 0.6f),
+                                MaterialTheme.colorScheme.primary.copy(alpha = 0.9f),
+                            ),
+                        )
+                    }
                 }
             }
 
+            // Kept even under hideImages: it is the card's own text, not an attachment, and it is
+            // what tells a reader of a collapsed group what was generated.
             val prompt = result.prompt
             if (showDescription && !prompt.isNullOrBlank()) {
                 Spacer(modifier = Modifier.height(8.dp))
@@ -210,4 +201,52 @@ fun ImageGenCard(
             }
         }
     }
+}
+
+@Composable
+private fun GeneratedImage(url: String, contentDescription: String, onClick: () -> Unit) {
+    SubcomposeAsyncImage(
+        model = url,
+        contentDescription = contentDescription,
+        contentScale = ContentScale.FillWidth,
+        modifier = Modifier
+            .fillMaxWidth()
+            .heightIn(max = 300.dp)
+            .clip(RoundedCornerShape(8.dp))
+            .clickable(onClick = onClick)
+            .semantics { role = Role.Image },
+        loading = {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(160.dp)
+                    .background(
+                        MaterialTheme.colorScheme.surfaceContainerHighest,
+                        RoundedCornerShape(8.dp),
+                    ),
+                contentAlignment = Alignment.Center,
+            ) {
+                CircularProgressIndicator(modifier = Modifier.size(24.dp))
+            }
+        },
+        error = {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(120.dp)
+                    .background(
+                        MaterialTheme.colorScheme.surfaceContainerHighest,
+                        RoundedCornerShape(8.dp),
+                    ),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    imageVector = Icons.Default.BrokenImage,
+                    contentDescription = stringResource(Res.string.cd_failed_to_load_generated_image),
+                    modifier = Modifier.size(32.dp),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        },
+    )
 }

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ImageGenCard.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ImageGenCard.kt
@@ -50,13 +50,11 @@ import kotlin.random.Random
 
 data class ImageGenResult(
     /**
-     * Every image the call produced, in attachment arrival order.
+     * Every image the call produced, in attachment arrival order — one call routinely returns
+     * several. A list where upstream renders only `attachments?.[0]` (`OpenAIImageGen.tsx`).
      *
-     * Deliberately a list where upstream renders only `attachments?.[0]` (`OpenAIImageGen.tsx`):
-     * one image-gen call routinely returns several images, and dropping all but the first is the
-     * same class of defect as burying them in a collapsed block. There is intentionally no
-     * single-image convenience accessor — a shadow `imageUrl` is exactly how a caller keeps
-     * silently showing one of N.
+     * Deliberately has no single-image convenience accessor: a shadow `imageUrl` is how a caller
+     * ends up silently showing one of N.
      */
     val imageUrls: List<String> = emptyList(),
     val prompt: String? = null,
@@ -72,8 +70,7 @@ data class ImageGenResult(
  *
  * [hideImages] suppresses the media block only — the header, progress and prompt still render, so a
  * card inside an activity group whose images were hoisted out still reads as "an image was
- * generated, here is what it was". Web gates the same way (`isAgentStyle && !hideAttachments`
- * wraps the image block while the icon and progress text sit outside it).
+ * generated, here is what it was". Web gates the same way in `OpenAIImageGen.tsx`.
  */
 @Composable
 fun ImageGenCard(
@@ -188,7 +185,7 @@ fun ImageGenCard(
                 }
             }
 
-            // Kept even under hideImages: it is the card's own text, not an attachment, and it is
+            // Outside the hideImages gate on purpose: the prompt is the card's own text, and it is
             // what tells a reader of a collapsed group what was generated.
             val prompt = result.prompt
             if (showDescription && !prompt.isNullOrBlank()) {

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/MessageContentAndActions.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/MessageContentAndActions.kt
@@ -55,6 +55,7 @@ import com.garfiec.librechat.feature.chat.util.ContentGroup
 import com.garfiec.librechat.feature.chat.util.IndexedContentPart
 import com.garfiec.librechat.feature.chat.util.activityLabelText
 import com.garfiec.librechat.feature.chat.util.groupContentParts
+import com.garfiec.librechat.feature.chat.util.groupedToolCallIds
 import com.garfiec.librechat.feature.chat.util.steerText
 import org.jetbrains.compose.resources.stringResource
 
@@ -365,7 +366,7 @@ internal fun MessageContentAndActions(
                     }
 
                     @Composable
-                    fun PartContent(entry: IndexedContentPart) {
+                    fun PartContent(entry: IndexedContentPart, hideAttachments: Boolean = false) {
                         val part = entry.part
                         val focusedInPart =
                             if (isCurrentSearchMatch) searchFocusedOccurrence - partOffsets[entry.index] else -1
@@ -393,6 +394,7 @@ internal fun MessageContentAndActions(
                                 searchFocusedOccurrence = focusedInPart,
                                 onFocusedOccurrencePosition = if (isCurrentSearchMatch) onFocusedOccurrencePosition else null,
                                 stateKey = "${message.messageId}:${entry.index}",
+                                hideAttachments = hideAttachments,
                                 modifier = Modifier.padding(vertical = 2.dp),
                             )
                         }
@@ -419,14 +421,40 @@ internal fun MessageContentAndActions(
                                     key(group.key) {
                                         when (group) {
                                             is ContentGroup.Single -> PartContent(group.entry)
-                                            is ContentGroup.Activity -> ActivityGroup(
-                                                group = group,
-                                                stateKey = "${message.messageId}:${group.key}",
-                                                autoExpand = group.key == focusedGroupKey,
-                                                autoExpandKey = LocalSearchFocusNonce.current,
-                                            ) {
-                                                group.entries.forEach { entry ->
-                                                    key(entry.index) { PartContent(entry) }
+                                            is ContentGroup.Activity -> {
+                                                // The block's own output, lifted out so folding the
+                                                // process does not fold the result away with it.
+                                                val hoisted = remember(message.attachments, group) {
+                                                    collectGroupAttachments(
+                                                        message.attachments.orEmpty(),
+                                                        group.groupedToolCallIds(),
+                                                    )
+                                                }
+                                                ActivityGroup(
+                                                    group = group,
+                                                    stateKey = "${message.messageId}:${group.key}",
+                                                    autoExpand = group.key == focusedGroupKey,
+                                                    autoExpandKey = LocalSearchFocusNonce.current,
+                                                    hoistedAttachments = {
+                                                        // Chrome, like the office-preview block
+                                                        // below: the inline path gets this from the
+                                                        // dispatcher, the hoisted one sits outside
+                                                        // it and would leak filenames into
+                                                        // "Select all".
+                                                        DisableSelection {
+                                                            ToolAttachmentBuckets(
+                                                                buckets = hoisted,
+                                                                baseUrl = baseUrl,
+                                                                modifier = Modifier.padding(top = 4.dp),
+                                                            )
+                                                        }
+                                                    },
+                                                ) {
+                                                    group.entries.forEach { entry ->
+                                                        key(entry.index) {
+                                                            PartContent(entry, hideAttachments = true)
+                                                        }
+                                                    }
                                                 }
                                             }
                                         }

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/MessageContentAndActions.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/MessageContentAndActions.kt
@@ -422,8 +422,6 @@ internal fun MessageContentAndActions(
                                         when (group) {
                                             is ContentGroup.Single -> PartContent(group.entry)
                                             is ContentGroup.Activity -> {
-                                                // The block's own output, lifted out so folding the
-                                                // process does not fold the result away with it.
                                                 val hoisted = remember(message.attachments, group) {
                                                     collectGroupAttachments(
                                                         message.attachments.orEmpty(),
@@ -436,11 +434,10 @@ internal fun MessageContentAndActions(
                                                     autoExpand = group.key == focusedGroupKey,
                                                     autoExpandKey = LocalSearchFocusNonce.current,
                                                     hoistedAttachments = {
-                                                        // Chrome, like the office-preview block
-                                                        // below: the inline path gets this from the
-                                                        // dispatcher, the hoisted one sits outside
-                                                        // it and would leak filenames into
-                                                        // "Select all".
+                                                        // Required: the inline path gets this from
+                                                        // the dispatcher, the hoisted one sits
+                                                        // outside it and would otherwise leak
+                                                        // filenames into "Select all".
                                                         DisableSelection {
                                                             ToolAttachmentBuckets(
                                                                 buckets = hoisted,

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/PlatformChatComponents.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/PlatformChatComponents.kt
@@ -69,6 +69,10 @@ expect fun ContentPartRenderer(
     // wrong part once grouping wraps parts, and is dropped outright when the lazy item scrolls
     // out of the viewport.
     stateKey: String = "",
+    // True while rendering inside an activity group, whose tool calls' files are hoisted out and
+    // rendered below the collapsible instead. Without it a generated image would render twice
+    // when the block is open and vanish when it folds.
+    hideAttachments: Boolean = false,
 )
 
 /** Platform-specific markdown content rendering. */

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/PlatformChatComponents.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/PlatformChatComponents.kt
@@ -70,8 +70,8 @@ expect fun ContentPartRenderer(
     // out of the viewport.
     stateKey: String = "",
     // True while rendering inside an activity group, whose tool calls' files are hoisted out and
-    // rendered below the collapsible instead. Without it a generated image would render twice
-    // when the block is open and vanish when it folds.
+    // rendered below the collapsible instead. Without it they render twice while the block is
+    // open, and vanish with it when it folds.
     hideAttachments: Boolean = false,
 )
 

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/SharedContentParts.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/SharedContentParts.kt
@@ -54,6 +54,8 @@ internal fun ContentPartDispatcher(
     // When false, a `subagent` tool_call renders flat instead of as a trace card.
     // Set false while rendering a subagent's own nested parts (depth-1 guard).
     allowSubagentCard: Boolean = true,
+    // True while rendering inside an activity group, which hoists its tool calls' files out.
+    hideAttachments: Boolean = false,
 ) {
     val mod = modifier.fillMaxWidth()
     when (part.type) {
@@ -91,6 +93,7 @@ internal fun ContentPartDispatcher(
                 showImageDescriptions = showImageDescriptions,
                 stateKey = stateKey,
                 allowSubagentCard = allowSubagentCard,
+                hideAttachments = hideAttachments,
             )
         }
         ContentType.IMAGE_FILE -> DisableSelection {

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ToolCallAttachments.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ToolCallAttachments.kt
@@ -86,13 +86,9 @@ private val SANDBOX_PLACEHOLDER = Regex("""^_\.(?:dirkeep|gitkeep)-[0-9a-f]{6}$"
  *  Upstream `SANITIZED_DOTFILE_PATTERN`. */
 private val SANITIZED_DOTFILE = Regex("""^_\.(.+?)-[0-9a-f]{6}(\.[^.]+)?$""", RegexOption.IGNORE_CASE)
 
-/**
- * Upstream `imageExtRegex` (`packages/data-provider/src/file-config.ts`), copied verbatim.
- *
- * Deliberately excludes `svg`, `bmp` and `avif` even though they are images: an `.svg` the server
- * extracted text for renders far better as an artifact, and widening this list to be "complete"
- * would silently move it out of [ToolAttachment.ArtifactContent].
- */
+/** Upstream `imageExtRegex` (`packages/data-provider/src/file-config.ts`), verbatim. Excluding
+ *  `svg`/`bmp`/`avif` is deliberate: an `.svg` the server extracted text for belongs in
+ *  [ToolAttachment.ArtifactContent], and "completing" this list silently moves it out. */
 private val IMAGE_EXTENSIONS = Regex("""\.(?:jpg|jpeg|png|gif|webp|heic|heif)$""", RegexOption.IGNORE_CASE)
 
 /** Extensions rendered as syntax-highlighted code (fenced markdown) in the artifacts panel. */
@@ -142,13 +138,9 @@ internal fun partitionToolCallAttachments(
  * hoisted counterpart of [partitionToolCallAttachments]. Mirrors upstream's per-group
  * `groupAttachments` (`ContentParts.tsx`) fed into `AttachmentGroup` (`Attachment.tsx`).
  *
- * Built by running the single-call partition per id rather than by a bulk filter, so the hoisted
- * and inline paths can never disagree about *what* is renderable.
- *
- * Cross-call dedupe is by `fileId` **only**. Two different calls may legitimately each emit a
- * `chart.png` carrying no fileId, and collapsing those on filename would drop real output — the
- * per-call filename dedupe inside [partitionToolCallAttachments] still applies within one call.
- * Pure — unit-tested.
+ * Cross-call dedupe is by `fileId` **only**: two calls may each legitimately emit a `chart.png`
+ * carrying no fileId, and collapsing those on filename drops real output. The per-call filename
+ * dedupe inside [partitionToolCallAttachments] still applies within one call. Pure — unit-tested.
  */
 internal fun collectGroupAttachments(
     attachments: List<Attachment>,
@@ -163,13 +155,7 @@ internal fun collectGroupAttachments(
             },
     )
 
-/**
- * One run of same-kind attachments, emitted in final render order; empty runs are omitted.
- *
- * The render order is the *return* order of [bucketToolAttachments] rather than the declaration
- * order of a composable, which is the only way it can be pinned — this module has no Compose test
- * harness.
- */
+/** One run of same-kind attachments, emitted in final render order; empty runs are omitted. */
 internal sealed interface ToolAttachmentBucket {
     val items: List<ToolAttachment>
 
@@ -181,17 +167,11 @@ internal sealed interface ToolAttachmentBucket {
 
 /**
  * Buckets [items] into upstream `AttachmentGroup`'s render order: files → artifacts → previews →
- * **images last** (`Attachment.tsx`). Mobile's order was images-first; the swap is what keeps a
- * long generated image from pushing the files that describe it off screen.
+ * **images last** (`Attachment.tsx`), each bucket stable-sorted by [attachmentSalience].
  *
- * Two deliberate mapping choices, because the buckets do not line up 1:1. Upstream's separate
- * mermaid and inline-text buckets fold into [ToolAttachment.ArtifactContent] — `.mmd` already maps
- * to `application/vnd.mermaid` there and all three render as the same button, so their position
- * relative to files and images is preserved. [ToolAttachment.Pdf] has no upstream counterpart (a
- * PDF falls to web's generic file row) and sits with the artifacts: like them it is a card that
- * opens a preview, not a download chip.
- *
- * Each bucket is stable-sorted by [attachmentSalience]. Pure — unit-tested.
+ * The buckets do not line up 1:1 with upstream's: [ToolAttachment.ArtifactContent] covers its
+ * separate mermaid and inline-text buckets, and [ToolAttachment.Pdf] (no upstream counterpart)
+ * sits with the artifacts. Pure — unit-tested.
  */
 internal fun bucketToolAttachments(items: List<ToolAttachment>): List<ToolAttachmentBucket> {
     fun <T : ToolAttachment> List<T>.bySalience(): List<T> = sortedBy { attachmentSalience(it.attachment) }
@@ -207,22 +187,16 @@ internal fun bucketToolAttachments(items: List<ToolAttachment>): List<ToolAttach
     )
 }
 
-/**
- * Upstream `attachmentSalience` (`attachmentTypes.ts`): a zero-byte file is an empty placeholder
- * and sinks below real output within its bucket. An absent `bytes` weighs 0 — the server simply
- * did not report it, matching JS where `undefined === 0` is false.
- */
+/** Upstream `attachmentSalience` (`attachmentTypes.ts`): a zero-byte file is an empty placeholder
+ *  and sinks below real output within its bucket. An absent `bytes` is unreported, not zero, and
+ *  must not sink with it. */
 private fun attachmentSalience(attachment: Attachment): Int = if (attachment.bytes == 0L) 1 else 0
 
 /**
  * Mirrors upstream `isImageAttachment` (`attachmentTypes.ts`) on the MIME and filename halves, and
- * deliberately drops its `width`/`height`/`filepath` requirements.
- *
- * Upstream needs the dimensions to reserve DOM layout space; mobile renders through
- * `SubcomposeAsyncImage` with its own loading slot and a height cap, so a dimensionless image lays
- * out fine — and requiring them would *hide* every image whose `attachment` event omitted them,
- * which is the failure this classification exists to prevent. `filepath` is likewise optional:
- * `resolveAttachmentUrl` falls back to `$baseUrl/api/files/$fileId`.
+ * deliberately drops its `width`/`height`/`filepath` requirements: upstream needs the dimensions
+ * to reserve DOM layout space, and requiring them here would *hide* every image whose `attachment`
+ * event omitted them. `resolveAttachmentUrl` falls back to `$baseUrl/api/files/$fileId`.
  */
 private fun isImageAttachment(attachment: Attachment): Boolean =
     attachment.type?.startsWith("image/") == true ||
@@ -332,8 +306,7 @@ internal fun ToolCallAttachments(
 
 /**
  * Renders pre-bucketed attachments in the order [bucketToolAttachments] returned them. Shared by
- * the per-tool-call path and the hoisted-out-of-an-activity-group path, so both sort and present a
- * tool's output identically.
+ * the per-tool-call path and the hoisted-out-of-an-activity-group path.
  *
  * Emits no searchable text of its own — no section headers. `SearchMatchEnumeration` counts zero
  * occurrences for tool calls and images, and the renderer walks the same function, so a heading
@@ -390,7 +363,7 @@ internal fun ToolAttachmentBuckets(
                     } else {
                         // Classification is by MIME *or* extension, so an entry can reach this
                         // bucket with nothing resolvable to load. Degrade to a chip rather than
-                        // rendering nothing, which is how a generated file goes missing silently.
+                        // rendering nothing, which loses the file silently.
                         AttachmentDownloadChip(attachment = item.attachment)
                     }
                 }

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ToolCallAttachments.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ToolCallAttachments.kt
@@ -86,6 +86,15 @@ private val SANDBOX_PLACEHOLDER = Regex("""^_\.(?:dirkeep|gitkeep)-[0-9a-f]{6}$"
  *  Upstream `SANITIZED_DOTFILE_PATTERN`. */
 private val SANITIZED_DOTFILE = Regex("""^_\.(.+?)-[0-9a-f]{6}(\.[^.]+)?$""", RegexOption.IGNORE_CASE)
 
+/**
+ * Upstream `imageExtRegex` (`packages/data-provider/src/file-config.ts`), copied verbatim.
+ *
+ * Deliberately excludes `svg`, `bmp` and `avif` even though they are images: an `.svg` the server
+ * extracted text for renders far better as an artifact, and widening this list to be "complete"
+ * would silently move it out of [ToolAttachment.ArtifactContent].
+ */
+private val IMAGE_EXTENSIONS = Regex("""\.(?:jpg|jpeg|png|gif|webp|heic|heif)$""", RegexOption.IGNORE_CASE)
+
 /** Extensions rendered as syntax-highlighted code (fenced markdown) in the artifacts panel. */
 private val CODE_EXTENSIONS = setOf(
     "py", "js", "jsx", "ts", "tsx", "kt", "kts", "java", "c", "cc", "cpp", "h", "hpp",
@@ -118,7 +127,7 @@ internal fun partitionToolCallAttachments(
         }
         .map { att ->
             when {
-                att.type?.startsWith("image/") == true -> ToolAttachment.Image(att)
+                isImageAttachment(att) -> ToolAttachment.Image(att)
                 // A PDF needs its downloadable fileId to preview; without one it stays a file chip.
                 isPdf(att) && att.fileId != null -> ToolAttachment.Pdf(att)
                 else -> attachmentToArtifact(att)?.let { ToolAttachment.ArtifactContent(att, it) }
@@ -127,6 +136,97 @@ internal fun partitionToolCallAttachments(
         }
         .toList()
 }
+
+/**
+ * Every renderable attachment produced by a run of tool calls, flattened in call order — the
+ * hoisted counterpart of [partitionToolCallAttachments]. Mirrors upstream's per-group
+ * `groupAttachments` (`ContentParts.tsx`) fed into `AttachmentGroup` (`Attachment.tsx`).
+ *
+ * Built by running the single-call partition per id rather than by a bulk filter, so the hoisted
+ * and inline paths can never disagree about *what* is renderable.
+ *
+ * Cross-call dedupe is by `fileId` **only**. Two different calls may legitimately each emit a
+ * `chart.png` carrying no fileId, and collapsing those on filename would drop real output — the
+ * per-call filename dedupe inside [partitionToolCallAttachments] still applies within one call.
+ * Pure — unit-tested.
+ */
+internal fun collectGroupAttachments(
+    attachments: List<Attachment>,
+    toolCallIds: List<String>,
+): List<ToolAttachmentBucket> =
+    bucketToolAttachments(
+        toolCallIds
+            .flatMap { partitionToolCallAttachments(attachments, it) }
+            .distinctBy { item ->
+                item.attachment.fileId
+                    ?: "${item.attachment.toolCallId}:${attachmentName(item.attachment)}"
+            },
+    )
+
+/**
+ * One run of same-kind attachments, emitted in final render order; empty runs are omitted.
+ *
+ * The render order is the *return* order of [bucketToolAttachments] rather than the declaration
+ * order of a composable, which is the only way it can be pinned — this module has no Compose test
+ * harness.
+ */
+internal sealed interface ToolAttachmentBucket {
+    val items: List<ToolAttachment>
+
+    data class Files(override val items: List<ToolAttachment.File>) : ToolAttachmentBucket
+    data class Artifacts(override val items: List<ToolAttachment.ArtifactContent>) : ToolAttachmentBucket
+    data class Pdfs(override val items: List<ToolAttachment.Pdf>) : ToolAttachmentBucket
+    data class Images(override val items: List<ToolAttachment.Image>) : ToolAttachmentBucket
+}
+
+/**
+ * Buckets [items] into upstream `AttachmentGroup`'s render order: files → artifacts → previews →
+ * **images last** (`Attachment.tsx`). Mobile's order was images-first; the swap is what keeps a
+ * long generated image from pushing the files that describe it off screen.
+ *
+ * Two deliberate mapping choices, because the buckets do not line up 1:1. Upstream's separate
+ * mermaid and inline-text buckets fold into [ToolAttachment.ArtifactContent] — `.mmd` already maps
+ * to `application/vnd.mermaid` there and all three render as the same button, so their position
+ * relative to files and images is preserved. [ToolAttachment.Pdf] has no upstream counterpart (a
+ * PDF falls to web's generic file row) and sits with the artifacts: like them it is a card that
+ * opens a preview, not a download chip.
+ *
+ * Each bucket is stable-sorted by [attachmentSalience]. Pure — unit-tested.
+ */
+internal fun bucketToolAttachments(items: List<ToolAttachment>): List<ToolAttachmentBucket> {
+    fun <T : ToolAttachment> List<T>.bySalience(): List<T> = sortedBy { attachmentSalience(it.attachment) }
+    return listOfNotNull(
+        items.filterIsInstance<ToolAttachment.File>().bySalience()
+            .takeIf { it.isNotEmpty() }?.let(ToolAttachmentBucket::Files),
+        items.filterIsInstance<ToolAttachment.ArtifactContent>().bySalience()
+            .takeIf { it.isNotEmpty() }?.let(ToolAttachmentBucket::Artifacts),
+        items.filterIsInstance<ToolAttachment.Pdf>().bySalience()
+            .takeIf { it.isNotEmpty() }?.let(ToolAttachmentBucket::Pdfs),
+        items.filterIsInstance<ToolAttachment.Image>().bySalience()
+            .takeIf { it.isNotEmpty() }?.let(ToolAttachmentBucket::Images),
+    )
+}
+
+/**
+ * Upstream `attachmentSalience` (`attachmentTypes.ts`): a zero-byte file is an empty placeholder
+ * and sinks below real output within its bucket. An absent `bytes` weighs 0 — the server simply
+ * did not report it, matching JS where `undefined === 0` is false.
+ */
+private fun attachmentSalience(attachment: Attachment): Int = if (attachment.bytes == 0L) 1 else 0
+
+/**
+ * Mirrors upstream `isImageAttachment` (`attachmentTypes.ts`) on the MIME and filename halves, and
+ * deliberately drops its `width`/`height`/`filepath` requirements.
+ *
+ * Upstream needs the dimensions to reserve DOM layout space; mobile renders through
+ * `SubcomposeAsyncImage` with its own loading slot and a height cap, so a dimensionless image lays
+ * out fine — and requiring them would *hide* every image whose `attachment` event omitted them,
+ * which is the failure this classification exists to prevent. `filepath` is likewise optional:
+ * `resolveAttachmentUrl` falls back to `$baseUrl/api/files/$fileId`.
+ */
+private fun isImageAttachment(attachment: Attachment): Boolean =
+    attachment.type?.startsWith("image/") == true ||
+        attachmentName(attachment)?.let { IMAGE_EXTENSIONS.containsMatchIn(it) } == true
 
 private fun isPdf(attachment: Attachment): Boolean =
     attachment.type == "application/pdf" ||
@@ -217,7 +317,6 @@ internal fun attachmentToArtifact(attachment: Attachment): Artifact? {
     )
 }
 
-@OptIn(ExperimentalLayoutApi::class)
 @Composable
 internal fun ToolCallAttachments(
     attachments: List<Attachment>,
@@ -225,53 +324,75 @@ internal fun ToolCallAttachments(
     baseUrl: String,
     modifier: Modifier = Modifier,
 ) {
-    val items = remember(attachments, toolCallId) {
-        partitionToolCallAttachments(attachments, toolCallId)
+    val buckets = remember(attachments, toolCallId) {
+        bucketToolAttachments(partitionToolCallAttachments(attachments, toolCallId))
     }
-    if (items.isEmpty()) return
+    ToolAttachmentBuckets(buckets = buckets, baseUrl = baseUrl, modifier = modifier)
+}
+
+/**
+ * Renders pre-bucketed attachments in the order [bucketToolAttachments] returned them. Shared by
+ * the per-tool-call path and the hoisted-out-of-an-activity-group path, so both sort and present a
+ * tool's output identically.
+ *
+ * Emits no searchable text of its own — no section headers. `SearchMatchEnumeration` counts zero
+ * occurrences for tool calls and images, and the renderer walks the same function, so a heading
+ * here would desync the two walks and send prev/next to the wrong match.
+ */
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+internal fun ToolAttachmentBuckets(
+    buckets: List<ToolAttachmentBucket>,
+    baseUrl: String,
+    modifier: Modifier = Modifier,
+) {
+    if (buckets.isEmpty()) return
 
     val openArtifact = LocalOpenArtifact.current
     val openPdf = LocalOpenPdf.current
     val fallbackName = stringResource(Res.string.attachment_fallback)
-    val images = items.filterIsInstance<ToolAttachment.Image>()
-    val artifacts = items.filterIsInstance<ToolAttachment.ArtifactContent>()
-    val pdfs = items.filterIsInstance<ToolAttachment.Pdf>()
-    val files = items.filterIsInstance<ToolAttachment.File>()
 
     Column(modifier = modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(8.dp)) {
-        images.forEach { item ->
-            val url = resolveAttachmentUrl(item.attachment, baseUrl)
-            if (url != null) {
-                MessageImagePreview(
-                    imageUrl = url,
-                    altText = item.attachment.filename?.let { displayFilename(it) } ?: fallbackName,
-                )
-            }
-        }
+        buckets.forEach { bucket ->
+            when (bucket) {
+                is ToolAttachmentBucket.Files -> FlowRow(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    bucket.items.forEach { item ->
+                        AttachmentDownloadChip(attachment = item.attachment)
+                    }
+                }
 
-        artifacts.forEach { item ->
-            ArtifactButton(
-                artifact = item.artifact,
-                onClick = { openArtifact?.invoke(item.artifact, listOf(item.artifact)) },
-            )
-        }
+                is ToolAttachmentBucket.Artifacts -> bucket.items.forEach { item ->
+                    ArtifactButton(
+                        artifact = item.artifact,
+                        onClick = { openArtifact?.invoke(item.artifact, listOf(item.artifact)) },
+                    )
+                }
 
-        pdfs.forEach { item ->
-            val fileId = item.attachment.fileId ?: return@forEach
-            val name = attachmentName(item.attachment)?.let { displayFilename(it) } ?: fallbackName
-            PdfAttachmentCard(
-                title = name,
-                onClick = { openPdf(fileId, name) },
-            )
-        }
+                is ToolAttachmentBucket.Pdfs -> bucket.items.forEach { item ->
+                    val fileId = item.attachment.fileId ?: return@forEach
+                    val name = attachmentName(item.attachment)?.let { displayFilename(it) } ?: fallbackName
+                    PdfAttachmentCard(
+                        title = name,
+                        onClick = { openPdf(fileId, name) },
+                    )
+                }
 
-        if (files.isNotEmpty()) {
-            FlowRow(
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                verticalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                files.forEach { item ->
-                    AttachmentDownloadChip(attachment = item.attachment)
+                is ToolAttachmentBucket.Images -> bucket.items.forEach { item ->
+                    val url = resolveAttachmentUrl(item.attachment, baseUrl)
+                    if (url != null) {
+                        MessageImagePreview(
+                            imageUrl = url,
+                            altText = item.attachment.filename?.let { displayFilename(it) } ?: fallbackName,
+                        )
+                    } else {
+                        // Classification is by MIME *or* extension, so an entry can reach this
+                        // bucket with nothing resolvable to load. Degrade to a chip rather than
+                        // rendering nothing, which is how a generated file goes missing silently.
+                        AttachmentDownloadChip(attachment = item.attachment)
+                    }
                 }
             }
         }

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ToolCallContentPart.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ToolCallContentPart.kt
@@ -58,6 +58,9 @@ internal fun ToolCallDispatcher(
     // then keeps its state across a reorder — falling back to the caller's per-part key.
     stateKey: String = "",
     allowSubagentCard: Boolean = true,
+    // True while this call renders inside an activity group, whose collapsible would otherwise
+    // swallow the files it generated — they are hoisted out and rendered below it instead.
+    hideAttachments: Boolean = false,
 ) {
     val toolCall = part.toolCall
     val cardKey = toolCall?.id?.takeIf { it.isNotEmpty() } ?: stateKey
@@ -70,6 +73,10 @@ internal fun ToolCallDispatcher(
     // `subagentContent` (reload) takes precedence inside the card. Depth-1:
     // nested parts pass allowSubagentCard=false so this never recurses. Nested parts
     // render their own attachments, so this branch keeps its pass-through return.
+    //
+    // hideAttachments is deliberately NOT forwarded. A group hoists the files of its OWN parts,
+    // whose ids are the only ones it collects; a subagent's nested calls carry different ids, so
+    // nothing of theirs is ever hoisted and suppressing them here would render them nowhere.
     if (allowSubagentCard && toolNameLower == ToolConstants.SUBAGENT) {
         val toolCallId = toolCall?.id
         val liveTrace = toolCallId?.let { LocalSubagentProgress.current[it] }
@@ -171,7 +178,12 @@ internal fun ToolCallDispatcher(
                 val imageResult = remember(toolCall, baseUrl, attachments) {
                     parseImageGenResult(toolCall, baseUrl, attachments)
                 }
-                ImageGenCard(result = imageResult, showDescription = showImageDescriptions, modifier = cardModifier)
+                ImageGenCard(
+                    result = imageResult,
+                    showDescription = showImageDescriptions,
+                    hideImages = hideAttachments,
+                    modifier = cardModifier,
+                )
             }
             toolNameLower.contains("log") -> {
                 val logContent = remember(toolCall) { parseLogContent(toolCall) }
@@ -182,7 +194,7 @@ internal fun ToolCallDispatcher(
             }
         }
 
-        if (!isImageGen) {
+        if (!isImageGen && !hideAttachments) {
             ToolCallAttachments(
                 attachments = attachments,
                 toolCallId = toolCall?.id,

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ToolCallContentPart.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ToolCallContentPart.kt
@@ -58,8 +58,7 @@ internal fun ToolCallDispatcher(
     // then keeps its state across a reorder — falling back to the caller's per-part key.
     stateKey: String = "",
     allowSubagentCard: Boolean = true,
-    // True while this call renders inside an activity group, whose collapsible would otherwise
-    // swallow the files it generated — they are hoisted out and rendered below it instead.
+    // True while this call renders inside an activity group, which hoists its tool calls' files out.
     hideAttachments: Boolean = false,
 ) {
     val toolCall = part.toolCall
@@ -73,10 +72,9 @@ internal fun ToolCallDispatcher(
     // `subagentContent` (reload) takes precedence inside the card. Depth-1:
     // nested parts pass allowSubagentCard=false so this never recurses. Nested parts
     // render their own attachments, so this branch keeps its pass-through return.
-    //
-    // hideAttachments is deliberately NOT forwarded. A group hoists the files of its OWN parts,
-    // whose ids are the only ones it collects; a subagent's nested calls carry different ids, so
-    // nothing of theirs is ever hoisted and suppressing them here would render them nowhere.
+    // hideAttachments is deliberately NOT forwarded: a group only collects the ids of its OWN
+    // parts, so a subagent's nested calls are never hoisted and suppressing them here would
+    // render them nowhere.
     if (allowSubagentCard && toolNameLower == ToolConstants.SUBAGENT) {
         val toolCallId = toolCall?.id
         val liveTrace = toolCallId?.let { LocalSubagentProgress.current[it] }

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ToolCallParsing.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ToolCallParsing.kt
@@ -306,15 +306,23 @@ internal fun parseImageGenResult(
     }
 
     val outputStr = toolCall.output ?: toolCall.function?.output
-    var imageUrl: String? = null
 
+    // EVERY attachment for this call, not just the first: one image-gen call routinely returns
+    // several images, and the old firstOrNull dropped all but one of them everywhere the result
+    // was consumed (the card, the fullscreen pager, the conversation gallery).
     val toolCallId = toolCall.id
-    if (toolCallId != null) {
-        val attachment = attachments.firstOrNull { it.toolCallId == toolCallId }
-        imageUrl = resolveAttachmentUrl(attachment, baseUrl)
+    val attachmentUrls = if (toolCallId != null) {
+        attachments.filter { it.toolCallId == toolCallId }
+            .mapNotNull { resolveAttachmentUrl(it, baseUrl) }
+            .distinct()
+    } else {
+        emptyList()
     }
 
-    if (imageUrl == null && !outputStr.isNullOrBlank()) {
+    // Legacy output shape — only reachable when the call produced no attachments at all, and it
+    // can only ever describe one image.
+    var imageUrl: String? = null
+    if (attachmentUrls.isEmpty() && !outputStr.isNullOrBlank()) {
         try {
             val outputObj = toolCallJson.parseToJsonElement(outputStr).jsonObject
             imageUrl = outputObj["url"]?.jsonPrimitive?.contentOrNull
@@ -345,10 +353,11 @@ internal fun parseImageGenResult(
         }
     }
 
+    val imageUrls = attachmentUrls.ifEmpty { listOfNotNull(imageUrl) }
     return ImageGenResult(
-        imageUrl = imageUrl,
+        imageUrls = imageUrls,
         prompt = prompt,
-        isGenerating = outputStr.isNullOrBlank() && imageUrl == null,
+        isGenerating = outputStr.isNullOrBlank() && imageUrls.isEmpty(),
     )
 }
 
@@ -367,12 +376,14 @@ internal fun parseStreamingImageGenResult(
     attachments: List<Attachment>,
 ): ImageGenResult {
     val (prompt, quality) = parseImageGenArgs(toolCall.input)
-    val attachment = attachments.firstOrNull { it.toolCallId == toolCall.id }
-    val imageUrl = resolveAttachmentUrl(attachment, baseUrl)
+    // Attachments arrive one SSE event at a time, so the card grows 1 → N as they land.
+    val imageUrls = attachments.filter { it.toolCallId == toolCall.id }
+        .mapNotNull { resolveAttachmentUrl(it, baseUrl) }
+        .distinct()
     return ImageGenResult(
-        imageUrl = imageUrl,
+        imageUrls = imageUrls,
         prompt = prompt,
-        isGenerating = imageUrl == null,
+        isGenerating = imageUrls.isEmpty(),
         quality = quality,
     )
 }

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ToolCallParsing.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ToolCallParsing.kt
@@ -307,9 +307,6 @@ internal fun parseImageGenResult(
 
     val outputStr = toolCall.output ?: toolCall.function?.output
 
-    // EVERY attachment for this call, not just the first: one image-gen call routinely returns
-    // several images, and the old firstOrNull dropped all but one of them everywhere the result
-    // was consumed (the card, the fullscreen pager, the conversation gallery).
     val toolCallId = toolCall.id
     val attachmentUrls = if (toolCallId != null) {
         attachments.filter { it.toolCallId == toolCallId }
@@ -319,8 +316,8 @@ internal fun parseImageGenResult(
         emptyList()
     }
 
-    // Legacy output shape — only reachable when the call produced no attachments at all, and it
-    // can only ever describe one image.
+    // Legacy output shape: reachable only when the call produced no attachments, and it can
+    // describe at most one image.
     var imageUrl: String? = null
     if (attachmentUrls.isEmpty() && !outputStr.isNullOrBlank()) {
         try {
@@ -376,7 +373,6 @@ internal fun parseStreamingImageGenResult(
     attachments: List<Attachment>,
 ): ImageGenResult {
     val (prompt, quality) = parseImageGenArgs(toolCall.input)
-    // Attachments arrive one SSE event at a time, so the card grows 1 → N as they land.
     val imageUrls = attachments.filter { it.toolCallId == toolCall.id }
         .mapNotNull { resolveAttachmentUrl(it, baseUrl) }
         .distinct()

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/util/BranchMedia.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/util/BranchMedia.kt
@@ -44,9 +44,10 @@ internal fun extractBranchMedia(
     activeToolCalls.forEach { toolCall ->
         if (isImageGenToolCall(toolCall.name.lowercase())) {
             val result = parseStreamingImageGenResult(toolCall, baseUrl, streamingAttachments)
-            val url = result.imageUrl
-            if (!url.isNullOrBlank()) {
-                items += MediaItem(url, contentDescription = result.prompt.orEmpty())
+            result.imageUrls.forEach { url ->
+                if (url.isNotBlank()) {
+                    items += MediaItem(url, contentDescription = result.prompt.orEmpty())
+                }
             }
         }
     }
@@ -94,9 +95,10 @@ internal fun collectMessageMedia(message: Message, baseUrl: String): List<MediaI
                 val name = (toolCall?.name ?: toolCall?.function?.name).orEmpty().lowercase()
                 if (isImageGenToolCall(name)) {
                     val result = parseImageGenResult(toolCall, baseUrl, attachments)
-                    val url = result.imageUrl
-                    if (!url.isNullOrBlank()) {
-                        items += MediaItem(url, contentDescription = result.prompt.orEmpty())
+                    result.imageUrls.forEach { url ->
+                        if (url.isNotBlank()) {
+                            items += MediaItem(url, contentDescription = result.prompt.orEmpty())
+                        }
                     }
                 }
             }

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/util/ContentSegments.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/util/ContentSegments.kt
@@ -121,11 +121,9 @@ sealed interface ContentGroup {
  * The ids of the tool calls inside this block, in render order; blank ids and non-tool entries
  * drop out.
  *
- * Lives here rather than on [ContentGroup] itself so [groupContentParts] stays a pure
- * parts-only transform: the attachment join happens at the render site, mirroring upstream, where
- * `groupSequentialToolCalls` never sees attachments and `ContentParts.tsx` does the join. Folding
- * it in would widen the grouping memo's key to include attachments and re-run the whole
- * segmentation pass on every mid-stream `attachment` event.
+ * Keep the attachment join at the render site rather than folding it into [ContentGroup]: that
+ * would widen the grouping memo's key to include attachments and re-run the whole segmentation
+ * pass on every mid-stream `attachment` event.
  */
 fun ContentGroup.Activity.groupedToolCallIds(): List<String> =
     entries.mapNotNull { it.part.toolCall?.id?.takeIf(String::isNotEmpty) }

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/util/ContentSegments.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/util/ContentSegments.kt
@@ -117,6 +117,19 @@ sealed interface ContentGroup {
     }
 }
 
+/**
+ * The ids of the tool calls inside this block, in render order; blank ids and non-tool entries
+ * drop out.
+ *
+ * Lives here rather than on [ContentGroup] itself so [groupContentParts] stays a pure
+ * parts-only transform: the attachment join happens at the render site, mirroring upstream, where
+ * `groupSequentialToolCalls` never sees attachments and `ContentParts.tsx` does the join. Folding
+ * it in would widen the grouping memo's key to include attachments and re-run the whole
+ * segmentation pass on every mid-stream `attachment` event.
+ */
+fun ContentGroup.Activity.groupedToolCallIds(): List<String> =
+    entries.mapNotNull { it.part.toolCall?.id?.takeIf(String::isNotEmpty) }
+
 /** The label text an activity-label part carries, trimmed; empty when it is still a reservation. */
 fun MessageContentPart.activityLabelText(): String =
     if (type == ContentType.ACTIVITY_LABEL) activityLabel?.trim().orEmpty() else ""

--- a/feature/chat/src/commonTest/kotlin/com/garfiec/librechat/feature/chat/util/ContentSegmentsTest.kt
+++ b/feature/chat/src/commonTest/kotlin/com/garfiec/librechat/feature/chat/util/ContentSegmentsTest.kt
@@ -297,10 +297,9 @@ class ContentSegmentsTest {
         assertTrue(group.failed)
     }
 
-    // Upstream groups image-gen calls like any other tool — there is no image special-case in
-    // `groupToolCalls.ts`. The generated images stay visible because the render layer hoists them
-    // out of the collapsible, NOT because the grouping skips them. Excluding image tools here
-    // would diverge from upstream and re-break the parity this grouping exists to provide.
+    // Image-gen calls group like any other tool, matching `groupToolCalls.ts`. Generated images
+    // stay visible because the render layer hoists them out of the collapsible, NOT because the
+    // grouping skips them — do not add an image special-case here.
     @Test
     fun imageGenCallsStillGroupIntoOneActivityBlock() {
         val groups = onlySegment(

--- a/feature/chat/src/commonTest/kotlin/com/garfiec/librechat/feature/chat/util/ContentSegmentsTest.kt
+++ b/feature/chat/src/commonTest/kotlin/com/garfiec/librechat/feature/chat/util/ContentSegmentsTest.kt
@@ -296,4 +296,34 @@ class ContentSegmentsTest {
             .groups.single() as ContentGroup.Activity
         assertTrue(group.failed)
     }
+
+    // Upstream groups image-gen calls like any other tool — there is no image special-case in
+    // `groupToolCalls.ts`. The generated images stay visible because the render layer hoists them
+    // out of the collapsible, NOT because the grouping skips them. Excluding image tools here
+    // would diverge from upstream and re-break the parity this grouping exists to provide.
+    @Test
+    fun imageGenCallsStillGroupIntoOneActivityBlock() {
+        val groups = onlySegment(
+            listOf(tool("t1", name = "image_gen_oai"), tool("t2", name = "image_gen_oai")),
+        ).groups
+
+        val group = groups.single() as ContentGroup.Activity
+        assertEquals(2, group.toolCount)
+    }
+
+    @Test
+    fun groupedToolCallIdsReturnsToolCallsInOrderAndSkipsReasoning() {
+        val group = onlySegment(listOf(tool("t1"), think("pondering"), tool("t2"), label("Looked it up")))
+            .groups.single() as ContentGroup.Activity
+
+        assertEquals(listOf("t1", "t2"), group.groupedToolCallIds())
+    }
+
+    @Test
+    fun groupedToolCallIdsSkipsBlankIds() {
+        val group = onlySegment(listOf(tool(""), tool("t2")))
+            .groups.single() as ContentGroup.Activity
+
+        assertEquals(listOf("t2"), group.groupedToolCallIds())
+    }
 }

--- a/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/components/PlatformChatComponents.ios.kt
+++ b/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/components/PlatformChatComponents.ios.kt
@@ -459,6 +459,7 @@ actual fun ContentPartRenderer(
     showImageDescriptions: Boolean, searchQuery: String?, searchFocusedOccurrence: Int,
     onFocusedOccurrencePosition: ((LayoutCoordinates, Rect) -> Unit)?,
     stateKey: String,
+    hideAttachments: Boolean,
 ) {
     ContentPartDispatcher(
         part = part,
@@ -472,6 +473,7 @@ actual fun ContentPartRenderer(
         searchFocusedOccurrence = searchFocusedOccurrence,
         onFocusedOccurrencePosition = onFocusedOccurrencePosition,
         stateKey = stateKey,
+        hideAttachments = hideAttachments,
     )
 }
 

--- a/scripts/mirrors.json
+++ b/scripts/mirrors.json
@@ -105,6 +105,20 @@
       "failure_mode": "A type upstream added to the parser is never routed to text, so it stays on a provider that cannot read it. A type upstream removed is routed to text and returns a generic 500."
     },
     {
+      "id": "image-ext-regex",
+      "upstream": {
+        "file": "packages/data-provider/src/file-config.ts",
+        "symbol": "imageExtRegex",
+        "mode": "block"
+      },
+      "kotlin": {
+        "file": "feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ToolCallAttachments.kt",
+        "symbol": "IMAGE_EXTENSIONS"
+      },
+      "why": "Decides whether a tool call's generated file renders as an inline image preview or as a download chip, for the attachments that arrive with no MIME type. The exclusions are load-bearing: svg is absent upstream, and an .svg the server extracted text for is meant to reach the artifacts panel instead, so 'completing' this list is itself the drift.",
+      "failure_mode": "An extension upstream added renders as a download chip instead of an image the user can see. One removed sends a non-image down the image path, where a null resolved URL degrades it to a chip. Neither errors."
+    },
+    {
       "id": "feedback-tags",
       "upstream": {
         "file": "packages/data-provider/src/feedback.ts",


### PR DESCRIPTION
## Summary

Generating multiple images wrapped them in a collapsed "Used N tools" block instead of showing them at the top level of the message. This restores the structure the web client uses to keep them visible, and closes a related gap where a single image-gen call returning several images surfaced only the first.

## Root cause

The 0.8.8 sync (#318) ported upstream's tool-call grouping (`groupSequentialToolCalls` → `groupContentParts`) but not the attachment hoisting that makes grouping safe on web. `ActivityGroup` placed its entire body inside `AnimatedVisibility(visible = isExpanded)` with nothing outside it, so a grouped image-gen card — images included — went away with the fold.

Upstream keeps grouped output on screen with two mechanisms this client lacked:

- each group's attachments hoisted and rendered as a sibling **after** the collapsible region
- `hideAttachments` passed to parts rendered **inside** the group, suppressing their inline copy

Both are ported here.

Two properties of the symptom shaped the fix. It is not limited to two or more images — a filled `activity_label` claims its batch regardless of size and a labeled single call collapses by default, so one image under a label disappeared the same way, and a fix keyed on the tool count would have been wrong. And it is settled-message-only: streaming renders the cards flat and `LocalSuppressGroupAutoCollapse` holds the just-settled message open, so the images vanish on a later load or scroll rather than at completion.

Upstream has no image-gen special case in its grouping code — it groups image tools like any other tool, and only the render layer keeps the images visible. A test pins that this client does the same, so the tempting "exclude image tools from grouping" shortcut doesn't get introduced later.

## Changes

- **`ActivityGroup`** gains a `hoistedAttachments` slot rendered after the collapsible. Its KDoc marks the placement load-bearing: upstream pins the same structure with a test, and this module has no Compose harness to do likewise.
- **`hideAttachments`** threaded through the `ContentPartRenderer` expect/actual triple, the shared dispatcher, and `ToolCallDispatcher`. Deliberately not forwarded into the subagent branch — a group collects only its own parts' ids, so nested calls' attachments are never hoisted and suppressing them would render them nowhere.
- **Attachment ordering** moves from implicit composable declaration order into a pure `bucketToolAttachments`, adopting upstream `AttachmentGroup`'s buckets: files → artifacts → previews → **images last**. `collectGroupAttachments` flattens a whole block's output through the existing single-call partition, so the hoisted and inline paths cannot disagree about what is renderable. Cross-call dedupe keys on `fileId` only, since two calls may each legitimately emit a `chart.png` carrying none.
- **`ImageGenResult.imageUrl` → `imageUrls: List<String>`**, with both the settled and streaming parsers collecting every attachment matching the tool call. No single-image convenience accessor, deliberately. `BranchMedia` follows, so the fullscreen viewer and conversation gallery surface all of them.
- **Image classification** now accepts an image filename extension as well as an `image/*` MIME type, so a generated image arriving without a type is no longer misfiled as a download chip. Registered in `scripts/mirrors.json` as `image-ext-regex`, since it copies a constant the server never serves.
- **`Attachment.bytes`** added to carry upstream's salience sort, which sinks zero-byte files below real output within their bucket.
- **An image whose URL will not resolve now degrades to a download chip** instead of rendering nothing. Classification accepts a MIME type *or* an extension, so an entry can reach the image bucket with nothing loadable; the previous branch drew nothing at all, losing the file silently.

## Deliberate divergences from upstream

- **Image classification drops upstream's `width`/`height`/`filepath` requirements.** Upstream needs the dimensions to reserve DOM layout space; mobile renders through `SubcomposeAsyncImage`, which has its own loading slot and a height cap, so a dimensionless image lays out fine. Requiring them would *hide* every image whose `attachment` event omitted them — the failure this change exists to prevent. `filepath` is optional because `resolveAttachmentUrl` falls back to `$baseUrl/api/files/$fileId`.
- **The ported extension list excludes `svg`**, matching upstream exactly. This is load-bearing rather than an oversight: an `.svg` the server extracted text for is meant to reach the artifacts panel, so "completing" the list is itself the drift. A test pins it.
- **`attachmentSalience` treats an absent `bytes` as weight 0** rather than sinking it, matching JS where `undefined === 0` is false — an unreported size is not an empty file.

## Behaviour changes worth flagging

- The bucket reorder applies to the ungrouped tool card and the live streaming card too, not only the hoisted path: a code-interpreter turn emitting a plot and a CSV now lists the CSV above the plot. Deliberate — one ordering function, or a group and a lone call would sort the same files differently.
- Multi-image rendering diverges from upstream, which caps its inline render at the first attachment.

## Testing

- Manually verified on a Pixel 9 Pro Fold.
- `./gradlew test` — full suite green. 31 new unit tests covering bucket ordering, group collection and dedupe, image classification, and both image-gen parsers. `BranchMediaTest` is new: the gallery/pager path had no test.
- `./gradlew detekt detektMetadataCommonMain :app:lint --continue`
- `./gradlew :app:assembleDebug` and `:feature:chat:assembleDebugAndroidTest`
- `./gradlew :feature:chat:compileKotlinIosSimulatorArm64` — required rather than optional here: the `expect` signature changed, so the iOS actual had to move in lockstep and no Android task catches a mismatch.

## Known limitation

Provider tool-call ids can repeat across agents in a handoff run (`call_0` under two different agents), so one attachment could hoist under two groups. Upstream guards this by scoping attachments to the part's agent id; `Attachment` carries no `agentId`, so there is nothing to scope on. Pre-existing, but newly visible now that grouped output renders.
