### PR TITLE
feat(auth): renew an expiring access token before its request 401s (#323)

### DIFF
--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/datastore/AccountRegistryTest.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/datastore/AccountRegistryTest.kt
@@ -144,14 +144,18 @@ class AccountRegistryTest {
         override val isAuthenticated: Boolean = false
         override suspend fun getAccessToken(): String? = null
         override suspend fun setTokens(accessToken: String, refreshToken: String) {}
-        override suspend fun refreshAccessToken(): RefreshResult = RefreshResult.HardExpired
+        override suspend fun refreshAccessToken(usedAccessToken: String?): RefreshResult = RefreshResult.HardExpired
         override suspend fun clearTokens() {}
         override suspend fun getAccessTokenFor(accountId: String): String? = null
         override suspend fun getStagedAccessToken(): String? = null
         override suspend fun clearStagedTokens() {}
         override suspend fun selectAccount(accountId: String) { selected = accountId }
         override suspend fun removeAccount(accountId: String) {}
-        override suspend fun refreshAccessTokenFor(accountId: String, baseUrl: String): RefreshResult = RefreshResult.HardExpired
+        override suspend fun refreshAccessTokenFor(
+            accountId: String,
+            baseUrl: String,
+            usedAccessToken: String?,
+        ): RefreshResult = RefreshResult.HardExpired
         override suspend fun onAccountResolved(accountId: String) {}
         override suspend fun onAccountCleared() { cleared = true }
         override fun emitSessionExpired(expiredAccountId: String?, reason: SessionEndReason) {}

--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/datastore/CommonTokenDataStoreAccountKeyingTest.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/datastore/CommonTokenDataStoreAccountKeyingTest.kt
@@ -27,44 +27,16 @@ import org.junit.Test
 @OptIn(ExperimentalCoroutinesApi::class)
 class CommonTokenDataStoreAccountKeyingTest {
 
-    private class FakeKeyedStore(
-        refreshClient: Lazy<HttpClient>,
-        seed: Map<String, String> = emptyMap(),
-    ) : CommonTokenDataStore(refreshClient) {
-        val store = seed.toMutableMap()
-
-        init {
-            initializeTokenCache()
-        }
-
-        override fun readValue(key: String): String? = store[key]
-        override fun writeValue(key: String, value: String) {
-            store[key] = value
-        }
-
-        override fun writeValues(values: Map<String, String>) {
-            store.putAll(values)
-        }
-
-        override fun removeValue(key: String) {
-            store.remove(key)
-        }
-
-        override fun onKeystoreCorruption() = Unit
-    }
-
     private val noRefresh: Lazy<HttpClient> = lazy { error("refresh client not expected in this test") }
 
-    private fun accessKey(account: String) = "acct:$account:access_token"
-    private fun refreshKeyOf(account: String) = "acct:$account:refresh_token"
 
     @Test
     fun `init seeds cached bearer from the mirror's keyed slot`() = runTest {
-        val store = FakeKeyedStore(
+        val store = FakeTokenStore(
             noRefresh,
             seed = mapOf(
                 "active_account_id" to "acctA",
-                accessKey("acctA") to "A-access",
+                accessKeyOf("acctA") to "A-access",
             ),
         )
 
@@ -74,7 +46,7 @@ class CommonTokenDataStoreAccountKeyingTest {
 
     @Test
     fun `init falls back to the bare key for a legacy pre-keying install`() = runTest {
-        val store = FakeKeyedStore(noRefresh, seed = mapOf("access_token" to "legacy-access"))
+        val store = FakeTokenStore(noRefresh, seed = mapOf("access_token" to "legacy-access"))
 
         assertThat(store.isAuthenticated).isTrue()
         assertThat(store.getAccessToken()).isEqualTo("legacy-access")
@@ -82,7 +54,7 @@ class CommonTokenDataStoreAccountKeyingTest {
 
     @Test
     fun `init reports logged out when storage is empty`() = runTest {
-        val store = FakeKeyedStore(noRefresh)
+        val store = FakeTokenStore(noRefresh)
 
         assertThat(store.isAuthenticated).isFalse()
         assertThat(store.getAccessToken()).isNull()
@@ -90,13 +62,13 @@ class CommonTokenDataStoreAccountKeyingTest {
 
     @Test
     fun `onAccountResolved migrates bare tokens into the keyed slot and writes the mirror`() = runTest {
-        val store = FakeKeyedStore(noRefresh)
+        val store = FakeTokenStore(noRefresh)
         // Fresh login: no account resolved yet, so setTokens lands under the bare keys.
         store.setTokens(accessToken = "A-access", refreshToken = "A-refresh")
 
         store.onAccountResolved("acctA")
 
-        assertThat(store.store[accessKey("acctA")]).isEqualTo("A-access")
+        assertThat(store.store[accessKeyOf("acctA")]).isEqualTo("A-access")
         assertThat(store.store[refreshKeyOf("acctA")]).isEqualTo("A-refresh")
         assertThat(store.store["active_account_id"]).isEqualTo("acctA")
         assertThat(store.store).doesNotContainKey("access_token")
@@ -106,13 +78,13 @@ class CommonTokenDataStoreAccountKeyingTest {
 
     @Test
     fun `onAccountResolved with a torn staging pair does not cache an unpersisted bearer`() = runTest {
-        val store = FakeKeyedStore(
+        val store = FakeTokenStore(
             noRefresh,
             seed = mapOf(
                 // Torn staging: a bare access token survived but its refresh partner didn't (e.g. a
                 // partial keychain write). The keyed slot still holds the prior value.
                 "access_token" to "torn-access",
-                accessKey("acctA") to "A-access",
+                accessKeyOf("acctA") to "A-access",
                 refreshKeyOf("acctA") to "A-refresh",
             ),
         )
@@ -121,7 +93,7 @@ class CommonTokenDataStoreAccountKeyingTest {
 
         // The keyed slot is NOT overwritten from the torn pair, and the cached bearer matches storage
         // (the keyed value), never the unpersisted staged token.
-        assertThat(store.store[accessKey("acctA")]).isEqualTo("A-access")
+        assertThat(store.store[accessKeyOf("acctA")]).isEqualTo("A-access")
         assertThat(store.getAccessToken()).isEqualTo("A-access")
         // Bare staging keys are cleared regardless.
         assertThat(store.store).doesNotContainKey("access_token")
@@ -129,24 +101,24 @@ class CommonTokenDataStoreAccountKeyingTest {
 
     @Test
     fun `onAccountResolved is a no-op when the account is unchanged`() = runTest {
-        val store = FakeKeyedStore(
+        val store = FakeTokenStore(
             noRefresh,
-            seed = mapOf("active_account_id" to "acctA", accessKey("acctA") to "A-access"),
+            seed = mapOf("active_account_id" to "acctA", accessKeyOf("acctA") to "A-access"),
         )
 
         store.onAccountResolved("acctA")
 
         assertThat(store.getAccessToken()).isEqualTo("A-access")
-        assertThat(store.store[accessKey("acctA")]).isEqualTo("A-access")
+        assertThat(store.store[accessKeyOf("acctA")]).isEqualTo("A-access")
     }
 
     @Test
     fun `authenticating a different account while one is active retains the previous account's tokens`() = runTest {
-        val store = FakeKeyedStore(
+        val store = FakeTokenStore(
             noRefresh,
             seed = mapOf(
                 "active_account_id" to "acctA",
-                accessKey("acctA") to "A-access",
+                accessKeyOf("acctA") to "A-access",
                 refreshKeyOf("acctA") to "A-refresh",
             ),
         )
@@ -156,10 +128,10 @@ class CommonTokenDataStoreAccountKeyingTest {
 
         store.onAccountResolved("acctB")
 
-        assertThat(store.store[accessKey("acctB")]).isEqualTo("B-access")
+        assertThat(store.store[accessKeyOf("acctB")]).isEqualTo("B-access")
         assertThat(store.store[refreshKeyOf("acctB")]).isEqualTo("B-refresh")
         // A's tokens are RETAINED (multi-account) — a switch back needs no re-login.
-        assertThat(store.store[accessKey("acctA")]).isEqualTo("A-access")
+        assertThat(store.store[accessKeyOf("acctA")]).isEqualTo("A-access")
         assertThat(store.store[refreshKeyOf("acctA")]).isEqualTo("A-refresh")
         assertThat(store.store).doesNotContainKey("access_token")
         assertThat(store.store).doesNotContainKey("refresh_token")
@@ -169,11 +141,11 @@ class CommonTokenDataStoreAccountKeyingTest {
 
     @Test
     fun `staged tokens are readable while staged and clearStagedTokens drops only the bare keys`() = runTest {
-        val store = FakeKeyedStore(
+        val store = FakeTokenStore(
             noRefresh,
             seed = mapOf(
                 "active_account_id" to "acctA",
-                accessKey("acctA") to "A-access",
+                accessKeyOf("acctA") to "A-access",
                 refreshKeyOf("acctA") to "A-refresh",
             ),
         )
@@ -188,17 +160,17 @@ class CommonTokenDataStoreAccountKeyingTest {
         assertThat(store.getStagedAccessToken()).isNull()
         assertThat(store.store).doesNotContainKey("access_token")
         assertThat(store.store).doesNotContainKey("refresh_token")
-        assertThat(store.store[accessKey("acctA")]).isEqualTo("A-access")
+        assertThat(store.store[accessKeyOf("acctA")]).isEqualTo("A-access")
         assertThat(store.store[refreshKeyOf("acctA")]).isEqualTo("A-refresh")
     }
 
     @Test
     fun `getAccessTokenFor reads an account's own slot even while another sign-in is staged`() = runTest {
-        val store = FakeKeyedStore(
+        val store = FakeTokenStore(
             noRefresh,
             seed = mapOf(
                 "active_account_id" to "acctA",
-                accessKey("acctA") to "A-access",
+                accessKeyOf("acctA") to "A-access",
                 refreshKeyOf("acctA") to "A-refresh",
             ),
         )
@@ -214,13 +186,13 @@ class CommonTokenDataStoreAccountKeyingTest {
 
     @Test
     fun `selectAccount switches to an already-keyed account without writing or deleting tokens`() = runTest {
-        val store = FakeKeyedStore(
+        val store = FakeTokenStore(
             noRefresh,
             seed = mapOf(
                 "active_account_id" to "acctA",
-                accessKey("acctA") to "A-access",
+                accessKeyOf("acctA") to "A-access",
                 refreshKeyOf("acctA") to "A-refresh",
-                accessKey("acctB") to "B-access",
+                accessKeyOf("acctB") to "B-access",
                 refreshKeyOf("acctB") to "B-refresh",
             ),
         )
@@ -230,9 +202,9 @@ class CommonTokenDataStoreAccountKeyingTest {
         assertThat(store.store["active_account_id"]).isEqualTo("acctB")
         assertThat(store.getAccessToken()).isEqualTo("B-access")
         // Neither slot is written or deleted; no bare staging keys appear.
-        assertThat(store.store[accessKey("acctA")]).isEqualTo("A-access")
+        assertThat(store.store[accessKeyOf("acctA")]).isEqualTo("A-access")
         assertThat(store.store[refreshKeyOf("acctA")]).isEqualTo("A-refresh")
-        assertThat(store.store[accessKey("acctB")]).isEqualTo("B-access")
+        assertThat(store.store[accessKeyOf("acctB")]).isEqualTo("B-access")
         assertThat(store.store).doesNotContainKey("access_token")
 
         // Switch back is cold-free.
@@ -242,20 +214,20 @@ class CommonTokenDataStoreAccountKeyingTest {
 
     @Test
     fun `removeAccount drops a non-active account and leaves the active one untouched`() = runTest {
-        val store = FakeKeyedStore(
+        val store = FakeTokenStore(
             noRefresh,
             seed = mapOf(
                 "active_account_id" to "acctA",
-                accessKey("acctA") to "A-access",
+                accessKeyOf("acctA") to "A-access",
                 refreshKeyOf("acctA") to "A-refresh",
-                accessKey("acctB") to "B-access",
+                accessKeyOf("acctB") to "B-access",
                 refreshKeyOf("acctB") to "B-refresh",
             ),
         )
 
         store.removeAccount("acctB")
 
-        assertThat(store.store).doesNotContainKey(accessKey("acctB"))
+        assertThat(store.store).doesNotContainKey(accessKeyOf("acctB"))
         assertThat(store.store).doesNotContainKey(refreshKeyOf("acctB"))
         assertThat(store.store["active_account_id"]).isEqualTo("acctA")
         assertThat(store.getAccessToken()).isEqualTo("A-access")
@@ -263,30 +235,30 @@ class CommonTokenDataStoreAccountKeyingTest {
 
     @Test
     fun `removeAccount of the active account clears the mirror and cached bearer`() = runTest {
-        val store = FakeKeyedStore(
+        val store = FakeTokenStore(
             noRefresh,
             seed = mapOf(
                 "active_account_id" to "acctA",
-                accessKey("acctA") to "A-access",
+                accessKeyOf("acctA") to "A-access",
                 refreshKeyOf("acctA") to "A-refresh",
             ),
         )
 
         store.removeAccount("acctA")
 
-        assertThat(store.store).doesNotContainKey(accessKey("acctA"))
+        assertThat(store.store).doesNotContainKey(accessKeyOf("acctA"))
         assertThat(store.store).doesNotContainKey("active_account_id")
         assertThat(store.getAccessToken()).isNull()
     }
 
     @Test
     fun `getAccessTokenFor reads a non-active account's keyed slot`() = runTest {
-        val store = FakeKeyedStore(
+        val store = FakeTokenStore(
             noRefresh,
             seed = mapOf(
                 "active_account_id" to "acctA",
-                accessKey("acctA") to "A-access",
-                accessKey("acctB") to "B-access",
+                accessKeyOf("acctA") to "A-access",
+                accessKeyOf("acctB") to "B-access",
             ),
         )
 
@@ -299,18 +271,18 @@ class CommonTokenDataStoreAccountKeyingTest {
 
     @Test
     fun `onAccountCleared removes the active account's tokens and the mirror`() = runTest {
-        val store = FakeKeyedStore(
+        val store = FakeTokenStore(
             noRefresh,
             seed = mapOf(
                 "active_account_id" to "acctA",
-                accessKey("acctA") to "A-access",
+                accessKeyOf("acctA") to "A-access",
                 refreshKeyOf("acctA") to "A-refresh",
             ),
         )
 
         store.onAccountCleared()
 
-        assertThat(store.store).doesNotContainKey(accessKey("acctA"))
+        assertThat(store.store).doesNotContainKey(accessKeyOf("acctA"))
         assertThat(store.store).doesNotContainKey(refreshKeyOf("acctA"))
         assertThat(store.store).doesNotContainKey("active_account_id")
         assertThat(store.getAccessToken()).isNull()
@@ -318,7 +290,7 @@ class CommonTokenDataStoreAccountKeyingTest {
 
     @Test
     fun `setTokens stages under the bare keys even when an account is active`() = runTest {
-        val store = FakeKeyedStore(noRefresh)
+        val store = FakeTokenStore(noRefresh)
         store.setTokens("bootstrap", "bootstrap-refresh")
         store.onAccountResolved("acctA")
 
@@ -327,12 +299,12 @@ class CommonTokenDataStoreAccountKeyingTest {
         store.setTokens("A-access-2", "A-refresh-2")
 
         assertThat(store.store["access_token"]).isEqualTo("A-access-2")
-        assertThat(store.store[accessKey("acctA")]).isEqualTo("bootstrap")
+        assertThat(store.store[accessKeyOf("acctA")]).isEqualTo("bootstrap")
         assertThat(store.getAccessToken()).isEqualTo("A-access-2")
 
         // Re-home overwrites the account's slot with the freshly-staged pair.
         store.onAccountResolved("acctA")
-        assertThat(store.store[accessKey("acctA")]).isEqualTo("A-access-2")
+        assertThat(store.store[accessKeyOf("acctA")]).isEqualTo("A-access-2")
         assertThat(store.store[refreshKeyOf("acctA")]).isEqualTo("A-refresh-2")
         assertThat(store.store).doesNotContainKey("access_token")
     }
@@ -340,11 +312,11 @@ class CommonTokenDataStoreAccountKeyingTest {
     @Test
     fun `setTokens clears the persisted mirror so a staging-window cold start can't resurrect the previous account`() =
         runTest {
-            val store = FakeKeyedStore(
+            val store = FakeTokenStore(
                 noRefresh,
                 seed = mapOf(
                     "active_account_id" to "acctA",
-                    accessKey("acctA") to "A-access",
+                    accessKeyOf("acctA") to "A-access",
                     refreshKeyOf("acctA") to "A-refresh",
                 ),
             )
@@ -355,16 +327,16 @@ class CommonTokenDataStoreAccountKeyingTest {
             assertThat(store.store).doesNotContainKey("active_account_id")
             assertThat(store.store["access_token"]).isEqualTo("B-access")
             // A's keyed tokens are still retained for a later switch back.
-            assertThat(store.store[accessKey("acctA")]).isEqualTo("A-access")
+            assertThat(store.store[accessKeyOf("acctA")]).isEqualTo("A-access")
         }
 
     @Test
     fun `clearTokens fully tears down the active session including any leftover bare staging keys`() = runTest {
-        val store = FakeKeyedStore(
+        val store = FakeTokenStore(
             noRefresh,
             seed = mapOf(
                 "active_account_id" to "acctA",
-                accessKey("acctA") to "A-access",
+                accessKeyOf("acctA") to "A-access",
                 refreshKeyOf("acctA") to "A-refresh",
                 // A stale staged pair left behind by an abandoned/killed login.
                 "access_token" to "orphan-access",
@@ -374,7 +346,7 @@ class CommonTokenDataStoreAccountKeyingTest {
 
         store.clearTokens()
 
-        assertThat(store.store).doesNotContainKey(accessKey("acctA"))
+        assertThat(store.store).doesNotContainKey(accessKeyOf("acctA"))
         assertThat(store.store).doesNotContainKey(refreshKeyOf("acctA"))
         assertThat(store.store).doesNotContainKey("active_account_id")
         // The orphaned staging pair is purged too, so it can't cold-start a phantom session.
@@ -401,11 +373,11 @@ class CommonTokenDataStoreAccountKeyingTest {
                 }
             }
         }
-        val store = FakeKeyedStore(
+        val store = FakeTokenStore(
             refreshClient,
             seed = mapOf(
                 "active_account_id" to "acctA",
-                accessKey("acctA") to "A-access",
+                accessKeyOf("acctA") to "A-access",
                 refreshKeyOf("acctA") to "A-refresh",
             ),
         )
@@ -413,7 +385,7 @@ class CommonTokenDataStoreAccountKeyingTest {
         val ok = store.refreshAccessToken()
 
         assertThat(ok).isEqualTo(RefreshResult.Refreshed)
-        assertThat(store.store[accessKey("acctA")]).isEqualTo("A-access-refreshed")
+        assertThat(store.store[accessKeyOf("acctA")]).isEqualTo("A-access-refreshed")
         assertThat(store.getAccessToken()).isEqualTo("A-access-refreshed")
     }
 
@@ -439,13 +411,13 @@ class CommonTokenDataStoreAccountKeyingTest {
                 }
             }
         }
-        val store = FakeKeyedStore(
+        val store = FakeTokenStore(
             refreshClient,
             seed = mapOf(
                 "active_account_id" to "acctA",
-                accessKey("acctA") to "A-access",
+                accessKeyOf("acctA") to "A-access",
                 refreshKeyOf("acctA") to "A-refresh",
-                accessKey("acctB") to "B-access",
+                accessKeyOf("acctB") to "B-access",
                 refreshKeyOf("acctB") to "B-refresh",
             ),
         )
@@ -454,16 +426,16 @@ class CommonTokenDataStoreAccountKeyingTest {
 
         assertThat(ok).isEqualTo(RefreshResult.Refreshed)
         assertThat(requestedUrl).startsWith("https://b.example.com/api/auth/refresh")
-        assertThat(store.store[accessKey("acctB")]).isEqualTo("B-access-refreshed")
+        assertThat(store.store[accessKeyOf("acctB")]).isEqualTo("B-access-refreshed")
         // acctB is not the active account, so the cached bearer (A's) is untouched.
         assertThat(store.getAccessToken()).isEqualTo("A-access")
     }
 
     @Test
     fun `session expiry scoped to the active account emits`() = runTest {
-        val store = FakeKeyedStore(
+        val store = FakeTokenStore(
             noRefresh,
-            seed = mapOf("active_account_id" to "acctA", accessKey("acctA") to "A-access"),
+            seed = mapOf("active_account_id" to "acctA", accessKeyOf("acctA") to "A-access"),
         )
         var emissions = 0
         val job = backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
@@ -482,9 +454,9 @@ class CommonTokenDataStoreAccountKeyingTest {
 
     @Test
     fun `session expiry for a non-active account is suppressed`() = runTest {
-        val store = FakeKeyedStore(
+        val store = FakeTokenStore(
             noRefresh,
-            seed = mapOf("active_account_id" to "acctA", accessKey("acctA") to "A-access"),
+            seed = mapOf("active_account_id" to "acctA", accessKeyOf("acctA") to "A-access"),
         )
         var emissions = 0
         val job = backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {

--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/datastore/CommonTokenDataStoreConcurrencyTest.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/datastore/CommonTokenDataStoreConcurrencyTest.kt
@@ -2,21 +2,12 @@ package com.garfiec.librechat.core.data.datastore
 
 import com.garfiec.librechat.core.network.client.RefreshResult
 import com.google.common.truth.Truth.assertThat
-import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
-import io.ktor.client.engine.mock.MockEngineConfig
-import io.ktor.client.engine.mock.MockRequestHandler
 import io.ktor.client.engine.mock.respond
-import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
-import io.ktor.client.plugins.defaultRequest
-import io.ktor.client.request.url
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
-import io.ktor.http.contentType
 import io.ktor.http.headersOf
-import io.ktor.serialization.kotlinx.json.json
 import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
@@ -31,93 +22,19 @@ import java.io.IOException
 @OptIn(ExperimentalCoroutinesApi::class)
 class CommonTokenDataStoreConcurrencyTest {
 
-    /**
-     * Test double that records every platform storage mutation. It deliberately
-     * mirrors `TokenDataStore` semantics (read-through reads, write-through
-     * writes) without pulling in `EncryptedSharedPreferences`.
-     */
-    private class FakeTokenDataStore(
-        refreshClient: Lazy<HttpClient>,
-        initialAccess: String? = "initial-access",
-        initialRefresh: String? = "initial-refresh",
-    ) : CommonTokenDataStore(refreshClient) {
-
-        private val store = mutableMapOf<String, String>()
-
-        val writeLog = mutableListOf<Pair<String, String>>()
-        var removeCount = 0
-
-        // No account is resolved in these tests, so the store uses the bare token keys.
-        fun persistedAccess(): String? = store[KEY_ACCESS_TOKEN]
-        fun persistedRefresh(): String? = store[KEY_REFRESH_TOKEN]
-
-        init {
-            initialAccess?.let { store[KEY_ACCESS_TOKEN] = it }
-            initialRefresh?.let { store[KEY_REFRESH_TOKEN] = it }
-            initializeTokenCache()
-        }
-
-        override fun readValue(key: String): String? = store[key]
-
-        override fun writeValue(key: String, value: String) {
-            store[key] = value
-            // setTokens writes access then refresh; log the pair once, keyed off the access write.
-            if (key == KEY_ACCESS_TOKEN) writeLog += value to (store[KEY_REFRESH_TOKEN] ?: "")
-        }
-
-        override fun writeValues(values: Map<String, String>) {
-            values.forEach { (key, value) -> writeValue(key, value) }
-        }
-
-        override fun removeValue(key: String) {
-            store.remove(key)
-            // clearTokens removes access then refresh; count the logical clear off the access removal.
-            if (key == KEY_ACCESS_TOKEN) removeCount++
-        }
-
-        override fun onKeystoreCorruption() = Unit
-    }
-
-    // MockEngine defaults its dispatcher to Dispatchers.IO, which hops the handler (and everything
-    // downstream of release.await()/respond()) onto a real thread pool outside the UnconfinedTestDispatcher's
-    // virtual scheduler. yield()/advanceUntilIdle() can't wait for that real-thread work, so the assertions
-    // below would race it. Pinning the engine to Dispatchers.Unconfined keeps the whole request handling
-    // synchronous with the test dispatcher, eliminating the race.
-    private fun mockEngine(handler: MockRequestHandler): MockEngine = MockEngine(
-        MockEngineConfig().apply {
-            requestHandlers.add(handler)
-            dispatcher = Dispatchers.Unconfined
-        },
-    )
-
-    private fun mockRefreshClient(engine: MockEngine): Lazy<HttpClient> = lazy {
-        HttpClient(engine) {
-            install(ContentNegotiation) { json() }
-            defaultRequest {
-                url("https://chat.example.com")
-                contentType(ContentType.Application.Json)
-            }
-        }
-    }
-
-    private fun refreshResponseBody(token: String): String =
-        """{"token":"$token"}"""
-
-    private val jsonHeaders = headersOf("Content-Type", ContentType.Application.Json.toString())
-
     @Test
     fun `clearTokens does not block on an in-flight refresh and the refresh discards its result`() =
         runTest(UnconfinedTestDispatcher()) {
             val release = CompletableDeferred<Unit>()
-            val engine = mockEngine {
+            val engine = unconfinedMockEngine {
                 release.await()
                 respond(
                     content = refreshResponseBody("new-access"),
                     status = HttpStatusCode.OK,
-                    headers = jsonHeaders,
+                    headers = jsonResponseHeaders,
                 )
             }
-            val store = FakeTokenDataStore(mockRefreshClient(engine))
+            val store = FakeTokenStore(refreshClientOf(engine), bareSeed())
 
             val refreshJob = async { store.refreshAccessToken() }
             // Give the refresh coroutine a chance to read the stored token and suspend inside the
@@ -151,15 +68,15 @@ class CommonTokenDataStoreConcurrencyTest {
     fun `refresh does not resurrect a logout that raced its network call`() =
         runTest(UnconfinedTestDispatcher()) {
             val release = CompletableDeferred<Unit>()
-            val engine = mockEngine {
+            val engine = unconfinedMockEngine {
                 release.await()
                 respond(
                     content = refreshResponseBody("resurrected-access"),
                     status = HttpStatusCode.OK,
-                    headers = jsonHeaders,
+                    headers = jsonResponseHeaders,
                 )
             }
-            val store = FakeTokenDataStore(mockRefreshClient(engine))
+            val store = FakeTokenStore(refreshClientOf(engine), bareSeed())
 
             val refreshJob = async { store.refreshAccessToken() }
             yield()
@@ -182,14 +99,14 @@ class CommonTokenDataStoreConcurrencyTest {
     @Test
     fun `refresh without a concurrent clear still writes the new token`() =
         runTest(UnconfinedTestDispatcher()) {
-            val engine = mockEngine {
+            val engine = unconfinedMockEngine {
                 respond(
                     content = refreshResponseBody("fresh-access"),
                     status = HttpStatusCode.OK,
-                    headers = jsonHeaders,
+                    headers = jsonResponseHeaders,
                 )
             }
-            val store = FakeTokenDataStore(mockRefreshClient(engine))
+            val store = FakeTokenStore(refreshClientOf(engine), bareSeed())
 
             val result = store.refreshAccessToken()
 
@@ -202,14 +119,14 @@ class CommonTokenDataStoreConcurrencyTest {
     @Test
     fun `sequential clearTokens and refreshAccessToken do not deadlock`() =
         runTest(UnconfinedTestDispatcher()) {
-            val engine = mockEngine {
+            val engine = unconfinedMockEngine {
                 respond(
                     content = refreshResponseBody("seq-access"),
                     status = HttpStatusCode.OK,
-                    headers = jsonHeaders,
+                    headers = jsonResponseHeaders,
                 )
             }
-            val store = FakeTokenDataStore(mockRefreshClient(engine))
+            val store = FakeTokenStore(refreshClientOf(engine), bareSeed())
 
             store.clearTokens()
             assertThat(store.removeCount).isEqualTo(1)
@@ -225,7 +142,7 @@ class CommonTokenDataStoreConcurrencyTest {
     fun `a persistent refresh 401 retries the full budget then classifies HardExpired`() =
         runTest(UnconfinedTestDispatcher()) {
             var requestCount = 0
-            val engine = mockEngine {
+            val engine = unconfinedMockEngine {
                 requestCount++
                 // text/html 401, exactly like the backend's "Refresh token expired or not found".
                 respond(
@@ -234,7 +151,7 @@ class CommonTokenDataStoreConcurrencyTest {
                     headers = headersOf("Content-Type", "text/html"),
                 )
             }
-            val store = FakeTokenDataStore(mockRefreshClient(engine))
+            val store = FakeTokenStore(refreshClientOf(engine), bareSeed())
 
             val result = store.refreshAccessToken()
 
@@ -253,7 +170,7 @@ class CommonTokenDataStoreConcurrencyTest {
             // The exact "occasional logout" scenario: a transient server session-lookup miss returns
             // 401, then the very next attempt with the same token succeeds. Retrying absorbs it.
             var requestCount = 0
-            val engine = mockEngine {
+            val engine = unconfinedMockEngine {
                 requestCount++
                 if (requestCount == 1) {
                     respond("transient miss", HttpStatusCode.Unauthorized, headersOf("Content-Type", "text/html"))
@@ -261,11 +178,11 @@ class CommonTokenDataStoreConcurrencyTest {
                     respond(
                         content = """{"token":"recovered-access"}""",
                         status = HttpStatusCode.OK,
-                        headers = jsonHeaders,
+                        headers = jsonResponseHeaders,
                     )
                 }
             }
-            val store = FakeTokenDataStore(mockRefreshClient(engine))
+            val store = FakeTokenStore(refreshClientOf(engine), bareSeed())
 
             val result = store.refreshAccessToken()
 
@@ -278,11 +195,11 @@ class CommonTokenDataStoreConcurrencyTest {
     fun `a persistent 5xx retries the full budget then classifies Transient`() =
         runTest(UnconfinedTestDispatcher()) {
             var requestCount = 0
-            val engine = mockEngine {
+            val engine = unconfinedMockEngine {
                 requestCount++
                 respond("boom", HttpStatusCode.InternalServerError, headersOf("Content-Type", "text/html"))
             }
-            val store = FakeTokenDataStore(mockRefreshClient(engine))
+            val store = FakeTokenStore(refreshClientOf(engine), bareSeed())
 
             val result = store.refreshAccessToken()
 
@@ -298,11 +215,11 @@ class CommonTokenDataStoreConcurrencyTest {
             // A proxy interstitial: HTTP 200 but an HTML body. The body-deserialization failure is
             // recoverable, not a dead session, so it is classified transient and retried.
             var requestCount = 0
-            val engine = mockEngine {
+            val engine = unconfinedMockEngine {
                 requestCount++
                 respond("<html>login</html>", HttpStatusCode.OK, headersOf("Content-Type", "text/html"))
             }
-            val store = FakeTokenDataStore(mockRefreshClient(engine))
+            val store = FakeTokenStore(refreshClientOf(engine), bareSeed())
 
             val result = store.refreshAccessToken()
 
@@ -317,7 +234,7 @@ class CommonTokenDataStoreConcurrencyTest {
             // A genuinely-dead session that 401s, then hits a 5xx blip on the final attempt, must still
             // route to re-auth — not be masked as Transient by the last attempt.
             var requestCount = 0
-            val engine = mockEngine {
+            val engine = unconfinedMockEngine {
                 requestCount++
                 if (requestCount < 3) {
                     respond("expired", HttpStatusCode.Unauthorized, headersOf("Content-Type", "text/html"))
@@ -325,7 +242,7 @@ class CommonTokenDataStoreConcurrencyTest {
                     respond("boom", HttpStatusCode.InternalServerError, headersOf("Content-Type", "text/html"))
                 }
             }
-            val store = FakeTokenDataStore(mockRefreshClient(engine))
+            val store = FakeTokenStore(refreshClientOf(engine), bareSeed())
 
             val result = store.refreshAccessToken()
 
@@ -339,11 +256,11 @@ class CommonTokenDataStoreConcurrencyTest {
             // A hung/unreachable server (POST throws) must NOT re-POST twice more while holding the
             // per-account flight lock — one attempt, then keep the session.
             var requestCount = 0
-            val engine = mockEngine {
+            val engine = unconfinedMockEngine {
                 requestCount++
                 throw IOException("connection reset")
             }
-            val store = FakeTokenDataStore(mockRefreshClient(engine))
+            val store = FakeTokenStore(refreshClientOf(engine), bareSeed())
 
             val result = store.refreshAccessToken()
 
@@ -358,7 +275,7 @@ class CommonTokenDataStoreConcurrencyTest {
             // A confirmed-dead session (401) followed by the server going unreachable must still route
             // to re-auth, not be downgraded to Transient by the transport error.
             var requestCount = 0
-            val engine = mockEngine {
+            val engine = unconfinedMockEngine {
                 requestCount++
                 if (requestCount == 1) {
                     respond("expired", HttpStatusCode.Unauthorized, headersOf("Content-Type", "text/html"))
@@ -366,7 +283,7 @@ class CommonTokenDataStoreConcurrencyTest {
                     throw IOException("connection reset")
                 }
             }
-            val store = FakeTokenDataStore(mockRefreshClient(engine))
+            val store = FakeTokenStore(refreshClientOf(engine), bareSeed())
 
             val result = store.refreshAccessToken()
 
@@ -378,7 +295,7 @@ class CommonTokenDataStoreConcurrencyTest {
     fun `a 429 with a Retry-After beyond the cap stops instead of hammering`() =
         runTest(UnconfinedTestDispatcher()) {
             var requestCount = 0
-            val engine = mockEngine {
+            val engine = unconfinedMockEngine {
                 requestCount++
                 respond(
                     content = "slow down",
@@ -386,7 +303,7 @@ class CommonTokenDataStoreConcurrencyTest {
                     headers = headersOf("Retry-After", "60"),
                 )
             }
-            val store = FakeTokenDataStore(mockRefreshClient(engine))
+            val store = FakeTokenStore(refreshClientOf(engine), bareSeed())
 
             val result = store.refreshAccessToken()
 
@@ -399,7 +316,7 @@ class CommonTokenDataStoreConcurrencyTest {
     fun `a 429 is retried and recovers on the next attempt`() =
         runTest(UnconfinedTestDispatcher()) {
             var requestCount = 0
-            val engine = mockEngine {
+            val engine = unconfinedMockEngine {
                 requestCount++
                 if (requestCount == 1) {
                     respond(
@@ -408,10 +325,10 @@ class CommonTokenDataStoreConcurrencyTest {
                         headers = headersOf("Retry-After", "1"),
                     )
                 } else {
-                    respond("""{"token":"post-429-access"}""", HttpStatusCode.OK, headers = jsonHeaders)
+                    respond("""{"token":"post-429-access"}""", HttpStatusCode.OK, headers = jsonResponseHeaders)
                 }
             }
-            val store = FakeTokenDataStore(mockRefreshClient(engine))
+            val store = FakeTokenStore(refreshClientOf(engine), bareSeed())
 
             val result = store.refreshAccessToken()
 
@@ -423,7 +340,7 @@ class CommonTokenDataStoreConcurrencyTest {
     @Test
     fun `a successful refresh persists the rotated refresh token from Set-Cookie`() =
         runTest(UnconfinedTestDispatcher()) {
-            val engine = mockEngine {
+            val engine = unconfinedMockEngine {
                 respond(
                     content = """{"token":"rotated-access"}""",
                     status = HttpStatusCode.OK,
@@ -433,7 +350,7 @@ class CommonTokenDataStoreConcurrencyTest {
                     ),
                 )
             }
-            val store = FakeTokenDataStore(mockRefreshClient(engine))
+            val store = FakeTokenStore(refreshClientOf(engine), bareSeed())
 
             val result = store.refreshAccessToken()
 

--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/datastore/CommonTokenDataStoreGatewayTest.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/datastore/CommonTokenDataStoreGatewayTest.kt
@@ -33,40 +33,12 @@ class CommonTokenDataStoreGatewayTest {
         const val ACCESS_LOGIN = "https://team.cloudflareaccess.com/cdn-cgi/access/login/chat.example.com"
     }
 
-    private class FakeStore(
-        refreshClient: Lazy<HttpClient>,
-        seed: Map<String, String> = emptyMap(),
-    ) : CommonTokenDataStore(refreshClient) {
-        val store = seed.toMutableMap()
 
-        init {
-            initializeTokenCache()
-        }
-
-        override fun readValue(key: String): String? = store[key]
-        override fun writeValue(key: String, value: String) {
-            store[key] = value
-        }
-
-        override fun writeValues(values: Map<String, String>) {
-            store.putAll(values)
-        }
-
-        override fun removeValue(key: String) {
-            store.remove(key)
-        }
-
-        override fun onKeystoreCorruption() = Unit
-    }
-
-    private fun accessKey(account: String) = "acct:$account:access_token"
-    private fun refreshKeyOf(account: String) = "acct:$account:refresh_token"
-
-    private fun seededStore(refreshClient: Lazy<HttpClient>) = FakeStore(
+    private fun seededStore(refreshClient: Lazy<HttpClient>) = FakeTokenStore(
         refreshClient,
         seed = mapOf(
             "active_account_id" to "acctA",
-            accessKey("acctA") to "A-access",
+            accessKeyOf("acctA") to "A-access",
             refreshKeyOf("acctA") to "A-refresh",
         ),
     )
@@ -109,7 +81,7 @@ class CommonTokenDataStoreGatewayTest {
         assertThat(result).isEqualTo(RefreshResult.Transient)
         // The tokens must survive for the retry that follows the header fix.
         assertThat(store.store[refreshKeyOf("acctA")]).isEqualTo("A-refresh")
-        assertThat(store.store[accessKey("acctA")]).isEqualTo("A-access")
+        assertThat(store.store[accessKeyOf("acctA")]).isEqualTo("A-access")
     }
 
     /** Deterministic until the user edits the credential, and the budget is spent under the flight lock. */

--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/datastore/CommonTokenDataStoreProactiveRenewalTest.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/datastore/CommonTokenDataStoreProactiveRenewalTest.kt
@@ -1,0 +1,315 @@
+package com.garfiec.librechat.core.data.datastore
+
+import com.google.common.truth.Truth.assertThat
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
+import kotlin.time.Clock
+
+/**
+ * Proactive renewal (issue #323): renew an access token whose `exp` has passed *before* the request
+ * goes out, instead of paying a 401-then-refresh-then-retry round trip per fanned-out request.
+ *
+ * Two families of test carry the weight. The **runaway-loop** ones cover a token that reads as stale
+ * the instant it is issued (a fast device clock, or a `SESSION_EXPIRY` shorter than the skew window),
+ * which would otherwise be one refresh POST per request forever — strictly worse than the reactive
+ * path this replaces. The **best-effort** ones pin the rule that a renewal nobody is waiting on can
+ * neither log the user out nor stall the requests behind it.
+ */
+@OptIn(ExperimentalCoroutinesApi::class, ExperimentalEncodingApi::class)
+class CommonTokenDataStoreProactiveRenewalTest {
+
+    private companion object {
+        const val ACCOUNT = "acctA"
+        const val CALLS = 4
+    }
+
+    /** A JWT whose `exp` is [secondsFromNow] away. Only the payload is real; nothing verifies it. */
+    private fun jwt(secondsFromNow: Long, id: String = "u1"): String {
+        val exp = Clock.System.now().toEpochMilliseconds() / 1000 + secondsFromNow
+        val encoder = Base64.UrlSafe.withPadding(Base64.PaddingOption.ABSENT)
+        val header = encoder.encode("""{"alg":"HS256"}""".encodeToByteArray())
+        val payload = encoder.encode("""{"id":"$id","exp":$exp}""".encodeToByteArray())
+        return "$header.$payload.sig"
+    }
+
+    private fun seeded(refreshClient: Lazy<HttpClient>, access: String?): FakeTokenStore = FakeTokenStore(
+        refreshClient,
+        seed = buildMap {
+            put(ACTIVE_ACCOUNT_KEY, ACCOUNT)
+            access?.let { put(accessKeyOf(ACCOUNT), it) }
+            put(refreshKeyOf(ACCOUNT), "R0")
+        },
+    )
+
+    /** Answers every refresh with a token expiring [secondsFromNow] away, counting the POSTs. */
+    private fun renewingEngine(secondsFromNow: Long, counter: IntArray): MockEngine = unconfinedMockEngine {
+        counter[0]++
+        respond(
+            refreshResponseBody(jwt(secondsFromNow, id = "renewed${counter[0]}")),
+            HttpStatusCode.OK,
+            jsonResponseHeaders,
+        )
+    }
+
+    @Test
+    fun `an expired access token is renewed before the request goes out`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val posts = intArrayOf(0)
+            val stale = jwt(-60)
+            val store = seeded(refreshClientOf(renewingEngine(900, posts)), access = stale)
+
+            val bearer = store.ensureFreshAccessToken(ACCOUNT, TEST_SERVER, stale)
+
+            assertThat(posts[0]).isEqualTo(1)
+            assertThat(bearer).isNotEqualTo(stale)
+            assertThat(bearer).isEqualTo(store.getAccessTokenFor(ACCOUNT))
+            // The renewed token is good, so a second pass must not fire again.
+            store.ensureFreshAccessToken(ACCOUNT, TEST_SERVER, bearer)
+            assertThat(posts[0]).isEqualTo(1)
+        }
+
+    @Test
+    fun `a token still inside its lifetime is left alone`() = runTest(UnconfinedTestDispatcher()) {
+        val posts = intArrayOf(0)
+        val fresh = jwt(900)
+        val store = seeded(refreshClientOf(renewingEngine(900, posts)), access = fresh)
+
+        repeat(CALLS) { assertThat(store.ensureFreshAccessToken(ACCOUNT, TEST_SERVER, fresh)).isEqualTo(fresh) }
+
+        assertThat(posts[0]).isEqualTo(0)
+    }
+
+    @Test
+    fun `a token with no readable deadline is left to the reactive path`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val posts = intArrayOf(0)
+            // An OpenID pass-through: opaque, no `exp` to read. Unknown must mean "do nothing".
+            val opaque = "opaque-provider-token"
+            val store = seeded(refreshClientOf(renewingEngine(900, posts)), access = opaque)
+
+            assertThat(store.ensureFreshAccessToken(ACCOUNT, TEST_SERVER, opaque)).isEqualTo(opaque)
+
+            assertThat(posts[0]).isEqualTo(0)
+        }
+
+    @Test
+    fun `an absent token does nothing`() = runTest(UnconfinedTestDispatcher()) {
+        val posts = intArrayOf(0)
+        val store = seeded(refreshClientOf(renewingEngine(900, posts)), access = null)
+
+        assertThat(store.ensureFreshAccessToken(ACCOUNT, TEST_SERVER, null)).isNull()
+
+        assertThat(posts[0]).isEqualTo(0)
+    }
+
+    /**
+     * Clock skew / a `SESSION_EXPIRY` under the skew window: the server issues a **new** token that is
+     * already stale by our reading. Without the guard this is one POST per request, forever.
+     */
+    @Test
+    fun `a freshly-issued token that still reads as stale suppresses further renewal`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val posts = intArrayOf(0)
+            val store = seeded(refreshClientOf(renewingEngine(-30, posts)), access = jwt(-60))
+
+            var bearer: String? = jwt(-60)
+            repeat(CALLS) { bearer = store.ensureFreshAccessToken(ACCOUNT, TEST_SERVER, bearer) }
+
+            assertThat(posts[0]).isEqualTo(1)
+        }
+
+    /**
+     * The OpenID reuse path (`OPENID_REUSE_EXPIRY_BUFFER_SECONDS`): a 2xx that hands back *the same*
+     * token with no rotation. The stored value never moves, so the coalescing short-circuit can never
+     * fire — only the runaway guard stops this one.
+     */
+    @Test
+    fun `a refresh that returns the same stale token suppresses further renewal`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val posts = intArrayOf(0)
+            val stale = jwt(-60)
+            val engine = unconfinedMockEngine {
+                posts[0]++
+                respond(refreshResponseBody(stale), HttpStatusCode.OK, jsonResponseHeaders)
+            }
+            val store = seeded(refreshClientOf(engine), access = stale)
+
+            repeat(CALLS) { store.ensureFreshAccessToken(ACCOUNT, TEST_SERVER, stale) }
+
+            assertThat(posts[0]).isEqualTo(1)
+        }
+
+    /**
+     * A null account means "the live active binding", which is the *keyed* slot on any post-#179
+     * install — not the bare key. Reading the wrong one would silently no-op and the whole feature
+     * would be dead on the main client.
+     */
+    @Test
+    fun `a null account renews the active binding's keyed slot`() = runTest(UnconfinedTestDispatcher()) {
+        val posts = intArrayOf(0)
+        val stale = jwt(-60)
+        val store = seeded(refreshClientOf(renewingEngine(900, posts)), access = stale)
+
+        store.ensureFreshAccessToken(null, TEST_SERVER, stale)
+
+        assertThat(posts[0]).isEqualTo(1)
+        assertThat(store.store[accessKeyOf(ACCOUNT)]).isNotEqualTo(stale)
+    }
+
+    /**
+     * **Every** branch posts to the server the caller snapshotted — including the null-account one,
+     * which the reactive path leaves aimed at the *live* base URL. A refresh token must never be
+     * reachable by a deployment the request was not bound to, and "an account happened to be resolved"
+     * is not a property worth making that guarantee depend on.
+     */
+    @Test
+    fun `the renewal POST is pinned to the snapshot's server for both keyed and null accounts`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val pinnedServer = "https://pinned.example.com"
+            for (account in listOf(ACCOUNT, null)) {
+                val urls = mutableListOf<String>()
+                val stale = jwt(-60)
+                val engine = unconfinedMockEngine { request ->
+                    urls += request.url.toString()
+                    respond(refreshResponseBody(jwt(900)), HttpStatusCode.OK, jsonResponseHeaders)
+                }
+                // The client's own default URL is a DIFFERENT server, standing in for a live base URL
+                // that a switch has already moved on to. The POST must ignore it.
+                val store = seeded(refreshClientOf(engine, baseUrl = "https://live-elsewhere.example.com"), stale)
+
+                store.ensureFreshAccessToken(account, pinnedServer, stale)
+
+                assertThat(urls).containsExactly("$pinnedServer/api/auth/refresh")
+            }
+        }
+
+    /**
+     * **A proactive renewal must never log anyone out.** The backend answers `401` identically for a
+     * dead session and a transiently-missed one, which is why the reactive path retries before
+     * settling. A single best-effort attempt cannot tell them apart, so it must not settle the
+     * question at all: the slot stays, the request proceeds on its old bearer, and the reactive ladder
+     * keeps sole ownership of the teardown.
+     */
+    @Test
+    fun `a rejected renewal neither drops the slot nor reports the session expired`() =
+        runTest(UnconfinedTestDispatcher()) {
+            var posts = 0
+            var reported = 0
+            val stale = jwt(-60)
+            val engine = unconfinedMockEngine {
+                posts++
+                respond("", HttpStatusCode.Unauthorized)
+            }
+            val store = seeded(refreshClientOf(engine), access = stale)
+            backgroundScope.launch { store.sessionExpiredFlow.collect { reported++ } }
+
+            val bearer = store.ensureFreshAccessToken(ACCOUNT, TEST_SERVER, stale)
+
+            assertThat(reported).isEqualTo(0)
+            assertThat(store.store[accessKeyOf(ACCOUNT)]).isEqualTo(stale)
+            assertThat(store.store[refreshKeyOf(ACCOUNT)]).isEqualTo("R0")
+            assertThat(bearer).isEqualTo(stale)
+            // One attempt, not the reactive ladder's three: retrying cannot change the answer for a
+            // caller that is going to ignore it either way.
+            assertThat(posts).isEqualTo(1)
+        }
+
+    /**
+     * Negative caching. A renewal that cannot succeed changes nothing for the coalescing check to see,
+     * so without suppression every request in a cold-start fan-out queues behind the flight lock and
+     * spends its own timeout *before being sent* — far worse than the reactive path, where the same
+     * requests fail in parallel.
+     */
+    @Test
+    fun `a failed renewal is not retried by every subsequent request`() =
+        runTest(UnconfinedTestDispatcher()) {
+            var posts = 0
+            val stale = jwt(-60)
+            val engine = unconfinedMockEngine {
+                posts++
+                respond("", HttpStatusCode.ServiceUnavailable)
+            }
+            val store = seeded(refreshClientOf(engine), access = stale)
+
+            repeat(CALLS) { store.ensureFreshAccessToken(ACCOUNT, TEST_SERVER, stale) }
+
+            assertThat(posts).isEqualTo(1)
+        }
+
+    /**
+     * The slot has an access token but no refresh token — a torn pair, or the bare staging slot after a
+     * re-home. A best-effort renewal must return without POSTing and **without dropping the access
+     * token**: the reactive path decides what a missing refresh token means, not this one.
+     */
+    @Test
+    fun `a slot with no refresh token skips the POST and keeps the access token`() =
+        runTest(UnconfinedTestDispatcher()) {
+            var posts = 0
+            val stale = jwt(-60)
+            val engine = unconfinedMockEngine {
+                posts++
+                respond(refreshResponseBody(jwt(900)), HttpStatusCode.OK, jsonResponseHeaders)
+            }
+            val store = FakeTokenStore(
+                refreshClientOf(engine),
+                seed = mapOf(ACTIVE_ACCOUNT_KEY to ACCOUNT, accessKeyOf(ACCOUNT) to stale),
+            )
+
+            val bearer = store.ensureFreshAccessToken(ACCOUNT, TEST_SERVER, stale)
+
+            assertThat(posts).isEqualTo(0)
+            assertThat(bearer).isEqualTo(stale)
+            assertThat(store.store[accessKeyOf(ACCOUNT)]).isEqualTo(stale)
+        }
+
+    /**
+     * Suppression is per account, not per process: the conditions that trigger it are properties of
+     * one deployment, and one account on a misconfigured server must not silently turn the feature off
+     * for another account on a healthy one.
+     */
+    @Test
+    fun `suppressing one account leaves another account renewing`() = runTest(UnconfinedTestDispatcher()) {
+        var posts = 0
+        val staleA = jwt(-60, id = "a")
+        val staleB = jwt(-60, id = "b")
+        val engine = unconfinedMockEngine { request ->
+            posts++
+            // Account A's server is down; account B's answers normally.
+            if (request.url.toString().startsWith("https://a.example.com")) {
+                respond("", HttpStatusCode.ServiceUnavailable)
+            } else {
+                respond(refreshResponseBody(jwt(900, id = "b-renewed")), HttpStatusCode.OK, jsonResponseHeaders)
+            }
+        }
+        val store = FakeTokenStore(
+            refreshClientOf(engine),
+            seed = mapOf(
+                ACTIVE_ACCOUNT_KEY to "acctA",
+                accessKeyOf("acctA") to staleA,
+                refreshKeyOf("acctA") to "RA",
+                accessKeyOf("acctB") to staleB,
+                refreshKeyOf("acctB") to "RB",
+            ),
+        )
+
+        // A fails and is suppressed; a second attempt for A must not POST again.
+        store.ensureFreshAccessToken("acctA", "https://a.example.com", staleA)
+        store.ensureFreshAccessToken("acctA", "https://a.example.com", staleA)
+        assertThat(posts).isEqualTo(1)
+
+        val bearerB = store.ensureFreshAccessToken("acctB", "https://b.example.com", staleB)
+
+        assertThat(posts).isEqualTo(2)
+        assertThat(bearerB).isNotEqualTo(staleB)
+        assertThat(store.store[accessKeyOf("acctB")]).isEqualTo(bearerB)
+    }
+}

--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/datastore/CommonTokenDataStoreRefreshCoalescingTest.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/datastore/CommonTokenDataStoreRefreshCoalescingTest.kt
@@ -2,22 +2,10 @@ package com.garfiec.librechat.core.data.datastore
 
 import com.garfiec.librechat.core.network.client.RefreshResult
 import com.google.common.truth.Truth.assertThat
-import io.ktor.client.HttpClient
-import io.ktor.client.engine.mock.MockEngine
-import io.ktor.client.engine.mock.MockEngineConfig
-import io.ktor.client.engine.mock.MockRequestHandler
 import io.ktor.client.engine.mock.respond
-import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
-import io.ktor.client.plugins.defaultRequest
-import io.ktor.client.request.url
-import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
-import io.ktor.http.contentType
-import io.ktor.http.headersOf
-import io.ktor.serialization.kotlinx.json.json
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Deferred
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.test.TestScope
@@ -28,9 +16,9 @@ import kotlinx.coroutines.yield
 import org.junit.Test
 
 /**
- * The flight mutex serializes same-account refreshes but does not *coalesce* them: before this, a
- * cold-start fan-out of N 401s meant N sequential refresh POSTs, each waiting out the one before it,
- * before any content rendered (issue #323).
+ * The flight mutex serializes same-account refreshes but does not *coalesce* them: on its own, a
+ * cold-start fan-out of N 401s costs N sequential refresh POSTs, each waiting out the one before it,
+ * before any content renders (issue #323).
  *
  * A caller that passes the bearer its request actually sent lets a waiter detect that the holder
  * before it already rotated the slot, and skip its own POST. These tests pin both halves: the burst
@@ -42,88 +30,35 @@ import org.junit.Test
 class CommonTokenDataStoreRefreshCoalescingTest {
 
     private companion object {
-        const val SERVER = "https://chat.example.com"
         const val ACCOUNT = "acctA"
         const val STALE_ACCESS = "T0"
         const val WAITERS = 5
     }
 
-    private class FakeStore(
-        refreshClient: Lazy<HttpClient>,
-        seed: Map<String, String>,
-    ) : CommonTokenDataStore(refreshClient) {
-        val store = seed.toMutableMap()
-
-        init {
-            initializeTokenCache()
-        }
-
-        override fun readValue(key: String): String? = store[key]
-
-        override fun writeValue(key: String, value: String) {
-            store[key] = value
-        }
-
-        override fun writeValues(values: Map<String, String>) {
-            store.putAll(values)
-        }
-
-        override fun removeValue(key: String) {
-            store.remove(key)
-        }
-
-        override fun onKeystoreCorruption() = Unit
-    }
-
-    private fun accessKey(account: String) = "acct:$account:access_token"
-    private fun refreshKeyOf(account: String) = "acct:$account:refresh_token"
-
-    // MockEngine defaults to Dispatchers.IO, which hops the handler onto a real thread pool outside the
-    // virtual scheduler; yield()/advanceUntilIdle() cannot wait for that, so the assertions would race
-    // it. Pinning to Unconfined keeps request handling synchronous with the test dispatcher.
-    private fun mockEngine(handler: MockRequestHandler): MockEngine = MockEngine(
-        MockEngineConfig().apply {
-            requestHandlers.add(handler)
-            dispatcher = Dispatchers.Unconfined
-        },
-    )
-
-    private fun client(engine: MockEngine): Lazy<HttpClient> = lazy {
-        HttpClient(engine) {
-            install(ContentNegotiation) { json() }
-            defaultRequest {
-                url(SERVER)
-                contentType(ContentType.Application.Json)
-            }
-        }
-    }
-
-    private val jsonHeaders = headersOf("Content-Type", ContentType.Application.Json.toString())
-
     private fun seeded(
-        refreshClient: Lazy<HttpClient>,
+        refreshClient: Lazy<io.ktor.client.HttpClient>,
         access: String? = STALE_ACCESS,
-    ): FakeStore = FakeStore(
+    ): FakeTokenStore = FakeTokenStore(
         refreshClient,
         seed = buildMap {
-            put("active_account_id", ACCOUNT)
-            access?.let { put(accessKey(ACCOUNT), it) }
+            put(ACTIVE_ACCOUNT_KEY, ACCOUNT)
+            access?.let { put(accessKeyOf(ACCOUNT), it) }
             put(refreshKeyOf(ACCOUNT), "R0")
         },
     )
 
     /**
      * Park the first POST, queue [WAITERS] more callers behind the flight lock, then release. Returns
-     * the POST count and every caller's result.
+     * every caller's result.
      */
     private suspend fun TestScope.burst(
-        store: FakeStore,
+        store: FakeTokenStore,
         release: CompletableDeferred<Unit>,
         usedAccessToken: String?,
     ): List<RefreshResult> {
         val callers = mutableListOf<Deferred<RefreshResult>>()
         repeat(WAITERS + 1) {
-            callers += async { store.refreshAccessTokenFor(ACCOUNT, SERVER, usedAccessToken) }
+            callers += async { store.refreshAccessTokenFor(ACCOUNT, TEST_SERVER, usedAccessToken) }
             // Let each caller reach the flight lock (or the parked POST) before starting the next, so
             // they genuinely queue rather than interleaving arbitrarily.
             yield()
@@ -138,18 +73,18 @@ class CommonTokenDataStoreRefreshCoalescingTest {
         runTest(UnconfinedTestDispatcher()) {
             var posts = 0
             val release = CompletableDeferred<Unit>()
-            val engine = mockEngine {
+            val engine = unconfinedMockEngine {
                 posts++
                 release.await()
-                respond(content = """{"token":"T1"}""", status = HttpStatusCode.OK, headers = jsonHeaders)
+                respond(refreshResponseBody("T1"), HttpStatusCode.OK, jsonResponseHeaders)
             }
-            val store = seeded(client(engine))
+            val store = seeded(refreshClientOf(engine))
 
             val results = burst(store, release, usedAccessToken = STALE_ACCESS)
 
             assertThat(posts).isEqualTo(1)
             assertThat(results).containsExactlyElementsIn(List(WAITERS + 1) { RefreshResult.Refreshed })
-            assertThat(store.store[accessKey(ACCOUNT)]).isEqualTo("T1")
+            assertThat(store.store[accessKeyOf(ACCOUNT)]).isEqualTo("T1")
         }
 
     @Test
@@ -157,12 +92,12 @@ class CommonTokenDataStoreRefreshCoalescingTest {
         runTest(UnconfinedTestDispatcher()) {
             var posts = 0
             val release = CompletableDeferred<Unit>()
-            val engine = mockEngine {
+            val engine = unconfinedMockEngine {
                 posts++
                 release.await()
-                respond(content = """{"token":"T$posts"}""", status = HttpStatusCode.OK, headers = jsonHeaders)
+                respond(refreshResponseBody("T$posts"), HttpStatusCode.OK, jsonResponseHeaders)
             }
-            val store = seeded(client(engine))
+            val store = seeded(refreshClientOf(engine))
 
             val results = burst(store, release, usedAccessToken = null)
 
@@ -180,16 +115,12 @@ class CommonTokenDataStoreRefreshCoalescingTest {
         runTest(UnconfinedTestDispatcher()) {
             var posts = 0
             val release = CompletableDeferred<Unit>()
-            val engine = mockEngine {
+            val engine = unconfinedMockEngine {
                 posts++
                 release.await()
-                respond(
-                    content = """{"token":"$STALE_ACCESS"}""",
-                    status = HttpStatusCode.OK,
-                    headers = jsonHeaders,
-                )
+                respond(refreshResponseBody(STALE_ACCESS), HttpStatusCode.OK, jsonResponseHeaders)
             }
-            val store = seeded(client(engine))
+            val store = seeded(refreshClientOf(engine))
 
             burst(store, release, usedAccessToken = STALE_ACCESS)
 
@@ -205,14 +136,14 @@ class CommonTokenDataStoreRefreshCoalescingTest {
     fun `a dropped slot still settles hard-expired instead of short-circuiting`() =
         runTest(UnconfinedTestDispatcher()) {
             var posts = 0
-            val engine = mockEngine {
+            val engine = unconfinedMockEngine {
                 posts++
-                respond(content = """{"error":"jwt expired"}""", status = HttpStatusCode.Unauthorized)
+                respond("""{"error":"jwt expired"}""", HttpStatusCode.Unauthorized)
             }
             // No access token in the slot: the shape left behind by a prior hard-expiry's invalidate.
-            val store = seeded(client(engine), access = null)
+            val store = seeded(refreshClientOf(engine), access = null)
 
-            val result = store.refreshAccessTokenFor(ACCOUNT, SERVER, usedAccessToken = STALE_ACCESS)
+            val result = store.refreshAccessTokenFor(ACCOUNT, TEST_SERVER, usedAccessToken = STALE_ACCESS)
             advanceUntilIdle()
 
             assertThat(result).isEqualTo(RefreshResult.HardExpired)
@@ -227,10 +158,10 @@ class CommonTokenDataStoreRefreshCoalescingTest {
      */
     @Test
     fun `onAccountResolved writes only its own account's slot`() = runTest(UnconfinedTestDispatcher()) {
-        val store = FakeStore(
+        val store = FakeTokenStore(
             lazy { error("no refresh expected") },
             seed = mapOf(
-                accessKey("acctB") to "B-access",
+                accessKeyOf("acctB") to "B-access",
                 refreshKeyOf("acctB") to "B-refresh",
                 CommonTokenDataStore.KEY_ACCESS_TOKEN to "staged-access",
                 CommonTokenDataStore.KEY_REFRESH_TOKEN to "staged-refresh",
@@ -239,8 +170,8 @@ class CommonTokenDataStoreRefreshCoalescingTest {
 
         store.onAccountResolved("acctA")
 
-        assertThat(store.store[accessKey("acctA")]).isEqualTo("staged-access")
-        assertThat(store.store[accessKey("acctB")]).isEqualTo("B-access")
+        assertThat(store.store[accessKeyOf("acctA")]).isEqualTo("staged-access")
+        assertThat(store.store[accessKeyOf("acctB")]).isEqualTo("B-access")
         assertThat(store.store[refreshKeyOf("acctB")]).isEqualTo("B-refresh")
     }
 }

--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/datastore/CommonTokenDataStoreRefreshCoalescingTest.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/datastore/CommonTokenDataStoreRefreshCoalescingTest.kt
@@ -1,0 +1,246 @@
+package com.garfiec.librechat.core.data.datastore
+
+import com.garfiec.librechat.core.network.client.RefreshResult
+import com.google.common.truth.Truth.assertThat
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.MockEngineConfig
+import io.ktor.client.engine.mock.MockRequestHandler
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.defaultRequest
+import io.ktor.client.request.url
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.yield
+import org.junit.Test
+
+/**
+ * The flight mutex serializes same-account refreshes but does not *coalesce* them: before this, a
+ * cold-start fan-out of N 401s meant N sequential refresh POSTs, each waiting out the one before it,
+ * before any content rendered (issue #323).
+ *
+ * A caller that passes the bearer its request actually sent lets a waiter detect that the holder
+ * before it already rotated the slot, and skip its own POST. These tests pin both halves: the burst
+ * collapses to one POST, and every case where the stored value did *not* move must still POST — a
+ * false short-circuit would report a refresh that never happened and, on a dead session, swallow the
+ * logout.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class CommonTokenDataStoreRefreshCoalescingTest {
+
+    private companion object {
+        const val SERVER = "https://chat.example.com"
+        const val ACCOUNT = "acctA"
+        const val STALE_ACCESS = "T0"
+        const val WAITERS = 5
+    }
+
+    private class FakeStore(
+        refreshClient: Lazy<HttpClient>,
+        seed: Map<String, String>,
+    ) : CommonTokenDataStore(refreshClient) {
+        val store = seed.toMutableMap()
+
+        init {
+            initializeTokenCache()
+        }
+
+        override fun readValue(key: String): String? = store[key]
+
+        override fun writeValue(key: String, value: String) {
+            store[key] = value
+        }
+
+        override fun writeValues(values: Map<String, String>) {
+            store.putAll(values)
+        }
+
+        override fun removeValue(key: String) {
+            store.remove(key)
+        }
+
+        override fun onKeystoreCorruption() = Unit
+    }
+
+    private fun accessKey(account: String) = "acct:$account:access_token"
+    private fun refreshKeyOf(account: String) = "acct:$account:refresh_token"
+
+    // MockEngine defaults to Dispatchers.IO, which hops the handler onto a real thread pool outside the
+    // virtual scheduler; yield()/advanceUntilIdle() cannot wait for that, so the assertions would race
+    // it. Pinning to Unconfined keeps request handling synchronous with the test dispatcher.
+    private fun mockEngine(handler: MockRequestHandler): MockEngine = MockEngine(
+        MockEngineConfig().apply {
+            requestHandlers.add(handler)
+            dispatcher = Dispatchers.Unconfined
+        },
+    )
+
+    private fun client(engine: MockEngine): Lazy<HttpClient> = lazy {
+        HttpClient(engine) {
+            install(ContentNegotiation) { json() }
+            defaultRequest {
+                url(SERVER)
+                contentType(ContentType.Application.Json)
+            }
+        }
+    }
+
+    private val jsonHeaders = headersOf("Content-Type", ContentType.Application.Json.toString())
+
+    private fun seeded(
+        refreshClient: Lazy<HttpClient>,
+        access: String? = STALE_ACCESS,
+    ): FakeStore = FakeStore(
+        refreshClient,
+        seed = buildMap {
+            put("active_account_id", ACCOUNT)
+            access?.let { put(accessKey(ACCOUNT), it) }
+            put(refreshKeyOf(ACCOUNT), "R0")
+        },
+    )
+
+    /**
+     * Park the first POST, queue [WAITERS] more callers behind the flight lock, then release. Returns
+     * the POST count and every caller's result.
+     */
+    private suspend fun TestScope.burst(
+        store: FakeStore,
+        release: CompletableDeferred<Unit>,
+        usedAccessToken: String?,
+    ): List<RefreshResult> {
+        val callers = mutableListOf<Deferred<RefreshResult>>()
+        repeat(WAITERS + 1) {
+            callers += async { store.refreshAccessTokenFor(ACCOUNT, SERVER, usedAccessToken) }
+            // Let each caller reach the flight lock (or the parked POST) before starting the next, so
+            // they genuinely queue rather than interleaving arbitrarily.
+            yield()
+        }
+        release.complete(Unit)
+        advanceUntilIdle()
+        return callers.map { it.await() }
+    }
+
+    @Test
+    fun `a queued burst collapses to one refresh POST once the token has rotated`() =
+        runTest(UnconfinedTestDispatcher()) {
+            var posts = 0
+            val release = CompletableDeferred<Unit>()
+            val engine = mockEngine {
+                posts++
+                release.await()
+                respond(content = """{"token":"T1"}""", status = HttpStatusCode.OK, headers = jsonHeaders)
+            }
+            val store = seeded(client(engine))
+
+            val results = burst(store, release, usedAccessToken = STALE_ACCESS)
+
+            assertThat(posts).isEqualTo(1)
+            assertThat(results).containsExactlyElementsIn(List(WAITERS + 1) { RefreshResult.Refreshed })
+            assertThat(store.store[accessKey(ACCOUNT)]).isEqualTo("T1")
+        }
+
+    @Test
+    fun `a null usedAccessToken keeps the pre-existing one POST per caller behaviour`() =
+        runTest(UnconfinedTestDispatcher()) {
+            var posts = 0
+            val release = CompletableDeferred<Unit>()
+            val engine = mockEngine {
+                posts++
+                release.await()
+                respond(content = """{"token":"T$posts"}""", status = HttpStatusCode.OK, headers = jsonHeaders)
+            }
+            val store = seeded(client(engine))
+
+            val results = burst(store, release, usedAccessToken = null)
+
+            assertThat(posts).isEqualTo(WAITERS + 1)
+            assertThat(results).containsExactlyElementsIn(List(WAITERS + 1) { RefreshResult.Refreshed })
+        }
+
+    /**
+     * The OpenID reuse path: the server answers 2xx with the *same* token. Nothing rotated, so nothing
+     * may short-circuit — a comparison that treated "a token is present" as "someone refreshed" would
+     * report success here off a token that is still the stale one.
+     */
+    @Test
+    fun `an unchanged stored token does not short-circuit`() =
+        runTest(UnconfinedTestDispatcher()) {
+            var posts = 0
+            val release = CompletableDeferred<Unit>()
+            val engine = mockEngine {
+                posts++
+                release.await()
+                respond(
+                    content = """{"token":"$STALE_ACCESS"}""",
+                    status = HttpStatusCode.OK,
+                    headers = jsonHeaders,
+                )
+            }
+            val store = seeded(client(engine))
+
+            burst(store, release, usedAccessToken = STALE_ACCESS)
+
+            assertThat(posts).isEqualTo(WAITERS + 1)
+        }
+
+    /**
+     * A dropped slot reads back null, not "changed". If that counted as a rotation the whole burst
+     * would report [RefreshResult.Refreshed] against an account with no tokens at all and the user
+     * would never be routed to re-auth.
+     */
+    @Test
+    fun `a dropped slot still settles hard-expired instead of short-circuiting`() =
+        runTest(UnconfinedTestDispatcher()) {
+            var posts = 0
+            val engine = mockEngine {
+                posts++
+                respond(content = """{"error":"jwt expired"}""", status = HttpStatusCode.Unauthorized)
+            }
+            // No access token in the slot: the shape left behind by a prior hard-expiry's invalidate.
+            val store = seeded(client(engine), access = null)
+
+            val result = store.refreshAccessTokenFor(ACCOUNT, SERVER, usedAccessToken = STALE_ACCESS)
+            advanceUntilIdle()
+
+            assertThat(result).isEqualTo(RefreshResult.HardExpired)
+            assertThat(posts).isAtLeast(1)
+            assertThat(store.store[refreshKeyOf(ACCOUNT)]).isNull()
+        }
+
+    /**
+     * The short-circuit compares against `accountKey`'s own slot, so it is only sound while nothing
+     * writes one account's token into another's. `onAccountResolved` is the one path that re-homes a
+     * token into a keyed slot, and it must take the id derived from the staged pair.
+     */
+    @Test
+    fun `onAccountResolved writes only its own account's slot`() = runTest(UnconfinedTestDispatcher()) {
+        val store = FakeStore(
+            lazy { error("no refresh expected") },
+            seed = mapOf(
+                accessKey("acctB") to "B-access",
+                refreshKeyOf("acctB") to "B-refresh",
+                CommonTokenDataStore.KEY_ACCESS_TOKEN to "staged-access",
+                CommonTokenDataStore.KEY_REFRESH_TOKEN to "staged-refresh",
+            ),
+        )
+
+        store.onAccountResolved("acctA")
+
+        assertThat(store.store[accessKey("acctA")]).isEqualTo("staged-access")
+        assertThat(store.store[accessKey("acctB")]).isEqualTo("B-access")
+        assertThat(store.store[refreshKeyOf("acctB")]).isEqualTo("B-refresh")
+    }
+}

--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/datastore/CommonTokenDataStoreSessionExpiryTest.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/datastore/CommonTokenDataStoreSessionExpiryTest.kt
@@ -33,34 +33,6 @@ class CommonTokenDataStoreSessionExpiryTest {
         const val SERVER = "https://chat.example.com"
     }
 
-    private class FakeStore(
-        refreshClient: Lazy<HttpClient>,
-        seed: Map<String, String> = emptyMap(),
-    ) : CommonTokenDataStore(refreshClient) {
-        val store = seed.toMutableMap()
-
-        init {
-            initializeTokenCache()
-        }
-
-        override fun readValue(key: String): String? = store[key]
-        override fun writeValue(key: String, value: String) {
-            store[key] = value
-        }
-
-        override fun writeValues(values: Map<String, String>) {
-            store.putAll(values)
-        }
-
-        override fun removeValue(key: String) {
-            store.remove(key)
-        }
-
-        override fun onKeystoreCorruption() = Unit
-    }
-
-    private fun accessKey(account: String) = "acct:$account:access_token"
-    private fun refreshKeyOf(account: String) = "acct:$account:refresh_token"
 
     private val noRefresh: Lazy<HttpClient> = lazy { error("refresh client not expected in this test") }
 
@@ -74,11 +46,11 @@ class CommonTokenDataStoreSessionExpiryTest {
         }
     }
 
-    private fun seededStore(refreshClient: Lazy<HttpClient>) = FakeStore(
+    private fun seededStore(refreshClient: Lazy<HttpClient>) = FakeTokenStore(
         refreshClient,
         seed = mapOf(
             "active_account_id" to "acctA",
-            accessKey("acctA") to "A-access",
+            accessKeyOf("acctA") to "A-access",
             refreshKeyOf("acctA") to "A-refresh",
         ),
     )
@@ -90,7 +62,7 @@ class CommonTokenDataStoreSessionExpiryTest {
         val result = store.refreshAccessTokenFor("acctA", SERVER)
 
         assertThat(result).isEqualTo(RefreshResult.HardExpired)
-        assertThat(store.store[accessKey("acctA")]).isNull()
+        assertThat(store.store[accessKeyOf("acctA")]).isNull()
         assertThat(store.store[refreshKeyOf("acctA")]).isNull()
         // The cold-start check reads through these, so this is what stops the replay.
         assertThat(store.isAuthenticated).isFalse()
@@ -116,7 +88,7 @@ class CommonTokenDataStoreSessionExpiryTest {
         // A 5xx is a server-side blip, not evidence the session is dead — tearing down here would
         // log the user out over a transient failure a later request would have recovered from.
         assertThat(result).isEqualTo(RefreshResult.Transient)
-        assertThat(store.store[accessKey("acctA")]).isEqualTo("A-access")
+        assertThat(store.store[accessKeyOf("acctA")]).isEqualTo("A-access")
         assertThat(store.store[refreshKeyOf("acctA")]).isEqualTo("A-refresh")
         assertThat(store.isAuthenticated).isTrue()
     }
@@ -144,7 +116,7 @@ class CommonTokenDataStoreSessionExpiryTest {
         val result = store.refreshAccessTokenFor("acctA", SERVER)
 
         assertThat(result).isEqualTo(RefreshResult.Refreshed)
-        assertThat(store.store[accessKey("acctA")]).isEqualTo("A-access-2")
+        assertThat(store.store[accessKeyOf("acctA")]).isEqualTo("A-access-2")
     }
 
     @Test
@@ -222,7 +194,7 @@ class CommonTokenDataStoreSessionExpiryTest {
      */
     @Test
     fun `an expiry discovered with no subscriber leaves the signal armed`() = runTest {
-        val store = FakeStore(lazy { throw AssertionError("no refresh expected") })
+        val store = FakeTokenStore(lazy { throw AssertionError("no refresh expected") })
 
         // Nobody listening — the report is dropped, and the latch must survive it.
         store.emitSessionExpired(null)
@@ -241,7 +213,7 @@ class CommonTokenDataStoreSessionExpiryTest {
     /** The storm guard still holds once someone is actually listening. */
     @Test
     fun `repeated expiries with a subscriber report once`() = runTest {
-        val store = FakeStore(lazy { throw AssertionError("no refresh expected") })
+        val store = FakeTokenStore(lazy { throw AssertionError("no refresh expected") })
 
         var emissions = 0
         val job = launch(UnconfinedTestDispatcher(testScheduler)) {

--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/datastore/TokenDataStoreTestFixtures.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/datastore/TokenDataStoreTestFixtures.kt
@@ -1,0 +1,108 @@
+package com.garfiec.librechat.core.data.datastore
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.MockEngineConfig
+import io.ktor.client.engine.mock.MockRequestHandler
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.defaultRequest
+import io.ktor.client.request.url
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.Dispatchers
+
+/**
+ * The one in-memory [CommonTokenDataStore] the datastore tests share: read-through/write-through
+ * over a map, with no `EncryptedSharedPreferences`. Add to this rather than re-rolling a local copy
+ * — a per-suite fake also re-rolls the `Dispatchers.Unconfined` rule below, whose omission surfaces
+ * only as a flaking assertion.
+ */
+internal class FakeTokenStore(
+    refreshClient: Lazy<HttpClient>,
+    seed: Map<String, String> = emptyMap(),
+) : CommonTokenDataStore(refreshClient) {
+
+    val store = seed.toMutableMap()
+
+    /** Access tokens written, paired with the refresh token stored alongside at the time. */
+    val writeLog = mutableListOf<Pair<String, String>>()
+
+    /** Logical clears, counted off the access-key removal so a pair teardown counts once. */
+    var removeCount = 0
+        private set
+
+    init {
+        initializeTokenCache()
+    }
+
+    /** The bare (no-account-resolved) slots, which is what a store with no active account uses. */
+    fun persistedAccess(): String? = store[KEY_ACCESS_TOKEN]
+
+    fun persistedRefresh(): String? = store[KEY_REFRESH_TOKEN]
+
+    override fun readValue(key: String): String? = store[key]
+
+    override fun writeValue(key: String, value: String) {
+        store[key] = value
+        if (key == KEY_ACCESS_TOKEN) writeLog += value to (store[KEY_REFRESH_TOKEN] ?: "")
+    }
+
+    override fun writeValues(values: Map<String, String>) {
+        values.forEach { (key, value) -> writeValue(key, value) }
+    }
+
+    override fun removeValue(key: String) {
+        store.remove(key)
+        if (key == KEY_ACCESS_TOKEN) removeCount++
+    }
+
+    override fun onKeystoreCorruption() = Unit
+}
+
+/** Seeds the bare keys, the shape a store has before any account is resolved. */
+internal fun bareSeed(
+    access: String? = "initial-access",
+    refresh: String? = "initial-refresh",
+): Map<String, String> = buildMap {
+    access?.let { put(CommonTokenDataStore.KEY_ACCESS_TOKEN, it) }
+    refresh?.let { put(CommonTokenDataStore.KEY_REFRESH_TOKEN, it) }
+}
+
+internal fun accessKeyOf(account: String) = "acct:$account:access_token"
+
+internal fun refreshKeyOf(account: String) = "acct:$account:refresh_token"
+
+internal const val ACTIVE_ACCOUNT_KEY = "active_account_id"
+
+/**
+ * A [MockEngine] pinned to [Dispatchers.Unconfined].
+ *
+ * MockEngine defaults its dispatcher to `Dispatchers.IO`, which hops the handler — and everything
+ * downstream of it — onto a real thread pool outside the test scheduler's virtual clock.
+ * `yield()`/`advanceUntilIdle()` cannot wait for real-thread work, so assertions race it. Pinning to
+ * Unconfined keeps request handling synchronous with the test dispatcher.
+ */
+internal fun unconfinedMockEngine(handler: MockRequestHandler): MockEngine = MockEngine(
+    MockEngineConfig().apply {
+        requestHandlers.add(handler)
+        dispatcher = Dispatchers.Unconfined
+    },
+)
+
+internal fun refreshClientOf(engine: MockEngine, baseUrl: String = TEST_SERVER): Lazy<HttpClient> = lazy {
+    HttpClient(engine) {
+        install(ContentNegotiation) { json() }
+        defaultRequest {
+            url(baseUrl)
+            contentType(ContentType.Application.Json)
+        }
+    }
+}
+
+internal const val TEST_SERVER = "https://chat.example.com"
+
+internal val jsonResponseHeaders = headersOf("Content-Type", ContentType.Application.Json.toString())
+
+internal fun refreshResponseBody(token: String): String = """{"token":"$token"}"""

--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/repository/AccountSwitcherTestHarness.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/repository/AccountSwitcherTestHarness.kt
@@ -36,7 +36,7 @@ internal class RecordingTokenManager : TokenManager {
     override suspend fun setTokens(accessToken: String, refreshToken: String) {
         stagedAccess = accessToken
     }
-    override suspend fun refreshAccessToken(): RefreshResult = RefreshResult.HardExpired
+    override suspend fun refreshAccessToken(usedAccessToken: String?): RefreshResult = RefreshResult.HardExpired
     override suspend fun clearTokens() {}
     override suspend fun getAccessTokenFor(accountId: String): String? = null
     override suspend fun getStagedAccessToken(): String? = stagedAccess
@@ -49,7 +49,11 @@ internal class RecordingTokenManager : TokenManager {
     override suspend fun removeAccount(accountId: String) {
         removedAccounts += accountId
     }
-    override suspend fun refreshAccessTokenFor(accountId: String, baseUrl: String): RefreshResult = RefreshResult.HardExpired
+    override suspend fun refreshAccessTokenFor(
+        accountId: String,
+        baseUrl: String,
+        usedAccessToken: String?,
+    ): RefreshResult = RefreshResult.HardExpired
     override suspend fun onAccountResolved(accountId: String) {
         resolvedAccount = accountId
         stagedAccess = null

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/CommonTokenDataStore.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/CommonTokenDataStore.kt
@@ -12,6 +12,7 @@ import com.garfiec.librechat.core.network.client.RefreshResult
 import com.garfiec.librechat.core.network.client.SecureTokenStorage
 import com.garfiec.librechat.core.network.client.SessionEndReason
 import com.garfiec.librechat.core.network.client.TokenManager
+import com.garfiec.librechat.core.network.client.expiresAtEpochMillisOrNull
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.header
@@ -27,6 +28,7 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlin.concurrent.Volatile
 import kotlin.random.Random
+import kotlin.time.Clock
 
 /**
  * Account-keyed secure token store. Tokens are namespaced by account
@@ -142,6 +144,23 @@ abstract class CommonTokenDataStore(
 
     @Volatile
     private var sessionExpiryReported = false
+
+    /** One-entry cache for [memoizedExpiryOf], so the per-request decode is a string comparison. */
+    @Volatile
+    private var expiryMemo: ExpiryMemo? = null
+
+    /**
+     * When each slot may next attempt a proactive renewal ([Long.MAX_VALUE] = never again), keyed like
+     * [flights] (bare = [BARE_FLIGHT_KEY]). Reactive 401 renewal is never suppressed.
+     *
+     * Per slot rather than process-wide: both conditions that suppress it — a refresh endpoint that
+     * cannot answer, and a deployment issuing tokens already inside the skew window — are properties
+     * of one server, and one account's bad deployment must not silently turn the feature off for
+     * another account on a healthy one. Immutable map behind a single [Volatile] so the per-request
+     * read stays lock-free.
+     */
+    @Volatile
+    private var proactiveSuppressedUntil: Map<String, Long> = emptyMap()
 
     // Platform implementations provide a plain synchronously-readable key/value secure store.
     protected abstract fun readValue(key: String): String?
@@ -307,6 +326,104 @@ abstract class CommonTokenDataStore(
             usedAccessToken = usedAccessToken,
         )
 
+    override suspend fun ensureFreshAccessToken(
+        accountId: String?,
+        baseUrl: String,
+        currentAccessToken: String?,
+    ): String? {
+        // Everything before the refresh is pure computation on values the caller already holds: no
+        // storage read, no mutex. That matters because this runs on EVERY request the barrier builds,
+        // on the caller's dispatcher, which for several cold-start repositories is main (issue #326).
+        if (currentAccessToken == null) return currentAccessToken
+        if (!isNearingExpiry(currentAccessToken)) return currentAccessToken
+        // Resolve the slot exactly as [performRefresh] will, so suppression is tracked against the
+        // same key the refresh actually targets rather than a bare-key approximation of it.
+        val accountKey = accountId ?: activeAccountKey
+        val slot = accountKey ?: BARE_FLIGHT_KEY
+        if (Clock.System.now().toEpochMilliseconds() < (proactiveSuppressedUntil[slot] ?: 0L)) {
+            return currentAccessToken
+        }
+        Diag.d(
+            "Auth",
+            origin = LogOrigin.CLIENT,
+            attrs = mapOf("event" to "refresh_proactive"),
+        ) { "Access token is at or past its expiry; renewing before the request goes out" }
+        // Pin the POST to the URL the caller snapshotted, on EVERY branch — including the
+        // no-account one, where the reactive [refreshAccessToken] posts to the *live* base URL and a
+        // concurrent server switch can therefore redirect this slot's refresh token to another
+        // deployment. Left unpinned only when the base URL is genuinely unknown, where an empty
+        // `pinnedBaseUrl` would derive the wrong serverId and cost the gateway headers.
+        val pinned = baseUrl.trimTrailingSlash().takeIf { it.isNotEmpty() }
+        val result = performRefresh(
+            accountKey = accountKey,
+            absoluteRefreshUrl = pinned?.let { "$it$REFRESH_PATH" },
+            pinnedBaseUrl = pinned,
+            usedAccessToken = currentAccessToken,
+            bestEffort = true,
+        )
+        if (result != RefreshResult.Refreshed) {
+            // Negative caching, and NOT an optimization. A renewal that cannot succeed — offline, or
+            // a 5xx-ing refresh endpoint — changes nothing for the coalescing check to see, so
+            // without this every request in a cold-start fan-out queues behind the flight lock and
+            // spends its own connect timeout BEFORE being sent, serially. Suppressed per slot; the
+            // request still goes out on its old bearer and a real 401 still gets the full reactive
+            // ladder.
+            suppressProactiveRenewal(slot, Clock.System.now().toEpochMilliseconds() + PROACTIVE_RETRY_COOLDOWN_MS)
+            return currentAccessToken
+        }
+        val renewed = (if (accountId != null) getAccessTokenFor(accountId) else getAccessToken())
+        // A token that reads as stale the moment it is issued means the deadline and our clock
+        // disagree — a device clock fast by more than the token's lifetime, or a deployment whose
+        // SESSION_EXPIRY is shorter than the skew window. Left alone that is a refresh POST per
+        // request, forever. One wasted refresh detects both causes. Suppressed per slot, not
+        // process-wide: the cause is a property of one deployment, and a second account on a normal
+        // server must keep the feature.
+        if (renewed != null && isNearingExpiry(renewed)) {
+            suppressProactiveRenewal(slot, Long.MAX_VALUE)
+            Diag.w(
+                "Auth",
+                origin = LogOrigin.CLIENT,
+                attrs = mapOf("event" to "refresh_proactive_disabled"),
+            ) { "A freshly-issued access token already reads as expired; disabling proactive renewal" }
+        }
+        return renewed
+    }
+
+    /**
+     * Copy-on-write so the hot-path read above needs no lock. A lost update under a race just costs a
+     * redundant renewal attempt, never a wrong suppression.
+     */
+    private fun suppressProactiveRenewal(slot: String, untilEpochMillis: Long) {
+        proactiveSuppressedUntil = proactiveSuppressedUntil + (slot to untilEpochMillis)
+    }
+
+    /**
+     * True when [token] carries a deadline at or inside [PROACTIVE_RENEWAL_SKEW_MS]. An unreadable or
+     * absent `exp` is false — unknown means leave it to the reactive path.
+     */
+    private fun isNearingExpiry(token: String): Boolean {
+        val expiresAt = memoizedExpiryOf(token) ?: return false
+        return expiresAt - Clock.System.now().toEpochMilliseconds() <= PROACTIVE_RENEWAL_SKEW_MS
+    }
+
+    /**
+     * [expiresAtEpochMillisOrNull] for [token], reusing the last result when the string is unchanged.
+     *
+     * This runs at the request barrier, so without the memo every request base64-decodes and
+     * JSON-parses the access token — including the overwhelmingly common case where it is fresh and
+     * nothing happens — on the caller's dispatcher, which for several cold-start repositories is the
+     * main thread (issue #326). One immutable entry swapped under a single [Volatile] write: a race
+     * can only recompute, never publish a half-built memo or pair a token with another's deadline.
+     */
+    private fun memoizedExpiryOf(token: String): Long? {
+        expiryMemo?.let { if (it.token == token) return it.expiresAtMillis }
+        val computed = expiresAtEpochMillisOrNull(token)
+        expiryMemo = ExpiryMemo(token, computed)
+        return computed
+    }
+
+    private class ExpiryMemo(val token: String, val expiresAtMillis: Long?)
+
     /**
      * Refresh [accountKey]'s tokens with a bounded retry loop, classifying the outcome so a caller can
      * tell a hard-expired session (route to re-auth) from a transient failure (keep the session).
@@ -332,12 +449,22 @@ abstract class CommonTokenDataStore(
      * does not *coalesce* them, so N callers each POST in turn. A waiter that arrives holding the bearer
      * its request sent can compare it against the slot once it gets the lock — if the value has already
      * moved, the holder before it rotated on its behalf and there is nothing left to do.
+     *
+     * [bestEffort] is the proactive-renewal mode ([ensureFreshAccessToken]) and changes two things:
+     * a **single** attempt instead of the retry ladder, and **never** dropping the slot — any failure
+     * returns [Transient]. Both follow from the same fact: a proactive renewal nobody is waiting on
+     * must not be able to log the user out. The ladder exists because the backend answers `401`
+     * identically for a dead session and a transiently-missed one, so a single attempt cannot tell
+     * them apart — which is exactly why a single attempt must not be allowed to settle the question.
+     * The request proceeds on its old bearer and the reactive 401 path, with its full ladder, keeps
+     * sole ownership of the logout decision.
      */
     private suspend fun performRefresh(
         accountKey: String?,
         absoluteRefreshUrl: String?,
         pinnedBaseUrl: String?,
         usedAccessToken: String? = null,
+        bestEffort: Boolean = false,
     ): RefreshResult =
         flightFor(accountKey).withLock {
             // Coalesce: another caller rotated this slot while we waited for the flight lock, so its
@@ -367,7 +494,7 @@ abstract class CommonTokenDataStore(
             // teardown that landed while the last POST was in flight still wins.
             var lastEpoch = NO_EPOCH
             suspend fun settle(): RefreshResult =
-                if (sawHardRejection) {
+                if (sawHardRejection && !bestEffort) {
                     // The session is dead, so drop the slot. `isLoggedIn()` is a token-PRESENCE check:
                     // a retained dead pair is replayed on every later cold start.
                     invalidateRefresh(accountKey, lastEpoch)
@@ -380,7 +507,7 @@ abstract class CommonTokenDataStore(
                 } else {
                     RefreshResult.Transient
                 }
-            repeat(MAX_REFRESH_ATTEMPTS) { attempt ->
+            repeat(if (bestEffort) 1 else MAX_REFRESH_ATTEMPTS) { attempt ->
                 // Capture the slot's epoch BEFORE the stored-token read, so any teardown of THIS slot
                 // that races the POST below is detected (and its result discarded) with no lock held
                 // across the network call. Re-read each attempt: a teardown or a sibling that landed
@@ -391,8 +518,9 @@ abstract class CommonTokenDataStore(
                 if (storedRefreshToken.isNullOrBlank()) {
                     // Attempt 0 with no token = no session at all → hard. A LATER attempt losing the
                     // token means a teardown (logout/removal) landed mid-loop and already owns the
-                    // routing → Transient, so we don't double-emit session-expired over it.
-                    return@withLock if (attempt == 0) {
+                    // routing → Transient, so we don't double-emit session-expired over it. A
+                    // best-effort renewal never makes that call at all — see [bestEffort].
+                    return@withLock if (attempt == 0 && !bestEffort) {
                         Diag.w(
                             "Auth",
                             origin = LogOrigin.CLIENT,
@@ -404,6 +532,15 @@ abstract class CommonTokenDataStore(
                         invalidateRefresh(accountKey, epochAtStart)
                         RefreshResult.HardExpired
                     } else {
+                        // A best-effort renewal against an empty slot, or a teardown that landed
+                        // between retries. Logged so every renewal reconciles to an outcome: this is
+                        // the one arm that can return without a POST, and untraced it makes
+                        // `refresh_proactive` read as a POST counter when it isn't.
+                        Diag.d(
+                            "Auth",
+                            origin = LogOrigin.CLIENT,
+                            attrs = mapOf("event" to "refresh_skipped", "reason" to "no_refresh_token"),
+                        ) { "No refresh token in this slot; skipping the refresh without a POST" }
                         RefreshResult.Transient
                     }
                 }
@@ -718,6 +855,30 @@ abstract class CommonTokenDataStore(
         /** "No attempt has captured an epoch yet". Never equals a real epoch, so an
          *  [invalidateRefresh] against it is a no-op rather than an unguarded clear. */
         private const val NO_EPOCH = -1
+
+        /**
+         * How far ahead of an access token's `exp` a proactive renewal fires.
+         *
+         * **Must stay under 30 s.** On an OpenID deployment the refresh endpoint has a reuse path
+         * (`OPENID_REUSE_EXPIRY_BUFFER_SECONDS = 30` in `AuthController.js`): while
+         * `decoded.exp > now + 30` it answers 2xx with *the same token* and no rotation. A wider
+         * window would fire inside that band, get the identical token back, and repeat on the next
+         * request with nothing to coalesce against. Below 30 s the same call falls through to a
+         * genuine renewal.
+         *
+         * Nothing is lost by keeping it small: this only governs how far *ahead* of expiry we
+         * preempt, and the case the feature exists for — a cold start after idle — has an `exp`
+         * already minutes in the past, which any positive threshold catches.
+         */
+        private const val PROACTIVE_RENEWAL_SKEW_MS = 20_000L
+
+        /**
+         * How long a slot stops attempting proactive renewal after one fails. Long enough that a
+         * cold-start fan-out spends at most one failed attempt rather than one per request, and
+         * costless when wrong: the request goes out on its old bearer and a real 401 still gets the
+         * full reactive ladder immediately.
+         */
+        private const val PROACTIVE_RETRY_COOLDOWN_MS = 60_000L
 
         /** Total refresh attempts (initial + retries) before a persistent failure is classified. */
         private const val MAX_REFRESH_ATTEMPTS = 3

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/CommonTokenDataStore.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/CommonTokenDataStore.kt
@@ -282,11 +282,20 @@ abstract class CommonTokenDataStore(
         }
     }
 
-    override suspend fun refreshAccessToken(): RefreshResult =
+    override suspend fun refreshAccessToken(usedAccessToken: String?): RefreshResult =
         // The live active account, against the live base URL (the refresh client's defaultRequest).
-        performRefresh(accountKey = activeAccountKey, absoluteRefreshUrl = null, pinnedBaseUrl = null)
+        performRefresh(
+            accountKey = activeAccountKey,
+            absoluteRefreshUrl = null,
+            pinnedBaseUrl = null,
+            usedAccessToken = usedAccessToken,
+        )
 
-    override suspend fun refreshAccessTokenFor(accountId: String, baseUrl: String): RefreshResult =
+    override suspend fun refreshAccessTokenFor(
+        accountId: String,
+        baseUrl: String,
+        usedAccessToken: String?,
+    ): RefreshResult =
         // URL-pinned: post to an absolute URL so a concurrent server switch can't redirect this
         // account's refresh token to another server. [pinnedBaseUrl] carries the *server* half of that
         // pin to ServerHeadersPlugin — the request URL alone can't serve as the key, because it is the
@@ -295,6 +304,7 @@ abstract class CommonTokenDataStore(
             accountKey = accountId,
             absoluteRefreshUrl = "${baseUrl.trimTrailingSlash()}$REFRESH_PATH",
             pinnedBaseUrl = baseUrl.trimTrailingSlash(),
+            usedAccessToken = usedAccessToken,
         )
 
     /**
@@ -317,13 +327,38 @@ abstract class CommonTokenDataStore(
      * rather than retried, so the flight lock is not held across repeated full request timeouts.
      *
      * A settled [HardExpired] also **drops the account's token slot** — see [settle].
+     *
+     * [usedAccessToken] collapses a queued burst: the flight lock serializes same-account refreshes but
+     * does not *coalesce* them, so N callers each POST in turn. A waiter that arrives holding the bearer
+     * its request sent can compare it against the slot once it gets the lock — if the value has already
+     * moved, the holder before it rotated on its behalf and there is nothing left to do.
      */
     private suspend fun performRefresh(
         accountKey: String?,
         absoluteRefreshUrl: String?,
         pinnedBaseUrl: String?,
+        usedAccessToken: String? = null,
     ): RefreshResult =
         flightFor(accountKey).withLock {
+            // Coalesce: another caller rotated this slot while we waited for the flight lock, so its
+            // POST already did our work. Only a *changed* value counts — an absent one means a teardown
+            // or a hard-expiry dropped the slot, which must still fall through to the loop below and
+            // settle as HardExpired rather than reporting a refresh that never happened.
+            //
+            // Read outside [stateMutex], like the stored-refresh-token read below: the failure mode is
+            // one-directional. A stale read can only miss a rotation, which costs a redundant POST —
+            // never the reverse.
+            if (usedAccessToken != null) {
+                val current = readValue(accessKey(accountKey)).nonBlankOrNull()
+                if (current != null && current != usedAccessToken) {
+                    Diag.d(
+                        "Auth",
+                        origin = LogOrigin.CLIENT,
+                        attrs = mapOf("event" to "refresh_coalesced"),
+                    ) { "Token already rotated by a concurrent refresh; skipping this POST" }
+                    return@withLock RefreshResult.Refreshed
+                }
+            }
             // Any auth rejection ⇒ a genuinely dead session ⇒ route to re-auth, even if a later attempt
             // hit a transient blip; a purely transient run (5xx / rate-limit / transport) keeps the
             // session. This fold is the terminal classification for every non-Success exit of the loop.

--- a/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/client/AccessTokenExpiryTest.kt
+++ b/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/client/AccessTokenExpiryTest.kt
@@ -1,0 +1,98 @@
+package com.garfiec.librechat.core.network.client
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
+
+/**
+ * The contract is "never throws, null when unsure". A throw here would propagate out of the request
+ * barrier and fail an otherwise-fine request; a wrong non-null would drive a refresh loop. Every
+ * malformed shape a server (or a proxy, or an OpenID pass-through) can hand us is enumerated.
+ */
+@OptIn(ExperimentalEncodingApi::class)
+class AccessTokenExpiryTest {
+
+    private fun jwt(payloadJson: String, padded: Boolean = false): String {
+        val encoder = if (padded) {
+            Base64.UrlSafe
+        } else {
+            Base64.UrlSafe.withPadding(Base64.PaddingOption.ABSENT)
+        }
+        val header = encoder.encode("""{"alg":"HS256","typ":"JWT"}""".encodeToByteArray())
+        val payload = encoder.encode(payloadJson.encodeToByteArray())
+        return "$header.$payload.signature-not-verified"
+    }
+
+    @Test
+    fun `reads exp from a well-formed token`() {
+        val token = jwt("""{"id":"u1","exp":1754000000}""")
+        assertThat(expiresAtEpochMillisOrNull(token)).isEqualTo(1_754_000_000_000L)
+    }
+
+    @Test
+    fun `accepts a payload whose base64 padding survived`() {
+        // jwt.sign strips '=' padding, but nothing in the wire format forbids it and a proxy or a
+        // non-Node issuer may leave it on.
+        val token = jwt("""{"exp":1754000000}""", padded = true)
+        assertThat(expiresAtEpochMillisOrNull(token)).isEqualTo(1_754_000_000_000L)
+    }
+
+    @Test
+    fun `accepts exp as a double`() {
+        // jwt.sign emits an integer, but the decoder must not depend on that.
+        val token = jwt("""{"exp":1754000000.75}""")
+        assertThat(expiresAtEpochMillisOrNull(token)).isEqualTo(1_754_000_000_750L)
+    }
+
+    @Test
+    fun `decodes a payload containing url-safe alphabet characters`() {
+        // Padding aside, the difference between the standard and URL-safe alphabets is '+/' vs '-_'.
+        // A payload that happens to encode to either would fail to decode under the wrong one, and the
+        // failure is data-dependent — it would show up as an occasional token that never renews.
+        val token = jwt("""{"sub":"a?b>c~dÿþ","exp":1754000000}""")
+        assertThat(expiresAtEpochMillisOrNull(token)).isEqualTo(1_754_000_000_000L)
+    }
+
+    @Test
+    fun `returns null when exp is absent`() {
+        assertThat(expiresAtEpochMillisOrNull(jwt("""{"id":"u1"}"""))).isNull()
+    }
+
+    @Test
+    fun `returns null when exp is a string`() {
+        assertThat(expiresAtEpochMillisOrNull(jwt("""{"exp":"1754000000"}"""))).isNull()
+    }
+
+    @Test
+    fun `returns null when exp is not a primitive`() {
+        assertThat(expiresAtEpochMillisOrNull(jwt("""{"exp":{"at":1754000000}}"""))).isNull()
+    }
+
+    @Test
+    fun `returns null for an opaque non-jwt token`() {
+        // The OpenID pass-through case: a provider access token that is not a JWT at all.
+        assertThat(expiresAtEpochMillisOrNull("gho_16C7e42F292c6912E7710c838347Ae178B4a")).isNull()
+    }
+
+    @Test
+    fun `returns null for a three-segment token whose payload is not base64`() {
+        assertThat(expiresAtEpochMillisOrNull("aaa.!!!not-base64!!!.ccc")).isNull()
+    }
+
+    @Test
+    fun `returns null for a three-segment token whose payload is not json`() {
+        val payload = Base64.UrlSafe.withPadding(Base64.PaddingOption.ABSENT).encode("not json".encodeToByteArray())
+        assertThat(expiresAtEpochMillisOrNull("aaa.$payload.ccc")).isNull()
+    }
+
+    @Test
+    fun `returns null for an empty payload segment`() {
+        assertThat(expiresAtEpochMillisOrNull("aaa..ccc")).isNull()
+    }
+
+    @Test
+    fun `returns null for an empty string`() {
+        assertThat(expiresAtEpochMillisOrNull("")).isNull()
+    }
+}

--- a/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/client/AuthInterceptorTest.kt
+++ b/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/client/AuthInterceptorTest.kt
@@ -40,7 +40,7 @@ class AuthInterceptorTest {
             this.accessToken = accessToken
         }
 
-        override suspend fun refreshAccessToken(): RefreshResult {
+        override suspend fun refreshAccessToken(usedAccessToken: String?): RefreshResult {
             refreshCallCount++
             if (refreshOutcome == RefreshResult.Refreshed) accessToken = refreshedToken
             return refreshOutcome
@@ -62,8 +62,11 @@ class AuthInterceptorTest {
             accessToken = null
         }
 
-        override suspend fun refreshAccessTokenFor(accountId: String, baseUrl: String): RefreshResult =
-            refreshAccessToken()
+        override suspend fun refreshAccessTokenFor(
+            accountId: String,
+            baseUrl: String,
+            usedAccessToken: String?,
+        ): RefreshResult = refreshAccessToken(usedAccessToken)
 
         override suspend fun onAccountResolved(accountId: String) = Unit
 

--- a/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/client/AuthSkipPathsTest.kt
+++ b/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/client/AuthSkipPathsTest.kt
@@ -1,0 +1,48 @@
+package com.garfiec.librechat.core.network.client
+
+import com.google.common.truth.Truth.assertThat
+import io.ktor.http.URLBuilder
+import org.junit.Test
+
+/**
+ * The skip list is shared by two plugins that must not drift: [AuthInterceptorPlugin] keeps these
+ * paths out of the bearer attach and the 401-refresh leg, and [SwitchBarrierPlugin] keeps them out of
+ * proactive renewal. A sign-in POST that first drove a refresh of the session it is replacing would
+ * put that whole round trip in front of the Sign in button on a slow or failing server.
+ */
+class AuthSkipPathsTest {
+
+    private fun matches(path: String): Boolean = isAuthSkipPath(URLBuilder(path))
+
+    @Test
+    fun `matches the auth endpoints that take no bearer`() {
+        assertThat(matches("https://chat.example.com/api/auth/login")).isTrue()
+        assertThat(matches("https://chat.example.com/api/auth/register")).isTrue()
+        assertThat(matches("https://chat.example.com/api/auth/refresh")).isTrue()
+        assertThat(matches("https://chat.example.com/api/auth/requestPasswordReset")).isTrue()
+        assertThat(matches("https://chat.example.com/api/auth/resetPassword")).isTrue()
+        assertThat(matches("https://chat.example.com/api/auth/2fa/verify-temp")).isTrue()
+    }
+
+    @Test
+    fun `matches a relative path, which is the form the barrier sees`() {
+        // The barrier phase runs before the base URL is applied, so its URLBuilder has no host yet.
+        assertThat(matches("/api/auth/login")).isTrue()
+    }
+
+    @Test
+    fun `does not match ordinary api paths`() {
+        assertThat(matches("/api/convos")).isFalse()
+        assertThat(matches("/api/agents/chat")).isFalse()
+        assertThat(matches("/api/user")).isFalse()
+    }
+
+    @Test
+    fun `matches whole segments only`() {
+        // A path-prefixed deployment must not have every request it serves treated as an auth path.
+        assertThat(matches("/apps/auth/login-x")).isFalse()
+        assertThat(matches("/api/auth/loginhistory")).isFalse()
+        // ...but a genuine prefix deployment's real login endpoint still matches.
+        assertThat(matches("/apps/librechat/api/auth/login")).isTrue()
+    }
+}

--- a/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/client/ServerHeadersPluginTest.kt
+++ b/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/client/ServerHeadersPluginTest.kt
@@ -60,7 +60,7 @@ class ServerHeadersPluginTest {
             this.accessToken = accessToken
         }
 
-        override suspend fun refreshAccessToken(): RefreshResult {
+        override suspend fun refreshAccessToken(usedAccessToken: String?): RefreshResult {
             accessToken = "refreshed-token"
             return RefreshResult.Refreshed
         }
@@ -74,8 +74,11 @@ class ServerHeadersPluginTest {
         override suspend fun clearStagedTokens() = Unit
         override suspend fun selectAccount(accountId: String) = Unit
         override suspend fun removeAccount(accountId: String) = Unit
-        override suspend fun refreshAccessTokenFor(accountId: String, baseUrl: String): RefreshResult =
-            refreshAccessToken()
+        override suspend fun refreshAccessTokenFor(
+            accountId: String,
+            baseUrl: String,
+            usedAccessToken: String?,
+        ): RefreshResult = refreshAccessToken(usedAccessToken)
 
         override suspend fun onAccountResolved(accountId: String) = Unit
         override fun emitSessionExpired(expiredAccountId: String?, reason: SessionEndReason) = Unit

--- a/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/client/SwitchBarrierRenewalTest.kt
+++ b/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/client/SwitchBarrierRenewalTest.kt
@@ -1,0 +1,142 @@
+package com.garfiec.librechat.core.network.client
+
+import com.garfiec.librechat.core.common.identity.AccountId
+import com.garfiec.librechat.core.common.identity.AccountState
+import com.garfiec.librechat.core.common.identity.InMemoryActiveAccountProvider
+import com.google.common.truth.Truth.assertThat
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.http.HttpStatusCode
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import org.junit.Test
+
+/**
+ * Which requests the barrier opts into proactive token renewal, driven through a real Ktor client so
+ * the *wiring* is under test and not just the predicate.
+ *
+ * The auth-path exclusion has no faithful device check: reaching the Login screen normally requires a
+ * hard refresh rejection, which clears the tokens first, so "no renewal happened" is vacuously true
+ * there. Only here can the stored token and the request path be set independently.
+ */
+class SwitchBarrierRenewalTest {
+
+    private class RecordingTokenManager(private val token: String?) : TokenManager {
+        val renewedPaths = mutableListOf<String>()
+
+        override val isAuthenticated: Boolean get() = token != null
+        override suspend fun getAccessToken(): String? = token
+        override suspend fun getAccessTokenFor(accountId: String): String? = token
+        override suspend fun setTokens(accessToken: String, refreshToken: String) = Unit
+        override suspend fun refreshAccessToken(usedAccessToken: String?): RefreshResult =
+            RefreshResult.Transient
+
+        override suspend fun refreshAccessTokenFor(
+            accountId: String,
+            baseUrl: String,
+            usedAccessToken: String?,
+        ): RefreshResult = RefreshResult.Transient
+
+        override suspend fun ensureFreshAccessToken(
+            accountId: String?,
+            baseUrl: String,
+            currentAccessToken: String?,
+        ): String? {
+            renewedPaths += baseUrl
+            return currentAccessToken
+        }
+
+        override suspend fun clearTokens() = Unit
+        override suspend fun getStagedAccessToken(): String? = null
+        override suspend fun clearStagedTokens() = Unit
+        override suspend fun selectAccount(accountId: String) = Unit
+        override suspend fun removeAccount(accountId: String) = Unit
+        override suspend fun onAccountResolved(accountId: String) = Unit
+        override fun emitSessionExpired(expiredAccountId: String?, reason: SessionEndReason) = Unit
+        override val sessionExpiredFlow: SharedFlow<SessionEndReason> = MutableSharedFlow()
+    }
+
+    private class FixedUrlProvider(private val baseUrl: String) : ServerUrlProvider {
+        override fun getBaseUrl(): String = baseUrl
+    }
+
+    private fun clientWith(tokenManager: TokenManager): HttpClient {
+        val gate = SwitchGate(
+            activeAccountProvider = InMemoryActiveAccountProvider(AccountState.Resolved(AccountId("acct-a"))),
+            serverUrlProvider = FixedUrlProvider("https://a.example.com"),
+            tokenManager = tokenManager,
+            accountReadyGate = null,
+        )
+        return HttpClient(MockEngine { respond("{}", HttpStatusCode.OK) }) {
+            install(ContentNegotiation) { json() }
+            install(SwitchBarrierPlugin) { switchGate = gate }
+            install(AuthInterceptorPlugin) { this.tokenManager = tokenManager }
+        }
+    }
+
+    @Test
+    fun `an ordinary api request opts into renewal`() = runTest {
+        val tokens = RecordingTokenManager("stored-token")
+
+        clientWith(tokens).get("/api/convos")
+
+        // The positive control. Without it, every "no renewal" assertion below could pass simply
+        // because renewal is broken everywhere.
+        assertThat(tokens.renewedPaths).containsExactly("https://a.example.com")
+    }
+
+    /**
+     * A sign-in POST issued while an expired token is still stored must not fire a refresh first —
+     * that puts a full round trip in front of the Sign in button, on the server least likely to be
+     * answering.
+     */
+    @Test
+    fun `auth endpoints never opt into renewal even with a token stored`() = runTest {
+        val paths = listOf(
+            "/api/auth/login",
+            "/api/auth/register",
+            "/api/auth/refresh",
+            "/api/auth/requestPasswordReset",
+            "/api/auth/resetPassword",
+            "/api/auth/2fa/verify-temp",
+        )
+
+        for (path in paths) {
+            val tokens = RecordingTokenManager("stored-token")
+            clientWith(tokens).post(path)
+            assertThat(tokens.renewedPaths).isEmpty()
+        }
+    }
+
+    /**
+     * A presigned CDN fetch carries a host of its own at this phase, and the bearer is host-scoped away
+     * from it anyway — so renewing the session token on its behalf is work no request will use.
+     */
+    @Test
+    fun `an absolute cross-host request does not opt into renewal`() = runTest {
+        val tokens = RecordingTokenManager("stored-token")
+
+        clientWith(tokens).get("https://cdn.example.org/presigned/file.png")
+
+        assertThat(tokens.renewedPaths).isEmpty()
+    }
+
+    @Test
+    fun `a pending add-account request does not opt into renewal`() = runTest {
+        val tokens = RecordingTokenManager("stored-token")
+        val client = clientWith(tokens)
+
+        withContext(PendingRequestIdentity("https://b.example.com") { "staged-b" }) {
+            client.get("/api/user")
+        }
+
+        assertThat(tokens.renewedPaths).isEmpty()
+    }
+}

--- a/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/client/SwitchGateTest.kt
+++ b/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/client/SwitchGateTest.kt
@@ -26,14 +26,37 @@ class SwitchGateTest {
 
     private class FakeTokenManager(
         private val liveToken: String?,
-        private val keyed: Map<String, String> = emptyMap(),
+        keyed: Map<String, String> = emptyMap(),
+        /** What a proactive renewal rewrites the account's keyed slot to, or null to renew nothing. */
+        private val renewsTo: String? = null,
     ) : TokenManager {
+        private val keyed = keyed.toMutableMap()
+
+        /** How many times [ensureFreshAccessToken] was reached. The gate is opt-in, so this is the assertion. */
+        var renewals = 0
+            private set
+
+        /** The `(accountId, baseUrl, bearer)` each renewal was handed — the pair-coherence assertion. */
+        val renewalArgs = mutableListOf<Triple<String?, String, String?>>()
+
         override val isAuthenticated: Boolean get() = liveToken != null
         override suspend fun getAccessToken(): String? = liveToken
         override suspend fun setTokens(accessToken: String, refreshToken: String) = Unit
         override suspend fun refreshAccessToken(usedAccessToken: String?): RefreshResult = RefreshResult.HardExpired
         override suspend fun clearTokens() = Unit
         override suspend fun getAccessTokenFor(accountId: String): String? = keyed[accountId]
+
+        override suspend fun ensureFreshAccessToken(
+            accountId: String?,
+            baseUrl: String,
+            currentAccessToken: String?,
+        ): String? {
+            renewals++
+            renewalArgs += Triple(accountId, baseUrl, currentAccessToken)
+            if (renewsTo != null && accountId != null) keyed[accountId] = renewsTo
+            return renewsTo ?: currentAccessToken
+        }
+
         override suspend fun getStagedAccessToken(): String? = null
         override suspend fun clearStagedTokens() = Unit
         override suspend fun selectAccount(accountId: String) = Unit
@@ -154,5 +177,154 @@ class SwitchGateTest {
 
         releaseFlip.complete(Unit)
         switch.join()
+    }
+
+    /**
+     * Proactive renewal is opt-in per capture. The default must stay off: logout and the post-login
+     * profile fetch snapshot through here too, and renewing for either is wrong rather than merely
+     * wasteful — logout would rotate a token it is about to revoke.
+     */
+    @Test
+    fun `the default capture never renews`() = runTest {
+        val tokens = FakeTokenManager(liveToken = "a", keyed = mapOf("acct-a" to "a-keyed"))
+        val gate = SwitchGate(
+            activeAccountProvider = InMemoryActiveAccountProvider(Resolved(AccountId("acct-a"))),
+            serverUrlProvider = FakeServerUrlProvider("https://a.example.com"),
+            tokenManager = tokens,
+            accountReadyGate = null,
+        )
+
+        gate.captureSnapshot()
+
+        assertThat(tokens.renewals).isEqualTo(0)
+    }
+
+    @Test
+    fun `an opted-in capture renews and snapshots the renewed bearer`() = runTest {
+        val tokens = FakeTokenManager(
+            liveToken = "a",
+            keyed = mapOf("acct-a" to "a-stale"),
+            renewsTo = "a-renewed",
+        )
+        val gate = SwitchGate(
+            activeAccountProvider = InMemoryActiveAccountProvider(Resolved(AccountId("acct-a"))),
+            serverUrlProvider = FakeServerUrlProvider("https://a.example.com"),
+            tokenManager = tokens,
+            accountReadyGate = null,
+        )
+
+        val snapshot = gate.captureSnapshot(renewIfStale = true)
+
+        assertThat(tokens.renewals).isEqualTo(1)
+        // The renewal runs before the triple is read, so the request carries the new bearer rather
+        // than sending the stale one and recovering from its 401.
+        assertThat(snapshot.bearer).isEqualTo("a-renewed")
+    }
+
+    @Test
+    fun `a pending identity never renews even when opted in`() = runTest {
+        // An add-account probe has no keyed account to refresh, and renewing the *active* account's
+        // token on its behalf would be the live session's traffic done under another flow's identity.
+        val tokens = FakeTokenManager(liveToken = "a", keyed = mapOf("acct-a" to "a-keyed"))
+        val gate = SwitchGate(
+            activeAccountProvider = InMemoryActiveAccountProvider(Resolved(AccountId("acct-a"))),
+            serverUrlProvider = FakeServerUrlProvider("https://a.example.com"),
+            tokenManager = tokens,
+            accountReadyGate = null,
+        )
+
+        withContext(PendingRequestIdentity("https://b.example.com") { "staged-b" }) {
+            gate.captureSnapshot(renewIfStale = true)
+        }
+
+        assertThat(tokens.renewals).isEqualTo(0)
+    }
+
+    /**
+     * The renewal must be handed the snapshot's own values, never a fresh read of the live providers.
+     *
+     * A switch publishes the new server URL *before* the new account id, so two independent reads can
+     * straddle it and produce (old account, new URL). Refreshing against that pair POSTs one account's
+     * refresh token to another deployment — the exact tearing this class exists to prevent — and the
+     * rejection then drops that account's slot. Pinned here with a provider that changes value on
+     * every read: whatever the renewal is given must equal what the snapshot froze.
+     */
+    @Test
+    fun `renewal is handed the snapshot's own account, url and bearer`() = runTest {
+        // Stands in for a switch landing between two reads: every call returns something new, so any
+        // value the renewal did not take from the snapshot is immediately visible as a mismatch.
+        class ShiftingUrlProvider : ServerUrlProvider {
+            var reads = 0
+                private set
+
+            override fun getBaseUrl(): String = "https://server-${reads++}.example.com"
+        }
+
+        val baseline = ShiftingUrlProvider()
+        SwitchGate(
+            activeAccountProvider = InMemoryActiveAccountProvider(Resolved(AccountId("acct-a"))),
+            serverUrlProvider = baseline,
+            tokenManager = FakeTokenManager(liveToken = "a", keyed = mapOf("acct-a" to "a-stale")),
+            accountReadyGate = null,
+        ).captureSnapshot()
+
+        val shifting = ShiftingUrlProvider()
+        val tokens = FakeTokenManager(liveToken = "a", keyed = mapOf("acct-a" to "a-stale"))
+        val gate = SwitchGate(
+            activeAccountProvider = InMemoryActiveAccountProvider(Resolved(AccountId("acct-a"))),
+            serverUrlProvider = shifting,
+            tokenManager = tokens,
+            accountReadyGate = null,
+        )
+
+        val snapshot = gate.captureSnapshot(renewIfStale = true)
+
+        assertThat(tokens.renewalArgs).hasSize(1)
+        val (account, baseUrl, bearer) = tokens.renewalArgs.single()
+        assertThat(account).isEqualTo(snapshot.accountId)
+        assertThat(baseUrl).isEqualTo(snapshot.baseUrl)
+        assertThat(bearer).isEqualTo("a-stale")
+        // Renewing costs no extra provider read: it reuses the snapshot rather than re-reading.
+        assertThat(shifting.reads).isEqualTo(baseline.reads)
+    }
+
+    /**
+     * The renewal must happen outside [SwitchGate]'s lock — it is the same mutex a switch takes, and a
+     * refresh POST suspended inside it would stall every account switch behind a network round trip.
+     */
+    @Test
+    fun `a renewal in progress does not block an account switch`() = runTest {
+        val releaseRenewal = CompletableDeferred<Unit>()
+        val renewalStarted = CompletableDeferred<Unit>()
+        val gate = SwitchGate(
+            activeAccountProvider = InMemoryActiveAccountProvider(Resolved(AccountId("acct-a"))),
+            serverUrlProvider = FakeServerUrlProvider("https://a.example.com"),
+            tokenManager = object : TokenManager by FakeTokenManager("a", mapOf("acct-a" to "a-keyed")) {
+                override suspend fun ensureFreshAccessToken(
+                    accountId: String?,
+                    baseUrl: String,
+                    currentAccessToken: String?,
+                ): String? {
+                    renewalStarted.complete(Unit)
+                    releaseRenewal.await()
+                    return currentAccessToken
+                }
+            },
+            accountReadyGate = null,
+        )
+
+        val capture = async { gate.captureSnapshot(renewIfStale = true) }
+        renewalStarted.await()
+
+        var flipped = false
+        val switch = launch { gate.withSwitch { flipped = true } }
+        yield()
+
+        assertThat(flipped).isTrue()
+        assertThat(capture.isCompleted).isFalse()
+
+        releaseRenewal.complete(Unit)
+        switch.join()
+        capture.await()
     }
 }

--- a/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/client/SwitchGateTest.kt
+++ b/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/client/SwitchGateTest.kt
@@ -31,14 +31,18 @@ class SwitchGateTest {
         override val isAuthenticated: Boolean get() = liveToken != null
         override suspend fun getAccessToken(): String? = liveToken
         override suspend fun setTokens(accessToken: String, refreshToken: String) = Unit
-        override suspend fun refreshAccessToken(): RefreshResult = RefreshResult.HardExpired
+        override suspend fun refreshAccessToken(usedAccessToken: String?): RefreshResult = RefreshResult.HardExpired
         override suspend fun clearTokens() = Unit
         override suspend fun getAccessTokenFor(accountId: String): String? = keyed[accountId]
         override suspend fun getStagedAccessToken(): String? = null
         override suspend fun clearStagedTokens() = Unit
         override suspend fun selectAccount(accountId: String) = Unit
         override suspend fun removeAccount(accountId: String) = Unit
-        override suspend fun refreshAccessTokenFor(accountId: String, baseUrl: String): RefreshResult = RefreshResult.HardExpired
+        override suspend fun refreshAccessTokenFor(
+            accountId: String,
+            baseUrl: String,
+            usedAccessToken: String?,
+        ): RefreshResult = RefreshResult.HardExpired
         override suspend fun onAccountResolved(accountId: String) = Unit
         override suspend fun onAccountCleared() = Unit
         override fun emitSessionExpired(expiredAccountId: String?, reason: SessionEndReason) = Unit

--- a/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/di/NetworkGraphTestFakes.kt
+++ b/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/di/NetworkGraphTestFakes.kt
@@ -45,15 +45,18 @@ internal object NetworkGraphTestFakes {
         override val isAuthenticated: Boolean = false
         override suspend fun getAccessToken(): String? = null
         override suspend fun setTokens(accessToken: String, refreshToken: String) = Unit
-        override suspend fun refreshAccessToken(): RefreshResult = RefreshResult.Transient
+        override suspend fun refreshAccessToken(usedAccessToken: String?): RefreshResult = RefreshResult.Transient
         override suspend fun clearTokens() = Unit
         override suspend fun getAccessTokenFor(accountId: String): String? = null
         override suspend fun getStagedAccessToken(): String? = null
         override suspend fun clearStagedTokens() = Unit
         override suspend fun selectAccount(accountId: String) = Unit
         override suspend fun removeAccount(accountId: String) = Unit
-        override suspend fun refreshAccessTokenFor(accountId: String, baseUrl: String): RefreshResult =
-            RefreshResult.Transient
+        override suspend fun refreshAccessTokenFor(
+            accountId: String,
+            baseUrl: String,
+            usedAccessToken: String?,
+        ): RefreshResult = RefreshResult.Transient
 
         override suspend fun onAccountResolved(accountId: String) = Unit
         override fun emitSessionExpired(expiredAccountId: String?, reason: SessionEndReason) = Unit

--- a/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/AccessTokenExpiry.kt
+++ b/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/AccessTokenExpiry.kt
@@ -1,0 +1,56 @@
+package com.garfiec.librechat.core.network.client
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
+
+/** Tolerant reader for a payload we did not mint; only the `exp` claim is ever looked at. */
+private val expiryJson = Json { ignoreUnknownKeys = true; isLenient = true }
+
+/**
+ * When the LibreChat access token expires, read out of the token itself.
+ *
+ * The backend mints it with `jwt.sign(payload, secret, { expiresIn })`
+ * (`packages/data-schemas/src/crypto/index.ts`), so the deadline is already in the string we hold —
+ * no third per-account storage key to write, re-home, delete and migrate at every token call site,
+ * and nothing that can desync from the token it describes.
+ *
+ * Returns the `exp` claim as epoch millis, or null when [token] is not a JWT whose payload carries a
+ * numeric `exp`. Never throws — every malformed shape (wrong segment count, non-base64 payload,
+ * non-JSON payload, absent or non-numeric `exp`) is a null.
+ *
+ * **Null means "unknown", and callers must treat it as "do nothing".** It is not merely defensive: an
+ * OpenID deployment that hands through the provider's own access token may give us something opaque,
+ * and the only safe reading of an undecodable token is to leave it to the reactive 401 path.
+ */
+@OptIn(ExperimentalEncodingApi::class)
+fun expiresAtEpochMillisOrNull(token: String): Long? {
+    val segments = token.split('.')
+    if (segments.size != JWT_SEGMENTS) return null
+    val payload = segments[1]
+    if (payload.isEmpty()) return null
+    val decoded = try {
+        // JWT payloads are base64url with the padding stripped; the URL-safe alphabet is required
+        // (a payload containing '-' or '_' fails to decode under the standard one) and
+        // `withPadding(ABSENT_OPTIONAL)` accepts the segment whether or not '=' survived.
+        Base64.UrlSafe.withPadding(Base64.PaddingOption.ABSENT_OPTIONAL).decode(payload).decodeToString()
+    } catch (_: IllegalArgumentException) {
+        return null
+    }
+    val exp = try {
+        (expiryJson.parseToJsonElement(decoded) as? JsonObject)?.get("exp")
+    } catch (_: Exception) {
+        // parseToJsonElement throws SerializationException, but a payload that decoded to invalid
+        // UTF-8 can surface other shapes; nothing here is worth failing a request over.
+        return null
+    }
+    // Read through the safe accessor, not `.jsonPrimitive` — that throws on a non-primitive `exp`
+    // (an object or array), which is exactly the malformed input this function exists to absorb.
+    val seconds = (exp as? JsonPrimitive)?.takeUnless { it.isString }?.content?.toDoubleOrNull() ?: return null
+    return (seconds * MILLIS_PER_SECOND).toLong()
+}
+
+private const val JWT_SEGMENTS = 3
+private const val MILLIS_PER_SECOND = 1000

--- a/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/AuthInterceptorPlugin.kt
+++ b/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/AuthInterceptorPlugin.kt
@@ -45,19 +45,9 @@ class AuthInterceptorPlugin private constructor(
 
         override fun install(plugin: AuthInterceptorPlugin, scope: HttpClient) {
             // Endpoints that take no bearer and whose 401 is the endpoint's own verdict, not an
-            // expired session — kept out of the refresh/session-expiry leg below.
-            val skipPaths = setOf(
-                "auth/login", "auth/register", "auth/refresh",
-                "auth/requestPasswordReset", "auth/resetPassword",
-                "auth/2fa/verify-temp",
-            )
-
-            // Matched on whole path segments, not as a substring of the URL, so a path-prefixed
-            // deployment (e.g. /apps/auth/login-x) doesn't match every request it serves.
-            fun isSkipPath(url: URLBuilder): Boolean {
-                val path = url.encodedPathSegments.filter { it.isNotEmpty() }.joinToString("/")
-                return skipPaths.any { path == it || path.endsWith("/$it") }
-            }
+            // expired session — kept out of the refresh/session-expiry leg below. Shared with
+            // SwitchBarrierPlugin; see AuthSkipPaths.kt.
+            fun isSkipPath(url: URLBuilder): Boolean = isAuthSkipPath(url)
 
             // Attach token to outgoing requests. Runs at State, which is after
             // the SwitchBarrier/defaultRequest phases have applied the base URL —

--- a/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/AuthSkipPaths.kt
+++ b/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/AuthSkipPaths.kt
@@ -1,0 +1,35 @@
+package com.garfiec.librechat.core.network.client
+
+import io.ktor.http.URLBuilder
+
+/**
+ * Endpoints that take no session bearer and whose `401` is the endpoint's own verdict rather than an
+ * expired session.
+ *
+ * Two plugins must agree on this list. [AuthInterceptorPlugin] keeps these out of the attach and the
+ * 401-refresh leg; the [SwitchBarrierPlugin] keeps them out of *proactive* renewal, for the same
+ * reason — a sign-in POST must not first drive a refresh of the session it is replacing, and on a slow
+ * or failing server that would put the whole refresh in front of the Sign in button.
+ *
+ * Shared rather than duplicated because a path added to one copy and not the other is silent: the
+ * behaviour it protects only shows up on a server that is misbehaving at the time.
+ *
+ * Note this is deliberately **not** the gate for gateway headers — see `core/network/CLAUDE.md`.
+ * Those must reach the auth endpoints or the app cannot sign in at all.
+ */
+private val AUTH_SKIP_PATHS = setOf(
+    "auth/login", "auth/register", "auth/refresh",
+    "auth/requestPasswordReset", "auth/resetPassword",
+    "auth/2fa/verify-temp",
+)
+
+/**
+ * True when [url] addresses one of [AUTH_SKIP_PATHS].
+ *
+ * Matched on whole path segments, not as a substring of the URL, so a path-prefixed deployment (e.g.
+ * `/apps/auth/login-x`) doesn't match every request it serves.
+ */
+internal fun isAuthSkipPath(url: URLBuilder): Boolean {
+    val path = url.encodedPathSegments.filter { it.isNotEmpty() }.joinToString("/")
+    return AUTH_SKIP_PATHS.any { path == it || path.endsWith("/$it") }
+}

--- a/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/RequestIdentityAuth.kt
+++ b/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/RequestIdentityAuth.kt
@@ -23,13 +23,18 @@ sealed interface BearerResult {
  * Maps the refresh [RefreshResult] to a [BearerResult]: only a genuine [RefreshResult.HardExpired]
  * (or a refreshed-but-empty slot, meaning a logout/removal raced the refresh) becomes [Expired] and
  * logs the user out; a [RefreshResult.Transient] becomes [Transient] and keeps the session.
+ *
+ * The snapshot's bearer is handed to the refresh as `usedAccessToken`: it is exactly what this request
+ * put on the wire (the attach phase reads the snapshot, never the live cache), so a cold-start fan-out
+ * of N 401s collapses to one refresh POST — every waiter behind the flight lock sees the rotated token
+ * and skips its own.
  */
 suspend fun TokenManager.refreshBearerFor(identity: RequestIdentity?): BearerResult {
     val account = identity?.accountId
     val result = if (account != null) {
-        refreshAccessTokenFor(account, identity.baseUrl)
+        refreshAccessTokenFor(account, identity.baseUrl, usedAccessToken = identity.bearer)
     } else {
-        refreshAccessToken()
+        refreshAccessToken(usedAccessToken = identity?.bearer)
     }
     return when (result) {
         RefreshResult.Refreshed -> {

--- a/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/SwitchBarrierPlugin.kt
+++ b/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/SwitchBarrierPlugin.kt
@@ -44,13 +44,33 @@ class SwitchBarrierPlugin private constructor(
         override fun install(plugin: SwitchBarrierPlugin, scope: HttpClient) {
             scope.requestPipeline.insertPhaseBefore(HttpRequestPipeline.Before, SwitchBarrierPhase)
             scope.requestPipeline.intercept(SwitchBarrierPhase) {
-                val snapshot = plugin.switchGate.captureSnapshot()
+                val snapshot = plugin.switchGate.captureSnapshot(renewIfStale = shouldRenewFor(context.url))
                 context.attributes.put(RequestIdentityKey, snapshot)
                 if (snapshot.baseUrl.isNotEmpty()) {
                     applyBaseUrl(context.url, snapshot.baseUrl)
                 }
             }
         }
+
+        /**
+         * Whether this request should proactively renew a near-expired access token before being
+         * sent. Both exclusions cover requests that will never carry the session bearer, so a refresh
+         * on their behalf is at best wasted and at worst harmful:
+         *
+         * - **Auth endpoints** ([isAuthSkipPath]) — a sign-in or password-reset POST issued while an
+         *   expired token is still stored would otherwise put a full refresh in front of the Sign in
+         *   button. The bearer is deliberately never attached to these; renewing it is not this
+         *   request's business.
+         * - **Absolute URLs** — a request that already carries a host at this phase is a cross-host
+         *   fetch (a presigned CDN download), which [AuthInterceptorPlugin] host-scopes the bearer
+         *   away from anyway. A relative URL has no host yet and will be resolved against the
+         *   snapshot's base below, so it is same-server by construction.
+         *
+         * An absolute URL that happens to *be* the server is excluded too — a missed head start on a
+         * rare path, and it falls back to the reactive 401. Fail-safe is the right side to err on.
+         */
+        private fun shouldRenewFor(requestUrl: URLBuilder): Boolean =
+            requestUrl.host.isEmpty() && !isAuthSkipPath(requestUrl)
 
         /**
          * Merge [baseUrlString] into [requestUrl] with the same semantics as Ktor's

--- a/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/SwitchGate.kt
+++ b/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/SwitchGate.kt
@@ -122,8 +122,14 @@ class SwitchGate(
      * A caller running under a [PendingRequestIdentity] (the add-account flow) short-circuits to the
      * pending identity: no gates, no live-provider reads — the pending flow is self-contained and a
      * concurrent switch doesn't affect it.
+     *
+     * [renewIfStale] opts this snapshot into proactive token renewal
+     * ([TokenManager.ensureFreshAccessToken]) — only the transports pass it. It is **not** the default
+     * because `captureSnapshot` has non-transport callers for which a renewal is wrong rather than
+     * merely wasteful: logout pins an identity before revoking the session, and refreshing a session
+     * we are about to destroy adds a round trip to it and rotates a token nobody will use.
      */
-    suspend fun captureSnapshot(): RequestIdentity {
+    suspend fun captureSnapshot(renewIfStale: Boolean = false): RequestIdentity {
         coroutineContext[PendingRequestIdentity]?.let { return it.identity() }
         accountReadyGate?.awaitReady()
         serverUrlProvider.awaitBaseUrl()
@@ -137,7 +143,7 @@ class SwitchGate(
         // directly avoids allocating a flow collector on every request and only suspends when a switch
         // is actually mid-flip.
         if (!open.value) open.first { it }
-        return lock.withLock {
+        val snapshot = lock.withLock {
             val accountId = activeAccountProvider.currentAccountId()?.value
             val baseUrl = serverUrlProvider.getBaseUrl()
             RequestIdentity(
@@ -156,6 +162,26 @@ class SwitchGate(
                 customHeaders = serverHeadersProvider.headersFor(baseUrl),
             )
         }
+        if (!renewIfStale) return snapshot
+        // Renew AFTER the snapshot and OUTSIDE [lock], and feed it the snapshot's own values.
+        //
+        // Outside the lock because it is the same mutex [withSwitch] takes, and a refresh POST
+        // suspended inside it would stall every account switch — the rule the header warm-up above
+        // follows too. Off the *snapshot* rather than re-reading the providers because those two reads
+        // would not be atomic with each other: a switch publishes the new server URL before the new
+        // account, so an unguarded pair can be (old account, new URL), and refreshing against that
+        // POSTs one account's refresh token to another deployment — the exact tearing this class
+        // exists to prevent. Reusing the snapshot also keeps the triple to one read per request.
+        //
+        // A switch landing between the snapshot and the renewal is harmless: this request is already
+        // pinned to that account, refreshAccessTokenFor writes only that account's keyed slot, and a
+        // switched-away account's tokens are retained.
+        val renewed = tokenManager.ensureFreshAccessToken(
+            accountId = snapshot.accountId,
+            baseUrl = snapshot.baseUrl,
+            currentAccessToken = snapshot.bearer,
+        )
+        return if (renewed == snapshot.bearer) snapshot else snapshot.copy(bearer = renewed)
     }
 
     /**

--- a/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/TokenManager.kt
+++ b/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/TokenManager.kt
@@ -18,7 +18,17 @@ interface TokenManager {
     val isAuthenticated: Boolean
     suspend fun getAccessToken(): String?
     suspend fun setTokens(accessToken: String, refreshToken: String)
-    suspend fun refreshAccessToken(): RefreshResult
+
+    /**
+     * Refresh the live active account against the live base URL.
+     *
+     * [usedAccessToken] is **the bearer the caller's failing request actually sent**. Refreshes of one
+     * account are single-flighted, so a cold-start fan-out queues N callers behind one lock, all
+     * holding the same stale bearer; passing it lets a waiter notice that the holder of the lock
+     * already rotated the token and return [RefreshResult.Refreshed] without POSTing a second time.
+     * Null (the default) disables that check and preserves the unconditional-POST behaviour.
+     */
+    suspend fun refreshAccessToken(usedAccessToken: String? = null): RefreshResult
 
     /**
      * Full teardown of the active session — keyed tokens, any bare staging keys, and the persisted
@@ -73,8 +83,14 @@ interface TokenManager {
      * [accountId]'s keyed slot and updates the cached bearer only while [accountId] is still the active
      * account. Distinct from [refreshAccessToken], which refreshes the live active account against the
      * live base URL.
+     *
+     * [usedAccessToken] carries the same coalescing hint as on [refreshAccessToken].
      */
-    suspend fun refreshAccessTokenFor(accountId: String, baseUrl: String): RefreshResult
+    suspend fun refreshAccessTokenFor(
+        accountId: String,
+        baseUrl: String,
+        usedAccessToken: String? = null,
+    ): RefreshResult
 
     /**
      * Bind token storage to [accountId] once identity resolves (login, cold-start restore, upgrade).

--- a/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/TokenManager.kt
+++ b/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/client/TokenManager.kt
@@ -93,6 +93,37 @@ interface TokenManager {
     ): RefreshResult
 
     /**
+     * Renew [accountId]'s access token **before** a request goes out, if [currentAccessToken] is at or
+     * near its expiry, and return the bearer the caller should use. Returns [currentAccessToken]
+     * unchanged when the token is still good, absent, carries no readable deadline, or the renewal
+     * did not succeed.
+     *
+     * Renewal is otherwise driven entirely by failure — a token is refreshed only after a request
+     * using it has come back `401`. Access tokens live 15 minutes by default, so every cold start
+     * after an idle period pays a full round trip of 401-then-refresh-then-retry on the critical path
+     * before anything renders (issue #323). Checking the deadline we already hold turns that into one
+     * refresh with no 401 at all.
+     *
+     * The current bearer is passed **in** rather than re-read: this runs on every request the barrier
+     * builds, and the caller has already read the identity triple under its own lock. Re-reading here
+     * would both cost a second lock acquisition per request and risk pairing a token with a different
+     * account than the caller snapshotted.
+     *
+     * **Best-effort and non-signalling.** It must never tear down a session or emit session-expired:
+     * a failed renewal leaves everything as it was and the request proceeds on the old bearer, so the
+     * reactive 401 path — which retries and can distinguish a dead session from a server
+     * false-negative — remains the only thing that logs anyone out.
+     *
+     * Defaulted to returning the token unchanged, so an implementation that is not the token store
+     * opts out by saying nothing rather than being forced into a stub.
+     */
+    suspend fun ensureFreshAccessToken(
+        accountId: String?,
+        baseUrl: String,
+        currentAccessToken: String?,
+    ): String? = currentAccessToken
+
+    /**
      * Bind token storage to [accountId] once identity resolves (login, cold-start restore, upgrade).
      * Re-homes the staged (bare-key) authentication tokens into this account's keyed slot and repoints
      * the synchronously-readable mirror, so subsequent cold starts seed the right account's bearer with

--- a/core/network/src/iosMain/kotlin/com/garfiec/librechat/core/network/sse/SseHttpTransport.ios.kt
+++ b/core/network/src/iosMain/kotlin/com/garfiec/librechat/core/network/sse/SseHttpTransport.ios.kt
@@ -108,7 +108,7 @@ actual class SseHttpTransport(
         // is the SwitchBarrierPlugin equivalent for the NWConnection path (which can't use Ktor
         // plugins): a switch mid-stream can't tear the URL and token apart — the stream keeps running
         // against the account and server it started on, whose tokens are retained.
-        val snapshot = switchGate.captureSnapshot()
+        val snapshot = switchGate.captureSnapshot(renewIfStale = true)
         var token = snapshot.bearer
         var triedRefresh = false
         while (true) {


### PR DESCRIPTION
## Summary

Access-token renewal was driven entirely by failure: a token was refreshed only *after* a request
carrying it came back `401`. Access tokens live 15 minutes by default (`SESSION_EXPIRY`), and the app
fans out many requests at cold start, so every launch after an idle period paid a
401-then-refresh-then-retry round trip **per in-flight request**, serialized behind the per-account
flight mutex, before anything rendered.

The deadline is already in the token we hold — the backend mints it with
`jwt.sign(payload, secret, { expiresIn })` — so this reads the `exp` claim and renews once, ahead of
the request. Two changes that each stand on their own:

1. **Coalesce** — a queued refresh burst costs one POST instead of one per waiter.
2. **Preempt** — decode `exp` at the request barrier and renew before the request goes out, so there
   is no `401` at all.

Measured on an emulator against a LibreChat server, same restored session state: a cold start on an
aged-out session went from **16** `401 received` and **21** refresh POSTs to **0** and **1**.

## Changes

**Collapse a queued refresh burst to one POST** (`TokenManager`, `RequestIdentityAuth`,
`CommonTokenDataStore`)

- `refreshAccessToken` / `refreshAccessTokenFor` take `usedAccessToken` — the bearer the caller's
  failing request actually put on the wire. `refreshBearerFor` passes the request identity's own
  bearer, which is exactly what the attach phase used, so this covers the Ktor path and the iOS raw
  SSE transport alike.
- A waiter that takes the flight lock and finds the slot holding a *different* value knows the
  holder before it already rotated on its behalf, and returns `Refreshed` without POSTing.
- Only a **changed** value coalesces. An absent one means a teardown or a hard expiry dropped the
  slot, which must still fall through and settle `HardExpired` — treating "present" as "rotated"
  would report a refresh that never happened and the user would never be routed to re-auth.
- A null `usedAccessToken` (the refresh client, tests) keeps the unconditional-POST behaviour.

**Read the expiry out of the token** (new `AccessTokenExpiry.kt`)

- `expiresAtEpochMillisOrNull` base64url-decodes the JWT payload and returns `exp` as epoch millis.
- No new stored field. An `expiresAt` key would have to be written, re-homed, deleted and migrated
  at every token call site, and iOS `writeValues` is non-atomic, so it could persist out of step
  with the token it describes. The issue also suggested parsing the refresh cookie's `Expires`; that
  attribute only ever described the *refresh* token, which is itself a JWT with its own `exp`.
- Never throws. Null means "unknown" and callers must do nothing — an OpenID deployment that passes
  through the provider's own access token may hand us something opaque, and the only safe reading is
  to leave it to the reactive path.

**Renew at the request barrier** (`TokenManager.ensureFreshAccessToken`, `SwitchGate`,
`SwitchBarrierPlugin`, iOS `SseHttpTransport`)

- `captureSnapshot(renewIfStale)` is **opt-in**, and only the two transports opt in — the barrier
  per request, the iOS SSE transport unconditionally. Logout
  snapshots through the same seam, and refreshing a session about to be revoked adds a round trip to
  logout and rotates a token nobody will use; the post-login profile fetch holds a token just issued.
- Renewal runs **after** the locked snapshot, **outside** the lock, and is handed the snapshot's own
  `(accountId, baseUrl, bearer)`. Outside the lock because it is the same mutex `withSwitch` takes,
  and a refresh POST suspended inside it would stall every account switch. Off the snapshot because
  a switch publishes the new server URL before the new account id, so two fresh reads can pair
  (old account, new URL) — and refreshing against that POSTs one account's refresh token to another
  deployment. This also removes the second read of the identity triple per request.
- Every branch of the proactive path pins the POST to the snapshotted server, including the
  no-account one, where the reactive path posts to the live base URL.
- The skew window is **20 s and must stay under 30 s**. On an OpenID deployment the refresh endpoint
  answers 2xx with *the same token* while `exp` is more than `OPENID_REUSE_EXPIRY_BUFFER_SECONDS`
  (30) away, so a wider window would fire inside that band, get the identical token back, and repeat
  on the next request with nothing to coalesce against.
- The decode is memoized on the token string. `captureSnapshot` runs per request, on a dispatcher
  that for several cold-start repositories is main (#326), so the steady-state cost is a string
  comparison rather than a base64 decode plus a JSON parse.

**Keep proactive renewal from ever making things worse**

- **Best-effort semantics.** One attempt instead of the retry ladder, and it never drops a slot. The
  ladder exists because the backend answers `401` identically for a dead session and a transiently
  missed one, so a single attempt cannot tell them apart — which is exactly why it must not settle
  the question. The reactive 401 path keeps sole ownership of the logout decision.
- **Failure suppression, per account.** A renewal that cannot succeed changes nothing for the
  coalescing check to see, so without a cooldown every request in a cold-start fan-out would queue
  behind the flight lock and spend its own connect timeout *before* being sent — worse than the
  reactive path, where those requests fail in parallel. Per account rather than process-wide,
  because both suppression causes are properties of one deployment.
- **Runaway guard.** A token that reads as stale the moment it is issued — a device clock fast by
  more than the token's lifetime, or a `SESSION_EXPIRY` below the skew window — would otherwise cost
  one POST per sequential request forever. One wasted refresh detects it and disables the proactive
  path for that slot.

**Share the auth-path exclusion** (new `AuthSkipPaths.kt`)

The list of endpoints that take no session bearer moves out of `AuthInterceptorPlugin` so the
barrier can exclude the same paths from proactive renewal. Without that, a sign-in or password-reset
POST issued while an expired token is still stored would put a full refresh in front of the Sign in
button — on the server least likely to be answering. The barrier also skips absolute URLs, which are
cross-host fetches the bearer is scoped away from anyway.

**Observability**

Every proactive renewal reconciles to a log line: `refresh_proactive` on entry, then
`refresh_coalesced`, `refresh_skipped`, `refresh_proactive_disabled`, or one of the pre-existing
outcome arms. That matters most for the one arm that can return without POSTing — a slot holding an
access token but no refresh token — because untraced it makes `refresh_proactive` read as a POST
counter when it is not.

## Testing

- **Unit** — `AccessTokenExpiryTest` (12) pins "never throws, null when unsure" across padded and
  unpadded payloads, url-safe alphabet characters, `exp` as a double, `exp` absent / a string / a
  non-primitive, an opaque non-JWT, non-base64 and non-JSON payloads, and an empty string.
  `CommonTokenDataStoreRefreshCoalescingTest` (5) covers the burst collapsing to one POST plus the
  three cases that must *not* short-circuit, and pins that `onAccountResolved` writes only its own
  account's slot. `CommonTokenDataStoreProactiveRenewalTest` (12) covers renew / leave-alone /
  unreadable-deadline / absent, both runaway shapes (a new-but-still-stale token and the OpenID
  same-token reply), URL pinning on the keyed and null-account branches, that a rejected renewal
  neither drops the slot nor reports the session expired, the failure cooldown, and that suppressing
  one account leaves another renewing. `AuthSkipPathsTest` covers whole-segment matching.
  `SwitchBarrierRenewalTest` drives a real Ktor client to pin which requests opt in, with a positive
  control. `SwitchGateTest` gains five: default never renews, opted-in renews and snapshots the new
  bearer, a pending identity never renews, renewal is handed the snapshot's own triple, and a
  renewal in progress does not block an account switch.
- **Gate** — `:core:network` and `:core:data` unit tests, `detektMetadataCommonMain` (the task that
  actually covers `commonMain`), and `:app:assembleDebug`.
- **Device** — Pixel-class emulator, API 37, against a local LibreChat server with `SESSION_EXPIRY`
  lowered so the aged-out state is reproducible. Cold start on an expired-but-live session: **0**
  `401 received` (baseline 16), **1** refresh POST (baseline 21), content renders. Cold start inside
  the token's lifetime: 0 renewals, confirmed against the positive breadcrumb rather than against
  absence. Dead session: unchanged — one teardown, one notice. Airplane mode: one suppressed attempt,
  not one per request. Logout: 0 `refresh_proactive`.
- **Partially verified: the account-switch case.** A warm A↔B switch stays responsive, costs one
  POST, and retains the switched-away account's tokens with no cross-account write. It does **not**
  verify the cross-deployment pinning: both test accounts sat on one server, so the leak cannot
  arise there, and the "switch strictly during the cold-start fan-out" variant is unreachable on the
  emulator (renewals finish ~15 s after launch, the account chip is only tappable ~22 s in). That
  property is unit-tested only.
- **Not verified: iOS.** Every production file changed is `commonMain` apart from the one-line
  `SseHttpTransport.ios.kt` opt-in. No iOS build or run was done.
- **Not verified: OpenID.** The 30 s reuse-buffer reasoning behind the skew window is read off
  upstream `AuthController.js`, not observed — no OpenID deployment was available.

## Notes

- Six near-identical in-memory `CommonTokenDataStore` fakes across the datastore suites collapse
  into one shared `TokenDataStoreTestFixtures`. The copies had already drifted: only one documented
  that `MockEngine` must be pinned to `Dispatchers.Unconfined`, without which handling hops to a real
  thread pool outside the test scheduler's virtual clock and `advanceUntilIdle()` races the
  assertions.
- The auth-path exclusion is unit-tested rather than device-tested because there is no faithful
  device route to it: reaching the Login screen normally requires a hard refresh rejection, which
  clears the tokens first, so "no renewal happened" would be vacuously true.
- More frequent renewal means more refresh-token rotations, which raises exposure to a pre-existing
  bug: `handleSuccess` treats a 2xx without a rotated `Set-Cookie` as "the server didn't rotate" and
  retains the stored token, so a proxy that strips the cookie strands the client permanently. Not
  caused here, and not seen on the device pass.
- This does not change how often the user is logged out. LibreChat has no sliding session —
  `setAuthTokens` copies `session.expiration` unchanged and `updateExpiration()` is never called, so
  the 7-day deadline is stamped once at login. This is about the cost and timing of renewal only.
- `captureSnapshot` still runs on the caller's dispatcher, which for several cold-start repositories
  is main. Renewal suspends rather than blocks, but it makes #326 more prominent; the fix belongs
  there.

Closes #323
