### PR TITLE
fix(prompts): refresh the / picker and library when a prompt changes (#317, #315)

### DIFF
--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/repository/PromptRepositoryRevisionTest.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/repository/PromptRepositoryRevisionTest.kt
@@ -1,0 +1,87 @@
+package com.garfiec.librechat.core.data.repository
+
+import com.garfiec.librechat.core.model.Prompt
+import com.garfiec.librechat.core.model.PromptGroup
+import com.garfiec.librechat.core.model.request.AddPromptToGroupRequest
+import com.garfiec.librechat.core.model.request.CreatePromptData
+import com.garfiec.librechat.core.model.request.CreatePromptGroupData
+import com.garfiec.librechat.core.model.request.CreatePromptRequest
+import com.garfiec.librechat.core.model.request.UpdatePromptGroupRequest
+import com.garfiec.librechat.core.model.request.UpdatePromptTagRequest
+import com.garfiec.librechat.core.network.api.PromptsApi
+import com.google.common.truth.Truth.assertThat
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+/**
+ * The contract under test is that `revision` follows the *server's* answer: an accepted mutation
+ * announces itself, a rejected one stays silent. A bump on a failed call would make the prompts
+ * library and the `/` picker refetch and repaint unchanged data as though the user's edit landed.
+ */
+class PromptRepositoryRevisionTest {
+
+    private val promptsApi = mockk<PromptsApi>(relaxed = true)
+    private val repository = PromptRepositoryImpl(promptsApi)
+
+    private val group = PromptGroup(id = "g-1", name = "Group", author = "a", authorName = "A")
+    private val prompt = Prompt(id = "p-1", groupId = "g-1", author = "a", prompt = "body", type = "text")
+
+    private val createRequest = CreatePromptRequest(
+        prompt = CreatePromptData(prompt = "body", type = "text"),
+        group = CreatePromptGroupData(name = "Group"),
+    )
+
+    @Test
+    fun everyAcceptedMutationBumpsTheRevision() = runTest {
+        coEvery { promptsApi.createPrompt(any()) } returns group
+        coEvery { promptsApi.updatePromptGroup(any(), any()) } returns group
+        coEvery { promptsApi.deletePromptGroup(any()) } returns Unit
+        coEvery { promptsApi.addPromptToGroup(any(), any()) } returns prompt
+        coEvery { promptsApi.updatePromptProductionTag(any(), any()) } returns prompt
+
+        val start = repository.revision.value
+        repository.create(createRequest)
+        repository.update("g-1", UpdatePromptGroupRequest(name = "Group"))
+        repository.addPromptToGroup("g-1", AddPromptToGroupRequest(prompt = "new body", type = "text"))
+        repository.updatePromptProductionTag("p-1", UpdatePromptTagRequest(productionPromptId = "p-1"))
+        repository.delete("g-1")
+
+        // One per mutation: a missed bump is a surface left serving pre-save values with nothing
+        // reporting it, which is the whole bug class this counter exists to close.
+        assertThat(repository.revision.value).isEqualTo(start + 5)
+    }
+
+    @Test
+    fun readsDoNotBumpTheRevision() = runTest {
+        coEvery { promptsApi.getAllPromptGroups() } returns listOf(group)
+        coEvery { promptsApi.getPromptGroup(any()) } returns group
+        coEvery { promptsApi.getPromptsByGroupId(any()) } returns listOf(prompt)
+
+        val start = repository.revision.value
+        repository.getAllGroups()
+        repository.getGroup("g-1")
+        repository.getPromptsByGroupId("g-1")
+
+        // Each consumer reloads on a bump, so a read that bumps is an infinite refetch loop.
+        assertThat(repository.revision.value).isEqualTo(start)
+    }
+
+    @Test
+    fun aRejectedMutationStaysSilent() = runTest {
+        coEvery { promptsApi.createPrompt(any()) } throws RuntimeException("500")
+        coEvery { promptsApi.deletePromptGroup(any()) } throws RuntimeException("403")
+        coEvery { promptsApi.addPromptToGroup(any(), any()) } throws RuntimeException("offline")
+
+        val start = repository.revision.value
+        repository.create(createRequest)
+        repository.delete("g-1")
+        repository.addPromptToGroup("g-1", AddPromptToGroupRequest(prompt = "new body", type = "text"))
+
+        // The bump sits after the API call inside `safeApiCall`, so a throw skips it. Announcing a
+        // failed delete would make the library refetch and repaint the prompt the user was told
+        // was gone.
+        assertThat(repository.revision.value).isEqualTo(start)
+    }
+}

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/PromptRepository.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/PromptRepository.kt
@@ -8,8 +8,22 @@ import com.garfiec.librechat.core.model.request.CreatePromptRequest
 import com.garfiec.librechat.core.model.request.UpdatePromptGroupRequest
 import com.garfiec.librechat.core.model.request.UpdatePromptTagRequest
 import com.garfiec.librechat.core.model.response.PromptGroupListResponse
+import kotlinx.coroutines.flow.StateFlow
 
 interface PromptRepository {
+
+    /**
+     * Bumped after any prompt mutation this repository accepted — create, group update, delete,
+     * a new version added to a group, or a production-tag change.
+     *
+     * Prompts are network-direct with no Room cache, so a screen that fetched them once has no
+     * observable to re-read from and nothing else reports the staleness: the composer's `/` picker
+     * keeps offering a deleted prompt and inserting a superseded body. Every prompt mutation in the
+     * app goes through the methods below, so a mutation added there must bump here too. Mirrors
+     * [AgentRepository.revision]; the consumer side is in `feature/chat/CLAUDE.md`.
+     */
+    val revision: StateFlow<Long>
+
     suspend fun getGroups(pageSize: Int = 10, cursor: String? = null): Result<PromptGroupListResponse>
 
     /** Every visible prompt group in one call, for surfaces that must not truncate (the `/` picker). */

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/PromptRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/PromptRepositoryImpl.kt
@@ -10,10 +10,21 @@ import com.garfiec.librechat.core.model.request.UpdatePromptGroupRequest
 import com.garfiec.librechat.core.model.request.UpdatePromptTagRequest
 import com.garfiec.librechat.core.model.response.PromptGroupListResponse
 import com.garfiec.librechat.core.network.api.PromptsApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 
 class PromptRepositoryImpl(
     private val promptsApi: PromptsApi,
 ) : PromptRepository {
+
+    private val _revision = MutableStateFlow(0L)
+    override val revision: StateFlow<Long> = _revision.asStateFlow()
+
+    /** Inside `safeApiCall` and after the call, so a rejected mutation never announces a change. */
+    private fun bumpRevision() {
+        _revision.value += 1
+    }
 
     override suspend fun getGroups(pageSize: Int, cursor: String?): Result<PromptGroupListResponse> {
         return safeApiCall {
@@ -35,31 +46,32 @@ class PromptRepositoryImpl(
 
     override suspend fun create(request: CreatePromptRequest): Result<PromptGroup> {
         return safeApiCall {
-            promptsApi.createPrompt(request)
+            promptsApi.createPrompt(request).also { bumpRevision() }
         }
     }
 
     override suspend fun update(groupId: String, request: UpdatePromptGroupRequest): Result<PromptGroup> {
         return safeApiCall {
-            promptsApi.updatePromptGroup(groupId, request)
+            promptsApi.updatePromptGroup(groupId, request).also { bumpRevision() }
         }
     }
 
     override suspend fun delete(groupId: String): Result<Unit> {
         return safeApiCall {
             promptsApi.deletePromptGroup(groupId)
+            bumpRevision()
         }
     }
 
     override suspend fun addPromptToGroup(groupId: String, request: AddPromptToGroupRequest): Result<Prompt> {
         return safeApiCall {
-            promptsApi.addPromptToGroup(groupId, request)
+            promptsApi.addPromptToGroup(groupId, request).also { bumpRevision() }
         }
     }
 
     override suspend fun updatePromptProductionTag(promptId: String, request: UpdatePromptTagRequest): Result<Prompt> {
         return safeApiCall {
-            promptsApi.updatePromptProductionTag(promptId, request)
+            promptsApi.updatePromptProductionTag(promptId, request).also { bumpRevision() }
         }
     }
 

--- a/feature/chat/CLAUDE.md
+++ b/feature/chat/CLAUDE.md
@@ -150,6 +150,30 @@ Two consequences worth knowing before touching that block:
 - `PromptsLibraryScreen` and `PromptDetailScreen` live in `chat/prompts/`
 - `PromptsViewModel` loads prompt groups from `PromptRepository`
 - `handlePromptMention()` on ChatViewModel inserts prompt command text at `@` position
+- **`PromptRepository.revision` is how a mutation reaches the screens beneath it.** The editor is
+  *pushed on top of* both the library and the chat entry, so their ViewModels are retained and
+  `init` — the only caller of `loadGroups` / `loadAvailablePrompts` — never runs again; prompts are
+  network-direct with no `Flow` and no Room cache, so there is no observable to re-drive them from
+  either. The counter is bumped **inside the repository**, after the API call, so it announces only
+  mutations the server accepted and no call site can forget it (same shape as
+  `AgentRepository.revision`). A ViewModel mutation must **not** also call `refresh()` itself: the
+  revision is the single reload path, and doing both fetches the same list twice.
+- **The reload is driven from the composition, not from a ViewModel collector.** Both screens read
+  the revision (`ChatRoot`'s required `promptLibraryRevision`/`onRefreshPrompts` pair for the chat,
+  a `LaunchedEffect` in `PromptsLibraryScreen` for the library) and call a `refreshIfStale`. That is
+  the visibility gate: a bump while the screen is off-screen costs nothing until the user returns,
+  so an editor that bumps five times flipping through versions costs one reload — and the picker's
+  route is the deliberately unpaginated one. Keying the effect on the revision (rather than firing
+  once on entry) is what keeps it correct if a screen *stays* composed: it still reloads the moment
+  the revision moves, so nothing here depends on Nav3 disposing the entry underneath.
+  Each consumer records the revision it loaded and the one it is fetching, so a re-entry with
+  nothing changed is free, the first composition does not duplicate `init`'s in-flight load, and a
+  load that *failed* (which records nothing) is retried on the next visit. Reloads are
+  cancel-replace: the fetches are unordered and the write is last-writer-wins, so a superseded one
+  could otherwise re-list a prompt the user just deleted. The chat's refresh sits behind the
+  `PROMPTS.USE` gate, so a denied user issues no request; the revision-driven library reload
+  swallows its own errors (nobody asked for that fetch — only the pull-to-refresh gesture and the
+  initial load report failure).
 
 ## `ask_user_question`: one question, two cards (v0.8.8)
 

--- a/feature/chat/CLAUDE.md
+++ b/feature/chat/CLAUDE.md
@@ -174,6 +174,13 @@ Two consequences worth knowing before touching that block:
   `PROMPTS.USE` gate, so a denied user issues no request; the revision-driven library reload
   swallows its own errors (nobody asked for that fetch — only the pull-to-refresh gesture and the
   initial load report failure).
+- **A prompt save is two or three requests, and `saved` may only flip when all of them landed.**
+  The create route carries neither the oneliner nor the `/` command, and a body edit rides on
+  `addPromptToGroup` rather than the group update — so each save reads every follow-up `Result`
+  before reporting success. Every `PromptRepository` method is `safeApiCall`-wrapped: failure
+  arrives as a returned `Result.Error`, never as a throw, so a `try/catch` around one is dead code.
+  `PromptEditorScreen` pops on `saved`, so discarding a result loses the user's edit behind a
+  success animation.
 
 ## `ask_user_question`: one question, two cards (v0.8.8)
 

--- a/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatScreen.kt
+++ b/feature/chat/src/androidMain/kotlin/com/garfiec/librechat/feature/chat/screen/ChatScreen.kt
@@ -137,6 +137,7 @@ actual fun ChatScreen(
     val attachedFiles by viewModel.attachedFiles.collectAsStateWithLifecycle()
     val shareLinkUrl by viewModel.shareLinkUrl.collectAsStateWithLifecycle()
     val prefs by viewModel.chatPreferences.collectAsStateWithLifecycle()
+    val promptLibraryRevision by viewModel.promptLibraryRevision.collectAsStateWithLifecycle()
     val showImageDescriptions = prefs.showImageDescriptions
     val dismissKeyboardOnSend = prefs.dismissKeyboardOnSend
     val chatLayoutStyle = prefs.chatLayoutStyle
@@ -237,6 +238,8 @@ actual fun ChatScreen(
         onOpenMedia = viewModel::openMedia,
         onCloseMedia = viewModel::closeMedia,
         onDownloadAttachment = viewModel::downloadFileBytes,
+        promptLibraryRevision = promptLibraryRevision,
+        onRefreshPrompts = viewModel::refreshPromptsIfStale,
     ) {
     Scaffold(
         modifier = modifier

--- a/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/prompts/PromptEditorSaveOutcomeTest.kt
+++ b/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/prompts/PromptEditorSaveOutcomeTest.kt
@@ -1,0 +1,139 @@
+package com.garfiec.librechat.feature.chat.prompts
+
+import com.garfiec.librechat.core.common.result.Result
+import com.garfiec.librechat.core.data.repository.PromptRepository
+import com.garfiec.librechat.core.model.Prompt
+import com.garfiec.librechat.core.model.PromptGroup
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * A save is reported as successful by `saved`, which `PromptEditorScreen` pops the editor on — so
+ * every call the save depends on has to be read before it flips.
+ *
+ * A prompt's body and its `/` command each ride on a *separate* follow-up request, and every
+ * repository method is `safeApiCall`-wrapped: failure arrives as a returned `Result.Error`, never
+ * as a throw. Discarding those results loses the user's edit behind a success animation.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class PromptEditorSaveOutcomeTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private val promptRepository = mockk<PromptRepository>(relaxed = true)
+
+    private val createdGroup = PromptGroup(id = "g-1", name = "Summarize", author = "a", authorName = "A")
+    private val existingPrompt =
+        Prompt(id = "p-1", groupId = "g-1", author = "a", prompt = "old body", type = "text")
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        every { promptRepository.revision } returns MutableStateFlow(0L)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun newEditor(groupId: String? = null) = PromptEditorViewModel(promptRepository, groupId)
+
+    private fun loadedEditor(): PromptEditorViewModel {
+        coEvery { promptRepository.getGroup("g-1") } returns Result.Success(
+            createdGroup.copy(productionId = "p-1", prompts = listOf(existingPrompt)),
+        )
+        coEvery { promptRepository.getPromptsByGroupId("g-1") } returns Result.Success(listOf(existingPrompt))
+        return newEditor("g-1")
+    }
+
+    @Test
+    fun aFailedCommandUpdateDoesNotReportTheCreateAsSaved() = runTest(testDispatcher) {
+        coEvery { promptRepository.create(any()) } returns Result.Success(createdGroup)
+        coEvery { promptRepository.update(any(), any()) } returns Result.Error(message = "offline")
+
+        val editor = newEditor()
+        editor.updateName("Summarize")
+        editor.updatePromptText("Summarize this: {{text}}")
+        editor.updateCommand("summarize")
+        editor.save()
+        advanceUntilIdle()
+
+        // The create route takes neither the oneliner nor the command, so a prompt saved without
+        // this follow-up is not findable by the `/summarize` the user typed.
+        val state = editor.uiState.value
+        assertFalse(state.saved)
+        assertNotNull(state.error)
+        assertFalse(state.isSaving)
+        // The group exists now: keeping its id is what makes a retry an update rather than a
+        // second copy of the same prompt.
+        assertEquals("g-1", state.groupId)
+    }
+
+    @Test
+    fun aCreateWithNoMetadataStillSaves() = runTest(testDispatcher) {
+        coEvery { promptRepository.create(any()) } returns Result.Success(createdGroup)
+
+        val editor = newEditor()
+        editor.updateName("Summarize")
+        editor.updatePromptText("Summarize this")
+        editor.save()
+        advanceUntilIdle()
+
+        // No oneliner and no command means no follow-up call to fail; the create alone is the save.
+        assertTrue(editor.uiState.value.saved)
+        assertNull(editor.uiState.value.error)
+        coVerify(exactly = 0) { promptRepository.update(any(), any()) }
+    }
+
+    @Test
+    fun aFailedBodyUpdateDoesNotReportTheEditAsSaved() = runTest(testDispatcher) {
+        val editor = loadedEditor()
+        advanceUntilIdle()
+        coEvery { promptRepository.update(any(), any()) } returns Result.Success(createdGroup)
+        coEvery { promptRepository.addPromptToGroup(any(), any()) } returns Result.Error(message = "offline")
+
+        editor.updatePromptText("new body")
+        editor.save()
+        advanceUntilIdle()
+
+        // addPromptToGroup is the call that carries the body — the metadata update above does not.
+        val state = editor.uiState.value
+        assertFalse(state.saved)
+        assertNotNull(state.error)
+        assertFalse(state.isSaving)
+    }
+
+    @Test
+    fun anAcceptedBodyUpdateReportsSaved() = runTest(testDispatcher) {
+        val editor = loadedEditor()
+        advanceUntilIdle()
+        coEvery { promptRepository.update(any(), any()) } returns Result.Success(createdGroup)
+        coEvery { promptRepository.addPromptToGroup(any(), any()) } returns
+            Result.Success(existingPrompt.copy(id = "p-2", prompt = "new body"))
+
+        editor.updatePromptText("new body")
+        editor.save()
+        advanceUntilIdle()
+
+        assertTrue(editor.uiState.value.saved)
+        assertNull(editor.uiState.value.error)
+    }
+}

--- a/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/prompts/PromptsViewModelLibraryRefreshTest.kt
+++ b/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/prompts/PromptsViewModelLibraryRefreshTest.kt
@@ -149,4 +149,45 @@ class PromptsViewModelLibraryRefreshTest {
         assertNotNull(viewModel.uiState.value.error)
     }
 
+    @Test
+    fun aFailedDeleteReportsTheFailureAndKeepsTheDetailOpen() = runTest(testDispatcher) {
+        coEvery { promptRepository.getGroups(any(), any()) } returns response(group("g-1", "First"))
+        coEvery { promptRepository.getGroup(any()) } returns Result.Success(group("g-1", "First"))
+        coEvery { promptRepository.getPromptsByGroupId(any()) } returns Result.Success(emptyList())
+
+        val viewModel = newViewModel()
+        advanceUntilIdle()
+        viewModel.selectGroup("g-1")
+        advanceUntilIdle()
+        assertNotNull(viewModel.uiState.value.selectedGroup)
+
+        // `delete` REPORTS failure by returning Result.Error and never throws, so a try/catch
+        // around it sees nothing: closing the detail view here tells the user a prompt is gone
+        // while it is still on the server.
+        coEvery { promptRepository.delete(any()) } returns Result.Error(message = "forbidden")
+        viewModel.deleteGroup("g-1")
+        advanceUntilIdle()
+
+        assertNotNull(viewModel.uiState.value.error)
+        assertNotNull(viewModel.uiState.value.selectedGroup)
+    }
+
+    @Test
+    fun anAcceptedDeleteClosesTheDetailView() = runTest(testDispatcher) {
+        coEvery { promptRepository.getGroups(any(), any()) } returns response(group("g-1", "First"))
+        coEvery { promptRepository.getGroup(any()) } returns Result.Success(group("g-1", "First"))
+        coEvery { promptRepository.getPromptsByGroupId(any()) } returns Result.Success(emptyList())
+
+        val viewModel = newViewModel()
+        advanceUntilIdle()
+        viewModel.selectGroup("g-1")
+        advanceUntilIdle()
+
+        coEvery { promptRepository.delete(any()) } returns Result.Success(Unit)
+        viewModel.deleteGroup("g-1")
+        advanceUntilIdle()
+
+        assertNull(viewModel.uiState.value.selectedGroup)
+        assertNull(viewModel.uiState.value.error)
+    }
 }

--- a/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/prompts/PromptsViewModelLibraryRefreshTest.kt
+++ b/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/prompts/PromptsViewModelLibraryRefreshTest.kt
@@ -1,0 +1,152 @@
+package com.garfiec.librechat.feature.chat.prompts
+
+import com.garfiec.librechat.core.common.result.Result
+import com.garfiec.librechat.core.data.repository.PromptRepository
+import com.garfiec.librechat.core.data.repository.RoleRepository
+import com.garfiec.librechat.core.data.util.PermissionGate
+import com.garfiec.librechat.core.model.Prompt
+import com.garfiec.librechat.core.model.PromptGroup
+import com.garfiec.librechat.core.model.permissions.UserRolePermissions
+import com.garfiec.librechat.core.model.response.PromptGroupListResponse
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * The library list as the second consumer of `PromptRepository.revision` (#315).
+ *
+ * The revision is driven by hand here; that the repository bumps it on exactly the right calls is
+ * `PromptRepositoryRevisionTest`'s job. `refreshIfStale()` stands in for the screen's composition,
+ * which drives it keyed on `promptLibraryRevision`.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class PromptsViewModelLibraryRefreshTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    private val promptRepository = mockk<PromptRepository>(relaxed = true)
+    private val roleRepository = mockk<RoleRepository>(relaxed = true)
+    private val permissionGate = mockk<PermissionGate>(relaxed = true)
+    private val revision = MutableStateFlow(0L)
+
+    private fun group(id: String, name: String) = PromptGroup(
+        id = id,
+        name = name,
+        author = "author-1",
+        authorName = "Author",
+        productionId = "$id-p",
+        prompts = listOf(
+            Prompt(id = "$id-p", groupId = id, author = "author-1", prompt = "body of $name", type = "text"),
+        ),
+    )
+
+    private fun response(vararg groups: PromptGroup) =
+        Result.Success(PromptGroupListResponse(promptGroups = groups.toList()))
+
+    private fun newViewModel() = PromptsViewModel(promptRepository, roleRepository, permissionGate)
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        every { roleRepository.userPermissions } returns MutableStateFlow(null)
+        every { promptRepository.revision } returns revision
+        // A relaxed mock returns a chained mock whose `hasAccess` is false, which would gate the
+        // initial load off for the wrong reason. Stub the ordinary permissive role instead.
+        coEvery { permissionGate.awaitRole() } returns UserRolePermissions(name = "USER")
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun aSaveInTheEditorRefreshesTheRetainedList() = runTest(testDispatcher) {
+        coEvery { promptRepository.getGroups(any(), any()) } returns response(group("g-1", "First"))
+
+        val viewModel = newViewModel()
+        advanceUntilIdle()
+        assertEquals(listOf("First"), viewModel.uiState.value.groups.map { it.name })
+
+        coEvery { promptRepository.getGroups(any(), any()) } returns
+            response(group("g-1", "First"), group("g-2", "Just authored"))
+        revision.value += 1
+        advanceUntilIdle()
+
+        // Still in the editor: nothing fetched yet.
+        coVerify(exactly = 1) { promptRepository.getGroups(any(), any()) }
+
+        viewModel.refreshIfStale()
+        advanceUntilIdle()
+
+        assertEquals(
+            listOf("First", "Just authored"),
+            viewModel.uiState.value.groups.map { it.name },
+        )
+    }
+
+    @Test
+    fun returningWithNothingChangedFetchesNothing() = runTest(testDispatcher) {
+        coEvery { promptRepository.getGroups(any(), any()) } returns response(group("g-1", "First"))
+
+        val viewModel = newViewModel()
+        advanceUntilIdle()
+        viewModel.refreshIfStale()
+        viewModel.refreshIfStale()
+        advanceUntilIdle()
+
+        // Every re-entry drives this; without the revision check, backing out of the editor would
+        // re-fetch the list each time even when nothing changed.
+        coVerify(exactly = 1) { promptRepository.getGroups(any(), any()) }
+    }
+
+    @Test
+    fun aBackgroundReloadFailureIsNotShownToTheUser() = runTest(testDispatcher) {
+        coEvery { promptRepository.getGroups(any(), any()) } returns response(group("g-1", "First"))
+
+        val viewModel = newViewModel()
+        advanceUntilIdle()
+
+        coEvery { promptRepository.getGroups(any(), any()) } returns Result.Error(message = "offline")
+        revision.value += 1
+        viewModel.refreshIfStale()
+        advanceUntilIdle()
+
+        // The screen pops a snackbar off `error`. Nobody asked for this fetch, so a failure here
+        // would greet the user with "Failed to refresh prompts" after a save that worked.
+        assertNull(viewModel.uiState.value.error)
+        assertEquals(listOf("First"), viewModel.uiState.value.groups.map { it.name })
+    }
+
+    @Test
+    fun aPullToRefreshFailureIsShownToTheUser() = runTest(testDispatcher) {
+        coEvery { promptRepository.getGroups(any(), any()) } returns response(group("g-1", "First"))
+
+        val viewModel = newViewModel()
+        advanceUntilIdle()
+
+        coEvery { promptRepository.getGroups(any(), any()) } returns Result.Error(message = "offline")
+        viewModel.refresh()
+        advanceUntilIdle()
+
+        // The counterpart to the test above: silencing the gesture the user did make would be a
+        // pull that spins and reports nothing.
+        assertNotNull(viewModel.uiState.value.error)
+    }
+
+}

--- a/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModelCacheFirstLoadTest.kt
+++ b/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModelCacheFirstLoadTest.kt
@@ -1,51 +1,18 @@
 package com.garfiec.librechat.feature.chat.viewmodel
 
-import com.garfiec.librechat.core.common.identity.AccountId
-import com.garfiec.librechat.core.common.identity.AccountState
-import com.garfiec.librechat.core.common.identity.InMemoryActiveAccountProvider
 import com.garfiec.librechat.core.common.result.Result
-import com.garfiec.librechat.core.data.datastore.ChatFontSize
-import com.garfiec.librechat.core.data.datastore.ChatHeaderAlignment
-import com.garfiec.librechat.core.data.datastore.ChatHeaderContent
-import com.garfiec.librechat.core.data.datastore.ContextBarPlacement
-import com.garfiec.librechat.core.data.datastore.DuringRunAction
-import com.garfiec.librechat.core.data.datastore.StarredModelsDisplay
-import com.garfiec.librechat.core.data.repository.AgentRepository
-import com.garfiec.librechat.core.data.repository.ChatRepository
-import com.garfiec.librechat.core.data.repository.ConfigRepository
-import com.garfiec.librechat.core.data.repository.ConversationRepository
-import com.garfiec.librechat.core.data.repository.DraftRepository
-import com.garfiec.librechat.core.data.repository.EndpointTokenRepository
-import com.garfiec.librechat.core.data.repository.FavoritesRepository
-import com.garfiec.librechat.core.data.repository.FileRepository
-import com.garfiec.librechat.core.data.repository.KeyRepository
-import com.garfiec.librechat.core.data.repository.McpRepository
-import com.garfiec.librechat.core.data.repository.MessageRepository
-import com.garfiec.librechat.core.data.repository.PresetRepository
-import com.garfiec.librechat.core.data.repository.PromptRepository
-import com.garfiec.librechat.core.data.repository.ResumePinStore
-import com.garfiec.librechat.core.data.repository.RoleRepository
-import com.garfiec.librechat.core.data.repository.ShareRepository
-import com.garfiec.librechat.core.data.repository.UserRepository
-import com.garfiec.librechat.core.data.util.PermissionGate
 import com.garfiec.librechat.core.model.Message
-import com.garfiec.librechat.feature.chat.viewmodel.delegate.PlatformDelegateFactory
 import io.mockk.coEvery
 import io.mockk.every
-import io.mockk.mockk
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
-import kotlinx.serialization.json.Json
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -65,33 +32,18 @@ class ChatViewModelCacheFirstLoadTest {
 
     private val testDispatcher = UnconfinedTestDispatcher()
 
-    private val agentRepository = mockk<AgentRepository>(relaxed = true)
-    private val chatRepository = mockk<ChatRepository>(relaxed = true)
-    private val messageRepository = mockk<MessageRepository>(relaxed = true)
-    private val fileRepository = mockk<FileRepository>(relaxed = true)
-    private val configRepository = mockk<ConfigRepository>(relaxed = true)
-    private val conversationRepository = mockk<ConversationRepository>(relaxed = true)
-    private val endpointTokenRepository = mockk<EndpointTokenRepository>(relaxed = true)
-    private val draftRepository = mockk<DraftRepository>(relaxed = true)
-    private val favoritesRepository = mockk<FavoritesRepository>(relaxed = true)
-    private val keyRepository = mockk<KeyRepository>(relaxed = true)
-    private val presetRepository = mockk<PresetRepository>(relaxed = true)
-    private val promptRepository = mockk<PromptRepository>(relaxed = true)
-    private val shareRepository = mockk<ShareRepository>(relaxed = true)
-    private val mcpRepository = mockk<McpRepository>(relaxed = true)
-    private val userRepository = mockk<UserRepository>(relaxed = true)
-    private val roleRepository = mockk<RoleRepository>(relaxed = true)
-    private val permissionGate = mockk<PermissionGate>(relaxed = true)
-    private val connectivityObserver =
-        mockk<com.garfiec.librechat.core.common.network.ConnectivityObserver>(relaxed = true)
-    private val serverDataStore =
-        mockk<com.garfiec.librechat.core.data.datastore.ServerDataStore>(relaxed = true)
-    private val settingsDataStore =
-        mockk<com.garfiec.librechat.core.data.datastore.SettingsDataStore>(relaxed = true)
-    private val platformDelegateFactory = mockk<PlatformDelegateFactory>(relaxed = true)
-    private val serverFileSelectionHandoff = mockk<ServerFileSelectionHandoff>(relaxed = true)
-
-    private val selectionHandoff = NewChatSelectionHandoff()
+    private val fixture = ChatViewModelTestFixture()
+    private val agentRepository get() = fixture.agentRepository
+    private val messageRepository get() = fixture.messageRepository
+    private val configRepository get() = fixture.configRepository
+    private val conversationRepository get() = fixture.conversationRepository
+    private val favoritesRepository get() = fixture.favoritesRepository
+    private val keyRepository get() = fixture.keyRepository
+    private val roleRepository get() = fixture.roleRepository
+    private val serverDataStore get() = fixture.serverDataStore
+    private val settingsDataStore get() = fixture.settingsDataStore
+    private val platformDelegateFactory get() = fixture.platformDelegateFactory
+    private val serverFileSelectionHandoff get() = fixture.serverFileSelectionHandoff
 
     /** Holds `getMessages` open so the pre-settle window can be asserted on. */
     private val fetchGate = CompletableDeferred<Result<List<Message>>>()
@@ -108,33 +60,10 @@ class ChatViewModelCacheFirstLoadTest {
     @Before
     fun setUp() {
         Dispatchers.setMain(testDispatcher)
+        fixture.stubDefaults()
 
-        every { configRepository.startupConfig } returns MutableStateFlow(null)
-        every { configRepository.detectedBackendVersion } returns MutableStateFlow("0.8.7")
-        every { configRepository.detectedBackend } returns MutableStateFlow(null)
-        every { roleRepository.userPermissions } returns MutableStateFlow(null)
-        every { configRepository.endpointConfigs } returns MutableStateFlow(emptyMap())
-        every { configRepository.availableModels } returns MutableStateFlow(emptyMap())
-        every { favoritesRepository.favorites } returns MutableStateFlow(emptyList())
         every { settingsDataStore.selectedMcpServers } returns flowOf(emptySet())
         every { settingsDataStore.enabledTools } returns flowOf(emptySet())
-        every { serverFileSelectionHandoff.selectionsFor(any()) } returns emptyFlow()
-        every { keyRepository.keyInvalidations } returns MutableSharedFlow()
-        // StateFlow.collect returns Nothing, so a relaxed mock throws in the delegate's collector.
-        every { agentRepository.revision } returns MutableStateFlow(0L)
-        every { platformDelegateFactory.createShareConsumer().sharesFor(any()) } returns emptyFlow()
-
-        // `uiState` is combine(_uiState, these pref flows).stateIn(Eagerly, ChatUiState()): until
-        // EVERY one of them emits, `uiState.value` is the untouched initial state no matter what
-        // the ViewModel did. Relaxed mocks never emit — these stubs are load-bearing.
-        every { serverDataStore.currentUrlFlow } returns MutableStateFlow("https://example.test")
-        every { settingsDataStore.chatFontSize } returns MutableStateFlow(ChatFontSize.MEDIUM)
-        every { settingsDataStore.starredModelsDisplay } returns MutableStateFlow(StarredModelsDisplay.OFF)
-        every { settingsDataStore.chatHeaderContent } returns MutableStateFlow(ChatHeaderContent.MODEL)
-        every { settingsDataStore.chatHeaderAlignment } returns MutableStateFlow(ChatHeaderAlignment.CENTER)
-        every { settingsDataStore.contextBarPlacement } returns MutableStateFlow(ContextBarPlacement.HIDDEN)
-        every { settingsDataStore.contextGaugeExpanded } returns MutableStateFlow(false)
-        every { settingsDataStore.duringRunAction } returns MutableStateFlow(DuringRunAction.QUEUE)
 
         coEvery { conversationRepository.getConversation(any(), any()) } returns Result.Error(message = "test")
         coEvery { messageRepository.getMessages(any()) } coAnswers { fetchGate.await() }
@@ -220,36 +149,8 @@ class ChatViewModelCacheFirstLoadTest {
     }
 
     private fun newViewModel(): ChatViewModel =
-        ChatViewModel(
-            initialConversationId = "conv-1",
-            initialAgentId = null,
-            agentRepository = agentRepository,
-            chatRepository = chatRepository,
-            messageRepository = messageRepository,
-            fileRepository = fileRepository,
-            resumePinStore = ResumePinStore(),
-            configRepository = configRepository,
-            conversationRepository = conversationRepository,
-            endpointTokenRepository = endpointTokenRepository,
-            draftRepository = draftRepository,
-            favoritesRepository = favoritesRepository,
-            keyRepository = keyRepository,
-            presetRepository = presetRepository,
-            promptRepository = promptRepository,
-            shareRepository = shareRepository,
-            mcpRepository = mcpRepository,
-            userRepository = userRepository,
-            roleRepository = roleRepository,
-            permissionGate = permissionGate,
-            connectivityObserver = connectivityObserver,
-            serverDataStore = serverDataStore,
-            settingsDataStore = settingsDataStore,
-            platformDelegateFactory = platformDelegateFactory,
-            json = Json { ignoreUnknownKeys = true },
+        fixture.build(
             defaultDispatcher = testDispatcher,
-            selectionHandoff = selectionHandoff,
-            serverFileSelectionHandoff = serverFileSelectionHandoff,
-            promptInsertionHandoff = PromptInsertionHandoff(),
-            activeAccountProvider = InMemoryActiveAccountProvider(AccountState.Resolved(AccountId("srv:user-1"))),
+            initialConversationId = "conv-1",
         )
 }

--- a/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModelContextProjectionInitTest.kt
+++ b/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModelContextProjectionInitTest.kt
@@ -1,37 +1,14 @@
 package com.garfiec.librechat.feature.chat.viewmodel
 
 import com.garfiec.librechat.core.common.EndpointConstants
-import com.garfiec.librechat.core.common.identity.AccountId
-import com.garfiec.librechat.core.common.identity.AccountState
-import com.garfiec.librechat.core.common.identity.InMemoryActiveAccountProvider
 import com.garfiec.librechat.core.common.result.Result
-import com.garfiec.librechat.core.data.repository.AgentRepository
-import com.garfiec.librechat.core.data.repository.ChatRepository
-import com.garfiec.librechat.core.data.repository.ConfigRepository
-import com.garfiec.librechat.core.data.repository.ConversationRepository
-import com.garfiec.librechat.core.data.repository.DraftRepository
-import com.garfiec.librechat.core.data.repository.EndpointTokenRepository
-import com.garfiec.librechat.core.data.repository.FavoritesRepository
-import com.garfiec.librechat.core.data.repository.FileRepository
-import com.garfiec.librechat.core.data.repository.KeyRepository
-import com.garfiec.librechat.core.data.repository.McpRepository
-import com.garfiec.librechat.core.data.repository.MessageRepository
-import com.garfiec.librechat.core.data.repository.PresetRepository
-import com.garfiec.librechat.core.data.repository.PromptRepository
-import com.garfiec.librechat.core.data.repository.RoleRepository
-import com.garfiec.librechat.core.data.repository.ShareRepository
-import com.garfiec.librechat.core.data.repository.UserRepository
-import com.garfiec.librechat.core.data.util.PermissionGate
 import com.garfiec.librechat.core.model.Message
-import com.garfiec.librechat.feature.chat.viewmodel.delegate.PlatformDelegateFactory
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -39,11 +16,9 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
-import kotlinx.serialization.json.Json
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
-import com.garfiec.librechat.core.data.repository.ResumePinStore
 
 /**
  * Regression guard for the context-gauge init-order crash (agents endpoint).
@@ -73,66 +48,32 @@ class ChatViewModelContextProjectionInitTest {
 
     private val testDispatcher = UnconfinedTestDispatcher()
 
-    private val agentRepository = mockk<AgentRepository>(relaxed = true)
-    private val chatRepository = mockk<ChatRepository>(relaxed = true)
-    private val messageRepository = mockk<MessageRepository>(relaxed = true)
-    private val fileRepository = mockk<FileRepository>(relaxed = true)
-    private val configRepository = mockk<ConfigRepository>(relaxed = true)
-    private val conversationRepository = mockk<ConversationRepository>(relaxed = true)
-    private val endpointTokenRepository = mockk<EndpointTokenRepository>(relaxed = true)
-    private val draftRepository = mockk<DraftRepository>(relaxed = true)
-    private val favoritesRepository = mockk<FavoritesRepository>(relaxed = true)
-    private val keyRepository = mockk<KeyRepository>(relaxed = true)
-    private val presetRepository = mockk<PresetRepository>(relaxed = true)
-    private val promptRepository = mockk<PromptRepository>(relaxed = true)
-    private val shareRepository = mockk<ShareRepository>(relaxed = true)
-    private val mcpRepository = mockk<McpRepository>(relaxed = true)
-    private val userRepository = mockk<UserRepository>(relaxed = true)
-    private val roleRepository = mockk<RoleRepository>(relaxed = true)
-    private val permissionGate = mockk<PermissionGate>(relaxed = true)
-    private val connectivityObserver = mockk<com.garfiec.librechat.core.common.network.ConnectivityObserver>(relaxed = true)
-    private val serverDataStore = mockk<com.garfiec.librechat.core.data.datastore.ServerDataStore>(relaxed = true)
-    private val settingsDataStore = mockk<com.garfiec.librechat.core.data.datastore.SettingsDataStore>(relaxed = true)
-    private val platformDelegateFactory = mockk<PlatformDelegateFactory>(relaxed = true)
-    private val serverFileSelectionHandoff = mockk<ServerFileSelectionHandoff>(relaxed = true)
-
-    private val selectionHandoff = NewChatSelectionHandoff()
+    private val fixture = ChatViewModelTestFixture()
+    private val agentRepository get() = fixture.agentRepository
+    private val messageRepository get() = fixture.messageRepository
+    private val configRepository get() = fixture.configRepository
+    private val conversationRepository get() = fixture.conversationRepository
+    private val favoritesRepository get() = fixture.favoritesRepository
+    private val keyRepository get() = fixture.keyRepository
+    private val roleRepository get() = fixture.roleRepository
+    private val settingsDataStore get() = fixture.settingsDataStore
+    private val platformDelegateFactory get() = fixture.platformDelegateFactory
+    private val serverFileSelectionHandoff get() = fixture.serverFileSelectionHandoff
+    private val selectionHandoff get() = fixture.selectionHandoff
 
     @Before
     fun setUp() {
         Dispatchers.setMain(testDispatcher)
+        fixture.stubDefaults()
 
-        // Enable the context gauge: interface flag defaults true, backend gate needs >= 0.8.7.
-        every { configRepository.startupConfig } returns MutableStateFlow(null)
-        every { configRepository.detectedBackendVersion } returns MutableStateFlow("0.8.7")
-        // The feature-gate combine also reads the richer identity (HITL date gates). A relaxed
-        // mock returns a StateFlow that never emits, which would stall the whole combine — and
-        // with it the context-gauge flag this test depends on.
-        every { configRepository.detectedBackend } returns MutableStateFlow(null)
-        every { roleRepository.userPermissions } returns MutableStateFlow(null)
-
-        // Collection-typed flows read by init-time delegates (model refilter, favorites): relaxed
-        // mockk hands back a bare Object for the erased element type, which the delegates cast to
-        // Map/List. Feed empty containers so those paths run cleanly (irrelevant to the gauge).
-        every { configRepository.endpointConfigs } returns MutableStateFlow(emptyMap())
-        every { configRepository.availableModels } returns MutableStateFlow(emptyMap())
-        every { favoritesRepository.favorites } returns MutableStateFlow(emptyList())
+        // Keep the Room read-through silent so the handoff-seeded tail message survives as the
+        // projection's `displayMessages` tail — an emission here would rebuild the path. Restated
+        // over the fixture default because this test depends on it.
+        every { messageRepository.observeMessages(any()) } returns emptyFlow()
 
         // Two init-time `.first()` reads over relaxed flows (relaxed -> emptyFlow -> NoSuchElement).
         every { settingsDataStore.selectedMcpServers } returns flowOf(emptySet())
         every { settingsDataStore.enabledTools } returns flowOf(emptySet())
-
-        // Keep the Room read-through silent so the handoff-seeded tail message survives as the
-        // projection's `displayMessages` tail (an emission here would rebuild the path).
-        every { messageRepository.observeMessages(any()) } returns emptyFlow()
-        every { serverFileSelectionHandoff.selectionsFor(any()) } returns emptyFlow()
-        // Init-time collectors over relaxed SharedFlows: `SharedFlow.collect` returns `Nothing`,
-        // so a relaxed mock throws KotlinNothingValueException. Feed real never-emitting flows.
-        // (All unrelated to the gauge path under test.)
-        every { keyRepository.keyInvalidations } returns MutableSharedFlow()
-        // StateFlow.collect returns Nothing, so a relaxed mock throws in the delegate's collector.
-        every { agentRepository.revision } returns MutableStateFlow(0L)
-        every { platformDelegateFactory.createShareConsumer().sharesFor(any()) } returns emptyFlow()
 
         // On the agents branch `resolveProjectionModel` falls through the (empty) `resolvedAgentModels`
         // cache to the agent-detail fetch; a benign Error keeps the path deterministic and network-free.
@@ -185,36 +126,8 @@ class ChatViewModelContextProjectionInitTest {
     }
 
     private fun newViewModel(initialConversationId: String?): ChatViewModel =
-        ChatViewModel(
-            initialConversationId = initialConversationId,
-            initialAgentId = null,
-            agentRepository = agentRepository,
-            chatRepository = chatRepository,
-            messageRepository = messageRepository,
-            fileRepository = fileRepository,
-            resumePinStore = ResumePinStore(),
-            configRepository = configRepository,
-            conversationRepository = conversationRepository,
-            endpointTokenRepository = endpointTokenRepository,
-            draftRepository = draftRepository,
-            favoritesRepository = favoritesRepository,
-            keyRepository = keyRepository,
-            presetRepository = presetRepository,
-            promptRepository = promptRepository,
-            shareRepository = shareRepository,
-            mcpRepository = mcpRepository,
-            userRepository = userRepository,
-            roleRepository = roleRepository,
-            permissionGate = permissionGate,
-            connectivityObserver = connectivityObserver,
-            serverDataStore = serverDataStore,
-            settingsDataStore = settingsDataStore,
-            platformDelegateFactory = platformDelegateFactory,
-            json = Json { ignoreUnknownKeys = true },
+        fixture.build(
             defaultDispatcher = testDispatcher,
-            selectionHandoff = selectionHandoff,
-            serverFileSelectionHandoff = serverFileSelectionHandoff,
-            promptInsertionHandoff = PromptInsertionHandoff(),
-            activeAccountProvider = InMemoryActiveAccountProvider(AccountState.Resolved(AccountId("srv:user-1"))),
+            initialConversationId = initialConversationId,
         )
 }

--- a/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModelDuringRunSendTest.kt
+++ b/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModelDuringRunSendTest.kt
@@ -3,44 +3,20 @@ package com.garfiec.librechat.feature.chat.viewmodel
 import androidx.lifecycle.viewModelScope
 import com.garfiec.librechat.core.common.BackendBuildClass
 import com.garfiec.librechat.core.common.DetectedBackend
-import com.garfiec.librechat.core.common.identity.AccountId
-import com.garfiec.librechat.core.common.identity.AccountState
-import com.garfiec.librechat.core.common.identity.InMemoryActiveAccountProvider
 import com.garfiec.librechat.core.common.result.Result
 import com.garfiec.librechat.core.data.datastore.ChatFontSize
 import com.garfiec.librechat.core.data.datastore.ChatHeaderAlignment
 import com.garfiec.librechat.core.data.datastore.ChatHeaderContent
 import com.garfiec.librechat.core.data.datastore.ContextBarPlacement
 import com.garfiec.librechat.core.data.datastore.DuringRunAction
-import com.garfiec.librechat.core.data.datastore.ServerDataStore
-import com.garfiec.librechat.core.data.datastore.SettingsDataStore
 import com.garfiec.librechat.core.data.datastore.StarredModelsDisplay
 import com.garfiec.librechat.core.data.datastore.UploadRoutingMode
-import com.garfiec.librechat.core.data.repository.AgentRepository
-import com.garfiec.librechat.core.data.repository.ChatRepository
-import com.garfiec.librechat.core.data.repository.ConfigRepository
-import com.garfiec.librechat.core.data.repository.ConversationRepository
-import com.garfiec.librechat.core.data.repository.DraftRepository
-import com.garfiec.librechat.core.data.repository.EndpointTokenRepository
-import com.garfiec.librechat.core.data.repository.FavoritesRepository
-import com.garfiec.librechat.core.data.repository.FileRepository
-import com.garfiec.librechat.core.data.repository.KeyRepository
-import com.garfiec.librechat.core.data.repository.McpRepository
-import com.garfiec.librechat.core.data.repository.MessageRepository
-import com.garfiec.librechat.core.data.repository.PresetRepository
-import com.garfiec.librechat.core.data.repository.PromptRepository
-import com.garfiec.librechat.core.data.repository.ResumePinStore
-import com.garfiec.librechat.core.data.repository.RoleRepository
-import com.garfiec.librechat.core.data.repository.ShareRepository
-import com.garfiec.librechat.core.data.repository.UserRepository
-import com.garfiec.librechat.core.data.util.PermissionGate
 import com.garfiec.librechat.core.model.EndpointConfig
 import com.garfiec.librechat.core.model.PendingSteer
 import com.garfiec.librechat.core.model.StreamEvent
 import com.garfiec.librechat.core.model.request.SteerRequest
 import com.garfiec.librechat.core.model.response.ChatStatusResponse
 import com.garfiec.librechat.core.model.response.SteerResponse
-import com.garfiec.librechat.feature.chat.viewmodel.delegate.PlatformDelegateFactory
 import com.garfiec.librechat.feature.chat.viewmodel.delegate.PickedFile
 import com.garfiec.librechat.feature.chat.viewmodel.delegate.PlatformFileHandler
 import com.google.common.truth.Truth.assertThat
@@ -55,7 +31,6 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
@@ -63,7 +38,6 @@ import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
-import kotlinx.serialization.json.Json
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -102,32 +76,21 @@ class ChatViewModelDuringRunSendTest {
 
     private val testDispatcher = UnconfinedTestDispatcher()
 
-    private val agentRepository = mockk<AgentRepository>(relaxed = true)
-    private val chatRepository = mockk<ChatRepository>(relaxed = true)
-    private val messageRepository = mockk<MessageRepository>(relaxed = true)
-    private val fileRepository = mockk<FileRepository>(relaxed = true)
-    private val configRepository = mockk<ConfigRepository>(relaxed = true)
-    private val conversationRepository = mockk<ConversationRepository>(relaxed = true)
-    private val endpointTokenRepository = mockk<EndpointTokenRepository>(relaxed = true)
-    private val draftRepository = mockk<DraftRepository>(relaxed = true)
-    private val favoritesRepository = mockk<FavoritesRepository>(relaxed = true)
-    private val keyRepository = mockk<KeyRepository>(relaxed = true)
-    private val presetRepository = mockk<PresetRepository>(relaxed = true)
-    private val promptRepository = mockk<PromptRepository>(relaxed = true)
-    private val shareRepository = mockk<ShareRepository>(relaxed = true)
-    private val mcpRepository = mockk<McpRepository>(relaxed = true)
-    private val userRepository = mockk<UserRepository>(relaxed = true)
-    private val roleRepository = mockk<RoleRepository>(relaxed = true)
-    private val permissionGate = mockk<PermissionGate>(relaxed = true)
-    private val connectivityObserver =
-        mockk<com.garfiec.librechat.core.common.network.ConnectivityObserver>(relaxed = true)
-    private val serverDataStore = mockk<ServerDataStore>(relaxed = true)
-    private val settingsDataStore = mockk<SettingsDataStore>(relaxed = true)
-    private val platformDelegateFactory = mockk<PlatformDelegateFactory>(relaxed = true)
+    private val fixture = ChatViewModelTestFixture()
+    private val agentRepository get() = fixture.agentRepository
+    private val chatRepository get() = fixture.chatRepository
+    private val messageRepository get() = fixture.messageRepository
+    private val configRepository get() = fixture.configRepository
+    private val conversationRepository get() = fixture.conversationRepository
+    private val favoritesRepository get() = fixture.favoritesRepository
+    private val keyRepository get() = fixture.keyRepository
+    private val roleRepository get() = fixture.roleRepository
+    private val serverDataStore get() = fixture.serverDataStore
+    private val settingsDataStore get() = fixture.settingsDataStore
+    private val platformDelegateFactory get() = fixture.platformDelegateFactory
+    private val serverFileSelectionHandoff get() = fixture.serverFileSelectionHandoff
+    private val selectionHandoff get() = fixture.selectionHandoff
     private val fileHandler = mockk<PlatformFileHandler>(relaxed = true)
-    private val serverFileSelectionHandoff = mockk<ServerFileSelectionHandoff>(relaxed = true)
-
-    private val selectionHandoff = NewChatSelectionHandoff()
 
     /** The resumed run's SSE events. Hot, so a test can end the run by emitting an error. */
     private val resumedStream = MutableSharedFlow<StreamEvent>(extraBufferCapacity = 8)
@@ -135,14 +98,13 @@ class ChatViewModelDuringRunSendTest {
     @Before
     fun setUp() {
         Dispatchers.setMain(testDispatcher)
+        fixture.stubDefaults()
 
         // Open the steering gate: 0.8.8-rc1 clears the version comparison outright, so the test
         // does not depend on the dev-build date gate or on the generated commit map.
         every { configRepository.detectedBackend } returns
             MutableStateFlow(DetectedBackend("0.8.8-rc1", BackendBuildClass.RC))
         every { configRepository.detectedBackendVersion } returns MutableStateFlow("0.8.8-rc1")
-        every { configRepository.startupConfig } returns MutableStateFlow(null)
-        every { roleRepository.userPermissions } returns MutableStateFlow(null)
 
         // Collection-typed flows read by init-time delegates: relaxed mockk hands back a bare
         // Object for the erased element type, which those delegates cast to Map/List.
@@ -151,7 +113,6 @@ class ChatViewModelDuringRunSendTest {
         // the turn-identity test below would never start.
         every { configRepository.endpointConfigs } returns MutableStateFlow(mapOf(ENDPOINT to EndpointConfig()))
         every { configRepository.availableModels } returns MutableStateFlow(mapOf(ENDPOINT to listOf(MODEL)))
-        every { favoritesRepository.favorites } returns MutableStateFlow(emptyList())
         every { settingsDataStore.selectedMcpServers } returns flowOf(emptySet())
         every { settingsDataStore.enabledTools } returns flowOf(emptySet())
 
@@ -166,13 +127,6 @@ class ChatViewModelDuringRunSendTest {
         every { settingsDataStore.chatHeaderAlignment } returns flowOf(ChatHeaderAlignment.LEFT)
         every { settingsDataStore.contextBarPlacement } returns flowOf(ContextBarPlacement.OPTIONS_SHEET)
         every { settingsDataStore.contextGaugeExpanded } returns flowOf(false)
-        every { messageRepository.observeMessages(any()) } returns emptyFlow()
-        every { serverFileSelectionHandoff.selectionsFor(any()) } returns emptyFlow()
-        // `SharedFlow.collect` returns Nothing, so a relaxed mock throws on these init collectors.
-        every { keyRepository.keyInvalidations } returns MutableSharedFlow()
-        // StateFlow.collect returns Nothing, so a relaxed mock throws in the delegate's collector.
-        every { agentRepository.revision } returns MutableStateFlow(0L)
-        every { platformDelegateFactory.createShareConsumer().sharesFor(any()) } returns emptyFlow()
 
         // buildSendSpec reads the attachment list; the relaxed factory would hand back an
         // untyped stub that fails the List cast.
@@ -507,37 +461,9 @@ class ChatViewModelDuringRunSendTest {
     }
 
     private fun newViewModel(): ChatViewModel =
-        ChatViewModel(
-            initialConversationId = CONVERSATION_ID,
-            initialAgentId = null,
-            agentRepository = agentRepository,
-            chatRepository = chatRepository,
-            messageRepository = messageRepository,
-            fileRepository = fileRepository,
-            resumePinStore = ResumePinStore(),
-            configRepository = configRepository,
-            conversationRepository = conversationRepository,
-            endpointTokenRepository = endpointTokenRepository,
-            draftRepository = draftRepository,
-            favoritesRepository = favoritesRepository,
-            keyRepository = keyRepository,
-            presetRepository = presetRepository,
-            promptRepository = promptRepository,
-            shareRepository = shareRepository,
-            mcpRepository = mcpRepository,
-            userRepository = userRepository,
-            roleRepository = roleRepository,
-            permissionGate = permissionGate,
-            connectivityObserver = connectivityObserver,
-            serverDataStore = serverDataStore,
-            settingsDataStore = settingsDataStore,
-            platformDelegateFactory = platformDelegateFactory,
-            json = Json { ignoreUnknownKeys = true },
+        fixture.build(
             defaultDispatcher = testDispatcher,
-            selectionHandoff = selectionHandoff,
-            serverFileSelectionHandoff = serverFileSelectionHandoff,
-            promptInsertionHandoff = PromptInsertionHandoff(),
-            activeAccountProvider = InMemoryActiveAccountProvider(AccountState.Resolved(AccountId("srv:user-1"))),
+            initialConversationId = CONVERSATION_ID,
         )
 
     private companion object {

--- a/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModelMessageLoadFailureTest.kt
+++ b/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModelMessageLoadFailureTest.kt
@@ -1,50 +1,17 @@
 package com.garfiec.librechat.feature.chat.viewmodel
 
-import com.garfiec.librechat.core.common.identity.AccountId
-import com.garfiec.librechat.core.common.identity.AccountState
-import com.garfiec.librechat.core.common.identity.InMemoryActiveAccountProvider
 import com.garfiec.librechat.core.common.result.Result
-import com.garfiec.librechat.core.data.datastore.ChatFontSize
-import com.garfiec.librechat.core.data.datastore.ChatHeaderAlignment
-import com.garfiec.librechat.core.data.datastore.ChatHeaderContent
-import com.garfiec.librechat.core.data.datastore.ContextBarPlacement
-import com.garfiec.librechat.core.data.datastore.DuringRunAction
-import com.garfiec.librechat.core.data.datastore.StarredModelsDisplay
-import com.garfiec.librechat.core.data.repository.AgentRepository
-import com.garfiec.librechat.core.data.repository.ChatRepository
-import com.garfiec.librechat.core.data.repository.ConfigRepository
-import com.garfiec.librechat.core.data.repository.ConversationRepository
-import com.garfiec.librechat.core.data.repository.DraftRepository
-import com.garfiec.librechat.core.data.repository.EndpointTokenRepository
-import com.garfiec.librechat.core.data.repository.FavoritesRepository
-import com.garfiec.librechat.core.data.repository.FileRepository
-import com.garfiec.librechat.core.data.repository.KeyRepository
-import com.garfiec.librechat.core.data.repository.McpRepository
-import com.garfiec.librechat.core.data.repository.MessageRepository
-import com.garfiec.librechat.core.data.repository.PresetRepository
-import com.garfiec.librechat.core.data.repository.PromptRepository
-import com.garfiec.librechat.core.data.repository.ResumePinStore
-import com.garfiec.librechat.core.data.repository.RoleRepository
-import com.garfiec.librechat.core.data.repository.ShareRepository
-import com.garfiec.librechat.core.data.repository.UserRepository
-import com.garfiec.librechat.core.data.util.PermissionGate
 import com.garfiec.librechat.core.model.Message
-import com.garfiec.librechat.feature.chat.viewmodel.delegate.PlatformDelegateFactory
 import io.mockk.coEvery
 import io.mockk.every
-import io.mockk.mockk
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
-import kotlinx.serialization.json.Json
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -70,64 +37,27 @@ class ChatViewModelMessageLoadFailureTest {
 
     private val testDispatcher = UnconfinedTestDispatcher()
 
-    private val agentRepository = mockk<AgentRepository>(relaxed = true)
-    private val chatRepository = mockk<ChatRepository>(relaxed = true)
-    private val messageRepository = mockk<MessageRepository>(relaxed = true)
-    private val fileRepository = mockk<FileRepository>(relaxed = true)
-    private val configRepository = mockk<ConfigRepository>(relaxed = true)
-    private val conversationRepository = mockk<ConversationRepository>(relaxed = true)
-    private val endpointTokenRepository = mockk<EndpointTokenRepository>(relaxed = true)
-    private val draftRepository = mockk<DraftRepository>(relaxed = true)
-    private val favoritesRepository = mockk<FavoritesRepository>(relaxed = true)
-    private val keyRepository = mockk<KeyRepository>(relaxed = true)
-    private val presetRepository = mockk<PresetRepository>(relaxed = true)
-    private val promptRepository = mockk<PromptRepository>(relaxed = true)
-    private val shareRepository = mockk<ShareRepository>(relaxed = true)
-    private val mcpRepository = mockk<McpRepository>(relaxed = true)
-    private val userRepository = mockk<UserRepository>(relaxed = true)
-    private val roleRepository = mockk<RoleRepository>(relaxed = true)
-    private val permissionGate = mockk<PermissionGate>(relaxed = true)
-    private val connectivityObserver =
-        mockk<com.garfiec.librechat.core.common.network.ConnectivityObserver>(relaxed = true)
-    private val serverDataStore =
-        mockk<com.garfiec.librechat.core.data.datastore.ServerDataStore>(relaxed = true)
-    private val settingsDataStore =
-        mockk<com.garfiec.librechat.core.data.datastore.SettingsDataStore>(relaxed = true)
-    private val platformDelegateFactory = mockk<PlatformDelegateFactory>(relaxed = true)
-    private val serverFileSelectionHandoff = mockk<ServerFileSelectionHandoff>(relaxed = true)
-
-    private val selectionHandoff = NewChatSelectionHandoff()
+    private val fixture = ChatViewModelTestFixture()
+    private val agentRepository get() = fixture.agentRepository
+    private val messageRepository get() = fixture.messageRepository
+    private val configRepository get() = fixture.configRepository
+    private val conversationRepository get() = fixture.conversationRepository
+    private val favoritesRepository get() = fixture.favoritesRepository
+    private val keyRepository get() = fixture.keyRepository
+    private val roleRepository get() = fixture.roleRepository
+    private val serverDataStore get() = fixture.serverDataStore
+    private val settingsDataStore get() = fixture.settingsDataStore
+    private val platformDelegateFactory get() = fixture.platformDelegateFactory
+    private val serverFileSelectionHandoff get() = fixture.serverFileSelectionHandoff
+    private val selectionHandoff get() = fixture.selectionHandoff
 
     @Before
     fun setUp() {
         Dispatchers.setMain(testDispatcher)
+        fixture.stubDefaults()
 
-        every { configRepository.startupConfig } returns MutableStateFlow(null)
-        every { configRepository.detectedBackendVersion } returns MutableStateFlow("0.8.7")
-        every { configRepository.detectedBackend } returns MutableStateFlow(null)
-        every { roleRepository.userPermissions } returns MutableStateFlow(null)
-        every { configRepository.endpointConfigs } returns MutableStateFlow(emptyMap())
-        every { configRepository.availableModels } returns MutableStateFlow(emptyMap())
-        every { favoritesRepository.favorites } returns MutableStateFlow(emptyList())
         every { settingsDataStore.selectedMcpServers } returns flowOf(emptySet())
         every { settingsDataStore.enabledTools } returns flowOf(emptySet())
-        every { serverFileSelectionHandoff.selectionsFor(any()) } returns emptyFlow()
-        every { keyRepository.keyInvalidations } returns MutableSharedFlow()
-        // StateFlow.collect returns Nothing, so a relaxed mock throws in the delegate's collector.
-        every { agentRepository.revision } returns MutableStateFlow(0L)
-        every { platformDelegateFactory.createShareConsumer().sharesFor(any()) } returns emptyFlow()
-
-        // `uiState` is combine(_uiState, these pref flows).stateIn(Eagerly, ChatUiState()): until
-        // EVERY one of them emits, `uiState.value` is the untouched initial state no matter what
-        // the ViewModel did. Relaxed mocks never emit — these stubs are load-bearing.
-        every { serverDataStore.currentUrlFlow } returns MutableStateFlow("https://example.test")
-        every { settingsDataStore.chatFontSize } returns MutableStateFlow(ChatFontSize.MEDIUM)
-        every { settingsDataStore.starredModelsDisplay } returns MutableStateFlow(StarredModelsDisplay.OFF)
-        every { settingsDataStore.chatHeaderContent } returns MutableStateFlow(ChatHeaderContent.MODEL)
-        every { settingsDataStore.chatHeaderAlignment } returns MutableStateFlow(ChatHeaderAlignment.CENTER)
-        every { settingsDataStore.contextBarPlacement } returns MutableStateFlow(ContextBarPlacement.HIDDEN)
-        every { settingsDataStore.contextGaugeExpanded } returns MutableStateFlow(false)
-        every { settingsDataStore.duringRunAction } returns MutableStateFlow(DuringRunAction.QUEUE)
 
         // The offline case: nothing cached, so the Room read-through emits an empty list.
         every { messageRepository.observeMessages(any()) } returns flowOf(emptyList())
@@ -201,36 +131,8 @@ class ChatViewModelMessageLoadFailureTest {
     }
 
     private fun newViewModel(initialConversationId: String?): ChatViewModel =
-        ChatViewModel(
-            initialConversationId = initialConversationId,
-            initialAgentId = null,
-            agentRepository = agentRepository,
-            chatRepository = chatRepository,
-            messageRepository = messageRepository,
-            fileRepository = fileRepository,
-            resumePinStore = ResumePinStore(),
-            configRepository = configRepository,
-            conversationRepository = conversationRepository,
-            endpointTokenRepository = endpointTokenRepository,
-            draftRepository = draftRepository,
-            favoritesRepository = favoritesRepository,
-            keyRepository = keyRepository,
-            presetRepository = presetRepository,
-            promptRepository = promptRepository,
-            shareRepository = shareRepository,
-            mcpRepository = mcpRepository,
-            userRepository = userRepository,
-            roleRepository = roleRepository,
-            permissionGate = permissionGate,
-            connectivityObserver = connectivityObserver,
-            serverDataStore = serverDataStore,
-            settingsDataStore = settingsDataStore,
-            platformDelegateFactory = platformDelegateFactory,
-            json = Json { ignoreUnknownKeys = true },
+        fixture.build(
             defaultDispatcher = testDispatcher,
-            selectionHandoff = selectionHandoff,
-            serverFileSelectionHandoff = serverFileSelectionHandoff,
-            promptInsertionHandoff = PromptInsertionHandoff(),
-            activeAccountProvider = InMemoryActiveAccountProvider(AccountState.Resolved(AccountId("srv:user-1"))),
+            initialConversationId = initialConversationId,
         )
 }

--- a/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModelPromptLibraryRefreshTest.kt
+++ b/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModelPromptLibraryRefreshTest.kt
@@ -1,0 +1,179 @@
+package com.garfiec.librechat.feature.chat.viewmodel
+
+import com.garfiec.librechat.core.common.result.Result
+import com.garfiec.librechat.core.model.Prompt
+import com.garfiec.librechat.core.model.PromptGroup
+import com.garfiec.librechat.core.model.permissions.Permission
+import com.garfiec.librechat.core.model.permissions.PermissionType
+import com.garfiec.librechat.core.model.permissions.UserRolePermissions
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * A prompt authored while this chat is on the back stack must reach the composer's `/` picker (#317).
+ *
+ * These drive the real ViewModel rather than the delegate, so the permission gate and the wiring
+ * are covered too. `refreshPromptsIfStale()` stands in for the chat screen's composition, which
+ * drives it keyed on `promptLibraryRevision` (`ChatRoot`).
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class ChatViewModelPromptLibraryRefreshTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    private val fixture = ChatViewModelTestFixture()
+    private val agentRepository get() = fixture.agentRepository
+    private val messageRepository get() = fixture.messageRepository
+    private val configRepository get() = fixture.configRepository
+    private val conversationRepository get() = fixture.conversationRepository
+    private val favoritesRepository get() = fixture.favoritesRepository
+    private val keyRepository get() = fixture.keyRepository
+    private val promptRepository get() = fixture.promptRepository
+    private val roleRepository get() = fixture.roleRepository
+    private val permissionGate get() = fixture.permissionGate
+    private val serverDataStore get() = fixture.serverDataStore
+    private val settingsDataStore get() = fixture.settingsDataStore
+    private val platformDelegateFactory get() = fixture.platformDelegateFactory
+    private val serverFileSelectionHandoff get() = fixture.serverFileSelectionHandoff
+
+    private fun group(id: String, name: String) = PromptGroup(
+        id = id,
+        name = name,
+        author = "author-1",
+        authorName = "Author",
+        productionId = "$id-p",
+        prompts = listOf(
+            Prompt(id = "$id-p", groupId = id, author = "author-1", prompt = "body of $name", type = "text"),
+        ),
+    )
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        fixture.stubDefaults()
+
+        // A relaxed mock hands back a chained mock whose `hasAccess` is false, which would gate the
+        // prompt load off for the wrong reason. Stub the ordinary permissive role instead.
+        coEvery { permissionGate.awaitRole() } returns UserRolePermissions(name = "USER")
+
+        every { messageRepository.observeMessages(any()) } returns flowOf(emptyList())
+        coEvery { messageRepository.getMessages(any()) } returns Result.Success(emptyList())
+        coEvery { conversationRepository.getConversation(any(), any()) } returns Result.Error(message = "test")
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun aPromptSavedWhileTheChatIsRetainedReachesThePicker() = runTest(testDispatcher) {
+        coEvery { promptRepository.getAllGroups() } returns Result.Success(listOf(group("g-1", "First")))
+
+        val viewModel = newViewModel()
+        advanceUntilIdle()
+        assertEquals(listOf("First"), viewModel.uiState.value.availablePrompts.map { it.name })
+
+        // The editor's save, from a nav entry pushed on top of this one.
+        coEvery { promptRepository.getAllGroups() } returns
+            Result.Success(listOf(group("g-1", "First"), group("g-2", "Just authored")))
+        fixture.promptRevision.value += 1
+        advanceUntilIdle()
+
+        // Nothing yet: the chat is off screen, and its picker cannot be read from there.
+        coVerify(exactly = 1) { promptRepository.getAllGroups() }
+
+        viewModel.refreshPromptsIfStale()
+        advanceUntilIdle()
+
+        assertEquals(
+            listOf("First", "Just authored"),
+            viewModel.uiState.value.availablePrompts.map { it.name },
+        )
+    }
+
+    @Test
+    fun returningWithNothingChangedFetchesNothing() = runTest(testDispatcher) {
+        coEvery { promptRepository.getAllGroups() } returns Result.Success(listOf(group("g-1", "First")))
+
+        val viewModel = newViewModel()
+        advanceUntilIdle()
+
+        // Every re-entry drives this; without the revision check the picker would re-download every
+        // prompt group each time the user backed out of the library.
+        viewModel.refreshPromptsIfStale()
+        viewModel.refreshPromptsIfStale()
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { promptRepository.getAllGroups() }
+    }
+
+    @Test
+    fun severalSavesWhileAwayCostOneReload() = runTest(testDispatcher) {
+        coEvery { promptRepository.getAllGroups() } returns Result.Success(listOf(group("g-1", "First")))
+
+        val viewModel = newViewModel()
+        advanceUntilIdle()
+
+        // Flipping through versions in the editor bumps the revision per tap.
+        repeat(4) { fixture.promptRevision.value += 1 }
+        advanceUntilIdle()
+        viewModel.refreshPromptsIfStale()
+        advanceUntilIdle()
+
+        coVerify(exactly = 2) { promptRepository.getAllGroups() }
+    }
+
+    @Test
+    fun aFirstCompositionDoesNotDuplicateTheInitialLoad() = runTest(testDispatcher) {
+        coEvery { promptRepository.getAllGroups() } returns Result.Success(listOf(group("g-1", "First")))
+
+        val viewModel = newViewModel()
+        // Before `advanceUntilIdle`, so the initial load is still in flight — which is exactly when
+        // the screen's first composition fires this.
+        viewModel.refreshPromptsIfStale()
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { promptRepository.getAllGroups() }
+    }
+
+    @Test
+    fun aUserWithoutPromptAccessNeverFetches() = runTest(testDispatcher) {
+        coEvery { permissionGate.awaitRole() } returns UserRolePermissions(
+            name = "USER",
+            permissions = mapOf(
+                PermissionType.PROMPTS.serverKey to mapOf(Permission.USE.serverKey to false),
+            ),
+        )
+        coEvery { promptRepository.getAllGroups() } returns Result.Success(listOf(group("g-1", "First")))
+
+        val viewModel = newViewModel()
+        advanceUntilIdle()
+        fixture.promptRevision.value += 1
+        viewModel.refreshPromptsIfStale()
+        advanceUntilIdle()
+
+        // The refresh sits behind the permission gate, so a denied user's picker stays silent
+        // rather than issuing a request the server would 403.
+        coVerify(exactly = 0) { promptRepository.getAllGroups() }
+    }
+
+    private fun newViewModel(): ChatViewModel =
+        fixture.build(
+            defaultDispatcher = testDispatcher,
+            initialConversationId = "conv-1",
+        )
+}

--- a/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModelTestFixture.kt
+++ b/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModelTestFixture.kt
@@ -83,6 +83,9 @@ internal class ChatViewModelTestFixture {
 
     val selectionHandoff = NewChatSelectionHandoff()
 
+    /** Driven by hand where a test needs a prompt mutation to reach a retained ViewModel. */
+    val promptRevision = MutableStateFlow(0L)
+
     fun stubDefaults() {
         every { configRepository.startupConfig } returns MutableStateFlow(null)
         every { configRepository.detectedBackendVersion } returns MutableStateFlow("0.8.7")
@@ -93,6 +96,7 @@ internal class ChatViewModelTestFixture {
         every { favoritesRepository.favorites } returns MutableStateFlow(emptyList())
         every { keyRepository.keyInvalidations } returns MutableSharedFlow()
         every { agentRepository.revision } returns MutableStateFlow(0L)
+        every { promptRepository.revision } returns promptRevision
         every { messageRepository.observeMessages(any()) } returns emptyFlow()
         every { serverFileSelectionHandoff.selectionsFor(any()) } returns emptyFlow()
         every { platformDelegateFactory.createShareConsumer().sharesFor(any()) } returns emptyFlow()

--- a/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModelTestFixture.kt
+++ b/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModelTestFixture.kt
@@ -1,0 +1,152 @@
+package com.garfiec.librechat.feature.chat.viewmodel
+
+import com.garfiec.librechat.core.common.identity.AccountId
+import com.garfiec.librechat.core.common.identity.AccountState
+import com.garfiec.librechat.core.common.identity.ActiveAccountProvider
+import com.garfiec.librechat.core.common.identity.InMemoryActiveAccountProvider
+import com.garfiec.librechat.core.common.network.ConnectivityObserver
+import com.garfiec.librechat.core.data.datastore.ChatFontSize
+import com.garfiec.librechat.core.data.datastore.ChatHeaderAlignment
+import com.garfiec.librechat.core.data.datastore.ChatHeaderContent
+import com.garfiec.librechat.core.data.datastore.ContextBarPlacement
+import com.garfiec.librechat.core.data.datastore.DuringRunAction
+import com.garfiec.librechat.core.data.datastore.ServerDataStore
+import com.garfiec.librechat.core.data.datastore.SettingsDataStore
+import com.garfiec.librechat.core.data.datastore.StarredModelsDisplay
+import com.garfiec.librechat.core.data.repository.AgentRepository
+import com.garfiec.librechat.core.data.repository.ChatRepository
+import com.garfiec.librechat.core.data.repository.ConfigRepository
+import com.garfiec.librechat.core.data.repository.ConversationRepository
+import com.garfiec.librechat.core.data.repository.DraftRepository
+import com.garfiec.librechat.core.data.repository.EndpointTokenRepository
+import com.garfiec.librechat.core.data.repository.FavoritesRepository
+import com.garfiec.librechat.core.data.repository.FileRepository
+import com.garfiec.librechat.core.data.repository.KeyRepository
+import com.garfiec.librechat.core.data.repository.McpRepository
+import com.garfiec.librechat.core.data.repository.MessageRepository
+import com.garfiec.librechat.core.data.repository.PresetRepository
+import com.garfiec.librechat.core.data.repository.PromptRepository
+import com.garfiec.librechat.core.data.repository.ResumePinStore
+import com.garfiec.librechat.core.data.repository.RoleRepository
+import com.garfiec.librechat.core.data.repository.ShareRepository
+import com.garfiec.librechat.core.data.repository.UserRepository
+import com.garfiec.librechat.core.data.util.PermissionGate
+import com.garfiec.librechat.feature.chat.viewmodel.delegate.PlatformDelegateFactory
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.serialization.json.Json
+
+/**
+ * The collaborators of a [ChatViewModel] under test, and the stubs it cannot be constructed
+ * without.
+ *
+ * Every `ChatViewModel` test builds its subject from here, so adding a collaborator to the 30-odd
+ * constructor arguments stays a one-file change.
+ *
+ * Mocks are `relaxed`, but the stubs in [stubDefaults] are not optional decoration:
+ * - `uiState` is `combine(_uiState, <pref flows>).stateIn(Eagerly, ChatUiState())`, so until every
+ *   preference flow has emitted, `uiState.value` is the untouched initial state no matter what the
+ *   ViewModel did — an unstubbed pref makes a test assert against a value nothing produced.
+ * - `StateFlow.collect` returns `Nothing`, which a relaxed mock cannot fabricate, so an unstubbed
+ *   revision flow throws inside whichever collector reaches it first.
+ *
+ * A test that needs a different value just re-stubs after `stubDefaults()`; the later `every` wins.
+ */
+internal class ChatViewModelTestFixture {
+
+    val agentRepository = mockk<AgentRepository>(relaxed = true)
+    val chatRepository = mockk<ChatRepository>(relaxed = true)
+    val messageRepository = mockk<MessageRepository>(relaxed = true)
+    val fileRepository = mockk<FileRepository>(relaxed = true)
+    val configRepository = mockk<ConfigRepository>(relaxed = true)
+    val conversationRepository = mockk<ConversationRepository>(relaxed = true)
+    val endpointTokenRepository = mockk<EndpointTokenRepository>(relaxed = true)
+    val draftRepository = mockk<DraftRepository>(relaxed = true)
+    val favoritesRepository = mockk<FavoritesRepository>(relaxed = true)
+    val keyRepository = mockk<KeyRepository>(relaxed = true)
+    val presetRepository = mockk<PresetRepository>(relaxed = true)
+    val promptRepository = mockk<PromptRepository>(relaxed = true)
+    val shareRepository = mockk<ShareRepository>(relaxed = true)
+    val mcpRepository = mockk<McpRepository>(relaxed = true)
+    val userRepository = mockk<UserRepository>(relaxed = true)
+    val roleRepository = mockk<RoleRepository>(relaxed = true)
+    val permissionGate = mockk<PermissionGate>(relaxed = true)
+    val connectivityObserver = mockk<ConnectivityObserver>(relaxed = true)
+    val serverDataStore = mockk<ServerDataStore>(relaxed = true)
+    val settingsDataStore = mockk<SettingsDataStore>(relaxed = true)
+    val platformDelegateFactory = mockk<PlatformDelegateFactory>(relaxed = true)
+    val serverFileSelectionHandoff = mockk<ServerFileSelectionHandoff>(relaxed = true)
+
+    val selectionHandoff = NewChatSelectionHandoff()
+
+    fun stubDefaults() {
+        every { configRepository.startupConfig } returns MutableStateFlow(null)
+        every { configRepository.detectedBackendVersion } returns MutableStateFlow("0.8.7")
+        every { configRepository.detectedBackend } returns MutableStateFlow(null)
+        every { configRepository.endpointConfigs } returns MutableStateFlow(emptyMap())
+        every { configRepository.availableModels } returns MutableStateFlow(emptyMap())
+        every { roleRepository.userPermissions } returns MutableStateFlow(null)
+        every { favoritesRepository.favorites } returns MutableStateFlow(emptyList())
+        every { keyRepository.keyInvalidations } returns MutableSharedFlow()
+        every { agentRepository.revision } returns MutableStateFlow(0L)
+        every { messageRepository.observeMessages(any()) } returns emptyFlow()
+        every { serverFileSelectionHandoff.selectionsFor(any()) } returns emptyFlow()
+        every { platformDelegateFactory.createShareConsumer().sharesFor(any()) } returns emptyFlow()
+
+        every { serverDataStore.currentUrlFlow } returns MutableStateFlow("https://example.test")
+        every { settingsDataStore.selectedMcpServers } returns MutableStateFlow(emptySet())
+        every { settingsDataStore.enabledTools } returns MutableStateFlow(emptySet())
+        every { settingsDataStore.chatFontSize } returns MutableStateFlow(ChatFontSize.MEDIUM)
+        every { settingsDataStore.starredModelsDisplay } returns MutableStateFlow(StarredModelsDisplay.OFF)
+        every { settingsDataStore.chatHeaderContent } returns MutableStateFlow(ChatHeaderContent.MODEL)
+        every { settingsDataStore.chatHeaderAlignment } returns MutableStateFlow(ChatHeaderAlignment.CENTER)
+        every { settingsDataStore.contextBarPlacement } returns MutableStateFlow(ContextBarPlacement.HIDDEN)
+        every { settingsDataStore.contextGaugeExpanded } returns MutableStateFlow(false)
+        every { settingsDataStore.duringRunAction } returns MutableStateFlow(DuringRunAction.QUEUE)
+    }
+
+    fun build(
+        defaultDispatcher: CoroutineDispatcher,
+        initialConversationId: String? = null,
+        initialAgentId: String? = null,
+        initialIsTemporary: Boolean = false,
+        activeAccountProvider: ActiveAccountProvider =
+            InMemoryActiveAccountProvider(AccountState.Resolved(AccountId("srv:user-1"))),
+    ): ChatViewModel = ChatViewModel(
+        initialConversationId = initialConversationId,
+        initialAgentId = initialAgentId,
+        initialIsTemporary = initialIsTemporary,
+        agentRepository = agentRepository,
+        chatRepository = chatRepository,
+        messageRepository = messageRepository,
+        fileRepository = fileRepository,
+        resumePinStore = ResumePinStore(),
+        configRepository = configRepository,
+        conversationRepository = conversationRepository,
+        endpointTokenRepository = endpointTokenRepository,
+        draftRepository = draftRepository,
+        favoritesRepository = favoritesRepository,
+        keyRepository = keyRepository,
+        presetRepository = presetRepository,
+        promptRepository = promptRepository,
+        shareRepository = shareRepository,
+        mcpRepository = mcpRepository,
+        userRepository = userRepository,
+        roleRepository = roleRepository,
+        permissionGate = permissionGate,
+        connectivityObserver = connectivityObserver,
+        serverDataStore = serverDataStore,
+        settingsDataStore = settingsDataStore,
+        platformDelegateFactory = platformDelegateFactory,
+        json = Json { ignoreUnknownKeys = true },
+        defaultDispatcher = defaultDispatcher,
+        selectionHandoff = selectionHandoff,
+        serverFileSelectionHandoff = serverFileSelectionHandoff,
+        promptInsertionHandoff = PromptInsertionHandoff(),
+        activeAccountProvider = activeAccountProvider,
+    )
+}

--- a/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModelUploadRoutingTest.kt
+++ b/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModelUploadRoutingTest.kt
@@ -2,41 +2,17 @@ package com.garfiec.librechat.feature.chat.viewmodel
 
 import androidx.lifecycle.viewModelScope
 import com.garfiec.librechat.core.common.EndpointConstants
-import com.garfiec.librechat.core.common.identity.AccountId
-import com.garfiec.librechat.core.common.identity.AccountState
-import com.garfiec.librechat.core.common.identity.InMemoryActiveAccountProvider
 import com.garfiec.librechat.core.common.result.Result
 import com.garfiec.librechat.core.data.datastore.ChatFontSize
 import com.garfiec.librechat.core.data.datastore.ChatHeaderAlignment
 import com.garfiec.librechat.core.data.datastore.ChatHeaderContent
 import com.garfiec.librechat.core.data.datastore.ContextBarPlacement
 import com.garfiec.librechat.core.data.datastore.DuringRunAction
-import com.garfiec.librechat.core.data.datastore.ServerDataStore
-import com.garfiec.librechat.core.data.datastore.SettingsDataStore
 import com.garfiec.librechat.core.data.datastore.StarredModelsDisplay
 import com.garfiec.librechat.core.data.datastore.UploadRoutingMode
-import com.garfiec.librechat.core.data.repository.AgentRepository
-import com.garfiec.librechat.core.data.repository.ChatRepository
-import com.garfiec.librechat.core.data.repository.ConfigRepository
-import com.garfiec.librechat.core.data.repository.ConversationRepository
-import com.garfiec.librechat.core.data.repository.DraftRepository
-import com.garfiec.librechat.core.data.repository.EndpointTokenRepository
-import com.garfiec.librechat.core.data.repository.FavoritesRepository
-import com.garfiec.librechat.core.data.repository.FileRepository
-import com.garfiec.librechat.core.data.repository.KeyRepository
-import com.garfiec.librechat.core.data.repository.McpRepository
-import com.garfiec.librechat.core.data.repository.MessageRepository
-import com.garfiec.librechat.core.data.repository.PresetRepository
-import com.garfiec.librechat.core.data.repository.PromptRepository
-import com.garfiec.librechat.core.data.repository.ResumePinStore
-import com.garfiec.librechat.core.data.repository.RoleRepository
-import com.garfiec.librechat.core.data.repository.ShareRepository
-import com.garfiec.librechat.core.data.repository.UserRepository
-import com.garfiec.librechat.core.data.util.PermissionGate
 import com.garfiec.librechat.core.model.EndpointConfig
 import com.garfiec.librechat.core.model.response.UploadRoute
 import com.garfiec.librechat.feature.chat.viewmodel.delegate.PickedFile
-import com.garfiec.librechat.feature.chat.viewmodel.delegate.PlatformDelegateFactory
 import com.garfiec.librechat.feature.chat.viewmodel.delegate.PlatformFileHandler
 import com.garfiec.librechat.feature.chat.viewmodel.delegate.RoutedFile
 import com.garfiec.librechat.feature.chat.viewmodel.delegate.ShareData
@@ -52,7 +28,6 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -60,7 +35,6 @@ import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
-import kotlinx.serialization.json.Json
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -78,32 +52,21 @@ class ChatViewModelUploadRoutingTest {
 
     private val testDispatcher = UnconfinedTestDispatcher()
 
-    private val agentRepository = mockk<AgentRepository>(relaxed = true)
-    private val chatRepository = mockk<ChatRepository>(relaxed = true)
-    private val messageRepository = mockk<MessageRepository>(relaxed = true)
-    private val fileRepository = mockk<FileRepository>(relaxed = true)
-    private val configRepository = mockk<ConfigRepository>(relaxed = true)
-    private val conversationRepository = mockk<ConversationRepository>(relaxed = true)
-    private val endpointTokenRepository = mockk<EndpointTokenRepository>(relaxed = true)
-    private val draftRepository = mockk<DraftRepository>(relaxed = true)
-    private val favoritesRepository = mockk<FavoritesRepository>(relaxed = true)
-    private val keyRepository = mockk<KeyRepository>(relaxed = true)
-    private val presetRepository = mockk<PresetRepository>(relaxed = true)
-    private val promptRepository = mockk<PromptRepository>(relaxed = true)
-    private val shareRepository = mockk<ShareRepository>(relaxed = true)
-    private val mcpRepository = mockk<McpRepository>(relaxed = true)
-    private val userRepository = mockk<UserRepository>(relaxed = true)
-    private val roleRepository = mockk<RoleRepository>(relaxed = true)
-    private val permissionGate = mockk<PermissionGate>(relaxed = true)
-    private val connectivityObserver =
-        mockk<com.garfiec.librechat.core.common.network.ConnectivityObserver>(relaxed = true)
-    private val serverDataStore = mockk<ServerDataStore>(relaxed = true)
-    private val settingsDataStore = mockk<SettingsDataStore>(relaxed = true)
-    private val platformDelegateFactory = mockk<PlatformDelegateFactory>(relaxed = true)
+    private val fixture = ChatViewModelTestFixture()
+    private val agentRepository get() = fixture.agentRepository
+    private val chatRepository get() = fixture.chatRepository
+    private val messageRepository get() = fixture.messageRepository
+    private val configRepository get() = fixture.configRepository
+    private val conversationRepository get() = fixture.conversationRepository
+    private val favoritesRepository get() = fixture.favoritesRepository
+    private val keyRepository get() = fixture.keyRepository
+    private val roleRepository get() = fixture.roleRepository
+    private val serverDataStore get() = fixture.serverDataStore
+    private val settingsDataStore get() = fixture.settingsDataStore
+    private val platformDelegateFactory get() = fixture.platformDelegateFactory
+    private val serverFileSelectionHandoff get() = fixture.serverFileSelectionHandoff
     private val fileHandler = mockk<PlatformFileHandler>(relaxed = true)
-    private val serverFileSelectionHandoff = mockk<ServerFileSelectionHandoff>(relaxed = true)
 
-    private val selectionHandoff = NewChatSelectionHandoff()
     private val endpointConfigs = MutableStateFlow<Map<String, EndpointConfig>>(emptyMap())
     private val availableModels = MutableStateFlow<Map<String, List<String>>>(emptyMap())
     private val shares = MutableSharedFlow<ShareData>(extraBufferCapacity = 1)
@@ -111,17 +74,14 @@ class ChatViewModelUploadRoutingTest {
     @Before
     fun setUp() {
         Dispatchers.setMain(testDispatcher)
+        fixture.stubDefaults()
 
-        every { configRepository.detectedBackend } returns MutableStateFlow(null)
         every { configRepository.detectedBackendVersion } returns MutableStateFlow(null)
-        every { configRepository.startupConfig } returns MutableStateFlow(null)
-        every { roleRepository.userPermissions } returns MutableStateFlow(null)
         every { configRepository.endpointConfigs } returns endpointConfigs
         // A real model list, so the send-readiness gate lets `sendMessage` through: the staged-batch
         // test below has to observe the send being REFUSED, which is meaningless if the send would
         // have been refused anyway.
         every { configRepository.availableModels } returns availableModels
-        every { favoritesRepository.favorites } returns MutableStateFlow(emptyList())
         every { settingsDataStore.selectedMcpServers } returns flowOf(emptySet())
         every { settingsDataStore.enabledTools } returns flowOf(emptySet())
 
@@ -134,11 +94,7 @@ class ChatViewModelUploadRoutingTest {
         every { settingsDataStore.contextGaugeExpanded } returns flowOf(false)
         every { settingsDataStore.duringRunAction } returns flowOf(DuringRunAction.QUEUE)
         every { settingsDataStore.uploadRoutingMode } returns flowOf(UploadRoutingMode.AUTO)
-        every { messageRepository.observeMessages(any()) } returns emptyFlow()
-        every { serverFileSelectionHandoff.selectionsFor(any()) } returns emptyFlow()
-        every { keyRepository.keyInvalidations } returns MutableSharedFlow()
         // StateFlow.collect returns Nothing, so a relaxed mock throws in the delegate's collector.
-        every { agentRepository.revision } returns MutableStateFlow(0L)
         every { platformDelegateFactory.createShareConsumer().sharesFor(any()) } returns shares
 
         every { platformDelegateFactory.createFileHandler(any()) } returns fileHandler
@@ -626,37 +582,9 @@ class ChatViewModelUploadRoutingTest {
     }
 
     private fun newViewModel(): ChatViewModel =
-        ChatViewModel(
-            initialConversationId = CONVERSATION_ID,
-            initialAgentId = null,
-            agentRepository = agentRepository,
-            chatRepository = chatRepository,
-            messageRepository = messageRepository,
-            fileRepository = fileRepository,
-            resumePinStore = ResumePinStore(),
-            configRepository = configRepository,
-            conversationRepository = conversationRepository,
-            endpointTokenRepository = endpointTokenRepository,
-            draftRepository = draftRepository,
-            favoritesRepository = favoritesRepository,
-            keyRepository = keyRepository,
-            presetRepository = presetRepository,
-            promptRepository = promptRepository,
-            shareRepository = shareRepository,
-            mcpRepository = mcpRepository,
-            userRepository = userRepository,
-            roleRepository = roleRepository,
-            permissionGate = permissionGate,
-            connectivityObserver = connectivityObserver,
-            serverDataStore = serverDataStore,
-            settingsDataStore = settingsDataStore,
-            platformDelegateFactory = platformDelegateFactory,
-            json = Json { ignoreUnknownKeys = true },
+        fixture.build(
             defaultDispatcher = testDispatcher,
-            selectionHandoff = selectionHandoff,
-            serverFileSelectionHandoff = serverFileSelectionHandoff,
-            promptInsertionHandoff = PromptInsertionHandoff(),
-            activeAccountProvider = InMemoryActiveAccountProvider(AccountState.Resolved(AccountId("srv:user-1"))),
+            initialConversationId = CONVERSATION_ID,
         )
 
     private companion object {

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ChatRoot.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ChatRoot.kt
@@ -2,9 +2,11 @@ package com.garfiec.librechat.feature.chat.components
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.listSaver
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
@@ -40,8 +42,18 @@ fun ChatRoot(
     onOpenMedia: (url: String) -> Unit,
     onCloseMedia: () -> Unit,
     onDownloadAttachment: suspend (fileId: String) -> ByteArray?,
+    /** Required, not defaulted, so neither platform's `ChatScreen` can quietly drop the wiring. */
+    promptLibraryRevision: Long,
+    onRefreshPrompts: () -> Unit,
     content: @Composable () -> Unit,
 ) {
+    // Driven from the chat screen's composition rather than a ViewModel collector, which defers the
+    // refetch to a screen the user is looking at — the picker's route is the unpaginated one, and
+    // the editor can bump this several times before the user comes back. Keyed on the revision
+    // (not fired once on entry) so a chat that stays composed still refreshes.
+    val refreshPrompts by rememberUpdatedState(onRefreshPrompts)
+    LaunchedEffect(promptLibraryRevision) { refreshPrompts() }
+
     // Hosted here (not in the VM) so the tapped PDF card can scroll off-screen without dismissing
     // the viewer. rememberSaveable so the open preview survives configuration changes (rotation);
     // the opener just records the request and the overlay re-downloads + renders below.

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/prompts/PromptEditorViewModel.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/prompts/PromptEditorViewModel.kt
@@ -168,19 +168,27 @@ class PromptEditorViewModel(
         when (val result = promptRepository.create(request)) {
             is Result.Success -> {
                 val createdGroup = result.data
-                // If there is metadata to update (oneliner, command), do a follow-up update
-                if (state.oneliner.isNotBlank() || state.command.isNotBlank()) {
+                // The oneliner and the `/` command ride on a follow-up update — the create route
+                // takes neither — so its outcome decides this save's: a prompt saved without the
+                // command the user typed is not findable by the command they will type. `groupId`
+                // is adopted either way, so a retry updates the group just created rather than
+                // minting a duplicate.
+                val metadataSaved = if (state.oneliner.isNotBlank() || state.command.isNotBlank()) {
                     val updateRequest = UpdatePromptGroupRequest(
                         name = state.name,
                         oneliner = state.oneliner.ifBlank { null },
                         command = state.command.ifBlank { null },
                     )
-                    createdGroup.id?.let { promptRepository.update(it, updateRequest) }
+                    val groupId = createdGroup.id
+                    groupId != null && promptRepository.update(groupId, updateRequest) is Result.Success
+                } else {
+                    true
                 }
                 _uiState.value = _uiState.value.copy(
                     isSaving = false,
-                    saved = true,
+                    saved = metadataSaved,
                     groupId = createdGroup.id,
+                    error = if (metadataSaved) null else "Prompt created, but its details could not be saved",
                 )
             }
             is Result.Error -> {
@@ -204,18 +212,23 @@ class PromptEditorViewModel(
         )
         when (val result = promptRepository.update(groupId, updateRequest)) {
             is Result.Success -> {
-                // Check if prompt text changed; if so, add as new version
+                // A changed body is added as a new version. This call carries the body — the
+                // metadata update above does not — and the screen pops on `saved`, so flipping it
+                // without reading this result loses the user's edit behind a success animation.
                 val currentProduction = state.prompts.find { it.id == state.productionId }
-                if (currentProduction == null || currentProduction.prompt != state.promptText) {
+                val textSaved = if (currentProduction == null || currentProduction.prompt != state.promptText) {
                     val addRequest = AddPromptToGroupRequest(
                         prompt = state.promptText,
                         type = "text",
                     )
-                    promptRepository.addPromptToGroup(groupId, addRequest)
+                    promptRepository.addPromptToGroup(groupId, addRequest) is Result.Success
+                } else {
+                    true
                 }
                 _uiState.value = _uiState.value.copy(
                     isSaving = false,
-                    saved = true,
+                    saved = textSaved,
+                    error = if (textSaved) null else "Could not save the prompt text",
                 )
             }
             is Result.Error -> {

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/prompts/PromptsLibraryScreen.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/prompts/PromptsLibraryScreen.kt
@@ -67,6 +67,13 @@ fun PromptsLibraryScreen(
     viewModel: PromptsViewModel = koinViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    // Keyed on the revision from inside the composition, so the reload happens when this list is on
+    // screen: a user who saves three prompts in a row pays one reload on return, and a screen that
+    // stays composed still reloads as soon as one lands.
+    val promptLibraryRevision by viewModel.promptLibraryRevision.collectAsStateWithLifecycle()
+    LaunchedEffect(promptLibraryRevision) { viewModel.refreshIfStale() }
+
     val snackbarHostState = remember { SnackbarHostState() }
     LaunchedEffect(uiState.error) {
         val error = uiState.error

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/prompts/PromptsViewModel.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/prompts/PromptsViewModel.kt
@@ -12,11 +12,9 @@ import com.garfiec.librechat.core.model.PromptGroup
 import com.garfiec.librechat.core.model.permissions.Permission
 import com.garfiec.librechat.core.model.permissions.PermissionType
 import com.garfiec.librechat.core.model.permissions.hasAccessOrPermissive
-import com.garfiec.librechat.core.model.request.CreatePromptData
-import com.garfiec.librechat.core.model.request.CreatePromptGroupData
-import com.garfiec.librechat.core.model.request.CreatePromptRequest
 import com.garfiec.librechat.core.model.request.UpdatePromptTagRequest
 import com.garfiec.librechat.feature.chat.prompts.components.PromptSortOrder
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -61,9 +59,36 @@ class PromptsViewModel(
     // Keep raw domain groups for filtering/sorting by fields not in display data
     private var rawGroups: List<PromptGroup> = emptyList()
 
+    // The PromptRepository.revision this list was built from, and the one the in-flight fetch is
+    // for. Null until a load succeeds, so a failed one is retried on the next visit.
+    private var loadedRevision: Long? = null
+    private var requestedRevision: Long? = null
+    private var reloadJob: Job? = null
+
     init {
         observePermissionFlags()
         loadInitialGroups()
+    }
+
+    /**
+     * Bumped when any prompt is created, edited or deleted — the signal this list is stale.
+     * Read from the screen's composition and paired with [refreshIfStale].
+     */
+    val promptLibraryRevision: StateFlow<Long> = promptRepository.revision
+
+    /**
+     * Re-reads the list, but only when a prompt actually changed since it was loaded.
+     *
+     * Failures stay silent: nobody asked for this fetch, and reporting it would put "Failed to
+     * refresh prompts" on screen after a save that worked.
+     */
+    fun refreshIfStale() {
+        val current = promptRepository.revision.value
+        if (current == loadedRevision) return
+        // Already fetching this revision (the initial load): joining it is what keeps the first
+        // composition from duplicating it.
+        if (reloadJob?.isActive == true && requestedRevision == current) return
+        launchReload(current, surfaceErrors = false, fullSpinner = false)
     }
 
     /** Continuous collector mirroring CREATE/SHARE sub-action flags into UiState. */
@@ -87,71 +112,63 @@ class PromptsViewModel(
         }
     }
 
+    /** The initial load and the empty-state retry: a full-screen spinner, failures shown. */
     fun loadGroups() {
-        viewModelScope.launch {
-            _uiState.value = _uiState.value.copy(isLoading = true, error = null)
-            when (val result = promptRepository.getGroups()) {
-                is Result.Success -> {
-                    val response = result.data
-                    val groups = response.promptGroups
-                    rawGroups = groups
-                    val categories = groups
-                        .mapNotNull { it.category }
-                        .filter { it.isNotBlank() }
-                        .distinct()
-                        .sorted()
-
-                    _uiState.value = _uiState.value.copy(
-                        groups = groups.map { it.toDisplayData() },
-                        totalPages = if (response.hasMore) 9999 else 1,
-                        currentPage = 1,
-                        isLoading = false,
-                        availableCategories = categories,
-                    )
-                    applyFilters()
-                }
-                is Result.Error -> {
-                    _uiState.value = _uiState.value.copy(
-                        isLoading = false,
-                        error = result.message ?: "Failed to load prompts",
-                    )
-                }
-                is Result.Loading -> { /* no-op */ }
-            }
-        }
+        launchReload(promptRepository.revision.value, surfaceErrors = true, fullSpinner = true)
     }
 
+    /** The pull-to-refresh gesture. Its failures are the user's to see. */
     fun refresh() {
-        viewModelScope.launch {
-            _uiState.value = _uiState.value.copy(isRefreshing = true, error = null)
-            when (val result = promptRepository.getGroups()) {
-                is Result.Success -> {
-                    val response = result.data
-                    val groups = response.promptGroups
-                    rawGroups = groups
-                    val categories = groups
-                        .mapNotNull { it.category }
-                        .filter { it.isNotBlank() }
-                        .distinct()
-                        .sorted()
+        launchReload(promptRepository.revision.value, surfaceErrors = true, fullSpinner = false)
+    }
 
-                    _uiState.value = _uiState.value.copy(
-                        groups = groups.map { it.toDisplayData() },
-                        totalPages = if (response.hasMore) 9999 else 1,
-                        currentPage = 1,
-                        isRefreshing = false,
-                        availableCategories = categories,
-                    )
-                    applyFilters()
-                }
-                is Result.Error -> {
-                    _uiState.value = _uiState.value.copy(
-                        isRefreshing = false,
-                        error = result.message ?: "Failed to refresh prompts",
-                    )
-                }
-                is Result.Loading -> { /* no-op */ }
+    private fun launchReload(revision: Long, surfaceErrors: Boolean, fullSpinner: Boolean) {
+        // Cancel-replace: the fetches are unordered and the write is last-writer-wins, so a
+        // superseded reload could otherwise land on top of a newer list.
+        reloadJob?.cancel()
+        requestedRevision = revision
+        reloadJob = viewModelScope.launch { fetchGroups(revision, surfaceErrors, fullSpinner) }
+    }
+
+    private suspend fun fetchGroups(revision: Long, surfaceErrors: Boolean, fullSpinner: Boolean) {
+        _uiState.value = _uiState.value.copy(
+            isLoading = fullSpinner,
+            isRefreshing = !fullSpinner,
+            error = if (surfaceErrors) null else _uiState.value.error,
+        )
+        when (val result = promptRepository.getGroups()) {
+            is Result.Success -> {
+                val response = result.data
+                val groups = response.promptGroups
+                rawGroups = groups
+                loadedRevision = revision
+                val categories = groups
+                    .mapNotNull { it.category }
+                    .filter { it.isNotBlank() }
+                    .distinct()
+                    .sorted()
+
+                _uiState.value = _uiState.value.copy(
+                    groups = groups.map { it.toDisplayData() },
+                    totalPages = if (response.hasMore) 9999 else 1,
+                    currentPage = 1,
+                    isLoading = false,
+                    isRefreshing = false,
+                    availableCategories = categories,
+                )
+                applyFilters()
             }
+            is Result.Error -> {
+                Logger.d(result.exception) { "Failed to load prompts: ${result.message}" }
+                val message = result.message
+                    ?: if (fullSpinner) "Failed to load prompts" else "Failed to refresh prompts"
+                _uiState.value = _uiState.value.copy(
+                    isLoading = false,
+                    isRefreshing = false,
+                    error = if (surfaceErrors) message else _uiState.value.error,
+                )
+            }
+            is Result.Loading -> { /* no-op */ }
         }
     }
 
@@ -224,30 +241,11 @@ class PromptsViewModel(
         _uiState.value = state.copy(filteredGroups = filtered.map { it.toDisplayData() })
     }
 
-    fun createPrompt(promptText: String, type: String, groupName: String) {
-        viewModelScope.launch {
-            val request = CreatePromptRequest(
-                prompt = CreatePromptData(prompt = promptText, type = type),
-                group = CreatePromptGroupData(name = groupName),
-            )
-            try {
-                promptRepository.create(request)
-                refresh()
-            } catch (e: Exception) {
-                Logger.e(e) { "Failed to create prompt" }
-                _uiState.value = _uiState.value.copy(
-                    error = "Failed to create prompt",
-                )
-            }
-        }
-    }
-
     fun deleteGroup(groupId: String) {
         viewModelScope.launch {
             try {
                 promptRepository.delete(groupId)
                 _uiState.value = _uiState.value.copy(selectedGroup = null)
-                refresh()
             } catch (e: Exception) {
                 Logger.e(e) { "Failed to delete prompt" }
                 _uiState.value = _uiState.value.copy(

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/prompts/PromptsViewModel.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/prompts/PromptsViewModel.kt
@@ -243,14 +243,18 @@ class PromptsViewModel(
 
     fun deleteGroup(groupId: String) {
         viewModelScope.launch {
-            try {
-                promptRepository.delete(groupId)
-                _uiState.value = _uiState.value.copy(selectedGroup = null)
-            } catch (e: Exception) {
-                Logger.e(e) { "Failed to delete prompt" }
-                _uiState.value = _uiState.value.copy(
-                    error = "Failed to delete prompt",
-                )
+            // Close the detail view only on Success — doing it unconditionally reports a prompt as
+            // gone while it is still on the server. `delete` is safeApiCall-wrapped, so failure
+            // arrives as a returned Result.Error and a try/catch here would never see it.
+            when (val result = promptRepository.delete(groupId)) {
+                is Result.Success -> _uiState.value = _uiState.value.copy(selectedGroup = null)
+                is Result.Error -> {
+                    Logger.e(result.exception) { "Failed to delete prompt" }
+                    _uiState.value = _uiState.value.copy(
+                        error = result.message ?: "Failed to delete prompt",
+                    )
+                }
+                is Result.Loading -> { /* no-op */ }
             }
         }
     }

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModel.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/ChatViewModel.kt
@@ -136,7 +136,7 @@ class ChatViewModel(
     favoritesRepository: FavoritesRepository,
     private val keyRepository: KeyRepository,
     presetRepository: PresetRepository,
-    promptRepository: PromptRepository,
+    private val promptRepository: PromptRepository,
     shareRepository: ShareRepository,
     mcpRepository: McpRepository,
     private val userRepository: UserRepository,
@@ -155,6 +155,9 @@ class ChatViewModel(
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(ChatUiState())
+
+    /** Set once the role confirms PROMPTS.USE, so a denied user's screen issues no prompt fetch. */
+    private var promptsUseAllowed = false
 
     private val stateHandle = ChatStateHandle(_uiState, viewModelScope)
 
@@ -686,6 +689,7 @@ class ChatViewModel(
             val role = permissionGate.awaitRole()
             if (role?.hasAccess(PermissionType.PROMPTS, Permission.USE) != false) {
                 presetPromptDelegate.loadAvailablePrompts()
+                promptsUseAllowed = true
             }
             if (role?.hasAccess(PermissionType.MCP_SERVERS, Permission.USE) != false) {
                 modelDelegate.loadMcpServers()
@@ -1509,6 +1513,19 @@ class ChatViewModel(
     fun continueGeneration() {
         if (_uiState.value.isEditingQueued) return
         editingDelegate.continueGeneration()
+    }
+
+    /**
+     * Bumped when any prompt is created, edited or deleted — the signal the composer's `/` picker
+     * is stale. Read from the chat screen's composition (`ChatRoot`), not collected here, so the
+     * refetch lands on a screen the user is looking at.
+     */
+    val promptLibraryRevision: StateFlow<Long> = promptRepository.revision
+
+    /** Paired with [promptLibraryRevision]; a no-op unless a prompt changed since the last load. */
+    fun refreshPromptsIfStale() {
+        if (!promptsUseAllowed) return
+        presetPromptDelegate.refreshAvailablePromptsIfStale()
     }
 
     fun onPause() = streamingManager.onPause()

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/PresetPromptDelegate.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/PresetPromptDelegate.kt
@@ -14,6 +14,7 @@ import com.garfiec.librechat.feature.chat.prompts.resolvePromptInsertion
 import com.garfiec.librechat.feature.chat.prompts.resolvePromptText
 import com.garfiec.librechat.feature.chat.viewmodel.PendingVariablePrompt
 import com.garfiec.librechat.feature.chat.viewmodel.PresetPromptHandle
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 
 class PresetPromptDelegate(
@@ -25,6 +26,12 @@ class PresetPromptDelegate(
     // Keep domain objects for internal operations (loadPreset, handleSlashCommand, etc.)
     private var cachedPresets: List<Preset> = emptyList()
     private var cachedPromptGroups: List<PromptGroup> = emptyList()
+
+    // The PromptRepository.revision the picker's list was built from, and the one the in-flight
+    // fetch is for. Null until a load succeeds.
+    private var loadedRevision: Long? = null
+    private var requestedRevision: Long? = null
+    private var loadJob: Job? = null
 
     fun loadPresets() {
         handle.scope.launch {
@@ -51,11 +58,33 @@ class PresetPromptDelegate(
      * would hide groups with no indication that anything was omitted.
      */
     fun loadAvailablePrompts() {
-        handle.scope.launch {
+        launchLoad(promptRepository.revision.value)
+    }
+
+    /**
+     * Re-reads the picker's prompts, but only when a prompt actually changed since the list was
+     * loaded. A load that failed leaves [loadedRevision] null, so returning to the chat retries it.
+     */
+    fun refreshAvailablePromptsIfStale() {
+        val current = promptRepository.revision.value
+        if (current == loadedRevision) return
+        // Already fetching exactly this revision (the initial load, or a previous entry): joining
+        // it is what keeps the first composition from duplicating `init`'s load.
+        if (loadJob?.isActive == true && requestedRevision == current) return
+        launchLoad(current)
+    }
+
+    private fun launchLoad(revision: Long) {
+        // Cancel-replace: the fetches are unordered and the write below is last-writer-wins, so a
+        // superseded load could otherwise land on top of a newer list and re-list a deleted prompt.
+        loadJob?.cancel()
+        requestedRevision = revision
+        loadJob = handle.scope.launch {
             when (val result = promptRepository.getAllGroups()) {
                 is Result.Success -> {
                     val groups = result.data.filter { it.id != null }
                     cachedPromptGroups = groups
+                    loadedRevision = revision
                     handle.update {
                         presetPrompts = presetPrompts.copy(availablePrompts = groups.map { it.toDisplayData() })
                     }

--- a/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/screen/PlatformScreens.ios.kt
+++ b/feature/chat/src/iosMain/kotlin/com/garfiec/librechat/feature/chat/screen/PlatformScreens.ios.kt
@@ -104,6 +104,7 @@ actual fun ChatScreen(
     val uiState by chromeFlow.collectAsStateWithLifecycle(initialChrome)
     val attachedFiles by viewModel.attachedFiles.collectAsStateWithLifecycle()
     val prefs by viewModel.chatPreferences.collectAsStateWithLifecycle()
+    val promptLibraryRevision by viewModel.promptLibraryRevision.collectAsStateWithLifecycle()
 
     val useKatex = prefs.latexRenderer == LatexRenderer.KATEX
     val fontSizeMultiplier = when (uiState.chatFontSize) {
@@ -211,6 +212,8 @@ actual fun ChatScreen(
         onOpenMedia = viewModel::openMedia,
         onCloseMedia = viewModel::closeMedia,
         onDownloadAttachment = viewModel::downloadFileBytes,
+        promptLibraryRevision = promptLibraryRevision,
+        onRefreshPrompts = viewModel::refreshPromptsIfStale,
     ) {
     Scaffold(
         modifier = modifier.imePadding(),


### PR DESCRIPTION
## Summary

Prompts are network-direct — no Room cache, no `Flow` — and the prompts library and editor are pushed *on top of* the chat entry. Their ViewModels are retained through a save, so `init` (the only caller of the prompt loads) never runs again and nothing reports the staleness. The composer's `/` picker stayed frozen at whatever the server returned when the chat was opened, offering deleted prompts and inserting superseded bodies (#317); the library list under the editor was stale the same way, recoverable only by pull-to-refresh (#315).

`PromptRepository` now owns a revision counter, bumped after any mutation the server accepted. Both surfaces watch it from their own composition and reload only when what they hold is out of date.

Closes #315. Addresses #317 for the create, delete and group-metadata paths — deliberately not auto-closing it, because changing which version is production still leaves the picker stale for a reason outside this PR (see Known gaps).

## Changes

**`core:data`**
- `PromptRepository.revision`: a monotonic `StateFlow<Long>` bumped inside `safeApiCall`, after the API call, on create / group update / delete / add-version / production-tag change. A rejected mutation stays silent. Same shape as `AgentRepository.revision`.
- Caveat, found in device testing: two of those five call sites cannot currently succeed against a real server, for reasons that predate this PR (see Known gaps). The bump is wired to all five; only three are reachable today.

**Reload path (`feature:chat`)**
- `ChatRoot` takes `promptLibraryRevision` / `onRefreshPrompts` as **required** parameters — both platforms' `ChatScreen` pass them, so neither can silently drop the wiring. `PromptsLibraryScreen` has the equivalent effect.
- The effect is keyed on the revision rather than fired once on entry, so a screen that *stays* composed still reloads; nothing depends on Nav3 disposing the entry underneath.
- Driving it from the composition is the visibility gate: an editor that bumps the revision five times while the chat is away costs one reload on return, and the picker's route is the deliberately unpaginated one.
- Each consumer records the revision it loaded and the one it is fetching — re-entry with nothing changed issues no request, the first composition doesn't duplicate `init`'s in-flight load, and a failed load is retried on the next visit.
- Reloads are cancel-replace: the fetches are unordered and the write is last-writer-wins, so a superseded reload could otherwise re-list a just-deleted prompt.
- The chat-side refresh sits behind the `PROMPTS.USE` gate. The revision-driven library reload swallows its own errors; only pull-to-refresh and the initial load surface failure.

**Save outcomes (`feature:chat`)**

Every `PromptRepository` method is `safeApiCall`-wrapped, so failure returns `Result.Error` and only `CancellationException` propagates — the `try/catch` blocks around these calls were unreachable and the results were discarded, reporting each failure as a success:
- a failed delete closed the detail view and reported nothing, telling the user a prompt was gone while it was still on the server;
- a failed `addPromptToGroup` — the call that carries the body — still set `saved`, and the editor pops on `saved`, so an edit was lost behind a success animation;
- a failed oneliner/`command` update did the same, leaving a prompt the typed command can't find. The created group's id is now adopted either way, so a retry updates that group instead of minting a duplicate.

**Cleanup**
- `PromptsViewModel`'s initial load and refresh were near-identical copies; now one fetch with a spinner flag. Mutations no longer call `refresh()` themselves — the revision is the single reload path. Dropped the unused `PromptsViewModel.createPrompt`.
- Five `ChatViewModel` test files each rebuilt the same 22 mocks and 31-argument constructor; `ChatViewModelTestFixture` owns that now.

## Testing

New unit tests: the repository's revision contract (accepted mutations bump, rejected ones don't), the chat picker's refresh and permission gate, the library's refresh, and the editor's save outcomes. Each behavioural guard was mutation-checked — removing the guard fails exactly the intended test.

`:feature:chat:testDebugUnitTest`, `:core:data:testDebugUnitTest`, `:app:assembleDebug`, detekt on both modules, and `:feature:chat:compileKotlinIosSimulatorArm64` all pass.

Device-tested on a Pixel 10 Pro Fold emulator against a local LibreChat server, with the installed build fingerprinted by dex symbol to confirm it was this branch and not `develop`.

| Scenario | Result |
|---|---|
| Create a prompt in the library, return to chat, `/` picker offers it without a restart | Pass |
| Library list shows a saved prompt on return from the editor, no pull-to-refresh | Pass (create, edit, delete) |
| Delete a prompt, gone from both the library and the `/` picker | Pass |
| Edit a prompt's body, picker inserts the new body | Blocked — see Known gaps |

The refresh was confirmed to be revision-driven rather than incidental ViewModel re-creation: the chat entry leaves composition while the library is up but its ViewModel is retained, and the one mutation whose revision bump does not fire left the picker stale.

## Known gaps (pre-existing, present on `develop`)

Neither is introduced here, but both limit what this PR can deliver:

- **A prompt's body cannot be edited against any server.** `AddPromptToGroupRequest` serializes flat, while the route reads `req.body.prompt.prompt`, so every body edit is rejected. This PR changes the *symptom* rather than fixing it: the failure used to be swallowed and the editor popped on a success animation, losing the edit silently; it now keeps the text and reports the failure.
- **`updatePromptProductionTag` treats success as failure.** The route returns `{ message }`, the client decodes `Prompt`, and the decode throws before `bumpRevision()` runs. So changing which version is production does not refresh the `/` picker, and that specific path still reproduces #317's symptom until it is fixed separately.
