### PR TITLE
feat(skill): add /release-highlights for release-notes highlights

### DIFF
--- a/.claude/skills/release-highlights/SKILL.md
+++ b/.claude/skills/release-highlights/SKILL.md
@@ -156,5 +156,9 @@ say what happened.
 - GitHub appends a trailing newline to a body it stores. The script strips trailing
   whitespace before writing so repeat edits cannot accrete blank lines, and tolerates that
   single newline when verifying. Any other difference in the tail is treated as corruption.
-- Do not hand-roll this with `gh release view ... -q .body > f && edit f && gh release edit`.
-  That pipeline drops the CRLFs.
+- Reading a body with `-q .body` is fine — that is what step 2 does. What must never happen
+  is a **write** round-tripped that way (`gh release view -q .body > f && edit f && gh
+  release edit`): that pipeline drops the CRLFs and appends a newline per pass.
+- `--backfill` and `--since` are instructions in this file, not flags on the script. Nothing
+  enforces them; they hold only as long as they are followed. The script's own guards are
+  `--apply`, `--replace`, and the refusals listed above.

--- a/.claude/skills/release-highlights/SKILL.md
+++ b/.claude/skills/release-highlights/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: release-highlights
+description: >
+  Add a hand-written Highlights section to a GitHub release whose notes were
+  auto-generated, summarizing the release's PRs in user-facing language above
+  the generated changelog. Reads every PR in the range, drafts the section in
+  the repo's house style, asks about ambiguous wording, and writes only after
+  approval. Use when a release has shipped and its notes are still a bare
+  What's Changed list, or when backfilling releases that never got Highlights.
+allowed-tools: Bash, Read, Write, Edit, AskUserQuestion
+argument-hint: "[tag ...] (optional, defaults to the newest release) [--backfill] [--since <tag>]"
+---
+
+# Release Highlights
+
+Adds a `# Highlights` section between the badge row and `## What's Changed` on a
+published release. Nothing else about the release changes.
+
+## The invariant
+
+**Everything from `## What's Changed` down is generated once, at publish time, and cannot
+be rebuilt.** It carries the compare link, the New Contributors block, the build provenance
+attestation ID, and the CI run URL. Those come from the publish-time workflow run. If they
+are overwritten they are gone.
+
+So: never regenerate a release body. Never call `gh release edit --notes` with prose you
+composed. Never let `gh release create --generate-notes` near an existing release. The only
+supported write is `scripts/insert_highlights.py`, which fetches the live body, splits it at
+the marker, and reassembles it with the tail byte-identical — then re-fetches and proves the
+tail did not change, printing a restore command if it did.
+
+If the script refuses, that refusal is the feature. Do not work around it by editing the
+body by hand.
+
+## Steps
+
+### 1. Resolve the target
+
+- No argument → the newest release: `gh release list --repo garfiec/Librechat-Mobile --limit 1`
+- Explicit tags → exactly those, in the order given.
+- `--backfill` → every release with no Highlights section. **Enumerate them and confirm
+  before touching any.** There are releases going back to `v0.1.1` that predate both calver
+  and the Switchboard rename; they are almost never what the user meant. `--since <tag>`
+  sets a floor. Backfill never runs implicitly.
+
+Refuse a tag that already has a Highlights section. Replacing one is a separate, explicit
+request, and only then does `--replace` get passed.
+
+### 2. Read the release and every PR in it
+
+```bash
+gh release view "$TAG" --repo garfiec/Librechat-Mobile --json body -q .body
+```
+
+Extract the PR numbers from the What's Changed list, then read every one of them:
+
+```bash
+for p in $PRS; do
+  echo "=== #$p"
+  gh pr view "$p" --json title,body -q '.title + "\n" + (.body | .[0:800])'
+done
+```
+
+Read all of them, including the ones that look mechanical — a `chore(` prefix sometimes
+hides a user-visible change, and a `feat(` prefix sometimes hides pure plumbing. The title
+is a claim about the change, not a description of its effect; the body's Summary/Problem
+section is what tells you whether a user would notice.
+
+For each PR decide one thing: **what changes for someone using the app?** If the answer is
+"nothing they could observe", it is not a Highlights bullet.
+
+### 3. Ask about anything ambiguous — once, before drafting
+
+Collect every uncertain item across the whole release and ask them in a single round. Do
+not draft first and ask afterwards, and do not interrupt per-PR.
+
+What counts as ambiguous is not "I don't understand the change" — read the PR again for
+that. It is when the change is understood but its framing is a judgment call the user owns:
+
+- Was this broken in a shipped build, or never working at all? ("banners display again" vs.
+  "banners display" — the first claims a regression that may never have existed)
+- Is a fix worth naming, or is it noise that belongs in the Misc lines?
+- Does a staged feature land in this release or the next one?
+- Is an internal-sounding change actually user-visible?
+
+If nothing is ambiguous, ask nothing.
+
+### 4. Draft in the house style
+
+```markdown
+# Highlights
+
+* Features
+  * <short user-facing phrase>
+* Bug Fixes
+  * <short user-facing phrase>
+* Performance Improvements
+* Misc Tech Debt Refactors
+* Misc Stability Improvements
+```
+
+Rules, in force regardless of what prior releases happen to look like:
+
+- **Categories are fixed and ordered**: Features, Bug Fixes, Performance Improvements, Misc
+  Tech Debt Refactors, Misc Stability Improvements. Omit any with nothing to say — a release
+  with no features has no Features line. A new top-level category is allowed when a release
+  genuinely does not fit, but say so explicitly when presenting the draft.
+- **A category with nothing nameable stays a bare bullet.** `* Performance Improvements`
+  with no children is correct and common; it signals the work happened without itemizing it.
+- **Sub-bullets are user-facing effects**, in the user's vocabulary, sentence case, no
+  trailing period, no PR links, no PR numbers, no commit-message prefixes. "Two-factor
+  authentication now works end to end", not "fix(auth): make 2FA login work end to end".
+- **Collapse staged PRs into one bullet.** A feature delivered across several PRs is one
+  thing to a user. Five prefetch PRs (#335, #341, #342, #343, #344) are one line about
+  background cache warming; three access-gateway PRs (#294, #298, #312) are one line about
+  custom request headers.
+- **Never name infrastructure work individually.** Dependabot bumps, CI changes, test
+  additions, Claude skills, dead-code removal, comment cleanups, docs — these fold into the
+  two Misc lines and are never their own sub-bullet.
+- **Lead with the most visible change.** If the release renames the app or changes the
+  launcher icon, that is the first bullet.
+- Keep it to roughly 3–6 sub-bullets per category. If Bug Fixes runs to ten, the tail of the
+  list is Misc Stability Improvements.
+
+### 5. Propose, then write
+
+Present the draft as a fenced markdown block, plus the judgment calls worth flagging.
+**Do not write until the user approves.**
+
+On approval:
+
+```bash
+python3 .claude/skills/release-highlights/scripts/insert_highlights.py \
+  --tag "$TAG" --highlights-file "$HL" --apply
+```
+
+Drop `--apply` first to dry-run it. The script backs up the original body, refuses on a
+pre-existing Highlights section, refuses on a missing or duplicated marker, refuses on an
+empty body, and verifies the tail after writing. Report what it prints — including the
+backup path — rather than paraphrasing it as success.
+
+If it exits non-zero after the write, run the restore command it printed immediately and
+say what happened.
+
+## Notes
+
+- Repo is `garfiec/Librechat-Mobile`; the local directory is `LibreChat-Android` for legacy
+  reasons.
+- The app is **Switchboard**; LibreChat is the backend it talks to. Release notes describe
+  Switchboard. Do not rename backend references.
+- **GitHub stores release bodies with CRLF line endings.** Any pipeline that normalizes them
+  rewrites every line below the marker — the content survives, but the tail is no longer the
+  bytes that were published. The script reads the body verbatim, matches the existing line
+  ending when building the inserted block, and never converts. Do not pre-process a body
+  through `tr`, `sed`, or a Python `.replace("\r\n", "\n")` on the way in.
+- GitHub appends a trailing newline to a body it stores. The script strips trailing
+  whitespace before writing so repeat edits cannot accrete blank lines, and tolerates that
+  single newline when verifying. Any other difference in the tail is treated as corruption.
+- Do not hand-roll this with `gh release view ... -q .body > f && edit f && gh release edit`.
+  That pipeline drops the CRLFs.

--- a/.claude/skills/release-highlights/scripts/insert_highlights.py
+++ b/.claude/skills/release-highlights/scripts/insert_highlights.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Insert a Highlights section into a GitHub release body without touching anything else.
+
+Everything below `## What's Changed` is generated at publish time and cannot be rebuilt if
+overwritten, so this script never renders a body: it fetches the live one, splits it at the
+marker, and writes back `head + highlights + <original tail, byte for byte>`, then re-fetches
+and proves the tail is unchanged. See ../SKILL.md.
+
+Usage:
+    insert_highlights.py --tag v2026.08.1 --highlights-file hl.md            # dry run
+    insert_highlights.py --tag v2026.08.1 --highlights-file hl.md --apply    # write
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+MARKER = "## What's Changed"
+DEFAULT_REPO = "garfiec/Librechat-Mobile"
+
+
+def die(msg: str) -> None:
+    print(f"ERROR: {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+def gh(args: list[str]) -> str:
+    proc = subprocess.run(["gh", *args], capture_output=True, text=True)
+    if proc.returncode != 0:
+        die(f"gh {' '.join(args)} failed:\n{proc.stderr.strip()}")
+    return proc.stdout
+
+
+def fetch_body(tag: str, repo: str) -> str:
+    """Fetch the release body exactly. Parsed from JSON, not jq -r, which appends a newline."""
+    raw = gh(["release", "view", tag, "--repo", repo, "--json", "body"])
+    try:
+        body = json.loads(raw)["body"]
+    except (json.JSONDecodeError, KeyError) as exc:
+        die(f"could not parse the release body for {tag}: {exc}")
+    if not body or not body.strip():
+        die(f"{tag} has an empty body — refusing to write over it")
+    # Returned verbatim. GitHub stores release bodies with CRLF line endings; normalizing
+    # them here would silently rewrite every line below the marker.
+    return body
+
+
+def split_body(body: str, tag: str) -> tuple[str, str]:
+    """Return (head, tail) where tail starts at the marker and is never modified."""
+    count = body.count(MARKER)
+    if count == 0:
+        die(f"{tag} has no '{MARKER}' section — this skill only augments generated notes")
+    if count > 1:
+        die(f"{tag} contains {count} '{MARKER}' markers — too ambiguous to edit safely")
+    index = body.index(MARKER)
+    return body[:index], body[index:]
+
+
+def has_highlights(head: str) -> bool:
+    """Look only above the marker, so a PR title mentioning highlights can't false-positive."""
+    return any(line.strip().lstrip("#").strip().lower() == "highlights"
+               and line.lstrip().startswith("#")
+               for line in head.splitlines())
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--tag", required=True)
+    ap.add_argument("--highlights-file", required=True, type=Path)
+    ap.add_argument("--repo", default=DEFAULT_REPO)
+    ap.add_argument("--backup-dir", type=Path, default=Path(tempfile.gettempdir()))
+    ap.add_argument("--apply", action="store_true", help="write; otherwise dry-run")
+    ap.add_argument("--replace", action="store_true",
+                    help="allow replacing an existing Highlights section (must be explicit)")
+    args = ap.parse_args()
+
+    highlights = args.highlights_file.read_text().strip()
+    if not highlights.startswith("#"):
+        die("the highlights file must start with a '# Highlights' heading")
+
+    body = fetch_body(args.tag, args.repo)
+    head, tail = split_body(body, args.tag)
+
+    if has_highlights(head):
+        if not args.replace:
+            die(f"{args.tag} already has a Highlights section. "
+                f"Pass --replace only if the user explicitly asked to overwrite it.")
+        # Keep the badge lines above the old section; drop from its heading onward.
+        lines = head.splitlines(keepends=True)
+        cut = next(i for i, line in enumerate(lines) if line.lstrip().startswith("#"))
+        head = "".join(lines[:cut])
+
+    # Match the body's existing line endings so the inserted block doesn't mix styles.
+    nl = "\r\n" if "\r\n" in body else "\n"
+    block = nl.join(highlights.splitlines())
+
+    # Trailing whitespace is stripped so repeated edits cannot accrete blank lines.
+    new_body = f"{head.rstrip()}{nl}{nl}{block}{nl}{nl}{tail}".rstrip() + nl
+
+    if not new_body.rstrip().endswith(tail.rstrip()):
+        die("internal check failed: the reconstructed body does not end with the original tail")
+
+    backup = args.backup_dir / f"release-body-{args.tag}.bak.md"
+    backup.write_text(body)
+
+    if not args.apply:
+        print(f"DRY RUN — {args.tag}")
+        print(f"  original body : {len(body)} chars (backed up to {backup})")
+        print(f"  new body      : {len(new_body)} chars")
+        print(f"  tail preserved: {len(tail)} chars below the marker, unchanged")
+        print(f"  line endings  : {'CRLF' if nl == chr(13) + chr(10) else 'LF'} (preserved)")
+        print("\n--- head after edit ---")
+        print(new_body[:new_body.index(MARKER)])
+        return
+
+    with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False) as fh:
+        fh.write(new_body)
+        notes_path = fh.name
+    gh(["release", "edit", args.tag, "--repo", args.repo, "--notes-file", notes_path])
+
+    # GitHub normalizes trailing whitespace on its own; any other tail difference is corruption.
+    live = fetch_body(args.tag, args.repo)
+    _, live_tail = split_body(live, args.tag)
+    if live_tail.rstrip() != tail.rstrip():
+        print(f"\nCRITICAL: the section below the marker CHANGED on {args.tag}.", file=sys.stderr)
+        print(f"Restore it now with:\n"
+              f"  gh release edit {args.tag} --repo {args.repo} --notes-file {backup}",
+              file=sys.stderr)
+        sys.exit(2)
+    if not live.startswith(head.rstrip()):
+        print(f"WARNING: the badge header changed on {args.tag}; backup at {backup}",
+              file=sys.stderr)
+        sys.exit(2)
+
+    print(f"OK  {args.tag}")
+    print(f"    tail verified byte-identical ({len(tail.rstrip())} chars below the marker)")
+    print(f"    backup: {backup}")
+    print(f"    https://github.com/{args.repo}/releases/tag/{args.tag}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/release-highlights/scripts/insert_highlights.py
+++ b/.claude/skills/release-highlights/scripts/insert_highlights.py
@@ -61,11 +61,17 @@ def split_body(body: str, tag: str) -> tuple[str, str]:
     return body[:index], body[index:]
 
 
+def highlights_line(head: str) -> int | None:
+    """Index of the Highlights heading. Scans only above the marker, so a PR title
+    mentioning highlights can't false-positive."""
+    for i, line in enumerate(head.splitlines()):
+        if line.lstrip().startswith("#") and line.strip().lstrip("#").strip().lower() == "highlights":
+            return i
+    return None
+
+
 def has_highlights(head: str) -> bool:
-    """Look only above the marker, so a PR title mentioning highlights can't false-positive."""
-    return any(line.strip().lstrip("#").strip().lower() == "highlights"
-               and line.lstrip().startswith("#")
-               for line in head.splitlines())
+    return highlights_line(head) is not None
 
 
 def main() -> None:
@@ -86,14 +92,14 @@ def main() -> None:
     body = fetch_body(args.tag, args.repo)
     head, tail = split_body(body, args.tag)
 
-    if has_highlights(head):
+    cut = highlights_line(head)
+    if cut is not None:
         if not args.replace:
             die(f"{args.tag} already has a Highlights section. "
                 f"Pass --replace only if the user explicitly asked to overwrite it.")
-        # Keep the badge lines above the old section; drop from its heading onward.
-        lines = head.splitlines(keepends=True)
-        cut = next(i for i, line in enumerate(lines) if line.lstrip().startswith("#"))
-        head = "".join(lines[:cut])
+        # Cut at the Highlights heading itself, never at whatever heading comes first —
+        # anything above it (badges, an intro note) belongs to the author, not to us.
+        head = "".join(head.splitlines(keepends=True)[:cut])
 
     # Match the body's existing line endings so the inserted block doesn't mix styles.
     nl = "\r\n" if "\r\n" in body else "\n"
@@ -105,40 +111,49 @@ def main() -> None:
     if not new_body.rstrip().endswith(tail.rstrip()):
         die("internal check failed: the reconstructed body does not end with the original tail")
 
-    backup = args.backup_dir / f"release-body-{args.tag}.bak.md"
-    backup.write_text(body)
-
     if not args.apply:
-        print(f"DRY RUN — {args.tag}")
-        print(f"  original body : {len(body)} chars (backed up to {backup})")
+        print(f"DRY RUN — {args.tag} (nothing written, no backup taken)")
+        print(f"  original body : {len(body)} chars")
         print(f"  new body      : {len(new_body)} chars")
-        print(f"  tail preserved: {len(tail)} chars below the marker, unchanged")
+        print(f"  tail          : {len(tail.rstrip())} chars, carried over verbatim "
+              f"({tail.count(chr(13))} CR, {tail.count(chr(10))} LF)")
         print(f"  line endings  : {'CRLF' if nl == chr(13) + chr(10) else 'LF'} (preserved)")
         print("\n--- head after edit ---")
         print(new_body[:new_body.index(MARKER)])
         return
+
+    backup = args.backup_dir / f"release-body-{args.tag}.bak.md"
+    backup.write_text(body)
 
     with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False) as fh:
         fh.write(new_body)
         notes_path = fh.name
     gh(["release", "edit", args.tag, "--repo", args.repo, "--notes-file", notes_path])
 
-    # GitHub normalizes trailing whitespace on its own; any other tail difference is corruption.
-    live = fetch_body(args.tag, args.repo)
-    _, live_tail = split_body(live, args.tag)
-    if live_tail.rstrip() != tail.rstrip():
-        print(f"\nCRITICAL: the section below the marker CHANGED on {args.tag}.", file=sys.stderr)
+    def fatal(what: str) -> None:
+        print(f"\nFATAL: {what} on {args.tag}.", file=sys.stderr)
         print(f"Restore it now with:\n"
               f"  gh release edit {args.tag} --repo {args.repo} --notes-file {backup}",
               file=sys.stderr)
         sys.exit(2)
+
+    # GitHub normalizes trailing whitespace on its own; any other tail difference is corruption.
+    live = fetch_body(args.tag, args.repo)
+    live_head, live_tail = split_body(live, args.tag)
+    if live_tail.rstrip() != tail.rstrip():
+        fatal("the section below the marker CHANGED")
     if not live.startswith(head.rstrip()):
-        print(f"WARNING: the badge header changed on {args.tag}; backup at {backup}",
-              file=sys.stderr)
-        sys.exit(2)
+        fatal("the content above the Highlights section CHANGED")
+    # Without this the tool cannot tell a successful write from one that silently did nothing.
+    # Compared line-ending-insensitively so a normalization upstream can't fake a corruption
+    # report — a spurious FATAL here would send the user to restore over a good write.
+    if highlights.replace("\r\n", "\n") not in live_head.replace("\r\n", "\n"):
+        fatal("the Highlights section is missing or incomplete after the write")
 
     print(f"OK  {args.tag}")
-    print(f"    tail verified byte-identical ({len(tail.rstrip())} chars below the marker)")
+    print(f"    tail unchanged, trailing whitespace excepted "
+          f"({len(tail.rstrip())} chars below the marker)")
+    print(f"    Highlights section confirmed present")
     print(f"    backup: {backup}")
     print(f"    https://github.com/{args.repo}/releases/tag/{args.tag}")
 

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ Thumbs.db
 # Ephemeral runtime state from Claude Code's scheduler (per-session lock)
 .claude/scheduled_tasks.lock
 .claude/*.lock
+# Bytecode from the Python helpers bundled with .claude skills
+__pycache__/


### PR DESCRIPTION
## Summary

Adds a `/release-highlights` skill that drafts the hand-written Highlights
section for a published release and splices it above the auto-generated
`## What's Changed` block. Previously this was done by hand for a few releases
(v2026.07.3–.5); the skill makes the format and the safety rules explicit.

## Changes

- **`SKILL.md`** — the workflow: resolve the target release, read every PR in
  the range, ask about ambiguous framing in one batched round, draft in the
  house style, then propose before writing. Documents the category vocabulary
  (Features / Bug Fixes / Performance Improvements / the two Misc lines), the
  rule that staged PRs collapse into one user-facing bullet, and that
  infrastructure work is never named individually.
- **`scripts/insert_highlights.py`** — the only supported write path. Fetches
  the live body, splits at the marker, and reassembles it with the tail's
  content byte-for-byte; only the tail's trailing whitespace is normalized, so
  repeat edits cannot accrete blank lines. After writing it re-fetches and
  fails if the tail differs by anything beyond that trailing whitespace,
  printing a restore command and exiting non-zero. It also confirms the
  Highlights section is present afterwards, so a write that silently did
  nothing cannot report success. Refuses on a pre-existing Highlights section,
  a missing or duplicated marker, an empty body, and a highlights file that
  doesn't start with a heading. Defaults to a dry run; `--apply` writes and
  takes a backup first, `--replace` is opt-in and cuts at the Highlights
  heading so anything above it survives.
- **`.gitignore`** — ignore `__pycache__/` from the bundled Python helper.

## Why the write path is a script

Everything from `## What's Changed` down is generated once at publish time and
is not reproducible: the compare link, the New Contributors block, the build
provenance attestation ID, and the CI run URL. Putting the splice-and-verify in
a script makes that invariant mechanical rather than a rule to remember.

GitHub stores release bodies with CRLF line endings, so the helper reads them
verbatim and matches the existing ending rather than normalizing — normalizing
rewrites every line below the marker. It also parses `--json body` rather than
`-q .body`, since jq appends a newline that accretes across round-trips.

## Testing

- Guard paths exercised against live releases: refuses a pre-existing
  Highlights section, a missing marker, a duplicated marker, and an empty body;
  does not false-positive on a PR title containing the word "highlights";
  `--replace` preserves the badge row and drops only the old section.
- `--replace` on a head containing an intro heading above Highlights: the
  heading and its prose survive, only the old section is dropped.
- One real end-to-end write against a live release (v2026.07.6), with the
  post-write tail check passing.
- Dry-run against a CRLF release reports the tail carried over with its 22 CR
  bytes intact.

## Notes

- The skill only augments releases whose notes were auto-generated; it will not
  create or regenerate a body.
- `--backfill` and `--since` are instructions in `SKILL.md`, not flags on the
  script — nothing enforces them. Backfill is also unbounded: it enumerates and
  asks before touching anything, but nothing stops a confirmed sweep reaching
  v0.1.1, which predates both calver and the Switchboard rename.
- The script has no automated test surface; validation is the interactive
  testing above.
