### PR TITLE
fix(net): run API calls off the caller's dispatcher (#326)

### DIFF
--- a/core/common/CLAUDE.md
+++ b/core/common/CLAUDE.md
@@ -5,32 +5,43 @@ Pure Kotlin utilities shared by all modules. This is the lowest layer -- no othe
 ## What This Module Provides
 
 - **Result sealed class** (`result/Result.kt`): `Success<T>`, `Error(exception, message)`, `Loading`. Used by repositories and ViewModels to propagate outcomes.
-- **Dispatcher & Scope DI** (`di/CommonModule.kt`): Named Koin qualifiers (`named("io")`, `named("default")`, `named("main")`) for dispatchers and `named("applicationScope")` for coroutine scope. Always inject dispatchers -- never hardcode `Dispatchers.IO`.
+- **Dispatcher & Scope DI** (`di/CommonModule.kt`): Named Koin qualifiers (`named("io")`, `named("default")`, `named("main")`) for dispatchers and `named("applicationScope")` for coroutine scope. Always inject dispatchers -- never hardcode `Dispatchers.IO`. The sole exception is `safeApiCall` / `onApiDispatcher`, which read the platform `ioDispatcher` directly; see below for why.
 - **Extensions** (`extensions/`): `StringExt`, `DateExt`, `FlowExt` (includes `retryWithBackoff`, `throttleFirst`).
 - **ConnectivityObserver**: Wraps Android `ConnectivityManager.NetworkCallback` to detect network changes. Used by SSE reconnection logic.
 
 ## safeApiCall Pattern
 
-All repository implementations use this to wrap network calls:
+All repository implementations use this to wrap network calls. It does two things: run the block on
+the IO dispatcher, and turn a failure into a displayable `Result.Error` (`toSafeError` classifies it
+into a `FailureKind` and screens server text before it can reach the UI).
 
 ```kotlin
 suspend fun <T> safeApiCall(block: suspend () -> T): Result<T> =
     try {
-        Result.Success(block())
-    } catch (e: ClientRequestException) {      // 4xx
-        Result.Error(e, parseErrorMessage(e.response.bodyAsText()))
-    } catch (e: ServerResponseException) {      // 5xx
-        Result.Error(e, "Server error. Please try again.")
-    } catch (e: HttpRequestTimeoutException) {
-        Result.Error(e, "Request timed out.")
-    } catch (e: IOException) {
-        Result.Error(e, "Network unavailable. Check your connection.")
-    } catch (e: SerializationException) {
-        Result.Error(e, "Unexpected response format.")
+        Result.Success(withContext(ioDispatcher) { block() })
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        e.toSafeError()
     }
 ```
 
 This lives here (not in `:core:network`) because repositories in `:core:data` call it.
+
+**The dispatcher hop is deliberately here rather than at the call sites**, and it is the one
+sanctioned exception to the "always inject dispatchers" rule stated above. Ktor's engine does its socket
+I/O on engine threads, but the continuation resumes in the caller's context — so body
+deserialization, the auth plugin's `401` branch, the token refresh it drives and that refresh's
+keystore-backed reads all run wherever the call was launched from. Several cold-start paths launch
+from `viewModelScope`, which put all of it on the UI thread (#326). One hop in the wrapper every API
+call already funnels through covers all of them and cannot be forgotten by a repository added later.
+A Ktor plugin was the other candidate. It would have to cover two pipelines rather than one — the
+send, and the response pipeline that `body()` drives — and it still would not cover the Room and
+DataStore work that sits in the same block as the call.
+
+`onApiDispatcher { }` is the same hop **without** the error mapping, for the handful of calls that
+classify their own failures (a bespoke validation message, or a first attempt whose failure is
+expected and must not be logged as an error). Prefer `safeApiCall` unless you are one of those.
 
 ## Rules
 

--- a/core/common/src/commonMain/kotlin/com/garfiec/librechat/core/common/result/Result.kt
+++ b/core/common/src/commonMain/kotlin/com/garfiec/librechat/core/common/result/Result.kt
@@ -1,7 +1,9 @@
 package com.garfiec.librechat.core.common.result
 
 import co.touchlab.kermit.Logger
+import com.garfiec.librechat.core.common.di.ioDispatcher
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.withContext
 
 sealed interface Result<out T> {
     data class Success<T>(val data: T) : Result<T>
@@ -32,9 +34,21 @@ fun <T> Result<T>.getOrThrow(): T = when (this) {
     is Result.Loading -> throw IllegalStateException("Result is still loading")
 }
 
+/**
+ * Runs [block] on [ioDispatcher] and turns a failure into a displayable [Result.Error].
+ *
+ * The hop belongs here, not at the call sites: Ktor resumes the continuation in the caller's
+ * context, so body decode, the auth plugin's `401` branch and the token refresh it drives all run
+ * wherever the call was launched from — the UI thread, for anything on `viewModelScope`. Do not
+ * drop it on the grounds that the engine already does its socket I/O off-thread (#326); see
+ * `core/common/CLAUDE.md`.
+ *
+ * Note that this wraps the whole block, not just the network call — a block that also touches Room
+ * or DataStore gets those reads and writes on the IO dispatcher too, which is where they belong.
+ */
 suspend fun <T> safeApiCall(block: suspend () -> T): Result<T> =
     try {
-        Result.Success(block())
+        Result.Success(withContext(ioDispatcher) { block() })
     } catch (e: CancellationException) {
         // Cooperative cancellation must propagate — callers rely on cancel()ed jobs
         // not writing stale errors back to state (e.g. SettingsViewModel.loadUserJob).
@@ -42,6 +56,13 @@ suspend fun <T> safeApiCall(block: suspend () -> T): Result<T> =
     } catch (e: Exception) {
         e.toSafeError()
     }
+
+/**
+ * [safeApiCall]'s dispatcher hop without its error mapping, for the few API calls that classify
+ * their own failures. Prefer [safeApiCall] unless you are one of those: it logs at error level, so
+ * routing an expected failure through it puts a `Logger.e` on a path that fails by design.
+ */
+suspend fun <T> onApiDispatcher(block: suspend () -> T): T = withContext(ioDispatcher) { block() }
 
 /**
  * Turns a caught failure into a [Result.Error] whose message is fit to display, and sends the full

--- a/core/common/src/commonTest/kotlin/com/garfiec/librechat/core/common/result/SafeApiCallTest.kt
+++ b/core/common/src/commonTest/kotlin/com/garfiec/librechat/core/common/result/SafeApiCallTest.kt
@@ -1,7 +1,10 @@
 package com.garfiec.librechat.core.common.result
 
+import com.garfiec.librechat.core.common.di.ioDispatcher
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.test.runTest
+import kotlin.coroutines.ContinuationInterceptor
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -40,6 +43,35 @@ class SafeApiCallTest {
     fun safeApiCallPropagatesCancellation() = runTest {
         assertFailsWith<CancellationException> {
             safeApiCall<String> { throw CancellationException("cancelled") }
+        }
+    }
+
+    /**
+     * Asserts on the interceptor rather than a thread name so it holds on both platforms. `runTest`
+     * installs a dispatcher of its own, so a missing hop fails this rather than passing by
+     * coincidence.
+     */
+    @Test
+    fun safeApiCallRunsItsBlockOnTheIoDispatcher() = runTest {
+        var inside: ContinuationInterceptor? = null
+        val result = safeApiCall {
+            inside = currentCoroutineContext()[ContinuationInterceptor]
+            "ok"
+        }
+        assertIs<Result.Success<String>>(result)
+        assertSame(ioDispatcher, inside)
+    }
+
+    @Test
+    fun onApiDispatcherRunsItsBlockOnTheIoDispatcher() = runTest {
+        val inside = onApiDispatcher { currentCoroutineContext()[ContinuationInterceptor] }
+        assertSame(ioDispatcher, inside)
+    }
+
+    @Test
+    fun onApiDispatcherLetsFailuresEscape() = runTest {
+        assertFailsWith<IllegalStateException> {
+            onApiDispatcher { throw IllegalStateException("boom") }
         }
     }
 

--- a/core/common/src/iosMain/kotlin/com/garfiec/librechat/core/common/di/Dispatchers.ios.kt
+++ b/core/common/src/iosMain/kotlin/com/garfiec/librechat/core/common/di/Dispatchers.ios.kt
@@ -2,5 +2,12 @@ package com.garfiec.librechat.core.common.di
 
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
 
-actual val ioDispatcher: CoroutineDispatcher = Dispatchers.Default
+// Dispatchers.IO, not Default: this carries blocking work — sockets, the Keychain read behind a
+// token fetch, JSON decode — and on Native Default is a MultiWorkerDispatcher sized to the core
+// count, shared with applicationScope. Since safeApiCall routes every API call through here (#326),
+// leaving it on Default would let a cold-start fan-out occupy every CPU worker waiting on sockets.
+// Native's Dispatchers.IO is its own worker pool, so that contention goes away; Room's iOS query
+// context already uses it (DataPlatformModule.ios.kt).
+actual val ioDispatcher: CoroutineDispatcher = Dispatchers.IO

--- a/core/data/CLAUDE.md
+++ b/core/data/CLAUDE.md
@@ -72,7 +72,14 @@ re-login through the normal expired-session flow.
 
 - Dependencies: `:core:network`, `:core:model`, `:core:common`, Room, DataStore, security-crypto, Ktor, kotlinx-serialization, Timber, Koin.
 - Convention plugins: `librechat.mobile.library` + `librechat.mobile.koin` + `librechat.mobile.room` + `librechat.kotlin.serialization`.
-- Repositories must use `safeApiCall` from `:core:common` for all network calls.
+- Repositories must use `safeApiCall` from `:core:common` for all network calls. It carries the IO
+  dispatcher hop as well as the error mapping (#326), so an API invocation reached any other way runs
+  on whatever dispatcher the caller happened to launch from — the UI thread, for anything started
+  from `viewModelScope`. **The invariant: every `:core:network` API-service invocation sits inside
+  `safeApiCall`, inside `onApiDispatcher` (the same hop without the mapping, for calls that classify
+  their own failures), or inside a flow that ends in `.flowOn(dispatcher)`.** The one HTTP call in
+  this module that isn't an API-service method — `CommonTokenDataStore`'s token-refresh POST — is
+  always driven from inside a request that already took the hop.
 - Entities are internal to this module -- feature modules work with domain models from `:core:model`.
 - All DAO read methods that the UI observes should return `Flow`, not suspend functions.
 

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/CommonTokenDataStore.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/CommonTokenDataStore.kt
@@ -332,8 +332,9 @@ abstract class CommonTokenDataStore(
         currentAccessToken: String?,
     ): String? {
         // Everything before the refresh is pure computation on values the caller already holds: no
-        // storage read, no mutex. That matters because this runs on EVERY request the barrier builds,
-        // on the caller's dispatcher, which for several cold-start repositories is main (issue #326).
+        // storage read, no mutex. That matters because this runs on EVERY request the barrier builds.
+        // (It is no longer on the UI thread while doing so — safeApiCall now hops to the IO
+        // dispatcher before the request is issued, #326 — but per-request cost still has to be nil.)
         if (currentAccessToken == null) return currentAccessToken
         if (!isNearingExpiry(currentAccessToken)) return currentAccessToken
         // Resolve the slot exactly as [performRefresh] will, so suppression is tracked against the

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/ChatRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/ChatRepositoryImpl.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 
@@ -127,7 +128,9 @@ class ChatRepositoryImpl(
         conversationId: String,
         claimSteers: (List<PendingSteer>) -> Unit,
     ): ChatStatusResponse {
-        val status = chatApi.getChatStatus(conversationId)
+        // Throws rather than returning a Result, so it never gets safeApiCall's dispatcher hop;
+        // take it explicitly (#326).
+        val status = withContext(dispatcher) { chatApi.getChatStatus(conversationId) }
         // Before returning, so no staleness guard at the call site can sit between the read and
         // the claim. The server already deleted its copy answering this request.
         claimSteers(status.unrecoveredSteers)

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/ConfigRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/ConfigRepositoryImpl.kt
@@ -105,7 +105,9 @@ class ConfigRepositoryImpl(
         onValid: suspend (StartupConfig) -> Unit,
     ): Result<StartupConfig> {
         return try {
-            val config = configApi.getStartupConfig()
+            // Maps its own failures instead of going through safeApiCall, so it takes
+            // safeApiCall's dispatcher hop explicitly (#326).
+            val config = withContext(dispatcher) { configApi.getStartupConfig() }
             if (!isValidLibreChatConfig(config)) {
                 Result.Error(message = "This doesn't appear to be a LibreChat server")
             } else {

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/FileRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/FileRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.garfiec.librechat.core.data.repository
 
 import com.garfiec.librechat.core.common.BackendVersion
 import com.garfiec.librechat.core.common.result.Result
+import com.garfiec.librechat.core.common.result.onApiDispatcher
 import com.garfiec.librechat.core.common.result.safeApiCall
 import com.garfiec.librechat.core.model.FileObject
 import com.garfiec.librechat.core.model.request.DeleteFileEntry
@@ -105,8 +106,12 @@ class FileRepositoryImpl(
      */
     override suspend fun downloadFile(userId: String, fileId: String): Result<ByteArray> {
         try {
-            val urlResponse = filesApi.getDownloadUrl(userId, fileId)
-            return Result.Success(filesApi.downloadFromUrl(urlResponse.url))
+            // onApiDispatcher, not safeApiCall: safeApiCall would log every one of these expected
+            // failures at error level. The dispatcher hop is still required (#326).
+            return onApiDispatcher {
+                val urlResponse = filesApi.getDownloadUrl(userId, fileId)
+                Result.Success(filesApi.downloadFromUrl(urlResponse.url))
+            }
         } catch (e: CancellationException) {
             throw e
         } catch (_: Exception) {

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/RoleRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/RoleRepositoryImpl.kt
@@ -4,6 +4,7 @@ import co.touchlab.kermit.Logger
 import com.garfiec.librechat.core.common.identity.AccountState
 import com.garfiec.librechat.core.common.identity.ActiveAccountProvider
 import com.garfiec.librechat.core.common.result.Result
+import com.garfiec.librechat.core.common.result.onApiDispatcher
 import com.garfiec.librechat.core.common.result.safeApiCall
 import com.garfiec.librechat.core.data.datastore.RoleCacheDataStore
 import com.garfiec.librechat.core.model.permissions.UserRolePermissions
@@ -50,7 +51,9 @@ class RoleRepositoryImpl(
         }
 
         return try {
-            val role = rolesApi.getRole(user.role)
+            // Not safeApiCall: the catch below falls back to the cached role rather than mapping
+            // the failure. The hop is still needed (#326).
+            val role = onApiDispatcher { rolesApi.getRole(user.role) }
             _userPermissions.value = role
             cacheDataStore.save(role)
             Result.Success(role)

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/SkillsRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/SkillsRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.garfiec.librechat.core.data.repository
 
 import com.garfiec.librechat.core.common.result.ApiException
 import com.garfiec.librechat.core.common.result.Result
+import com.garfiec.librechat.core.common.result.onApiDispatcher
 import com.garfiec.librechat.core.common.result.safeApiCall
 import com.garfiec.librechat.core.model.Skill
 import com.garfiec.librechat.core.model.SkillFile
@@ -16,6 +17,12 @@ import com.garfiec.librechat.core.network.api.SkillsApi
 import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.json.Json
 
+/**
+ * Create, update, upload and import map their own failures — the server's `issues` array carries
+ * validation detail (reserved name prefix, path traversal, a name conflict) that a generic message
+ * would throw away — so they hand-roll the try/catch instead of using `safeApiCall`, and take its
+ * dispatcher hop explicitly via `onApiDispatcher` (#326). The rest of the class uses `safeApiCall`.
+ */
 class SkillsRepositoryImpl(
     private val skillsApi: SkillsApi,
     private val json: Json,
@@ -34,7 +41,7 @@ class SkillsRepositoryImpl(
 
     override suspend fun createSkill(request: CreateSkillRequest): Result<Skill> {
         return try {
-            Result.Success(skillsApi.createSkill(request))
+            Result.Success(onApiDispatcher { skillsApi.createSkill(request) })
         } catch (e: CancellationException) {
             throw e
         } catch (e: ApiException) {
@@ -48,7 +55,7 @@ class SkillsRepositoryImpl(
 
     override suspend fun updateSkill(id: String, request: UpdateSkillRequest): SkillUpdateResult {
         return try {
-            SkillUpdateResult.Success(skillsApi.updateSkill(id, request))
+            SkillUpdateResult.Success(onApiDispatcher { skillsApi.updateSkill(id, request) })
         } catch (e: CancellationException) {
             throw e
         } catch (e: ApiException) {
@@ -81,7 +88,9 @@ class SkillsRepositoryImpl(
         mimeType: String,
     ): Result<SkillFile> {
         return try {
-            Result.Success(skillsApi.uploadSkillFile(skillId, relativePath, bytes, filename, mimeType))
+            Result.Success(
+                onApiDispatcher { skillsApi.uploadSkillFile(skillId, relativePath, bytes, filename, mimeType) },
+            )
         } catch (e: CancellationException) {
             throw e
         } catch (e: ApiException) {
@@ -98,7 +107,7 @@ class SkillsRepositoryImpl(
 
     override suspend fun importSkill(bytes: ByteArray, filename: String, mimeType: String): Result<Skill> {
         return try {
-            Result.Success(skillsApi.importSkill(bytes, filename, mimeType))
+            Result.Success(onApiDispatcher { skillsApi.importSkill(bytes, filename, mimeType) })
         } catch (e: CancellationException) {
             throw e
         } catch (e: ApiException) {


### PR DESCRIPTION
## Summary

Nothing in the repository layer moved HTTP work off the caller's thread, so whether a response was
handled on the main thread was decided entirely by whichever scope launched the request. Ktor's
OkHttp engine does its socket I/O on engine threads, but the continuation resumes in the caller's
context — so body deserialization, the auth plugin's `401` branch, the token refresh that branch
drives and that refresh's keystore-backed `EncryptedSharedPreferences` reads all ran wherever the
call started. Several cold-start fetches launch from `viewModelScope`, which put all of that on the
UI thread while the app was drawing its first frame — `/api/banner` and `/api/config` from
`NavHostViewModel`, `/api/convos` and `/api/projects` from `DrawerViewModel`.

Closes #326.

## Changes

**The hop goes inside `safeApiCall` (`:core:common`)**, not into each repository as the issue
proposed. There are 148 call sites across the 28 repository impls that use it, and only 4 of those
inject a dispatcher today, so per-repository would mean 24 new constructor parameters plus the DI
and test churn — and it would stay forgettable for the next repository added. A Ktor plugin was the
other candidate: it would have to cover two pipelines rather than one — the send, and the response
pipeline that `body()` drives — and it still would not cover the Room and DataStore work sitting in
the same block as the call.

**iOS: the `io` qualifier moves from `Dispatchers.Default` to `Dispatchers.IO`.** Routing every API
call through `ioDispatcher` is what makes that matter. On Native, `Dispatchers.Default` is a worker
pool sized to the core count and shared with `applicationScope`, so without this the change would
park every CPU worker on a socket during a cold-start fan-out — a regression on iOS in exchange for
the Android fix. Native's `Dispatchers.IO` is a separate pool, and Room's iOS query context already
uses it.

The hop wraps the whole `safeApiCall` block rather than only its network call, so a block that also
touches Room or DataStore now does those reads and writes on the IO dispatcher too. That is a
widening beyond the title, and it is the right direction — those were the other things running on
the caller's thread.

**`onApiDispatcher`** is the same hop without the error mapping. Nine API invocations across five
repositories don't go through `safeApiCall` — they read a server validation message off the response
body, fall back to a cached value, make a first attempt whose failure is expected, or throw rather
than returning a `Result` — and routing those through `safeApiCall` would put a `Logger.e` on a path
that fails by design. They take the hop explicitly instead: `withContext(dispatcher)` where the
repository already injects one (`ChatRepositoryImpl.checkStreamStatus`,
`ConfigRepositoryImpl.fetchAndValidateConfig`), `onApiDispatcher` where it does not
(`FileRepositoryImpl.downloadFile`, `RoleRepositoryImpl.fetchUserRole`, and skill create / update /
upload / import).

**Documentation.** `core/common/CLAUDE.md`'s `safeApiCall` snippet was fictional — it showed catches
for `ClientRequestException` / `ServerResponseException` / `IOException` with hardcoded strings that
the function has never had — and is now the real implementation plus the reason the hop lives there.
`core/data/CLAUDE.md` gains the invariant: **every `:core:network` API-service invocation sits inside
`safeApiCall`, inside `onApiDispatcher`, or inside a flow that ends in `.flowOn(dispatcher)`.**
Streaming already satisfied it. A stale comment in `CommonTokenDataStore` that still described the
proactive-renewal path as running on the UI thread is corrected.

## Testing

Three new tests in `SafeApiCallTest`; two of them pin the hop on the `ContinuationInterceptor` rather
than on a thread name, so they assert the same thing on both platforms, and `runTest` installs a
dispatcher of its own, so removing the hop fails them rather than passing by coincidence.

Full unit suite: **2070 tests, 0 failures**. No existing test needed a dispatcher override, so no
test-only seam was added to production code.

`./gradlew testDebugUnitTest :app:assembleDebug detektMetadataCommonMain` passes.
`:core:common:compileKotlinIosSimulatorArm64` passes for the iOS dispatcher change. `:core:common`'s
iOS *test* compile fails on a pre-existing illegal test-method name in `SafeErrorMessageTest.kt`,
untouched by this branch. No iOS device or simulator run.

Coverage was checked mechanically rather than by inspection: every `*Api.method(...)` invocation in
`:core:data` was walked back to its enclosing function and required to sit inside `safeApiCall`,
inside `onApiDispatcher`, or inside a flow ending in `.flowOn(dispatcher)`. Zero uncovered remain.

### Device pass

Pixel 10 Pro Fold AVD (API 37) against a local LibreChat server, replaying one snapshotted
dead-session cold start so both builds see identical state. Each build fingerprinted by dex symbol
before its run, since the emulator is shared. StrictMode's thread policy was armed temporarily
(`detectDiskReads` / `detectDiskWrites` / `detectCustomSlowCalls` / `detectNetwork`, `penaltyLog`) —
instrumentation only, not committed.

Main-thread log lines, counted by TID == PID in `logcat -v threadtime`:

| | `develop` (57382993) | this branch |
|---|---|---|
| `401 received` on main | **10** of 19 | **0** of 19 |
| `refresh_rejected` on main | **2** of 11 | **0** of 21 |
| `refresh_proactive` on main | **2** of 7 | **0** of 18 |

The baseline reproduces the issue's original measurement (it reported 11 of 16). Both criteria pass.

StrictMode reported 11 main-thread violations on **both** builds, and on both every one attributes to
`TokenDataStore.createEncryptedPrefs` — the `MasterKey` / `EncryptedSharedPreferences` construction at
Koin startup — plus one `cacheDir` read in `DataPlatformModule`. **None come from the auth or HTTP
path on either build**, which is the criterion; the construction-time ones are the out-of-scope item
noted below, and this change neither fixes nor worsens them.

Outcome behaviour is unchanged: 19 refresh legs entered, 19 settled `session expired`, exactly **one**
`session_torn_down`, and the same `NewChat → ServerUrl` screen sequence — so #323's
one-teardown-per-session behaviour is preserved. The one delta is that more refresh POSTs complete
inside the 22 s capture window (11 → 21) with the same number of refresh legs entered; the retry loops
now actually run instead of being starved behind a blocked main thread.

## Notes

- `safeApiCall` bodies no longer run on the test dispatcher, so a mocked `delay()` inside one is now
  real time rather than virtual (two 50 ms sleeps in `RepositoryCacheMutexTest`). The shape that
  would actually break — `launch { repo.call() }`, `advanceUntilIdle()`, assert — appears in none of
  the 14 test files that construct a real repository, so no test-only dispatcher override was added
  to production code.
- Out of scope, and untouched: `EncryptedSharedPreferences.create` and the initial token decrypt
  still run on the main thread during `TokenDataStore` construction at `startKoin`. That is the
  largest remaining item in the #326 family; it is already flagged in a comment in
  `NavHostViewModel`, and it isn't reachable from this seam because it happens before any request.
- `CommonTokenDataStore`'s token-refresh POST is the one HTTP call in `:core:data` that isn't an
  API-service method and so isn't covered by the invariant above. It is always driven from inside a
  request that already took the hop.
