### PR TITLE
fix(chat): keep a subagent's generated files visible when its card collapses

### DIFF
--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ActivityGroup.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ActivityGroup.kt
@@ -74,7 +74,8 @@ internal fun ActivityGroup(
     autoExpand: Boolean = false,
     autoExpandKey: Any? = null,
     /**
-     * The files this block's tool calls produced.
+     * The files this block's tool calls produced, including those of the calls they ran nested
+     * inside a subagent.
      *
      * **Load-bearing: rendered as a SIBLING AFTER the collapsible, never inside it.** The block
      * folds away the *process*; a generated image is the *result*, and moving this inside folds

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/SubagentTraceCard.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/SubagentTraceCard.kt
@@ -47,6 +47,19 @@ import com.garfiec.librechat.feature.chat.viewmodel.SubagentTrace
 import org.jetbrains.compose.resources.stringResource
 
 /**
+ * The parts a trace card renders, in its reload precedence order: persisted content is
+ * authoritative over any live buffer.
+ *
+ * Shared with [ToolCallDispatcher], which walks the same run for the tool-call ids it has to hoist
+ * — resolve it twice by hand and the two drift into hoisting one run's ids while rendering another's.
+ */
+internal fun subagentTraceParts(
+    persistedParts: List<MessageContentPart>?,
+    liveTrace: SubagentTrace?,
+): List<MessageContentPart> =
+    persistedParts?.takeIf { it.isNotEmpty() } ?: liveTrace?.parts.orEmpty()
+
+/**
  * Collapsible card rendering a child agent's run (v0.8.6 subagents). Mirrors the
  * thinking/summary cards: a tappable header with the subagent's name + a live
  * ticker (phase), an in-progress spinner until the run resolves, and an
@@ -62,6 +75,11 @@ import org.jetbrains.compose.resources.stringResource
  * Depth is capped at 1: nested parts are rendered with `allowSubagentCard=false`
  * so a subagent tool_call inside a subagent never recurses into another trace
  * card (it falls back to the generic tool-call card).
+ *
+ * **Nested parts render with `hideAttachments`; the files they produced are the caller's to place.**
+ * [ToolCallDispatcher] hoists the whole subtree's output to a sibling below this card (or hands the
+ * ids to the enclosing activity group). Dropping the flag here renders those files twice; dropping
+ * the hoist renders them nowhere.
  */
 @Composable
 internal fun SubagentTraceCard(
@@ -76,8 +94,7 @@ internal fun SubagentTraceCard(
     // conversation slot, so expansion bled between unrelated cards.
     stateKey: String = "",
 ) {
-    // Reload precedence: persisted content is authoritative over any live buffer.
-    val parts = persistedParts?.takeIf { it.isNotEmpty() } ?: liveTrace?.parts.orEmpty()
+    val parts = subagentTraceParts(persistedParts, liveTrace)
     val isComplete = persistedParts != null || (liveTrace?.isComplete ?: true)
     val title = liveTrace?.subagentType?.takeIf { it.isNotBlank() }
         ?: liveTrace?.label?.takeIf { it.isNotBlank() }
@@ -145,6 +162,8 @@ internal fun SubagentTraceCard(
                             stateKey = "$stateKey:$index",
                             // Depth-1 guard: a nested subagent renders flat, never another card.
                             allowSubagentCard = false,
+                            // The caller hoists this subtree's files out — see the KDoc.
+                            hideAttachments = true,
                         )
                     }
                 }

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ToolCallContentPart.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ToolCallContentPart.kt
@@ -70,23 +70,35 @@ internal fun ToolCallDispatcher(
     // Subagent tool_call → collapsible trace card (v0.8.6). Live progress comes
     // from LocalSubagentProgress (keyed by the parent tool_call id); persisted
     // `subagentContent` (reload) takes precedence inside the card. Depth-1:
-    // nested parts pass allowSubagentCard=false so this never recurses. Nested parts
-    // render their own attachments, so this branch keeps its pass-through return.
-    // hideAttachments is deliberately NOT forwarded: a group only collects the ids of its OWN
-    // parts, so a subagent's nested calls are never hoisted and suppressing them here would
-    // render them nowhere.
+    // nested parts pass allowSubagentCard=false so this never recurses.
+    //
+    // The files this call itself produced render BELOW the card, under the same hideAttachments
+    // guard every other branch uses so an enclosing activity group can hoist them instead. Mirrors
+    // upstream `SubagentCall.tsx`, whose own AttachmentGroup sits outside the dialog behind that
+    // guard. Nested parts still render their own attachments: a group collects only the ids of its
+    // OWN parts, so nothing of theirs is hoisted and suppressing them would render them nowhere.
     if (allowSubagentCard && toolNameLower == ToolConstants.SUBAGENT) {
         val toolCallId = toolCall?.id
         val liveTrace = toolCallId?.let { LocalSubagentProgress.current[it] }
-        SubagentTraceCard(
-            persistedParts = toolCall?.subagentContent,
-            liveTrace = liveTrace,
-            modifier = modifier,
-            baseUrl = baseUrl,
-            attachments = attachments,
-            showImageDescriptions = showImageDescriptions,
-            stateKey = cardKey,
-        )
+        Column(modifier = modifier) {
+            SubagentTraceCard(
+                persistedParts = toolCall?.subagentContent,
+                liveTrace = liveTrace,
+                modifier = Modifier.fillMaxWidth(),
+                baseUrl = baseUrl,
+                attachments = attachments,
+                showImageDescriptions = showImageDescriptions,
+                stateKey = cardKey,
+            )
+            if (!hideAttachments) {
+                ToolCallAttachments(
+                    attachments = attachments,
+                    toolCallId = toolCallId,
+                    baseUrl = baseUrl,
+                    modifier = Modifier.padding(top = 8.dp),
+                )
+            }
+        }
         return
     }
 

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ToolCallContentPart.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ToolCallContentPart.kt
@@ -40,6 +40,7 @@ import com.garfiec.librechat.core.model.Attachment
 import com.garfiec.librechat.core.model.content.MessageContentPart
 import com.garfiec.librechat.feature.chat.resources.*
 import com.garfiec.librechat.feature.chat.resources.Res
+import com.garfiec.librechat.feature.chat.util.outputToolCallIds
 import org.jetbrains.compose.resources.stringResource
 
 // ─── ToolCallDispatcher ─────────────────────────────────────────────
@@ -72,14 +73,13 @@ internal fun ToolCallDispatcher(
     // `subagentContent` (reload) takes precedence inside the card. Depth-1:
     // nested parts pass allowSubagentCard=false so this never recurses.
     //
-    // The files this call itself produced render BELOW the card, under the same hideAttachments
-    // guard every other branch uses so an enclosing activity group can hoist them instead. Mirrors
-    // upstream `SubagentCall.tsx`, whose own AttachmentGroup sits outside the dialog behind that
-    // guard. Nested parts still render their own attachments: a group collects only the ids of its
-    // OWN parts, so nothing of theirs is hoisted and suppressing them would render them nowhere.
+    // The card's nested parts are drawn with hideAttachments, so the whole subtree's files — the
+    // subagent's own and its nested calls' — hoist out to here instead. Both ends move together;
+    // see [outputToolCallIds].
     if (allowSubagentCard && toolNameLower == ToolConstants.SUBAGENT) {
         val toolCallId = toolCall?.id
         val liveTrace = toolCallId?.let { LocalSubagentProgress.current[it] }
+        val tracedParts = subagentTraceParts(toolCall?.subagentContent, liveTrace)
         Column(modifier = modifier) {
             SubagentTraceCard(
                 persistedParts = toolCall?.subagentContent,
@@ -91,9 +91,14 @@ internal fun ToolCallDispatcher(
                 stateKey = cardKey,
             )
             if (!hideAttachments) {
-                ToolCallAttachments(
-                    attachments = attachments,
-                    toolCallId = toolCallId,
+                val hoisted = remember(attachments, toolCallId, tracedParts) {
+                    collectGroupAttachments(
+                        attachments,
+                        listOfNotNull(toolCallId?.takeIf { it.isNotEmpty() }) + outputToolCallIds(tracedParts),
+                    )
+                }
+                ToolAttachmentBuckets(
+                    buckets = hoisted,
                     baseUrl = baseUrl,
                     modifier = Modifier.padding(top = 8.dp),
                 )

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/util/ContentSegments.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/util/ContentSegments.kt
@@ -118,15 +118,40 @@ sealed interface ContentGroup {
 }
 
 /**
- * The ids of the tool calls inside this block, in render order; blank ids and non-tool entries
- * drop out.
+ * The ids of the tool calls whose output this block owns, in render order.
  *
  * Keep the attachment join at the render site rather than folding it into [ContentGroup]: that
  * would widen the grouping memo's key to include attachments and re-run the whole segmentation
  * pass on every mid-stream `attachment` event.
  */
 fun ContentGroup.Activity.groupedToolCallIds(): List<String> =
-    entries.mapNotNull { it.part.toolCall?.id?.takeIf(String::isNotEmpty) }
+    outputToolCallIds(entries.map { it.part })
+
+/**
+ * Every tool-call id whose output belongs to [parts]: each call's own id, then the ids of the calls
+ * it ran nested inside it (`subagent_content`), recursively. Blank ids and non-tool parts drop out.
+ *
+ * **Load-bearing that this descends.** A subagent draws its nested parts with `hideAttachments`, so
+ * this walk is the only thing that puts their files on screen. Narrow it back to the top level and
+ * nested output renders nowhere.
+ *
+ * **DELIBERATE DIVERGENCE — a sync must NOT "correct" this toward upstream.** Upstream builds a
+ * group's attachment set from `group.parts` alone (`ContentParts.tsx:365-369`) and hands its
+ * subagent dialog no attachments, so a file generated *inside* a subagent is surfaced nowhere on
+ * web. Restoring that parity reads as a harmless narrowing and silently takes the files off screen.
+ */
+fun outputToolCallIds(parts: List<MessageContentPart>): List<String> {
+    val ids = mutableListOf<String>()
+    fun walk(list: List<MessageContentPart>) {
+        list.forEach { part ->
+            val call = part.toolCall ?: return@forEach
+            call.id?.takeIf(String::isNotEmpty)?.let(ids::add)
+            call.subagentContent?.let(::walk)
+        }
+    }
+    walk(parts)
+    return ids
+}
 
 /** The label text an activity-label part carries, trimmed; empty when it is still a reservation. */
 fun MessageContentPart.activityLabelText(): String =

--- a/feature/chat/src/commonTest/kotlin/com/garfiec/librechat/feature/chat/util/ContentSegmentsTest.kt
+++ b/feature/chat/src/commonTest/kotlin/com/garfiec/librechat/feature/chat/util/ContentSegmentsTest.kt
@@ -22,6 +22,12 @@ class ContentSegmentsTest {
             toolCall = AgentToolCall(id = id, name = name, output = output),
         )
 
+    private fun subagent(id: String, nested: List<MessageContentPart>) =
+        MessageContentPart(
+            type = ContentType.TOOL_CALL,
+            toolCall = AgentToolCall(id = id, name = "subagent", output = "done", subagentContent = nested),
+        )
+
     private fun label(
         text: String?,
         pending: Boolean? = null,
@@ -324,5 +330,46 @@ class ContentSegmentsTest {
             .groups.single() as ContentGroup.Activity
 
         assertEquals(listOf("t2"), group.groupedToolCallIds())
+    }
+
+    @Test
+    fun groupedToolCallIdsIncludesCallsNestedInsideASubagent() {
+        val group = onlySegment(
+            listOf(
+                subagent("s1", nested = listOf(tool("n1", name = "image_gen_oai"), tool("n2"))),
+                tool("t2"),
+            ),
+        ).groups.single() as ContentGroup.Activity
+
+        assertEquals(listOf("s1", "n1", "n2", "t2"), group.groupedToolCallIds())
+    }
+
+    // The walk is deliberately uncapped where the render stops at depth 1: a depth-2 subagent draws
+    // no nested parts at all, but its files still have to reach the hoist.
+    @Test
+    fun groupedToolCallIdsDescendsThroughNestedSubagents() {
+        val group = onlySegment(
+            listOf(
+                subagent("s1", nested = listOf(subagent("s2", nested = listOf(tool("n1"))))),
+                label("Ran a subagent"),
+            ),
+        ).groups.single() as ContentGroup.Activity
+
+        assertEquals(listOf("s1", "s2", "n1"), group.groupedToolCallIds())
+    }
+
+    // The ungrouped path: a lone subagent call never forms a group, and mid-run there is no
+    // persisted `subagent_content` to walk — the live trace's parts are fed in directly.
+    @Test
+    fun outputToolCallIdsWalksALooseRunOfParts() {
+        assertEquals(
+            listOf("n1", "n2"),
+            outputToolCallIds(listOf(think("pondering"), tool("n1"), text("done"), tool("n2"))),
+        )
+    }
+
+    @Test
+    fun outputToolCallIdsSkipsBlankAndNonToolParts() {
+        assertEquals(listOf("n2"), outputToolCallIds(listOf(text("hi"), tool(""), tool("n2"))))
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to #348. That fix hoisted a tool group's attachments out of the collapsible so generated images stopped disappearing, but it could not reach files produced **inside** a subagent: a group collects only the ids of its own parts, and a nested call's id is not among them. A subagent's trace card renders its nested parts in its own collapsible and is itself groupable, so those images sat behind two folds and vanished on reopen.

## Changes

Two commits, deliberately separable:

- **parity** — The subagent branch of `ToolCallDispatcher` returned before reaching the attachment render, so files the `subagent` call itself produced rendered nowhere when the call wasn't grouped, and were hoisted when it was. Behaviour depended on whether grouping happened to kick in, which the user can neither see nor predict. They now render below the card under the same `hideAttachments` guard every other branch uses, so an enclosing activity group still hoists them instead. Mirrors upstream `SubagentCall.tsx:577`.

- **the nested case** — `outputToolCallIds` walks each call's own id and then the ids of the calls it ran nested inside it, so every id whose inline render is suppressed is already claimed by a hoist. Only then is it safe to draw the nested parts with `hideAttachments`. Both halves are one commit on purpose: the forward without the deeper walk reintroduces #348's bug one level down, and the walk without the forward renders each file twice. The dispatcher's hoist and the card's render now resolve the run through one shared `subagentTraceParts()` helper — resolving it twice by hand is how the two would drift into hoisting one run's ids while rendering another's.

**Depth asymmetry, deliberate:** the id walk is uncapped while the render stops at depth 1. A depth-2 subagent falls back to the generic card and draws no nested parts at all, but its output still has to reach the surface.

## Testing

- `./gradlew test detektMetadataCommonMain detekt :app:lint :app:assembleDebug` — green.
- `ContentSegmentsTest` covers the id walk, including a depth-2 nesting case (4 new tests).
- Reverting the second commit returns the tree to upstream parity, where coverage is carried by two tests that predate this work and are deliberately left untouched: `groupedToolCallIdsReturnsToolCallsInOrderAndSkipsReasoning` and `groupedToolCallIdsSkipsBlankIds`.
- **No device verification.** This has not been run on a device or emulator.

## Notes

- **Deliberate divergence from the web client.** Upstream builds a group's attachment set from `group.parts` alone (`ContentParts.tsx:365-369`) and passes its subagent dialog no attachments, so a file generated inside a subagent is surfaced nowhere on web. We hoist it instead, on the same reasoning as #348's choice to render every image rather than only the first: output the user cannot reach is the same class of defect as capping an image-gen render at the first attachment. The KDoc on `outputToolCallIds` records the prohibition and the upstream anchor, so a future `/sync-upstream` pass does not read this as accidental drift and "correct" it back.
- **Known limitation, widened but not introduced.** Provider tool-call ids such as `call_0` repeat across agents in a handoff run, and `Attachment` carries no `agentId` to scope on (web guards with `filterAttachmentsForPart`). Nested ids now join that set, so one attachment can hoist under two groups in a handoff run. Fixing it needs the DTO field; worth its own issue.
- Composable declaration order is untestable here — no Compose harness — so the sibling-after-the-collapsible contract stays in KDoc and the id walk carries the tests.
