### PR TITLE
feat(chat): decode and render file_search and memory attachment payloads

### DIFF
--- a/core/common/src/commonMain/kotlin/com/garfiec/librechat/core/common/Constants.kt
+++ b/core/common/src/commonMain/kotlin/com/garfiec/librechat/core/common/Constants.kt
@@ -20,9 +20,8 @@ object ToolConstants {
     const val PROGRAMMATIC_TOOLS = "programmatic_tools"
     const val DEFERRED_TOOLS = "deferred_tools"
 
-    /** Server-side retrieval tool (`retrieval` / RAG). Rendered as a generic tool card on
-     *  mobile — its structured sources live in the attachment's file_search payload, which
-     *  the mobile Attachment model does not yet carry. */
+    /** Server-side retrieval tool (`retrieval` / RAG). Renders the same sources card as
+     *  [FILE_SEARCH] — both carry their citations in the attachment's `file_search` payload. */
     const val RETRIEVAL = "retrieval"
 
     /** Sandbox "bash tool" — runs a shell command whose `code` arg is the command line.

--- a/core/model/src/commonMain/kotlin/com/garfiec/librechat/core/model/AttachmentPayloads.kt
+++ b/core/model/src/commonMain/kotlin/com/garfiec/librechat/core/model/AttachmentPayloads.kt
@@ -1,0 +1,80 @@
+package com.garfiec.librechat.core.model
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
+
+// The structured payloads a non-file attachment can carry, each nested under a key equal to the
+// attachment's own `type`. Mirrors upstream `TAttachmentMetadata` (`packages/data-provider/src/
+// schemas.ts`), whose four payload keys are `memory`, `ui_resources`, `web_search` and
+// `file_search`; `web_search` lives in `WebSearch.kt` beside the rest of that feature's model.
+
+/**
+ * File-search citations, present only when an attachment's `type` is `file_search`. The tool's
+ * own output is a flat human-readable digest ("File: … / Relevance: … / Content: …"); the
+ * per-source structure — and the `fileId` that ties a citation back to a real uploaded file —
+ * exists only here.
+ *
+ * Mirrors upstream `SearchResultData` for `Tools.file_search`, built by `processFileCitations`
+ * (`api/server/services/Files/Citations/index.js`). The server already applies its own relevance
+ * threshold and per-file caps before sending, so this is the *selected* set, not everything the
+ * retriever matched.
+ */
+@Serializable
+data class FileSearchData(
+    val sources: List<FileSearchSource>? = null,
+)
+
+/** One retrieved passage. Several sources may share a [fileId] — one per matched chunk. */
+@Serializable
+data class FileSearchSource(
+    val fileId: String? = null,
+    val fileName: String? = null,
+    /** The matched passage itself. */
+    val content: String? = null,
+    /** 0..1, higher is better (the server sends `1 - distance`). */
+    val relevance: Double? = null,
+    /** Pages the passage came from; empty for non-paginated sources. */
+    val pages: List<Int>? = null,
+    /** Per-page relevance, keyed by page number as a string (a JSON object key always is one). */
+    val pageRelevance: Map<String, Double>? = null,
+    val metadata: FileSearchSourceMetadata? = null,
+)
+
+/** File metadata the server joins in from its own records (`enhanceSourcesWithMetadata`). */
+@Serializable
+data class FileSearchSourceMetadata(
+    val fileType: String? = null,
+    val fileBytes: Long? = null,
+    val storageType: String? = null,
+)
+
+/**
+ * One memory write, present only when an attachment's `type` is `memory`.
+ *
+ * Emitted for both memory modes, and it is the *only* delivery path for the background memory
+ * agent (`memory.agent.enabled`), whose tool calls run in a separate sub-run and never become
+ * content parts of the reply. Mirrors upstream `MemoryArtifact` (`schemas.ts`), produced by
+ * `createMemoryTool`/`createDeleteMemoryTool` (`packages/api/src/agents/memory.ts`).
+ */
+@Serializable
+data class MemoryArtifactData(
+    /** The memory's key. `system` on the storage-limit errors, which belong to no single memory. */
+    val key: String? = null,
+    /** The remembered text on an `update`; absent on a `delete`; a JSON error blob on an `error`. */
+    val value: String? = null,
+    val tokenCount: Int? = null,
+    /** `update` | `delete` | `error`. */
+    val type: String? = null,
+    /** Set when the write targeted an agent-scoped partition rather than the shared pool. */
+    val agentId: String? = null,
+)
+
+/**
+ * MCP UI resources, present only when an attachment's `type` is `ui_resources`.
+ *
+ * Carried as raw JSON, not decoded structurally: the server forwards
+ * `artifact.ui_resources.data` verbatim and it is not always an array (upstream's own tests cover
+ * an index-keyed object), so a typed decode would reject the whole message's `attachments`.
+ * Nothing renders it yet — upstream's renderer is `@mcp-ui/client`'s `UIResourceRenderer`.
+ */
+typealias UiResources = JsonElement

--- a/core/model/src/commonMain/kotlin/com/garfiec/librechat/core/model/FileModel.kt
+++ b/core/model/src/commonMain/kotlin/com/garfiec/librechat/core/model/FileModel.kt
@@ -105,4 +105,11 @@ data class Attachment(
     /** Web-search sources, present only when [type] == `web_search` (no file_id/filename).
      *  Null for ordinary file attachments. */
     @SerialName("web_search") val webSearch: WebSearchData? = null,
+    /** Retrieval citations, present only when [type] == `file_search`. */
+    @SerialName("file_search") val fileSearch: FileSearchData? = null,
+    /** One memory write, present only when [type] == `memory`. */
+    val memory: MemoryArtifactData? = null,
+    /** MCP UI resources, present only when [type] == `ui_resources`. Carried, not yet rendered —
+     *  see [UiResources]. */
+    @SerialName("ui_resources") val uiResources: UiResources? = null,
 )

--- a/core/model/src/commonMain/kotlin/com/garfiec/librechat/core/model/StreamEvent.kt
+++ b/core/model/src/commonMain/kotlin/com/garfiec/librechat/core/model/StreamEvent.kt
@@ -51,6 +51,12 @@ sealed interface StreamEvent {
         val previewError: String? = null,
         /** Web-search sources when this is a `web_search` attachment (no file). */
         val webSearch: WebSearchData? = null,
+        /** Retrieval citations when this is a `file_search` attachment (no file). */
+        val fileSearch: FileSearchData? = null,
+        /** The memory write when this is a `memory` attachment (no file). */
+        val memory: MemoryArtifactData? = null,
+        /** MCP UI resources when this is a `ui_resources` attachment (no file). */
+        val uiResources: UiResources? = null,
     ) : StreamEvent
 
     data class Final(

--- a/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/sse/SseEventMapperTest.kt
+++ b/core/network/src/androidUnitTest/kotlin/com/garfiec/librechat/core/network/sse/SseEventMapperTest.kt
@@ -602,6 +602,55 @@ class SseEventMapperTest {
         assertThat(result.webSearch!!.topStories!!.single().title).isEqualTo("photosynthesis - Wiktionary")
     }
 
+    @Test
+    fun `maps file_search attachment carrying citations without a file`() {
+        val event = SseEvent(
+            event = "attachment",
+            data = """{"type":"file_search","toolCallId":"call_fs","messageId":"m1","file_search":{"sources":[{"type":"file","fileId":"f1","fileName":"handbook.pdf","content":"leave policy","relevance":0.82,"pages":[4],"pageRelevance":{"4":0.82},"metadata":{"fileType":"application/pdf","fileBytes":2048}}]}}""",
+        )
+        val result = mapper.map(event) as StreamEvent.AttachmentCreated
+        assertThat(result.type).isEqualTo("file_search")
+        assertThat(result.toolCallId).isEqualTo("call_fs")
+        val source = result.fileSearch!!.sources!!.single()
+        assertThat(source.fileId).isEqualTo("f1")
+        assertThat(source.fileName).isEqualTo("handbook.pdf")
+        assertThat(source.relevance).isEqualTo(0.82)
+        assertThat(source.pages).containsExactly(4)
+        assertThat(source.metadata!!.fileType).isEqualTo("application/pdf")
+    }
+
+    @Test
+    fun `maps memory attachment carrying a write without a file`() {
+        val event = SseEvent(
+            event = "attachment",
+            data = """{"type":"memory","toolCallId":"call_mem","messageId":"m1","memory":{"key":"favourite_colour","value":"blue","tokenCount":3,"type":"update"}}""",
+        )
+        val result = mapper.map(event) as StreamEvent.AttachmentCreated
+        assertThat(result.type).isEqualTo("memory")
+        assertThat(result.memory!!.key).isEqualTo("favourite_colour")
+        assertThat(result.memory!!.value).isEqualTo("blue")
+        assertThat(result.memory!!.type).isEqualTo("update")
+    }
+
+    @Test
+    fun `maps ui_resources attachment, keeping the payload as raw JSON`() {
+        // The server forwards `artifact.ui_resources.data` verbatim and it is not always an array,
+        // so the mapper must not impose a shape on it.
+        val event = SseEvent(
+            event = "attachment",
+            data = """{"type":"ui_resources","toolCallId":"call_ui","messageId":"m1","ui_resources":{"0":{"type":"chart","data":[]}}}""",
+        )
+        val result = mapper.map(event) as StreamEvent.AttachmentCreated
+        assertThat(result.type).isEqualTo("ui_resources")
+        assertThat(result.uiResources).isNotNull()
+    }
+
+    @Test
+    fun `still drops an attachment carrying neither a file nor a payload`() {
+        val event = SseEvent(event = "attachment", data = """{"type":"memory","messageId":"m1"}""")
+        assertThat(mapper.map(event)).isNull()
+    }
+
     // --- Legacy Flat Format ---
 
     @Test

--- a/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/sse/SseEventMapper.kt
+++ b/core/network/src/commonMain/kotlin/com/garfiec/librechat/core/network/sse/SseEventMapper.kt
@@ -639,9 +639,9 @@ class SseEventMapper(private val json: Json) {
         val fileId = data["file_id"]?.jsonPrimitive?.contentOrNull ?: ""
         val filename = data["filename"]?.jsonPrimitive?.contentOrNull ?: ""
         val type = data["type"]?.jsonPrimitive?.contentOrNull ?: ""
-        // Web-search results ride in as an attachment with no file — `type == "web_search"`
-        // and the sources nested under the `web_search` key. Parse it before the file guard
-        // so these aren't dropped as "empty" attachments.
+        // Four attachment types ride in with no file at all, carrying a structured payload nested
+        // under a key equal to the attachment's own type (upstream `TAttachmentMetadata`). All of
+        // them are parsed before the file guard below, which would otherwise drop them as "empty".
         val webSearch = data["web_search"]?.let { element ->
             try {
                 json.decodeFromJsonElement(com.garfiec.librechat.core.model.WebSearchData.serializer(), element)
@@ -650,7 +650,26 @@ class SseEventMapper(private val json: Json) {
                 null
             }
         }
-        if (fileId.isBlank() && filename.isBlank() && webSearch == null) return null
+        val fileSearch = data["file_search"]?.let { element ->
+            try {
+                json.decodeFromJsonElement(com.garfiec.librechat.core.model.FileSearchData.serializer(), element)
+            } catch (e: Exception) {
+                Logger.w("SSE", e) { "Failed to parse file_search attachment data" }
+                null
+            }
+        }
+        val memory = data["memory"]?.let { element ->
+            try {
+                json.decodeFromJsonElement(com.garfiec.librechat.core.model.MemoryArtifactData.serializer(), element)
+            } catch (e: Exception) {
+                Logger.w("SSE", e) { "Failed to parse memory attachment data" }
+                null
+            }
+        }
+        // Raw JSON on purpose — a typed decode would discard the whole attachment. See `UiResources`.
+        val uiResources = data["ui_resources"]
+        val hasPayload = webSearch != null || fileSearch != null || memory != null || uiResources != null
+        if (fileId.isBlank() && filename.isBlank() && !hasPayload) return null
         return StreamEvent.AttachmentCreated(
             fileId = fileId,
             filename = filename,
@@ -666,6 +685,9 @@ class SseEventMapper(private val json: Json) {
             textFormat = data["textFormat"]?.jsonPrimitive?.contentOrNull,
             previewError = data["previewError"]?.jsonPrimitive?.contentOrNull,
             webSearch = webSearch,
+            fileSearch = fileSearch,
+            memory = memory,
+            uiResources = uiResources,
         )
     }
 

--- a/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/components/FileSearchSourcesTest.kt
+++ b/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/components/FileSearchSourcesTest.kt
@@ -1,0 +1,144 @@
+package com.garfiec.librechat.feature.chat.components
+
+import com.garfiec.librechat.core.model.Attachment
+import com.garfiec.librechat.core.model.FileSearchData
+import com.garfiec.librechat.core.model.FileSearchSource
+import com.garfiec.librechat.core.model.FileSearchSourceMetadata
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class FileSearchSourcesTest {
+
+    private fun searchAttachment(
+        toolCallId: String?,
+        vararg sources: FileSearchSource,
+    ) = Attachment(
+        type = "file_search",
+        toolCallId = toolCallId,
+        fileSearch = FileSearchData(sources = sources.toList()),
+    )
+
+    @Test
+    fun `orders citations most relevant first`() {
+        val attachments = listOf(
+            searchAttachment(
+                "c1",
+                FileSearchSource(fileId = "f1", fileName = "low.pdf", relevance = 0.3),
+                FileSearchSource(fileId = "f2", fileName = "high.pdf", relevance = 0.9),
+            ),
+        )
+
+        val citations = collectFileSearchSources(attachments, "c1")
+
+        assertThat(citations.map { it.fileName }).containsExactly("high.pdf", "low.pdf").inOrder()
+    }
+
+    @Test
+    fun `merges the chunks that came from one file`() {
+        // The retriever returns one source per matched passage, so a single file arrives several
+        // times; upstream folds them into one row rather than listing the file repeatedly.
+        val attachments = listOf(
+            searchAttachment(
+                "c1",
+                FileSearchSource(
+                    fileId = "f1",
+                    fileName = "notes.pdf",
+                    relevance = 0.4,
+                    content = "first",
+                    pages = listOf(2),
+                ),
+                FileSearchSource(
+                    fileId = "f1",
+                    fileName = "notes.pdf",
+                    relevance = 0.8,
+                    content = "second",
+                    pages = listOf(5),
+                ),
+            ),
+        )
+
+        val citations = collectFileSearchSources(attachments, "c1")
+
+        assertThat(citations).hasSize(1)
+        assertThat(citations.first().relevance).isEqualTo(0.8)
+        assertThat(citations.first().content).isEqualTo("first\n\nsecond")
+        assertThat(citations.first().pages).containsExactly(2, 5).inOrder()
+    }
+
+    @Test
+    fun `orders one source's pages by their own relevance`() {
+        val attachments = listOf(
+            searchAttachment(
+                "c1",
+                FileSearchSource(
+                    fileId = "f1",
+                    fileName = "notes.pdf",
+                    relevance = 0.8,
+                    pages = listOf(2, 7, 4),
+                    pageRelevance = mapOf("2" to 0.1, "7" to 0.9, "4" to 0.5),
+                ),
+            ),
+        )
+
+        val citations = collectFileSearchSources(attachments, "c1")
+
+        assertThat(citations.first().pages).containsExactly(7, 4, 2).inOrder()
+    }
+
+    @Test
+    fun `carries the file type through for the row icon`() {
+        val attachments = listOf(
+            searchAttachment(
+                "c1",
+                FileSearchSource(
+                    fileId = "f1",
+                    fileName = "sheet.csv",
+                    relevance = 0.5,
+                    metadata = FileSearchSourceMetadata(fileType = "text/csv"),
+                ),
+            ),
+        )
+
+        assertThat(collectFileSearchSources(attachments, "c1").first().fileType).isEqualTo("text/csv")
+    }
+
+    @Test
+    fun `excludes attachments belonging to a different tool call`() {
+        val attachments = listOf(
+            searchAttachment("other", FileSearchSource(fileId = "f1", fileName = "a.pdf", relevance = 0.9)),
+            searchAttachment("c1", FileSearchSource(fileId = "f2", fileName = "b.pdf", relevance = 0.5)),
+        )
+
+        val citations = collectFileSearchSources(attachments, "c1")
+
+        assertThat(citations.map { it.fileName }).containsExactly("b.pdf")
+    }
+
+    @Test
+    fun `keeps attachments carrying no tool call id`() {
+        val attachments = listOf(
+            searchAttachment(null, FileSearchSource(fileId = "f1", fileName = "a.pdf", relevance = 0.9)),
+        )
+
+        assertThat(collectFileSearchSources(attachments, "c1")).hasSize(1)
+    }
+
+    @Test
+    fun `ignores web-search attachments`() {
+        val attachments = listOf(
+            Attachment(type = "web_search", toolCallId = "c1"),
+            Attachment(fileId = "f", filename = "chart.png", type = "image/png", toolCallId = "c1"),
+        )
+
+        assertThat(collectFileSearchSources(attachments, "c1")).isEmpty()
+    }
+
+    @Test
+    fun `routes file_search and retrieval away from the web-search card`() {
+        assertThat(isFileSearchToolCall("file_search")).isTrue()
+        assertThat(isFileSearchToolCall("retrieval")).isTrue()
+        assertThat(isWebSearchToolCall("file_search")).isFalse()
+        assertThat(isWebSearchToolCall("retrieval")).isFalse()
+        assertThat(isFileSearchToolCall("web_search")).isFalse()
+    }
+}

--- a/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/components/MemoryArtifactsTest.kt
+++ b/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/components/MemoryArtifactsTest.kt
@@ -1,0 +1,134 @@
+package com.garfiec.librechat.feature.chat.components
+
+import com.garfiec.librechat.core.model.Attachment
+import com.garfiec.librechat.core.model.ContentType
+import com.garfiec.librechat.core.model.MemoryArtifactData
+import com.garfiec.librechat.core.model.content.AgentToolCall
+import com.garfiec.librechat.core.model.content.MessageContentPart
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class MemoryArtifactsTest {
+
+    private fun memoryAttachment(
+        toolCallId: String?,
+        key: String? = "favourite_colour",
+        value: String? = "blue",
+        type: String? = "update",
+    ) = Attachment(
+        type = "memory",
+        toolCallId = toolCallId,
+        memory = MemoryArtifactData(key = key, value = value, type = type),
+    )
+
+    // Explicit return type: the function is recursive, so it cannot be inferred.
+    private fun toolCallPart(id: String, nested: List<String> = emptyList()): MessageContentPart =
+        MessageContentPart(
+            type = ContentType.TOOL_CALL,
+            toolCall = AgentToolCall(
+                id = id,
+                subagentContent = nested.map { toolCallPart(it) }.ifEmpty { null },
+            ),
+        )
+
+    @Test
+    fun `takes the key as the title and the value as the body`() {
+        val artifacts = collectMemoryArtifacts(listOf(memoryAttachment("c1")), "c1")
+
+        assertThat(artifacts).hasSize(1)
+        assertThat(artifacts.first().title).isEqualTo("favourite_colour")
+        assertThat(artifacts.first().content).isEqualTo("blue")
+        assertThat(artifacts.first().kind).isEqualTo(MemoryChangeKind.UPDATE)
+    }
+
+    @Test
+    fun `a delete carries no body of its own`() {
+        val artifacts = collectMemoryArtifacts(
+            listOf(memoryAttachment("c1", value = null, type = "delete")),
+            "c1",
+        )
+
+        assertThat(artifacts.first().kind).isEqualTo(MemoryChangeKind.DELETE)
+        assertThat(artifacts.first().content).isNull()
+    }
+
+    @Test
+    fun `parses a storage-limit failure into its type and token count`() {
+        val blob = """{"errorType":"would_exceed","tokenCount":42,"totalTokens":9000}"""
+        val artifacts = collectMemoryArtifacts(
+            listOf(memoryAttachment("c1", key = "system", value = blob, type = "error")),
+            "c1",
+        )
+
+        assertThat(artifacts.first().kind).isEqualTo(MemoryChangeKind.ERROR)
+        assertThat(artifacts.first().error?.errorType).isEqualTo(MEMORY_ERROR_WOULD_EXCEED)
+        assertThat(artifacts.first().error?.tokenCount).isEqualTo(42)
+        // The blob itself must never reach the card as body text.
+        assertThat(artifacts.first().content).isNull()
+    }
+
+    @Test
+    fun `an unparseable failure blob degrades to the generic error, not raw JSON`() {
+        val artifacts = collectMemoryArtifacts(
+            listOf(memoryAttachment("c1", value = "storage is full", type = "error")),
+            "c1",
+        )
+
+        assertThat(artifacts.first().kind).isEqualTo(MemoryChangeKind.ERROR)
+        assertThat(artifacts.first().error).isNull()
+    }
+
+    @Test
+    fun `excludes writes belonging to a different tool call`() {
+        val attachments = listOf(memoryAttachment("other"), memoryAttachment("c1", key = "mine"))
+
+        assertThat(collectMemoryArtifacts(attachments, "c1").map { it.title }).containsExactly("mine")
+    }
+
+    @Test
+    fun `orphan collection keeps only the writes no tool call rendered`() {
+        val attachments = listOf(
+            memoryAttachment("inline-call", key = "inline"),
+            memoryAttachment("background-subrun", key = "background"),
+        )
+
+        val orphans = collectUnrenderedMemoryArtifacts(attachments, setOf("inline-call"))
+
+        assertThat(orphans.map { it.title }).containsExactly("background")
+    }
+
+    @Test
+    fun `orphan collection keeps a write with no tool call id at all`() {
+        val orphans = collectUnrenderedMemoryArtifacts(listOf(memoryAttachment(null)), setOf("c1"))
+
+        assertThat(orphans).hasSize(1)
+    }
+
+    @Test
+    fun `rendered ids include tool calls nested inside a subagent trace`() {
+        val parts = listOf(
+            toolCallPart("outer", nested = listOf("inner")),
+            MessageContentPart(type = ContentType.TEXT, text = "hello"),
+        )
+
+        assertThat(renderedToolCallIds(parts)).containsExactly("outer", "inner")
+    }
+
+    @Test
+    fun `a memory write inside a subagent trace is not reported twice`() {
+        val parts = listOf(toolCallPart("subagent", nested = listOf("set-memory")))
+        val attachments = listOf(memoryAttachment("set-memory"))
+
+        assertThat(collectUnrenderedMemoryArtifacts(attachments, renderedToolCallIds(parts))).isEmpty()
+    }
+
+    @Test
+    fun `output parsing still yields a card when no payload was sent`() {
+        val artifact = parseMemoryArtifact("Memory set for key \"tone\" (12 tokens)")
+
+        assertThat(artifact).isNotNull()
+        assertThat(artifact?.title).isNull()
+        assertThat(artifact?.content).isEqualTo("Memory set for key \"tone\" (12 tokens)")
+        assertThat(artifact?.kind).isEqualTo(MemoryChangeKind.UPDATE)
+    }
+}

--- a/feature/chat/src/commonMain/composeResources/values/strings.xml
+++ b/feature/chat/src/commonMain/composeResources/values/strings.xml
@@ -230,6 +230,21 @@
     <string name="cd_memory_artifact">Memory artifact: %1$s</string>
     <string name="memory_artifact_untitled">Untitled</string>
     <string name="label_memory">Memory</string>
+    <string name="cd_memory_artifacts">Memory updates: %1$d</string>
+    <string name="memory_updated">Updated saved memory</string>
+    <string name="memory_error">Memory Error</string>
+    <string name="memory_updated_items">Updated Memories</string>
+    <string name="memory_deleted_items">Deleted Memories</string>
+    <string name="memory_deleted">Memory deleted</string>
+    <string name="memory_storage_full">Memory Storage Full</string>
+    <string name="memory_already_exceeded">Memory storage already full — exceeded by %1$d tokens. Delete existing memories before adding new ones.</string>
+    <string name="memory_would_exceed">Cannot save — would exceed limit by %1$d tokens. Delete existing memories to make space.</string>
+
+    <!-- File search sources -->
+    <string name="files_searched">Searched your files</string>
+    <string name="cd_file_search_source">File search source: %1$s</string>
+    <string name="file_search_relevance">%1$d%%</string>
+    <string name="file_search_pages">Pages: %1$s</string>
 
     <!-- Mermaid diagram -->
     <string name="label_mermaid">mermaid</string>

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/AttachmentPayloadParsing.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/AttachmentPayloadParsing.kt
@@ -1,0 +1,172 @@
+package com.garfiec.librechat.feature.chat.components
+
+import co.touchlab.kermit.Logger
+import com.garfiec.librechat.core.common.ToolConstants
+import com.garfiec.librechat.core.model.Attachment
+import com.garfiec.librechat.core.model.FileSearchSource
+import com.garfiec.librechat.core.model.MemoryArtifactData
+import com.garfiec.librechat.core.model.content.MessageContentPart
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+// Parsing for the structured pseudo-attachment payloads — `file_search` citations and `memory`
+// writes. These arrive on their own key alongside `type`, rather than as files, so none of it goes
+// through the file/tool-call paths in `ToolCallParsing.kt`.
+
+private val log = Logger.withTag("AttachmentPayloadParsing")
+
+/**
+ * Collects file-search citations from a message's `file_search` attachments — the structured
+ * counterpart of the digest the tool prints as its output, and the only place the `fileId` and
+ * per-page relevance exist.
+ *
+ * Scoped to a tool call by the same rule as [collectWebSearchSources]. Several sources describe
+ * the same file (one per matched chunk), so they're merged the way upstream `extractFileSources`
+ * (`RetrievalCall.tsx`) merges them.
+ */
+internal fun collectFileSearchSources(
+    attachments: List<Attachment>,
+    toolCallId: String?,
+): List<FileSearchCitation> {
+    val searchAttachments = attachments.filter {
+        it.type == ToolConstants.FILE_SEARCH && it.fileSearch != null
+    }
+    if (searchAttachments.isEmpty()) return emptyList()
+    val scoped = if (toolCallId == null) {
+        searchAttachments
+    } else {
+        searchAttachments.filter { it.toolCallId == toolCallId || it.toolCallId == null }
+    }
+
+    val merged = LinkedHashMap<String, FileSearchCitation>()
+    scoped.forEach { att ->
+        att.fileSearch?.sources.orEmpty().forEach { source ->
+            val key = source.fileId ?: source.fileName ?: return@forEach
+            val pages = orderedPages(source)
+            val existing = merged[key]
+            merged[key] = if (existing == null) {
+                FileSearchCitation(
+                    fileId = key,
+                    fileName = source.fileName.orEmpty().ifBlank { key },
+                    relevance = source.relevance ?: 0.0,
+                    content = source.content.orEmpty(),
+                    pages = pages,
+                    fileType = source.metadata?.fileType,
+                )
+            } else {
+                existing.copy(
+                    relevance = maxOf(existing.relevance, source.relevance ?: 0.0),
+                    content = listOf(existing.content, source.content.orEmpty())
+                        .filter { it.isNotBlank() }
+                        .joinToString("\n\n"),
+                    pages = (existing.pages + pages).distinct(),
+                    fileType = existing.fileType ?: source.metadata?.fileType,
+                )
+            }
+        }
+    }
+    return merged.values.sortedByDescending { it.relevance }
+}
+
+/** A source's pages, most relevant first when the payload says which those are. */
+private fun orderedPages(source: FileSearchSource): List<Int> {
+    val pages = source.pages.orEmpty()
+    val relevance = source.pageRelevance ?: return pages
+    return pages.sortedByDescending { relevance[it.toString()] ?: 0.0 }
+}
+
+// The storage-limit `errorType` values `set_memory` reports; each maps to its own user-facing
+// sentence. Upstream `packages/api/src/agents/memory.ts`; registered in scripts/mirrors.json
+// because a rename here degrades silently.
+internal const val MEMORY_ERROR_ALREADY_EXCEEDED = "already_exceeded"
+internal const val MEMORY_ERROR_WOULD_EXCEED = "would_exceed"
+
+/**
+ * One memory write from its attachment payload. An `error` artifact's `value` is a JSON blob
+ * rather than a sentence, so it is parsed out here and never carried as [MemoryArtifact.content] —
+ * anything unparseable falls back to the generic error label rather than printing the blob.
+ */
+internal fun memoryArtifactFrom(data: MemoryArtifactData): MemoryArtifact {
+    val kind = when (data.type) {
+        "delete" -> MemoryChangeKind.DELETE
+        "error" -> MemoryChangeKind.ERROR
+        else -> MemoryChangeKind.UPDATE
+    }
+    return MemoryArtifact(
+        title = data.key,
+        content = data.value.takeIf { kind != MemoryChangeKind.ERROR },
+        key = data.key,
+        kind = kind,
+        error = if (kind == MemoryChangeKind.ERROR) parseMemoryError(data.value) else null,
+    )
+}
+
+private fun parseMemoryError(value: String?): MemoryErrorInfo? {
+    if (value.isNullOrBlank()) return null
+    return try {
+        val obj = toolCallJson.parseToJsonElement(value).jsonObject
+        MemoryErrorInfo(
+            errorType = obj["errorType"]?.jsonPrimitive?.contentOrNull,
+            tokenCount = obj["tokenCount"]?.jsonPrimitive?.intOrNull,
+        )
+    } catch (e: Exception) {
+        log.d(e) { "Memory error artifact value is not structured JSON" }
+        null
+    }
+}
+
+/**
+ * The memory writes belonging to one tool call, for the inline `set_memory`/`delete_memory` card.
+ * Scoped by the same rule as [collectWebSearchSources].
+ */
+internal fun collectMemoryArtifacts(
+    attachments: List<Attachment>,
+    toolCallId: String?,
+): List<MemoryArtifact> {
+    val memoryAttachments = attachments.filter {
+        it.type == ToolConstants.MEMORY && it.memory != null
+    }
+    if (memoryAttachments.isEmpty()) return emptyList()
+    val scoped = if (toolCallId == null) {
+        memoryAttachments
+    } else {
+        memoryAttachments.filter { it.toolCallId == toolCallId || it.toolCallId == null }
+    }
+    return scoped.mapNotNull { it.memory?.let(::memoryArtifactFrom) }
+}
+
+/**
+ * Every tool call id a message renders a card for, including the calls nested one level inside a
+ * subagent trace — this must track the depth the dispatcher recurses to, or
+ * [collectUnrenderedMemoryArtifacts] double-reports the nested calls' writes.
+ */
+internal fun renderedToolCallIds(parts: List<MessageContentPart>?): Set<String> {
+    if (parts.isNullOrEmpty()) return emptySet()
+    val ids = LinkedHashSet<String>()
+    parts.forEach { part ->
+        val call = part.toolCall ?: return@forEach
+        call.id?.takeIf { it.isNotEmpty() }?.let(ids::add)
+        call.subagentContent.orEmpty().forEach { nested ->
+            nested.toolCall?.id?.takeIf { it.isNotEmpty() }?.let(ids::add)
+        }
+    }
+    return ids
+}
+
+/**
+ * The memory writes no tool call in this message accounts for — the background memory agent's,
+ * whose sub-run never contributes content parts, so the attachment is the only sign it ran.
+ *
+ * Anything whose `toolCallId` matches a rendered call is left out: that one already has its own
+ * inline card, and announcing it again here would double-report a single write. An attachment
+ * carrying no `toolCallId` at all cannot be attributed to a call, so it belongs here.
+ */
+internal fun collectUnrenderedMemoryArtifacts(
+    attachments: List<Attachment>,
+    renderedToolCallIds: Collection<String>,
+): List<MemoryArtifact> = attachments
+    .filter { it.type == ToolConstants.MEMORY && it.memory != null }
+    .filter { it.toolCallId !in renderedToolCallIds }
+    .mapNotNull { it.memory?.let(::memoryArtifactFrom) }

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/FileSearchSourcesCard.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/FileSearchSourcesCard.kt
@@ -1,0 +1,217 @@
+package com.garfiec.librechat.feature.chat.components
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Code
+import androidx.compose.material.icons.filled.Description
+import androidx.compose.material.icons.filled.ExpandLess
+import androidx.compose.material.icons.filled.ExpandMore
+import androidx.compose.material.icons.filled.Image
+import androidx.compose.material.icons.filled.InsertDriveFile
+import androidx.compose.material.icons.filled.TableChart
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.garfiec.librechat.feature.chat.resources.Res
+import com.garfiec.librechat.feature.chat.resources.cd_file_search_source
+import com.garfiec.librechat.feature.chat.resources.file_search_pages
+import com.garfiec.librechat.feature.chat.resources.file_search_relevance
+import com.garfiec.librechat.feature.chat.resources.files_searched
+import org.jetbrains.compose.resources.stringResource
+import kotlin.math.roundToInt
+
+/**
+ * One cited passage from a `file_search` attachment, already merged across the chunks that came
+ * from the same file. [fileId] is the dedup key; [relevance] is 0..1.
+ */
+data class FileSearchCitation(
+    val fileId: String,
+    val fileName: String,
+    val relevance: Double,
+    val content: String,
+    val pages: List<Int> = emptyList(),
+    val fileType: String? = null,
+)
+
+/** Upstream `getFileIcon` (`RetrievalCall.tsx`), on the MIME substrings it actually branches on. */
+private fun fileIconFor(mimeType: String?): ImageVector = when {
+    mimeType == null -> Icons.Default.Description
+    mimeType.contains("spreadsheet") || mimeType.contains("excel") || mimeType.contains("csv") ->
+        Icons.Default.TableChart
+    mimeType.contains("image") -> Icons.Default.Image
+    mimeType.contains("javascript") || mimeType.contains("typescript") ||
+        mimeType.contains("json") || mimeType.contains("xml") || mimeType.contains("html") ->
+        Icons.Default.Code
+    mimeType.contains("pdf") || mimeType.contains("text") || mimeType.contains("word") ->
+        Icons.Default.Description
+    else -> Icons.Default.InsertDriveFile
+}
+
+/**
+ * File-search citations, shaped like [WebSearchSourcesCard] and mirroring upstream
+ * `RetrievalCall.tsx`.
+ */
+@Composable
+fun FileSearchSourcesCard(
+    citations: List<FileSearchCitation>,
+    modifier: Modifier = Modifier,
+    stateKey: String = "",
+) {
+    var isExpanded by rememberSaveable(key = "filesearch:$stateKey") { mutableStateOf(false) }
+    val label = stringResource(Res.string.files_searched)
+
+    Column(modifier = modifier.fillMaxWidth()) {
+        Row(
+            modifier = Modifier
+                .clip(RoundedCornerShape(999.dp))
+                .clickable { isExpanded = !isExpanded }
+                .padding(vertical = 4.dp, horizontal = 2.dp)
+                .semantics {
+                    role = Role.Button
+                    contentDescription = label
+                },
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                imageVector = Icons.Default.Description,
+                contentDescription = null,
+                modifier = Modifier.size(16.dp),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+                text = label,
+                style = MaterialTheme.typography.titleSmall.copy(fontWeight = FontWeight.Medium),
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(modifier = Modifier.width(4.dp))
+            Icon(
+                imageVector = if (isExpanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
+                contentDescription = null,
+                modifier = Modifier.size(16.dp),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+
+        AnimatedVisibility(
+            visible = isExpanded,
+            enter = expandVertically(),
+            exit = shrinkVertically(),
+        ) {
+            Column(
+                modifier = Modifier
+                    .padding(top = 6.dp)
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(8.dp))
+                    .border(1.dp, MaterialTheme.colorScheme.outlineVariant, RoundedCornerShape(8.dp)),
+            ) {
+                citations.forEachIndexed { index, citation ->
+                    CitationRow(citation = citation, stateKey = "$stateKey:${citation.fileId}")
+                    if (index < citations.lastIndex) {
+                        HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun CitationRow(citation: FileSearchCitation, stateKey: String) {
+    var showContent by rememberSaveable(key = "filesearchsrc:$stateKey") { mutableStateOf(false) }
+    val hasContent = citation.content.isNotBlank()
+    val rowCd = stringResource(Res.string.cd_file_search_source, citation.fileName)
+    val relevancePercent = remember(citation.relevance) { (citation.relevance * 100).roundToInt() }
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(enabled = hasContent) { showContent = !showContent }
+            .padding(horizontal = 12.dp, vertical = 10.dp)
+            .semantics {
+                if (hasContent) role = Role.Button
+                contentDescription = rowCd
+            },
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Icon(
+                imageVector = fileIconFor(citation.fileType),
+                contentDescription = null,
+                modifier = Modifier.size(16.dp),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(modifier = Modifier.width(10.dp))
+            Text(
+                text = citation.fileName,
+                style = MaterialTheme.typography.bodySmall.copy(fontWeight = FontWeight.Medium),
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.weight(1f),
+            )
+            if (relevancePercent > 0) {
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    text = stringResource(Res.string.file_search_relevance, relevancePercent),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+
+        if (citation.pages.isNotEmpty()) {
+            Spacer(modifier = Modifier.height(2.dp))
+            Text(
+                text = stringResource(Res.string.file_search_pages, citation.pages.joinToString(", ")),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+
+        if (hasContent) {
+            AnimatedVisibility(
+                visible = showContent,
+                enter = expandVertically(),
+                exit = shrinkVertically(),
+            ) {
+                Text(
+                    text = citation.content,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(top = 6.dp),
+                )
+            }
+        }
+    }
+}

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/MemoryArtifactCard.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/MemoryArtifactCard.kt
@@ -32,17 +32,23 @@ import com.garfiec.librechat.feature.chat.resources.Res
 import org.jetbrains.compose.resources.stringResource
 
 /**
- * Data class representing a memory artifact parsed from tool call output.
+ * One memory write, from the call's `memory` attachment payload when the server sent one and from
+ * the tool-call output otherwise. The fallback carries the tool's readable sentence as [content]
+ * with no [title] — servers predating the payload, and any call whose artifact was dropped, still
+ * render a card that way.
  */
 data class MemoryArtifact(
     val title: String?,
     val content: String?,
     val key: String? = null,
+    val kind: MemoryChangeKind = MemoryChangeKind.UPDATE,
+    /** Set only when [kind] is [MemoryChangeKind.ERROR] and the failure blob parsed. */
+    val error: MemoryErrorInfo? = null,
 )
 
 /**
- * Card displaying a memory artifact with "Memory" badge, title, and expandable content preview.
- * Uses tertiary container color for distinction.
+ * The inline card for one memory write. Tertiary container colours, switching to the error
+ * container when the write was refused (upstream restyles its disclosure the same way).
  */
 @Composable
 fun MemoryArtifactCard(
@@ -50,6 +56,25 @@ fun MemoryArtifactCard(
     modifier: Modifier = Modifier,
 ) {
     var isExpanded by remember { mutableStateOf(false) }
+
+    val isError = artifact.kind == MemoryChangeKind.ERROR
+    val containerColor = if (isError) {
+        MaterialTheme.colorScheme.errorContainer
+    } else {
+        MaterialTheme.colorScheme.tertiaryContainer
+    }
+    val contentColor = if (isError) {
+        MaterialTheme.colorScheme.onErrorContainer
+    } else {
+        MaterialTheme.colorScheme.onTertiaryContainer
+    }
+    // A delete carries no value, so the card would otherwise be a bare key; an error's value is a
+    // JSON blob, which `memoryErrorMessage` turns into the sentence upstream shows.
+    val body = when (artifact.kind) {
+        MemoryChangeKind.ERROR -> memoryErrorMessage(artifact.error)
+        MemoryChangeKind.DELETE -> artifact.content ?: stringResource(Res.string.memory_deleted)
+        MemoryChangeKind.UPDATE -> artifact.content
+    }
 
     val memoryCd =
         stringResource(Res.string.cd_memory_artifact, artifact.title ?: stringResource(Res.string.memory_artifact_untitled))
@@ -60,7 +85,7 @@ fun MemoryArtifactCard(
                 contentDescription = memoryCd
             },
         colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.tertiaryContainer,
+            containerColor = containerColor,
         ),
         shape = RoundedCornerShape(8.dp),
     ) {
@@ -73,14 +98,22 @@ fun MemoryArtifactCard(
                     onClick = {},
                     label = {
                         Text(
-                            text = stringResource(Res.string.label_memory),
+                            text = if (isError) {
+                                stringResource(Res.string.memory_error)
+                            } else {
+                                stringResource(Res.string.label_memory)
+                            },
                             style = MaterialTheme.typography.labelSmall,
                         )
                     },
                     modifier = Modifier.height(24.dp),
                     colors = SuggestionChipDefaults.suggestionChipColors(
-                        containerColor = MaterialTheme.colorScheme.tertiary.copy(alpha = 0.2f),
-                        labelColor = MaterialTheme.colorScheme.onTertiaryContainer,
+                        containerColor = if (isError) {
+                            MaterialTheme.colorScheme.error.copy(alpha = 0.2f)
+                        } else {
+                            MaterialTheme.colorScheme.tertiary.copy(alpha = 0.2f)
+                        },
+                        labelColor = contentColor,
                     ),
                 )
 
@@ -91,7 +124,7 @@ fun MemoryArtifactCard(
                         style = MaterialTheme.typography.titleSmall.copy(
                             fontWeight = FontWeight.Bold,
                         ),
-                        color = MaterialTheme.colorScheme.onTertiaryContainer,
+                        color = contentColor,
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
                         modifier = Modifier.weight(1f),
@@ -100,12 +133,12 @@ fun MemoryArtifactCard(
             }
 
             // Content preview
-            if (!artifact.content.isNullOrBlank()) {
+            if (!body.isNullOrBlank()) {
                 Spacer(modifier = Modifier.height(8.dp))
                 Text(
-                    text = artifact.content,
+                    text = body,
                     style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onTertiaryContainer,
+                    color = contentColor,
                     maxLines = if (isExpanded) Int.MAX_VALUE else 2,
                     overflow = TextOverflow.Ellipsis,
                     modifier = Modifier.clickable {

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/MemoryArtifactsSection.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/MemoryArtifactsSection.kt
@@ -1,0 +1,255 @@
+package com.garfiec.librechat.feature.chat.components
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Bookmark
+import androidx.compose.material.icons.filled.ExpandLess
+import androidx.compose.material.icons.filled.ExpandMore
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.garfiec.librechat.feature.chat.resources.Res
+import com.garfiec.librechat.feature.chat.resources.cd_memory_artifacts
+import com.garfiec.librechat.feature.chat.resources.memory_already_exceeded
+import com.garfiec.librechat.feature.chat.resources.memory_deleted
+import com.garfiec.librechat.feature.chat.resources.memory_deleted_items
+import com.garfiec.librechat.feature.chat.resources.memory_error
+import com.garfiec.librechat.feature.chat.resources.memory_storage_full
+import com.garfiec.librechat.feature.chat.resources.memory_updated
+import com.garfiec.librechat.feature.chat.resources.memory_updated_items
+import com.garfiec.librechat.feature.chat.resources.memory_would_exceed
+import org.jetbrains.compose.resources.stringResource
+
+/** What a `memory` attachment records. Upstream `MemoryArtifact.type`. */
+enum class MemoryChangeKind { UPDATE, DELETE, ERROR }
+
+/**
+ * The parsed contents of a [MemoryChangeKind.ERROR] artifact's `value`, which the server sends as
+ * a JSON blob rather than a sentence. Absent when the blob was unparseable or carried an
+ * `errorType` this client has no message for; the generic error label covers both, exactly as
+ * upstream `MemoryInfo` does.
+ */
+data class MemoryErrorInfo(
+    val errorType: String?,
+    val tokenCount: Int?,
+)
+
+/** The message for a storage-limit error, or the generic label when it is not one we know. */
+@Composable
+internal fun memoryErrorMessage(error: MemoryErrorInfo?): String {
+    val tokens = error?.tokenCount
+    return when {
+        tokens == null -> stringResource(Res.string.memory_error)
+        error.errorType == MEMORY_ERROR_ALREADY_EXCEEDED ->
+            stringResource(Res.string.memory_already_exceeded, tokens)
+        error.errorType == MEMORY_ERROR_WOULD_EXCEED ->
+            stringResource(Res.string.memory_would_exceed, tokens)
+        else -> stringResource(Res.string.memory_error)
+    }
+}
+
+/**
+ * The memory writes no tool card in this message accounts for (see
+ * [collectUnrenderedMemoryArtifacts]), as a collapsed "Updated saved memory" line — red, "Memory
+ * Error", when any entry failed — expanding to the keys written, deleted, and refused. Mirrors
+ * upstream `MemoryArtifacts.tsx` + `MemoryInfo.tsx`.
+ */
+@Composable
+fun MemoryArtifactsSection(
+    artifacts: List<MemoryArtifact>,
+    modifier: Modifier = Modifier,
+    stateKey: String = "",
+) {
+    if (artifacts.isEmpty()) return
+
+    var isExpanded by rememberSaveable(key = "memoryartifacts:$stateKey") { mutableStateOf(false) }
+
+    val updated = artifacts.filter { it.kind == MemoryChangeKind.UPDATE }
+    val deleted = artifacts.filter { it.kind == MemoryChangeKind.DELETE }
+    val failed = artifacts.filter { it.kind == MemoryChangeKind.ERROR }
+
+    val accent = if (failed.isEmpty()) {
+        MaterialTheme.colorScheme.onSurfaceVariant
+    } else {
+        MaterialTheme.colorScheme.error
+    }
+    val label = if (failed.isEmpty()) {
+        stringResource(Res.string.memory_updated)
+    } else {
+        stringResource(Res.string.memory_error)
+    }
+    val sectionCd = stringResource(Res.string.cd_memory_artifacts, artifacts.size)
+
+    Column(modifier = modifier.fillMaxWidth()) {
+        Row(
+            modifier = Modifier
+                .clip(RoundedCornerShape(999.dp))
+                .clickable { isExpanded = !isExpanded }
+                .padding(vertical = 4.dp, horizontal = 2.dp)
+                .semantics {
+                    role = Role.Button
+                    contentDescription = sectionCd
+                },
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                imageVector = Icons.Default.Bookmark,
+                contentDescription = null,
+                modifier = Modifier.size(16.dp),
+                tint = accent,
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+                text = label,
+                style = MaterialTheme.typography.titleSmall.copy(fontWeight = FontWeight.Medium),
+                color = accent,
+            )
+            Spacer(modifier = Modifier.width(4.dp))
+            Icon(
+                imageVector = if (isExpanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
+                contentDescription = null,
+                modifier = Modifier.size(16.dp),
+                tint = accent,
+            )
+        }
+
+        AnimatedVisibility(
+            visible = isExpanded,
+            enter = expandVertically(),
+            exit = shrinkVertically(),
+        ) {
+            MemoryArtifactDetail(updated = updated, deleted = deleted, failed = failed)
+        }
+    }
+}
+
+/** The expanded body: written keys, deleted keys, then refusals. Upstream `MemoryInfo.tsx`. */
+@Composable
+private fun MemoryArtifactDetail(
+    updated: List<MemoryArtifact>,
+    deleted: List<MemoryArtifact>,
+    failed: List<MemoryArtifact>,
+) {
+    Column(
+        modifier = Modifier
+            .padding(top = 6.dp)
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(8.dp))
+            .border(1.dp, MaterialTheme.colorScheme.outlineVariant, RoundedCornerShape(8.dp))
+            .padding(12.dp),
+    ) {
+        if (updated.isNotEmpty()) {
+            GroupHeader(stringResource(Res.string.memory_updated_items))
+            updated.forEach { artifact ->
+                MemoryKeyRow(
+                    key = artifact.title,
+                    body = artifact.content,
+                    bodyColor = MaterialTheme.colorScheme.onSurface,
+                )
+            }
+        }
+        if (deleted.isNotEmpty()) {
+            if (updated.isNotEmpty()) {
+                Spacer(modifier = Modifier.height(12.dp))
+            }
+            GroupHeader(stringResource(Res.string.memory_deleted_items))
+            deleted.forEach { artifact ->
+                MemoryKeyRow(
+                    key = artifact.title,
+                    body = stringResource(Res.string.memory_deleted),
+                    bodyColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                    italicBody = true,
+                )
+            }
+        }
+        if (failed.isNotEmpty()) {
+            if (updated.isNotEmpty() || deleted.isNotEmpty()) {
+                Spacer(modifier = Modifier.height(12.dp))
+            }
+            GroupHeader(
+                text = stringResource(Res.string.memory_storage_full),
+                color = MaterialTheme.colorScheme.error,
+            )
+            failed.forEach { artifact ->
+                Text(
+                    text = memoryErrorMessage(artifact.error),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onErrorContainer,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = 4.dp)
+                        .clip(RoundedCornerShape(6.dp))
+                        .background(MaterialTheme.colorScheme.errorContainer)
+                        .padding(horizontal = 8.dp, vertical = 6.dp),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun GroupHeader(text: String, color: Color = MaterialTheme.colorScheme.onSurface) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.labelMedium.copy(fontWeight = FontWeight.SemiBold),
+        color = color,
+        modifier = Modifier.padding(bottom = 2.dp),
+    )
+}
+
+@Composable
+private fun MemoryKeyRow(
+    key: String?,
+    body: String?,
+    bodyColor: Color,
+    italicBody: Boolean = false,
+) {
+    Column(modifier = Modifier.fillMaxWidth().padding(top = 4.dp)) {
+        if (!key.isNullOrBlank()) {
+            Text(
+                text = key,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        if (!body.isNullOrBlank()) {
+            Text(
+                text = body,
+                style = MaterialTheme.typography.bodySmall.copy(
+                    fontStyle = if (italicBody) FontStyle.Italic else FontStyle.Normal,
+                ),
+                color = bodyColor,
+            )
+        }
+    }
+}

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/MessageContentAndActions.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/MessageContentAndActions.kt
@@ -479,6 +479,19 @@ internal fun MessageContentAndActions(
                         isDarkTheme = isSurfaceDark(),
                     )
                 }
+
+                val orphanMemory = remember(message.attachments, message.content) {
+                    collectUnrenderedMemoryArtifacts(
+                        message.attachments.orEmpty(),
+                        renderedToolCallIds(message.content),
+                    )
+                }
+                DisableSelection {
+                    MemoryArtifactsSection(
+                        artifacts = orphanMemory,
+                        stateKey = message.messageId,
+                    )
+                }
             }
         }
     }

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/MessageList.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/MessageList.kt
@@ -637,6 +637,20 @@ fun MessageList(
                     }
                 }
 
+                val orphanMemory = collectUnrenderedMemoryArtifacts(
+                    streamingAttachments,
+                    renderedToolCalls.map { it.id },
+                )
+                if (orphanMemory.isNotEmpty()) {
+                    item(key = "streaming_memory_artifacts") {
+                        MemoryArtifactsSection(
+                            artifacts = orphanMemory,
+                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
+                            stateKey = "streaming",
+                        )
+                    }
+                }
+
                 // Human-review pause (v0.8.8): the run is waiting on the user, so the resolve
                 // controls sit at the tail of the still-unfinished reply — the continuation
                 // streams back into the bubble above.

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ToolCallContentPart.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ToolCallContentPart.kt
@@ -161,6 +161,22 @@ internal fun ToolCallDispatcher(
                     GenericToolCallCard(displayName, displayArgs, output, cardModifier, cardKey)
                 }
             }
+            isFileSearchToolCall(toolNameLower) -> {
+                // Same split as web search: the citations live in the `file_search` attachment,
+                // while the tool output is only a flat digest of them.
+                val citations = remember(attachments, toolCall?.id) {
+                    collectFileSearchSources(attachments, toolCall?.id)
+                }
+                if (citations.isNotEmpty()) {
+                    FileSearchSourcesCard(
+                        citations = citations,
+                        modifier = cardModifier,
+                        stateKey = cardKey,
+                    )
+                } else {
+                    GenericToolCallCard(displayName, displayArgs, output, cardModifier, cardKey)
+                }
+            }
             isCodeExecutionToolCall(toolNameLower) -> {
                 val result = remember(toolCall, toolNameLower) {
                     parseCodeExecution(toolCall)?.let { r ->
@@ -173,10 +189,18 @@ internal fun ToolCallDispatcher(
                     GenericToolCallCard(displayName, displayArgs, output, cardModifier, cardKey)
                 }
             }
-            toolNameLower.contains("memory") -> {
-                val artifact = remember(output) { parseMemoryArtifact(output) }
-                if (artifact != null) {
-                    MemoryArtifactCard(artifact = artifact, modifier = cardModifier)
+            toolNameLower.contains(ToolConstants.MEMORY) -> {
+                // The `memory` attachment carries the key and the remembered value; the tool's own
+                // output is only a sentence about them, which is all a server without the payload
+                // gives us.
+                val artifacts = remember(attachments, toolCall?.id, output) {
+                    collectMemoryArtifacts(attachments, toolCall?.id)
+                        .ifEmpty { listOfNotNull(parseMemoryArtifact(output)) }
+                }
+                if (artifacts.isNotEmpty()) {
+                    artifacts.forEach { artifact ->
+                        MemoryArtifactCard(artifact = artifact, modifier = cardModifier)
+                    }
                 } else {
                     GenericToolCallCard(displayName, displayArgs, output, cardModifier, cardKey)
                 }

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ToolCallParsing.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/ToolCallParsing.kt
@@ -67,13 +67,17 @@ internal fun isCodeExecutionToolCall(toolNameLower: String): Boolean {
 
 /**
  * Web-search-style tool calls that render as the "Searched the web" sources card. `file_search`
- * and `retrieval` also contain "search" but carry their sources in an attachment payload the
- * mobile model doesn't parse yet, so they're excluded and fall through to the generic card.
+ * and `retrieval` also contain "search" but cite local documents, not the web, so they're routed
+ * to [isFileSearchToolCall]'s card instead.
  */
 internal fun isWebSearchToolCall(toolNameLower: String): Boolean =
     toolNameLower != ToolConstants.FILE_SEARCH &&
         toolNameLower != ToolConstants.RETRIEVAL &&
         toolNameLower.contains("search")
+
+/** Retrieval tool calls whose citations render as the "Searched your files" card. */
+internal fun isFileSearchToolCall(toolNameLower: String): Boolean =
+    toolNameLower == ToolConstants.FILE_SEARCH || toolNameLower == ToolConstants.RETRIEVAL
 
 // --- Parsing helpers ---
 
@@ -223,6 +227,13 @@ internal fun parseCodeExecution(toolCall: AgentToolCall?): CodeExecutionResult? 
     }
 }
 
+/**
+ * The fallback for a memory tool call with no `memory` attachment payload — an older server, or a
+ * write whose artifact the run dropped. `set_memory` returns `content_and_artifact`, so its output
+ * is a readable sentence rather than JSON and lands in the catch below; that sentence is still
+ * worth a card, just without the key as a title. Prefer [collectMemoryArtifacts] when a payload
+ * exists.
+ */
 internal fun parseMemoryArtifact(output: String?): MemoryArtifact? {
     if (output.isNullOrBlank()) return null
     return try {

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/StreamingManagerDelegate.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/viewmodel/delegate/StreamingManagerDelegate.kt
@@ -389,6 +389,9 @@ class StreamingManagerDelegate(
                     textFormat = event.textFormat,
                     previewError = event.previewError,
                     webSearch = event.webSearch,
+                    fileSearch = event.fileSearch,
+                    memory = event.memory,
+                    uiResources = event.uiResources,
                 )
                 // Office-doc previews (v0.8.6) arrive twice per file_id (pending →
                 // ready/failed) — route through the delegate for upsert-by-file_id +

--- a/scripts/mirrors.json
+++ b/scripts/mirrors.json
@@ -171,6 +171,19 @@
       },
       "why": "Ported in shape from findArtifactClose/getOpeningCodeFence. The real contract is 'whatever micromark parses', so this is a behavioural port, not a table. Three divergences are deliberate and pinned by ArtifactDetectorCorpusTest.",
       "failure_mode": "An artifact renders as raw source, or swallows the rest of the reply. The corpus test pins current agreement at 22/25 with a known-divergent set, so a genuine drift shows up there -- but only if someone re-runs the corpus against the new upstream."
+    },
+    {
+      "id": "memory-storage-error-types",
+      "upstream": {
+        "file": "packages/api/src/agents/memory.ts",
+        "mode": "file"
+      },
+      "kotlin": {
+        "file": "feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/AttachmentPayloadParsing.kt",
+        "symbol": "MEMORY_ERROR_ALREADY_EXCEEDED / MEMORY_ERROR_WOULD_EXCEED"
+      },
+      "why": "The two errorType values set_memory stringifies into a failed memory artifact's value. They decide which sentence the user is shown -- that the memory store is already full, or that this particular write would overflow it -- and the server sends only the raw key, never a display string. Watched file-level rather than by block: both literals sit inside createMemoryTool's body, and no smaller exported symbol wraps them -- a block anchored on createMemoryTool extracts only its signature and would compare equal across every revision, which is the inert-watch trap check-mirrors.py warns about.",
+      "failure_mode": "A renamed or added errorType silently degrades every storage-limit failure to the generic 'Memory Error' label, dropping the token count and the 'delete some memories' instruction that tells the user how to fix it. Nothing errors: the artifact still decodes and a card still renders."
     }
   ]
 }


### PR DESCRIPTION
## Summary

LibreChat sends four structured "pseudo-attachments" — `web_search`, `file_search`, `memory`, `ui_resources` — each carrying a payload on its own key rather than being a file. The `Attachment` DTO modelled only `web_search`, so the other three were discarded at decode and nothing could render them. This adds the missing fields and their render surfaces, on the SSE path as well as the REST DTO.

## Changes

- **`Attachment` gains `file_search`, `memory` and `ui_resources`**, alongside the existing `web_search`. The new payload types live in `AttachmentPayloads.kt`.
- **`file_search` citations render as a sources card.** The tool's own output is a flat human-readable digest; the per-source structure — and the `fileId` tying a citation back to a real uploaded file — exists only in the payload. Sources describing the same file (one per matched chunk) are merged: pages unioned, best relevance kept, passages joined, most-relevant file first. `retrieval` calls route to the same card, since both carry their citations in the `file_search` payload.
- **Background memory agent writes now appear in chat.** This is the case with no fallback: the agent's sub-run contributes no content parts, so the attachment is the only sign it ran, and mobile previously showed nothing at all. Rendered as a section mirroring upstream's `MemoryArtifacts`, keyed on writes that no rendered tool call accounts for so an inline write is never double-reported. The section also renders during streaming, not only on a settled message.
- **Inline `set_memory`/`delete_memory` cards use the structured payload when present**, recovering the remembered key as the title and the value as the body. The existing output-parsing fallback is kept for servers that don't send one, so those are unaffected. The inline card also gains an error state (error-container styling and a "Memory Error" label) and a default body for a delete, which previously rendered as a bare key; a call reporting several writes now renders one card each rather than only the first.
- **Decoded on the SSE path too** (`SseEventMapper`), before the file guard that would otherwise drop a payload-only attachment as empty.
- `ui_resources` is carried but deliberately not rendered — see Notes.

## Testing

- `./gradlew test detektMetadataCommonMain detekt :app:lint :app:assembleDebug` — green.
- New unit tests: `FileSearchSourcesTest` (8) and `MemoryArtifactsTest` (10), plus `SseEventMapperTest` coverage for the payloads surviving the SSE decode (61 in that suite).
- **No device verification.** This has not been run on a device or emulator. In particular the background-memory-agent path — the one payload that renders nothing at all today — requires `memory.agent.enabled` server-side and has not been exercised end to end.

## Notes

- **`ui_resources` is carried as raw JSON and deliberately not rendered.** Upstream hands it to `@mcp-ui/client`'s `UIResourceRenderer`, which mounts each resource as a sandboxed auto-resizing iframe — a WebView surface with no counterpart in this client, and far larger than the DTO gap this change closes. Modelling it structurally would also be a guess: the server forwards the payload verbatim and it is not always an array, so a typed decode could reject the whole message's `attachments` and take the rest of them down with it. Raw JSON preserves it losslessly for whoever builds the renderer.
- **Citation merging is close to upstream's `extractFileSources` but not identical**, in two places worth knowing before comparing them: the dedup key is `fileId ?: fileName` rather than `fileId` alone, so a source with no id still merges by name instead of being dropped; and pages are ordered by relevance within each source and then concatenated, where upstream merges `pageRelevance` across chunks and orders the combined list. A file merged from several chunks therefore lists pages in arrival order rather than by relevance.
- `scripts/mirrors.json` gains an entry for the two `set_memory` storage-limit `errorType` values, which decide which sentence the user sees and are sent as raw keys only. It is watched file-level rather than by block: both literals sit inside `createMemoryTool`'s body with no smaller exported symbol wrapping them, and a block anchored on the function extracts only its signature — the inert-watch case `check-mirrors.py` warns about.
- The 13 new strings are English-only; the sibling locale directories are untouched, consistent with the existing i18n debt.
