### PR TITLE
fix(drawer): show Settings when the account roster is empty (#360)

### DIFF
--- a/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/drawer/DrawerContent.kt
+++ b/feature/conversations/src/commonMain/kotlin/com/garfiec/librechat/feature/conversations/drawer/DrawerContent.kt
@@ -203,20 +203,30 @@ fun DrawerContent(
     DrawerContent(
         uiState = uiState,
         footerContent = {
-            accounts.firstOrNull { it.isActive }?.let { active ->
-                Spacer(modifier = Modifier.height(8.dp))
-                // Footer row: Settings (icon + label) on the left takes the width; the account
-                // avatar (icon only, tap to switch) sits on the right.
-                Row(
-                    modifier = Modifier.fillMaxWidth().padding(end = 12.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    DrawerFooterItem(
-                        icon = Icons.Default.Settings,
-                        label = stringResource(Res.string.settings),
-                        onClick = onSettingsClick,
-                        modifier = Modifier.weight(1f),
-                    )
+            val active = accounts.firstOrNull { it.isActive }
+            Spacer(modifier = Modifier.height(8.dp))
+            // Footer row: Settings (icon + label) on the left takes the width; the account avatar
+            // (icon only, tap to switch) sits on the right.
+            //
+            // Settings must render even with an empty roster: it is the only route to the
+            // server/account screens, sign-out and the log export, and an empty roster is exactly
+            // the state a user needs them in. Only AccountChip needs a resolved account — do not
+            // fold Settings back under it. See issue #360.
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    // Inset for the chip only, so Settings still aligns with the rows above it
+                    // when there is no chip.
+                    .padding(end = if (active != null) 12.dp else 0.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                DrawerFooterItem(
+                    icon = Icons.Default.Settings,
+                    label = stringResource(Res.string.settings),
+                    onClick = onSettingsClick,
+                    modifier = Modifier.weight(1f),
+                )
+                if (active != null) {
                     AccountChip(
                         account = active,
                         onClick = { showAccountSheet = true },


### PR DESCRIPTION
Closes #360.

## Summary

The drawer footer rendered the Settings row and the account avatar inside a single `accounts.firstOrNull { it.isActive }?.let`, so an empty account roster removed both. That footer is the only route to Settings on either layout — the phone drawer and the tablet sidebar both render `DrawerContent`, and the chat overflow menu has no Settings item — so an empty roster leaves the server-connection screen, sign-out, and the data and diagnostic-log exports unreachable.

## Why the roster can be empty while signed in

`isLoggedIn` is a pure token check and does not consult the roster, so the two can disagree. An iOS reinstall guarantees it: the access token and the server URL live in the Keychain and survive app deletion, while the roster lives in DataStore and is wiped. The rebuild path, `AuthRepository.restoreAccountIfNeeded`, needs a live `getUser()` — so a user left pointed at an unreachable server can reach the screen that would fix the server only by first reaching the server.

The gate was not deliberate. Settings was an ungated footer item alongside Agents, Skills and Files until #221 moved it into the footer slot to share a row with the account avatar, where it was swept under the avatar's null check. (#215 had introduced that slot and its null check a day earlier, but held only the avatar.)

## Changes

- Render the Settings footer item unconditionally, and gate only `AccountChip` — the sole part that needs a resolved account.
- Make the row's trailing inset conditional on the chip being drawn, so Settings lines up with the Files and Agents rows above it when it renders alone.
- Cosmetic side effect: during the cold-start `Warming` window Settings now renders immediately rather than popping in once the roster resolves.

## Testing

- `:feature:conversations:detektMetadataCommonMain` and `:feature:conversations:testDebugUnitTest` pass.
- **Not device-tested.** The natural repro is an iOS reinstall against an unreachable server; it can also be forced on a debug Android build by deleting the DataStore file while leaving the token store intact.
- No regression test added: `feature/conversations` has no Compose test source set, and adding one is disproportionate to the remaining branch, which `AccountChip`'s non-null `account` parameter makes compiler-enforced.

## Notes

Reaching Settings is necessary but not sufficient to recover from this state. Sign-out skips its local teardown while identity is `Resolved(null)`, so the tokens survive it: `AuthRepositoryImpl.logout` skips `accountSwitcher.remove()` in the `account == null` branch, and that is the only thing that clears tokens and emits session-expired. The server-side revocation still fires. That, and letting `restoreAccountIfNeeded` fall back to an identity derived from the persisted server URL, are tracked separately on #360 and deliberately not in this PR — the latter touches tenancy scoping.
