### PR TITLE
perf(auth): build the token store lazily and warm it off the main thread

### DIFF
--- a/core/data/CLAUDE.md
+++ b/core/data/CLAUDE.md
@@ -60,6 +60,39 @@ master key, and if even a rebuild can't produce a working store it degrades to a
 the process. Construction never throws into `startKoin`. The next request then 401s and routes to
 re-login through the normal expired-session flow.
 
+**The store is built lazily and the cache is warmed off the main thread** (#326 follow-up). `MasterKey.Builder().build()`
+plus `EncryptedSharedPreferences.create` cost 300–900 ms on an emulator's software Keymaster, and the
+eager `AccountRegistry` single used to pay that on the thread `startKoin` runs on. So the encrypted
+store is created on first use behind a monitor, and `TokenCacheWarmer` (an eager single) calls
+`warmTokenCache()` on the IO dispatcher. Its registration position relative to `AccountRegistry` only
+sequences construction, not the launches, so it is not an invariant.
+
+Three rules keep that safe, each with a test in `CommonTokenDataStoreWarmTest`:
+
+- **The warmer performs the load; it never awaits one.** A logged-out cold start touches no other entry
+  point on the store — `AccountRegistry` takes its `activeEntry == null` branch and never calls
+  `selectAccount` — so a warm that waited for someone else's seed would never complete.
+- **`warmTokenCache()` takes `stateMutex`, and is the only writer of the cache fields outside a
+  mutation.** Every mutator holds that lock across its whole critical section, so a warm either
+  completes before one starts or begins after it finished — and in the latter case it reads back what
+  the mutation just wrote through to storage, since memory always mirrors disk. Note `tokenInitialized`
+  is set *only* by the load, so a post-mutation warm still runs; it is the mutex, not that flag, that
+  makes it harmless.
+- **`ensureTokenLoaded()` is the synchronous fallback, and it reads through without publishing.**
+  Populating the cache fields from there would be an unlocked read-read-write-write against the same
+  fields a mutator writes under `stateMutex`: a caller that began reading before `setTokens` wrote and
+  assigned after would replace the fresh bearer with the pre-login disk value *and* pin it by marking
+  the cache initialized — every later request on a stale bearer until process death. Reading through
+  costs a repeated decrypt in the startup window instead. Losing the race therefore costs a duplicated
+  read, never a wrong bearer, which is what licenses the design and what keeps `isAuthenticated` on
+  `TokenManager`.
+
+Two consequences worth knowing. `emitSessionExpired` is not `suspend`, so it cannot warm the cache; it
+suppresses a scoped emit only against a *seeded* identity, because an unseeded `activeAccountKey` is
+null and would swallow the expiry signal. And the "a write before the warm must not land in
+`memoryFallback`" trap has **no unit test** — Robolectric cannot build `EncryptedSharedPreferences`, so
+every write there goes to memory and a test would pass for the wrong reason. It is a device-pass item.
+
 ### DataModule Bindings
 
 `DataModule.kt` defines a Koin `module { }` that binds repository interfaces to their implementations via `singleOf(::Impl) bind Interface::class` and provides the Room database, DAOs, and DataStore instances.

--- a/core/data/src/androidMain/kotlin/com/garfiec/librechat/core/data/datastore/TokenDataStore.kt
+++ b/core/data/src/androidMain/kotlin/com/garfiec/librechat/core/data/datastore/TokenDataStore.kt
@@ -6,6 +6,7 @@ import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
 import co.touchlab.kermit.Logger
 import io.ktor.client.HttpClient
+import kotlinx.coroutines.CoroutineDispatcher
 import java.security.GeneralSecurityException
 import java.security.KeyStore
 import java.security.KeyStoreException
@@ -15,37 +16,59 @@ import kotlin.concurrent.Volatile
 class TokenDataStore(
     context: Context,
     refreshClient: Lazy<HttpClient>,
-) : CommonTokenDataStore(refreshClient) {
+    ioDispatcher: CoroutineDispatcher,
+) : CommonTokenDataStore(refreshClient, ioDispatcher) {
 
     private val appContext: Context = context.applicationContext
 
-    /**
-     * The encrypted store, or `null` once the device keystore is so broken that even a wipe + rebuild
-     * can't produce a working one. A `null` routes every override onto [memoryFallback] — the session
-     * lives only in memory until process death, then the user re-logs in — instead of crashing during
-     * `startKoin`. Keystore/keyset corruption (backup-restore, OS update, broken OEM keystore) would
-     * otherwise throw here and, via the eager `AccountRegistry` single, take down every launch.
-     *
-     * Reassigned at runtime (never back to a store known-broken) when a write rebuilds the keyset or
-     * drops to memory mode; `@Volatile` so the unlocked hot-path reads (`isAuthenticated`,
-     * `getAccessToken`) observe the swap.
-     */
-    @Volatile
-    private var prefs: SharedPreferences? = createEncryptedPrefsWithRecovery()
+    /** Holds a built store, where `value == null` means the keystore never recovered. */
+    private class PrefsState(val value: SharedPreferences?)
 
     /**
-     * Session-only backing used when [prefs] is `null` (the keystore never recovered). Reads/writes go
-     * here instead; nothing survives process death, so the user re-authenticates each launch — a
-     * degraded but usable app rather than a crash loop.
+     * The built encrypted store, or `null` while it has **not been built yet**. Once non-null, its
+     * [PrefsState.value] is the store — or `null` once the device keystore is so broken that even a
+     * wipe + rebuild can't produce a working one, which routes every override onto [memoryFallback]:
+     * the session lives only in memory until process death, then the user re-logs in, instead of
+     * crashing during `startKoin`.
+     *
+     * **Keep this one reference — never `prefs` + a `created` flag.** [write] reads "no usable store"
+     * as "go to [memoryFallback]", and with two fields a reader can observe `created == true` before
+     * `prefs` is published, take that for "the keystore gave up", and route a login into memory: a
+     * sign-in that reports success and is gone on relaunch.
+     *
+     * `@Volatile` for that publication, and for the unlocked hot-path reads (`isAuthenticated`,
+     * `getAccessToken`) that must observe a later rebuild's swap. Built on first use so the keystore
+     * work stays off the `startKoin` thread — see `core/data/CLAUDE.md`.
+     */
+    @Volatile
+    private var state: PrefsState? = null
+
+    /** Guards store construction + rebuild. A JVM monitor, and reentrant — [readValue]'s recovery nests. */
+    private val storeLock = Any()
+
+    /**
+     * Session-only backing used when the store could not be built (the keystore never recovered).
+     * Reads/writes go here instead; nothing survives process death, so the user re-authenticates each
+     * launch — a degraded but usable app rather than a crash loop.
      */
     private val memoryFallback = ConcurrentHashMap<String, String>()
 
-    init {
-        initializeTokenCache()
+    /**
+     * Build the encrypted store on first use, publishing the result — including a give-up `null` — so
+     * it is attempted exactly once per process unless a rebuild replaces it.
+     */
+    private fun store(): SharedPreferences? {
+        state?.let { return it.value }
+        return synchronized(storeLock) {
+            // Branch on the reference, not its contents: `state?.value ?: build()` reads a published
+            // PrefsState(null) — "built, and gave up" — as "not built yet" and rebuilds forever.
+            state?.let { return@synchronized it.value }
+            createEncryptedPrefsWithRecovery().also { state = PrefsState(it) }
+        }
     }
 
     override fun readValue(key: String): String? {
-        val store = prefs ?: return memoryFallback[key]
+        val store = store() ?: return memoryFallback[key]
         return try {
             store.getString(key, null)
         } catch (e: GeneralSecurityException) {
@@ -105,7 +128,9 @@ class TokenDataStore(
      * real bugs and re-thrown.
      */
     private inline fun write(toMemory: () -> Unit, mutate: (SharedPreferences.Editor) -> Unit) {
-        val store = prefs
+        // store() builds on demand, so a `null` here means the keystore gave up — never "not built
+        // yet". Conflating them lands a write in [memoryFallback], where it is lost at process death.
+        val store = store()
         if (store == null) {
             toMemory()
             return
@@ -125,7 +150,9 @@ class TokenDataStore(
             } catch (retry: Exception) {
                 if (!isCorruption(retry)) throw retry
                 Logger.e(retry) { "Token write still failing after rebuild — using in-memory fallback" }
-                prefs = null
+                // Publish "built, and gave up" — not "not built yet", which would rebuild on the very
+                // next read and re-enter this path indefinitely.
+                synchronized(storeLock) { state = PrefsState(null) }
                 toMemory()
             }
         }
@@ -135,8 +162,15 @@ class TokenDataStore(
     // and GeneralSecurityException / KeyStoreException (a subtype) on a broken keyset.
     private fun isCorruption(e: Exception): Boolean = e is SecurityException || e is GeneralSecurityException
 
-    /** Wipe the corrupt keystore state and recreate the store, publishing the result to [prefs]. */
-    private fun rebuildStore(): SharedPreferences? = createEncryptedPrefsWithRecovery().also { prefs = it }
+    /**
+     * Wipe the corrupt keystore state and recreate the store, publishing the result to [state].
+     *
+     * Takes [storeLock] so a rebuild and a first [store] build serialize rather than interleaving a
+     * wipe (which deletes the prefs file *and* the master key entry) with a build against them.
+     */
+    private fun rebuildStore(): SharedPreferences? = synchronized(storeLock) {
+        createEncryptedPrefsWithRecovery().also { state = PrefsState(it) }
+    }
 
     private fun createEncryptedPrefsWithRecovery(): SharedPreferences? = createWithRecovery(
         create = { createEncryptedPrefs(appContext) },

--- a/core/data/src/androidMain/kotlin/com/garfiec/librechat/core/data/di/DataPlatformModule.android.kt
+++ b/core/data/src/androidMain/kotlin/com/garfiec/librechat/core/data/di/DataPlatformModule.android.kt
@@ -6,6 +6,7 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.preferencesDataStore
 import androidx.room.Room
 import com.garfiec.librechat.core.common.di.KoinQualifiers
+import com.garfiec.librechat.core.data.datastore.CommonTokenDataStore
 import com.garfiec.librechat.core.data.datastore.TokenDataStore
 import com.garfiec.librechat.core.data.db.LibreChatDatabase
 import com.garfiec.librechat.core.data.db.migration.MIGRATION_3_4
@@ -53,13 +54,17 @@ actual val dataPlatformModule: Module = module {
         TokenDataStore(
             context = androidContext(),
             refreshClient = lazy(LazyThreadSafetyMode.NONE) { get<HttpClient>(KoinQualifiers.Refresh) },
+            ioDispatcher = get(KoinQualifiers.IO),
         )
-    } binds arrayOf(TokenManager::class, SecureTokenStorage::class)
+        // Bound as CommonTokenDataStore too: TokenCacheWarmer needs warmTokenCache(), which is
+        // deliberately not part of the TokenManager contract.
+    } binds arrayOf(TokenManager::class, SecureTokenStorage::class, CommonTokenDataStore::class)
 
     // --- Session Cache Cleaner ---
     single<SessionCacheCleaner> {
+        val context = androidContext()
         CommonSessionCacheCleaner(
-            cacheRoot = androidContext().cacheDir.absolutePath,
+            cacheRoot = { context.cacheDir.absolutePath },
         )
     }
 

--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/datastore/CommonTokenDataStoreWarmTest.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/datastore/CommonTokenDataStoreWarmTest.kt
@@ -1,0 +1,216 @@
+package com.garfiec.librechat.core.data.datastore
+
+import com.garfiec.librechat.core.network.client.SessionEndReason
+import com.google.common.truth.Truth.assertThat
+import io.ktor.client.HttpClient
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+/**
+ * The asynchronous token-cache warm: `TokenCacheWarmer` calls [CommonTokenDataStore.warmTokenCache] on
+ * the IO dispatcher at startup, so the keystore work and the decrypt stay off the main thread. These
+ * pin the properties that make that safe: the warm cannot revert a mutation, the synchronous fallback
+ * still answers before the warm lands, and nothing is read from storage until one of the two happens.
+ */
+class CommonTokenDataStoreWarmTest {
+
+    private fun store(
+        seed: Map<String, String> = emptyMap(),
+        warmEagerly: Boolean = false,
+    ): FakeTokenStore = FakeTokenStore(
+        refreshClient = lazy { error("refresh client not expected in this test") },
+        seed = seed,
+        warmEagerly = warmEagerly,
+    )
+
+    @Test
+    fun construction_touchesStorage_zeroTimes() {
+        val store = store(seed = bareSeed())
+
+        assertThat(store.readCount).isEqualTo(0)
+    }
+
+    @Test
+    fun warm_loadsTheActiveAccountAndItsBearer() = runTest {
+        val store = store(
+            seed = mapOf(
+                ACTIVE_ACCOUNT_KEY to "acct-1",
+                accessKeyOf("acct-1") to "keyed-access",
+            ),
+        )
+
+        store.warmTokenCache()
+
+        assertThat(store.getAccessToken()).isEqualTo("keyed-access")
+    }
+
+    @Test
+    fun warm_isIdempotent_underConcurrency() = runTest {
+        val store = store(seed = bareSeed())
+
+        List(16) { async { store.warmTokenCache() } }.awaitAll()
+
+        // loadCacheFromStorage performs exactly two reads: the mirror, then that account's access key.
+        assertThat(store.readCount).isEqualTo(2)
+    }
+
+    @Test
+    fun warmLandingAfterALogin_doesNotRevertIt() = runTest {
+        // The clobber this design exists to prevent. setTokens holds stateMutex across its whole
+        // critical section, so a warm arriving afterwards runs against storage the login has already
+        // written through — it reloads the fresh pair rather than the stale disk state. (It is the
+        // mutex that makes this safe, not tokenInitialized: only the load sets that flag.)
+        val store = store(seed = bareSeed(access = "stale-on-disk", refresh = "stale-refresh"))
+
+        store.setTokens(accessToken = "fresh-login", refreshToken = "fresh-refresh")
+        store.warmTokenCache()
+
+        assertThat(store.getAccessToken()).isEqualTo("fresh-login")
+    }
+
+    @Test
+    fun warmLandingAfterAnAccountResolve_doesNotRevertTheIdentity() = runTest {
+        val store = store(seed = bareSeed())
+
+        store.setTokens(accessToken = "fresh-login", refreshToken = "fresh-refresh")
+        store.onAccountResolved("acct-9")
+        store.warmTokenCache()
+
+        assertThat(store.getAccessToken()).isEqualTo("fresh-login")
+        assertThat(store.store[accessKeyOf("acct-9")]).isEqualTo("fresh-login")
+    }
+
+    @Test
+    fun warmRacingALogin_neverLosesTheLogin() = runTest {
+        // Same property as above, but with the two genuinely interleaved rather than ordered.
+        repeat(32) {
+            val store = store(seed = bareSeed(access = "stale-on-disk", refresh = "stale-refresh"))
+
+            val warm = launch { store.warmTokenCache() }
+            val login = launch { store.setTokens(accessToken = "fresh-login", refreshToken = "fresh") }
+            warm.join()
+            login.join()
+
+            assertThat(store.getAccessToken()).isEqualTo("fresh-login")
+        }
+    }
+
+    @Test
+    fun synchronousFallback_answersCorrectly_withNoWarmAtAll() {
+        val loggedIn = store(seed = bareSeed(access = "on-disk", refresh = "r"))
+        assertThat(loggedIn.isAuthenticated).isTrue()
+
+        val loggedOut = store(seed = emptyMap())
+        assertThat(loggedOut.isAuthenticated).isFalse()
+    }
+
+    @Test
+    fun synchronousFallback_readsThrough_untilTheWarmLands() = runTest {
+        val store = store(seed = bareSeed())
+
+        // Read-through: two decrypts per call, publishing nothing.
+        repeat(3) { store.isAuthenticated }
+        assertThat(store.readCount).isEqualTo(6)
+
+        store.warmTokenCache()
+        val afterWarm = store.readCount
+
+        // Once the warm has published, the fallback is never taken again.
+        repeat(3) { store.isAuthenticated }
+        assertThat(store.readCount).isEqualTo(afterWarm)
+    }
+
+    @Test
+    fun synchronousFallback_publishesNothing_soItCannotPinAStaleBearer() = runTest {
+        // If the fallback populated the cache fields, a reader that began before setTokens wrote and
+        // assigned after would overwrite the fresh bearer with the pre-login disk value AND set
+        // tokenInitialized, pinning it for the life of the process.
+        val store = store(seed = bareSeed(access = "stale-on-disk", refresh = "stale-refresh"))
+
+        // Take the fallback path first, so anything it might have published is already in place.
+        assertThat(store.isAuthenticated).isTrue()
+        store.setTokens(accessToken = "fresh-login", refreshToken = "fresh-refresh")
+
+        assertThat(store.getAccessToken()).isEqualTo("fresh-login")
+        store.warmTokenCache()
+        assertThat(store.getAccessToken()).isEqualTo("fresh-login")
+    }
+
+    @Test
+    fun emitSessionExpired_onAnUnseededStore_stillEmitsForTheActiveAccount() = runTest {
+        // Unseeded, activeAccountKey is null, so comparing against it would suppress every scoped emit
+        // — swallowing the signal and stranding the user on a dead session.
+        val store = store(seed = mapOf(ACTIVE_ACCOUNT_KEY to "acct-1"))
+        val received = async { store.sessionExpiredFlow.first() }
+        // Let the collector subscribe; emitSessionExpired drops the signal when nobody is listening.
+        kotlinx.coroutines.yield()
+
+        store.emitSessionExpired("acct-1", SessionEndReason.EXPIRED)
+
+        assertThat(received.await()).isEqualTo(SessionEndReason.EXPIRED)
+    }
+
+    @Test
+    fun emitSessionExpired_onAnUnseededStore_stillSuppressesARetainedAccount() = runTest {
+        // The other half: skipping the comparison while unseeded lets a straggler 401 for a
+        // switched-away account through, and sessionExpiryReported is one-shot per session — so that
+        // spurious emit latches and swallows the ACTIVE account's real expiry.
+        val store = store(seed = mapOf(ACTIVE_ACCOUNT_KEY to "acct-1"))
+        var emitted = false
+        val collector = launch { store.sessionExpiredFlow.first(); emitted = true }
+        kotlinx.coroutines.yield()
+
+        store.emitSessionExpired("acct-retained", SessionEndReason.EXPIRED)
+        kotlinx.coroutines.yield()
+
+        assertThat(emitted).isFalse()
+        collector.cancel()
+    }
+
+    @Test
+    fun emitSessionExpired_afterWarm_stillSuppressesAnInactiveAccount() = runTest {
+        // Only the ACTIVE binding's expiry routes to re-auth.
+        val store = store(seed = mapOf(ACTIVE_ACCOUNT_KEY to "acct-1"))
+        store.warmTokenCache()
+        var emitted = false
+        val collector = launch { store.sessionExpiredFlow.first(); emitted = true }
+        kotlinx.coroutines.yield()
+
+        store.emitSessionExpired("acct-other", SessionEndReason.EXPIRED)
+        kotlinx.coroutines.yield()
+
+        assertThat(emitted).isFalse()
+        collector.cancel()
+    }
+
+    @Test
+    fun warmer_survivesAStoreWhoseStorageThrows() = runTest {
+        // A broken keystore must degrade to the synchronous fallback, not take down the application
+        // scope the warmer launches on — every other startup coroutine shares it.
+        val store = object : CommonTokenDataStore(
+            refreshClient = lazy { error("refresh client not expected in this test") },
+            ioDispatcher = Dispatchers.Unconfined,
+        ) {
+            override fun readValue(key: String): String? = error("keystore is broken")
+            override fun writeValue(key: String, value: String) = Unit
+            override fun writeValues(values: Map<String, String>) = Unit
+            override fun removeValue(key: String) = Unit
+            override fun onKeystoreCorruption() = Unit
+        }
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined)
+
+        TokenCacheWarmer(store = store, appScope = scope)
+
+        assertThat(scope.isActive).isTrue()
+        scope.cancel()
+    }
+}

--- a/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/datastore/TokenDataStoreTestFixtures.kt
+++ b/core/data/src/androidUnitTest/kotlin/com/garfiec/librechat/core/data/datastore/TokenDataStoreTestFixtures.kt
@@ -12,6 +12,7 @@ import io.ktor.http.contentType
 import io.ktor.http.headersOf
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
 
 /**
  * The one in-memory [CommonTokenDataStore] the datastore tests share: read-through/write-through
@@ -22,7 +23,14 @@ import kotlinx.coroutines.Dispatchers
 internal class FakeTokenStore(
     refreshClient: Lazy<HttpClient>,
     seed: Map<String, String> = emptyMap(),
-) : CommonTokenDataStore(refreshClient) {
+    /**
+     * Warms the cache during construction, which is what production's `TokenCacheWarmer` does a moment
+     * after `startKoin`. Defaults to `true` so every suite sees a seeded store. Pass `false` to
+     * exercise the unwarmed window — the state a real store is in between construction and the warm
+     * landing.
+     */
+    warmEagerly: Boolean = true,
+) : CommonTokenDataStore(refreshClient, Dispatchers.Unconfined) {
 
     val store = seed.toMutableMap()
 
@@ -33,8 +41,12 @@ internal class FakeTokenStore(
     var removeCount = 0
         private set
 
+    /** Every [readValue], so a test can assert the store touched storage zero times before its warm. */
+    var readCount = 0
+        private set
+
     init {
-        initializeTokenCache()
+        if (warmEagerly) runBlocking { warmTokenCache() }
     }
 
     /** The bare (no-account-resolved) slots, which is what a store with no active account uses. */
@@ -42,7 +54,10 @@ internal class FakeTokenStore(
 
     fun persistedRefresh(): String? = store[KEY_REFRESH_TOKEN]
 
-    override fun readValue(key: String): String? = store[key]
+    override fun readValue(key: String): String? {
+        readCount++
+        return store[key]
+    }
 
     override fun writeValue(key: String, value: String) {
         store[key] = value

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/CommonTokenDataStore.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/CommonTokenDataStore.kt
@@ -20,12 +20,14 @@ import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.client.statement.HttpResponse
 import io.ktor.http.HttpHeaders
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
 import kotlin.concurrent.Volatile
 import kotlin.random.Random
 import kotlin.time.Clock
@@ -39,11 +41,13 @@ import kotlin.time.Clock
  * ([onAccountCleared]) drops only the active account's slot.
  *
  * The active account is mirrored into the same synchronously-readable secure storage (key
- * [KEY_ACTIVE_ACCOUNT]) rather than the async account registry, so the bearer for the right account
- * is seeded in the constructor — the first-frame `isAuthenticated` check and the first authed request
- * never read a blind bearer at cold start. When no account is resolved (fresh install, logged out, or
- * a legacy pre-keying upgrade) the keys fall back to their bare form, which is also how tokens from an
- * older build are read until [onAccountResolved] re-homes them.
+ * [KEY_ACTIVE_ACCOUNT]) rather than the async account registry, so the bearer for the right account is
+ * available without an async account lookup — the first-frame `isAuthenticated` check and the first
+ * authed request never read a blind bearer at cold start. The mirror is loaded by [warmTokenCache] on
+ * the IO dispatcher at startup, with [ensureTokenLoaded] as the synchronous fallback for whoever gets
+ * there first. When no account is resolved (fresh install, logged out, or a legacy pre-keying upgrade)
+ * the keys fall back to their bare form, which is also how tokens from an older build are read until
+ * [onAccountResolved] re-homes them.
  *
  * **Authentication staging.** An interactive sign-in ([setTokens] from login/OAuth/2FA) always writes
  * the freshly-issued pair to the **bare** keys and drops the active binding, even when another account
@@ -65,6 +69,7 @@ import kotlin.time.Clock
  */
 abstract class CommonTokenDataStore(
     private val refreshClient: Lazy<HttpClient>,
+    private val ioDispatcher: CoroutineDispatcher,
 ) : TokenManager, SecureTokenStorage {
 
     @Volatile
@@ -72,13 +77,19 @@ abstract class CommonTokenDataStore(
 
     /**
      * The account whose tokens are currently active, or `null` when logged out or on a legacy install
-     * whose tokens still live under the bare keys. Seeded synchronously from [KEY_ACTIVE_ACCOUNT] at
-     * construction. All key selection reads this, so the hot-path bearer read stays keyed without an
-     * async account lookup.
+     * whose tokens still live under the bare keys. Seeded from [KEY_ACTIVE_ACCOUNT] by
+     * [warmTokenCache]. All key selection reads this, so the hot-path bearer read stays keyed without
+     * an async account lookup.
      */
     @Volatile
     private var activeAccountKey: String? = null
 
+    /**
+     * `@Volatile`: [warmTokenCache] loads on the IO dispatcher while [ensureTokenLoaded] can read from
+     * any thread. Set *after* the two fields it guards, so a reader that observes `true` also observes
+     * their values.
+     */
+    @Volatile
     private var tokenInitialized = false
 
     private fun loadCacheFromStorage() {
@@ -88,15 +99,37 @@ abstract class CommonTokenDataStore(
     }
 
     /**
-     * Eagerly load the active account + its cached access token from platform storage.
-     * Must be called from each platform subclass's `init {}` block (not from the super constructor,
-     * which runs before subclass properties are initialised).
+     * Load the active account + its cached access token from platform storage, off the main thread.
+     * Idempotent, and driven by an eager `TokenCacheWarmer` single at `startKoin`.
+     *
+     * **This must be what performs the load — never something that waits for another caller to do it.**
+     * A logged-out cold start touches no other entry point on this class (`AccountRegistry` takes its
+     * `activeEntry == null` branch and never calls [selectAccount]), so a warm that only awaited
+     * someone else's seed would never complete.
+     *
+     * Takes [stateMutex] so the seed can never interleave with a mutation: the load either completes
+     * before one starts or begins after it has finished, and then reads back exactly what the mutation
+     * just wrote through to storage. Without that, a warm landing mid-[setTokens] could revert a
+     * completed login to whatever was on disk. This is the **only** writer of the cache fields outside
+     * a mutation.
      */
-    protected fun initializeTokenCache() = loadCacheFromStorage()
+    suspend fun warmTokenCache() = withContext(ioDispatcher) {
+        stateMutex.withLock { if (!tokenInitialized) loadCacheFromStorage() }
+    }
 
+    /**
+     * Synchronous fallback for the two non-suspend readers ([isAuthenticated], and [getAccessToken]'s
+     * lock-free hot path), for the window before [warmTokenCache] has landed.
+     *
+     * **It reads through and publishes nothing.** Populating the cache fields from here would be an
+     * unlocked read-read-write-write over the same two fields a mutator writes under [stateMutex]: a
+     * caller that read before [setTokens] wrote and assigned after would replace the fresh bearer with
+     * the pre-login disk value *and* pin it by marking the cache initialized — every later request on a
+     * stale bearer until process death. Reading through costs a repeated decrypt instead.
+     */
     private fun ensureTokenLoaded(): String? {
-        if (!tokenInitialized) loadCacheFromStorage()
-        return cachedAccessToken.nonBlankOrNull()
+        if (tokenInitialized) return cachedAccessToken.nonBlankOrNull()
+        return readValue(accessKey(readValue(KEY_ACTIVE_ACCOUNT))).nonBlankOrNull()
     }
 
     private fun String?.nonBlankOrNull(): String? = this?.takeUnless { it.isBlank() }
@@ -759,7 +792,15 @@ abstract class CommonTokenDataStore(
         // Scoped emit: only the ACTIVE binding's expiry routes the app to re-auth. A straggler
         // failure for a switched-away (retained) account is not a live-session event — its slot is
         // just stale until that account is selected again. Null = active/legacy session: always emit.
-        if (expiredAccountId != null && expiredAccountId != activeAccountKey) return
+        //
+        // Read the mirror through storage when the warm has not landed rather than approximating it;
+        // this is not suspend, so it cannot warm the cache, and neither guess is safe. Comparing
+        // against an unseeded (null) [activeAccountKey] suppresses every scoped emit and swallows a
+        // genuine expiry; skipping the comparison lets a straggler 401 for a switched-away account
+        // through, and [sessionExpiryReported] is one-shot — that spurious emit latches and swallows
+        // the ACTIVE account's real expiry.
+        val activeAccount = if (tokenInitialized) activeAccountKey else readValue(KEY_ACTIVE_ACCOUNT)
+        if (expiredAccountId != null && expiredAccountId != activeAccount) return
         // One signal per dead session. A cold start fans out ~a dozen requests, each of which 401s and
         // reaches here independently, spread far enough apart by the refresh retry/backoff that the
         // flow's 1-slot buffer coalesces nothing — and every emission replays the logout navigation.

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/TokenCacheWarmer.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/datastore/TokenCacheWarmer.kt
@@ -1,0 +1,27 @@
+package com.garfiec.librechat.core.data.datastore
+
+import co.touchlab.kermit.Logger
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+/**
+ * Drives [CommonTokenDataStore.warmTokenCache] once at startup, off the main thread.
+ *
+ * Bound `createdAtStart` so it runs without anyone resolving it.
+ *
+ * **It performs the load; it never waits for someone else to.** A logged-out cold start touches no
+ * other entry point on the store — `AccountRegistry` takes its `activeEntry == null` branch and never
+ * calls `selectAccount` — so a warmer that merely awaited a seed triggered elsewhere would never
+ * complete, and anything gated on it would hang.
+ */
+class TokenCacheWarmer(
+    store: CommonTokenDataStore,
+    appScope: CoroutineScope,
+) {
+    init {
+        appScope.launch {
+            runCatching { store.warmTokenCache() }
+                .onFailure { Logger.w(it) { "Token cache warm failed; falling back to a synchronous load" } }
+        }
+    }
+}

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/di/DataModule.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/di/DataModule.kt
@@ -12,6 +12,7 @@ import com.garfiec.librechat.core.data.datastore.RoleCacheDataStore
 import com.garfiec.librechat.core.data.datastore.ServerDataStore
 import com.garfiec.librechat.core.data.datastore.SettingsDataStore
 import com.garfiec.librechat.core.data.datastore.ThemeDataStore
+import com.garfiec.librechat.core.data.datastore.TokenCacheWarmer
 import com.garfiec.librechat.core.data.db.LibreChatDatabase
 import com.garfiec.librechat.core.data.prefetch.PrefetchBackgroundRunner
 import com.garfiec.librechat.core.data.prefetch.PrefetchController
@@ -129,6 +130,16 @@ val dataModule = module {
     single<ActiveAccountProvider> { InMemoryActiveAccountProvider() }
     // Persisted account roster (list + single active pointer). Pure storage.
     single { AccountRoster(dataStore = get(), json = get()) }
+    // Eager: its whole job is to pull the keystore work and the token decrypt off the thread startKoin
+    // runs on, so a lazy binding nobody resolves would never start it. Its position relative to
+    // AccountRegistry is not an invariant — both do their work in a launch, and the store's
+    // read-through fallback covers whoever gets there first.
+    single(createdAtStart = true) {
+        TokenCacheWarmer(
+            store = get(),
+            appScope = get<CoroutineScope>(KoinQualifiers.ApplicationScope),
+        )
+    }
     // Eager: at cold start it must migrate + reconcile + seed the provider (driving the URL from the
     // active roster entry) even before any consumer asks for it. Bound as the AccountReadyGate the
     // HTTP clients + first-frame routing await.

--- a/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/CacheDirectory.kt
+++ b/core/data/src/commonMain/kotlin/com/garfiec/librechat/core/data/repository/CacheDirectory.kt
@@ -27,14 +27,23 @@ internal expect fun deleteDirectoryRecursively(path: String)
  * Common implementation of [SessionCacheCleaner] that iterates [CACHE_SUBDIRECTORIES] and deletes
  * each from the provided [cacheRoot] directory. Account-blind: role permissions and other
  * account-scoped state are reaped by the account teardown, not here.
+ *
+ * [cacheRoot] must stay a function: resolving the platform cache directory is a disk read, and this
+ * cleaner is a constructor dependency of `AuthRepositoryImpl`, so an eagerly-evaluated root puts that
+ * read on the main thread when `NavHostViewModel` is first built. Deferred, it lands on the teardown
+ * paths that call [clearFileCaches] — logout and last-account removal — which already do file I/O.
+ *
+ * A platform root that cannot be resolved therefore throws here rather than at DI resolution, and is
+ * caught below: the caches go uncleared with a warning instead of taking down the first frame.
  */
 class CommonSessionCacheCleaner(
-    private val cacheRoot: String,
+    private val cacheRoot: () -> String,
 ) : SessionCacheCleaner {
     override fun clearFileCaches() {
         try {
+            val root = cacheRoot()
             for (subdir in CACHE_SUBDIRECTORIES) {
-                deleteDirectoryRecursively("$cacheRoot/$subdir")
+                deleteDirectoryRecursively("$root/$subdir")
             }
         } catch (e: Exception) {
             Logger.w(e) { "Failed to clear session caches on logout" }

--- a/core/data/src/iosMain/kotlin/com/garfiec/librechat/core/data/datastore/IosTokenDataStore.kt
+++ b/core/data/src/iosMain/kotlin/com/garfiec/librechat/core/data/datastore/IosTokenDataStore.kt
@@ -8,6 +8,7 @@ import kotlinx.cinterop.alloc
 import kotlinx.cinterop.memScoped
 import kotlinx.cinterop.ptr
 import kotlinx.cinterop.value
+import kotlinx.coroutines.CoroutineDispatcher
 import platform.CoreFoundation.CFDictionaryAddValue
 import platform.CoreFoundation.CFDictionaryCreateMutable
 import platform.CoreFoundation.CFRelease
@@ -38,11 +39,8 @@ import platform.Security.kSecValueData
 @OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
 class IosTokenDataStore(
     refreshClient: Lazy<HttpClient>,
-) : CommonTokenDataStore(refreshClient), ServerUrlKeychainFallback {
-
-    init {
-        initializeTokenCache()
-    }
+    ioDispatcher: CoroutineDispatcher,
+) : CommonTokenDataStore(refreshClient, ioDispatcher), ServerUrlKeychainFallback {
 
     override fun readValue(key: String): String? = keychainGet(key)
 

--- a/core/data/src/iosMain/kotlin/com/garfiec/librechat/core/data/di/DataPlatformModule.ios.kt
+++ b/core/data/src/iosMain/kotlin/com/garfiec/librechat/core/data/di/DataPlatformModule.ios.kt
@@ -6,6 +6,7 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.room.Room
 import androidx.sqlite.driver.bundled.BundledSQLiteDriver
 import com.garfiec.librechat.core.common.di.KoinQualifiers
+import com.garfiec.librechat.core.data.datastore.CommonTokenDataStore
 import com.garfiec.librechat.core.data.datastore.IosTokenDataStore
 import com.garfiec.librechat.core.data.datastore.ServerUrlKeychainFallback
 import com.garfiec.librechat.core.data.db.LibreChatDatabase
@@ -71,19 +72,29 @@ actual val dataPlatformModule: Module = module {
     single {
         IosTokenDataStore(
             refreshClient = lazy(LazyThreadSafetyMode.NONE) { get<HttpClient>(KoinQualifiers.Refresh) },
+            ioDispatcher = get(KoinQualifiers.IO),
         )
-    } binds arrayOf(TokenManager::class, SecureTokenStorage::class, ServerUrlKeychainFallback::class)
+        // Bound as CommonTokenDataStore too: TokenCacheWarmer needs warmTokenCache(), which is
+        // deliberately not part of the TokenManager contract.
+    } binds arrayOf(
+        TokenManager::class,
+        SecureTokenStorage::class,
+        ServerUrlKeychainFallback::class,
+        CommonTokenDataStore::class,
+    )
 
     // --- Session Cache Cleaner ---
     single<SessionCacheCleaner> {
-        @OptIn(ExperimentalForeignApi::class)
-        val cachePath = NSSearchPathForDirectoriesInDomains(
-            NSCachesDirectory,
-            NSUserDomainMask,
-            true,
-        ).firstOrNull() as? String ?: error("Unable to resolve NSCachesDirectory")
         CommonSessionCacheCleaner(
-            cacheRoot = cachePath,
+            cacheRoot = {
+                @OptIn(ExperimentalForeignApi::class)
+                val cachePath = NSSearchPathForDirectoriesInDomains(
+                    NSCachesDirectory,
+                    NSUserDomainMask,
+                    true,
+                ).firstOrNull() as? String ?: error("Unable to resolve NSCachesDirectory")
+                cachePath
+            },
         )
     }
 

--- a/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/NavHostViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/garfiec/librechat/shared/navigation/NavHostViewModel.kt
@@ -68,14 +68,15 @@ class NavHostViewModel(
     private val versionCheckStateHolder =
         VersionCheckStateHolder(configRepository, settingsDataStore, serverUrlProvider, viewModelScope)
 
-    // Seeded synchronously so first-frame routing (LibreChatNavHost reads isLoggedIn.value
-    // once in a LaunchedEffect to redirect to auth) gets the correct value with no flash.
-    // This is a non-blocking in-memory cache read: TokenManager decrypts the access token at
-    // its own construction (TokenDataStore.init -> initializeTokenCache), so by the time the
-    // VM is built the token is already cached and isAuthenticated is just a null check. The
-    // init{} block below re-resolves the same value asynchronously. (The Keychain/
-    // EncryptedSharedPreferences decrypt itself still runs on Main at TokenDataStore
-    // construction — see report follow-up; it is out of this stream's three files.)
+    // Seeded synchronously so first-frame routing (LibreChatNavHost reads isLoggedIn.value once in a
+    // LaunchedEffect to redirect to auth) gets the correct value with no flash. The init{} block below
+    // re-resolves the same value asynchronously.
+    //
+    // Usually an in-memory null check, because TokenCacheWarmer decrypts on the IO dispatcher at
+    // startKoin — but not guaranteed. The warmer only launches, so when it has not landed this falls
+    // through to the store's read-through fallback and pays the keystore build plus two decrypts here,
+    // on Main, during first composition. Don't gate the first frame on the warm instead: that hangs a
+    // logged-out cold start, which reaches no other entry point on the store.
     private val _isLoggedIn = MutableStateFlow(tokenManager.isAuthenticated)
     val isLoggedIn: StateFlow<Boolean> = _isLoggedIn.asStateFlow()
 


### PR DESCRIPTION
## Summary

Cold start built the encrypted token store and decrypted the active session on the
main thread, inside `startKoin`. The store is now created on first use, and an eager
`TokenCacheWarmer` performs the decrypt on the IO dispatcher instead.

The synchronous read behind `isAuthenticated` / `getAccessToken` stays, now reading
through to storage rather than seeding the cache. A reader arriving before the warm
lands therefore gets the same value it would have before — paying a decrypt per call
until the warm publishes, rather than risking a stale bearer.

## Changes

**Token store**
- `TokenDataStore` (Android) creates its `EncryptedSharedPreferences` on first use,
  published through a single `@Volatile` reference. One reference rather than a store
  plus a `created` flag: two fields let a reader observe "built" before the store is
  published, read that as "the keystore gave up", and route a login into the in-memory
  fallback, where it is lost at process death.
- `CommonTokenDataStore.warmTokenCache()` — idempotent, takes `stateMutex`, so a warm
  cannot interleave with a mutation; `tokenInitialized` becomes `@Volatile`.
- `ensureTokenLoaded()` reads through to storage and publishes nothing, leaving the
  warm as the only writer of the cache fields outside a mutation.
- `emitSessionExpired` resolves the active account through storage when the cache is
  not yet warm, instead of comparing against an unpopulated field. That comparison is
  a secure-storage read on the caller's thread during the pre-warm window.
- `TokenCacheWarmer`, an eager Koin single that performs the load rather than awaiting
  one triggered elsewhere.
- Both platform stores drop their constructor-time seed, so iOS moves to the same
  async warm (keychain rather than keystore) with the same unwarmed read-through
  window. `ServerUrlKeychainFallback.readServerUrl` stays synchronous and unwarmed by
  design.

**Session cache cleaner**
- `CommonSessionCacheCleaner` takes `cacheRoot: () -> String`, evaluated on the
  teardown paths that clear caches (logout and last-account removal). It is a
  constructor dependency of `AuthRepositoryImpl`, so an eagerly resolved root put a
  disk read on the main thread when `NavHostViewModel` was first built.
- Consequence on iOS: an unresolvable `NSCachesDirectory` now throws inside
  `clearFileCaches`, where it is caught and logged, rather than at DI resolution.
  Caches go uncleared with a warning instead of failing the first frame.

`TokenManager` is unchanged; `isAuthenticated` and `getAccessToken` are kept.

## Verification

Unit tests, including a new `CommonTokenDataStoreWarmTest` covering construction
touching storage zero times, warm idempotency under concurrency, a warm ordered
against a login, and the read-through fallback.

Android emulator (API 37), against the parent commit through an identical rig, five
cold starts per state:

| | before | after |
| --- | --- | --- |
| keystore build thread | `main`, 15/15 runs | IO worker, 15/15 runs |
| main-thread violations at `createEncryptedPrefs` | 10/run | 0/run |
| main-thread `cacheDir` read | 1/run | 0/run |
| cold-start time (`am start -W`, median) | 1687 ms | 1652 ms |

Logged-in, logged-out, expired-session cold starts, an account switch and a sign-out
all behave as before. With the warm suppressed for the length of a sign-in, the first
write still persists to the encrypted store and a logged-in launch is carried by the
synchronous fallback alone.

Not verified: physical hardware, and iOS beyond compilation.

## Notes

With the keystore work off the main thread, an unrelated pre-existing main-thread disk
read becomes visible at cold start: slf4j's `ServiceLoader` scanning the apk during Ktor
client creation. Not introduced here; worth its own issue.
