### PR TITLE
fix(chat): scope a comparison pane's attachments to its own lane

### DIFF
--- a/feature/chat/CLAUDE.md
+++ b/feature/chat/CLAUDE.md
@@ -97,6 +97,19 @@ Two consequences worth knowing before touching that block:
 - **Live streaming attribution:** SSE deltas carry only a step id, never an agentId. `SseEventMapper` records each `on_run_step`'s agentId keyed by step id and resolves deltas by their own step id — required because two agents' run steps interleave, and a last-write-wins would collapse both panes onto one agent. `ComparisonModeDelegate.isSecondaryEvent` then fans deltas into the primary/secondary buffers.
 - **Rendering (`ChatContent.buildComparisonDisplayMessages`):** each pane filters the parallel message's parts via `util/ParallelContent.partsForPane` — so it works for every comparison turn in history, not just the live one. The captured streaming buffer is only a Final→reload-gap fallback. The single (non-comparison) list runs `collapseParallelToPrimary` so a branched-away comparison never renders both agents concatenated.
 - **A pane's lane renders WITHOUT activity grouping**, matching upstream: `ContentParts.tsx` early-returns any content carrying a `groupId` to `ParallelContentRenderer`, which calls the bare `renderPart` — no `groupSequentialToolCalls` and no `hideAttachments`, so a lane folds no tool calls into a collapsed block and hoists no attachments out of one. `MessageContentAndActions` passes `groupActivity = !hasParallelGroupIds(parts)` into `groupContentParts`; the lane is keyed on `groupId` rather than the `____N` suffix because `partsForPane` has already run, leaving the primary lane unsuffixed. Only grouping is bypassed — steer segmentation still applies. The server strips `groupId` when branching one agent's parts out of a comparison (`POST /api/messages/branch`), so a branched sibling reads as ordinary content and groups again.
+- **A pane's attachments are scoped to its own lane** (`util/ComparisonDisplay.attachmentsForPane`).
+  A pane filters `content`, so anything a bubble draws from `message.attachments` rather than from a
+  pane-filtered part would otherwise render once per pane — the office previews unconditionally, and
+  the memory writes through a join (`collectUnrenderedMemoryArtifacts`) whose two halves then
+  disagree about which calls exist, so even an ordinary inline `set_memory` reads as an *orphan* in
+  the pane that does not hold its call. An attachment follows the lane whose parts contain the call
+  that produced it; one attributable to no call in the turn — the background memory agent writes
+  from its own sub-run, whose calls never become content parts — belongs to the turn rather than to
+  either agent and renders once, in the primary pane, where upstream also puts it
+  (`ParallelContent.tsx` renders `MemoryArtifacts` once above both columns). `collapseParallelToPrimary`
+  scopes the same way. **Ownership is the recursive `outputToolCallIds` walk, never
+  `renderedToolCallIds`** — the latter stops at one level because that is where the dispatcher stops
+  drawing cards, which is a different question.
 - **Reopen (`ComparisonModeDelegate.rehydrateFromMessage`):** nothing but the persisted attribution records that a conversation was a comparison, so `loadConversation` rehydrates comparison state from the assistant tail's parts on the first non-empty emission (latched once per load; respects a session toggle-off). Continue-with-response = `POST /api/messages/branch` filtered to one agent's parts; the branched sibling becomes a single-agent tail, so the next reopen is the normal view.
 
 ## Content Rendering

--- a/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/util/ComparisonDisplayTest.kt
+++ b/feature/chat/src/androidUnitTest/kotlin/com/garfiec/librechat/feature/chat/util/ComparisonDisplayTest.kt
@@ -1,7 +1,9 @@
 package com.garfiec.librechat.feature.chat.util
 
+import com.garfiec.librechat.core.model.Attachment
 import com.garfiec.librechat.core.model.ContentType
 import com.garfiec.librechat.core.model.Message
+import com.garfiec.librechat.core.model.content.AgentToolCall
 import com.garfiec.librechat.core.model.content.MessageContentPart
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
@@ -129,5 +131,163 @@ class ComparisonDisplayTest {
 
         assertThat(collapsed[0]).isSameInstanceAs(plain)
         assertThat(collapsed[1].message.content?.map { it.text }).containsExactly("primary reply")
+    }
+
+    // ── Attachment scoping (#359) ───────────────────────────────────────────────
+
+    private fun toolPart(callId: String, agentId: String?, nested: List<MessageContentPart>? = null) =
+        MessageContentPart(
+            type = ContentType.TOOL_CALL,
+            agentId = agentId,
+            toolCall = AgentToolCall(id = callId, name = "set_memory", subagentContent = nested),
+        )
+
+    private fun attachment(fileId: String, toolCallId: String?) =
+        Attachment(fileId = fileId, toolCallId = toolCallId, type = "memory")
+
+    private fun toolBearingParallelNode(attachments: List<Attachment>) = node(
+        Message(
+            messageId = "m1",
+            conversationId = "c1",
+            content = listOf(
+                toolPart("call-primary", agentId = "agent_a"),
+                toolPart("call-secondary", agentId = "agent_a____1"),
+            ),
+            attachments = attachments,
+        ),
+    )
+
+    private fun panesFor(attachments: List<Attachment>): Pair<List<Attachment>?, List<Attachment>?> {
+        val nodes = listOf(toolBearingParallelNode(attachments))
+        fun pane(secondary: Boolean) = buildComparisonDisplayMessages(
+            nodes,
+            secondary = secondary,
+            parallelMessageId = "m1",
+            finalContent = null,
+            senderName = "Sender",
+        )[0].message.attachments
+        return pane(secondary = false) to pane(secondary = true)
+    }
+
+    @Test
+    fun `an attachment follows the lane whose call produced it`() {
+        val (primary, secondary) = panesFor(
+            listOf(attachment("f-primary", "call-primary"), attachment("f-secondary", "call-secondary")),
+        )
+
+        assertThat(primary?.map { it.fileId }).containsExactly("f-primary")
+        assertThat(secondary?.map { it.fileId }).containsExactly("f-secondary")
+    }
+
+    @Test
+    fun `an attachment attributable to no call in the turn renders in the primary pane only`() {
+        // The background memory agent's sub-run contributes no content parts, so its toolCallId
+        // matches neither lane.
+        val (primary, secondary) = panesFor(listOf(attachment("f-bg", "call-from-a-sub-run")))
+
+        assertThat(primary?.map { it.fileId }).containsExactly("f-bg")
+        assertThat(secondary).isEmpty()
+    }
+
+    @Test
+    fun `an attachment carrying no toolCallId renders in the primary pane only`() {
+        val (primary, secondary) = panesFor(listOf(attachment("f-loose", null)))
+
+        assertThat(primary?.map { it.fileId }).containsExactly("f-loose")
+        assertThat(secondary).isEmpty()
+    }
+
+    @Test
+    fun `an attachment owned by a call nested inside a subagent follows that lane`() {
+        // Pins the RECURSIVE walk: a one-level id set would read this as unattributable and hand
+        // the secondary lane's file to the primary pane.
+        val nodes = listOf(
+            node(
+                Message(
+                    messageId = "m1",
+                    conversationId = "c1",
+                    content = listOf(
+                        toolPart("call-primary", agentId = "agent_a"),
+                        toolPart(
+                            "call-secondary",
+                            agentId = "agent_a____1",
+                            nested = listOf(toolPart("call-nested", agentId = null)),
+                        ),
+                    ),
+                    attachments = listOf(attachment("f-nested", "call-nested")),
+                ),
+            ),
+        )
+        fun pane(secondary: Boolean) = buildComparisonDisplayMessages(
+            nodes,
+            secondary = secondary,
+            parallelMessageId = "m1",
+            finalContent = null,
+            senderName = "Sender",
+        )[0].message.attachments
+
+        assertThat(pane(secondary = true)?.map { it.fileId }).containsExactly("f-nested")
+        assertThat(pane(secondary = false)).isEmpty()
+    }
+
+    @Test
+    fun `a non-parallel message keeps its attachments untouched`() {
+        val plain = node(
+            Message(
+                messageId = "m0",
+                conversationId = "c1",
+                content = listOf(textPart("hi", agentId = null)),
+                attachments = listOf(attachment("f-plain", "call-plain")),
+            ),
+        )
+        val secondary = buildComparisonDisplayMessages(
+            listOf(plain),
+            secondary = true,
+            parallelMessageId = "other",
+            finalContent = null,
+            senderName = "Sender",
+        )
+
+        assertThat(secondary[0]).isSameInstanceAs(plain)
+    }
+
+    @Test
+    fun `the Final-reload gap gives the turn's attachments to the primary pane only`() {
+        val plain = node(
+            Message(
+                messageId = "m1",
+                conversationId = "c1",
+                content = listOf(textPart("raw", agentId = null)),
+                attachments = listOf(attachment("f-gap", "call-gap")),
+            ),
+        )
+        fun pane(secondary: Boolean) = buildComparisonDisplayMessages(
+            listOf(plain),
+            secondary = secondary,
+            parallelMessageId = "m1",
+            finalContent = "gap buffer",
+            senderName = "Sender",
+        )[0].message.attachments
+
+        assertThat(pane(secondary = false)?.map { it.fileId }).containsExactly("f-gap")
+        assertThat(pane(secondary = true)).isNull()
+    }
+
+    @Test
+    fun `collapseParallelToPrimary drops the added agent's attachments`() {
+        val collapsed = collapseParallelToPrimary(
+            listOf(
+                toolBearingParallelNode(
+                    listOf(
+                        attachment("f-primary", "call-primary"),
+                        attachment("f-secondary", "call-secondary"),
+                        attachment("f-bg", null),
+                    ),
+                ),
+            ),
+        )
+
+        assertThat(collapsed[0].message.attachments?.map { it.fileId })
+            .containsExactly("f-primary", "f-bg")
     }
 }

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/AttachmentPayloadParsing.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/components/AttachmentPayloadParsing.kt
@@ -141,6 +141,10 @@ internal fun collectMemoryArtifacts(
  * Every tool call id a message renders a card for, including the calls nested one level inside a
  * subagent trace — this must track the depth the dispatcher recurses to, or
  * [collectUnrenderedMemoryArtifacts] double-reports the nested calls' writes.
+ *
+ * **Not interchangeable with `outputToolCallIds`, which recurses.** That one answers "which calls'
+ * output does this subtree own"; this one "which calls have a card". Nested parts render with
+ * `allowSubagentCard = false`, so a call two levels down is drawn by nothing and must NOT count.
  */
 internal fun renderedToolCallIds(parts: List<MessageContentPart>?): Set<String> {
     if (parts.isNullOrEmpty()) return emptySet()

--- a/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/util/ComparisonDisplay.kt
+++ b/feature/chat/src/commonMain/kotlin/com/garfiec/librechat/feature/chat/util/ComparisonDisplay.kt
@@ -1,5 +1,6 @@
 package com.garfiec.librechat.feature.chat.util
 
+import com.garfiec.librechat.core.model.Attachment
 import com.garfiec.librechat.core.model.ContentType
 import com.garfiec.librechat.core.model.Message
 import com.garfiec.librechat.core.model.content.MessageContentPart
@@ -29,8 +30,8 @@ fun buildComparisonDisplayMessages(
     secondaryEndpoint: String? = null,
     secondaryIconUrl: String? = null,
 ): List<MessageNode> {
-    fun Message.forPane(newContent: List<MessageContentPart>): Message {
-        val base = copy(content = newContent, sender = senderName ?: sender)
+    fun Message.forPane(newContent: List<MessageContentPart>, paneAttachments: List<Attachment>?): Message {
+        val base = copy(content = newContent, attachments = paneAttachments, sender = senderName ?: sender)
         // Only the secondary pane needs re-pointing; the primary message already carries
         // its own endpoint/iconURL. Force iconURL (even to null) so the primary's avatar
         // never bleeds into the secondary pane.
@@ -50,14 +51,24 @@ fun buildComparisonDisplayMessages(
                 } else {
                     paneParts
                 }
-                node.copy(message = message.forPane(content))
+                node.copy(
+                    message = message.forPane(
+                        newContent = content,
+                        paneAttachments = message.attachments?.let {
+                            attachmentsForPane(it, paneParts, message.content.orEmpty(), secondary)
+                        },
+                    ),
+                )
             }
             // Final→reload gap: the server message isn't parallel-attributed yet, so fall
-            // back to this pane's captured streaming buffer.
+            // back to this pane's captured streaming buffer. No attributed parts to scope
+            // attachments against yet, so the turn's go to the primary pane — where they land
+            // once the attributed message arrives.
             message.messageId == parallelMessageId && !finalContent.isNullOrBlank() -> {
                 node.copy(
                     message = message.forPane(
-                        listOf(MessageContentPart(type = ContentType.TEXT, text = finalContent)),
+                        newContent = listOf(MessageContentPart(type = ContentType.TEXT, text = finalContent)),
+                        paneAttachments = message.attachments?.takeIf { !secondary },
                     ),
                 )
             }
@@ -67,15 +78,59 @@ fun buildComparisonDisplayMessages(
 }
 
 /**
+ * The attachments one pane owns, given the parts it renders ([paneParts]) and the whole parallel
+ * message's parts ([allParts]).
+ *
+ * A pane filters `content` but a `copy` carries `attachments` whole, so an unscoped list renders
+ * once per pane on every surface drawn from `message.attachments` rather than from a part.
+ *
+ * An attachment follows the lane whose parts contain the call that produced it — the RECURSIVE
+ * [outputToolCallIds] walk, so a call nested inside a subagent still belongs to its lane. One
+ * attributable to no call in the turn — the background memory agent writes from its own sub-run,
+ * whose calls never become content parts — belongs to the turn rather than to either agent, so it
+ * renders once, in the primary pane. See `feature/chat/CLAUDE.md`, "Compare Models".
+ */
+internal fun attachmentsForPane(
+    attachments: List<Attachment>,
+    paneParts: List<MessageContentPart>,
+    allParts: List<MessageContentPart>,
+    secondary: Boolean,
+): List<Attachment> {
+    val paneCallIds = outputToolCallIds(paneParts).toSet()
+    val messageCallIds = outputToolCallIds(allParts).toSet()
+    return attachments.filter { attachment ->
+        val owner = attachment.toolCallId
+        when {
+            owner != null && owner in paneCallIds -> true
+            owner != null && owner in messageCallIds -> false
+            else -> !secondary
+        }
+    }
+}
+
+/**
  * Collapses any parallel (Compare Models) message to just its primary agent's parts,
  * so an old comparison turn never renders both agents' content concatenated in the
  * single (non-comparison) list — e.g. after branching, or when viewing a comparison
  * sibling that isn't the active-path tail.
+ *
+ * Attachments are scoped the same way ([attachmentsForPane]) — the added agent's files would
+ * otherwise outlive the content that explains them, and its memory writes would surface here as
+ * unattributed ones.
  */
 fun collapseParallelToPrimary(displayMessages: List<MessageNode>): List<MessageNode> =
     displayMessages.map { node ->
-        if (hasParallelParts(node.message)) {
-            node.copy(message = node.message.copy(content = partsForPane(node.message, secondary = false)))
+        val message = node.message
+        if (hasParallelParts(message)) {
+            val primaryParts = partsForPane(message, secondary = false)
+            node.copy(
+                message = message.copy(
+                    content = primaryParts,
+                    attachments = message.attachments?.let {
+                        attachmentsForPane(it, primaryParts, message.content.orEmpty(), secondary = false)
+                    },
+                ),
+            )
         } else {
             node
         }


### PR DESCRIPTION
## Summary

A Compare Models turn rendered the message's attachment-driven surfaces twice, once per pane. Each pane filters `content` per lane but carried `attachments` through whole, so anything a bubble draws from the attachment list rather than from a pane-filtered part was emitted in both panes. Panes now see only the attachments their own lane produced.

Three duplications this removes:

- An inline `set_memory` in one lane rendered its own card in that pane and — because its tool call is absent from the other pane's content — read as an *orphan* there and got a second card.
- A background-memory-agent write matches no call in either pane, so both rendered it.
- Office-doc previews render from `message.attachments` with no tool-call join at all, and duplicated unconditionally.

Closes #359.

## Changes

- `attachmentsForPane` (`util/ComparisonDisplay.kt`) — an attachment follows the lane whose parts contain the call that produced it; one attributable to no call in the turn renders once, in the primary pane.
- Wired into `buildComparisonDisplayMessages`' parallel branch and into `collapseParallelToPrimary`. In the single list this is a **removal**, not only a de-duplication: the added agent's attachments are dropped alongside its content, so a secondary-lane office preview or memory write that previously rendered there now renders nowhere. That path also feeds in-conversation search and the iOS screen.
- Where a pane ends up with no attributed parts — the Final→reload gap, or the in-branch empty-pane fallback — there is nothing to scope against, so the turn's attachments go to the primary pane, which is where they land once the attributed message arrives.
- `renderedToolCallIds` gains a KDoc note on why it stops one level down and is not interchangeable with the recursive walk.
- Module doc records the invariant.

## Testing

- `./gradlew test detektMetadataCommonMain detekt :app:lint :app:assembleDebug` — green.
- 7 new `ComparisonDisplayTest` cases. 6 of the 7 fail against the pre-change file; the seventh is the non-parallel regression guard and passes either way.
- Device A/B on an emulator against a seeded comparison turn carrying three memory writes — one per lane plus one attributable to neither. Before: every write rendered twice. After: each renders once, in its own lane, with the unattributable one in the primary pane. The single-list path was checked by toggling Compare Models off. No crashes; one pre-existing empty-body decode error appears identically on both builds.

## Notes

- Upstream hands `MemoryArtifacts` every attachment once above both columns, with no `toolCallId` filter (`ParallelContent.tsx:275`, `MemoryArtifacts.tsx`). Placing an unattributable write in the primary pane matches that. Routing an attributable one to its own lane is a deliberate divergence, needed because mobile also renders an inline per-call card that upstream has no equivalent of.
- Scoping lives in `ComparisonDisplay` rather than at the render site because the panes are derived in a pure function, so the fix is assertable in JVM tests — `feature:chat` has only an on-device Compose harness, the same reason `sendButtonModeFor` is a pure transform pulled out of its composable. A render-site fix would have to be repeated on every bubble surface that reads `message.attachments`.
- Ownership uses `outputToolCallIds` (recursive) and not the similarly-named `renderedToolCallIds`, which stops one level down because that is where the subagent *trace* recursion stops — a call two levels down is drawn by nothing. `outputToolCallIds` now serves two purposes across three call sites: attachment hoisting (activity groups and subagent cards) and this lane attribution.
- The background-agent case was exercised with a seeded attachment of that shape rather than a live background memory agent (`memory.agent.enabled` is not configured on the test server), so the rendering path is covered but not the server behaviour that produces it.
- The office-preview duplicate follows from the same rule but was not observed on a device.
