### PR TITLE
fix(settings): drop the stale CDN warning from inline artifact settings

### DIFF
--- a/feature/settings/src/commonMain/composeResources/values-ar/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-ar/strings.xml
@@ -253,9 +253,9 @@
     <string name="inline_artifact_svg">صور SVG</string>
     <string name="inline_artifact_svg_desc">عرض رسومات SVG المتجهة بشكل مضمّن</string>
     <string name="inline_artifact_html">HTML</string>
-    <string name="inline_artifact_html_desc">عرض صفحات HTML بشكل مضمّن (يحمّل Tailwind من CDN)</string>
+    <string name="inline_artifact_html_desc">عرض صفحات HTML بشكل مضمّن</string>
     <string name="inline_artifact_react">مكوّنات React</string>
-    <string name="inline_artifact_react_desc">عرض مكوّنات React بشكل مضمّن (يحمّل React + Babel من CDN)</string>
+    <string name="inline_artifact_react_desc">عرض مكوّنات React بشكل مضمّن</string>
     <string name="inline_artifact_markdown">مستندات Markdown</string>
     <string name="inline_artifact_markdown_desc">عرض عناصر Markdown التفاعلية بشكل مضمّن مع كتل أكواد مميزة بالتلوين النحوي</string>
 

--- a/feature/settings/src/commonMain/composeResources/values-de/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-de/strings.xml
@@ -253,9 +253,9 @@
     <string name="inline_artifact_svg">SVG-Bilder</string>
     <string name="inline_artifact_svg_desc">SVG-Vektorgrafiken eingebettet rendern</string>
     <string name="inline_artifact_html">HTML</string>
-    <string name="inline_artifact_html_desc">HTML-Seiten eingebettet rendern (lädt Tailwind vom CDN)</string>
+    <string name="inline_artifact_html_desc">HTML-Seiten eingebettet rendern</string>
     <string name="inline_artifact_react">React-Komponenten</string>
-    <string name="inline_artifact_react_desc">React-Komponenten eingebettet rendern (lädt React + Babel vom CDN)</string>
+    <string name="inline_artifact_react_desc">React-Komponenten eingebettet rendern</string>
     <string name="inline_artifact_markdown">Markdown-Dokumente</string>
     <string name="inline_artifact_markdown_desc">Markdown-Artefakte eingebettet mit syntaxhervorgehobenen Codeblöcken rendern</string>
 

--- a/feature/settings/src/commonMain/composeResources/values-es/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-es/strings.xml
@@ -253,9 +253,9 @@
     <string name="inline_artifact_svg">Imágenes SVG</string>
     <string name="inline_artifact_svg_desc">Renderiza gráficos vectoriales SVG en línea</string>
     <string name="inline_artifact_html">HTML</string>
-    <string name="inline_artifact_html_desc">Renderiza páginas HTML en línea (carga Tailwind desde la CDN)</string>
+    <string name="inline_artifact_html_desc">Renderiza páginas HTML en línea</string>
     <string name="inline_artifact_react">Componentes de React</string>
-    <string name="inline_artifact_react_desc">Renderiza componentes de React en línea (carga React + Babel desde la CDN)</string>
+    <string name="inline_artifact_react_desc">Renderiza componentes de React en línea</string>
     <string name="inline_artifact_markdown">Documentos de Markdown</string>
     <string name="inline_artifact_markdown_desc">Renderiza artefactos de Markdown en línea con bloques de código con resaltado de sintaxis</string>
 

--- a/feature/settings/src/commonMain/composeResources/values-fr/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-fr/strings.xml
@@ -253,9 +253,9 @@
     <string name="inline_artifact_svg">Images SVG</string>
     <string name="inline_artifact_svg_desc">Afficher les images vectorielles SVG en ligne</string>
     <string name="inline_artifact_html">HTML</string>
-    <string name="inline_artifact_html_desc">Afficher les pages HTML en ligne (charge Tailwind depuis le CDN)</string>
+    <string name="inline_artifact_html_desc">Afficher les pages HTML en ligne</string>
     <string name="inline_artifact_react">Composants React</string>
-    <string name="inline_artifact_react_desc">Afficher les composants React en ligne (charge React + Babel depuis le CDN)</string>
+    <string name="inline_artifact_react_desc">Afficher les composants React en ligne</string>
     <string name="inline_artifact_markdown">Documents Markdown</string>
     <string name="inline_artifact_markdown_desc">Afficher les artefacts Markdown en ligne avec des blocs de code à coloration syntaxique</string>
 

--- a/feature/settings/src/commonMain/composeResources/values-ja/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-ja/strings.xml
@@ -253,9 +253,9 @@
     <string name="inline_artifact_svg">SVG画像</string>
     <string name="inline_artifact_svg_desc">SVGベクター画像をインラインでレンダリング</string>
     <string name="inline_artifact_html">HTML</string>
-    <string name="inline_artifact_html_desc">HTMLページをインラインでレンダリング（TailwindをCDNから読み込み）</string>
+    <string name="inline_artifact_html_desc">HTMLページをインラインでレンダリング</string>
     <string name="inline_artifact_react">Reactコンポーネント</string>
-    <string name="inline_artifact_react_desc">Reactコンポーネントをインラインでレンダリング（React + BabelをCDNから読み込み）</string>
+    <string name="inline_artifact_react_desc">Reactコンポーネントをインラインでレンダリング</string>
     <string name="inline_artifact_markdown">Markdownドキュメント</string>
     <string name="inline_artifact_markdown_desc">構文ハイライト付きのコードブロックでMarkdownアーティファクトをインラインでレンダリング</string>
 

--- a/feature/settings/src/commonMain/composeResources/values-ko/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-ko/strings.xml
@@ -253,9 +253,9 @@
     <string name="inline_artifact_svg">SVG 이미지</string>
     <string name="inline_artifact_svg_desc">SVG 벡터 그래픽을 인라인으로 렌더링</string>
     <string name="inline_artifact_html">HTML</string>
-    <string name="inline_artifact_html_desc">HTML 페이지를 인라인으로 렌더링 (CDN에서 Tailwind 로드)</string>
+    <string name="inline_artifact_html_desc">HTML 페이지를 인라인으로 렌더링</string>
     <string name="inline_artifact_react">React 컴포넌트</string>
-    <string name="inline_artifact_react_desc">React 컴포넌트를 인라인으로 렌더링 (CDN에서 React + Babel 로드)</string>
+    <string name="inline_artifact_react_desc">React 컴포넌트를 인라인으로 렌더링</string>
     <string name="inline_artifact_markdown">Markdown 문서</string>
     <string name="inline_artifact_markdown_desc">구문 강조된 코드 블록과 함께 Markdown 아티팩트를 인라인으로 렌더링</string>
 

--- a/feature/settings/src/commonMain/composeResources/values-pt/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-pt/strings.xml
@@ -253,9 +253,9 @@
     <string name="inline_artifact_svg">Imagens SVG</string>
     <string name="inline_artifact_svg_desc">Renderizar gráficos vetoriais SVG embutidos</string>
     <string name="inline_artifact_html">HTML</string>
-    <string name="inline_artifact_html_desc">Renderizar páginas HTML embutidas (carrega o Tailwind via CDN)</string>
+    <string name="inline_artifact_html_desc">Renderizar páginas HTML embutidas</string>
     <string name="inline_artifact_react">Componentes React</string>
-    <string name="inline_artifact_react_desc">Renderizar componentes React embutidos (carrega React + Babel via CDN)</string>
+    <string name="inline_artifact_react_desc">Renderizar componentes React embutidos</string>
     <string name="inline_artifact_markdown">Documentos Markdown</string>
     <string name="inline_artifact_markdown_desc">Renderizar artefatos Markdown embutidos com blocos de código com destaque de sintaxe</string>
 

--- a/feature/settings/src/commonMain/composeResources/values-ru/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-ru/strings.xml
@@ -253,9 +253,9 @@
     <string name="inline_artifact_svg">Изображения SVG</string>
     <string name="inline_artifact_svg_desc">Отображать векторную графику SVG встроенно</string>
     <string name="inline_artifact_html">HTML</string>
-    <string name="inline_artifact_html_desc">Отображать страницы HTML встроенно (загружает Tailwind из CDN)</string>
+    <string name="inline_artifact_html_desc">Отображать страницы HTML встроенно</string>
     <string name="inline_artifact_react">Компоненты React</string>
-    <string name="inline_artifact_react_desc">Отображать компоненты React встроенно (загружает React + Babel из CDN)</string>
+    <string name="inline_artifact_react_desc">Отображать компоненты React встроенно</string>
     <string name="inline_artifact_markdown">Документы Markdown</string>
     <string name="inline_artifact_markdown_desc">Отображать артефакты Markdown встроенно с подсветкой синтаксиса в блоках кода</string>
 

--- a/feature/settings/src/commonMain/composeResources/values-zh/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-zh/strings.xml
@@ -253,9 +253,9 @@
     <string name="inline_artifact_svg">SVG 图片</string>
     <string name="inline_artifact_svg_desc">内嵌渲染 SVG 矢量图形</string>
     <string name="inline_artifact_html">HTML</string>
-    <string name="inline_artifact_html_desc">内嵌渲染 HTML 页面（从 CDN 加载 Tailwind）</string>
+    <string name="inline_artifact_html_desc">内嵌渲染 HTML 页面</string>
     <string name="inline_artifact_react">React 组件</string>
-    <string name="inline_artifact_react_desc">内嵌渲染 React 组件（从 CDN 加载 React + Babel）</string>
+    <string name="inline_artifact_react_desc">内嵌渲染 React 组件</string>
     <string name="inline_artifact_markdown">Markdown 文档</string>
     <string name="inline_artifact_markdown_desc">内嵌渲染 Markdown artifact，并对代码块进行语法高亮</string>
 

--- a/feature/settings/src/commonMain/composeResources/values/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values/strings.xml
@@ -277,9 +277,9 @@
     <string name="inline_artifact_svg">SVG images</string>
     <string name="inline_artifact_svg_desc">Render SVG vector graphics inline</string>
     <string name="inline_artifact_html">HTML</string>
-    <string name="inline_artifact_html_desc">Render HTML pages inline (loads Tailwind from CDN)</string>
+    <string name="inline_artifact_html_desc">Render HTML pages inline</string>
     <string name="inline_artifact_react">React components</string>
-    <string name="inline_artifact_react_desc">Render React components inline (loads React + Babel from CDN)</string>
+    <string name="inline_artifact_react_desc">Render React components inline</string>
     <string name="inline_artifact_markdown">Markdown documents</string>
     <string name="inline_artifact_markdown_desc">Render Markdown artifacts inline with syntax-highlighted code blocks</string>
 


### PR DESCRIPTION
## Summary

The inline-artifact settings told users that HTML rendering "loads Tailwind from CDN" and React rendering "loads React + Babel from CDN". Neither is true any more — #368 vendored every script the WebView renderers execute into the APK. The settings screen was describing network behaviour the app no longer has.

## Changes

- Drops the CDN parenthetical from `inline_artifact_html_desc` and `inline_artifact_react_desc` in all ten locale files.
- The clause is removed rather than reworded, so no translated copy is invented: the remaining text in each language already describes the setting completely.

## Verification

The claim is false in both directions. Tailwind, Babel, React and React-DOM are all pinned and vendored in `scripts/web-assets.json`, and the React artifact page's CSP is `script-src 'self' 'unsafe-inline' 'unsafe-eval' blob: file:` — with no `https:`, a remote script cannot load even if one were referenced. `ReactArtifactRenderTest` already asserts that an unbundled package fails by name instead of falling back to a CDN.

Swept the tree for the same claim elsewhere: the only other mentions are developer docs describing the bundled state correctly, and the store listing, which already says every script is bundled rather than fetched from a CDN.

`detekt`, `detektMetadataCommonMain`, `test` and `:app:assembleDebug` pass. All ten files verified well-formed.

Not device-tested; the change is display text only.

## Notes

- The parenthetical existed as a privacy warning. There is no longer a cost to warn about, so it is dropped rather than replaced — telling users which library is bundled is a separate, optional improvement that would need nine translations.
